### PR TITLE
Do not auto open panel in convo on mobile

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -61,6 +61,7 @@ import {
   CompactionStartedEvent,
 } from "@app/lib/notifications/events";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
 import { getNextWakeUpFireAtFromScheduleConfig } from "@app/lib/utils/wakeup_description";
 import logger from "@app/logger/logger";
@@ -738,6 +739,12 @@ export const ConversationViewer = ({
     currentPanelRef.current = currentPanel;
   }, [currentPanel]);
 
+  const isMobile = useIsMobile();
+  const isMobileRef = useRef(isMobile);
+  useEffect(() => {
+    isMobileRef.current = isMobile;
+  }, [isMobile]);
+
   // Only conversation related events are handled here.
   const onEventCallback = useCallback(
     (eventStr: string) => {
@@ -1055,7 +1062,11 @@ export const ConversationViewer = ({
             lastPlanVersionRef.current = event.version;
             if (event.isClosed && currentPanelRef.current === "plan") {
               closePanel();
-            } else if (prevVersion === 1 && event.version >= 2) {
+            } else if (
+              prevVersion === 1 &&
+              event.version >= 2 &&
+              !isMobileRef.current
+            ) {
               openPanel({ type: "plan" });
             }
             void mutate(

--- a/front/components/assistant/conversation/files_panel/useAutoOpenFilesPanel.ts
+++ b/front/components/assistant/conversation/files_panel/useAutoOpenFilesPanel.ts
@@ -1,5 +1,6 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import type { AgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { isInteractiveContentType } from "@app/types/files";
 import React from "react";
 
@@ -17,6 +18,7 @@ export function useAutoOpenFilesPanel({
   agentMessage,
 }: UseAutoOpenFilesPanelProps) {
   const { openPanel, currentPanel } = useConversationSidePanelContext();
+  const isMobile = useIsMobile();
 
   // Stores the sId of the last message that triggered auto-open, so the comparison itself encodes
   // "already opened for this message" without a separate reset effect.
@@ -32,19 +34,23 @@ export function useAutoOpenFilesPanel({
 
   React.useEffect(() => {
     if (
-      regularGeneratedFiles.length > 0 &&
-      isLastMessage &&
-      autoOpenedForRef.current !== agentMessage.sId &&
-      currentPanel !== "files"
+      isMobile ||
+      regularGeneratedFiles.length === 0 ||
+      !isLastMessage ||
+      autoOpenedForRef.current === agentMessage.sId ||
+      currentPanel === "files"
     ) {
-      autoOpenedForRef.current = agentMessage.sId;
-      openPanel({ type: "files" });
+      return;
     }
+
+    autoOpenedForRef.current = agentMessage.sId;
+    openPanel({ type: "files" });
   }, [
     regularGeneratedFiles,
     isLastMessage,
     agentMessage.sId,
     openPanel,
     currentPanel,
+    isMobile,
   ]);
 }

--- a/front/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent.ts
+++ b/front/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent.ts
@@ -1,6 +1,7 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import type { AgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
 import { isInteractiveContentFileContentOutput } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { isInteractiveContentType } from "@app/types/files";
 import { removeNulls } from "@app/types/shared/utils/general";
 import React from "react";
@@ -23,6 +24,7 @@ export function useAutoOpenInteractiveContent({
   agentMessage,
 }: useAutoOpenInteractiveContentProps) {
   const { openPanel } = useConversationSidePanelContext();
+  const isMobile = useIsMobile();
 
   // Track the last opened fileId to prevent double-opening glitch.
   //
@@ -66,6 +68,10 @@ export function useAutoOpenInteractiveContent({
   );
 
   React.useEffect(() => {
+    if (isMobile) {
+      return;
+    }
+
     // Handle progress notifications - always open drawer (supports generated->progress refresh).
     if (interactiveFilesFromProgress.length > 0) {
       const [firstFile] = interactiveFilesFromProgress;
@@ -98,6 +104,7 @@ export function useAutoOpenInteractiveContent({
     interactiveFilesFromProgress,
     isLastMessage,
     openPanel,
+    isMobile,
   ]);
 
   // Reset tracking when message changes.


### PR DESCRIPTION
## Description

On mobile, the conversation side panel auto-opens and covers the conversation view, which is disruptive since there's no way to see both simultaneously. Added `useIsMobile` guards to the three auto-open hooks — `useAutoOpenFilesPanel`, `useAutoOpenInteractiveContent`, and the plan-panel trigger in `ConversationViewer` — so panels are never auto-opened on mobile. Users can still open them manually.

## Tests

Tested locally on mobile viewport.

## Risk

Low. The guard is additive — mobile users simply no longer get the side panel auto-opened. Desktop behavior is unchanged. Safe to rollback by reverting the `isMobile` guards.

## Deploy Plan

Deploy front.
