### PR TITLE
Fix selected spaces migration FK

### DIFF
--- a/front/migrations/pre-deploy/20260624143314_add_conversation_selected_spaces.sql
+++ b/front/migrations/pre-deploy/20260624143314_add_conversation_selected_spaces.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS "conversation_selected_spaces" (
     "createdAt" timestamp WITH time zone NOT NULL DEFAULT NOW(),
     "updatedAt" timestamp WITH time zone NOT NULL DEFAULT NOW(),
     "conversationId" bigint NOT NULL REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-    "spaceId" bigint NOT NULL REFERENCES "spaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "spaceId" bigint NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     "selectedByUserId" bigint NOT NULL REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     "origin" varchar(255) NOT NULL,
     "removedAt" timestamp WITH time zone,


### PR DESCRIPTION
## Description

Fix the selected spaces pre-deploy migration by pointing `spaceId` at `vaults`, the physical table behind `SpaceModel`. PR #27539 referenced `spaces`, which does not exist in the front database.

## Tests

- Ran `npm run migration:status` in `front` and confirmed the migration is pending.
- Checked local DB metadata: `public.vaults` exists and `public.spaces` does not.
- Ran the migration file with `psql -f` in a throwaway schema with minimal FK tables.

## Risk

Low. SQL-only fix for a migration that currently fails before creating `conversation_selected_spaces`.

## Deploy Plan

- [ ] Merge this fix.
- [ ] Rerun `./scripts/run-migrations.sh pre-deploy front`.
- [ ] Confirm `pre-deploy/20260624143314_add_conversation_selected_spaces.sql` is no longer pending.
