### PR TITLE
[front] enh: allow skill imports to set editors

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -3511,6 +3511,14 @@
                       "override"
                     ],
                     "description": "Conflict handling strategy. Defaults to error."
+                  },
+                  "editors": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "description": "Optional editor email addresses to add to imported or updated skills. Editors must be active workspace builders. Existing skills keep their current editors."
                   }
                 }
               }

--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -1,10 +1,33 @@
+// @vitest-environment node: adm-zip requires Node builtins (Buffer, zlib)
+// This directive makes them available in the test environment.
+
+import { randomUUID } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { importSkillsFromFiles } from "@app/lib/api/skills/detection/files/import_skills";
 import { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { honoApp } from "@front-api/app";
-import { describe, expect, it } from "vitest";
+import AdmZip from "adm-zip";
+import type formidable from "formidable";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/skills/icon_suggestion", () => ({
+  getSkillIconSuggestion: vi.fn(async () => ({
+    isOk: () => true,
+    value: "sparkles",
+  })),
+}));
+
+vi.mock("@app/lib/api/skills/detection/suggest_mcp_servers", () => ({
+  suggestMCPServersForDetectedSkill: vi.fn(async () => []),
+}));
 
 function getSkills(
   workspace: { sId: string },
@@ -15,6 +38,38 @@ function getSkills(
   return honoApp.request(`/api/v1/w/${workspace.sId}/skills${params}`, {
     headers: { authorization: `Bearer ${key.secret}` },
   });
+}
+
+function makeSkillMd(name: string, instructions: string): string {
+  return `---
+name: ${name}
+description: ${name} description
+---
+${instructions}`;
+}
+
+async function makeSkillZipFile({
+  instructions,
+  name,
+}: {
+  instructions: string;
+  name: string;
+}): Promise<formidable.File> {
+  const zip = new AdmZip();
+  zip.addFile(
+    "skills/imported/SKILL.md",
+    Buffer.from(makeSkillMd(name, instructions), "utf-8")
+  );
+  const buffer = zip.toBuffer();
+  const filepath = path.join(tmpdir(), `skill-import-${randomUUID()}.zip`);
+  await writeFile(filepath, buffer);
+
+  return {
+    filepath,
+    originalFilename: "skills.zip",
+    mimetype: "application/zip",
+    size: buffer.length,
+  } as formidable.File;
 }
 
 describe("GET /api/v1/w/[wId]/skills", () => {
@@ -78,5 +133,75 @@ describe("GET /api/v1/w/[wId]/skills", () => {
 
     expect(skillNames).toContain("Archived API Skill");
     expect(skillNames).not.toContain("Active API Skill");
+  });
+});
+
+describe("POST /api/v1/w/[wId]/skills", () => {
+  it("adds provided editors to new and existing imported skills", async () => {
+    const { auth, workspace } = await createPublicApiMockRequest();
+    await SpaceFactory.defaults(
+      await Authenticator.internalAdminForWorkspace(workspace.sId)
+    );
+    const firstEditor = await UserFactory.basic();
+    const secondEditor = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, firstEditor, {
+      role: "builder",
+    });
+    await MembershipFactory.associate(workspace, secondEditor, {
+      role: "builder",
+    });
+
+    const firstImport = await importSkillsFromFiles(auth, {
+      uploadedFiles: [
+        await makeSkillZipFile({
+          name: "Imported API Skill",
+          instructions: "Use the first version.",
+        }),
+      ],
+      source: "api",
+      onConflict: "error",
+      editors: [firstEditor.email],
+    });
+
+    expect(firstImport.isOk()).toBe(true);
+    if (firstImport.isErr()) {
+      throw firstImport.error;
+    }
+    expect(firstImport.value.imported).toHaveLength(1);
+    const importedSkill = firstImport.value.imported[0];
+    const importedEditors = await importedSkill.listEditors(auth);
+    expect(importedEditors?.map((editor) => editor.email).sort()).toEqual([
+      firstEditor.email.toLowerCase(),
+    ]);
+
+    const secondImport = await importSkillsFromFiles(auth, {
+      uploadedFiles: [
+        await makeSkillZipFile({
+          name: "Imported API Skill",
+          instructions: "Use the second version.",
+        }),
+      ],
+      source: "api",
+      onConflict: "error",
+      editors: [secondEditor.email],
+    });
+
+    expect(secondImport.isOk()).toBe(true);
+    if (secondImport.isErr()) {
+      throw secondImport.error;
+    }
+    expect(secondImport.value.updated).toHaveLength(1);
+
+    const updatedSkill = await SkillResource.fetchById(auth, importedSkill.sId);
+    expect(updatedSkill).not.toBeNull();
+    if (!updatedSkill) {
+      throw new Error("Expected imported skill to be found.");
+    }
+    const updatedEditors = await updatedSkill.listEditors(auth);
+    expect(updatedEditors?.map((editor) => editor.email).sort()).toEqual(
+      [firstEditor.email, secondEditor.email]
+        .map((email) => email.toLowerCase())
+        .sort()
+    );
   });
 });

--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -5,10 +5,7 @@ import { randomUUID } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import {
-  importSkillsFromFiles,
-  type UploadedSkillFile,
-} from "@app/lib/api/skills/detection/files/import_skills";
+import { importSkillsFromFiles } from "@app/lib/api/skills/detection/files/import_skills";
 import { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
@@ -18,6 +15,7 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { honoApp } from "@front-api/app";
 import AdmZip from "adm-zip";
+import type formidable from "formidable";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/skills/icon_suggestion", () => ({
@@ -56,7 +54,7 @@ async function makeSkillZipFile({
 }: {
   instructions: string;
   name: string;
-}): Promise<UploadedSkillFile> {
+}): Promise<formidable.File> {
   const zip = new AdmZip();
   zip.addFile(
     "skills/imported/SKILL.md",
@@ -65,10 +63,31 @@ async function makeSkillZipFile({
   const buffer = zip.toBuffer();
   const filepath = path.join(tmpdir(), `skill-import-${randomUUID()}.zip`);
   await writeFile(filepath, buffer);
+  const newFilename = path.basename(filepath);
 
   return {
     filepath,
-  };
+    hashAlgorithm: false,
+    mimetype: "application/zip",
+    newFilename,
+    originalFilename: "skills.zip",
+    size: buffer.length,
+    toJSON() {
+      return {
+        filepath,
+        hash: null,
+        length: buffer.length,
+        mimetype: "application/zip",
+        mtime: null,
+        newFilename,
+        originalFilename: "skills.zip",
+        size: buffer.length,
+      };
+    },
+    toString() {
+      return `PersistentFile: ${newFilename}, Original: skills.zip, Path: ${filepath}`;
+    },
+  } satisfies formidable.File;
 }
 
 describe("GET /api/v1/w/[wId]/skills", () => {

--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -5,7 +5,10 @@ import { randomUUID } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { importSkillsFromFiles } from "@app/lib/api/skills/detection/files/import_skills";
+import {
+  importSkillsFromFiles,
+  type UploadedSkillFile,
+} from "@app/lib/api/skills/detection/files/import_skills";
 import { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
@@ -15,7 +18,6 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { honoApp } from "@front-api/app";
 import AdmZip from "adm-zip";
-import type formidable from "formidable";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/skills/icon_suggestion", () => ({
@@ -54,7 +56,7 @@ async function makeSkillZipFile({
 }: {
   instructions: string;
   name: string;
-}): Promise<formidable.File> {
+}): Promise<UploadedSkillFile> {
   const zip = new AdmZip();
   zip.addFile(
     "skills/imported/SKILL.md",
@@ -66,10 +68,7 @@ async function makeSkillZipFile({
 
   return {
     filepath,
-    originalFilename: "skills.zip",
-    mimetype: "application/zip",
-    size: buffer.length,
-  } as formidable.File;
+  };
 }
 
 describe("GET /api/v1/w/[wId]/skills", () => {

--- a/front-api/routes/v1/w/[wId]/skills/index.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.ts
@@ -111,6 +111,12 @@ const app = createHono<PublicApiCtx & { Bindings: HttpBindings }>();
  *                 type: string
  *                 enum: [error, skip, override]
  *                 description: Conflict handling strategy. Defaults to error.
+ *               editors:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                   format: email
+ *                 description: Optional editor email addresses to add to imported or updated skills. Editors must be active workspace builders. Existing skills keep their current editors.
  *     responses:
  *       200:
  *         description: Skills import result.
@@ -204,7 +210,7 @@ app.post("/", async (ctx): HandlerResult<ImportSkillsResponseBody> => {
     });
   }
 
-  const { names } = fields;
+  const { editors, names } = fields;
 
   const onConflict = fields.onConflict?.[0] ?? "error";
   if (!isImportConflictStrategy(onConflict)) {
@@ -219,6 +225,7 @@ app.post("/", async (ctx): HandlerResult<ImportSkillsResponseBody> => {
 
   const result = await importSkillsFromFiles(auth, {
     uploadedFiles,
+    editors,
     names,
     source: "api",
     onConflict,

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -40,6 +40,8 @@ export function isImportConflictStrategy(
 
 type FileImportSource = Extract<SkillSourceType, "api" | "local_file">;
 
+export type UploadedSkillFile = Pick<formidable.File, "filepath">;
+
 type ImportSkillsResult = {
   imported: SkillResource[];
   updated: SkillResource[];
@@ -64,7 +66,7 @@ export async function importSkillsFromFiles(
     source = "local_file",
     onConflict = "skip",
   }: {
-    uploadedFiles: formidable.File[];
+    uploadedFiles: UploadedSkillFile[];
     names?: string[];
     editors?: string[];
     source?: FileImportSource;
@@ -365,7 +367,7 @@ async function uploadAttachment(
   return uploadResult.value;
 }
 
-async function cleanupTempFiles(files: formidable.File[]): Promise<void> {
+async function cleanupTempFiles(files: UploadedSkillFile[]): Promise<void> {
   await concurrentExecutor(files, (f) => unlink(f.filepath).catch(() => {}), {
     concurrency: 8,
   });

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -40,8 +40,6 @@ export function isImportConflictStrategy(
 
 type FileImportSource = Extract<SkillSourceType, "api" | "local_file">;
 
-export type UploadedSkillFile = Pick<formidable.File, "filepath">;
-
 type ImportSkillsResult = {
   imported: SkillResource[];
   updated: SkillResource[];
@@ -66,7 +64,7 @@ export async function importSkillsFromFiles(
     source = "local_file",
     onConflict = "skip",
   }: {
-    uploadedFiles: UploadedSkillFile[];
+    uploadedFiles: formidable.File[];
     names?: string[];
     editors?: string[];
     source?: FileImportSource;
@@ -367,7 +365,7 @@ async function uploadAttachment(
   return uploadResult.value;
 }
 
-async function cleanupTempFiles(files: UploadedSkillFile[]): Promise<void> {
+async function cleanupTempFiles(files: formidable.File[]): Promise<void> {
   await concurrentExecutor(files, (f) => unlink(f.filepath).catch(() => {}), {
     concurrency: 8,
   });

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -10,7 +10,9 @@ import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import type { Authenticator } from "@app/lib/auth";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { SkillSourceType } from "@app/types/assistant/skill_configuration";
@@ -58,11 +60,13 @@ export async function importSkillsFromFiles(
   {
     uploadedFiles,
     names,
+    editors,
     source = "local_file",
     onConflict = "skip",
   }: {
     uploadedFiles: formidable.File[];
     names?: string[];
+    editors?: string[];
     source?: FileImportSource;
     onConflict?: ImportConflictStrategyType;
   }
@@ -125,6 +129,15 @@ export async function importSkillsFromFiles(
   if (selectedSkills.length === 0) {
     return new Err(new Error("No matching importable skills found."));
   }
+
+  const editorUsersResult = await resolveEditorUsersFromEmails(
+    auth,
+    editors ?? []
+  );
+  if (editorUsersResult.isErr()) {
+    return editorUsersResult;
+  }
+  const editorUsers = editorUsersResult.value;
 
   const user = auth.user();
   const imported: SkillResource[] = [];
@@ -190,6 +203,11 @@ export async function importSkillsFromFiles(
         skillId: existing.sId,
       });
 
+      const editorsResult = await existing.upsertEditors(auth, editorUsers);
+      if (editorsResult.isErr()) {
+        return editorsResult;
+      }
+
       updated.push(existing);
     } else {
       let icon: string | null = null;
@@ -240,11 +258,71 @@ export async function importSkillsFromFiles(
         skillId: skillResource.sId,
       });
 
+      const editorsResult = await skillResource.upsertEditors(
+        auth,
+        editorUsers
+      );
+      if (editorsResult.isErr()) {
+        return editorsResult;
+      }
+
       imported.push(skillResource);
     }
   }
 
   return new Ok({ imported, updated, skipped });
+}
+
+async function resolveEditorUsersFromEmails(
+  auth: Authenticator,
+  editorEmails: string[]
+): Promise<Result<UserResource[], Error>> {
+  const normalizedEditorEmails = [
+    ...new Set(
+      editorEmails.map((email) => email.trim().toLowerCase()).filter(Boolean)
+    ),
+  ];
+
+  if (normalizedEditorEmails.length === 0) {
+    return new Ok([]);
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const editorUsers = await UserResource.listUserWithExactEmails(
+    workspace,
+    normalizedEditorEmails
+  );
+  const foundEmails = new Set(editorUsers.map((u) => u.email.toLowerCase()));
+  const missingEmails = normalizedEditorEmails.filter(
+    (email) => !foundEmails.has(email)
+  );
+
+  if (missingEmails.length > 0) {
+    return new Err(
+      new Error(`Editors not found in workspace: ${missingEmails.join(", ")}`)
+    );
+  }
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    users: editorUsers,
+    workspace,
+  });
+  const membershipByUserId = new Map(
+    memberships.map((membership) => [membership.userId, membership])
+  );
+  const nonBuilderEmails = editorUsers
+    .filter((user) => !membershipByUserId.get(user.id)?.isBuilder)
+    .map((user) => user.email);
+
+  if (nonBuilderEmails.length > 0) {
+    return new Err(
+      new Error(
+        `Editors must be workspace builders: ${nonBuilderEmails.join(", ")}`
+      )
+    );
+  }
+
+  return new Ok(editorUsers);
 }
 
 async function uploadAttachment(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2068,22 +2068,49 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return this.editorGroup?.getActiveMembers(auth) ?? null;
   }
 
+  async upsertEditors(
+    auth: Authenticator,
+    users: UserResource[]
+  ): Promise<Result<void, Error>> {
+    if (users.length === 0) {
+      return new Ok(undefined);
+    }
+
+    if (!this.canWrite(auth)) {
+      return new Err(
+        new Error("User is not authorized to update skill editors.")
+      );
+    }
+
+    if (!this.editorGroup) {
+      return new Err(new Error("The skill does not have an editors group."));
+    }
+
+    const existingEditors = await this.listEditors(auth);
+    const existingEditorIds = new Set(existingEditors?.map((u) => u.id) ?? []);
+    const usersToAdd = users.filter((u) => !existingEditorIds.has(u.id));
+
+    if (usersToAdd.length === 0) {
+      return new Ok(undefined);
+    }
+
+    const addResult = await this.editorGroup.dangerouslyAddMembers(auth, {
+      users: usersToAdd.map((u) => u.toJSON()),
+    });
+    if (addResult.isErr()) {
+      return new Err(new Error(addResult.error.message));
+    }
+
+    return new Ok(undefined);
+  }
+
   private async upsertCurrentUserAsEditor(auth: Authenticator): Promise<void> {
     const user = auth.user();
-    if (!this.editorGroup || !user) {
+    if (!user) {
       return;
     }
 
-    if (!this.editorGroup.canWrite(auth)) {
-      return;
-    }
-
-    const isMember = await this.editorGroup.isMember(user);
-    if (!isMember) {
-      await this.editorGroup.dangerouslyAddMember(auth, {
-        user: user.toJSON(),
-      });
-    }
+    await this.upsertEditors(auth, [user]);
   }
 
   async fetchEditedByUser(auth: Authenticator): Promise<UserResource | null> {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/9130.
- Allows public API skill imports/upserts to include `editors` as email addresses, so API-created skills can be assigned visible editors. Puts a lot of responsibility on the caller of the API as this allows them to add anyone as editor to a skill (but not different from what you can do in the UI, just programmatic).
- Resolves provided emails to active workspace builders, then upserts them on both newly imported and updated skills.

## Tests

- Added a test + tested manually.

## Risk

- Low. Retro-compatible and safe to rollback.

## Deploy Plan

- Deploy front.
- Deploy docs.
