### PR TITLE
Update seatType to none for non credit-priced plans

### DIFF
--- a/front/scripts/backfill_non_credit_membership_seat_type.ts
+++ b/front/scripts/backfill_non_credit_membership_seat_type.ts
@@ -1,0 +1,107 @@
+/**
+ * Backfill `memberships.seatType` to `"none"` for all active memberships in
+ * non-credit-priced workspaces. For these workspaces `syncMetronomeSeat` never
+ * runs, so the seat type has no billing meaning; `"none"` is the correct
+ * default and avoids false positives in queries that filter on `seatType`.
+ *
+ * Idempotent: memberships already on `"none"` are counted but not re-written.
+ *
+ * Run with:
+ *   npx tsx scripts/backfill_non_credit_membership_seat_type.ts [--execute]
+ *   npx tsx scripts/backfill_non_credit_membership_seat_type.ts --wId <sId> [--execute]
+ */
+
+import { Op } from "sequelize";
+
+import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+makeScript(
+  {
+    wId: {
+      type: "string",
+      required: false,
+      description: "Run on a single workspace (sId).",
+    },
+  },
+  async ({ execute, wId }, logger) => {
+    let totalWorkspaces = 0;
+    let totalUpdated = 0;
+    let totalAlreadyNone = 0;
+    let totalSkippedCreditPriced = 0;
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const subscription =
+          await SubscriptionResource.fetchActiveByWorkspaceModelId(
+            workspace.id
+          );
+        if (!subscription) {
+          return;
+        }
+
+        const planCode = subscription.getPlan().code;
+        if (isCreditPricedPlanPrefix(planCode)) {
+          totalSkippedCreditPriced++;
+          return;
+        }
+
+        totalWorkspaces++;
+
+        const now = new Date();
+        const toUpdateCount = await MembershipModel.count({
+          where: {
+            workspaceId: workspace.id,
+            seatType: { [Op.ne]: "none" },
+            endAt: { [Op.or]: [{ [Op.eq]: null }, { [Op.gt]: now }] },
+          },
+        });
+        const alreadyNoneCount = await MembershipModel.count({
+          where: {
+            workspaceId: workspace.id,
+            seatType: "none",
+            endAt: { [Op.or]: [{ [Op.eq]: null }, { [Op.gt]: now }] },
+          },
+        });
+
+        totalAlreadyNone += alreadyNoneCount;
+
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            planCode,
+            toUpdate: toUpdateCount,
+            alreadyNone: alreadyNoneCount,
+          },
+          execute
+            ? "Resetting active memberships to seatType=none"
+            : "[DRY-RUN] Would reset active memberships to seatType=none"
+        );
+
+        if (!execute || toUpdateCount === 0) {
+          totalUpdated += toUpdateCount;
+          return;
+        }
+
+        await MembershipResource.resetAllSeatsToNoneForWorkspace({ workspace });
+        totalUpdated += toUpdateCount;
+      },
+      { wId }
+    );
+
+    logger.info(
+      {
+        totalWorkspaces,
+        totalUpdated,
+        totalAlreadyNone,
+        totalSkippedCreditPriced,
+        execute,
+      },
+      execute ? "Backfill complete" : "[DRY-RUN] Backfill summary"
+    );
+  }
+);


### PR DESCRIPTION
## Description

One-shot backfill script that resets `memberships.seatType` to `"none"` for all active memberships in non-credit-priced workspaces.

`syncMetronomeSeat` only runs for workspaces with a Metronome contract, so `seatType` has no billing meaning for legacy/non-CP plans. Existing rows carry the old DB default (`"workspace"`), which can cause false positives in queries that filter on seat type (e.g. `hasAnyMembershipOfUserInWorkspace`). `"none"` is the correct sentinel for "no Metronome seat assigned".

The script is idempotent and has a dry-run mode (default). Pass `--execute` to apply, `--wId` to target a single workspace.

## Tests

Dry-run on staging before executing in prod.

## Risk

Low — `resetAllSeatsToNoneForWorkspace` only touches active/future memberships and invalidates the seats cache. No Metronome calls are made; non-credit workspaces are unaffected by seat sync.

## Deploy Plan

1. Deploy
2. Run dry-run: `npx tsx scripts/backfill_non_credit_membership_seat_type.ts`
3. Run with execute: `npx tsx scripts/backfill_non_credit_membership_seat_type.ts --execute`