### PR TITLE
[Skills] Drop deprecated skill response fields

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -13776,20 +13776,9 @@
             "type": "boolean",
             "description": "Whether the authenticated actor can edit the skill"
           },
-          "isExtendable": {
-            "type": "boolean",
-            "deprecated": true,
-            "description": "Deprecated compatibility field. Always false."
-          },
           "isDefault": {
             "type": "boolean",
             "description": "Whether this skill is enabled by default"
-          },
-          "extendedSkillId": {
-            "type": "string",
-            "nullable": true,
-            "deprecated": true,
-            "description": "Deprecated compatibility field. Always null."
           },
           "instructions": {
             "type": "string",

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -676,18 +676,9 @@
  *         canWrite:
  *           type: boolean
  *           description: Whether the authenticated actor can edit the skill
- *         isExtendable:
- *           type: boolean
- *           deprecated: true
- *           description: Deprecated compatibility field. Always false.
  *         isDefault:
  *           type: boolean
  *           description: Whether this skill is enabled by default
- *         extendedSkillId:
- *           type: string
- *           nullable: true
- *           deprecated: true
- *           description: Deprecated compatibility field. Always null.
  *         instructions:
  *           type: string
  *           nullable: true

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -27,9 +27,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     tools: [],
     fileAttachments: [],
     canWrite: true,
-    isExtendable: false,
     isDefault: false,
-    extendedSkillId: null,
     ...overrides,
   };
 }

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -26,9 +26,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     tools: [],
     fileAttachments: [],
     canWrite: true,
-    isExtendable: false,
     isDefault: false,
-    extendedSkillId: null,
     ...overrides,
   };
 }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -3678,9 +3678,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         fileName: file.fileName,
       })),
       canWrite: this.canWrite(auth),
-      isExtendable: false,
       isDefault: this.isDefault,
-      extendedSkillId: null,
     };
   }
 

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -89,9 +89,7 @@ function makeSkillType(config: MockSkillConfig): SkillType {
     })),
     fileAttachments: [],
     canWrite: false,
-    isExtendable: false,
     isDefault: false,
-    extendedSkillId: null,
   };
 }
 

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -55,9 +55,7 @@ export const SkillWithoutInstructionsAndToolsSchema = z.object({
     })
   ),
   canWrite: z.boolean(),
-  isExtendable: z.boolean(),
   isDefault: z.boolean(),
-  extendedSkillId: z.string().nullable(),
 });
 
 export type SkillWithoutInstructionsAndToolsType = z.infer<


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/8616. Follows https://github.com/dust-tt/dust/pull/27781 and https://github.com/dust-tt/dust/pull/27899.

Removes the deprecated skill response compatibility fields `isExtendable` and `extendedSkillId` from `SkillType`, `SkillResource.toJSON()`, and the public OpenAPI schema. These fields were legacy customized-skill compatibility shims and have only returned `false` / `null` since the customized-skill cleanup.

This is a breaking response-shape cleanup for clients still reading those deprecated fields.

## Risks
Blast radius: public skill API responses and internal code typed against `SkillType`.
Risk: standard. The removed fields were deprecated constant values, but API consumers that still read them must stop depending on them.

## Deploy Plan
- Deploy `front`

- ⚠️ For this API change we could wonder about backwards compatibility. IMO we don't need to address it, as it's 1. a cleanup, 2. very small product surface; ifever it breaks a few api calls, we can address directly via support
