### PR TITLE
[front] skip phone verification if already done for workspace

### DIFF
--- a/front-api/routes/w/[wId]/verification/start.ts
+++ b/front-api/routes/w/[wId]/verification/start.ts
@@ -91,8 +91,12 @@ app.post(
       );
     }
 
+    if (result.value.status === "already_verified") {
+      return ctx.json({ status: "already_verified" as const });
+    }
+
     return ctx.json({
-      success: true as const,
+      status: "code_sent" as const,
       message: "Verification code sent successfully.",
     });
   }

--- a/front/components/pages/onboarding/VerifyPage.tsx
+++ b/front/components/pages/onboarding/VerifyPage.tsx
@@ -27,7 +27,7 @@ import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Country } from "react-phone-number-input";
 
-type Step = "captcha" | "phone" | "code" | "done";
+type Step = "captcha" | "phone" | "code" | "start-trial" | "done";
 
 export function VerifyPage() {
   const { workspace } = useAuth();
@@ -169,11 +169,45 @@ export function VerifyPage() {
       return;
     }
 
+    const data = await response.json();
+    if (data.status === "already_verified") {
+      setStep("start-trial");
+      return;
+    }
+
     lastAutoSubmittedCodeRef.current = null;
     setCode(Array(CODE_LENGTH).fill(""));
     setResendCooldown(RESEND_COOLDOWN_SECONDS);
     setStep("code");
   };
+
+  const activateTrial = useCallback(async () => {
+    const trialResponse = await clientFetch(
+      `/api/w/${workspace.sId}/trial/start`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+
+    if (!trialResponse.ok) {
+      const data = await trialResponse.json();
+      setPhoneError(data.api_error?.message ?? "Failed to start trial");
+      return;
+    }
+
+    // Revalidate the auth context so the SPA picks up the new subscription
+    // (canUseProduct is now true) and doesn't redirect back to /trial.
+    await mutateAuthContext();
+
+    // With the credit-priced checkout flow we show a welcome screen before
+    // entering the workspace instead of redirecting there directly.
+    if (isMetronomeCheckout) {
+      setStep("done");
+    } else {
+      goToWorkspace();
+    }
+  }, [workspace.sId, mutateAuthContext, isMetronomeCheckout, goToWorkspace]);
 
   const verifyCode = useCallback(
     async (fullCode: string) => {
@@ -202,44 +236,14 @@ export function VerifyPage() {
           return;
         }
 
-        const trialResponse = await clientFetch(
-          `/api/w/${workspace.sId}/trial/start`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-          }
-        );
-
-        if (!trialResponse.ok) {
-          const data = await trialResponse.json();
-          setPhoneError(data.api_error?.message ?? "Failed to start trial");
-          return;
-        }
-
-        // Revalidate the auth context so the SPA picks up the new subscription
-        // (canUseProduct is now true) and doesn't redirect back to /trial.
-        await mutateAuthContext();
-
-        // With the credit-priced checkout flow we show a welcome screen before
-        // entering the workspace instead of redirecting there directly.
-        if (isMetronomeCheckout) {
-          setStep("done");
-        } else {
-          goToWorkspace();
-        }
+        await activateTrial();
       } catch {
         setPhoneError("Network error. Please try again.");
       } finally {
         setIsLoading(false);
       }
     },
-    [
-      phoneNumber,
-      workspace.sId,
-      mutateAuthContext,
-      isMetronomeCheckout,
-      goToWorkspace,
-    ]
+    [phoneNumber, workspace.sId, activateTrial]
   );
 
   const handleVerifyCode = useCallback(() => {
@@ -359,6 +363,24 @@ export function VerifyPage() {
         <WelcomeStep
           credits={FREE_SEAT_LIFETIME_AWU_CREDITS}
           onStartBuilding={goToWorkspace}
+        />
+      );
+    case "start-trial":
+      return (
+        <StartTrialStep
+          error={phoneError}
+          isLoading={isLoading}
+          onActivate={async () => {
+            setIsLoading(true);
+            setPhoneError(null);
+            try {
+              await activateTrial();
+            } catch {
+              setPhoneError("Network error. Please try again.");
+            } finally {
+              setIsLoading(false);
+            }
+          }}
         />
       );
     case "captcha":
@@ -632,6 +654,40 @@ function CaptchaStep({
               />
               <p className="min-h-5 text-sm text-red-500">{error}</p>
             </div>
+          </Page.Vertical>
+        </Page.Horizontal>
+      </div>
+    </Page>
+  );
+}
+
+interface StartTrialStepProps {
+  error: string | null;
+  isLoading: boolean;
+  onActivate: () => void;
+}
+
+function StartTrialStep({ error, isLoading, onActivate }: StartTrialStepProps) {
+  return (
+    <Page>
+      <div className="flex h-full flex-col justify-center">
+        <Page.Horizontal>
+          <Page.Vertical sizing="grow" gap="lg">
+            <div className="flex flex-col gap-2">
+              <h1 className="text-2xl font-bold text-foreground dark:text-foreground-night">
+                Your phone number has already been verified.
+              </h1>
+              <p className="text-muted-foreground dark:text-muted-foreground-night">
+                Click below to activate your free subscription.
+              </p>
+            </div>
+            <p className="min-h-5 text-sm text-red-500">{error}</p>
+            <Button
+              onClick={onActivate}
+              variant="primary"
+              label={isLoading ? "Activating..." : "Activate trial"}
+              disabled={isLoading}
+            />
           </Page.Vertical>
         </Page.Horizontal>
       </div>

--- a/front/lib/api/workspace_verification/start_verification.ts
+++ b/front/lib/api/workspace_verification/start_verification.ts
@@ -71,10 +71,14 @@ export type StartVerificationError = {
   retryAfterSeconds?: number;
 };
 
+export type StartVerificationStatus = "code_sent" | "already_verified";
+
 export async function startVerification(
   auth: Authenticator,
   phoneNumber: string
-): Promise<Result<void, StartVerificationError>> {
+): Promise<
+  Result<{ status: StartVerificationStatus }, StartVerificationError>
+> {
   const workspace = auth.getNonNullableWorkspace();
   const workspaceModelId = workspace.id;
   const phoneNumberHash =
@@ -88,10 +92,7 @@ export async function startVerification(
 
   if (existingAttempt) {
     if (existingAttempt.status === "verified") {
-      return new Err({
-        type: "invalid_request_error",
-        message: "This workspace is already verified.",
-      });
+      return new Ok({ status: "already_verified" });
     }
   } else {
     const isPhoneUsedElsewhere =
@@ -208,5 +209,5 @@ export async function startVerification(
     );
   }
 
-  return new Ok(undefined);
+  return new Ok({ status: "code_sent" });
 }

--- a/front/lib/api/workspace_verification/validate_verification.ts
+++ b/front/lib/api/workspace_verification/validate_verification.ts
@@ -36,10 +36,8 @@ export async function validateVerification(
   }
 
   if (attempt.status === "verified") {
-    return new Err({
-      type: "invalid_request_error",
-      message: "This workspace is already verified.",
-    });
+    // Already verified — idempotent success so callers can proceed to trial activation.
+    return new Ok({ verified: true });
   }
 
   const verifyResult = await checkOtp(phoneNumber, code);

--- a/front/lib/api/workspace_verification/workspace_verification.test.ts
+++ b/front/lib/api/workspace_verification/workspace_verification.test.ts
@@ -5,7 +5,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { WorkspaceVerificationAttemptFactory } from "@app/tests/utils/WorkspaceVerificationAttemptFactory";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockLookupPhoneNumber } = vi.hoisted(() => {
   return {
@@ -100,7 +100,8 @@ describe("workspace_verification", () => {
     it("should create a new verification attempt on success", async () => {
       const result = await startVerification(authW1, validPhoneNumber);
 
-      expect(result.isOk()).toBe(true);
+      assert(result.isOk());
+      expect(result.value.status).toBe("code_sent");
       expect(mockLookupPhoneNumber).toHaveBeenCalledWith(validPhoneNumber);
       expect(mockSendOtp).toHaveBeenCalledWith(validPhoneNumber);
 
@@ -131,7 +132,8 @@ describe("workspace_verification", () => {
 
       const result = await startVerification(authW1, validPhoneNumber);
 
-      expect(result.isOk()).toBe(true);
+      assert(result.isOk());
+      expect(result.value.status).toBe("code_sent");
 
       const attempt =
         await WorkspaceVerificationAttemptResource.fetchByPhoneHash(
@@ -142,7 +144,7 @@ describe("workspace_verification", () => {
       expect(attempt?.twilioVerificationSid).toBe("VA987654321");
     });
 
-    it("should return error if workspace is already verified", async () => {
+    it("should return already_verified if workspace phone is already verified", async () => {
       const phoneNumberHash =
         WorkspaceVerificationAttemptResource.hashPhoneNumber(validPhoneNumber);
       const attempt = await WorkspaceVerificationAttemptFactory.create(authW1, {
@@ -152,13 +154,10 @@ describe("workspace_verification", () => {
 
       const result = await startVerification(authW1, validPhoneNumber);
 
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect(result.error.type).toBe("invalid_request_error");
-        expect(result.error.message).toBe(
-          "This workspace is already verified."
-        );
-      }
+      assert(result.isOk());
+      expect(result.value.status).toBe("already_verified");
+      expect(mockLookupPhoneNumber).not.toHaveBeenCalled();
+      expect(mockSendOtp).not.toHaveBeenCalled();
     });
 
     it("should return error if phone is already verified in another workspace", async () => {
@@ -387,7 +386,7 @@ describe("workspace_verification", () => {
       }
     });
 
-    it("should return error if workspace is already verified", async () => {
+    it("should return verified true if workspace is already verified (idempotent)", async () => {
       const phoneNumberHash =
         WorkspaceVerificationAttemptResource.hashPhoneNumber(validPhoneNumber);
       const attempt = await WorkspaceVerificationAttemptFactory.create(authW1, {
@@ -401,13 +400,9 @@ describe("workspace_verification", () => {
         validCode
       );
 
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect(result.error.type).toBe("invalid_request_error");
-        expect(result.error.message).toBe(
-          "This workspace is already verified."
-        );
-      }
+      assert(result.isOk());
+      expect(result.value.verified).toBe(true);
+      expect(mockCheckOtp).not.toHaveBeenCalled();
     });
 
     it("should return error if OTP is invalid", async () => {

--- a/front/types/workspace_verification.ts
+++ b/front/types/workspace_verification.ts
@@ -8,10 +8,9 @@ export type StartVerificationRequest = {
   captchaToken: string;
 };
 
-export type StartVerificationResponse = {
-  success: true;
-  message: string;
-};
+export type StartVerificationResponse =
+  | { status: "code_sent"; message: string }
+  | { status: "already_verified" };
 
 export type VerifyCodeRequest = {
   phoneNumber: string;


### PR DESCRIPTION
## Description

### Context
The verify page makes two sequential calls: /verification/validate (commits verifiedAt to DB) then /trial/start. If /trial/start failed, the user was permanently stuck — retrying the code hit "already verified", and requesting a new code hit phone_already_used_error.

### Solution
Rather than treating an already-verified attempt as an error in /verification/start, return Ok({ status: "already_verified" }). The page detects this status and routes directly to a lightweight "start-trial" step that retries /trial/start without going through phone/code entry again. As a secondary fix, validateVerification is made idempotent (returns Ok if already verified) so the in-session retry path also works.

### Changes
* types/workspace_verification.ts — StartVerificationResponse is now a discriminated union: { status: "code_sent" } | { status: "already_verified" }.
* start_verification.ts — already_verified case returns Ok instead of Err; normal success returns Ok({ status: "code_sent" }).
* verification/start.ts — Handler passes the discriminated status through to the response.
* validate_verification.ts — Returns Ok when attempt is already verified.
* VerifyPage.tsx — handleSendCode routes to new "start-trial" step on status === "already_verified"; extracted activateTrial callback shared by both paths.

## Tests

Tested locally with:
- classic flow when free plan start succeeds => OK
- error flow where the free plan start fails and we try to go through the verification again later with same phone number => OK

## Risk

Medium, impacts the free plan creation flow

## Deploy Plan

Deploy front