### PR TITLE
Improve file search to search in nested folders.

### DIFF
--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -101,6 +101,7 @@ export function FileExplorer({
 
   const [viewMode, setViewMode] = useState<ViewMode>(defaultViewMode);
   const [searchQuery, setSearchQuery] = useState("");
+  const searchFolderPath = searchQuery.trim() ? currentFolderPath : undefined;
   const [activeFilter, setActiveFilter] = useState<FileExplorerFilter>("all");
   const [sortMode, setSortMode] =
     useState<FileExplorerSortMode>("last-modified");
@@ -333,6 +334,7 @@ export function FileExplorer({
                 ? getMenuItems
                 : undefined
             }
+            searchFolderPath={searchFolderPath}
           />
         </div>
       </div>

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -35,6 +35,8 @@ interface FileExplorerContentProps {
   onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
   onNodeOpen: (entry: ContentNodeEntry) => void;
   getFileMenuItems?: (entry: FileExplorerEntry) => FileExplorerMenuAction[];
+  /** When set, file cards show paths relative to this folder (search mode). */
+  searchFolderPath?: string;
 }
 
 export function FileExplorerContent({
@@ -51,6 +53,7 @@ export function FileExplorerContent({
   onMoveFileDrop,
   onNodeOpen,
   getFileMenuItems,
+  searchFolderPath,
 }: FileExplorerContentProps) {
   const items = sortedNodes.map((node) => {
     if (node.isDirectory) {
@@ -98,6 +101,7 @@ export function FileExplorerContent({
             key={`file:${entry.path}`}
             draggable={fileDragEnabled && isFileExplorerMovableFile(entry)}
             entry={entry}
+            searchFolderPath={searchFolderPath}
             viewMode={viewMode}
             onOpen={onFileOpen}
             onDownload={onFileDownload}

--- a/front/components/file_explorer/FileExplorerItem.tsx
+++ b/front/components/file_explorer/FileExplorerItem.tsx
@@ -12,6 +12,7 @@ import type {
 } from "@app/components/file_explorer/types";
 import {
   getCategoryFromContentType,
+  getFileExplorerSearchResultTitle,
   getSingularFileCategoryLabelForContentType,
 } from "@app/components/file_explorer/utils";
 import { cn } from "@app/components/poke/shadcn/lib/utils";
@@ -312,6 +313,8 @@ export function FileExplorerFolderCard({
 export interface FileExplorerFileCardProps {
   draggable?: boolean;
   entry: FileEntry;
+  /** When set, title shows path relative to this folder (search mode). */
+  searchFolderPath?: string;
   viewMode: ViewMode;
   onOpen: (entry: FileEntry) => void;
   onDownload: (entry: FileEntry) => Promise<void>;
@@ -358,12 +361,17 @@ function FileExplorerDraggableWrapper({
 export function FileExplorerFileCard({
   draggable: draggableProp = false,
   entry,
+  searchFolderPath,
   viewMode,
   onOpen,
   onDownload,
   extraMenuItems,
 }: FileExplorerFileCardProps) {
   const subtitle = getFileSubtitle(entry, viewMode);
+  const title =
+    searchFolderPath !== undefined
+      ? getFileExplorerSearchResultTitle(entry, searchFolderPath)
+      : entry.fileName;
 
   const handleDragStart = (e: React.DragEvent) => {
     if (e.target instanceof HTMLElement && e.target.closest("button")) {
@@ -384,7 +392,7 @@ export function FileExplorerFileCard({
         kind="thumbnail"
         thumbnailSrc={entry.thumbnailUrl}
         viewMode={viewMode}
-        title={entry.fileName}
+        title={title}
         subtitle={subtitle}
         containerClassName={dragContainerClassName}
         onOpen={() => onOpen(entry)}
@@ -396,7 +404,7 @@ export function FileExplorerFileCard({
         kind="icon"
         visual={getFileTypeIcon(entry.contentType, entry.fileName)}
         viewMode={viewMode}
-        title={entry.fileName}
+        title={title}
         subtitle={subtitle}
         containerClassName={dragContainerClassName}
         onOpen={() => onOpen(entry)}

--- a/front/components/file_explorer/fileExplorerPipeline.test.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.test.ts
@@ -63,3 +63,84 @@ describe("getFileExplorerPipeline virtualScopeRoots", () => {
     expect(sortedNodes.map((n) => n.path)).toEqual(["conversation/notes.txt"]);
   });
 });
+
+describe("getFileExplorerPipeline search", () => {
+  it("searches within the current folder and its descendants", () => {
+    const files = [
+      withVirtualExplorerPath(
+        mountFile("conversation-c1/reports/summary.txt", "summary.txt"),
+        "conversation"
+      ),
+      withVirtualExplorerPath(
+        mountFile("conversation-c1/notes.txt"),
+        "conversation"
+      ),
+      withVirtualExplorerPath(
+        mountFile("pod-p1/archive/readme.md", "readme.md"),
+        "pod"
+      ),
+    ];
+
+    const { sortedNodes } = getFileExplorerPipeline({
+      activeFilter: "all",
+      contentNodes: [],
+      currentFolderPath: "conversation",
+      files,
+      searchQuery: "readme",
+      sortMode: "last-modified",
+      virtualScopeRoots: ["conversation", "pod"],
+    });
+
+    expect(sortedNodes).toEqual([]);
+  });
+
+  it("finds nested files under the current folder", () => {
+    const files = [
+      withVirtualExplorerPath(
+        mountFile("conversation-c1/reports/q1/summary.txt", "summary.txt"),
+        "conversation"
+      ),
+      withVirtualExplorerPath(
+        mountFile("pod-p1/readme.md", "readme.md"),
+        "pod"
+      ),
+    ];
+
+    const { sortedNodes } = getFileExplorerPipeline({
+      activeFilter: "all",
+      contentNodes: [],
+      currentFolderPath: "conversation",
+      files,
+      searchQuery: "summary",
+      sortMode: "last-modified",
+      virtualScopeRoots: ["conversation", "pod"],
+    });
+
+    expect(sortedNodes.map((n) => n.path)).toEqual([
+      "conversation/reports/q1/summary.txt",
+    ]);
+  });
+
+  it("searches the entire tree from the virtual root", () => {
+    const files = [
+      withVirtualExplorerPath(
+        mountFile("conversation-c1/reports/q1/summary.txt", "summary.txt"),
+        "conversation"
+      ),
+    ];
+
+    const { sortedNodes } = getFileExplorerPipeline({
+      activeFilter: "all",
+      contentNodes: [],
+      currentFolderPath: "",
+      files,
+      searchQuery: "reports",
+      sortMode: "last-modified",
+      virtualScopeRoots: ["conversation", "pod"],
+    });
+
+    expect(sortedNodes.map((n) => n.path)).toEqual([
+      "conversation/reports/q1/summary.txt",
+    ]);
+  });
+});

--- a/front/components/file_explorer/fileExplorerPipeline.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.ts
@@ -8,13 +8,15 @@ import type {
 } from "@app/components/file_explorer/types";
 import {
   buildFileSystemTree,
+  collectFileTreeNodesAtOrBelow,
   compareTreeNodesForSort,
+  fileExplorerNodeMatchesSearch,
   getChildrenAtFolderPath,
   getExplorerRelativePath,
   getFileExplorerBucket,
   getVirtualScopeRootNodes,
+  isFileExplorerNodeHidden,
 } from "@app/components/file_explorer/utils";
-import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 
 export interface FileExplorerPipeline {
   /** Tree nodes at the current folder level, filtered + sorted. */
@@ -38,6 +40,23 @@ interface GetFileExplorerPipelineParams {
   sortMode: FileExplorerSortMode;
   /** Top-level scope folders at the virtual root (e.g. `conversation`, `pod`). */
   virtualScopeRoots?: readonly string[];
+}
+
+function filterVisibleNodes(
+  nodes: FileSystemTreeNode[],
+  q: string
+): FileSystemTreeNode[] {
+  return nodes.filter((node) => {
+    if (isFileExplorerNodeHidden(node)) {
+      return false;
+    }
+
+    if (q.length > 0 && !fileExplorerNodeMatchesSearch(node, q)) {
+      return false;
+    }
+
+    return true;
+  });
 }
 
 /**
@@ -81,24 +100,20 @@ export function getFileExplorerPipeline({
     children: [],
   }));
 
-  const currentNodes = currentFolderPath
-    ? getChildrenAtFolderPath(tree, currentFolderPath)
-    : virtualScopeRoots
-      ? getVirtualScopeRootNodes(tree, virtualScopeRoots)
-      : [...tree, ...contentNodeTreeNodes];
-
   const q = searchQuery.trim().toLowerCase();
-  const visibleNodes = currentNodes.filter((node) => {
-    if (node.name.startsWith(".") && node.name !== TOOL_OUTPUTS_FOLDER_NAME) {
-      return false;
-    }
+  const isSearching = q.length > 0;
+  const currentNodes = isSearching
+    ? [
+        ...collectFileTreeNodesAtOrBelow(tree, currentFolderPath),
+        ...(currentFolderPath ? [] : contentNodeTreeNodes),
+      ]
+    : currentFolderPath
+      ? getChildrenAtFolderPath(tree, currentFolderPath)
+      : virtualScopeRoots
+        ? getVirtualScopeRootNodes(tree, virtualScopeRoots)
+        : [...tree, ...contentNodeTreeNodes];
 
-    if (q.length > 0 && !node.name.toLowerCase().includes(q)) {
-      return false;
-    }
-
-    return true;
-  });
+  const visibleNodes = filterVisibleNodes(currentNodes, q);
 
   const filterCounts: Partial<Record<FileExplorerFilter, number>> = {};
   for (const node of visibleNodes) {

--- a/front/components/file_explorer/utils.test.ts
+++ b/front/components/file_explorer/utils.test.ts
@@ -8,6 +8,7 @@ import {
   findTreeNodeByPath,
   getChildrenAtFolderPath,
   getExplorerRelativePath,
+  getFileExplorerSearchResultTitle,
   getVirtualScopeRootNodes,
   isFileExplorerMovableFile,
   withVirtualExplorerPath,
@@ -266,6 +267,38 @@ describe("getExplorerRelativePath", () => {
     expect(getExplorerRelativePath({ path: "pod-xyz/data.csv" })).toBe(
       "data.csv"
     );
+  });
+});
+
+describe("getFileExplorerSearchResultTitle", () => {
+  it("strips the current folder prefix from the explorer path", () => {
+    expect(
+      getFileExplorerSearchResultTitle(
+        {
+          path: "conversation-c1/reports/q1/summary.txt",
+          virtualPath: "conversation/reports/q1/summary.txt",
+        },
+        "conversation"
+      )
+    ).toBe("reports/q1/summary.txt");
+  });
+
+  it("returns the full explorer path at the virtual root", () => {
+    expect(
+      getFileExplorerSearchResultTitle(
+        {
+          path: "pod-p1/archive/readme.md",
+          virtualPath: "pod/archive/readme.md",
+        },
+        ""
+      )
+    ).toBe("pod/archive/readme.md");
+  });
+
+  it("falls back to mount-relative path when virtualPath is unset", () => {
+    expect(
+      getFileExplorerSearchResultTitle({ path: "pod-xyz/data.csv" }, "")
+    ).toBe("data.csv");
   });
 });
 

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -1,3 +1,4 @@
+import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import {
   frameSlideshowContentType,
@@ -394,6 +395,61 @@ export function getVirtualScopeRootNodes(
         fileId: null,
         children: [],
       }
+  );
+}
+
+/** Search result card title: explorer path with the current folder prefix stripped. */
+export function getFileExplorerSearchResultTitle(
+  entry: Pick<FileExplorerPathEntry, "path"> & { virtualPath?: string },
+  currentFolderPath: string
+): string {
+  const explorerPath = getExplorerRelativePath(entry);
+  if (!currentFolderPath) {
+    return explorerPath;
+  }
+
+  const prefix = `${currentFolderPath}/`;
+  if (explorerPath.startsWith(prefix)) {
+    return explorerPath.slice(prefix.length);
+  }
+
+  return explorerPath;
+}
+
+/** All file leaves in a tree (folders excluded). */
+export function collectAllFileTreeNodes(
+  nodes: FileSystemTreeNode[]
+): FileSystemTreeNode[] {
+  return nodes.flatMap((node) =>
+    node.isDirectory ? collectAllFileTreeNodes(node.children) : [node]
+  );
+}
+
+/** File leaves at `folderPath` and in descendant folders (empty path = entire tree). */
+export function collectFileTreeNodesAtOrBelow(
+  tree: FileSystemTreeNode[],
+  folderPath: string
+): FileSystemTreeNode[] {
+  const allFiles = collectAllFileTreeNodes(tree);
+  if (!folderPath) {
+    return allFiles;
+  }
+
+  const prefix = `${folderPath}/`;
+  return allFiles.filter((node) => node.path.startsWith(prefix));
+}
+
+export function isFileExplorerNodeHidden(node: FileSystemTreeNode): boolean {
+  return node.name.startsWith(".") && node.name !== TOOL_OUTPUTS_FOLDER_NAME;
+}
+
+/** Match file name or explorer-relative path (query must be lowercased). */
+export function fileExplorerNodeMatchesSearch(
+  node: FileSystemTreeNode,
+  q: string
+): boolean {
+  return (
+    node.name.toLowerCase().includes(q) || node.path.toLowerCase().includes(q)
   );
 }
 


### PR DESCRIPTION
## Description

`getFileExplorerPipeline` previously filtered only immediate children of `currentFolderPath` on search, so files in subdirectories were invisible. When `searchQuery` is non-empty, the pipeline now uses `collectFileTreeNodesAtOrBelow` to flatten all file leaves at or below the current folder before applying `filterVisibleNodes`. Match logic is also extended to check the full `node.path`, not just `node.name`, so partial path segments (e.g. folder names) match. In search mode, `FileExplorerFileCard` receives `searchFolderPath` and displays the explorer-relative path (current folder prefix stripped) via `getFileExplorerSearchResultTitle`, giving users context on where each result lives.

https://github.com/user-attachments/assets/509fed36-9ab6-46ad-8f6c-36c961ef97f3


## Tests

Tested locally. Added Vitest unit tests covering:
- `getFileExplorerPipeline` search: scoped-to-folder filtering, nested file discovery, root-level tree search.
- `getFileExplorerSearchResultTitle`: prefix stripping, root path passthrough, fallback when `virtualPath` is unset.

## Risk

Low. Pure function changes to the pipeline and presentational title logic. No API or persistence changes. Search in the current folder still works identically when `searchFolderPath` is `undefined`.

## Deploy Plan

Deploy front.
