### PR TITLE
fix: normalize empty-string nodeId/cursor in company_data and skill_fs MCP tools

### DIFF
--- a/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
@@ -34,6 +34,9 @@ export async function find(
   }: DataSourceFilesystemFindInputType & TagsInputType,
   { auth }: { auth: Authenticator }
 ): Promise<Result<CallToolResult["content"], MCPError>> {
+  const effectiveRootNodeId = !!rootNodeId ? rootNodeId : null;
+  const effectiveCursor = !!nextPageCursor ? nextPageCursor : undefined;
+
   const invalidMimeTypes = mimeTypes?.filter((m) => !isDustMimeType(m));
   if (invalidMimeTypes && invalidMimeTypes.length > 0) {
     return new Err(
@@ -60,8 +63,8 @@ export async function find(
     return new Err(new MCPError(conflictingTags, { tracked: false }));
   }
 
-  const dataSourceNodeId = rootNodeId
-    ? extractDataSourceIdFromNodeId(rootNodeId)
+  const dataSourceNodeId = effectiveRootNodeId
+    ? extractDataSourceIdFromNodeId(effectiveRootNodeId)
     : null;
 
   // If rootNodeId is provided and is a data source node ID, search only in
@@ -79,12 +82,12 @@ export async function find(
     viewFilter = viewFilter.filter(
       (view) => view.data_source_id === dataSourceNodeId
     );
-  } else if (rootNodeId) {
+  } else if (effectiveRootNodeId) {
     // Checking that we do have access to the root node.
     const rootNodeSearchResult = await coreAPI.searchNodes({
       filter: {
         data_source_views: viewFilter,
-        node_ids: [rootNodeId],
+        node_ids: [effectiveRootNodeId],
       },
     });
     if (rootNodeSearchResult.isErr()) {
@@ -97,10 +100,10 @@ export async function find(
     // If we could not access the root node, we return an error early here.
     if (
       rootNodeSearchResult.value.nodes.length === 0 ||
-      rootNodeSearchResult.value.nodes[0].node_id !== rootNodeId
+      rootNodeSearchResult.value.nodes[0].node_id !== effectiveRootNodeId
     ) {
       return new Err(
-        new MCPError(`Could not find node: ${rootNodeId}`, {
+        new MCPError(`Could not find node: ${effectiveRootNodeId}`, {
           tracked: false,
         })
       );
@@ -108,7 +111,7 @@ export async function find(
 
     viewFilter = viewFilter.map((view) => ({
       ...view,
-      filter: [rootNodeId],
+      filter: [effectiveRootNodeId],
     }));
   }
 
@@ -119,7 +122,7 @@ export async function find(
       mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
     },
     options: {
-      cursor: nextPageCursor,
+      cursor: effectiveCursor,
       limit: limit ?? DEFAULT_FIND_LIMIT,
     },
   });

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
@@ -42,6 +42,9 @@ export async function list(
   },
   { auth }: { auth: Authenticator }
 ) {
+  const effectiveNodeId = !!nodeId ? nodeId : null;
+  const effectiveCursor = !!nextPageCursor ? nextPageCursor : undefined;
+
   const invalidMimeTypes = mimeTypes?.filter((m) => !isDustMimeType(m));
   if (invalidMimeTypes && invalidMimeTypes.length > 0) {
     return new Err(
@@ -61,7 +64,7 @@ export async function list(
   const agentDataSourceConfigurations = fetchResult.value;
 
   const options = {
-    cursor: nextPageCursor,
+    cursor: effectiveCursor,
     limit: limit ?? DEFAULT_LIST_LIMIT,
     sort: sortBy
       ? [
@@ -78,7 +81,7 @@ export async function list(
   // By-pass tag filters when exploring the filesystem hierarchy
   const includeTagFilters = false;
 
-  if (!nodeId) {
+  if (!effectiveNodeId) {
     // When nodeId is null, search for data sources only.
     const dataSourceViewFilter = makeCoreSearchNodesFilters({
       agentDataSourceConfigurations,
@@ -95,9 +98,9 @@ export async function list(
       },
       options,
     });
-  } else if (isDataSourceNodeId(nodeId)) {
+  } else if (isDataSourceNodeId(effectiveNodeId)) {
     // If it's a data source node ID, extract the data source ID and list its root contents.
-    const dataSourceId = extractDataSourceIdFromNodeId(nodeId);
+    const dataSourceId = extractDataSourceIdFromNodeId(effectiveNodeId);
     if (!dataSourceId) {
       return new Err(
         new MCPError("Invalid data source node ID format", {
@@ -140,7 +143,7 @@ export async function list(
           agentDataSourceConfigurations,
           includeTagFilters,
         }),
-        parent_id: nodeId,
+        parent_id: effectiveNodeId,
         mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
       },
       options,


### PR DESCRIPTION
## Description

This PR fixes a bug where LLM tool calls pass empty strings for optional `nodeId` and `nextPageCursor` parameters in the `skill_fs` MCP tools (`find` and `list`), causing them to be treated as valid values instead of absent ones.

Related logs here https://app.datadoghq.eu/logs?query=region%3Aus-central1%20%40toolName%3Alist%20%22Tool%20execution%20error%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&event=AwAAAZ76enGj5jH0hQAAABhBWjc2ZW5Lc0FBQ1FTZnE3cml6MlZnQXQAAAAkMDE5ZWZhODYtZWFmNy00ZWNkLWFjNzItZjFlNjI3ZTA1NjYyAAPSbA&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1782318379000&to_ts=1782319579000&live=false

## Tests

Manually.

## Risks

## Deploy Plan

