### PR TITLE
[Agent Builder] Restore save hydration guard

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -561,8 +561,17 @@ export default function AgentBuilder({
     });
   };
 
+  const { isDirty, isSubmitting } = form.formState;
+
+  const isSaveDisabled =
+    isSubmitting ||
+    isActionsLoading ||
+    isSkillsLoading ||
+    isTriggersLoading ||
+    isEditorsLoading;
+
   const handleSave = async () => {
-    if (isSaving) {
+    if (isSaving || isSaveDisabled) {
       return;
     }
 
@@ -587,14 +596,8 @@ export default function AgentBuilder({
     }
   };
 
-  const { isDirty, isSubmitting } = form.formState;
-
   // Disable navigation lock during save process for new agents
   useNavigationLock((isDirty || !!duplicateAgentId) && !isSaving);
-
-  const isSaveDisabled = duplicateAgentId
-    ? false
-    : isSubmitting || isActionsLoading || isTriggersLoading;
 
   const saveLabel = isSubmitting ? "Saving..." : "Save";
 

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -128,26 +128,26 @@ export default function AgentBuilder({
   const [pendingAgentId, setPendingAgentId] = useState<string | null>(null);
   const hasPendingCreationRef = useRef(false);
 
-  const { actions, isActionsLoading, mutateActions } =
+  const { actions, isActionsError, isActionsLoading, mutateActions } =
     useAgentConfigurationActions(
       owner.sId,
       duplicateAgentId ?? agentConfiguration?.sId ?? null
     );
 
-  const { triggers, isTriggersLoading, mutateTriggers } = useAgentTriggers({
-    workspaceId: owner.sId,
-    agentConfigurationId: agentConfiguration?.sId ?? null,
-  });
+  const { triggers, isTriggersError, isTriggersLoading, mutateTriggers } =
+    useAgentTriggers({
+      workspaceId: owner.sId,
+      agentConfigurationId: agentConfiguration?.sId ?? null,
+    });
 
   const agentConfigurationIdForSkills =
     duplicateAgentId ?? agentConfiguration?.sId ?? null;
-  const { skills, isSkillsLoading, mutateSkills } = useAgentConfigurationSkills(
-    {
+  const { skills, isSkillsError, isSkillsLoading, mutateSkills } =
+    useAgentConfigurationSkills({
       owner,
       agentConfigurationId: agentConfigurationIdForSkills ?? "",
       disabled: !agentConfigurationIdForSkills,
-    }
-  );
+    });
 
   const shouldLoadEditors = !!agentConfiguration && !duplicateAgentId;
   const { editors, isEditorsError, isEditorsLoading, mutateEditors } =
@@ -565,8 +565,12 @@ export default function AgentBuilder({
 
   const { isDirty, isSubmitting } = form.formState;
 
+  const hasAgentDataLoadError =
+    isActionsError || isSkillsError || !!isTriggersError || isEditorsError;
+
   const isSaveDisabled =
     isSubmitting ||
+    hasAgentDataLoadError ||
     isActionsLoading ||
     isSkillsLoading ||
     isTriggersLoading ||

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -128,34 +128,54 @@ export default function AgentBuilder({
   const [pendingAgentId, setPendingAgentId] = useState<string | null>(null);
   const hasPendingCreationRef = useRef(false);
 
-  const { actions, isActionsError, isActionsLoading, mutateActions } =
-    useAgentConfigurationActions(
-      owner.sId,
-      duplicateAgentId ?? agentConfiguration?.sId ?? null
-    );
+  const {
+    actions,
+    isActionsError,
+    isActionsLoading,
+    isActionsValidating,
+    mutateActions,
+  } = useAgentConfigurationActions(
+    owner.sId,
+    duplicateAgentId ?? agentConfiguration?.sId ?? null
+  );
 
-  const { triggers, isTriggersError, isTriggersLoading, mutateTriggers } =
-    useAgentTriggers({
-      workspaceId: owner.sId,
-      agentConfigurationId: agentConfiguration?.sId ?? null,
-    });
+  const {
+    triggers,
+    isTriggersError,
+    isTriggersLoading,
+    isTriggersValidating,
+    mutateTriggers,
+  } = useAgentTriggers({
+    workspaceId: owner.sId,
+    agentConfigurationId: agentConfiguration?.sId ?? null,
+  });
 
   const agentConfigurationIdForSkills =
     duplicateAgentId ?? agentConfiguration?.sId ?? null;
-  const { skills, isSkillsError, isSkillsLoading, mutateSkills } =
-    useAgentConfigurationSkills({
-      owner,
-      agentConfigurationId: agentConfigurationIdForSkills ?? "",
-      disabled: !agentConfigurationIdForSkills,
-    });
+  const {
+    skills,
+    isSkillsError,
+    isSkillsLoading,
+    isSkillsValidating,
+    mutateSkills,
+  } = useAgentConfigurationSkills({
+    owner,
+    agentConfigurationId: agentConfigurationIdForSkills ?? "",
+    disabled: !agentConfigurationIdForSkills,
+  });
 
   const shouldLoadEditors = !!agentConfiguration && !duplicateAgentId;
-  const { editors, isEditorsError, isEditorsLoading, mutateEditors } =
-    useEditors({
-      owner,
-      agentConfigurationId: agentConfiguration?.sId ?? null,
-      disabled: !shouldLoadEditors,
-    });
+  const {
+    editors,
+    isEditorsError,
+    isEditorsLoading,
+    isEditorsValidating,
+    mutateEditors,
+  } = useEditors({
+    owner,
+    agentConfigurationId: agentConfiguration?.sId ?? null,
+    disabled: !shouldLoadEditors,
+  });
   const updateEditors = useUpdateEditors({
     owner,
     agentConfigurationId: agentConfiguration?.sId ?? null,
@@ -568,9 +588,16 @@ export default function AgentBuilder({
   const hasAgentDataLoadError =
     isActionsError || isSkillsError || !!isTriggersError || isEditorsError;
 
+  const isAgentDataValidating =
+    isActionsValidating ||
+    isSkillsValidating ||
+    isTriggersValidating ||
+    isEditorsValidating;
+
   const isSaveDisabled =
     isSubmitting ||
     hasAgentDataLoadError ||
+    isAgentDataValidating ||
     isActionsLoading ||
     isSkillsLoading ||
     isTriggersLoading ||

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -149,10 +149,12 @@ export default function AgentBuilder({
     }
   );
 
+  const shouldLoadEditors = !!agentConfiguration && !duplicateAgentId;
   const { editors, isEditorsError, isEditorsLoading, mutateEditors } =
     useEditors({
       owner,
       agentConfigurationId: agentConfiguration?.sId ?? null,
+      disabled: !shouldLoadEditors,
     });
   const updateEditors = useUpdateEditors({
     owner,

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -34,6 +34,7 @@ export function useAgentConfigurationActions(
   return {
     actions: actionsWithIds,
     isActionsLoading: !error && !data && !disabled,
+    isActionsError: !!error,
     mutateActions: mutate,
     error,
   };

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -12,7 +12,7 @@ export function useAgentConfigurationActions(
   const { fetcher } = useFetcher();
   const disabled = agentConfigurationId === null;
   const actionsFetcher: Fetcher<GetActionsResponseBody> = fetcher;
-  const { data, error, mutate } = useSWRWithDefaults(
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
     `/api/w/${ownerId}/builder/assistants/${agentConfigurationId}/actions`,
     actionsFetcher,
     {
@@ -35,6 +35,7 @@ export function useAgentConfigurationActions(
     actions: actionsWithIds,
     isActionsLoading: !error && !data && !disabled,
     isActionsError: !!error,
+    isActionsValidating: isValidating,
     mutateActions: mutate,
     error,
   };

--- a/front/lib/swr/agent_editors.ts
+++ b/front/lib/swr/agent_editors.ts
@@ -25,7 +25,7 @@ export function useEditors({
     AgentEditorsResponseBody | AgentEditorsLightResponseBody
   > = fetcher;
 
-  const { data, error, mutate } = useSWRWithDefaults(
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
     agentConfigurationId
       ? `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationId}/editors`
       : null,
@@ -40,6 +40,7 @@ export function useEditors({
     editors: data?.editors ?? emptyArray(),
     isEditorsLoading: !error && !data && !disabled,
     isEditorsError: !!error,
+    isEditorsValidating: isValidating,
     mutateEditors: mutate,
   };
 }

--- a/front/lib/swr/skills.ts
+++ b/front/lib/swr/skills.ts
@@ -15,7 +15,7 @@ export function useAgentConfigurationSkills({
   const { fetcher } = useFetcher();
   const skillsFetcher: Fetcher<GetAgentSkillsResponseBody> = fetcher;
 
-  const { data, error, isLoading, mutate } = useSWRWithDefaults(
+  const { data, error, isLoading, isValidating, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationId}/skills`,
     skillsFetcher,
     { disabled }
@@ -25,6 +25,7 @@ export function useAgentConfigurationSkills({
     skills: data?.skills ?? emptyArray(),
     isSkillsLoading: isLoading,
     isSkillsError: !!error,
+    isSkillsValidating: isValidating,
     mutateSkills: mutate,
   };
 }

--- a/front/lib/swr/skills.ts
+++ b/front/lib/swr/skills.ts
@@ -15,7 +15,7 @@ export function useAgentConfigurationSkills({
   const { fetcher } = useFetcher();
   const skillsFetcher: Fetcher<GetAgentSkillsResponseBody> = fetcher;
 
-  const { data, isLoading, mutate } = useSWRWithDefaults(
+  const { data, error, isLoading, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationId}/skills`,
     skillsFetcher,
     { disabled }
@@ -24,6 +24,7 @@ export function useAgentConfigurationSkills({
   return {
     skills: data?.skills ?? emptyArray(),
     isSkillsLoading: isLoading,
+    isSkillsError: !!error,
     mutateSkills: mutate,
   };
 }


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/8990

Reapplies https://github.com/dust-tt/dust/pull/27898 after https://github.com/dust-tt/dust/pull/27925.

Save stays disabled until existing agent data has loaded/revalidated, but create and duplicate flows do not wait on editors.

## Risks
Blast radius: Agent Builder save button state.
Risk: low

## Deploy Plan
- pmrr (this time it does not block save)
- deploy front