### PR TITLE
Unify pod and conversation files in a tree.

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -1,6 +1,8 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
+import type { FileExplorerPathEntry } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
+import { withVirtualExplorerPath } from "@app/components/file_explorer/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { downloadFile, getFilePathViewUrl } from "@app/lib/swr/files";
@@ -10,10 +12,10 @@ import {
   isPodConversation,
 } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, ButtonGroup, cn, XClose } from "@dust-tt/sparkle";
-import { useCallback, useState } from "react";
+import { Button, XClose } from "@dust-tt/sparkle";
+import { useCallback, useMemo } from "react";
 
-type FilesTab = "conversation" | "pod";
+const POD_CONVERSATION_SCOPE_ROOTS = ["conversation", "pod"] as const;
 
 interface ConversationFileExplorerProps {
   conversation: ConversationWithoutContentType;
@@ -26,7 +28,6 @@ export function ConversationFileExplorer({
 }: ConversationFileExplorerProps) {
   const { closePanel, openPanel } = useConversationSidePanelContext();
   const isPod = isPodConversation(conversation);
-  const [activeTab, setActiveTab] = useState<FilesTab>("conversation");
 
   const { sandboxFiles, isSandboxFilesLoading } = useConversationSandboxFiles({
     conversationId: conversation.sId,
@@ -38,6 +39,17 @@ export function ConversationFileExplorer({
     podId: isPod ? conversation.spaceId : "",
     disabled: !isPod,
   });
+
+  const files = useMemo((): FileExplorerPathEntry[] => {
+    if (!isPod) {
+      return sandboxFiles;
+    }
+
+    return [
+      ...sandboxFiles.map((f) => withVirtualExplorerPath(f, "conversation")),
+      ...podFiles.map((f) => withVirtualExplorerPath(f, "pod")),
+    ];
+  }, [isPod, podFiles, sandboxFiles]);
 
   const getFileUrl = useCallback(
     (path: string) => getFilePathViewUrl(owner, path),
@@ -61,29 +73,9 @@ export function ConversationFileExplorer({
     <div className="flex h-panel min-h-0 flex-col">
       <AppLayoutTitle>
         <div className="flex h-full items-center justify-between gap-2">
-          {isPod ? (
-            <ButtonGroup
-              removeGaps={false}
-              className="rounded-lg bg-muted p-0.5 dark:bg-muted-night"
-            >
-              <Button
-                size="xs"
-                variant={activeTab === "conversation" ? "outline" : "ghost"}
-                label="Conversation Files"
-                onClick={() => setActiveTab("conversation")}
-              />
-              <Button
-                size="xs"
-                variant={activeTab === "pod" ? "outline" : "ghost"}
-                label="Pod Files"
-                onClick={() => setActiveTab("pod")}
-              />
-            </ButtonGroup>
-          ) : (
-            <span className="text-sm text-foreground dark:text-foreground-night">
-              Conversation Files
-            </span>
-          )}
+          <span className="text-sm text-foreground dark:text-foreground-night">
+            {isPod ? "Files" : "Conversation Files"}
+          </span>
           <Button
             variant="ghost"
             size="sm"
@@ -94,42 +86,21 @@ export function ConversationFileExplorer({
       </AppLayoutTitle>
 
       <div className="flex min-h-0 flex-1 flex-col">
-        <div
-          className={cn(
-            "flex min-h-0 flex-1 flex-col",
-            isPod && activeTab !== "conversation" && "hidden"
-          )}
-        >
-          <FileExplorer
-            files={sandboxFiles}
-            hideBreadcrumbAtRoot
-            isLoading={isSandboxFilesLoading}
-            getFileUrl={getFileUrl}
-            onFileDownload={onFileDownload}
-            onOpenInteractive={onOpenInteractive}
-            owner={owner}
-          />
-        </div>
-
-        {isPod && (
-          <div
-            className={cn(
-              "flex min-h-0 flex-1 flex-col",
-              activeTab !== "pod" && "hidden"
-            )}
-          >
-            <FileExplorer
-              defaultViewMode="list"
-              files={podFiles}
-              hideBreadcrumbAtRoot
-              isLoading={isPodFilesLoading}
-              getFileUrl={getFileUrl}
-              onFileDownload={onFileDownload}
-              onOpenInteractive={onOpenInteractive}
-              owner={owner}
-            />
-          </div>
-        )}
+        <FileExplorer
+          defaultViewMode={isPod ? "list" : "grid"}
+          files={files}
+          hideBreadcrumbAtRoot={!isPod}
+          isLoading={
+            isPod
+              ? isSandboxFilesLoading || isPodFilesLoading
+              : isSandboxFilesLoading
+          }
+          getFileUrl={getFileUrl}
+          onFileDownload={onFileDownload}
+          onOpenInteractive={onOpenInteractive}
+          owner={owner}
+          virtualScopeRoots={isPod ? POD_CONVERSATION_SCOPE_ROOTS : undefined}
+        />
       </div>
     </div>
   );

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -14,6 +14,7 @@ import type {
   FileExplorerEntry,
   FileExplorerFilter,
   FileExplorerMenuAction,
+  FileExplorerPathEntry,
   FileExplorerSortMode,
   FileSystemTreeNode,
   FolderEntry,
@@ -25,7 +26,6 @@ import {
   getScopedRelativePath,
   isFileExplorerMovableFile,
 } from "@app/components/file_explorer/utils";
-import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import { isInteractiveContentType } from "@app/types/files";
 import { Err, type Result } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -39,7 +39,7 @@ interface FileExplorerProps {
   defaultViewMode?: ViewMode;
   emptyState?: React.ReactNode;
   hideBreadcrumbAtRoot?: boolean;
-  files: FileSystemEntry[];
+  files: FileExplorerPathEntry[];
   getFileUrl: (path: string) => string;
   toolbarExtraActions?: React.ReactNode;
   isLoading: boolean;
@@ -57,6 +57,8 @@ interface FileExplorerProps {
   getExtraFileMenuItems?: (
     entry: FileExplorerEntry
   ) => FileExplorerMenuAction[];
+  /** Top-level scope folders at the virtual root (e.g. `conversation`, `pod`). */
+  virtualScopeRoots?: readonly string[];
 }
 
 export function FileExplorer({
@@ -78,6 +80,7 @@ export function FileExplorer({
   onRename,
   owner,
   getExtraFileMenuItems,
+  virtualScopeRoots,
 }: FileExplorerProps) {
   const [currentFolderPath, setCurrentFolderPath] = useState("");
   const prevNavigationResetKey = useRef(navigationResetKey);
@@ -122,6 +125,7 @@ export function FileExplorer({
         searchQuery,
         activeFilter,
         sortMode,
+        virtualScopeRoots,
       }),
     [
       contentNodes,
@@ -130,6 +134,7 @@ export function FileExplorer({
       searchQuery,
       activeFilter,
       sortMode,
+      virtualScopeRoots,
     ]
   );
 
@@ -275,7 +280,7 @@ export function FileExplorer({
           className={cn("flex flex-1 min-h-0 flex-col gap-5", contentClassName)}
         >
           {showBreadcrumb && (
-            <div className={cn("px-4", hideBreadcrumbAtRoot && "pt-5")}>
+            <div className="px-4 pt-5">
               <FileExplorerBreadcrumb
                 currentFolderPath={currentFolderPath}
                 onNavigate={handleBreadcrumbNavigate}

--- a/front/components/file_explorer/fileExplorerPipeline.test.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.test.ts
@@ -1,0 +1,65 @@
+import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
+import { withVirtualExplorerPath } from "@app/components/file_explorer/utils";
+import type { FileSystemEntry } from "@app/types/api/file_system/types";
+import { describe, expect, it } from "vitest";
+
+function mountFile(
+  scopedPath: string,
+  fileName = scopedPath.split("/").pop() ?? scopedPath
+): FileSystemEntry {
+  return {
+    isDirectory: false,
+    fileName,
+    path: scopedPath,
+    contentType: "text/plain",
+    fileId: "file-1",
+    sizeBytes: 100,
+    lastModifiedMs: 0,
+    thumbnailUrl: null,
+  };
+}
+
+describe("getFileExplorerPipeline virtualScopeRoots", () => {
+  it("shows scope folders at the virtual root", () => {
+    const files = [
+      withVirtualExplorerPath(
+        mountFile("conversation-c1/notes.txt"),
+        "conversation"
+      ),
+    ];
+
+    const { sortedNodes } = getFileExplorerPipeline({
+      activeFilter: "all",
+      contentNodes: [],
+      currentFolderPath: "",
+      files,
+      searchQuery: "",
+      sortMode: "last-modified",
+      virtualScopeRoots: ["conversation", "pod"],
+    });
+
+    expect(sortedNodes.map((n) => n.path)).toEqual(["conversation", "pod"]);
+  });
+
+  it("lists files inside a scope folder", () => {
+    const files = [
+      withVirtualExplorerPath(
+        mountFile("conversation-c1/notes.txt"),
+        "conversation"
+      ),
+      withVirtualExplorerPath(mountFile("pod-p1/readme.md"), "pod"),
+    ];
+
+    const { sortedNodes } = getFileExplorerPipeline({
+      activeFilter: "all",
+      contentNodes: [],
+      currentFolderPath: "conversation",
+      files,
+      searchQuery: "",
+      sortMode: "last-modified",
+      virtualScopeRoots: ["conversation", "pod"],
+    });
+
+    expect(sortedNodes.map((n) => n.path)).toEqual(["conversation/notes.txt"]);
+  });
+});

--- a/front/components/file_explorer/fileExplorerPipeline.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.ts
@@ -2,6 +2,7 @@ import type {
   ContentNodeEntry,
   FileExplorerEntry,
   FileExplorerFilter,
+  FileExplorerPathEntry,
   FileExplorerSortMode,
   FileSystemTreeNode,
 } from "@app/components/file_explorer/types";
@@ -9,10 +10,11 @@ import {
   buildFileSystemTree,
   compareTreeNodesForSort,
   getChildrenAtFolderPath,
+  getExplorerRelativePath,
   getFileExplorerBucket,
+  getVirtualScopeRootNodes,
 } from "@app/components/file_explorer/utils";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
-import type { FileSystemEntry } from "@app/types/api/file_system/types";
 
 export interface FileExplorerPipeline {
   /** Tree nodes at the current folder level, filtered + sorted. */
@@ -23,7 +25,7 @@ export interface FileExplorerPipeline {
   fileCount: number;
   /** Files at the current level in their rendering order (used by preview prev/next). */
   filesAtLevel: FileExplorerEntry[];
-  /** Tree-relative path → original entry. Used when rendering file cards. */
+  /** Explorer-relative path → original entry. Used when rendering file cards. */
   entryByRelativePath: Map<string, FileExplorerEntry>;
 }
 
@@ -31,14 +33,11 @@ interface GetFileExplorerPipelineParams {
   activeFilter: FileExplorerFilter;
   contentNodes: ContentNodeEntry[];
   currentFolderPath: string;
-  files: FileSystemEntry[];
+  files: FileExplorerPathEntry[];
   searchQuery: string;
   sortMode: FileExplorerSortMode;
-}
-
-function toRelativePath(entry: FileSystemEntry): string {
-  const slashIdx = entry.path.indexOf("/");
-  return slashIdx >= 0 ? entry.path.slice(slashIdx + 1) : entry.path;
+  /** Top-level scope folders at the virtual root (e.g. `conversation`, `pod`). */
+  virtualScopeRoots?: readonly string[];
 }
 
 /**
@@ -52,6 +51,7 @@ export function getFileExplorerPipeline({
   files,
   searchQuery,
   sortMode,
+  virtualScopeRoots,
 }: GetFileExplorerPipelineParams): FileExplorerPipeline {
   const entryByRelativePath = new Map<string, FileExplorerEntry>();
   for (const f of files) {
@@ -59,7 +59,7 @@ export function getFileExplorerPipeline({
       continue;
     }
 
-    const relativePath = toRelativePath(f);
+    const relativePath = getExplorerRelativePath(f);
     entryByRelativePath.set(relativePath, { ...f, kind: "file" });
   }
 
@@ -83,7 +83,9 @@ export function getFileExplorerPipeline({
 
   const currentNodes = currentFolderPath
     ? getChildrenAtFolderPath(tree, currentFolderPath)
-    : [...tree, ...contentNodeTreeNodes];
+    : virtualScopeRoots
+      ? getVirtualScopeRootNodes(tree, virtualScopeRoots)
+      : [...tree, ...contentNodeTreeNodes];
 
   const q = searchQuery.trim().toLowerCase();
   const visibleNodes = currentNodes.filter((node) => {

--- a/front/components/file_explorer/types.ts
+++ b/front/components/file_explorer/types.ts
@@ -1,8 +1,20 @@
-import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
+import type {
+  FileSystemEntry,
+  FileSystemFileEntry,
+} from "@app/types/api/file_system/types";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type React from "react";
 
-export type FileEntry = FileSystemFileEntry & { kind: "file" };
+/** Explorer input: canonical `path` plus an optional UI-only navigation path. */
+export type FileExplorerPathEntry = FileSystemEntry & {
+  virtualPath?: string;
+};
+
+export type FileEntry = FileSystemFileEntry & {
+  kind: "file";
+  /** UI navigation path when entries from multiple scopes are merged. */
+  virtualPath?: string;
+};
 export type FileEntryWithId = FileEntry & { fileId: string };
 
 export type ContentNodeEntry = {
@@ -44,7 +56,7 @@ export type FilePanelCategory =
 
 export type FileSystemTreeNode = {
   name: string;
-  /** Relative path within the mount (scope prefix stripped), e.g. `"reports/q1.pdf"`. */
+  /** Explorer-relative path (mount-relative, or virtual when `virtualPath` is used). */
   path: string;
   isDirectory: boolean;
   contentType: string | null;

--- a/front/components/file_explorer/utils.test.ts
+++ b/front/components/file_explorer/utils.test.ts
@@ -7,7 +7,10 @@ import {
   buildFolderTree,
   findTreeNodeByPath,
   getChildrenAtFolderPath,
+  getExplorerRelativePath,
+  getVirtualScopeRootNodes,
   isFileExplorerMovableFile,
+  withVirtualExplorerPath,
 } from "@app/components/file_explorer/utils";
 import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import { frameContentType, frameSlideshowContentType } from "@app/types/files";
@@ -246,5 +249,70 @@ describe("buildFolderTree", () => {
     expect(collectTreeNodes(tree).every((n) => n.isDirectory)).toBe(true);
     expect(findTreeNodeByPath(tree, "docs/readme.txt")).toBeUndefined();
     expect(findTreeNodeByPath(tree, "docs")?.isDirectory).toBe(true);
+  });
+});
+
+describe("getExplorerRelativePath", () => {
+  it("uses virtualPath when set", () => {
+    expect(
+      getExplorerRelativePath({
+        path: "conversation-abc/report.pdf",
+        virtualPath: "conversation/report.pdf",
+      })
+    ).toBe("conversation/report.pdf");
+  });
+
+  it("falls back to stripping the scoped prefix from path", () => {
+    expect(getExplorerRelativePath({ path: "pod-xyz/data.csv" })).toBe(
+      "data.csv"
+    );
+  });
+});
+
+describe("withVirtualExplorerPath", () => {
+  it("prefixes the mount-relative path with a scope label", () => {
+    const entry = withVirtualExplorerPath(
+      mountFile("reports/q1.pdf", "conversation"),
+      "conversation"
+    );
+    expect(entry.virtualPath).toBe("conversation/reports/q1.pdf");
+    expect(entry.path).toBe("conversation/reports/q1.pdf");
+  });
+});
+
+describe("buildFileSystemTree with virtualPath", () => {
+  it("builds a merged tree with conversation and pod scope folders", () => {
+    const tree = buildFileSystemTree([
+      withVirtualExplorerPath(
+        mountFile("notes.txt", "conversation"),
+        "conversation"
+      ),
+      withVirtualExplorerPath(mountFile("shared/readme.md"), "pod"),
+    ]);
+
+    expect(
+      getChildrenAtFolderPath(tree, "")
+        .map((n) => n.path)
+        .sort()
+    ).toEqual(["conversation", "pod"]);
+    expect(
+      getChildrenAtFolderPath(tree, "conversation").map((n) => n.path)
+    ).toEqual(["conversation/notes.txt"]);
+    expect(
+      getChildrenAtFolderPath(tree, "pod/shared").map((n) => n.path)
+    ).toEqual(["pod/shared/readme.md"]);
+  });
+});
+
+describe("getVirtualScopeRootNodes", () => {
+  it("includes empty scope folders missing from the tree", () => {
+    const tree = buildFileSystemTree([
+      withVirtualExplorerPath(mountFile("a.txt"), "pod"),
+    ]);
+
+    const roots = getVirtualScopeRootNodes(tree, ["conversation", "pod"]);
+    expect(roots.map((n) => n.path)).toEqual(["conversation", "pod"]);
+    expect(roots[0]?.children).toEqual([]);
+    expect(roots[1]?.children).toHaveLength(1);
   });
 });

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -127,6 +127,7 @@ import type {
   FileEntry,
   FileExplorerBucket,
   FileExplorerEntry,
+  FileExplorerPathEntry,
   FileExplorerSortMode,
   FilePanelCategory,
   FileSystemTreeNode,
@@ -350,22 +351,64 @@ function ensureDirectoryNode(
   }
 }
 
+/** Explorer navigation path: `virtualPath` when set, else mount-relative path. */
+export function getExplorerRelativePath(
+  entry: Pick<FileSystemEntry, "path"> & { virtualPath?: string }
+): string {
+  if (entry.virtualPath !== undefined) {
+    return entry.virtualPath;
+  }
+  return getScopedRelativePath(entry.path);
+}
+
+/** Attach a UI-only path prefix for merged multi-scope explorers. */
+export function withVirtualExplorerPath(
+  entry: FileSystemEntry,
+  scopeLabel: string
+): FileExplorerPathEntry {
+  return {
+    ...entry,
+    virtualPath: `${scopeLabel}/${getScopedRelativePath(entry.path)}`,
+  };
+}
+
+/** Top-level scope folders shown at the virtual root (includes empty scopes). */
+export function getVirtualScopeRootNodes(
+  tree: FileSystemTreeNode[],
+  scopeRoots: readonly string[]
+): FileSystemTreeNode[] {
+  const topLevelDirs = new Map<string, FileSystemTreeNode>();
+  for (const node of tree) {
+    if (node.isDirectory && !node.path.includes("/")) {
+      topLevelDirs.set(node.path, node);
+    }
+  }
+
+  return scopeRoots.map(
+    (label) =>
+      topLevelDirs.get(label) ?? {
+        name: label,
+        path: label,
+        isDirectory: true,
+        contentType: null,
+        fileId: null,
+        children: [],
+      }
+  );
+}
+
 /**
  * Build a tree from flat file entries by inferring directories from paths.
- * entry.path is a scoped path (e.g. "conversation/subdir/file.png"); the
- * use-case prefix (first segment) is stripped so tree paths start at the
- * sandbox working directory root.
+ * Uses `virtualPath` when set; otherwise strips the scoped prefix from `path`.
  */
 export function buildFileSystemTree(
-  entries: FileSystemEntry[]
+  entries: FileExplorerPathEntry[]
 ): FileSystemTreeNode[] {
   const root: FileSystemTreeNode[] = [];
   const nodeMap = new Map<string, FileSystemTreeNode>();
 
   for (const entry of entries) {
-    const slashIdx = entry.path.indexOf("/");
-    const relativePath =
-      slashIdx >= 0 ? entry.path.slice(slashIdx + 1) : entry.path;
+    const relativePath = getExplorerRelativePath(entry);
 
     if (!relativePath) {
       continue;
@@ -447,7 +490,7 @@ function filterDirectoryNodes(
 
 /** Folder-only view of the sandbox tree (no files). */
 export function buildFolderTree(
-  entries: FileSystemEntry[]
+  entries: FileExplorerPathEntry[]
 ): FileSystemTreeNode[] {
   return filterDirectoryNodes(buildFileSystemTree(entries));
 }


### PR DESCRIPTION
## Description

Replaces the tab switcher ("Conversation Files" / "Pod Files") in `ConversationFileExplorer` with a single `FileExplorer` tree that merges both scopes under virtual root folders (`conversation/`, `pod/`). For pod conversations, `withVirtualExplorerPath` remaps each `FileSystemEntry` to a `FileExplorerPathEntry` with a `virtualPath` prefixed by its scope label; the explorer navigates this virtual tree using `getExplorerRelativePath` and `getVirtualScopeRootNodes` (which injects empty scope folders if one scope has no files). Non-pod conversations are unaffected.

<img width="572" height="297" alt="image" src="https://github.com/user-attachments/assets/30e49a15-a200-4dfd-854c-ace79a9fdebe" />

## Tests

- Added `fileExplorerPipeline.test.ts` covering `virtualScopeRoots` at the virtual root and inside a scope folder.
- Extended `utils.test.ts` with cases for `getExplorerRelativePath`, `withVirtualExplorerPath`, `buildFileSystemTree` with mixed scopes, and `getVirtualScopeRootNodes` (including empty-scope placeholder nodes).
- Tested manually in pod and non-pod conversation file panels.

## Risk

Low. Front-only change — no API, no persistence, no data model changes. The tab UX removal is a behavioral delta for pod conversations only; the underlying file fetches (`useConversationSandboxFiles`, `usePodFiles`) are unchanged.

## Deploy Plan

Deploy front.
