### PR TITLE
[front] enh: improve skill reference prompt wording

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -217,7 +217,8 @@ function constructSkillsSection({
     "Enable skills proactively when a user's request matches a skill's purpose.\n" +
     `Skill references can also appear as \`<skill id=\"...\" name=\"...\" />\` tags in user messages or enabled skill instructions. ` +
     "These tags are strong hints that the referenced skill is relevant, including when a skill author nested one skill inside another. " +
-    `If the referenced skill would help and is not already enabled, call \`${toolDisplayName}\` with \`skillName\` set to the tag's \`name\` value.\n` +
+    `You can enable the skill using \`${toolDisplayName}\` with \`skillName\` set to the tag's \`name\` value.\n` +
+    "It is not useful to enable skills that are already enabled, this would only output the skill's content again.\n" +
     "Referenced skills may not appear in the available-skills list; a tag is enough to enable the skill by name. " +
     "Only enable skills you actually need, because enabling a skill loads its full instructions into context.\n" +
     `Enabled skill instructions can also contain \`<unavailable_skill id=\"...\" />\` tags. ` +


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/8998.

This PR adjusts the skills section of the assistant prompt so `<skill ...>` to encourage enabling referenced skills (removes "If the referenced skill would help").

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
