### PR TITLE
Skip user removal

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -534,14 +534,15 @@ export async function deleteMembersActivity({
           users: [user],
         });
 
-      // If the user we're removing the membership of only has one membership, we delete the user.
+      // If the user we're removing the membership of only has one membership, we delete their
+      // workspace data but keep the user row to avoid expensive FK constraint scans.
       if (membershipsOfUser.length === 1) {
         childLogger.info(
           {
             membershipId: membership.id,
             userId: user.sId,
           },
-          "Deleting Membership and user"
+          "Deleting Membership and user data"
         );
 
         // Delete the user's files.
@@ -560,8 +561,6 @@ export async function deleteMembersActivity({
         // Cancel any remaining Temporal workflows/schedules and delete wake-up rows owned by the
         // user in this workspace.
         await WakeUpResource.deleteAllForUser(auth, user.toJSON());
-
-        await user.delete(auth, {});
       }
     } else {
       hardDeleteLogger.info(


### PR DESCRIPTION
## Summary

- Skip `user.delete()` in `deleteMembersActivity` when a user's only membership is the workspace being deleted. The user row is preserved; all workspace-scoped data (files, membership, agent memories, onboarding tasks, wake-up schedules) is still cleaned up.

## Why we stopped deleting the user

`DELETE FROM users WHERE id = ?` was taking **2m49s** in production traces, making `deleteMembersActivity` the bottleneck of the delete-workspace workflow.

The root cause is Postgres FK constraint enforcement: before deleting a user row, Postgres must check (or apply) **55 foreign key constraints** referencing `users.id`. Most of those referencing tables have no leading-field index on the FK column, so each check triggers a full sequential scan.

Tables with **no index at all** on the FK column:

| table | column | on delete |
|---|---|---|
| `shareable_files` | `sharedBy` | RESTRICT |
| `content_fragments` | `userId` | SET NULL |
| `mentions` | `userId` | SET NULL |
| `agent_message_skills` | `addedByUserId` | SET NULL |
| `conversation_skills` | `addedByUserId` | SET NULL |
| `membership_invitations` | `invitedUserId` | SET NULL |
| `dust_app_secrets` | `userId` | SET NULL |
| `data_sources` | `editedByUserId` | SET NULL |
| `data_source_views` | `editedByUserId` | SET NULL |
| `mcp_server_views` | `editedByUserId` | SET NULL |
| `webhook_sources_views` | `editedByUserId` | SET NULL |
| `workspace_sandbox_env_vars` | `createdByUserId` | SET NULL |
| `workspace_sandbox_env_vars` | `lastUpdatedByUserId` | SET NULL |
| `conversation_mcp_server_views` | `userId` | RESTRICT |
| `project_todo_versions` | `userId` | RESTRICT |
| `project_todo_versions` | `createdByUserId` | RESTRICT |
| `project_todo_versions` | `markedAsDoneByUserId` | RESTRICT |
| `project_todo_versions` | `agentSuggestionReviewedByUserId` | RESTRICT |
| `project_todos` | `agentSuggestionReviewedByUserId` | RESTRICT |
| `provider_credentials` | `editedByUserId` | SET NULL |
| `sharing_grants` | `grantedBy` | SET NULL |
| `skill_configurations` | `editedBy` | RESTRICT |
| `skill_versions` | `editedBy` | RESTRICT |
| `triggers` | `editor` | NO ACTION |
| `credits` | `boughtByUserId` | SET NULL |

Tables with a **composite index where `userId` is not the leading field** (Postgres can't do a targeted seek, falls back to a full index scan):

| table | column | existing index |
|---|---|---|
| `files` | `userId` | `(workspaceId, userId)` |
| `agent_memories` | `userId` | `(workspaceId, agentConfigurationId, userId, updatedAt)` |
| `wake_ups` | `userId` | `(workspaceId, userId)` |
| `user_conversation_reads` | `userId` | `(workspaceId, userId)` — ON DELETE CASCADE |
| `user_messages` | `userId` | `(workspaceId, userId)` |
| `conversation_participants` | `userId` | `(workspaceId, userId, …)` |
| `onboarding_tasks` | `userId` | `(workspaceId, userId)` |
| `agent_configurations` | `authorId` | `(workspaceId, …, authorId)` |
| `agent_user_relations` | `userId` | `(workspaceId, userId)` |
| `conversation_branches` | `userId` | `(workspaceId, conversationId, userId)` |
| `mcp_server_connections` | `userId` | `(workspaceId, …, userId)` |

## Potential follow-up

- **Add leading-field indexes on all FK columns above** — this is the correct long-term fix per [BACK13]. It would allow user deletion to be restored and make the overall schema more robust. Each table needs a `CONCURRENTLY` index migration; ~36 migrations total, best done as a dedicated PR.
- **Decide on user lifecycle** — a user with no remaining memberships is now an orphan row. A periodic cleanup job or a separate low-priority deletion path (outside the delete-workspace critical path) could handle this safely once the indexes are in place.