### PR TITLE
Fix: agent builder stuck on screen after saving from the Preview tab

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -93,6 +93,11 @@ function PreviewContent({
   isTrialPlan,
   isAdmin,
 }: PreviewContentProps) {
+  const stickyMentions = useMemo(
+    () => (draftAgent ? [toRichAgentMentionType(draftAgent)] : []),
+    [draftAgent]
+  );
+
   return (
     <>
       <div className={currentPanel ? "hidden" : "flex h-full flex-col"}>
@@ -133,9 +138,7 @@ function PreviewContent({
               owner={owner}
               user={user}
               onSubmit={createConversation}
-              stickyMentions={
-                draftAgent ? [toRichAgentMentionType(draftAgent)] : []
-              }
+              stickyMentions={stickyMentions}
               draftKey={`agent-${draftAgent?.name}-builder-preview`}
               actions={["attachment", "agents-list"]}
               disableAutoFocus


### PR DESCRIPTION
## Problem

When the agent builder's right panel is on the **Preview** tab, editing instructions → Save → clicking the **X** to close left the user stuck: the URL updated to `/w/:wId/conversation/new` but the builder kept rendering and never unmounted. Switching to the Sidekick tab while stuck would then immediately complete the close. The bug did not reproduce when the Sidekick tab was active.

## Root cause

`AgentBuilderPreview` passed `stickyMentions` to the Preview `InputBar` as an inline expression:

```tsx
stickyMentions={draftAgent ? [toRichAgentMentionType(draftAgent)] : []}
```

This allocates a new array and a new object (toRichAgentMentionType) on every render. That unstable identity is a dependency of two input-bar effects:

- InputBarContainer's content-restore effect, which synchronously drives the TipTap editor (editorService.resetWithMentions).
- useHandleMentions, which calls setSelectedSingleAgent(...) with a never-equal object, so it never bails out.

During the close navigation (a React Router route swap, handled as a React transition), every re-render of the still-mounted Preview subtree fed the input bar a new stickyMentions identity, re-firing those effects. Inspecting the React fiber root in the stuck state showed an expired transition lane that never committed (suspendedLanes: 0, main thread idle) — a parked commit, not an infinite loop or a Suspense hang. Unmounting the Preview subtree (e.g. switching tabs) released the parked transition, which is why the close completed on tab switch.

Fix

Memoize stickyMentions on draftAgent so its reference is stable across unrelated re-renders. Also aligns with REACT4 (memoize derived values).

```
const stickyMentions = useMemo(
  () => (draftAgent ? [toRichAgentMentionType(draftAgent)] : []),
  [draftAgent]
);
```

Testing

Reproduced and verified the fix locally against the running app: Preview tab → edit instructions → Save → X now navigates to /conversation/new and fully unmounts the builder, with the conversation page rendering correctly. Sidekick-tab behavior unchanged.