### PR TITLE
fix(mobile): keep input bar agent in sync with the conversation

### DIFF
--- a/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
@@ -78,6 +78,14 @@ final class ConversationDetailViewModel: ObservableObject {
         turn?.snapshot.completedSteps ?? []
     }
 
+    /// The agent used in the conversation's latest agent message, so the input bar can target it.
+    var currentAgentId: String? {
+        for message in messages.reversed() {
+            if case let .agent(agentMsg) = message { return agentMsg.configuration.sId }
+        }
+        return nil
+    }
+
     /// Overlays the streaming message with its live snapshot until finalize commits it.
     func renderMessage(_ message: ConversationMessage) -> ConversationMessage {
         guard case let .agent(agent) = message,

--- a/x/adrsimon/mobile/Dust/ViewModels/InputBarViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/InputBarViewModel.swift
@@ -7,6 +7,8 @@ private let logger = Logger(subsystem: AppConfig.bundleId, category: "InputBar")
 
 @MainActor
 final class InputBarViewModel: ObservableObject {
+    private static let defaultAgentId = "dust"
+
     @Published var agents: [LightAgentConfiguration] = []
     @Published var selectedAgent: LightAgentConfiguration?
     @Published var messageText: String = ""
@@ -22,6 +24,8 @@ final class InputBarViewModel: ObservableObject {
     @Published var selectedCapabilities: [Capability] = []
     @Published var selectedKnowledgeItems: [KnowledgeItem] = []
     private var hasLoadedCapabilities = false
+    /// Id of the conversation's agent, kept until the agents list is available to resolve it.
+    private var pendingAgentId: String?
 
     lazy var speechService = SpeechService(workspaceId: workspaceId, tokenProvider: tokenProvider)
 
@@ -54,8 +58,9 @@ final class InputBarViewModel: ObservableObject {
                 }
                 return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
+            applyPendingAgent()
             if selectedAgent == nil {
-                selectedAgent = agents.first { $0.sId == "dust" } ?? agents.first
+                selectedAgent = agents.first { $0.sId == Self.defaultAgentId } ?? agents.first
             }
         } catch {
             logger.error("Failed to load agents: \(error)")
@@ -137,6 +142,19 @@ final class InputBarViewModel: ObservableObject {
                 showAgentPicker = true
             }
         }
+    }
+
+    /// Target the agent used in the conversation's latest message (existing conversations).
+    func selectConversationAgent(id: String) {
+        pendingAgentId = id
+        applyPendingAgent()
+    }
+
+    private func applyPendingAgent() {
+        guard let id = pendingAgentId,
+              let match = agents.first(where: { $0.sId == id }) else { return }
+        selectedAgent = match
+        pendingAgentId = nil
     }
 
     func selectAgent(_ agent: LightAgentConfiguration) {
@@ -354,7 +372,7 @@ final class InputBarViewModel: ObservableObject {
     }
 
     private func resolveMentions() -> [MentionPayload] {
-        let agentId = selectedAgent?.sId ?? "dust"
+        let agentId = selectedAgent?.sId ?? Self.defaultAgentId
         return [MentionPayload(configurationId: agentId)]
     }
 

--- a/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
+++ b/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
@@ -93,6 +93,11 @@ struct ConversationDetailView: View {
             async let caps: () = inputBarViewModel.loadCapabilities()
             _ = await (agents, caps)
         }
+        .onChange(of: viewModel.currentAgentId) { _, agentId in
+            if let agentId {
+                inputBarViewModel.selectConversationAgent(id: agentId)
+            }
+        }
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {
                 Task { await viewModel.resyncOnForeground() }


### PR DESCRIPTION
## Description

The conversation detail screen sometimes lost the assigned agent: after a few messages it would silently revert to the default `dust` agent, and replies were routed to the wrong agent.

Root cause: `ConversationDetailView` and `NewConversationView` each own a separate `@StateObject InputBarViewModel`, and the only thing that ever set the selected agent was `loadAgents()`, which always defaulted to `dust` (or the first agent). The detail screen's input bar had no link to the agent the conversation was actually with — so on the new-conversation → detail handoff (and on reopening any existing conversation) the selection reset to `dust`.

Fix:
- `ConversationDetailViewModel` exposes `currentAgentId`, derived from the conversation's latest agent message.
- `ConversationDetailView` observes it and tells the input bar to target that agent.
- `InputBarViewModel` resolves it against the loaded agents list, buffering until the list is available (the agents list and the messages load independently).

Existing conversations now preselect the agent from their latest message; brand-new conversations still default to `dust`; and since sending never clears `selectedAgent`, the selection persists across messages.

## Tests

Manual, in the iOS app:
- Open an existing conversation with a non-default agent — input bar shows that agent, replies route to it.
- Create a new conversation with a custom agent, send, land on the detail screen — bar locks onto that agent once it replies.
- Send several follow-up messages — the assigned agent stays put.
- New conversation with no agent picked — still defaults to `dust`.

## Risk

Low and client-only (no API/schema changes). Worst case the input bar shows the `dust` default instead of the conversation's agent (the prior behavior) — e.g. if the conversation's agent isn't in the fetched agents list. Safe to rollback.

## Deploy Plan

Mobile client change — ships with the app build, no deploy ordering.