### PR TITLE
feat(workspace): let admins configure the default model

### DIFF
--- a/front-api/routes/w/[wId]/index.test.ts
+++ b/front-api/routes/w/[wId]/index.test.ts
@@ -143,3 +143,78 @@ describe("POST /api/w/:wId (workspace default agent)", () => {
     }
   });
 });
+
+describe("POST /api/w/:wId (workspace default model)", () => {
+  const sonnet = {
+    providerId: "anthropic",
+    modelId: "claude-sonnet-4-6",
+  };
+
+  it("pins a valid, enabled model when the flag is enabled", async () => {
+    const { workspace, auth } = await setup();
+    await FeatureFlagFactory.basic(auth, "workspace_default_model");
+
+    const response = await post(workspace, {
+      workspaceDefaultModel: sonnet,
+    });
+
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.metadata?.workspaceDefaultModel).toEqual(sonnet);
+  });
+
+  it("clears the default and preserves other metadata when passed null", async () => {
+    const { workspace, auth } = await setup();
+    await FeatureFlagFactory.basic(auth, "workspace_default_model");
+
+    await post(workspace, { reinforcementCapAwuCredits: 5_000 });
+    await post(workspace, { workspaceDefaultModel: sonnet });
+
+    const response = await post(workspace, { workspaceDefaultModel: null });
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.metadata?.workspaceDefaultModel).toBeUndefined();
+    expect(updated?.metadata?.reinforcementCapAwuCredits).toBe(5_000);
+  });
+
+  it("returns 400 for an unknown model", async () => {
+    const { workspace, auth } = await setup();
+    await FeatureFlagFactory.basic(auth, "workspace_default_model");
+
+    const response = await post(workspace, {
+      workspaceDefaultModel: {
+        providerId: "anthropic",
+        modelId: "not-a-real-model",
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 403 when the feature flag is disabled", async () => {
+    const { workspace } = await setup();
+
+    const response = await post(workspace, {
+      workspaceDefaultModel: sonnet,
+    });
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("feature_flag_not_found");
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    for (const role of ["builder", "user"] as const) {
+      const { workspace } = await setup(role);
+
+      const response = await post(workspace, {
+        workspaceDefaultModel: sonnet,
+      });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
+    }
+  });
+});

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -1,4 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { isModelEnabledForWorkspace } from "@app/lib/api/assistant/models";
 import { listActiveAgentsUsingNonRegionalModels } from "@app/lib/api/assistant/workspace_capabilities";
 import {
   buildAuditLogTarget,
@@ -203,6 +204,17 @@ const WorkspaceDefaultAgentUpdateBodySchema = z.object({
   workspaceDefaultAgentId: z.string().nullable(),
 });
 
+// A null value clears the workspace default model ("automatic": resolve live to
+// the best available model).
+const WorkspaceDefaultModelUpdateBodySchema = z.object({
+  workspaceDefaultModel: z
+    .object({
+      providerId: z.string(),
+      modelId: z.string(),
+    })
+    .nullable(),
+});
+
 const PostWorkspaceRequestBodySchema = z.union([
   WorkspaceAllowedDomainUpdateBodySchema,
   WorkspaceBatchDomainUpdateBodySchema,
@@ -229,6 +241,7 @@ const PostWorkspaceRequestBodySchema = z.union([
   WorkspaceSelfImprovementCapPerSkillAwuCreditsUpdateBodySchema,
   WorkspaceAuditLogsUpdateBodySchema,
   WorkspaceDefaultAgentUpdateBodySchema,
+  WorkspaceDefaultModelUpdateBodySchema,
 ]);
 
 const app = workspaceApp();
@@ -698,6 +711,53 @@ app.post(
       owner.metadata = {
         ...(owner.metadata ?? {}),
         workspaceDefaultAgentId,
+      };
+    } else if ("workspaceDefaultModel" in body) {
+      if (!(await hasFeatureFlag(auth, "workspace_default_model"))) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "feature_flag_not_found",
+            message:
+              "The workspace default model feature is not enabled for this workspace.",
+          },
+        });
+      }
+
+      // Validate the pinned model is a real model enabled for the workspace. A
+      // null value clears the default (falls back to the live best model).
+      if (body.workspaceDefaultModel) {
+        const isValid = await isModelEnabledForWorkspace(
+          auth,
+          body.workspaceDefaultModel
+        );
+        if (!isValid) {
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Model "${body.workspaceDefaultModel.modelId}" was not found or is not enabled for this workspace.`,
+            },
+          });
+        }
+      }
+
+      const workspaceDefaultModel = body.workspaceDefaultModel ?? undefined;
+      const updateRes = await updateWorkspaceMetadata(owner, {
+        workspaceDefaultModel,
+      });
+      if (updateRes.isErr()) {
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: updateRes.error.message,
+          },
+        });
+      }
+      owner.metadata = {
+        ...(owner.metadata ?? {}),
+        workspaceDefaultModel,
       };
     } else if ("domainUpdates" in body) {
       for (const update of body.domainUpdates) {

--- a/front/components/pages/workspace/model_providers/DefaultModelSelect.tsx
+++ b/front/components/pages/workspace/model_providers/DefaultModelSelect.tsx
@@ -1,0 +1,118 @@
+import { getResolvedWorkspaceDefaultModel } from "@app/components/agent_builder/transformAgentConfiguration";
+import { ConfirmContext } from "@app/components/Confirm";
+import { getModelProviderLogo } from "@app/components/providers/types";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { useWorkspaceDefaultModel } from "@app/hooks/useWorkspaceDefaultModel";
+import { useModels } from "@app/lib/swr/models";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { WorkspaceType } from "@app/types/user";
+import { getWorkspaceDefaultModelSetting } from "@app/types/user";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import { useContext } from "react";
+
+interface DefaultModelSelectProps {
+  workspace: WorkspaceType;
+  mutateWorkspace: () => Promise<unknown>;
+}
+
+export function DefaultModelSelect({
+  workspace,
+  mutateWorkspace,
+}: DefaultModelSelectProps) {
+  const { isDark } = useTheme();
+  const confirm = useContext(ConfirmContext);
+  const { models } = useModels({ owner: workspace });
+  const { updateDefaultModel, isSaving } = useWorkspaceDefaultModel({
+    owner: workspace,
+    mutateWorkspace,
+  });
+
+  const setting = getWorkspaceDefaultModelSetting(workspace);
+  const isAutomatic = setting === null;
+  const resolvedModel = getResolvedWorkspaceDefaultModel(workspace, models);
+
+  const onSelectModel = async (model: ModelConfigurationType) => {
+    const confirmed = await confirm({
+      title: `Set ${model.displayName} as the workspace default?`,
+      message: (
+        <div className="flex flex-col gap-2">
+          <div>{model.shortDescription}</div>
+          <div>
+            This model powers Dust, dust-task and every agent set to follow the
+            workspace default — it changes the cost and latency of those agents.
+          </div>
+        </div>
+      ),
+      validateLabel: "Set as default",
+      validateVariant: "warning",
+    });
+    if (confirmed) {
+      await updateDefaultModel({
+        providerId: model.providerId,
+        modelId: model.modelId,
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 p-3">
+      <div className="flex items-center justify-between">
+        <div className="font-semibold">Default model:</div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild disabled={isSaving}>
+            <Button
+              isSelect
+              disabled={isSaving}
+              label={isAutomatic ? "Not selected" : resolvedModel.displayName}
+              icon={
+                isAutomatic
+                  ? undefined
+                  : getModelProviderLogo(resolvedModel.providerId, isDark)
+              }
+              variant="outline"
+              size="sm"
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem onClick={() => updateDefaultModel(null)}>
+              <div className="flex flex-col">
+                <span>Not selected</span>
+                <span className="text-xs text-gray-500">
+                  Currently{" "}
+                  <span className="font-bold">{resolvedModel.displayName}</span>
+                </span>
+              </div>
+            </DropdownMenuItem>
+            {models.map((model) => (
+              <DropdownMenuItem
+                key={`${model.providerId}/${model.modelId}`}
+                label={model.displayName}
+                description={model.shortDescription}
+                icon={getModelProviderLogo(model.providerId, isDark)}
+                onClick={() => onSelectModel(model)}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      <div className="text-sm text-gray-500">
+        The default model backs the standard agents (Dust, dust-task, …) and is
+        the default for newly created agents, which follow it automatically.
+        Leave it unset to always use the best available model, or pin a specific
+        model to freeze it.{" "}
+        {isAutomatic && (
+          <>
+            No model is selected — agents currently use{" "}
+            <span className="font-medium">{resolvedModel.displayName}</span>.
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/components/pages/workspace/model_providers/DefaultModelSelect.tsx
+++ b/front/components/pages/workspace/model_providers/DefaultModelSelect.tsx
@@ -44,8 +44,10 @@ export function DefaultModelSelect({
         <div className="flex flex-col gap-2">
           <div>{model.shortDescription}</div>
           <div>
-            This model powers Dust, dust-task and every agent set to follow the
-            workspace default — it changes the cost and latency of those agents.
+            This model powers @dust, @dust-task and every default agent. It is
+            also the default option for newly created agents. Cost and latency
+            may vary depending on the model you select. You can always change it
+            later.
           </div>
         </div>
       ),
@@ -108,8 +110,11 @@ export function DefaultModelSelect({
         model to freeze it.{" "}
         {isAutomatic && (
           <>
-            No model is selected — agents currently use{" "}
-            <span className="font-medium">{resolvedModel.displayName}</span>.
+            <br />
+            <b>
+              No model is set. Agents currently default to Dust's recommended
+              model: {resolvedModel.displayName}
+            </b>
           </>
         )}
       </div>

--- a/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
@@ -33,6 +33,7 @@ export function ModelProvidersPage() {
           isWorkspaceValidating={isWorkspaceValidating}
           onToggleProvider={toggleProvider}
           onSelectAllProviders={selectAllProviders}
+          mutateWorkspace={mutateWorkspace}
         />
       </Page.Vertical>
     </Page.Vertical>

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -1,4 +1,5 @@
 import { AllProvidersToggle } from "@app/components/pages/workspace/model_providers/AllProvidersToggle";
+import { DefaultModelSelect } from "@app/components/pages/workspace/model_providers/DefaultModelSelect";
 import { EmbeddingModelSelect } from "@app/components/pages/workspace/model_providers/EmbeddingModelSelect";
 import { ProvidersConfigurationList } from "@app/components/pages/workspace/model_providers/ProvidersConfigurationList";
 import { ProvidersToggleList } from "@app/components/pages/workspace/model_providers/ProvidersToggleList";
@@ -23,6 +24,7 @@ interface ModelProvidersPageContentProps {
   isWorkspaceValidating: boolean;
   onToggleProvider: (provider: ModelProviderIdType) => void;
   onSelectAllProviders: () => void;
+  mutateWorkspace: () => Promise<unknown>;
 }
 
 export function ModelProvidersPageContent({
@@ -31,10 +33,11 @@ export function ModelProvidersPageContent({
   isWorkspaceValidating,
   onToggleProvider,
   onSelectAllProviders,
+  mutateWorkspace,
 }: ModelProvidersPageContentProps) {
   const { subscription } = useAuth();
   const { plan } = subscription;
-  const { featureFlags } = useFeatureFlags();
+  const { featureFlags, hasFeature } = useFeatureFlags();
   const { regionInfo } = useRegionContext();
 
   // Filter models based on feature flags and build modelProviders dynamically
@@ -78,6 +81,12 @@ export function ModelProvidersPageContent({
             modelsDescriptionByProvider={modelsDescriptionByProvider}
           />
         </>
+      )}
+      {hasFeature("workspace_default_model") && (
+        <DefaultModelSelect
+          workspace={workspace}
+          mutateWorkspace={mutateWorkspace}
+        />
       )}
       <EmbeddingModelSelect workspace={workspace} />
     </div>

--- a/front/hooks/useWorkspaceDefaultModel.ts
+++ b/front/hooks/useWorkspaceDefaultModel.ts
@@ -1,0 +1,64 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import type {
+  LightWorkspaceType,
+  WorkspaceDefaultModelSetting,
+} from "@app/types/user";
+import { useCallback, useState } from "react";
+
+interface UseWorkspaceDefaultModelParams {
+  owner: LightWorkspaceType;
+  mutateWorkspace: () => Promise<unknown>;
+}
+
+// Persists the workspace default model. Pass `null` to clear it ("automatic":
+// resolve live to the best available model). Success/failure notifications are
+// sent from here per [REACT2].
+export function useWorkspaceDefaultModel({
+  owner,
+  mutateWorkspace,
+}: UseWorkspaceDefaultModelParams) {
+  const sendNotification = useSendNotification();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const updateDefaultModel = useCallback(
+    async (model: WorkspaceDefaultModelSetting | null) => {
+      setIsSaving(true);
+      try {
+        const response = await clientFetch(`/api/w/${owner.sId}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ workspaceDefaultModel: model }),
+        });
+
+        if (!response.ok) {
+          throw new Error("Failed to update the workspace default model");
+        }
+
+        sendNotification({
+          type: "success",
+          title: "Default model updated",
+          description: model
+            ? "The workspace default model has been set."
+            : "The workspace default model is now automatic.",
+        });
+
+        await mutateWorkspace();
+        return true;
+      } catch {
+        sendNotification({
+          type: "error",
+          title: "Update failed",
+          description:
+            "An unexpected error occurred while updating the default model.",
+        });
+        return false;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [owner.sId, mutateWorkspace, sendNotification]
+  );
+
+  return { updateDefaultModel, isSaving };
+}


### PR DESCRIPTION
## Description

Part of the **workspace default model** stack (builds on #27921, #27922).

Lets admins configure the workspace default model:

- `POST /api/w/[wId]` gains a `workspaceDefaultModel` body variant (`{ providerId, modelId }` or `null` to clear). Admin-only, gated by the `workspace_default_model` flag, validates the model is real and enabled for the workspace (`isModelEnabledForWorkspace`), then persists via `updateWorkspaceMetadata`. Mirrors the existing `workspaceDefaultAgentId` handler.
- **Model Providers** admin page gets a "Default model" section (`DefaultModelSelect`) showing `Automatic (currently X)` and the list of available models, saved through the new `useWorkspaceDefaultModel` hook. Picking a model shows a **cost/latency confirmation warning** ("this powers Dust, dust-task and every agent set to follow the workspace default"). No dollar figures — model configs carry no price data.

After this PR the standard agents (#27922) are fully controllable. New custom agents don't follow the default yet — that's #27924.

## Tests

Functional endpoint tests added in `front-api/routes/w/[wId]/index.test.ts`: pin a valid model, clear with `null` (preserving other metadata), 400 on unknown model, 403 when the flag is off, 403 for non-admins.

## Risk

Low. Endpoint and UI are flag-gated; clearing/invalid input handled. The setting only takes effect for agents wired in #27922 / #27924.
