### PR TITLE
[front] enh: add link to GitHub source on imported skills

### DIFF
--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -44,7 +44,6 @@ export function SkillBuilderSettingsSection({
             >
               <span>GitHub</span>
               <Icon visual={LinkExternal01} size="xs" />
-              <span className="sr-only">Open GitHub repository</span>
             </LinkWrapper>
             <span>.</span>
           </div>
@@ -104,7 +103,7 @@ function getGitHubSkillFolderUrl(skill?: SkillType): string | null {
   }
 
   const { owner, repo } = parsedRepoUrl.value;
-  const repoUrl = `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+  const repoUrl = `https://github.com/${owner}/${repo}`;
 
   if (!skill.sourceMetadata.filePath) {
     return repoUrl;
@@ -114,7 +113,6 @@ function getGitHubSkillFolderUrl(skill?: SkillType): string | null {
     .split("/")
     .filter(Boolean)
     .slice(0, -1)
-    .map(encodeURIComponent)
     .join("/");
 
   return `${repoUrl}/tree/main${folderPath ? `/${folderPath}` : ""}`;

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -4,12 +4,16 @@ import { SkillBuilderIsDefaultSection } from "@app/components/skill_builder/Skil
 import { SkillBuilderNameSection } from "@app/components/skill_builder/SkillBuilderNameSection";
 import { SkillBuilderUserFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderUserFacingDescriptionSection";
 import { SkillEditorsSheet } from "@app/components/skill_builder/SkillEditorsSheet";
+import { parseGitHubRepoUrl } from "@app/lib/skill_detection";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  Icon,
   Label,
+  LinkExternal01,
+  LinkWrapper,
 } from "@dust-tt/sparkle";
 
 interface SkillBuilderSettingsSectionProps {
@@ -21,11 +25,31 @@ export function SkillBuilderSettingsSection({
   skill,
   hasSelfImprovingSkills,
 }: SkillBuilderSettingsSectionProps) {
+  const githubRepoUrl = getGitHubRepoUrl(skill);
+
   return (
     <div className="space-y-5">
-      <h2 className="heading-lg text-foreground dark:text-foreground-night">
-        Skill settings
-      </h2>
+      <div className="space-y-1">
+        <h2 className="heading-lg text-foreground dark:text-foreground-night">
+          Skill settings
+        </h2>
+        {githubRepoUrl && (
+          <div className="flex items-center gap-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+            <span>This skill was originally imported from</span>
+            <LinkWrapper
+              href={githubRepoUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-highlight-500 hover:text-highlight-600 dark:text-highlight-500-night dark:hover:text-highlight-600-night"
+            >
+              <span>GitHub</span>
+              <Icon visual={LinkExternal01} size="xs" />
+              <span className="sr-only">Open GitHub repository</span>
+            </LinkWrapper>
+            <span>.</span>
+          </div>
+        )}
+      </div>
       <div className="flex items-end gap-8">
         <div className="flex-grow">
           <SkillBuilderNameSection />
@@ -67,4 +91,18 @@ export function SkillBuilderSettingsSection({
       )}
     </div>
   );
+}
+
+function getGitHubRepoUrl(skill?: SkillType): string | null {
+  if (skill?.source !== "github" || !skill.sourceMetadata?.repoUrl) {
+    return null;
+  }
+
+  const parsedRepoUrl = parseGitHubRepoUrl(skill.sourceMetadata.repoUrl);
+  if (parsedRepoUrl.isErr()) {
+    return null;
+  }
+
+  const { owner, repo } = parsedRepoUrl.value;
+  return `https://github.com/${owner}/${repo}`;
 }

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -94,11 +94,7 @@ export function SkillBuilderSettingsSection({
 }
 
 function getGitHubSkillFolderUrl(skill?: SkillType): string | null {
-  if (
-    skill?.source !== "github" ||
-    !skill.sourceMetadata?.repoUrl ||
-    !skill.sourceMetadata.filePath
-  ) {
+  if (skill?.source !== "github" || !skill.sourceMetadata?.repoUrl) {
     return null;
   }
 
@@ -108,6 +104,12 @@ function getGitHubSkillFolderUrl(skill?: SkillType): string | null {
   }
 
   const { owner, repo } = parsedRepoUrl.value;
+  const repoUrl = `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+
+  if (!skill.sourceMetadata.filePath) {
+    return repoUrl;
+  }
+
   const folderPath = skill.sourceMetadata.filePath
     .split("/")
     .filter(Boolean)
@@ -115,5 +117,5 @@ function getGitHubSkillFolderUrl(skill?: SkillType): string | null {
     .map(encodeURIComponent)
     .join("/");
 
-  return `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/tree/main${folderPath ? `/${folderPath}` : ""}`;
+  return `${repoUrl}/tree/main${folderPath ? `/${folderPath}` : ""}`;
 }

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -40,7 +40,7 @@ export function SkillBuilderSettingsSection({
               href={githubSkillFolderUrl}
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center gap-1 underline hover:text-foreground dark:hover:text-foreground-night"
+              className="inline-flex items-center gap-1 hover:text-foreground hover:underline dark:hover:text-foreground-night"
             >
               <span>GitHub</span>
               <Icon visual={LinkExternal01} size="xs" />

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -40,7 +40,7 @@ export function SkillBuilderSettingsSection({
               href={githubRepoUrl}
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center gap-1 text-highlight-500 hover:text-highlight-600 dark:text-highlight-500-night dark:hover:text-highlight-600-night"
+              className="inline-flex items-center gap-1 underline hover:text-foreground dark:hover:text-foreground-night"
             >
               <span>GitHub</span>
               <Icon visual={LinkExternal01} size="xs" />

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -25,7 +25,7 @@ export function SkillBuilderSettingsSection({
   skill,
   hasSelfImprovingSkills,
 }: SkillBuilderSettingsSectionProps) {
-  const githubRepoUrl = getGitHubRepoUrl(skill);
+  const githubSkillFolderUrl = getGitHubSkillFolderUrl(skill);
 
   return (
     <div className="space-y-5">
@@ -33,11 +33,11 @@ export function SkillBuilderSettingsSection({
         <h2 className="heading-lg text-foreground dark:text-foreground-night">
           Skill settings
         </h2>
-        {githubRepoUrl && (
+        {githubSkillFolderUrl && (
           <div className="flex items-center gap-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
             <span>This skill was originally imported from</span>
             <LinkWrapper
-              href={githubRepoUrl}
+              href={githubSkillFolderUrl}
               target="_blank"
               rel="noreferrer"
               className="inline-flex items-center gap-1 underline hover:text-foreground dark:hover:text-foreground-night"
@@ -93,8 +93,12 @@ export function SkillBuilderSettingsSection({
   );
 }
 
-function getGitHubRepoUrl(skill?: SkillType): string | null {
-  if (skill?.source !== "github" || !skill.sourceMetadata?.repoUrl) {
+function getGitHubSkillFolderUrl(skill?: SkillType): string | null {
+  if (
+    skill?.source !== "github" ||
+    !skill.sourceMetadata?.repoUrl ||
+    !skill.sourceMetadata.filePath
+  ) {
     return null;
   }
 
@@ -104,5 +108,12 @@ function getGitHubRepoUrl(skill?: SkillType): string | null {
   }
 
   const { owner, repo } = parsedRepoUrl.value;
-  return `https://github.com/${owner}/${repo}`;
+  const folderPath = skill.sourceMetadata.filePath
+    .split("/")
+    .filter(Boolean)
+    .slice(0, -1)
+    .map(encodeURIComponent)
+    .join("/");
+
+  return `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/tree/main${folderPath ? `/${folderPath}` : ""}`;
 }


### PR DESCRIPTION
## Description

This PR adds a small provenance line under Skill Builder settings for skills originally imported from GitHub.
The line links back to the repository link on github.com.

<img width="1042" height="284" alt="image" src="https://github.com/user-attachments/assets/8ee11de2-5ccd-4aeb-88a2-0e27bae5a911" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
