### PR TITLE
Add seats info in poke

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -141,6 +141,7 @@ export function WorkspacePage() {
     defaultAlerts,
     programmaticCreditState,
     programmaticWarningReached,
+    seatPlan,
     stripeSubscription,
     stripeCustomerId,
     subscriptions,
@@ -252,6 +253,7 @@ export function WorkspacePage() {
                   programmaticUsageConfig={programmaticUsageConfig}
                   hasMetronomeBillingFeature={hasMetronomeFeature}
                   stripeCustomerId={stripeCustomerId}
+                  seatPlan={seatPlan}
                 />
               </TabsContent>
               <TabsContent value="planlimitations">

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -11,6 +11,7 @@ import DowngradeToNoPlanButton from "@app/components/poke/subscriptions/Downgrad
 import EnterpriseUpgradeDialog from "@app/components/poke/subscriptions/EnterpriseUpgradeDialog";
 import FreePlanUpgradeDialog from "@app/components/poke/subscriptions/FreePlanUpgradeDialog";
 import SwitchContractDialog from "@app/components/poke/subscriptions/SwitchContractDialog";
+import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { getMetronomeContractUrl } from "@app/lib/metronome/urls";
@@ -306,6 +307,36 @@ function CancelPendingSubscriptionButton({
   );
 }
 
+function SeatCommitmentsSection({
+  seatPlan,
+}: {
+  seatPlan: SeatPlanResponseBody | null;
+}) {
+  const entries = Object.entries(seatPlan ?? {});
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="pb-1 pt-4 text-sm font-semibold">Seat Commitments</div>
+      <PokeTable>
+        <PokeTableBody>
+          {entries.map(([seatType, info]) => (
+            <PokeTableRow key={seatType}>
+              <PokeTableCell>{info.name}</PokeTableCell>
+              <PokeTableCell>
+                {info.minSeats} min / {info.maxSeats ?? "∞"} max /{" "}
+                {info.assignedCount} used
+              </PokeTableCell>
+            </PokeTableRow>
+          ))}
+        </PokeTableBody>
+      </PokeTable>
+    </>
+  );
+}
+
 interface ActiveSubscriptionTableProps {
   owner: WorkspaceType;
   metronomeCustomerId: string | null;
@@ -315,6 +346,7 @@ interface ActiveSubscriptionTableProps {
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
   hasMetronomeBillingFeature: boolean;
   stripeCustomerId: string | null;
+  seatPlan: SeatPlanResponseBody | null;
 }
 
 export function ActiveSubscriptionTable({
@@ -326,6 +358,7 @@ export function ActiveSubscriptionTable({
   programmaticUsageConfig,
   hasMetronomeBillingFeature,
   stripeCustomerId,
+  seatPlan,
 }: ActiveSubscriptionTableProps) {
   const status = getSubscriptionDisplayStatus(subscription);
   const { chipColor, chipLabel, cardClass } = STATUS_CONFIG[status];
@@ -381,6 +414,7 @@ export function ActiveSubscriptionTable({
             subscription={subscription}
             metronomeCustomerId={metronomeCustomerId}
           />
+          <SeatCommitmentsSection seatPlan={seatPlan} />
         </div>
       </div>
       {pendingSubscription && (

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -1,4 +1,8 @@
 import config from "@app/lib/api/config";
+import {
+  getSeatPlan,
+  type SeatPlanResponseBody,
+} from "@app/lib/api/credits/seat_plan";
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { getWorkspaceCreationDate } from "@app/lib/api/workspace";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
@@ -66,6 +70,7 @@ export type PokeWorkspaceInfo = {
   metronomeCustomerId: string | null;
   pendingSubscription: SubscriptionType | null;
   poolCreditState: WorkspacePoolCreditState;
+  seatPlan: SeatPlanResponseBody | null;
   // The Metronome alerts backing each credit dimension — id and current status —
   // for deep-linking and display from Poke. Null when not configured / not
   // Metronome-billed.
@@ -176,10 +181,14 @@ export async function getPokeWorkspaceInfo(
     );
   const pendingSubscription = pendingSubscriptionResource?.toJSON() ?? null;
 
-  const membersCount = await MembershipResource.getMembersCountForWorkspace({
-    workspace: owner,
-    activeOnly: true,
-  });
+  const [membersCount, seatPlanResult] = await Promise.all([
+    MembershipResource.getMembersCountForWorkspace({
+      workspace: owner,
+      activeOnly: true,
+    }),
+    getSeatPlan(auth),
+  ]);
+  const seatPlan = seatPlanResult.isOk() ? seatPlanResult.value : null;
 
   let stripeSubscription: Stripe.Subscription | null = null;
   if (activeSubscription.stripeSubscriptionId) {
@@ -215,6 +224,7 @@ export async function getPokeWorkspaceInfo(
     hasMetronomeFeature,
     membersCount,
     metronomeCustomerId: workspaceResource.metronomeCustomerId ?? null,
+    seatPlan,
     pendingSubscription,
     poolCreditState: workspaceResource.poolCreditState,
     poolAlert,


### PR DESCRIPTION
## Description

Shows seat commitments (min seats, max seats) and current seat usage in the poke admin UI, under the Subscriptions tab.

**What's added:**
- `seatPlan` field on `PokeWorkspaceInfo` — fetched in parallel with the members count, best-effort (returns `null` for non-Metronome or non-seat-billed workspaces)
- `SeatCommitmentsSection` component in the subscription card: one row per seat type showing `{name} | {min} min / {max} max / {used} used`
- Section is hidden when there are no seat types (free plans, MAU contracts, etc.)

## Tests

Manually verified type-check passes. The `getSeatPlan` function is already unit-tested; this change only adds a display layer on top of existing logic.

## Risk

Low. Read-only display change. `getSeatPlan` failures degrade gracefully to `null` (section hidden), so no impact on workspaces without a seat-billed Metronome contract.

## Deploy Plan

Standard deploy, no migration needed.