### PR TITLE
feat(models): add workspace default model foundations

### DIFF
--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -14,8 +14,10 @@ import type {
   ModelConfigurationType,
   ModelIdType,
 } from "@app/types/assistant/models/types";
+import { WORKSPACE_DEFAULT_MODEL_SETTINGS } from "@app/types/assistant/models/workspace_default";
 import { GROK_4_MODEL_ID } from "@app/types/assistant/models/xai";
-import type { UserType } from "@app/types/user";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+import { getWorkspaceDefaultModelSetting } from "@app/types/user";
 import uniqueId from "lodash/uniqueId";
 
 /**
@@ -43,10 +45,15 @@ export function transformAgentConfigurationToFormData(
     instructions: agentConfiguration.instructions ?? "",
     instructionsHtml: agentConfiguration.instructionsHtml ?? undefined,
     generationSettings: {
-      modelSettings: {
-        modelId: agentConfiguration.model.modelId,
-        providerId: agentConfiguration.model.providerId,
-      },
+      // When the agent follows the workspace default, the server resolves the
+      // model to a concrete one but flags it. Round-trip the sentinel so the
+      // picker shows "Workspace default" and saving keeps following the default.
+      modelSettings: agentConfiguration.model.usesWorkspaceDefault
+        ? { ...WORKSPACE_DEFAULT_MODEL_SETTINGS }
+        : {
+            modelId: agentConfiguration.model.modelId,
+            providerId: agentConfiguration.model.providerId,
+          },
       temperature: agentConfiguration.model.temperature,
       reasoningEffort: agentConfiguration.model.reasoningEffort ?? "none",
       responseFormat: agentConfiguration.model.responseFormat,
@@ -89,6 +96,28 @@ export function getDefaultModel(
     availableModels.find((m) => !m.largeModel);
 
   return fallbackModel ?? CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
+}
+
+/**
+ * The model the workspace default currently resolves to, for display ("Workspace
+ * default (currently X)"). Mirrors the backend `getWorkspaceDefaultModel`: the
+ * admin-pinned model when set and available, otherwise the live best model.
+ */
+export function getResolvedWorkspaceDefaultModel(
+  owner: LightWorkspaceType,
+  availableModels: ModelConfigurationType[]
+): ModelConfigurationType {
+  const setting = getWorkspaceDefaultModelSetting(owner);
+  if (setting) {
+    const pinned = availableModels.find(
+      (m) =>
+        m.modelId === setting.modelId && m.providerId === setting.providerId
+    );
+    if (pinned) {
+      return pinned;
+    }
+  }
+  return getDefaultModel(availableModels);
 }
 
 export function getDefaultAgentFormData({

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -1,6 +1,7 @@
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { isModelEnabled } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
@@ -15,6 +16,7 @@ import {
   MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
 } from "@app/types/assistant/models/mistral";
+import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import {
   GPT_5_5_MODEL_CONFIG,
   GPT_5_MINI_MODEL_CONFIG,
@@ -32,6 +34,7 @@ import {
   GROK_4_MODEL_CONFIG,
 } from "@app/types/assistant/models/xai";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import { getWorkspaceDefaultModelSetting } from "@app/types/user";
 
 export function getWhitelistedProviders(
   auth: Authenticator
@@ -79,6 +82,78 @@ export function isProviderWhitelisted(
 ): boolean {
   const whitelistedProviders = getWhitelistedProviders(auth);
   return whitelistedProviders.has(providerId);
+}
+
+// Whether a given model is a real, supported model that is currently enabled
+// for the workspace (provider whitelist + plan + region + feature flags). Used
+// to validate the workspace default model an admin tries to pin.
+export async function isModelEnabledForWorkspace(
+  auth: Authenticator,
+  { providerId, modelId }: { providerId: string; modelId: string }
+): Promise<boolean> {
+  const config = SUPPORTED_MODEL_CONFIGS.find(
+    (m) => m.modelId === modelId && m.providerId === providerId
+  );
+  if (!config) {
+    return false;
+  }
+
+  const featureFlags = await getFeatureFlags(auth);
+  const context = {
+    ...getModelEnablementContextWithoutFeatureFlag(auth),
+    featureFlags,
+  };
+  return isModelEnabled(config, context);
+}
+
+// The model an admin pinned as the workspace default, looked up in the model
+// registry. Returns `null` when unset or when the pinned model is no longer in
+// the registry. Does NOT check availability or fall back — callers decide what
+// to do when the pinned model is disabled (the global agents let their normal
+// fallback handle it; `getWorkspaceDefaultModel` falls back to the live
+// default).
+export function getPinnedWorkspaceDefaultModel(
+  auth: Authenticator
+): ModelConfigurationType | null {
+  const setting = getWorkspaceDefaultModelSetting(
+    auth.getNonNullableWorkspace()
+  );
+  if (!setting) {
+    return null;
+  }
+  return (
+    SUPPORTED_MODEL_CONFIGS.find(
+      (m) =>
+        m.modelId === setting.modelId && m.providerId === setting.providerId
+    ) ?? null
+  );
+}
+
+// Resolves the workspace default model to a concrete, enabled model
+// configuration. This is the single source of truth for "what the default model
+// currently is": it backs every custom agent that follows the workspace
+// default.
+//
+// - If an admin pinned a model and it is still enabled for the workspace, that
+//   model is returned (the default is "frozen").
+// - Otherwise (unset, or the pinned model is no longer available) it falls back
+//   to the live best large model, which is exactly today's behavior.
+export function getWorkspaceDefaultModel(
+  auth: Authenticator,
+  { featureFlags = [] }: { featureFlags?: WhitelistableFeature[] } = {}
+): ModelConfigurationType | null {
+  const pinned = getPinnedWorkspaceDefaultModel(auth);
+  if (pinned) {
+    const context = {
+      ...getModelEnablementContextWithoutFeatureFlag(auth),
+      featureFlags,
+    };
+    if (isModelEnabled(pinned, context)) {
+      return pinned;
+    }
+  }
+
+  return getLargeWhitelistedModel(auth);
 }
 
 type ModelEnablementContext = Parameters<typeof isModelEnabled>[1];

--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -372,6 +372,12 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     input: 0,
     output: 0,
   },
+  // Sentinel for agents following the workspace default model; resolved to a
+  // concrete model before execution, so it is never actually billed.
+  "workspace-default": {
+    input: 0,
+    output: 0,
+  },
 };
 
 const IMAGE_MODEL_PRICING: Record<string, PricingEntry> = {

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -575,6 +575,10 @@ export interface WorkspaceMetadata {
   webSearchProvider?: WebSearchProvider;
   webBrowseProvider?: WebBrowseProvider;
   workspaceDefaultAgentId?: string;
+  // Model pinned by an admin as the workspace default. Absent = "automatic"
+  // (resolve live to the best available model). Backs standard agents and every
+  // custom agent that follows the workspace default.
+  workspaceDefaultModel?: { providerId: string; modelId: string };
 }
 
 export async function updateWorkspaceMetadata(

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -136,6 +136,11 @@ export const AgentModelConfigurationSchema = z.object({
   reasoningEffort: z.enum(ORDERED_REASONING_EFFORTS).optional(),
   responseFormat: z.string().optional(),
   metaData: z.record(z.string(), z.unknown()).optional(),
+  // Output-only flag: set during serialization when the agent follows the
+  // workspace default model. When true, `modelId`/`providerId` already hold the
+  // *resolved* concrete model, so this flag only tells the UI to render
+  // "Workspace default (currently X)". Ignored on input.
+  usesWorkspaceDefault: z.boolean().optional(),
 });
 
 export type AgentModelConfigurationType = z.infer<

--- a/front/types/assistant/models/models.ts
+++ b/front/types/assistant/models/models.ts
@@ -152,6 +152,7 @@ import {
   TOGETHERAI_QWEN_QWQ_32B_PREVIEW_MODEL_ID,
 } from "./togetherai";
 import type { ModelConfigurationType } from "./types";
+import { WORKSPACE_DEFAULT_MODEL_ID } from "./workspace_default";
 import {
   GROK_3_MINI_MODEL_CONFIG,
   GROK_3_MINI_MODEL_ID,
@@ -242,6 +243,10 @@ export const STATIC_MODEL_IDS = [
   GROK_4_1_FAST_NON_REASONING_MODEL_ID,
   GROK_4_1_FAST_REASONING_MODEL_ID,
   NOOP_MODEL_ID,
+  // Sentinel for custom agents following the workspace default model. Not a real
+  // model: resolved to a concrete config before execution and never listed in
+  // SUPPORTED_MODEL_CONFIGS.
+  WORKSPACE_DEFAULT_MODEL_ID,
 ] as const;
 
 // Type for static model IDs only (excludes custom models from GCS).

--- a/front/types/assistant/models/workspace_default.ts
+++ b/front/types/assistant/models/workspace_default.ts
@@ -1,0 +1,26 @@
+import type { ModelProviderIdType } from "./types";
+
+// Sentinel model used by custom agents that "follow" the workspace default
+// model. It is never a real, runnable model: it is resolved to a concrete model
+// configuration at the single serialization boundary
+// (`getModelForAgentConfiguration`) before it can reach execution. It mirrors
+// the `noop` virtual model pattern and is intentionally NOT added to
+// `SUPPORTED_MODEL_CONFIGS`, so it never shows up in model pickers or the
+// `/models` endpoint.
+export const WORKSPACE_DEFAULT_MODEL_ID = "workspace-default" as const;
+
+// The sentinel reuses the virtual `noop` provider: it carries no real provider
+// semantics and is always whitelisted, which is harmless because the value is
+// resolved away before it is used.
+export const WORKSPACE_DEFAULT_MODEL_PROVIDER_ID: ModelProviderIdType = "noop";
+
+export const WORKSPACE_DEFAULT_MODEL_SETTINGS = {
+  modelId: WORKSPACE_DEFAULT_MODEL_ID,
+  providerId: WORKSPACE_DEFAULT_MODEL_PROVIDER_ID,
+} as const;
+
+export function isFollowingWorkspaceDefaultModel(model: {
+  modelId: string;
+}): boolean {
+  return model.modelId === WORKSPACE_DEFAULT_MODEL_ID;
+}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -340,6 +340,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Workspace default agent: admins can pre-select a workspace-wide default agent for new conversations.",
     stage: "on_demand",
   },
+  workspace_default_model: {
+    description:
+      "Workspace default model: admins can pick the model behind standard agents and the default for new agents; new agents follow it dynamically.",
+    stage: "on_demand",
+  },
   whitelabel_frames: {
     description:
       "Whitelabel frames: customize the workspace logo, favicon and OG image shown on shared Frames.",

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -85,6 +85,38 @@ export function getWorkspaceDefaultAgentId(
   return typeof value === "string" ? value : null;
 }
 
+// Plain-string shape on purpose: the pair is validated against the model
+// registry at write time, and resolved by string match against
+// SUPPORTED_MODEL_CONFIGS at read time, so we avoid carrying the branded
+// ModelIdType/ModelProviderIdType here (and importing the io-ts-heavy model
+// registry into this widely-shared types module).
+export type WorkspaceDefaultModelSetting = {
+  providerId: string;
+  modelId: string;
+};
+
+/**
+ * The model an admin pinned as the workspace default, read from workspace
+ * metadata. Returns `null` when unset ("automatic": resolve live to the best
+ * available model). Client-safe: reads `owner.metadata` only.
+ */
+export function getWorkspaceDefaultModelSetting(
+  owner: LightWorkspaceType
+): WorkspaceDefaultModelSetting | null {
+  const value = owner.metadata?.workspaceDefaultModel;
+  if (
+    value &&
+    typeof value === "object" &&
+    "providerId" in value &&
+    "modelId" in value &&
+    typeof value.providerId === "string" &&
+    typeof value.modelId === "string"
+  ) {
+    return { providerId: value.providerId, modelId: value.modelId };
+  }
+  return null;
+}
+
 /**
  * The default agent that should be pre-selected for new conversations.
  * A pod-level default agent takes precedence over the workspace-level default agent.

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -99,7 +99,8 @@ export type KnownModelLLMId =
   | "grok-4-fast-reasoning-latest"
   | "grok-4-1-fast-non-reasoning-latest"
   | "grok-4-1-fast-reasoning-latest"
-  | "noop"; // Noop
+  | "noop" // Noop
+  | "workspace-default"; // Sentinel: agent follows the workspace default model
 
 // Cast to allow custom/unknown model IDs while preserving autocomplete.
 const ModelLLMIdSchema = FlexibleEnumSchema<KnownModelLLMId>() as z.ZodType<
@@ -782,6 +783,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "live_speech_to_text"
   | "force_us_api_url"
   | "workspace_default_agent"
+  | "workspace_default_model"
   | "whitelabel_frames"
 >();
 


### PR DESCRIPTION
## Description

First PR of a stack introducing a **workspace-level default model**: a model an admin can pick to back the standard agents (Dust, dust-task, …) and to be the default for newly created custom agents. When unset, it resolves live to the best available model (today Sonnet 4.6); an admin can pin a model to freeze it.

This PR lands the foundations only — **no behavior change**, nothing consumes the setting yet:

- New sentinel model `workspace-default` (mirrors the `noop` virtual model) for custom agents that follow the default. Stored in the existing `STRING` columns, so no DB migration. Added to `STATIC_MODEL_IDS`, the token-pricing map (zero entry), and the `@dust-tt/client` SDK unions (model id + feature flag).
- Workspace setting plumbing: `workspaceDefaultModel` in `WorkspaceMetadata`, `getWorkspaceDefaultModelSetting` reader, and `LightWorkspaceType.metadata` typing.
- Resolution helpers in `lib/api/assistant/models.ts`: `getPinnedWorkspaceDefaultModel`, `getWorkspaceDefaultModel` (pinned-if-enabled, else live best large model), and `isModelEnabledForWorkspace`.
- `usesWorkspaceDefault` output flag on `AgentModelConfigurationSchema`.
- `workspace_default_model` feature flag (on-demand) — gates the whole feature across the stack.
- Client helper `getResolvedWorkspaceDefaultModel` for "currently X" display.

Stack:
1. **#27921 — foundations (this PR)**
2. #27922 — standard agents honor the default
3. #27923 — admins can configure it (endpoint + UI)
4. #27924 — new agents follow it (builder + display)

## Tests

Covered by later PRs in the stack (endpoint tests in #27923). This PR is type-only scaffolding; `tsgo` passes for `front`, `front-api`, and `sdks/js`.

## Risk

None. No code path reads the setting yet, and the SDK changes are additive union members (the `dist` is regenerated at build time).
