### PR TITLE
Fix: use double click to go to edit mode (allow for easy copy pasting)

### DIFF
--- a/front/components/file_explorer/MarkdownFilePreview.tsx
+++ b/front/components/file_explorer/MarkdownFilePreview.tsx
@@ -263,7 +263,7 @@ export function MarkdownFilePreview({
               "min-h-0 flex-1 overflow-y-auto overflow-x-hidden",
               canEdit && "cursor-text"
             )}
-            onClick={handlePreviewClick}
+            onDoubleClick={handlePreviewClick}
           >
             <div ref={previewRef}>
               <Markdown


### PR DESCRIPTION
## Description

Changed `MarkdownFilePreview` to require a double-click to trigger `handlePreviewClick` (entering edit mode), instead of a single click. Single-click now leaves the preview in read mode, making it easy to select and copy text without accidentally switching to the editor.


## Tests

Tested locally by clicking (no mode switch) and double-clicking (enters edit mode) on a markdown file preview.

## Risk

Low. One-line change swapping `onClick` for `onDoubleClick` on the preview container. No logic change, no data mutations. Fully reversible.

## Deploy Plan

Deploy `front`.
