### PR TITLE
Plan mode > all in DustFileSystem

### DIFF
--- a/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.test.ts
+++ b/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.test.ts
@@ -42,10 +42,7 @@ function planUpdatedEvent(): ConversationEvent {
       type: "plan_updated",
       created: 0,
       conversationId: "conv",
-      planFileId: "file",
-      version: 1,
       isClosed: false,
-      hasApproval: false,
     },
   };
 }

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
@@ -1,19 +1,10 @@
-import {
-  PLAN_MODE_SERVER_NAME,
-  REQUEST_PLAN_APPROVAL_TOOL_NAME,
-} from "@app/lib/api/actions/servers/plan_mode/metadata";
 import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { findActivePlanFile } from "@app/lib/api/assistant/plan_mode";
-import { getFileContent } from "@app/lib/api/files/utils";
-import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import type {
-  GetConversationPlanModeResponseBody,
-  PlanApprovalState,
-} from "@app/types/api/assistant/plan_mode";
+import { getActivePlanContent } from "@app/lib/api/assistant/plan_mode";
+import type { GetConversationPlanModeResponseBody } from "@app/types/api/assistant/plan_mode";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
@@ -32,51 +23,28 @@ app.get(
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
 
-    // Ensure the caller has access to the conversation.
     const conversationRes = await getLightConversation(auth, cId);
     if (conversationRes.isErr()) {
       return apiErrorForConversation(ctx, conversationRes.error);
     }
 
-    const planFile = await findActivePlanFile(auth, cId);
-    if (!planFile) {
-      return ctx.json({
-        planFile: null,
-        content: null,
-        approvalState: "draft" as PlanApprovalState,
-      });
+    const contentRes = await getActivePlanContent(auth, conversationRes.value);
+    if (contentRes.isErr()) {
+      // A missing plan is Ok(null); an Err here is a real read failure, surfaced not silenced.
+      return apiError(
+        ctx,
+        {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to read the plan content.",
+          },
+        },
+        contentRes.error
+      );
     }
 
-    // Sequential fetches to avoid holding multiple DB connections from the pool simultaneously.
-    const content = await getFileContent(auth, planFile, "original");
-    const conversationResource = await ConversationResource.fetchById(
-      auth,
-      cId
-    );
-    const blockedActions = conversationResource
-      ? await AgentMCPActionResource.listBlockedActionsForConversation(
-          auth,
-          conversationResource
-        )
-      : [];
-
-    const hasPendingApproval = blockedActions.some(
-      (a) =>
-        a.metadata.mcpServerName === PLAN_MODE_SERVER_NAME &&
-        a.metadata.toolName === REQUEST_PLAN_APPROVAL_TOOL_NAME
-    );
-
-    const approvalState: PlanApprovalState = hasPendingApproval
-      ? "pending"
-      : planFile.useCaseMetadata?.planModeLastApproval != null
-        ? "approved"
-        : "draft";
-
-    return ctx.json({
-      planFile: planFile.toJSON(auth),
-      content,
-      approvalState,
-    });
+    return ctx.json({ content: contentRes.value });
   }
 );
 

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -248,20 +248,6 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
     return accessCheck;
   }
 
-  // Plan-mode files are agent-owned: the user interacts with them only through
-  // the agent (via messages and approval decisions), never by direct mutation.
-  // The agent can retire a plan via the `close_plan` tool.
-  if (file.useCaseMetadata?.isPlanFile) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "plan.md is managed by the agent and cannot be deleted directly. Ask the agent to close the plan.",
-      },
-    });
-  }
-
   const space = await getSpaceForFile(auth, file);
   const isFileAuthor = file.userId === auth.user()?.id;
   const isUploadUseCase =
@@ -319,18 +305,6 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const accessCheck = await checkFileAccess(ctx, file);
   if (accessCheck) {
     return accessCheck;
-  }
-
-  // Plan-mode files are agent-owned; users cannot upload over them.
-  if (file.useCaseMetadata?.isPlanFile) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "plan.md is managed by the agent and cannot be overwritten directly.",
-      },
-    });
   }
 
   const space = await getSpaceForFile(auth, file);

--- a/front-api/routes/w/[wId]/files/[fileId]/rename.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/rename.ts
@@ -39,18 +39,6 @@ app.patch(
       });
     }
 
-    // Plan-mode files are agent-owned; users cannot rename them.
-    if (file.useCaseMetadata?.isPlanFile) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "plan.md is managed by the agent and cannot be renamed directly.",
-        },
-      });
-    }
-
     const space = file.useCaseMetadata?.spaceId
       ? await SpaceResource.fetchById(auth, file.useCaseMetadata.spaceId)
       : null;

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -725,11 +725,10 @@ export const ConversationViewer = ({
 
   const eventIds = useRef<string[]>([]);
 
-  // Last-seen plan.md version for this conversation. Used to auto-open the plan panel on the
-  // skeleton-to-first-edit transition (v1 -> v2+). If the user lands on an already-populated
-  // plan, no auto-open. ConversationViewer is keyed on conversationId by its parent, so the
-  // ref is naturally reset on conversation switch via remount.
-  const lastPlanVersionRef = useRef<number | undefined>(undefined);
+  // Whether we have already auto-opened the plan panel for this conversation, so we open it once
+  // (on the first non-closed plan update) rather than on every edit. ConversationViewer is keyed
+  // on conversationId by its parent, so the ref is naturally reset on conversation switch.
+  const planAutoOpenedRef = useRef(false);
 
   // `onEventCallback` is bound by `useConversationEvents` once at mount and does not re-subscribe
   // on identity changes (see useEventSource intentional behavior). Any state read from the
@@ -1058,15 +1057,12 @@ export const ConversationViewer = ({
             window.dispatchEvent(new CompactionCompletedEvent());
             break;
           case "plan_updated": {
-            const prevVersion = lastPlanVersionRef.current;
-            lastPlanVersionRef.current = event.version;
-            if (event.isClosed && currentPanelRef.current === "plan") {
-              closePanel();
-            } else if (
-              prevVersion === 1 &&
-              event.version >= 2 &&
-              !isMobileRef.current
-            ) {
+            if (event.isClosed) {
+              if (currentPanelRef.current === "plan") {
+                closePanel();
+              }
+            } else if (!planAutoOpenedRef.current && !isMobileRef.current) {
+              planAutoOpenedRef.current = true;
               openPanel({ type: "plan" });
             }
             void mutate(

--- a/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
+++ b/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
@@ -1,6 +1,6 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import {
-  ApprovalStateChip,
+  contentHash,
   extractPlanTitle,
 } from "@app/components/assistant/conversation/plan_mode/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
@@ -8,6 +8,7 @@ import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, Markdown, Spinner, XClose } from "@dust-tt/sparkle";
+import { useMemo } from "react";
 
 interface ConversationPlanModePanelProps {
   conversation: ConversationWithoutContentType;
@@ -19,12 +20,16 @@ export function ConversationPlanModePanel({
   owner,
 }: ConversationPlanModePanelProps) {
   const { closePanel } = useConversationSidePanelContext();
-  const { planFile, content, approvalState, isPlanLoading } = usePlanFile({
+  const { content, isPlanLoading } = usePlanFile({
     conversationId: conversation.sId,
     workspaceId: owner.sId,
   });
 
   const title = extractPlanTitle(content);
+  const markdownKey = useMemo(
+    () => (content ? contentHash(content) : ""),
+    [content]
+  );
 
   return (
     <div className="flex h-full flex-col">
@@ -34,7 +39,6 @@ export function ConversationPlanModePanel({
             <span className="truncate text-sm font-semibold text-foreground dark:text-foreground-night">
               Plan: {title}
             </span>
-            <ApprovalStateChip state={approvalState} />
           </div>
           <Button
             variant="ghost"
@@ -49,15 +53,14 @@ export function ConversationPlanModePanel({
           <div className="flex h-full items-center justify-center">
             <Spinner />
           </div>
-        ) : !planFile ? (
+        ) : !content ? (
           <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
             No active plan for this conversation.
           </div>
         ) : (
-          // Key by planFile.version so React remounts on each edit. Sparkle's `Markdown`
-          // memoizes AST nodes for streaming reveal, which can hold stale child nodes when the
-          // full content prop changes between edits. Remounting forces a clean render.
-          content && <Markdown key={planFile.version} content={content} />
+          // Remount on each edit: Sparkle's `Markdown` memoizes AST nodes for streaming reveal and
+          // can keep stale children when the whole content prop is replaced between edits.
+          <Markdown key={markdownKey} content={content} />
         )}
       </div>
     </div>

--- a/front/components/assistant/conversation/plan_mode/PlanCard.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanCard.tsx
@@ -1,8 +1,5 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import {
-  ApprovalStateChip,
-  extractPlanTitle,
-} from "@app/components/assistant/conversation/plan_mode/utils";
+import { extractPlanTitle } from "@app/components/assistant/conversation/plan_mode/utils";
 import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { ChevronRight, cn, File04, Icon } from "@dust-tt/sparkle";
@@ -37,7 +34,7 @@ export const PlanCard = React.memo(function PlanCard({
 }: PlanCardProps) {
   const { hasFeature } = useFeatureFlags();
   const isPlanModeEnabled = hasFeature("plan_mode");
-  const { planFile, content, approvalState } = usePlanFile({
+  const { content } = usePlanFile({
     // Skip the fetch entirely for workspaces without the plan_mode feature flag.
     conversationId: isPlanModeEnabled ? conversationId : null,
     workspaceId,
@@ -47,12 +44,8 @@ export const PlanCard = React.memo(function PlanCard({
   const title = useMemo(() => extractPlanTitle(content), [content]);
   const progress = useMemo(() => countProgress(content), [content]);
 
-  // Hide the card until the plan has been edited at least once (version >= 2). The skeleton
-  // upload from `create_plan` produces version 1; the first `edit_plan` bumps it to 2. This
-  // matches the side-panel auto-open trigger so the card appears at the same moment the panel
-  // first opens. `findActivePlanFile` already filters closed plans server-side, so `!planFile`
-  // also covers the post-close_plan case.
-  if (!planFile || planFile.version < 2) {
+  // No active plan (including post-close): `getActivePlanContent` returns null.
+  if (!content) {
     return null;
   }
 
@@ -69,7 +62,6 @@ export const PlanCard = React.memo(function PlanCard({
     >
       <Icon visual={File04} size="sm" />
       <span className="heading-sm grow truncate">Plan: {title}</span>
-      <ApprovalStateChip state={approvalState} />
       {progress.total > 0 && (
         <span className="copy-xs shrink-0 text-muted-foreground dark:text-muted-foreground-night">
           {progress.done}/{progress.total} done

--- a/front/components/assistant/conversation/plan_mode/utils.tsx
+++ b/front/components/assistant/conversation/plan_mode/utils.tsx
@@ -1,7 +1,3 @@
-import type { PlanApprovalState } from "@app/types/api/assistant/plan_mode";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import { Chip } from "@dust-tt/sparkle";
-
 const TITLE_REGEX = /^#\s+(.+)$/m;
 
 export function extractPlanTitle(content: string | null): string {
@@ -12,16 +8,12 @@ export function extractPlanTitle(content: string | null): string {
   return match ? match[1].trim() : "Untitled plan";
 }
 
-export function ApprovalStateChip({ state }: { state: PlanApprovalState }) {
-  switch (state) {
-    case "approved":
-      return <Chip size="mini" color="success" label="Approved" />;
-    case "pending":
-      return <Chip size="mini" color="warning" label="Pending approval" />;
-    case "draft":
-      return null;
-    default:
-      assertNeverAndIgnore(state);
-      return null;
+// Short, content-sensitive key (djb2) so the Markdown remounts on any edit without using the full
+// content string as a React key.
+export function contentHash(content: string): string {
+  let hash = 5381;
+  for (let i = 0; i < content.length; i++) {
+    hash = (hash * 33) ^ content.charCodeAt(i);
   }
+  return (hash >>> 0).toString(36);
 }

--- a/front/hooks/conversations/usePlanFile.ts
+++ b/front/hooks/conversations/usePlanFile.ts
@@ -28,9 +28,7 @@ export function usePlanFile({
   );
 
   return {
-    planFile: data?.planFile ?? null,
     content: data?.content ?? null,
-    approvalState: data?.approvalState ?? "draft",
     isPlanLoading: conversationId != null && !error && !data,
     isPlanError: error,
     mutatePlan: mutate,

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -487,7 +487,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "close_plan": "never_ask",
     "create_plan": "never_ask",
     "edit_plan": "never_ask",
-    "request_plan_approval": "high",
   },
   "pod_manager": {
     "add_content_node": "never_ask",

--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -19,13 +19,15 @@ export const CREATE_PLAN_TOOL_NAME = "create_plan" as const;
 export const EDIT_PLAN_TOOL_NAME = "edit_plan" as const;
 export const CLOSE_PLAN_TOOL_NAME = "close_plan" as const;
 
+export const PLAN_FILE_NAME = "plan.md" as const;
+
 export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
   create_plan: {
     description:
-      "Create the conversation's `plan.md` with the markdown you pass as `content`. Write the " +
+      `Create the conversation's \`${PLAN_FILE_NAME}\` with the markdown you pass as \`content\`. Write the ` +
       "full plan directly; do not create an empty plan and then edit it. Exactly one active " +
-      "plan is allowed per conversation; call `close_plan` to retire the current one first if " +
-      "the user wants a fresh plan. Use `edit_plan` for subsequent updates.\n\n" +
+      `plan is allowed per conversation; call \`${CLOSE_PLAN_TOOL_NAME}\` to retire the current one first if ` +
+      `the user wants a fresh plan. Use \`${EDIT_PLAN_TOOL_NAME}\` for subsequent updates.\n\n` +
       "Recommended structure:\n\n" +
       "```markdown\n" +
       PLAN_MODE_SKELETON +
@@ -47,8 +49,8 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
   },
   edit_plan: {
     description:
-      "Edit the active `plan.md` by replacing `old_string` with `new_string`. The full updated " +
-      "contents of plan.md are returned so you can see your change.\n\n" +
+      `Edit the active \`${PLAN_FILE_NAME}\` by replacing \`old_string\` with \`new_string\`. The full updated ` +
+      `contents of ${PLAN_FILE_NAME} are returned so you can see your change.\n\n` +
       "`old_string` must match exactly once in the current file. If it matches zero or multiple " +
       "times, the edit fails and you must retry with a more specific string. Use an empty " +
       "`new_string` to delete `old_string`.\n\n" +
@@ -57,7 +59,7 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
       old_string: z
         .string()
         .describe(
-          "The exact string in plan.md to replace. Must match exactly once."
+          `The exact string in ${PLAN_FILE_NAME} to replace. Must match exactly once.`
         ),
       new_string: z
         .string()
@@ -73,9 +75,9 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
   },
   close_plan: {
     description:
-      "Retire the current plan. After close_plan, the plan is hidden from the UI and this " +
-      "skill will not reference it again. You can call `create_plan` to start a fresh plan " +
-      "later. Close is terminal; use `edit_plan` to iterate on the plan instead of closing it.\n\n" +
+      `Retire the current plan. After ${CLOSE_PLAN_TOOL_NAME}, the plan is hidden from the UI and this ` +
+      `skill will not reference it again. You can call \`${CREATE_PLAN_TOOL_NAME}\` to start a fresh plan ` +
+      `later. Close is terminal; use \`${EDIT_PLAN_TOOL_NAME}\` to iterate on the plan instead of closing it.\n\n` +
       "See skill instructions for when to call this.",
     schema: {
       reason: z
@@ -99,7 +101,7 @@ export const PLAN_MODE_SERVER = {
     name: PLAN_MODE_SERVER_NAME,
     version: "1.0.0",
     description:
-      "Create and maintain a living `plan.md` that gives the user visibility on non-trivial " +
+      `Create and maintain a living \`${PLAN_FILE_NAME}\` that gives the user visibility on non-trivial ` +
       "work. When you need explicit sign-off before proceeding, ask the user with the standard " +
       "question flow.",
     icon: "ActionDocumentTextIcon" as const,

--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -4,32 +4,41 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-// Initial content seeded into plan.md on create_plan.
-export const PLAN_MODE_SKELETON = `# Untitled plan
+export const PLAN_MODE_SKELETON = `# <plan title>
 
 ## Context
-_Fill in: why we're doing this, what the user asked for._
+_Why we're doing this, what the user asked for._
 
 ## Tasks
-- [ ] _Fill in the first task_
+- [ ] _First task_
 `;
 
 export const PLAN_MODE_SERVER_NAME = "plan_mode" as const;
 
 export const CREATE_PLAN_TOOL_NAME = "create_plan" as const;
 export const EDIT_PLAN_TOOL_NAME = "edit_plan" as const;
-export const REQUEST_PLAN_APPROVAL_TOOL_NAME = "request_plan_approval" as const;
 export const CLOSE_PLAN_TOOL_NAME = "close_plan" as const;
 
 export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
   create_plan: {
     description:
-      "Create a `plan.md` file attached to this conversation, seeded with a Context + Tasks " +
-      "skeleton. Exactly one active plan is allowed per conversation; call `close_plan` to " +
-      "retire the current one first if the user wants a fresh plan. After creating, populate " +
-      "the skeleton via `edit_plan`.\n\n" +
+      "Create the conversation's `plan.md` with the markdown you pass as `content`. Write the " +
+      "full plan directly; do not create an empty plan and then edit it. Exactly one active " +
+      "plan is allowed per conversation; call `close_plan` to retire the current one first if " +
+      "the user wants a fresh plan. Use `edit_plan` for subsequent updates.\n\n" +
+      "Recommended structure:\n\n" +
+      "```markdown\n" +
+      PLAN_MODE_SKELETON +
+      "```\n\n" +
       "See skill instructions for when to call this and the end-to-end workflow.",
-    schema: {},
+    schema: {
+      content: z
+        .string()
+        .describe(
+          "The full markdown content of the plan. Use a `# title`, a `## Context` section, and " +
+            "a `## Tasks` checklist (`- [ ]` items)."
+        ),
+    },
     stake: "never_ask",
     displayLabels: {
       running: "Creating plan",
@@ -43,11 +52,6 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
       "`old_string` must match exactly once in the current file. If it matches zero or multiple " +
       "times, the edit fails and you must retry with a more specific string. Use an empty " +
       "`new_string` to delete `old_string`.\n\n" +
-      "A freshly-created plan.md (via `create_plan`) contains this exact skeleton you need to " +
-      "populate with your first edits:\n\n" +
-      "```markdown\n" +
-      PLAN_MODE_SKELETON +
-      "```\n\n" +
       "See skill instructions for when to edit and how to use task markers.",
     schema: {
       old_string: z
@@ -65,34 +69,6 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Updating plan",
       done: "Plan updated",
-    },
-  },
-  request_plan_approval: {
-    description:
-      "Surface the current plan.md to the user and pause execution pending their decision. " +
-      "The user sees an approval card and either approves or rejects. On approve, the tool " +
-      "returns success and execution resumes. On reject, the tool returns with `denied` status " +
-      "and the handler does not run.\n\n" +
-      "Only call when plan.md is ready. Do not call with an incomplete plan.\n\n" +
-      "See skill instructions for when to request approval and how to handle rejection.",
-    schema: {
-      summary: z
-        .string()
-        .optional()
-        .describe(
-          "Optional one-sentence TL;DR shown to the user as the body of the approval card. " +
-            "Provide it when the plan is long enough that a one-liner helps the user decide at " +
-            "a glance; omit for short plans."
-        ),
-    },
-    // `high` routes the tool through the existing MCP tool-approval machinery: the workflow exits
-    // cleanly with the action in `blocked_validation_required`, the UI renders an approval card,
-    // and on approve the tool handler runs (stamping approval onto plan.md). On reject the
-    // handler does not run; the agent sees the action as denied and can iterate.
-    stake: "high",
-    displayLabels: {
-      running: "Requesting plan approval",
-      done: "Plan approved",
     },
   },
   close_plan: {
@@ -124,7 +100,8 @@ export const PLAN_MODE_SERVER = {
     version: "1.0.0",
     description:
       "Create and maintain a living `plan.md` that gives the user visibility on non-trivial " +
-      "work. Optionally surface the plan for explicit user approval before proceeding.",
+      "work. When you need explicit sign-off before proceeding, ask the user with the standard " +
+      "question flow.",
     icon: "ActionDocumentTextIcon" as const,
     authorization: null,
     documentationUrl: null,

--- a/front/lib/api/actions/servers/plan_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/tools/index.ts
@@ -3,50 +3,45 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { PLAN_MODE_TOOLS_METADATA } from "@app/lib/api/actions/servers/plan_mode/metadata";
 import {
-  createPlanFile,
-  findActivePlanFile,
-  markPlanApproved,
-  markPlanClosed,
+  closePlan,
+  getActivePlanContent,
   withPlanModeLock,
+  writePlanContent,
 } from "@app/lib/api/assistant/plan_mode";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
-import {
-  getFileContent,
-  getUpdatedContentAndOccurrences,
-} from "@app/lib/api/files/utils";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 async function publishPlanUpdated(
   conversationId: string,
-  planFile: FileResource
+  { isClosed }: { isClosed: boolean }
 ): Promise<void> {
   await publishConversationEvent(
     {
       type: "plan_updated",
       created: Date.now(),
       conversationId,
-      planFileId: planFile.sId,
-      version: planFile.version,
-      isClosed: planFile.useCaseMetadata?.isPlanClosed === true,
-      hasApproval: planFile.useCaseMetadata?.planModeLastApproval != null,
+      isClosed,
     },
     { conversationId }
   );
 }
 
 const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
-  create_plan: async (_params, { auth, agentLoopContext }) => {
+  create_plan: async ({ content }, { auth, agentLoopContext }) => {
     if (!agentLoopContext?.runContext) {
       return new Err(new MCPError("Agent loop context is required."));
     }
-    const { conversation, agentConfiguration } = agentLoopContext.runContext;
+    const { conversation } = agentLoopContext.runContext;
 
     return withPlanModeLock(conversation.sId, async () => {
-      const existing = await findActivePlanFile(auth, conversation.sId);
-      if (existing) {
+      const existing = await getActivePlanContent(auth, conversation);
+      if (existing.isErr()) {
+        return new Err(new MCPError(existing.error.message));
+      }
+      if (existing.value !== null) {
         return new Err(
           new MCPError(
             "A plan already exists for this conversation. Use `edit_plan` to update it, or " +
@@ -55,17 +50,17 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
         );
       }
 
-      const planFile = await createPlanFile(auth, {
-        conversationId: conversation.sId,
-        agentConfigurationId: agentConfiguration.sId,
-      });
+      const created = await writePlanContent(auth, conversation, content);
+      if (created.isErr()) {
+        return new Err(new MCPError(created.error.message));
+      }
 
-      await publishPlanUpdated(conversation.sId, planFile);
+      await publishPlanUpdated(conversation.sId, { isClosed: false });
 
       return new Ok([
         {
           type: "text",
-          text: `plan.md created (file id: ${planFile.sId}). Populate it via \`edit_plan\`.`,
+          text: `plan.md created. Current contents:\n\n${content}`,
         },
       ]);
     });
@@ -75,22 +70,21 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     if (!agentLoopContext?.runContext) {
       return new Err(new MCPError("Agent loop context is required."));
     }
-    const { conversation, agentConfiguration } = agentLoopContext.runContext;
+    const { conversation } = agentLoopContext.runContext;
 
     try {
       return await withPlanModeLock(conversation.sId, async () => {
-        const planFile = await findActivePlanFile(auth, conversation.sId);
-        if (!planFile) {
+        const contentRes = await getActivePlanContent(auth, conversation);
+        if (contentRes.isErr()) {
+          return new Err(new MCPError("Failed to read plan.md."));
+        }
+        const currentContent = contentRes.value;
+        if (currentContent === null) {
           return new Err(
             new MCPError(
               "No active plan.md for this conversation. Call `create_plan` first to start one."
             )
           );
-        }
-
-        const currentContent = await getFileContent(auth, planFile, "original");
-        if (currentContent === null) {
-          return new Err(new MCPError("Failed to read plan.md."));
         }
 
         const { updatedContent, occurrences } = getUpdatedContentAndOccurrences(
@@ -118,19 +112,16 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
           );
         }
 
-        await planFile.uploadContent(auth, updatedContent);
-
-        if (
-          planFile.useCaseMetadata?.lastEditedByAgentConfigurationId !==
-          agentConfiguration.sId
-        ) {
-          await planFile.setUseCaseMetadata(auth, {
-            ...planFile.useCaseMetadata,
-            lastEditedByAgentConfigurationId: agentConfiguration.sId,
-          });
+        const writeRes = await writePlanContent(
+          auth,
+          conversation,
+          updatedContent
+        );
+        if (writeRes.isErr()) {
+          return new Err(new MCPError(writeRes.error.message));
         }
 
-        await publishPlanUpdated(conversation.sId, planFile);
+        await publishPlanUpdated(conversation.sId, { isClosed: false });
 
         return new Ok([
           {
@@ -148,65 +139,6 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     }
   },
 
-  request_plan_approval: async ({ summary }, { auth, agentLoopContext }) => {
-    if (!agentLoopContext?.runContext) {
-      return new Err(new MCPError("Agent loop context is required."));
-    }
-    const { conversation } = agentLoopContext.runContext;
-
-    // Handler only runs after user approval (tool stake is "high" → routes through the standard
-    // MCP tool-approval flow). On reject, this function is never called; the agent sees the
-    // action as denied.
-    return withPlanModeLock(conversation.sId, async () => {
-      const planFile = await findActivePlanFile(auth, conversation.sId);
-      if (!planFile) {
-        return new Err(
-          new MCPError(
-            "No active plan.md for this conversation. `request_plan_approval` requires an " +
-              "existing plan — create one first with `create_plan` and populate it."
-          )
-        );
-      }
-
-      const user = auth.user();
-      if (!user) {
-        return new Err(
-          new MCPError("No user on auth context; cannot record approval.")
-        );
-      }
-
-      // Note: `user.sId` here is the author of the user message that triggered the agent loop,
-      // not necessarily the person who clicked Approve. The existing validate-action check
-      // requires those to be the same user, so in practice they match — but if validate-action
-      // is ever opened up, this needs to become the actual approver's sId from the approval
-      // callback.
-      const approval = await markPlanApproved(auth, planFile, user.sId);
-      if (!approval) {
-        // Plan was closed between approval request and approval decision (close_plan race).
-        return new Err(
-          new MCPError(
-            "The plan was closed while approval was pending. It cannot be approved anymore."
-          )
-        );
-      }
-
-      await publishPlanUpdated(conversation.sId, planFile);
-
-      return new Ok([
-        {
-          type: "text",
-          text:
-            `Plan approved by ${user.sId} at ${approval.approvedAt} ` +
-            `(plan.md version ${approval.fileVersion}). Proceed with execution: work ` +
-            `through the tasks in plan.md, using \`edit_plan\` to check them off as you ` +
-            `go. Stay within the approved scope; if scope changes, surface it to the user ` +
-            `before acting.` +
-            (summary ? `\n\nSummary shown to user: ${summary}` : ""),
-        },
-      ]);
-    });
-  },
-
   close_plan: async ({ reason }, { auth, agentLoopContext }) => {
     if (!agentLoopContext?.runContext) {
       return new Err(new MCPError("Agent loop context is required."));
@@ -214,8 +146,11 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     const { conversation } = agentLoopContext.runContext;
 
     return withPlanModeLock(conversation.sId, async () => {
-      const planFile = await findActivePlanFile(auth, conversation.sId);
-      if (!planFile) {
+      const existing = await getActivePlanContent(auth, conversation);
+      if (existing.isErr()) {
+        return new Err(new MCPError(existing.error.message));
+      }
+      if (existing.value === null) {
         return new Err(
           new MCPError(
             "No active plan.md for this conversation. Nothing to close."
@@ -223,19 +158,18 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
         );
       }
 
-      // Intentionally do not resolve any pending `request_plan_approval` blocked action here.
-      // The codebase only transitions blocked actions to terminal via user action on the
-      // approval card itself (UI or email). If a stale card remains after close, existing
-      // paths degrade gracefully: `markPlanApproved` already no-ops on closed plans, and a
-      // reject goes through the normal relaunch flow.
-      await markPlanClosed(auth, planFile);
-      await publishPlanUpdated(conversation.sId, planFile);
+      // Closing only moves plan.md into the archive folder; the content is preserved.
+      const closed = await closePlan(auth, conversation);
+      if (closed.isErr()) {
+        return new Err(new MCPError(closed.error.message));
+      }
+
+      await publishPlanUpdated(conversation.sId, { isClosed: true });
 
       if (reason) {
         logger.info(
           {
             conversationId: conversation.sId,
-            planFileId: planFile.sId,
             reason,
           },
           "Plan closed by agent"
@@ -246,9 +180,8 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
         {
           type: "text",
           text:
-            "Plan closed. The plan.md is now hidden from the UI and will no longer be " +
-            "referenced. If the user later asks for a new plan, call `create_plan` to " +
-            "start a fresh one.",
+            "Plan closed. The plan.md is now archived and will no longer be referenced. If the " +
+            "user later asks for a new plan, call `create_plan` to start a fresh one.",
         },
       ]);
     });

--- a/front/lib/api/actions/servers/plan_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/tools/index.ts
@@ -1,7 +1,13 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { PLAN_MODE_TOOLS_METADATA } from "@app/lib/api/actions/servers/plan_mode/metadata";
+import {
+  CLOSE_PLAN_TOOL_NAME,
+  CREATE_PLAN_TOOL_NAME,
+  EDIT_PLAN_TOOL_NAME,
+  PLAN_FILE_NAME,
+  PLAN_MODE_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/plan_mode/metadata";
 import {
   closePlan,
   getActivePlanContent,
@@ -44,8 +50,8 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
       if (existing.value !== null) {
         return new Err(
           new MCPError(
-            "A plan already exists for this conversation. Use `edit_plan` to update it, or " +
-              "`close_plan` first if the user explicitly wants to drop it and start over."
+            `A plan already exists for this conversation. Use \`${EDIT_PLAN_TOOL_NAME}\` to update it, or ` +
+              `\`${CLOSE_PLAN_TOOL_NAME}\` first if the user explicitly wants to drop it and start over.`
           )
         );
       }
@@ -60,7 +66,7 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text",
-          text: `plan.md created. Current contents:\n\n${content}`,
+          text: `${PLAN_FILE_NAME} created. Current contents:\n\n${content}`,
         },
       ]);
     });
@@ -76,13 +82,13 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
       return await withPlanModeLock(conversation.sId, async () => {
         const contentRes = await getActivePlanContent(auth, conversation);
         if (contentRes.isErr()) {
-          return new Err(new MCPError("Failed to read plan.md."));
+          return new Err(new MCPError(`Failed to read ${PLAN_FILE_NAME}.`));
         }
         const currentContent = contentRes.value;
         if (currentContent === null) {
           return new Err(
             new MCPError(
-              "No active plan.md for this conversation. Call `create_plan` first to start one."
+              `No active ${PLAN_FILE_NAME} for this conversation. Call \`${CREATE_PLAN_TOOL_NAME}\` first to start one.`
             )
           );
         }
@@ -98,7 +104,7 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
         if (occurrences === 0) {
           return new Err(
             new MCPError(
-              `\`old_string\` not found in plan.md. Make sure it matches the file content ` +
+              `\`old_string\` not found in ${PLAN_FILE_NAME}. Make sure it matches the file content ` +
                 `exactly (including whitespace).`
             )
           );
@@ -106,7 +112,7 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
         if (occurrences > 1) {
           return new Err(
             new MCPError(
-              `\`old_string\` matches ${occurrences} locations in plan.md. Provide a more ` +
+              `\`old_string\` matches ${occurrences} locations in ${PLAN_FILE_NAME}. Provide a more ` +
                 `specific string so it matches exactly once.`
             )
           );
@@ -126,14 +132,14 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
         return new Ok([
           {
             type: "text",
-            text: `plan.md updated. Current contents:\n\n${updatedContent}`,
+            text: `${PLAN_FILE_NAME} updated. Current contents:\n\n${updatedContent}`,
           },
         ]);
       });
     } catch (err) {
       return new Err(
         new MCPError(
-          `plan.md is currently being edited by another operation: ${normalizeError(err).message}`
+          `${PLAN_FILE_NAME} is currently being edited by another operation: ${normalizeError(err).message}`
         )
       );
     }
@@ -153,7 +159,7 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
       if (existing.value === null) {
         return new Err(
           new MCPError(
-            "No active plan.md for this conversation. Nothing to close."
+            `No active ${PLAN_FILE_NAME} for this conversation. Nothing to close.`
           )
         );
       }
@@ -180,8 +186,8 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
         {
           type: "text",
           text:
-            "Plan closed. The plan.md is now archived and will no longer be referenced. If the " +
-            "user later asks for a new plan, call `create_plan` to start a fresh one.",
+            `Plan closed. The ${PLAN_FILE_NAME} is now archived and will no longer be referenced. If the ` +
+            `user later asks for a new plan, call \`${CREATE_PLAN_TOOL_NAME}\` to start a fresh one.`,
         },
       ]);
     });

--- a/front/lib/api/assistant/plan_mode.test.ts
+++ b/front/lib/api/assistant/plan_mode.test.ts
@@ -1,0 +1,125 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import {
+  closePlan,
+  getActivePlanContent,
+  writePlanContent,
+} from "@app/lib/api/assistant/plan_mode";
+import type { FileSystemEntry } from "@app/lib/api/file_system/dust_file_system";
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import type { Authenticator } from "@app/lib/auth";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { Ok } from "@app/types/shared/result";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The GCS mock records `file.save(...)` (writes) and gates reads on `exists`, but it does not
+// implement bucket listing/copy or stream reads. So we assert on what was written, on the
+// missing-file read path, and stub the file system for `closePlan`. Reading back real content is
+// out of reach of this mock.
+async function setup(): Promise<{
+  auth: Authenticator;
+  conversation: ConversationWithoutContentType;
+}> {
+  const { authenticator: auth } = await createResourceTest({ role: "admin" });
+  const conversation = await createConversation(auth, {
+    title: "Plan mode test",
+    visibility: "unlisted",
+    spaceId: null,
+  });
+  return { auth, conversation };
+}
+
+function lastPlanWrite(): string | null {
+  const calls = fileStorageMock.saveFileCalls.filter((c) =>
+    c.filePath.endsWith("/files/plan.md")
+  );
+  const last = calls[calls.length - 1];
+  return last ? last.content.toString() : null;
+}
+
+function fileEntry(fileName: string): FileSystemEntry {
+  return {
+    isDirectory: false,
+    fileName,
+    path: `x/${fileName}`,
+    sizeBytes: 0,
+    lastModifiedMs: 0,
+    contentType: "text/markdown",
+    fileId: null,
+    thumbnailUrl: null,
+  };
+}
+
+// closePlan lists the archive folder then moves plan.md to the next index. The storage mock can't
+// list/move, so spy on the file system methods to assert the index computation and destination path.
+function stubFsForClose(archivedEntries: FileSystemEntry[]) {
+  vi.spyOn(DustFileSystem.prototype, "list").mockResolvedValue(
+    new Ok(archivedEntries)
+  );
+  const move = vi
+    .spyOn(DustFileSystem.prototype, "move")
+    .mockResolvedValue(new Ok({ sourceDeletionFailed: false }));
+  return { move };
+}
+
+describe("plan_mode", () => {
+  beforeEach(() => {
+    fileStorageMock.reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writePlanContent writes the given content to plan.md at the conversation root", async () => {
+    const { auth, conversation } = await setup();
+
+    const res = await writePlanContent(
+      auth,
+      conversation,
+      "# My plan\n\n- [ ] step one\n"
+    );
+    expect(res.isOk()).toBe(true);
+    expect(lastPlanWrite()).toBe("# My plan\n\n- [ ] step one\n");
+  });
+
+  it("getActivePlanContent returns Ok(null) when there is no active plan", async () => {
+    const { auth, conversation } = await setup();
+
+    fileStorageMock.setFileExists(() => false);
+    const res = await getActivePlanContent(auth, conversation);
+    expect(res.isOk()).toBe(true);
+    if (res.isOk()) {
+      expect(res.value).toBeNull();
+    }
+  });
+
+  it("closePlan archives plan.md as plan-1.md when the archive folder is empty", async () => {
+    const { auth, conversation } = await setup();
+    const { move } = stubFsForClose([]);
+
+    const res = await closePlan(auth, conversation);
+    expect(res.isOk()).toBe(true);
+    expect(move).toHaveBeenCalledTimes(1);
+    expect(move.mock.calls[0][0].dest).toBe(
+      `conversation-${conversation.sId}/archived_plans/plan-1.md`
+    );
+  });
+
+  it("closePlan archives at max existing index + 1, ignoring non-plan files", async () => {
+    const { auth, conversation } = await setup();
+    const { move } = stubFsForClose([
+      fileEntry("plan-1.md"),
+      fileEntry("plan-3.md"),
+      fileEntry("notes.txt"),
+    ]);
+
+    const res = await closePlan(auth, conversation);
+    expect(res.isOk()).toBe(true);
+    expect(move.mock.calls[0][0]).toEqual({
+      src: `conversation-${conversation.sId}/plan.md`,
+      dest: `conversation-${conversation.sId}/archived_plans/plan-4.md`,
+    });
+  });
+});

--- a/front/lib/api/assistant/plan_mode.ts
+++ b/front/lib/api/assistant/plan_mode.ts
@@ -1,3 +1,4 @@
+import { PLAN_FILE_NAME } from "@app/lib/api/actions/servers/plan_mode/metadata";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system/types";
 import { writeToConversationFolder } from "@app/lib/api/files/action_output_fs";
@@ -7,7 +8,6 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 import { Err, Ok, type Result } from "@app/types/shared/result";
 
 // Plan mode has no database model: all state is derived from the conversation file system.
-const PLAN_FILE_NAME = "plan.md";
 const ARCHIVED_PLANS_DIR = "archived_plans";
 
 function planPath(conversation: ConversationWithoutContentType): string {

--- a/front/lib/api/assistant/plan_mode.ts
+++ b/front/lib/api/assistant/plan_mode.ts
@@ -1,12 +1,26 @@
-import { PLAN_MODE_SKELETON } from "@app/lib/api/actions/servers/plan_mode/metadata";
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system/types";
+import { writeToConversationFolder } from "@app/lib/api/files/action_output_fs";
 import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
-import { FileResource } from "@app/lib/resources/file_resource";
-import type { PlanModeApproval } from "@app/types/files";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 
-// Conversation-scoped lock for all plan-mode operations. One plan per conversation, so a single
-// lock keyed on conversation sId serializes create/edit/approve/close and prevents races (e.g.
-// edit landing on a just-closed plan, two concurrent creates, approval stamping a closed plan).
+// Plan mode has no database model: all state is derived from the conversation file system.
+const PLAN_FILE_NAME = "plan.md";
+const ARCHIVED_PLANS_DIR = "archived_plans";
+
+function planPath(conversation: ConversationWithoutContentType): string {
+  return `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/${PLAN_FILE_NAME}`;
+}
+
+function archivedPlansDir(
+  conversation: ConversationWithoutContentType
+): string {
+  return `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/${ARCHIVED_PLANS_DIR}`;
+}
+
+// One plan per conversation: a conversation-scoped lock serializes create/edit/close.
 export async function withPlanModeLock<T>(
   conversationId: string,
   fn: () => Promise<T>
@@ -14,97 +28,74 @@ export async function withPlanModeLock<T>(
   return executeWithLock(`plan_mode:${conversationId}`, fn);
 }
 
-// Find the currently active plan file for a conversation. "Active" = attached to the conversation
-// with `isPlanFile: true` and NOT `isPlanClosed: true`. Returns null if no active plan exists.
-//
-// Plan counts per conversation are small (1-2), so the TS-side filter is cheap. If plan mode
-// sees heavy use, a partial expression index on
-// `(workspaceId, useCase, (useCaseMetadata ->> 'conversationId'))` would help.
-export async function findActivePlanFile(
+// Read the active plan's markdown. Ok(null) when there is no active plan; Err only on a real read
+// failure, so callers can tell "no plan" apart from "failed to read".
+export async function getActivePlanContent(
   auth: Authenticator,
-  conversationId: string
-): Promise<FileResource | null> {
-  const files = await FileResource.listPlanFilesForConversation(auth, {
-    conversationId,
-  });
-  return files.find((f) => !f.useCaseMetadata?.isPlanClosed) ?? null;
+  conversation: ConversationWithoutContentType
+): Promise<Result<string | null, Error>> {
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(new Error(fsResult.error.message));
+  }
+
+  const bufferResult = await fsResult.value.readBuffer(planPath(conversation));
+  if (bufferResult.isErr()) {
+    return new Err(new Error(bufferResult.error.message));
+  }
+
+  return new Ok(
+    bufferResult.value ? bufferResult.value.toString("utf8") : null
+  );
 }
 
-// Create a fresh plan.md file attached to the conversation, seeded with the skeleton. Does not
-// check for existing active plans — callers should guard against that.
-export async function createPlanFile(
+// Shared by create_plan and edit_plan; the "is there already an active plan" guard lives in the
+// handlers.
+export async function writePlanContent(
   auth: Authenticator,
-  {
-    conversationId,
-    agentConfigurationId,
-  }: {
-    conversationId: string;
-    agentConfigurationId?: string;
-  }
-): Promise<FileResource> {
-  const workspace = auth.getNonNullableWorkspace();
-
-  const file = await FileResource.makeNew({
-    workspaceId: workspace.id,
-    fileName: "plan.md",
+  conversation: ConversationWithoutContentType,
+  content: string
+): Promise<Result<void, Error>> {
+  const writeResult = await writeToConversationFolder(auth, conversation, {
+    content,
     contentType: "text/markdown",
-    fileSize: 0,
-    useCase: "conversation",
-    useCaseMetadata: {
-      conversationId,
-      isPlanFile: true,
-      planModeLastApproval: null,
-      lastEditedByAgentConfigurationId: agentConfigurationId,
-    },
+    fileName: PLAN_FILE_NAME,
   });
-
-  await file.uploadContent(auth, PLAN_MODE_SKELETON);
-
-  return file;
-}
-
-// Stamp the plan file with approval metadata. Called by the request_plan_approval tool handler
-// after user approval. No-ops (returns null) if the plan is already closed — this covers the race
-// where close_plan runs between approval request and approval decision.
-export async function markPlanApproved(
-  auth: Authenticator,
-  planFile: FileResource,
-  approvedByUserId: string
-): Promise<PlanModeApproval | null> {
-  if (planFile.useCaseMetadata?.isPlanClosed) {
-    return null;
+  if (writeResult.isErr()) {
+    return new Err(new Error(writeResult.error.message));
   }
 
-  const approval: PlanModeApproval = {
-    approvedAt: new Date().toISOString(),
-    approvedByUserId,
-    fileVersion: planFile.version,
-  };
-
-  await planFile.setUseCaseMetadata(auth, {
-    ...planFile.useCaseMetadata,
-    planModeLastApproval: approval,
-  });
-
-  return approval;
+  return new Ok(undefined);
 }
 
-// Retire the plan. Sets `isPlanClosed: true`. The file stays in DB for audit; the skill and UI
-// stop referencing it. Any pending approval on this plan should be resolved separately by the
-// caller (close_plan handler).
-export async function markPlanClosed(
+export async function closePlan(
   auth: Authenticator,
-  planFile: FileResource
-): Promise<void> {
-  if (planFile.useCaseMetadata?.isPlanClosed) {
-    return;
+  conversation: ConversationWithoutContentType
+): Promise<Result<void, Error>> {
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(new Error(fsResult.error.message));
   }
-  await planFile.setUseCaseMetadata(auth, {
-    ...planFile.useCaseMetadata,
-    isPlanClosed: true,
-  });
-}
+  const fs = fsResult.value;
 
-export function isPlanApproved(file: FileResource): boolean {
-  return file.useCaseMetadata?.planModeLastApproval != null;
+  const listResult = await fs.list(archivedPlansDir(conversation));
+  if (listResult.isErr()) {
+    return new Err(new Error(listResult.error.message));
+  }
+
+  // Next index = max existing `plan-{n}.md` + 1 (robust to gaps). Empty folder => 1.
+  const maxIndex = listResult.value.reduce((max, entry) => {
+    const match = entry.isDirectory
+      ? null
+      : entry.fileName.match(/^plan-(\d+)\.md$/);
+    return match ? Math.max(max, parseInt(match[1], 10)) : max;
+  }, 0);
+
+  const dest = `${archivedPlansDir(conversation)}/plan-${maxIndex + 1}.md`;
+  const moveResult = await fs.move({ src: planPath(conversation), dest });
+  if (moveResult.isErr()) {
+    return new Err(new Error(moveResult.error.message));
+  }
+
+  return new Ok(undefined);
 }

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -413,28 +413,6 @@ export class FileResource extends BaseResource<FileModel> {
     return files.map((f) => new this(this.model, f.get()));
   }
 
-  // List plan-mode files attached to a conversation. Callers filter active vs. closed via the
-  // returned `useCaseMetadata.isPlanClosed` flag (present only on closed plans). Ordered by
-  // createdAt DESC so the most recent plan is first.
-  static async listPlanFilesForConversation(
-    auth: Authenticator,
-    { conversationId }: { conversationId: string }
-  ): Promise<FileResource[]> {
-    const owner = auth.getNonNullableWorkspace();
-
-    const files = await this.model.findAll({
-      where: {
-        workspaceId: owner.id,
-        useCase: "conversation",
-        status: "ready",
-        useCaseMetadata: { conversationId, isPlanFile: true },
-      },
-      order: [["createdAt", "DESC"]],
-    });
-
-    return files.map((f) => new this(this.model, f.get()));
-  }
-
   static async fetchByMountFilePaths(
     auth: Authenticator,
     mountFilePaths: string[]

--- a/front/lib/resources/skill/code_defined/plan_mode.ts
+++ b/front/lib/resources/skill/code_defined/plan_mode.ts
@@ -4,7 +4,6 @@ import {
   CREATE_PLAN_TOOL_NAME,
   EDIT_PLAN_TOOL_NAME,
   PLAN_MODE_SERVER_NAME,
-  REQUEST_PLAN_APPROVAL_TOOL_NAME,
 } from "@app/lib/api/actions/servers/plan_mode/metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -26,16 +25,14 @@ Exactly one active plan is allowed per conversation. If a plan already exists in
 
 Clarifying questions go through \`${ASK_USER_QUESTION_TOOL_NAME}\`: use it liberally before drafting the plan and whenever ambiguity arises mid-execution.
 
-**Approval (\`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\`)**:
-- MANDATORY when the user explicitly asked for plan mode (e.g. "use plan mode", "plan this for me", "draft a plan before you do anything"). Call it once the plan is populated and before starting execution.
-- Otherwise optional. Call it only if the stakes warrant a human checkpoint (irreversible actions, big scope, ambiguous intent). For transparency-only flows, skip it and just keep editing the plan as you execute.
-- Only call when plan.md is ready. Do not call with an incomplete plan.
+**Approval**: plan mode has no dedicated approval tool. When you need explicit sign-off before executing, you MUST request it through \`${ASK_USER_QUESTION_TOOL_NAME}\` with a question like "Approve this plan?" and options such as "Approve" and "Reject". Never ask for approval in your normal response text: a plain sentence like "Do you approve?" gives the user no clear choice, is not an approval gate, and does not pause for a decision. If you are seeking approval, the LAST thing you do in the turn is the \`${ASK_USER_QUESTION_TOOL_NAME}\` call, not a written question.
+- Request approval this way when the user explicitly asked for plan mode (e.g. "use plan mode", "plan this for me", "draft a plan before you do anything"): ask once the plan is populated and before starting execution.
+- Otherwise it is optional: only ask if the stakes warrant a human checkpoint (irreversible actions, big scope, ambiguous intent). For transparency-only flows, skip approval and just keep editing the plan as you execute.
+- Only ask for approval when plan.md is ready. Do not ask with an incomplete plan.
 
-**If \`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\` is REJECTED (tool result status: denied): STOP.** Do NOT proceed with execution under any circumstance. Do NOT call research, side-effect, or write tools.
-
-Your next step MUST be to call \`${ASK_USER_QUESTION_TOOL_NAME}\` to ask the user what to change. Offer options like: a concrete revision direction, "proceed anyway without approval", or "drop the plan". Based on the user's answer:
-- If they give you a revision, revise the plan via \`${EDIT_PLAN_TOOL_NAME}\` and call \`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\` again.
-- If they say to proceed anyway, continue execution without re-requesting approval (keep updating plan.md via \`${EDIT_PLAN_TOOL_NAME}\` for transparency).
+**If the user does NOT approve: STOP.** Do NOT proceed with execution under any circumstance. Do NOT call research, side-effect, or write tools. Ask again via \`${ASK_USER_QUESTION_TOOL_NAME}\` what to change, offering options like a concrete revision direction, "proceed anyway without approval", or "drop the plan". Based on the answer:
+- If they give you a revision, revise the plan via \`${EDIT_PLAN_TOOL_NAME}\` and ask for approval again.
+- If they say to proceed anyway, continue execution without re-asking (keep updating plan.md via \`${EDIT_PLAN_TOOL_NAME}\` for transparency).
 - If they ask to drop the plan, call \`${CLOSE_PLAN_TOOL_NAME}\`.
 
 **Closing the plan (\`${CLOSE_PLAN_TOOL_NAME}\`)** in two cases:
@@ -51,9 +48,9 @@ export const planModeSkill = {
   sId: "plan_mode",
   name: "Plan Mode",
   userFacingDescription:
-    "Let agents maintain a live plan.md the user can follow, with an optional approval step for risky work.",
+    "Let agents maintain a live plan.md the user can follow as work progresses.",
   agentFacingDescription:
-    "Create and maintain a plan.md for non-trivial tasks to give the user visibility. Optionally request approval for risky steps.",
+    "Create and maintain a plan.md for non-trivial tasks to give the user visibility.",
   instructions: PLAN_MODE_INSTRUCTIONS,
   mcpServers: [{ name: PLAN_MODE_SERVER_NAME }],
   version: 1,

--- a/front/types/api/assistant/plan_mode.ts
+++ b/front/types/api/assistant/plan_mode.ts
@@ -1,9 +1,3 @@
-import type { FileType } from "@app/types/files";
-
-export type PlanApprovalState = "draft" | "pending" | "approved";
-
 export type GetConversationPlanModeResponseBody = {
-  planFile: FileType | null;
   content: string | null;
-  approvalState: PlanApprovalState;
 };

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -772,17 +772,14 @@ export type ConversationTitleEvent = {
   title: string;
 };
 
-// Event sent when the conversation's plan.md is created, edited, approved, or closed. Carries
-// only metadata (id, version, status flags) — the UI refetches the full file contents via the
-// plan_mode GET endpoint on receipt.
+// Event sent when the conversation's plan.md is created, edited, or closed. A refetch signal: the
+// UI re-reads the plan content via the plan_mode GET endpoint on receipt. `isClosed` lets the UI
+// close the plan panel.
 export type PlanUpdatedEvent = {
   type: "plan_updated";
   created: number;
   conversationId: string;
-  planFileId: string;
-  version: number;
   isClosed: boolean;
-  hasApproval: boolean;
 };
 
 // Event sent when a wake-up in the conversation is created or changes status. Thin payload: the

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -35,14 +35,6 @@ export type FileUseCase =
   // Workspace branding: logo/favicon uploaded by workspace admins.
   | "workspace_branding";
 
-// Audit trail for a plan-mode approval. Recorded on `plan.md.useCaseMetadata` when the user
-// approves a `request_plan_approval` call.
-export type PlanModeApproval = {
-  approvedAt: string; // ISO timestamp.
-  approvedByUserId: string; // sId of the approving user.
-  fileVersion: number; // FileModel.version at the moment of approval.
-};
-
 export type FileUseCaseMetadata = {
   conversationId?: string;
   skillId?: string;
@@ -59,13 +51,6 @@ export type FileUseCaseMetadata = {
   // only the original blob exists. Stamped together for sandbox-mounted raw delimited files.
   skipDataSourceIndexing?: boolean;
   skipFileProcessing?: boolean;
-  // Plan mode. `isPlanFile: true` marks a file as agent-owned (user can't directly mutate).
-  // `planModeLastApproval` is set when the agent's `request_plan_approval` is approved.
-  // `isPlanClosed: true` marks the plan as retired — hidden from UI and ignored by the skill.
-  // Active plans omit `isPlanClosed` (only closed plans have it set).
-  isPlanFile?: boolean;
-  planModeLastApproval?: PlanModeApproval | null;
-  isPlanClosed?: boolean;
   // Which branding asset this file was uploaded for (workspace_branding use case only).
   asset?: string;
 };


### PR DESCRIPTION
## Description

Plan mode now stores its `plan.md` in `DustFileSystem` instead of a `FileResource`, with no database model. All state is derived from the file system: the active plan is `plan.md` at the conversation root, and closing a plan moves it into a visible `archived_plans/` folder. Approval no longer has its own tool or the high-stake validate flow; the agent asks for sign-off through the existing `ask_user_question` tool.

## New flow

Behind the `plan_mode` feature flag, with a non-trivial request: the agent calls `create_plan` with the full markdown and the plan appears as `plan.md` at the conversation root, surfaced in the plan card and panel. As work progresses it calls `edit_plan` (exact string replace, overwriting the file) and the panel updates live. When it needs sign-off it calls `ask_user_question` with Approve and Reject, and on reject it stops and asks what to change. Closing the plan moves the file to `archived_plans/plan-{n}.md`, so the root frees up for a new plan while past plans stay browsable as history. There is always at most one active plan per conversation, enforced by the single fixed path plus the per-conversation lock.

## Next steps

This is the functional migration. The next iteration is to improve the overall design and play with the edge cases: approval is currently best-effort since there is no enforced gate (the agent can lapse into a prose "Do you approve?"), the active `plan.md` has no path-level mutation guard, and behaviors like create-while-active, rapid edits, and close-then-recreate deserve more hardening. Expect follow-ups there.


## Deploy

Deploy front-sse.
Deploy fornt. 