### PR TITLE
Switch sandbox reads to ownership table

### DIFF
--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -531,6 +531,96 @@ describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
   });
 });
 
+describe("SandboxResource.fetchByConversation", () => {
+  let authenticator: Authenticator;
+  let agentConfigId: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const testSetup = await createResourceTest({ role: "admin" });
+    authenticator = testSetup.authenticator;
+
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    agentConfigId = agentConfig.sId;
+  });
+
+  async function makeConversation(): Promise<ConversationType> {
+    return ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfigId,
+      messagesCreatedAt: [new Date()],
+    });
+  }
+
+  it("reads from conversation_sandboxes before the legacy conversationId column", async () => {
+    const conversation = await makeConversation();
+    const otherConversation = await makeConversation();
+    const sandbox = await SandboxFactory.create(authenticator, conversation);
+
+    await SandboxModel.update(
+      { conversationId: otherConversation.id },
+      { where: { id: sandbox.id } }
+    );
+
+    const fetched = await SandboxResource.fetchByConversation(
+      authenticator,
+      conversation
+    );
+
+    expect(fetched?.id).toBe(sandbox.id);
+  });
+
+  it("falls back to the legacy conversationId column when no ownership row exists", async () => {
+    const conversation = await makeConversation();
+    const sandbox = await SandboxFactory.create(authenticator, conversation);
+
+    await ConversationSandboxModel.destroy({
+      where: {
+        sandboxId: sandbox.id,
+        workspaceId: authenticator.getNonNullableWorkspace().id,
+      },
+    });
+
+    const fetched = await SandboxResource.fetchByConversation(
+      authenticator,
+      conversation
+    );
+
+    expect(fetched?.id).toBe(sandbox.id);
+  });
+
+  it("loads conversation ownership mappings by sandboxes", async () => {
+    const conversation = await makeConversation();
+    const sandbox = await SandboxFactory.create(authenticator, conversation);
+
+    const conversationModelIdsBySandboxModelId =
+      await SandboxResource.dangerouslyFetchConversationModelIdsBySandboxes([
+        sandbox,
+      ]);
+
+    expect(conversationModelIdsBySandboxModelId.get(sandbox.id)).toBe(
+      conversation.id
+    );
+  });
+
+  it("does not load ownership mappings for the wrong workspace", async () => {
+    const conversation = await makeConversation();
+    const sandbox = await SandboxFactory.create(authenticator, conversation);
+
+    const conversationModelIdsBySandboxModelId =
+      await SandboxResource.dangerouslyFetchConversationModelIdsBySandboxes([
+        {
+          id: sandbox.id,
+          workspaceId: sandbox.workspaceId + 1,
+        },
+      ]);
+
+    expect(
+      conversationModelIdsBySandboxModelId.get(sandbox.id)
+    ).toBeUndefined();
+  });
+});
+
 describe("SandboxResource.ensureActive", () => {
   let authenticator: Authenticator;
   let conversation: ConversationType;

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -53,6 +53,8 @@ export interface SandboxResource extends ReadonlyAttributesType<SandboxModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SandboxResource extends BaseResource<SandboxModel> {
   static model: ModelStaticWorkspaceAware<SandboxModel> = SandboxModel;
+  private static conversationSandboxModel: ModelStaticWorkspaceAware<ConversationSandboxModel> =
+    ConversationSandboxModel;
 
   private static deleteEgressPolicyAfterDestroy(
     sandbox: SandboxResource
@@ -196,19 +198,36 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   }
 
   /**
-   * Fetch the sandbox for a conversation across all workspaces (no auth).
-   * Only used by the reaper inside the lifecycle lock.
-   *
-   * / WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
+   * Fetch the sandbox for a conversation without an Authenticator. Only used by
+   * the reaper inside the lifecycle lock. Every query remains scoped to the
+   * conversation workspace.
    */
   private static async dangerouslyFetchByConversation(
     conversation: ConversationResource
   ): Promise<SandboxResource | null> {
+    const link = await this.conversationSandboxModel.findOne({
+      where: {
+        workspaceId: conversation.workspaceId,
+        conversationId: conversation.id,
+      },
+    });
+    if (link) {
+      const sandbox = await this.model.findOne({
+        where: {
+          id: link.sandboxId,
+          workspaceId: conversation.workspaceId,
+        },
+      });
+
+      if (sandbox) {
+        return new this(this.model, sandbox.get());
+      }
+    }
+
     const row = await this.model.findOne({
-      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
-      dangerouslyBypassWorkspaceIsolationSecurity: true,
       where: {
         conversationId: conversation.id,
+        workspaceId: conversation.workspaceId,
       },
     });
 
@@ -219,6 +238,25 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     auth: Authenticator,
     conversation: ConversationWithoutContentType
   ): Promise<SandboxResource | null> {
+    const link = await this.conversationSandboxModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    if (link) {
+      const sandboxes = await this.baseFetch(auth, {
+        where: {
+          id: link.sandboxId,
+        },
+      });
+
+      if (sandboxes[0]) {
+        return sandboxes[0];
+      }
+    }
+
     const sandboxes = await this.baseFetch(auth, {
       where: {
         conversationId: conversation.id,
@@ -230,6 +268,49 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     }
 
     return sandboxes[0];
+  }
+
+  /**
+   * Fetch conversation owners for sandbox rows touched by the reaper. Queries
+   * are grouped by workspace so every lookup remains workspace-scoped without
+   * issuing unbounded parallel DB queries.
+   */
+  static async dangerouslyFetchConversationModelIdsBySandboxes(
+    sandboxes: Pick<SandboxResource, "id" | "workspaceId">[]
+  ): Promise<Map<ModelId, ModelId>> {
+    if (sandboxes.length === 0) {
+      return new Map();
+    }
+
+    const sandboxModelIdsByWorkspaceModelId = new Map<ModelId, ModelId[]>();
+    for (const sandbox of sandboxes) {
+      const sandboxModelIds =
+        sandboxModelIdsByWorkspaceModelId.get(sandbox.workspaceId) ?? [];
+      sandboxModelIds.push(sandbox.id);
+      sandboxModelIdsByWorkspaceModelId.set(
+        sandbox.workspaceId,
+        sandboxModelIds
+      );
+    }
+
+    const rows: ConversationSandboxModel[] = [];
+    for (const [
+      workspaceModelId,
+      sandboxModelIds,
+    ] of sandboxModelIdsByWorkspaceModelId.entries()) {
+      const workspaceRows = await this.conversationSandboxModel.findAll({
+        where: {
+          workspaceId: workspaceModelId,
+          sandboxId: {
+            [Op.in]: sandboxModelIds,
+          },
+        },
+        attributes: ["sandboxId", "conversationId"],
+      });
+      rows.push(...workspaceRows);
+    }
+
+    return new Map(rows.map((r) => [r.sandboxId, r.conversationId]));
   }
 
   async updateStatus(
@@ -620,8 +701,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * Sleep a running sandbox for the given conversation. Acquires the lifecycle
    * lock, re-fetches the sandbox inside it, and only sleeps if still running.
    * If the provider reports the sandbox as gone, marks it deleted instead.
-   *
-   * / WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
    */
   static async dangerouslySleepIfRunning(
     auth: Authenticator,
@@ -711,8 +790,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * Transition a pending_approval sandbox to sleeping. The sandbox is already
    * paused via betaPause(), so no provider call is needed — we just update the
    * DB status so the regular destroy phase can reap it later.
-   *
-   * WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
    */
   static async dangerouslySleepIfPendingApproval(
     auth: Authenticator,
@@ -740,8 +817,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * lifecycle lock, re-fetches the sandbox inside it, and only destroys if
    * still sleeping. If the provider reports the sandbox as gone, marks it
    * deleted anyway.
-   *
-   * / WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
    */
   static async dangerouslyDestroyIfSleeping(
     auth: Authenticator,
@@ -870,8 +945,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * status. Acquires the lifecycle lock, re-fetches the sandbox, and only
    * destroys if it is non-deleted and still has `killRequestedAt`. Treats
    * `SandboxNotFoundError` as success.
-   *
-   * WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
    */
   static async dangerouslyDestroyIfKillRequested(
     auth: Authenticator,

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -17,6 +17,11 @@ import {
 
 const REAPER_CONCURRENCY = 16;
 
+type ConversationMaps = {
+  conversationModelIdsBySandboxModelId: Map<ModelId, ModelId>;
+  conversationsBySandboxModelId: Map<ModelId, ConversationResource>;
+};
+
 /**
  * Build a workspace-scoped internal Authenticator for each workspace touched by
  * the batch. One query for all workspaces, then one builder per workspace.
@@ -48,17 +53,42 @@ async function fetchAuthMap(
 
 /**
  * Fetch the ConversationResource for each sandbox, keyed by conversation
- * ModelId. The reaper spans every workspace, so we issue a single
+ * sandbox ModelId. The reaper spans every workspace, so we issue a single
  * cross-workspace query instead of one scoped query per workspace.
  */
 async function fetchConversationMap(
   sandboxes: SandboxResource[]
-): Promise<Map<ModelId, ConversationResource>> {
-  const conversations = await ConversationResource.dangerouslyFetchByModelIds(
-    sandboxes.map((s) => s.conversationId)
-  );
+): Promise<ConversationMaps> {
+  const conversationModelIdsBySandboxModelId =
+    await SandboxResource.dangerouslyFetchConversationModelIdsBySandboxes(
+      sandboxes
+    );
+  const conversationModelIds = [
+    ...new Set(
+      sandboxes.map(
+        (sandbox) =>
+          conversationModelIdsBySandboxModelId.get(sandbox.id) ??
+          sandbox.conversationId
+      )
+    ),
+  ];
+  const conversations =
+    await ConversationResource.dangerouslyFetchByModelIds(conversationModelIds);
+  const conversationsById = new Map(conversations.map((c) => [c.id, c]));
 
-  return new Map(conversations.map((c) => [c.id, c]));
+  return {
+    conversationModelIdsBySandboxModelId,
+    conversationsBySandboxModelId: new Map(
+      sandboxes.flatMap((sandbox) => {
+        const conversationModelId =
+          conversationModelIdsBySandboxModelId.get(sandbox.id) ??
+          sandbox.conversationId;
+        const conversation = conversationsById.get(conversationModelId);
+
+        return conversation ? [[sandbox.id, conversation] as const] : [];
+      })
+    ),
+  };
 }
 
 /**
@@ -76,18 +106,25 @@ async function processSandboxes(
   errorMessage: string
 ): Promise<void> {
   const authMap = await fetchAuthMap(sandboxes);
-  const conversationMap = await fetchConversationMap(sandboxes);
+  const conversationMaps = await fetchConversationMap(sandboxes);
 
   await concurrentExecutor(
     sandboxes,
     async (sandbox) => {
       const auth = authMap.get(sandbox.workspaceId);
-      const conversation = conversationMap.get(sandbox.conversationId);
+      const conversation = conversationMaps.conversationsBySandboxModelId.get(
+        sandbox.id
+      );
 
       if (!auth || !conversation) {
         logger.warn(
           {
-            conversationModelId: sandbox.conversationId,
+            legacyConversationModelId: sandbox.conversationId,
+            ownershipConversationModelId:
+              conversationMaps.conversationModelIdsBySandboxModelId.get(
+                sandbox.id
+              ) ?? null,
+            sandboxModelId: sandbox.id,
             workspaceModelId: sandbox.workspaceId,
           },
           "Reaper: workspace or conversation not found, skipping."


### PR DESCRIPTION
## Description

Follow up of #27494.

Switch sandbox lookup paths to prefer `conversation_sandboxes` while keeping `sandboxes.conversationId` as the fallback during the migration window. The reaper now resolves conversation owners through the ownership table too.

## Tests

Added resource tests for preferred ownership reads, legacy fallback, the ownership-map helper, and its workspace guard.

Locally: `npm test -- lib/resources/sandbox_resource.test.ts`.

## Risk

Worst case, a bad ownership row points a lookup at the wrong sandbox. Safe to rollback because the legacy column remains, fallback still exists, and #27494 keeps writes mirrored.

## Deploy Plan

- [x] Merge and deploy #27494 first.
- [x] Run #27494's standalone data migration with `--execute` in every production region and confirm it completes with no missing or extra ownership rows.
- [x] Deploy this PR after the ownership table and legacy column are ISO.
- [ ] Monitor sandbox lifecycle and reaper warnings after deploy.