### PR TITLE
feat(agent-builder): new agents follow the workspace default model

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -26,6 +26,7 @@ import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgen
 import {
   getDefaultAgentFormData,
   getDefaultModel,
+  getResolvedWorkspaceDefaultModel,
   transformAgentConfigurationToFormData,
   transformDuplicateAgentToFormData,
   transformTemplateToFormData,
@@ -46,6 +47,7 @@ import type {
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { AdditionalConfigurationType } from "@app/lib/models/agent/actions/mcp";
 import { useAppRouter } from "@app/lib/platform";
@@ -60,6 +62,7 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { WORKSPACE_DEFAULT_MODEL_SETTINGS } from "@app/types/assistant/models/workspace_default";
 import type { TemplateInfo } from "@app/types/assistant/templates";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
@@ -117,6 +120,7 @@ export default function AgentBuilder({
   onSaved,
 }: AgentBuilderProps) {
   const { owner, user, isAdmin, assistantTemplate } = useAgentBuilderContext();
+  const { hasFeature } = useFeatureFlags();
   const { supportedDataSourceViews } = useDataSourceViewsContext();
   const { mcpServerViews } = useMCPServerViewsContext();
   const { fetcherWithBody } = useFetcher();
@@ -272,7 +276,23 @@ export default function AgentBuilder({
   useEffect(() => {
     const currentValues = form.getValues();
 
-    const defaultModel = getDefaultModel(availableModels);
+    // New agents follow the workspace default model when the feature is on
+    // (stored as the sentinel, resolved at fetch time). Otherwise they get the
+    // best available concrete model, as before.
+    const followsWorkspaceDefault = hasFeature("workspace_default_model");
+    const resolvedDefaultModel = getResolvedWorkspaceDefaultModel(
+      owner,
+      availableModels
+    );
+    const defaultModelSettings = followsWorkspaceDefault
+      ? { ...WORKSPACE_DEFAULT_MODEL_SETTINGS }
+      : (() => {
+          const defaultModel = getDefaultModel(availableModels);
+          return {
+            modelId: defaultModel.modelId,
+            providerId: defaultModel.providerId,
+          };
+        })();
     const userOwnedTriggers = triggers.filter(
       (trigger) => trigger.editor === user.id
     );
@@ -299,11 +319,8 @@ export default function AgentBuilder({
       ...(!agentConfiguration && {
         generationSettings: {
           ...currentValues.generationSettings,
-          modelSettings: {
-            modelId: defaultModel.modelId,
-            providerId: defaultModel.providerId,
-          },
-          reasoningEffort: defaultModel.defaultReasoningEffort,
+          modelSettings: defaultModelSettings,
+          reasoningEffort: resolvedDefaultModel.defaultReasoningEffort,
         },
       }),
     });

--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -3,6 +3,7 @@ import {
   getModelKey,
   getModelsCategorization,
 } from "@app/components/agent_builder/instructions/utils";
+import { getResolvedWorkspaceDefaultModel } from "@app/components/agent_builder/transformAgentConfiguration";
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { RegionalFlag } from "@app/components/shared/RegionalFlag";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
@@ -10,6 +11,10 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { getProviderDisplayName } from "@app/types/assistant/models/providers";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import {
+  WORKSPACE_DEFAULT_MODEL_ID,
+  WORKSPACE_DEFAULT_MODEL_SETTINGS,
+} from "@app/types/assistant/models/workspace_default";
 import type { RegionType } from "@app/types/region";
 import {
   DropdownMenuLabel,
@@ -74,7 +79,13 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
 
   const { regionInfo } = useRegionContext();
   const { hasFeature } = useFeatureFlags();
-  const { subscription } = useAuth();
+  const { subscription, workspace } = useAuth();
+
+  const showWorkspaceDefault = hasFeature("workspace_default_model");
+  const resolvedWorkspaceDefaultModel = getResolvedWorkspaceDefaultModel(
+    workspace,
+    models
+  );
 
   const showRegionalFlag =
     hasFeature("use_vertex_for_supported_models") &&
@@ -106,11 +117,36 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
     reasoningEffortField.onChange(modelConfig.defaultReasoningEffort);
   };
 
+  const handleWorkspaceDefaultSelection = () => {
+    modelField.onChange({ ...WORKSPACE_DEFAULT_MODEL_SETTINGS });
+    reasoningEffortField.onChange(
+      resolvedWorkspaceDefaultModel.defaultReasoningEffort
+    );
+  };
+
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger label="Model selection" />
       <DropdownMenuPortal>
         <DropdownMenuSubContent className="w-80">
+          {showWorkspaceDefault && (
+            <>
+              <DropdownMenuLabel label="Default" />
+              <DropdownMenuRadioGroup value={currentModelKey}>
+                <DropdownMenuRadioItem
+                  value={WORKSPACE_DEFAULT_MODEL_ID}
+                  icon={getModelProviderLogo(
+                    resolvedWorkspaceDefaultModel.providerId,
+                    isDark
+                  )}
+                  label="Workspace default"
+                  description={`Currently ${resolvedWorkspaceDefaultModel.displayName} — follows your workspace setting`}
+                  onClick={handleWorkspaceDefaultSelection}
+                />
+              </DropdownMenuRadioGroup>
+            </>
+          )}
+
           {isSelectedModelNotInBest && selectedModel && (
             <>
               <DropdownMenuLabel label="Selected model" />

--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -103,7 +103,11 @@ export function AgentInfoTab({
               icon={getModelProviderLogo(model.providerId, isDark)}
               size="xs"
             />
-            <div>{model.displayName}</div>
+            <div>
+              {agentConfiguration.model.usesWorkspaceDefault
+                ? `Workspace default (currently ${model.displayName})`
+                : model.displayName}
+            </div>
           </div>
         </div>
       )}

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -74,6 +74,7 @@ import {
 } from "@app/types/assistant/assistant";
 import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 import { validateResponseFormat } from "@app/types/assistant/models/utils";
+import { WORKSPACE_DEFAULT_MODEL_SETTINGS } from "@app/types/assistant/models/workspace_default";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -111,6 +112,20 @@ export async function createPendingAgentConfiguration(
 
   const sId = generateRandomModelSId();
 
+  // When the workspace-default-model feature is enabled, new agents follow the
+  // workspace default by default: store the sentinel model, resolved at fetch
+  // time. Otherwise keep the historical hardcoded Sonnet default.
+  const featureFlags = await getFeatureFlags(auth);
+  const followsWorkspaceDefault = featureFlags.includes(
+    "workspace_default_model"
+  );
+  const defaultModel = followsWorkspaceDefault
+    ? WORKSPACE_DEFAULT_MODEL_SETTINGS
+    : {
+        providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+        modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+      };
+
   await withTransaction(async (t) => {
     const agent = await AgentConfigurationModel.create(
       {
@@ -121,8 +136,8 @@ export async function createPendingAgentConfiguration(
         name: PENDING_AGENT_PLACEHOLDER_NAME,
         description: PENDING_AGENT_PLACEHOLDER_DESCRIPTION,
         instructions: null,
-        providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
-        modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+        providerId: defaultModel.providerId,
+        modelId: defaultModel.modelId,
         temperature: 0.7,
         reasoningEffort:
           CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,


### PR DESCRIPTION
## Description

Final PR of the **workspace default model** stack (builds on #27921–#27923).

Makes newly created custom agents follow the workspace default dynamically, and surfaces it in the builder/details:

- `createPendingAgentConfiguration` stores the `workspace-default` sentinel for new agents when the flag is on (otherwise the historical hardcoded Sonnet default).
- Agent builder initializes new agents to the sentinel and round-trips it: the model picker gains a "Workspace default (currently X)" entry, and `transformAgentConfigurationToFormData` maps the `usesWorkspaceDefault` flag back to the sentinel so saving keeps following the default.
- Agent details (`AgentInfoTab`) renders "Workspace default (currently X)" for agents that follow it.

Because the sentinel is resolved at the serialization boundary (#27922), every existing execution path keeps seeing a concrete model. Existing agents with pinned models are unaffected — only new agents follow by default.

## Tests

Manual end-to-end (full stack + flag on): create a new agent → shows "Workspace default"; set the workspace default in Model Providers → the new agent and Dust both switch; clear it → both revert to the live default; pin then un-whitelist that provider → graceful fallback. Existing pinned agents unchanged.

## Risk

Low and flag-gated. With `workspace_default_model` off, new agents keep the previous concrete Sonnet default and the picker entry is hidden.
