### PR TITLE
feat(assistant): standard agents honor workspace default model

### DIFF
--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -1,6 +1,8 @@
 import { fetchMCPServerActionConfigurations } from "@app/lib/actions/configuration/mcp";
 import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
+import { getWorkspaceDefaultModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { getPublicUploadBucket } from "@app/lib/file_storage";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -14,11 +16,36 @@ import type {
   AgentFetchVariant,
   AgentModelConfigurationType,
 } from "@app/types/assistant/agent";
+import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { isFollowingWorkspaceDefaultModel } from "@app/types/assistant/models/workspace_default";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 
 function getModelForAgentConfiguration(
-  agent: AgentConfigurationModel
+  auth: Authenticator,
+  agent: AgentConfigurationModel,
+  { featureFlags }: { featureFlags: WhitelistableFeature[] }
 ): AgentModelConfigurationType {
+  // Agents that follow the workspace default store a sentinel model. Resolve it
+  // here, the single serialization boundary, to a concrete model so it never
+  // reaches execution. The `usesWorkspaceDefault` flag lets the UI display
+  // "Workspace default (currently X)" while everything downstream sees a real
+  // model.
+  if (isFollowingWorkspaceDefaultModel(agent)) {
+    const resolved =
+      getWorkspaceDefaultModel(auth, { featureFlags }) ??
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
+
+    return {
+      providerId: resolved.providerId,
+      modelId: resolved.modelId,
+      temperature: agent.temperature,
+      reasoningEffort: resolved.defaultReasoningEffort,
+      ...(agent.responseFormat ? { responseFormat: agent.responseFormat } : {}),
+      usesWorkspaceDefault: true,
+    };
+  }
+
   const model: AgentModelConfigurationType = {
     providerId: agent.providerId,
     modelId: agent.modelId,
@@ -134,6 +161,10 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
       : Promise.resolve([]),
   ]);
 
+  // Fetched once (memoized per workspace) and reused to resolve the workspace
+  // default model for agents that follow it.
+  const featureFlags = await getFeatureFlags(auth);
+
   const agentConfigurationTypes: AgentConfigurationType[] = [];
   for (const agent of agentConfigurations) {
     const actions =
@@ -141,7 +172,7 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
         ? (mcpServerActionsConfigurationsPerAgent.get(agent.id) ?? [])
         : [];
 
-    const model = getModelForAgentConfiguration(agent);
+    const model = getModelForAgentConfiguration(auth, agent, { featureFlags });
     const tags: TagResource[] = tagsPerAgent[agent.id] ?? [];
 
     const isAuthor = agent.authorId === auth.user()?.id;

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -21,6 +21,7 @@ import {
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import {
   getLargeWhitelistedModel,
+  getPinnedWorkspaceDefaultModel,
   selectEnabledModel,
 } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
@@ -360,7 +361,12 @@ function getModelConfig(
   modelConfiguration: ModelConfigurationType;
   reasoningEffort: ReasoningEffort;
 } | null {
+  // Prefer the admin-pinned workspace default when set; otherwise keep the
+  // historical Anthropic-then-OpenAI order. `selectEnabledModel` skips it if it
+  // is not available for the workspace.
+  const pinnedDefault = getPinnedWorkspaceDefaultModel(auth);
   const candidates = [
+    ...(pinnedDefault ? [pinnedDefault] : []),
     CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
     GPT_5_5_MODEL_CONFIG,
   ];

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -22,6 +22,7 @@ import {
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import {
   getLargeWhitelistedModel,
+  getPinnedWorkspaceDefaultModel,
   getSmallWhitelistedModel,
   selectEnabledModel,
 } from "@app/lib/api/assistant/models";
@@ -493,6 +494,17 @@ export function shouldUseOpus(auth: Authenticator): boolean {
   return isDustCompanyPlan(planCode) || isEnterprisePlanPrefix(planCode);
 }
 
+// The model the standard Dust agent (and its reasoning-effort variants) should
+// prefer: the admin-pinned workspace default when set, otherwise the historical
+// hardcoded fallback. `_getDustLikeGlobalAgent` still validates availability and
+// falls back to the best large model if the preferred one is disabled.
+function getDustPreferredModelConfiguration(
+  auth: Authenticator,
+  fallback: ModelConfigurationType
+): ModelConfigurationType {
+  return getPinnedWorkspaceDefaultModel(auth) ?? fallback;
+}
+
 export function _getDustGlobalAgent(
   auth: Authenticator,
   args: DustLikeGlobalAgentArgs
@@ -500,9 +512,12 @@ export function _getDustGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST,
     name: "dust",
-    preferredModelConfiguration: args.preferGpt55DefaultModel
-      ? GPT_5_5_MODEL_CONFIG
-      : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredModelConfiguration: getDustPreferredModelConfiguration(
+      auth,
+      args.preferGpt55DefaultModel
+        ? GPT_5_5_MODEL_CONFIG
+        : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG
+    ),
     preferredReasoningEffort: "medium",
   });
 }
@@ -514,7 +529,10 @@ export function _getDustHighGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST_HIGH,
     name: "dust-high",
-    preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredModelConfiguration: getDustPreferredModelConfiguration(
+      auth,
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG
+    ),
     preferredReasoningEffort: "high",
   });
 }
@@ -526,7 +544,10 @@ export function _getDustHighOmittedGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST_HIGH_OMITTED,
     name: "dust-high-omitted",
-    preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredModelConfiguration: getDustPreferredModelConfiguration(
+      auth,
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG
+    ),
     preferredReasoningEffort: "high",
     omittedThinking: true,
   });
@@ -539,7 +560,10 @@ export function _getDustOmittedGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST_OMITTED,
     name: "dust-omitted",
-    preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredModelConfiguration: getDustPreferredModelConfiguration(
+      auth,
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG
+    ),
     preferredReasoningEffort: "medium",
     omittedThinking: true,
   });


### PR DESCRIPTION
## Description

Part of the **workspace default model** stack (builds on #27921).

Wires the read path so the standard/global agents resolve their model through the workspace default:

- `getModelForAgentConfiguration` (the single agent-config serialization boundary) resolves the `workspace-default` sentinel to a concrete model via `getWorkspaceDefaultModel`, so it never reaches execution, and flags `usesWorkspaceDefault` for the UI.
- The Dust agent (and its reasoning-effort variants) and dust-task / deep-dive prefer the admin-pinned model when one is set, falling back to the existing preference list + `getLargeWhitelistedModel` otherwise. All existing special cases (free-tier small model, GPT-5.5 default flag, deep-dive enterprise Opus) are preserved when nothing is pinned.

**No behavior change in practice until #27923 lands** — there is no way to set a default value yet, so `getPinnedWorkspaceDefaultModel` always returns `null` and every agent keeps today's resolution.

## Tests

Manual once the full stack is in: pin a model in #27923 → confirm Dust and dust-task switch; clear it → confirm they revert. No standalone tests here (pure resolution logic exercised end-to-end via the stack).

## Risk

Low. With no pinned value the candidate lists and fallbacks are identical to today.
