### PR TITLE
[Skills] Allow enabling skills from earlier user messages

### DIFF
--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -40,8 +40,16 @@ describe("skill_management enable_skill tool", () => {
   const auth = {};
   const agentConfiguration = { sId: "agent-id" };
   const agentMessage = { sId: "agent-message-id" };
-  const conversation = { sId: "conversation-id" };
-  const userMessage = { content: "", sId: "user-message-id" };
+  const userMessage = {
+    content: "",
+    sId: "user-message-id",
+    type: "user_message",
+    visibility: "visible",
+  };
+  const conversation: {
+    content: (typeof userMessage)[][];
+    sId: string;
+  } = { content: [], sId: "conversation-id" };
   const skill = {
     enableForAgent: mockEnableForAgent,
     getFileAttachments: mockGetFileAttachments,
@@ -75,8 +83,10 @@ describe("skill_management enable_skill tool", () => {
   });
 
   function makeExtra({
+    conversationOverride = conversation,
     userMessageOverride = userMessage,
   }: {
+    conversationOverride?: typeof conversation;
     userMessageOverride?: typeof userMessage;
   } = {}) {
     return {
@@ -85,7 +95,7 @@ describe("skill_management enable_skill tool", () => {
         runContext: {
           agentConfiguration,
           agentMessage,
-          conversation,
+          conversation: conversationOverride,
           userMessage: userMessageOverride,
         },
       },
@@ -315,8 +325,8 @@ describe("skill_management enable_skill tool", () => {
       { skillName: "commit" },
       makeExtra({
         userMessageOverride: {
+          ...userMessage,
           content: '<skill id="parent-skill-id" name="parent" />',
-          sId: "user-message-id",
         },
       })
     );
@@ -326,6 +336,10 @@ describe("skill_management enable_skill tool", () => {
   });
 
   it("enables skills explicitly referenced by the current user message", async () => {
+    const currentUserMessage = {
+      ...userMessage,
+      content: '<skill id="skill-id" name="commit" />',
+    };
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [],
       equippedSkills: [],
@@ -336,10 +350,7 @@ describe("skill_management enable_skill tool", () => {
     const result = await getTool().handler(
       { skillName: "commit" },
       makeExtra({
-        userMessageOverride: {
-          content: '<skill id="skill-id" name="commit" />',
-          sId: "user-message-id",
-        },
+        userMessageOverride: currentUserMessage,
       })
     );
 
@@ -351,10 +362,45 @@ describe("skill_management enable_skill tool", () => {
         agentConfiguration,
         agentMessage,
         conversation,
-        userMessage: {
-          content: '<skill id="skill-id" name="commit" />',
-          sId: "user-message-id",
-        },
+        userMessage: currentUserMessage,
+      }
+    );
+    expect(mockEnableForAgent).toHaveBeenCalled();
+  });
+
+  it("enables skills explicitly referenced by earlier user messages", async () => {
+    const earlierUserMessage = {
+      ...userMessage,
+      content: '<skill id="skill-id" name="commit" />',
+      sId: "earlier-user-message-id",
+    };
+    const conversationWithEarlierSkill = {
+      ...conversation,
+      content: [[earlierUserMessage], [userMessage]],
+    };
+    mockListForAgentLoop.mockResolvedValue({
+      enabledSkills: [],
+      equippedSkills: [],
+      systemSkills: [],
+    });
+    mockFetchActiveByIdsForAgentLoop.mockResolvedValue([skill]);
+
+    const result = await getTool().handler(
+      { skillName: "commit" },
+      makeExtra({
+        conversationOverride: conversationWithEarlierSkill,
+      })
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockFetchActiveByIdsForAgentLoop).toHaveBeenCalledWith(
+      auth,
+      ["skill-id"],
+      {
+        agentConfiguration,
+        agentMessage,
+        conversation: conversationWithEarlierSkill,
+        userMessage,
       }
     );
     expect(mockEnableForAgent).toHaveBeenCalled();

--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -6,17 +6,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockEnableForAgent,
   mockBatchFetchUsedBySkills,
+  mockFetchActiveByName,
   mockFetchActiveByIdsForAgentLoop,
   mockGetFileAttachments,
-  mockListActiveByNameForAgentLoop,
   mockListForAgentLoop,
   mockLoadSkillFilesToConversation,
 } = vi.hoisted(() => ({
   mockEnableForAgent: vi.fn(),
   mockBatchFetchUsedBySkills: vi.fn(),
+  mockFetchActiveByName: vi.fn(),
   mockFetchActiveByIdsForAgentLoop: vi.fn(),
   mockGetFileAttachments: vi.fn(),
-  mockListActiveByNameForAgentLoop: vi.fn(),
   mockListForAgentLoop: vi.fn(),
   mockLoadSkillFilesToConversation: vi.fn(),
 }));
@@ -28,8 +28,8 @@ vi.mock("@app/lib/api/skills/conversation_files", () => ({
 vi.mock("@app/lib/resources/skill/skill_resource", () => ({
   SkillResource: {
     batchFetchUsedBySkills: mockBatchFetchUsedBySkills,
+    fetchActiveByName: mockFetchActiveByName,
     fetchActiveByIdsForAgentLoop: mockFetchActiveByIdsForAgentLoop,
-    listActiveByNameForAgentLoop: mockListActiveByNameForAgentLoop,
     listForAgentLoop: mockListForAgentLoop,
   },
 }));
@@ -88,8 +88,8 @@ describe("skill_management enable_skill tool", () => {
       systemSkills: [],
     });
     mockBatchFetchUsedBySkills.mockResolvedValue(new Map());
+    mockFetchActiveByName.mockResolvedValue(null);
     mockFetchActiveByIdsForAgentLoop.mockResolvedValue([]);
-    mockListActiveByNameForAgentLoop.mockResolvedValue([]);
     mockEnableForAgent.mockResolvedValue({ wasAlreadyEnabled: false });
     mockGetFileAttachments.mockReturnValue([{ fileName: "SKILL.md" }]);
     mockLoadSkillFilesToConversation.mockResolvedValue(
@@ -228,7 +228,7 @@ describe("skill_management enable_skill tool", () => {
       equippedSkills: [parentSkill],
       systemSkills: [],
     });
-    mockListActiveByNameForAgentLoop.mockResolvedValue([skill]);
+    mockFetchActiveByName.mockResolvedValue(skill);
     mockBatchFetchUsedBySkills.mockResolvedValue(
       new Map([
         [
@@ -244,16 +244,14 @@ describe("skill_management enable_skill tool", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockListActiveByNameForAgentLoop).toHaveBeenCalledWith(
-      auth,
-      "commit",
-      {
+    expect(mockFetchActiveByName).toHaveBeenCalledWith(auth, "commit", {
+      agentLoopData: {
         agentConfiguration,
         agentMessage,
         conversation,
         userMessage,
-      }
-    );
+      },
+    });
     expect(mockBatchFetchUsedBySkills).toHaveBeenCalledWith(auth, [skill]);
     expect(mockEnableForAgent).toHaveBeenCalledWith(auth, {
       agentConfiguration,
@@ -267,7 +265,7 @@ describe("skill_management enable_skill tool", () => {
       equippedSkills: [],
       systemSkills: [],
     });
-    mockListActiveByNameForAgentLoop.mockResolvedValue([skill]);
+    mockFetchActiveByName.mockResolvedValue(skill);
     mockBatchFetchUsedBySkills.mockResolvedValue(
       new Map([
         [
@@ -296,7 +294,7 @@ describe("skill_management enable_skill tool", () => {
       equippedSkills: [unavailableParentSkill],
       systemSkills: [],
     });
-    mockListActiveByNameForAgentLoop.mockResolvedValue([skill]);
+    mockFetchActiveByName.mockResolvedValue(skill);
     mockBatchFetchUsedBySkills.mockResolvedValue(
       new Map([
         [
@@ -328,7 +326,7 @@ describe("skill_management enable_skill tool", () => {
       systemSkills: [],
     });
     mockFetchActiveByIdsForAgentLoop.mockResolvedValue([parentSkill]);
-    mockListActiveByNameForAgentLoop.mockResolvedValue([skill]);
+    mockFetchActiveByName.mockResolvedValue(skill);
     mockBatchFetchUsedBySkills.mockResolvedValue(
       new Map([
         [
@@ -424,7 +422,7 @@ describe("skill_management enable_skill tool", () => {
     expect(mockEnableForAgent).toHaveBeenCalled();
   });
 
-  it("does not enable skills referenced before the latest compaction", async () => {
+  it("enables skills explicitly referenced before the latest compaction", async () => {
     const earlierUserMessage = {
       ...userMessage,
       content: '<skill id="skill-id" name="commit" />',
@@ -447,6 +445,7 @@ describe("skill_management enable_skill tool", () => {
       equippedSkills: [],
       systemSkills: [],
     });
+    mockFetchActiveByIdsForAgentLoop.mockResolvedValue([skill]);
 
     const result = await getTool().handler(
       { skillName: "commit" },
@@ -455,11 +454,49 @@ describe("skill_management enable_skill tool", () => {
       })
     );
 
+    expect(result.isOk()).toBe(true);
+    expect(mockFetchActiveByIdsForAgentLoop).toHaveBeenCalledWith(
+      auth,
+      ["skill-id"],
+      {
+        agentConfiguration,
+        agentMessage,
+        conversation: conversationWithCompaction,
+        userMessage,
+      }
+    );
+    expect(mockEnableForAgent).toHaveBeenCalled();
+  });
+
+  it("does not enable skills referenced by later user messages", async () => {
+    const laterUserMessage = {
+      ...userMessage,
+      content: '<skill id="skill-id" name="commit" />',
+      rank: 3,
+      sId: "later-user-message-id",
+    };
+    const conversationWithLaterSkill = {
+      ...conversation,
+      content: [[userMessage], [laterUserMessage]],
+    };
+    mockListForAgentLoop.mockResolvedValue({
+      enabledSkills: [],
+      equippedSkills: [],
+      systemSkills: [],
+    });
+
+    const result = await getTool().handler(
+      { skillName: "commit" },
+      makeExtra({
+        conversationOverride: conversationWithLaterSkill,
+      })
+    );
+
     expect(result.isErr()).toBe(true);
     expect(mockFetchActiveByIdsForAgentLoop).toHaveBeenCalledWith(auth, [], {
       agentConfiguration,
       agentMessage,
-      conversation: conversationWithCompaction,
+      conversation: conversationWithLaterSkill,
       userMessage,
     });
     expect(mockEnableForAgent).not.toHaveBeenCalled();

--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -37,17 +37,34 @@ vi.mock("@app/lib/resources/skill/skill_resource", () => ({
 import { TOOLS } from "./index";
 
 describe("skill_management enable_skill tool", () => {
+  type TestUserMessage = {
+    content: string;
+    rank: number;
+    sId: string;
+    type: "user_message";
+    visibility: "visible";
+  };
+  type TestCompactionMessage = {
+    content: string | null;
+    sId: string;
+    status: "succeeded";
+    type: "compaction_message";
+    visibility: "visible";
+  };
+  type TestMessage = TestUserMessage | TestCompactionMessage;
+
   const auth = {};
   const agentConfiguration = { sId: "agent-id" };
   const agentMessage = { sId: "agent-message-id" };
-  const userMessage = {
+  const userMessage: TestUserMessage = {
     content: "",
+    rank: 2,
     sId: "user-message-id",
     type: "user_message",
     visibility: "visible",
   };
   const conversation: {
-    content: (typeof userMessage)[][];
+    content: TestMessage[][];
     sId: string;
   } = { content: [], sId: "conversation-id" };
   const skill = {
@@ -372,6 +389,7 @@ describe("skill_management enable_skill tool", () => {
     const earlierUserMessage = {
       ...userMessage,
       content: '<skill id="skill-id" name="commit" />',
+      rank: 1,
       sId: "earlier-user-message-id",
     };
     const conversationWithEarlierSkill = {
@@ -404,5 +422,46 @@ describe("skill_management enable_skill tool", () => {
       }
     );
     expect(mockEnableForAgent).toHaveBeenCalled();
+  });
+
+  it("does not enable skills referenced before the latest compaction", async () => {
+    const earlierUserMessage = {
+      ...userMessage,
+      content: '<skill id="skill-id" name="commit" />',
+      rank: 1,
+      sId: "earlier-user-message-id",
+    };
+    const compactionMessage: TestCompactionMessage = {
+      content: "Earlier messages summarized.",
+      sId: "compaction-message-id",
+      status: "succeeded",
+      type: "compaction_message",
+      visibility: "visible",
+    };
+    const conversationWithCompaction = {
+      ...conversation,
+      content: [[earlierUserMessage], [compactionMessage], [userMessage]],
+    };
+    mockListForAgentLoop.mockResolvedValue({
+      enabledSkills: [],
+      equippedSkills: [],
+      systemSkills: [],
+    });
+
+    const result = await getTool().handler(
+      { skillName: "commit" },
+      makeExtra({
+        conversationOverride: conversationWithCompaction,
+      })
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(mockFetchActiveByIdsForAgentLoop).toHaveBeenCalledWith(auth, [], {
+      agentConfiguration,
+      agentMessage,
+      conversation: conversationWithCompaction,
+      userMessage,
+    });
+    expect(mockEnableForAgent).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -9,42 +9,17 @@ import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
-import {
-  isCompactionMessageType,
-  isUserMessageType,
-} from "@app/types/assistant/conversation";
+import { isUserMessageType } from "@app/types/assistant/conversation";
 import { Err, Ok } from "@app/types/shared/result";
 
-async function findAvailableSkillForAgentLoop({
-  auth,
-  agentLoopData,
-  skillName,
-}: {
-  auth: Authenticator;
-  agentLoopData: AgentLoopExecutionData;
-  skillName: string;
-}): Promise<SkillResource | null> {
-  const { enabledSkills, equippedSkills, systemSkills } =
-    await SkillResource.listForAgentLoop(auth, agentLoopData);
+function extractSkillIdsFromConversationMessages(
+  agentLoopData: AgentLoopExecutionData
+): string[] {
   const userMessageSkillIds = new Set(
     extractUniqueSkillIds(agentLoopData.userMessage.content)
   );
-  let startIndex = 0;
-  for (let i = agentLoopData.conversation.content.length - 1; i >= 0; i--) {
-    const message = agentLoopData.conversation.content[i].at(-1);
 
-    if (
-      message &&
-      isCompactionMessageType(message) &&
-      message.status === "succeeded"
-    ) {
-      startIndex = i;
-      break;
-    }
-  }
-
-  for (let i = startIndex; i < agentLoopData.conversation.content.length; i++) {
-    const messageVersions = agentLoopData.conversation.content[i];
+  for (const messageVersions of agentLoopData.conversation.content) {
     const message = messageVersions.at(-1);
 
     if (
@@ -59,9 +34,23 @@ async function findAvailableSkillForAgentLoop({
     }
   }
 
+  return [...userMessageSkillIds];
+}
+
+async function findAvailableSkillForAgentLoop({
+  auth,
+  agentLoopData,
+  skillName,
+}: {
+  auth: Authenticator;
+  agentLoopData: AgentLoopExecutionData;
+  skillName: string;
+}): Promise<SkillResource | null> {
+  const { enabledSkills, equippedSkills, systemSkills } =
+    await SkillResource.listForAgentLoop(auth, agentLoopData);
   const userMessageSkills = await SkillResource.fetchActiveByIdsForAgentLoop(
     auth,
-    [...userMessageSkillIds],
+    extractSkillIdsFromConversationMessages(agentLoopData),
     agentLoopData
   );
   const directlyAllowedSkills = [
@@ -83,31 +72,26 @@ async function findAvailableSkillForAgentLoop({
       skill,
     ])
   );
-  const candidates = await SkillResource.listActiveByNameForAgentLoop(
-    auth,
-    skillName,
-    agentLoopData
-  );
-  if (candidates.length === 0) {
+  const candidate = await SkillResource.fetchActiveByName(auth, skillName, {
+    agentLoopData,
+  });
+  if (!candidate) {
     return null;
   }
 
-  const usedBySkillsByChild = await SkillResource.batchFetchUsedBySkills(
-    auth,
-    candidates
-  );
+  const usedBySkillsByChild = await SkillResource.batchFetchUsedBySkills(auth, [
+    candidate,
+  ]);
 
-  return (
-    candidates.find((skill) =>
-      (usedBySkillsByChild.get(skill.sId) ?? []).some(({ sId }) => {
-        const parentSkill = parentSkillById.get(sId);
+  return (usedBySkillsByChild.get(candidate.sId) ?? []).some(({ sId }) => {
+    const parentSkill = parentSkillById.get(sId);
 
-        return parentSkill
-          ? extractUniqueSkillIds(parentSkill.instructions).includes(skill.sId)
-          : false;
-      })
-    ) ?? null
-  );
+    return parentSkill
+      ? extractUniqueSkillIds(parentSkill.instructions).includes(candidate.sId)
+      : false;
+  })
+    ? candidate
+    : null;
 }
 
 const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -9,7 +9,10 @@ import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
-import { isUserMessageType } from "@app/types/assistant/conversation";
+import {
+  isCompactionMessageType,
+  isUserMessageType,
+} from "@app/types/assistant/conversation";
 import { Err, Ok } from "@app/types/shared/result";
 
 async function findAvailableSkillForAgentLoop({
@@ -26,13 +29,29 @@ async function findAvailableSkillForAgentLoop({
   const userMessageSkillIds = new Set(
     extractUniqueSkillIds(agentLoopData.userMessage.content)
   );
-  for (const messageVersions of agentLoopData.conversation.content) {
+  let startIndex = 0;
+  for (let i = agentLoopData.conversation.content.length - 1; i >= 0; i--) {
+    const message = agentLoopData.conversation.content[i].at(-1);
+
+    if (
+      message &&
+      isCompactionMessageType(message) &&
+      message.status === "succeeded"
+    ) {
+      startIndex = i;
+      break;
+    }
+  }
+
+  for (let i = startIndex; i < agentLoopData.conversation.content.length; i++) {
+    const messageVersions = agentLoopData.conversation.content[i];
     const message = messageVersions.at(-1);
 
     if (
       message &&
       isUserMessageType(message) &&
-      message.visibility === "visible"
+      message.visibility === "visible" &&
+      message.rank <= agentLoopData.userMessage.rank
     ) {
       for (const skillId of extractUniqueSkillIds(message.content)) {
         userMessageSkillIds.add(skillId);

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -9,6 +9,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import { isUserMessageType } from "@app/types/assistant/conversation";
 import { Err, Ok } from "@app/types/shared/result";
 
 async function findAvailableSkillForAgentLoop({
@@ -22,9 +23,26 @@ async function findAvailableSkillForAgentLoop({
 }): Promise<SkillResource | null> {
   const { enabledSkills, equippedSkills, systemSkills } =
     await SkillResource.listForAgentLoop(auth, agentLoopData);
+  const userMessageSkillIds = new Set(
+    extractUniqueSkillIds(agentLoopData.userMessage.content)
+  );
+  for (const messageVersions of agentLoopData.conversation.content) {
+    const message = messageVersions.at(-1);
+
+    if (
+      message &&
+      isUserMessageType(message) &&
+      message.visibility === "visible"
+    ) {
+      for (const skillId of extractUniqueSkillIds(message.content)) {
+        userMessageSkillIds.add(skillId);
+      }
+    }
+  }
+
   const userMessageSkills = await SkillResource.fetchActiveByIdsForAgentLoop(
     auth,
-    extractUniqueSkillIds(agentLoopData.userMessage.content),
+    [...userMessageSkillIds],
     agentLoopData
   );
   const directlyAllowedSkills = [

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -892,38 +892,26 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async fetchActiveByName(
     auth: Authenticator,
-    name: string
-  ): Promise<SkillResource | null> {
-    const resources = await this.baseFetch(auth, {
-      where: {
-        name,
-        status: "active",
-      },
-      limit: 1,
-    });
-
-    if (resources.length === 0) {
-      return null;
-    }
-
-    return resources[0];
-  }
-
-  static async listActiveByNameForAgentLoop(
-    auth: Authenticator,
     name: string,
-    agentLoopData: AgentLoopExecutionData
-  ): Promise<SkillResource[]> {
-    return this.baseFetch(
+    { agentLoopData }: { agentLoopData?: AgentLoopExecutionData } = {}
+  ): Promise<SkillResource | null> {
+    const resources = await this.baseFetch(
       auth,
       {
         where: {
           name,
           status: "active",
         },
+        limit: 1,
       },
       { agentLoopData }
     );
+
+    if (resources.length === 0) {
+      return null;
+    }
+
+    return resources[0];
   }
 
   static async fetchByNames(


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/27754.

That PR allowed `enable_skill` to enable skills explicitly tagged in the current user message. A skill tag from an earlier visible user message can still represent user intent for the conversation, but the handler did not include those tags in the allow-list. In that case, the agent could see or refer back to `<skill id="..." name="..." />` from the conversation and still fail to enable the skill by name.

This extends the same user-message allow-list to visible user messages at or before the current user message rank. It keeps the current-user-message path, ignores later messages, and still resolves tagged skills through the agent-loop-aware active-skill fetch.

The PR also removes the redundant `listActiveByNameForAgentLoop` helper from the previous PR and lets `fetchActiveByName` receive optional agent-loop context.

## Risks

Blast radius: skill activation through the `skill_management` MCP tool.
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test

- [x] `NODE_ENV=test npm test lib/api/actions/servers/skill_management/tools/index.test.ts`