### PR TITLE
Move JIRA server instructions into the tool descriptions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/instructions.ts
@@ -43,27 +43,3 @@ The output includes:
 -   Other object-level properties.
 This is the most reliable way to discover the correct names for fields and relationships before writing an \`execute_read_query\`.
 `;
-
-export const JIRA_SERVER_INSTRUCTIONS = `
-      You have access to the following tools: get_issue, get_projects, get_project, get_transitions, create_comment, get_issues, get_issue_types, get_issue_create_fields, get_connection_info, transition_issue, create_issue, update_issue, create_issue_link, delete_issue_link, get_issue_link_types, get_users, get_issue_read_fields.
-
-      # General Workflow for JIRA Data:
-      1.  **Authenticate:** Use \`get_connection_info\` to authenticate with JIRA if you are not authenticated ("No access token found").
-      2.  **For Create/Update Operations:** Always use \`get_issue_types\` and \`get_issue_create_fields\` with the specific issue typename to get its create/update-time metadata (fields available on the Create/Update screens).
-      3.  **Execute Read Query:** Use \`get_issues\` to retrieve data using JQL. Construct your JQL queries based on the information obtained from \`get_issue_types\` to ensure you are using correct field and relationship names.
-
-      **Best Practices for Querying:**
-      1.  **Discover Object Structure First:** Use \`get_issue_create_fields\` to understand fields available for create/update in a given project and issue type. Alternatively, for a quick field list directly in a query, use \`get_issues\`.
-      2.  **Verify Field and Relationship Names:** If you encounter JIRA 400 errors suggesting that the field or relationship does not exist, use \`get_issue_types\` for the relevant object(s) to confirm the exact names and their availability.
-
-      **Field Selection for get_issue (Optional Performance Optimization):**
-      - By default, \`get_issue\` returns essential fields: summary, issuetype, priority, assignee, reporter, labels, duedate, parent, project, status
-      - Only use \`get_issue_read_fields\` if you need additional custom fields or want to optimize performance by requesting specific fields
-      - For built-in fields use the \`key\` (e.g., "summary", "issuetype", "status"). For custom fields use the \`id\` (e.g., "customfield_10020").
-
-      **User Lookup (get_users):**
-      - Provide emailAddress for exact match on email. Example: { "emailAddress": "jane.doe@acme.com" }
-      - Or provide name for case-insensitive contains on display name. Example: { "name": "Jane" }
-      - If neither emailAddress nor name is provided, the tool lists the first maxResults users.
-      - For pagination, pass startAt using the previous result's nextStartAt. Example: { "name": "Jane", "startAt": 100 }
-    `;

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -1,4 +1,3 @@
-import { JIRA_SERVER_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/instructions";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
@@ -26,7 +25,10 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_issue: {
-    description: "Retrieves a single JIRA issue by its key (e.g., 'PROJ-123').",
+    description:
+      "Retrieves a single JIRA issue by its key (e.g., 'PROJ-123'). " +
+      "By default it returns a minimal set of fields for performance: summary, issuetype, priority, assignee, reporter, labels, duedate, parent, project, status. " +
+      "To request others, pass them in the fields parameter using the key for built-in fields (e.g. summary) and the id for custom fields (e.g. customfield_10020), which you can discover with get_issue_read_fields.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       fields: z
@@ -166,7 +168,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_connection_info: {
     description:
-      "Gets comprehensive connection information including user details, cloud ID, and site URL for the currently authenticated JIRA instance. This tool is used when the user is referring about themselves",
+      "Gets comprehensive connection information including user details, cloud ID, and site URL for the currently authenticated JIRA instance. This tool is used when the user is referring about themselves. Also use it to authenticate when another tool reports that no access token was found.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -305,7 +307,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   update_issue: {
     description:
-      "Updates an existing JIRA issue with new field values (e.g., summary, description, priority, assignee). For textarea fields (like description), you can use either plain text or rich ADF format. Use get_issue_create_fields to identify textarea fields. Note: Issue links, attachments, and some system fields require separate APIs and are not supported.",
+      "Updates an existing JIRA issue with new field values (e.g., summary, description, priority, assignee). For textarea fields (like description), you can use either plain text or rich ADF format. Use get_issue_create_fields to discover which fields are available for the project and issue type, including which ones are textarea fields. Note: Issue links, attachments, and some system fields require separate APIs and are not supported.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       updateData: JiraCreateIssueRequestSchema.partial().describe(
@@ -386,7 +388,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
 });
 
 export const JIRA_SERVER = {
-  // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
   serverInfo: {
     name: "jira",
     version: "1.0.0",
@@ -397,7 +398,7 @@ export const JIRA_SERVER = {
     },
     icon: "JiraLogo",
     documentationUrl: "https://docs.dust.tt/docs/jira",
-    instructions: JIRA_SERVER_INSTRUCTIONS,
+    instructions: null,
   },
   tools: Object.values(JIRA_TOOLS_METADATA).map((t) => ({
     name: t.name,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/9208.

The JIRA server carried a block of server-level instructions that the model only sees once, far from the point where it actually picks a tool. Most of that guidance was already duplicated in the individual tool descriptions, so it added length without adding signal. This folds the two pieces that were not already present at a call site, the authentication step and the get_issue default fields with the built-in versus custom field naming convention, into the descriptions of the tools they concern, then removes the server instructions and the now unused constant. Behavior is unchanged and the guidance now sits next to the decision it informs.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
