### PR TITLE
Improvements and fixes in switch_contract

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -1,5 +1,5 @@
-import { Authenticator } from "@app/lib/auth";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
+import { Authenticator } from "@app/lib/auth";
 import {
   archiveMetronomeContract,
   listMetronomePackages,
@@ -217,7 +217,9 @@ function postSwitchContract(workspaceId: string, body: unknown) {
 
 beforeEach(() => {
   vi.mocked(getOrCreateWorkOSOrganization).mockResolvedValue(
-    new Ok({ id: "org_test" } as unknown as import("@workos-inc/node").Organization)
+    new Ok({
+      id: "org_test",
+    } as unknown as import("@workos-inc/node").Organization)
   );
   vi.mocked(archiveMetronomeContract).mockResolvedValue(new Ok(undefined));
   vi.mocked(reactivateMetronomeContract).mockResolvedValue(new Ok(undefined));

--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -1,4 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
+import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import {
   archiveMetronomeContract,
   listMetronomePackages,
@@ -61,6 +62,16 @@ vi.mock("@app/lib/metronome/seats", async () => {
   return {
     ...actual,
     remapMembershipSeatTypesForContract: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/api/workos/organization", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/api/workos/organization")
+  >("@app/lib/api/workos/organization");
+  return {
+    ...actual,
+    getOrCreateWorkOSOrganization: vi.fn(),
   };
 });
 
@@ -205,6 +216,9 @@ function postSwitchContract(workspaceId: string, body: unknown) {
 }
 
 beforeEach(() => {
+  vi.mocked(getOrCreateWorkOSOrganization).mockResolvedValue(
+    new Ok({ id: "org_test" } as unknown as import("@workos-inc/node").Organization)
+  );
   vi.mocked(archiveMetronomeContract).mockResolvedValue(new Ok(undefined));
   vi.mocked(reactivateMetronomeContract).mockResolvedValue(new Ok(undefined));
   vi.mocked(ensureMetronomeCustomerForWorkspace).mockResolvedValue(

--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.ts
@@ -25,7 +25,7 @@ function statusForKind(kind: SwitchContractErrorKind): {
     case "metronome_api_error":
     case "provision_inconsistent":
       return { status_code: 502, type: "internal_server_error" };
-    case "payg_config_failed":
+    case "credit_config_failed":
       return { status_code: 500, type: "internal_server_error" };
     default:
       assertNever(kind);

--- a/front/components/poke/shadcn/ui/form/fields.tsx
+++ b/front/components/poke/shadcn/ui/form/fields.tsx
@@ -158,7 +158,7 @@ export function InputField<T extends FieldValues>({
               min={min}
               step={step}
               {...field}
-              value={field.value}
+              value={field.value ?? ""}
               onChange={(e) => {
                 if (transformValue) {
                   field.onChange(transformValue(e.target.value));
@@ -166,6 +166,10 @@ export function InputField<T extends FieldValues>({
                 }
 
                 if (type === "number") {
+                  if (e.target.value === "") {
+                    field.onChange(undefined);
+                    return;
+                  }
                   const parsed = Number(e.target.value);
                   if (isFinite(parsed)) {
                     field.onChange(parsed);

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -20,6 +20,7 @@ import {
   usePokePlans,
   usePokeStripeCustomerCurrency,
 } from "@app/lib/swr/poke";
+import { usePokePluginAsyncArgs } from "@app/poke/swr/plugins";
 import assert from "@app/lib/utils/assert";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
@@ -39,7 +40,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -70,12 +71,20 @@ const SwitchContractFormSchema = z
       .min(0, "Net payment terms must be ≥ 0")
       .max(365, "Net payment terms must be ≤ 365")
       .optional(),
+    // Credit usage configuration.
     paygEnabled: z.boolean().default(false),
     usageCapCredits: z
       .number()
       .int("Usage cap must be an integer number of credits")
       .min(1, "Usage cap must be at least 1 credit")
       .optional(),
+    defaultDiscountPercent: z.number().int().min(0).max(100).default(0),
+    balanceThresholdCredits: z.number().int().min(0).optional(),
+    defaultPoolCapCredits: z.number().int().min(0).optional(),
+    programmaticMonthlyCapCredits: z.number().int().min(0).optional(),
+    autoSeatUpgradeEnabled: z.boolean().default(false),
+    topUpEnabled: z.boolean().default(false),
+    autoInvoiceFinalizationEnabled: z.boolean().default(true),
     // One-off initial credits (contract-level prepaid commit). Toggled on via
     // `showInitialCredits`; both fields are then required together and assembled
     // into `initialCredits` on submit.
@@ -165,6 +174,14 @@ function snapDatetimeLocalToHour(value: string): string {
 
 const isLegacyPackageName = (name: string) => /\blegacy\b/i.test(name);
 
+const DEFAULT_PERIODS_FOR_FREQUENCY: Record<string, number | undefined> = {
+  monthly: 12,
+  quarterly: 4,
+  semi_annually: 2,
+  annually: 1,
+  one_time: undefined,
+};
+
 interface SwitchContractDialogProps {
   owner: WorkspaceType;
   stripeCustomerId: string | null;
@@ -228,6 +245,13 @@ export default function SwitchContractDialog({
       netPaymentTermsDays: undefined,
       paygEnabled: false,
       usageCapCredits: undefined,
+      defaultDiscountPercent: 0,
+      balanceThresholdCredits: undefined,
+      defaultPoolCapCredits: undefined,
+      programmaticMonthlyCapCredits: undefined,
+      autoSeatUpgradeEnabled: false,
+      topUpEnabled: false,
+      autoInvoiceFinalizationEnabled: true,
       showInitialCredits: false,
       initialCreditsAmount: undefined,
       initialCreditsInvoiceAmount: undefined,
@@ -247,6 +271,77 @@ export default function SwitchContractDialog({
     stripeCustomerId: trimmedStripeCustomerId,
     disabled: !open,
   });
+
+  // Fetch the existing credit config so we pre-populate form fields with
+  // current values rather than schema defaults, avoiding accidental overwrites.
+  const { asyncArgs: existingCreditConfig } = usePokePluginAsyncArgs({
+    pluginId: "manage-credit-usage-configuration",
+    pluginResourceTarget: {
+      resourceType: "workspaces",
+      resourceId: owner.sId,
+      workspace: owner,
+    },
+    disabled: !open,
+  });
+  const creditConfigAppliedRef = useRef(false);
+  useEffect(() => {
+    if (!open) {
+      creditConfigAppliedRef.current = false;
+      return;
+    }
+    if (!existingCreditConfig || creditConfigAppliedRef.current) return;
+    creditConfigAppliedRef.current = true;
+    const c = existingCreditConfig as Record<string, unknown>;
+    form.setValue(
+      "defaultDiscountPercent",
+      typeof c.defaultDiscountPercent === "number"
+        ? c.defaultDiscountPercent
+        : 0
+    );
+    form.setValue(
+      "paygEnabled",
+      typeof c.paygEnabled === "boolean" ? c.paygEnabled : false
+    );
+    // The plugin uses 0 for "no cap"; the form uses undefined.
+    const usageCap =
+      typeof c.usageCapCredits === "number" && c.usageCapCredits > 0
+        ? c.usageCapCredits
+        : undefined;
+    form.setValue("usageCapCredits", usageCap);
+    const balanceThreshold =
+      typeof c.balanceThresholdCredits === "number" &&
+      c.balanceThresholdCredits > 0
+        ? c.balanceThresholdCredits
+        : undefined;
+    form.setValue("balanceThresholdCredits", balanceThreshold);
+    const poolCap =
+      typeof c.defaultPoolCapCredits === "number" && c.defaultPoolCapCredits > 0
+        ? c.defaultPoolCapCredits
+        : undefined;
+    form.setValue("defaultPoolCapCredits", poolCap);
+    const programmaticCap =
+      typeof c.programmaticMonthlyCapCredits === "number" &&
+      c.programmaticMonthlyCapCredits > 0
+        ? c.programmaticMonthlyCapCredits
+        : undefined;
+    form.setValue("programmaticMonthlyCapCredits", programmaticCap);
+    form.setValue(
+      "autoSeatUpgradeEnabled",
+      typeof c.autoSeatUpgradeEnabled === "boolean"
+        ? c.autoSeatUpgradeEnabled
+        : false
+    );
+    form.setValue(
+      "topUpEnabled",
+      typeof c.topUpEnabled === "boolean" ? c.topUpEnabled : false
+    );
+    form.setValue(
+      "autoInvoiceFinalizationEnabled",
+      typeof c.autoInvoiceFinalizationEnabled === "boolean"
+        ? c.autoInvoiceFinalizationEnabled
+        : true
+    );
+  }, [open, existingCreditConfig, form]);
 
   // Split packages into Current vs Legacy sections (name contains "legacy",
   // case-insensitive). Each section preserves the lib-side sort order.
@@ -431,11 +526,42 @@ export default function SwitchContractDialog({
   const paygEnabled = form.watch("paygEnabled");
   const paygEligible =
     selectedTier !== null && isPaygEligibleTier(selectedTier);
+  const autoSeatUpgradeEnabled = form.watch("autoSeatUpgradeEnabled");
+  const topUpEnabled = form.watch("topUpEnabled");
+  const autoInvoiceFinalizationEnabled = form.watch(
+    "autoInvoiceFinalizationEnabled"
+  );
 
   const showInitialCredits = form.watch("showInitialCredits");
   const initialCreditsFrequency = form.watch("initialCreditsFrequency");
+
   const stripeCollectionMethod = form.watch("stripeCollectionMethod");
   const watchedSeats = form.watch("seats");
+
+  // When any payment frequency field changes, pre-fill its sibling periods
+  // field with the canonical default. Uses form.watch(callback) — the only
+  // reliable way to know exactly which field changed (via the `name` argument).
+  useEffect(() => {
+    const { unsubscribe } = form.watch((value, { name }) => {
+      if (name === "initialCreditsFrequency") {
+        form.setValue(
+          "initialCreditsPeriods",
+          DEFAULT_PERIODS_FOR_FREQUENCY[
+            value.initialCreditsFrequency ?? "one_time"
+          ]
+        );
+      }
+      if (name?.startsWith("seats.") && name.endsWith(".paymentFrequency")) {
+        const seatType = name.split(".")[1];
+        const freq = value.seats?.[seatType]?.paymentFrequency ?? "one_time";
+        form.setValue(
+          `seats.${seatType}.paymentPeriods`,
+          DEFAULT_PERIODS_FOR_FREQUENCY[freq]
+        );
+      }
+    });
+    return unsubscribe;
+  }, [form]);
 
   const onSubmit = useCallback(
     (values: SwitchContractFormValues) => {
@@ -461,6 +587,21 @@ export default function SwitchContractDialog({
       }
       if (values.usageCapCredits !== undefined) {
         cleaned.usageCapCredits = values.usageCapCredits;
+      }
+      cleaned.defaultDiscountPercent = values.defaultDiscountPercent;
+      cleaned.autoSeatUpgradeEnabled = values.autoSeatUpgradeEnabled;
+      cleaned.topUpEnabled = values.topUpEnabled;
+      cleaned.autoInvoiceFinalizationEnabled =
+        values.autoInvoiceFinalizationEnabled;
+      if (values.balanceThresholdCredits !== undefined) {
+        cleaned.balanceThresholdCredits = values.balanceThresholdCredits;
+      }
+      if (values.defaultPoolCapCredits !== undefined) {
+        cleaned.defaultPoolCapCredits = values.defaultPoolCapCredits;
+      }
+      if (values.programmaticMonthlyCapCredits !== undefined) {
+        cleaned.programmaticMonthlyCapCredits =
+          values.programmaticMonthlyCapCredits;
       }
       // Initial credits: only sent when the operator toggled the section on.
       // Both the credit amount and the invoice amount are then required, and a
@@ -526,12 +667,17 @@ export default function SwitchContractDialog({
           ? (entry?.minSeats ?? 0)
           : 0;
         const rate = Number.isFinite(entry?.rate) ? (entry?.rate ?? 0) : 0;
-        const commitmentPrice =
+        // If the operator left commitment price blank, default to minSeats * rate
+        // (the list value of the committed seats).
+        const explicitPrice =
           typeof entry?.commitmentPrice === "number" &&
           Number.isFinite(entry.commitmentPrice) &&
           entry.commitmentPrice > 0
             ? entry.commitmentPrice
-            : undefined;
+            : null;
+        const commitmentPrice =
+          explicitPrice ??
+          (minSeats > 0 && rate > 0 ? minSeats * rate : undefined);
         const paymentFrequency = entry?.paymentFrequency ?? "one_time";
         const paymentPeriods = entry?.paymentPeriods;
         if (selected && !entitled && seatType !== "free" && !(rate > 0)) {
@@ -634,150 +780,257 @@ export default function SwitchContractDialog({
               onSubmit={form.handleSubmit(onSubmit)}
               style={{ display: "contents" }}
             >
-              <DialogContainer className="space-y-4">
-                {error && <div className="text-warning">{error}</div>}
-                <InputField
-                  control={form.control}
-                  name="stripeCustomerId"
-                  title="Stripe Customer Id (optional for free plans)"
-                  placeholder="cus_1234567890"
-                />
-                <InputField
-                  control={form.control}
-                  name="hubspotDealId"
-                  title="HubSpot Deal Id (optional)"
-                  placeholder="e.g., 12345678901"
-                />
-                {isCurrencyLoading && (
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    <Spinner size="sm" />
-                    <span>Resolving customer currency...</span>
-                  </div>
-                )}
-                {currencyError && (
-                  <div className="text-warning text-sm">
-                    Failed to resolve currency from Stripe customer:{" "}
-                    {currencyError.message}
-                  </div>
-                )}
-                {trimmedStripeCustomerId && (
-                  <SelectField
+              <DialogContainer>
+                <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
+                  {error && (
+                    <div className="col-span-2 text-warning">{error}</div>
+                  )}
+                  <Label className="text-sm">
+                    Stripe Customer ID
+                    <span className="ml-1 text-muted-foreground dark:text-muted-foreground-night">
+                      (optional)
+                    </span>
+                  </Label>
+                  <InputField
                     control={form.control}
-                    name="stripeCollectionMethod"
-                    title="Stripe Collection Method"
-                    mountPortalContainer={portalContainer}
-                    options={[
-                      {
-                        value: "charge_automatically",
-                        display: "Charge automatically (card on file)",
-                      },
-                      {
-                        value: "send_invoice",
-                        display: "Send invoice (manual payment)",
-                      },
-                    ]}
+                    name="stripeCustomerId"
+                    hideLabel
+                    placeholder="cus_1234567890"
                   />
-                )}
-                {trimmedStripeCustomerId &&
-                  stripeCollectionMethod === "send_invoice" && (
-                    <InputField
-                      control={form.control}
-                      name="netPaymentTermsDays"
-                      title="Net Payment Terms (days — e.g. 30 for Net 30)"
-                      type="number"
-                      placeholder="Leave empty for the Metronome account default"
-                    />
+                  <Label className="text-sm">
+                    HubSpot Deal ID
+                    <span className="ml-1 text-muted-foreground dark:text-muted-foreground-night">
+                      (optional)
+                    </span>
+                  </Label>
+                  <InputField
+                    control={form.control}
+                    name="hubspotDealId"
+                    hideLabel
+                    placeholder="e.g., 12345678901"
+                  />
+                  {isCurrencyLoading && (
+                    <div className="col-span-2 flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      <Spinner size="sm" />
+                      <span>Resolving customer currency...</span>
+                    </div>
                   )}
-                {isPackagesLoading && (
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    <Spinner size="sm" />
-                    <span>Loading Metronome packages...</span>
-                  </div>
-                )}
-                {!isPackagesLoading && packagesError && (
-                  <div className="text-warning text-sm">
-                    Failed to load Metronome packages: {packagesError.message}
-                  </div>
-                )}
-                {!isPackagesLoading &&
-                  !packagesError &&
-                  !isCurrencyLoading &&
-                  (resolvedCurrency || !trimmedStripeCustomerId) && (
-                    <SelectField
-                      control={form.control}
-                      name="metronomePackageId"
-                      title={
-                        resolvedCurrency
-                          ? `Metronome Package (${resolvedCurrency.toUpperCase()})`
-                          : "Metronome Package (free only — no Stripe customer)"
-                      }
-                      mountPortalContainer={portalContainer}
-                      groups={packageGroups}
-                    />
+                  {currencyError && (
+                    <div className="col-span-2 text-sm text-warning">
+                      Failed to resolve currency from Stripe customer:{" "}
+                      {currencyError.message}
+                    </div>
                   )}
-                {selectedTier === "enterprise" && (
-                  <>
-                    <SelectField
-                      control={form.control}
-                      name="planCode"
-                      title="Enterprise Plan"
-                      mountPortalContainer={portalContainer}
-                      options={enterprisePlanOptions}
-                    />
-                    <SelectField
-                      control={form.control}
-                      name="startMode"
-                      title="Start"
-                      mountPortalContainer={portalContainer}
-                      options={startModeOptions}
-                    />
-                    {startMode === "select" && (
-                      <div>
+                  {trimmedStripeCustomerId && (
+                    <>
+                      <Label className="text-sm">Collection method</Label>
+                      <SelectField
+                        control={form.control}
+                        name="stripeCollectionMethod"
+                        hideLabel
+                        mountPortalContainer={portalContainer}
+                        options={[
+                          {
+                            value: "charge_automatically",
+                            display: "Charge automatically (card on file)",
+                          },
+                          {
+                            value: "send_invoice",
+                            display: "Send invoice (manual payment)",
+                          },
+                        ]}
+                      />
+                    </>
+                  )}
+                  {trimmedStripeCustomerId &&
+                    stripeCollectionMethod === "send_invoice" && (
+                      <>
+                        <Label className="text-sm">
+                          Net payment terms (days)
+                        </Label>
                         <InputField
                           control={form.control}
-                          name="startingAt"
-                          title="Starts At (UTC — prefer midnight, past allowed)"
-                          type="datetime-local"
-                          step={3600}
-                          transformValue={snapDatetimeLocalToHour}
+                          name="netPaymentTermsDays"
+                          hideLabel
+                          type="number"
+                          placeholder="Metronome account default"
                         />
-                        {startingAtLocalLabel && (
-                          <p className="mt-1 text-xs text-muted-foreground dark:text-muted-foreground-night">
-                            Local time: {startingAtLocalLabel}
-                          </p>
-                        )}
-                      </div>
+                      </>
                     )}
-                  </>
-                )}
-                {(selectedTier === "pro" ||
-                  selectedTier === "business" ||
-                  selectedTier === "free") && (
-                  <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    Target plan:{" "}
-                    <span className="font-mono">{form.watch("planCode")}</span>{" "}
-                    — swap at the current hour, subscription flips
-                    synchronously.
-                  </div>
-                )}
-                {paygEligible && (
-                  <div className="space-y-4 border-t pt-4">
-                    <div className="flex items-center gap-2">
+                  {isPackagesLoading && (
+                    <div className="col-span-2 flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      <Spinner size="sm" />
+                      <span>Loading Metronome packages...</span>
+                    </div>
+                  )}
+                  {!isPackagesLoading && packagesError && (
+                    <div className="col-span-2 text-sm text-warning">
+                      Failed to load Metronome packages: {packagesError.message}
+                    </div>
+                  )}
+                  {!isPackagesLoading &&
+                    !packagesError &&
+                    !isCurrencyLoading &&
+                    (resolvedCurrency || !trimmedStripeCustomerId) && (
+                      <>
+                        <Label className="text-sm">
+                          Package
+                          {resolvedCurrency &&
+                            ` (${resolvedCurrency.toUpperCase()})`}
+                        </Label>
+                        <SelectField
+                          control={form.control}
+                          name="metronomePackageId"
+                          hideLabel
+                          mountPortalContainer={portalContainer}
+                          groups={packageGroups}
+                        />
+                      </>
+                    )}
+                  {selectedTier === "enterprise" && (
+                    <>
+                      <Label className="text-sm">Enterprise plan</Label>
+                      <SelectField
+                        control={form.control}
+                        name="planCode"
+                        hideLabel
+                        mountPortalContainer={portalContainer}
+                        options={enterprisePlanOptions}
+                      />
+                      <Label className="text-sm">Start</Label>
+                      <SelectField
+                        control={form.control}
+                        name="startMode"
+                        hideLabel
+                        mountPortalContainer={portalContainer}
+                        options={startModeOptions}
+                      />
+                      {startMode === "select" && (
+                        <>
+                          <Label className="text-sm">Starts at (UTC)</Label>
+                          <div className="relative">
+                            <InputField
+                              control={form.control}
+                              name="startingAt"
+                              hideLabel
+                              type="datetime-local"
+                              step={3600}
+                              transformValue={snapDatetimeLocalToHour}
+                            />
+                            {startingAtLocalLabel && (
+                              <p className="mt-1 text-xs text-muted-foreground dark:text-muted-foreground-night absolute top-2 right-2">
+                                Local: {startingAtLocalLabel}
+                              </p>
+                            )}
+                          </div>
+                        </>
+                      )}
+                    </>
+                  )}
+                  {(selectedTier === "pro" ||
+                    selectedTier === "business" ||
+                    selectedTier === "free") && (
+                    <div className="col-span-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      Target plan:{" "}
+                      <span className="font-mono">
+                        {form.watch("planCode")}
+                      </span>{" "}
+                      — swap at the current hour, subscription flips
+                      synchronously.
+                    </div>
+                  )}
+                </div>
+                {selectedTier && selectedTier !== "free" && (
+                  <div className="border-t pt-4">
+                    <Label className="mb-3 block text-sm font-medium">
+                      Credit configuration
+                    </Label>
+                    <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
+                      {paygEligible && (
+                        <>
+                          <Label className="text-sm">Pay-as-you-go</Label>
+                          <SliderToggle
+                            selected={paygEnabled}
+                            onClick={() =>
+                              form.setValue("paygEnabled", !paygEnabled)
+                            }
+                          />
+                        </>
+                      )}
+                      <Label className="text-sm">Monthly usage cap (AWU)</Label>
+                      <InputField
+                        control={form.control}
+                        name="usageCapCredits"
+                        hideLabel
+                        type="number"
+                        placeholder="no cap"
+                      />
+                      <Label className="text-sm">Default discount (%)</Label>
+                      <InputField
+                        control={form.control}
+                        name="defaultDiscountPercent"
+                        hideLabel
+                        type="number"
+                        placeholder="0"
+                      />
+                      <Label className="text-sm">Balance alert (AWU)</Label>
+                      <InputField
+                        control={form.control}
+                        name="balanceThresholdCredits"
+                        hideLabel
+                        type="number"
+                        placeholder="no alert"
+                      />
+                      <Label className="text-sm">
+                        Per-user pool access (AWU)
+                      </Label>
+                      <InputField
+                        control={form.control}
+                        name="defaultPoolCapCredits"
+                        hideLabel
+                        type="number"
+                        placeholder="no access"
+                      />
+                      <Label className="text-sm">
+                        Programmatic cap/mo (AWU)
+                      </Label>
+                      <InputField
+                        control={form.control}
+                        name="programmaticMonthlyCapCredits"
+                        hideLabel
+                        type="number"
+                        placeholder="no cap"
+                      />
+                      <Label className="text-sm">Auto-upgrade seats</Label>
                       <SliderToggle
-                        selected={paygEnabled}
+                        selected={autoSeatUpgradeEnabled}
                         onClick={() =>
-                          form.setValue("paygEnabled", !paygEnabled)
+                          form.setValue(
+                            "autoSeatUpgradeEnabled",
+                            !autoSeatUpgradeEnabled
+                          )
                         }
                       />
-                      <Label className="text-sm">Pay-as-you-go</Label>
+                      <Label className="text-sm">Top-up (Enterprise)</Label>
+                      <SliderToggle
+                        selected={topUpEnabled}
+                        onClick={() =>
+                          form.setValue("topUpEnabled", !topUpEnabled)
+                        }
+                      />
+                      <Label className="text-sm">
+                        Auto invoice finalization
+                      </Label>
+                      <SliderToggle
+                        selected={autoInvoiceFinalizationEnabled}
+                        onClick={() =>
+                          form.setValue(
+                            "autoInvoiceFinalizationEnabled",
+                            !autoInvoiceFinalizationEnabled
+                          )
+                        }
+                      />
                     </div>
-                    <InputField
-                      control={form.control}
-                      name="usageCapCredits"
-                      title="Usage Cap (AWU credits, optional)"
-                      type="number"
-                      placeholder="e.g., 100000 — leave empty for no alert"
-                    />
                   </div>
                 )}
                 {selectedSeats.length > 0 && (
@@ -819,6 +1072,13 @@ export default function SwitchContractDialog({
                       const seatPaymentFrequency =
                         watchedSeats?.[seatType]?.paymentFrequency ??
                         "one_time";
+                      const minSeats = watchedSeats?.[seatType]?.minSeats ?? 0;
+                      const rate = watchedSeats?.[seatType]?.rate ?? 0;
+                      const isAnnualSeat = seatType.endsWith("_yearly");
+                      const defaultCommitment =
+                        minSeats > 0 && rate > 0 ? minSeats * rate : null;
+                      const monthlyRate =
+                        isAnnualSeat && rate > 0 ? rate / 12 : null;
                       return (
                         <div key={seatType} className="flex items-center gap-3">
                           <div className="flex w-32 shrink-0 items-center gap-2">
@@ -850,7 +1110,7 @@ export default function SwitchContractDialog({
                               disabled={!isSelected}
                             />
                           </div>
-                          <div className="flex-1">
+                          <div className="flex-1 relative">
                             <InputField
                               control={form.control}
                               name={`seats.${seatType}.rate`}
@@ -859,6 +1119,14 @@ export default function SwitchContractDialog({
                               placeholder="0"
                               disabled={!isSelected}
                             />
+                            {isSelected && monthlyRate !== null && (
+                              <p className="mt-0.5 text-xs text-muted-foreground dark:text-muted-foreground-night absolute top-2 right-2">
+                                {monthlyRate % 1 === 0
+                                  ? monthlyRate
+                                  : monthlyRate.toFixed(2)}
+                                /mo
+                              </p>
+                            )}
                           </div>
                           <div className="flex-1">
                             <InputField
@@ -866,7 +1134,11 @@ export default function SwitchContractDialog({
                               name={`seats.${seatType}.commitmentPrice`}
                               hideLabel
                               type="number"
-                              placeholder="optional"
+                              placeholder={
+                                defaultCommitment !== null
+                                  ? String(defaultCommitment)
+                                  : "optional"
+                              }
                               disabled={!isSelected}
                             />
                           </div>
@@ -905,8 +1177,11 @@ export default function SwitchContractDialog({
                   </div>
                 )}
                 {trimmedStripeCustomerId && resolvedCurrency && (
-                  <div className="space-y-4 border-t pt-4">
-                    <div className="flex items-center gap-2">
+                  <div className="border-t pt-4">
+                    <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
+                      <Label className="text-sm font-medium">
+                        Initial credits (prepaid commit)
+                      </Label>
                       <SliderToggle
                         selected={showInitialCredits}
                         onClick={() =>
@@ -916,65 +1191,64 @@ export default function SwitchContractDialog({
                           )
                         }
                       />
-                      <Label className="text-sm">
-                        Initial credits (prepaid commit)
-                      </Label>
-                    </div>
-                    {showInitialCredits && (
-                      <>
-                        <InputField
-                          control={form.control}
-                          name="initialCreditsAmount"
-                          title="Initial Credits (AWU credits)"
-                          type="number"
-                          placeholder="e.g., 100000"
-                        />
-                        <InputField
-                          control={form.control}
-                          name="initialCreditsInvoiceAmount"
-                          title={`Total Amount to Invoice (${resolvedCurrency.toUpperCase()})`}
-                          type="number"
-                          placeholder="e.g., 5000 — total billed to the customer"
-                        />
-                        <SelectField
-                          control={form.control}
-                          name="initialCreditsFrequency"
-                          title="Payment schedule"
-                          mountPortalContainer={portalContainer}
-                          options={[
-                            {
-                              value: "one_time",
-                              display: "One-time (single invoice)",
-                            },
-                            {
-                              value: "monthly",
-                              display: "Monthly",
-                            },
-                            {
-                              value: "quarterly",
-                              display: "Quarterly (every 3 months)",
-                            },
-                            {
-                              value: "semi_annually",
-                              display: "Semi-annually (every 6 months)",
-                            },
-                            {
-                              value: "annually",
-                              display: "Annually",
-                            },
-                          ]}
-                        />
-                        {initialCreditsFrequency !== "one_time" && (
+                      {showInitialCredits && (
+                        <>
+                          <Label className="text-sm">Credits (AWU)</Label>
                           <InputField
                             control={form.control}
-                            name="initialCreditsPeriods"
-                            title="Number of periods"
+                            name="initialCreditsAmount"
+                            hideLabel
                             type="number"
-                            placeholder="e.g., 4 for 4 quarterly installments"
+                            placeholder="e.g., 100000"
                           />
-                        )}
-                      </>
-                    )}
+                          <Label className="text-sm">
+                            Invoice ({resolvedCurrency.toUpperCase()})
+                          </Label>
+                          <InputField
+                            control={form.control}
+                            name="initialCreditsInvoiceAmount"
+                            hideLabel
+                            type="number"
+                            placeholder="e.g., 5000"
+                          />
+                          <Label className="text-sm">Payment schedule</Label>
+                          <SelectField
+                            control={form.control}
+                            name="initialCreditsFrequency"
+                            hideLabel
+                            mountPortalContainer={portalContainer}
+                            options={[
+                              {
+                                value: "one_time",
+                                display: "One-time",
+                              },
+                              { value: "monthly", display: "Monthly" },
+                              {
+                                value: "quarterly",
+                                display: "Quarterly",
+                              },
+                              {
+                                value: "semi_annually",
+                                display: "Semi-annually",
+                              },
+                              { value: "annually", display: "Annually" },
+                            ]}
+                          />
+                          {initialCreditsFrequency !== "one_time" && (
+                            <>
+                              <Label className="text-sm">Periods</Label>
+                              <InputField
+                                control={form.control}
+                                name="initialCreditsPeriods"
+                                hideLabel
+                                type="number"
+                                placeholder="e.g., 4"
+                              />
+                            </>
+                          )}
+                        </>
+                      )}
+                    </div>
                   </div>
                 )}
               </DialogContainer>

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -3,6 +3,7 @@ import {
   InputField,
   SelectField,
 } from "@app/components/poke/shadcn/ui/form/fields";
+import { CreditUsageConfigurationSchema } from "@app/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration";
 import type { SwitchContractBodySchema } from "@app/lib/api/poke/switch_contract";
 import { clientFetch } from "@app/lib/egress/client";
 import { amountCents } from "@app/lib/metronome/amounts";
@@ -20,8 +21,8 @@ import {
   usePokePlans,
   usePokeStripeCustomerCurrency,
 } from "@app/lib/swr/poke";
-import { usePokePluginAsyncArgs } from "@app/poke/swr/plugins";
 import assert from "@app/lib/utils/assert";
+import { usePokePluginAsyncArgs } from "@app/poke/swr/plugins";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -289,57 +290,38 @@ export default function SwitchContractDialog({
       creditConfigAppliedRef.current = false;
       return;
     }
-    if (!existingCreditConfig || creditConfigAppliedRef.current) return;
+    if (!existingCreditConfig || creditConfigAppliedRef.current) {
+      return;
+    }
     creditConfigAppliedRef.current = true;
-    const c = existingCreditConfig as Record<string, unknown>;
+    const parsed =
+      CreditUsageConfigurationSchema.safeParse(existingCreditConfig);
+    if (!parsed.success) {
+      return;
+    }
+    const d = parsed.data;
+    // The plugin uses 0 for "no cap/limit"; the form uses undefined.
+    const orUndefined = (n: number) => (n > 0 ? n : undefined);
+    form.setValue("defaultDiscountPercent", d.defaultDiscountPercent);
+    form.setValue("paygEnabled", d.paygEnabled);
+    form.setValue("usageCapCredits", orUndefined(d.usageCapCredits));
     form.setValue(
-      "defaultDiscountPercent",
-      typeof c.defaultDiscountPercent === "number"
-        ? c.defaultDiscountPercent
-        : 0
+      "balanceThresholdCredits",
+      orUndefined(d.balanceThresholdCredits)
     );
     form.setValue(
-      "paygEnabled",
-      typeof c.paygEnabled === "boolean" ? c.paygEnabled : false
-    );
-    // The plugin uses 0 for "no cap"; the form uses undefined.
-    const usageCap =
-      typeof c.usageCapCredits === "number" && c.usageCapCredits > 0
-        ? c.usageCapCredits
-        : undefined;
-    form.setValue("usageCapCredits", usageCap);
-    const balanceThreshold =
-      typeof c.balanceThresholdCredits === "number" &&
-      c.balanceThresholdCredits > 0
-        ? c.balanceThresholdCredits
-        : undefined;
-    form.setValue("balanceThresholdCredits", balanceThreshold);
-    const poolCap =
-      typeof c.defaultPoolCapCredits === "number" && c.defaultPoolCapCredits > 0
-        ? c.defaultPoolCapCredits
-        : undefined;
-    form.setValue("defaultPoolCapCredits", poolCap);
-    const programmaticCap =
-      typeof c.programmaticMonthlyCapCredits === "number" &&
-      c.programmaticMonthlyCapCredits > 0
-        ? c.programmaticMonthlyCapCredits
-        : undefined;
-    form.setValue("programmaticMonthlyCapCredits", programmaticCap);
-    form.setValue(
-      "autoSeatUpgradeEnabled",
-      typeof c.autoSeatUpgradeEnabled === "boolean"
-        ? c.autoSeatUpgradeEnabled
-        : false
+      "defaultPoolCapCredits",
+      orUndefined(d.defaultPoolCapCredits)
     );
     form.setValue(
-      "topUpEnabled",
-      typeof c.topUpEnabled === "boolean" ? c.topUpEnabled : false
+      "programmaticMonthlyCapCredits",
+      orUndefined(d.programmaticMonthlyCapCredits)
     );
+    form.setValue("autoSeatUpgradeEnabled", d.autoSeatUpgradeEnabled);
+    form.setValue("topUpEnabled", d.topUpEnabled);
     form.setValue(
       "autoInvoiceFinalizationEnabled",
-      typeof c.autoInvoiceFinalizationEnabled === "boolean"
-        ? c.autoInvoiceFinalizationEnabled
-        : true
+      d.autoInvoiceFinalizationEnabled
     );
   }, [open, existingCreditConfig, form]);
 

--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -24,7 +24,7 @@ import { z } from "zod";
 export const MAX_AWU_USAGE_CAP_CREDITS = 2_000_000;
 const POKE_AUDIT_CONTEXT = { location: "poke" };
 
-const CreditUsageConfigurationSchema = z.object({
+export const CreditUsageConfigurationSchema = z.object({
   defaultDiscountPercent: z
     .number()
     .min(0, "Discount percentage must be at least 0")

--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -106,7 +106,7 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
       defaultPoolCapCredits: {
         type: "number",
         variant: "text",
-        label: "Default Per-User Pool Limit (credits)",
+        label: "Default Per-User Pool Access (credits)",
         description:
           "Default pool credit limit added on top of each seat's allowance. Set to 0 to prevent pool usage.",
         async: true,

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -3,7 +3,6 @@ import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import { metronomeAmount } from "@app/lib/metronome/amounts";
-import type { ContractEditParams } from "@metronome/sdk/resources/v2/contracts";
 import {
   ceilToHourISO,
   editMetronomeContract,
@@ -49,13 +48,14 @@ import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usag
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
-import type { LightWorkspaceType } from "@app/types/user";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import { isMembershipSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { ContractEditParams } from "@metronome/sdk/resources/v2/contracts";
 import { z } from "zod";
 
 const paymentScheduleSchema = z
@@ -164,8 +164,8 @@ export type SwitchContractErrorKind =
   | "invalid_request"
   // Metronome (or other upstream) API failure before any state was changed.
   | "metronome_api_error"
-  // PAYG configuration update/create failed (pre-provision, clean abort).
-  | "payg_config_failed"
+  // Credit configuration update/create failed (pre-provision, clean abort).
+  | "credit_config_failed"
   // Contract was provisioned but one or more post-provision steps failed.
   // The contract is live; the operator must address each listed item manually.
   | "provision_inconsistent";
@@ -371,7 +371,9 @@ async function resolveStripeCustomer(
 ): Promise<
   Result<{ resolvedCurrency: SupportedCurrency | null }, SwitchContractError>
 > {
-  if (!stripeCustomerId) return new Ok({ resolvedCurrency: null });
+  if (!stripeCustomerId) {
+    return new Ok({ resolvedCurrency: null });
+  }
   const stripeCustomer = await getStripeCustomer(stripeCustomerId);
   if (!stripeCustomer) {
     return new Err(
@@ -491,7 +493,9 @@ async function resolveAndValidatePackage(
   }
   const pkgSeatByType = new Map(pkg.seats.map((s) => [s.seatType, s]));
   for (const seat of body.seats ?? []) {
-    if (!isMembershipSeatType(seat.seatType)) continue;
+    if (!isMembershipSeatType(seat.seatType)) {
+      continue;
+    }
     const pkgSeat = pkgSeatByType.get(seat.seatType);
     if (
       seat.selected &&
@@ -554,7 +558,9 @@ async function persistSeatFloors(
   body: SwitchContractBody
 ): Promise<Result<void, SwitchContractError>> {
   for (const seat of body.seats ?? []) {
-    if (!isMembershipSeatType(seat.seatType)) continue;
+    if (!isMembershipSeatType(seat.seatType)) {
+      continue;
+    }
     if (seat.selected && seat.minSeats > 0) {
       const result = await WorkspaceSeatLimitResource.upsert({
         workspace,
@@ -589,7 +595,9 @@ async function cancelExistingPendingContract(
 ): Promise<Result<void, SwitchContractError>> {
   const existingPending =
     await SubscriptionResource.fetchPendingByWorkspaceModelId(workspaceModelId);
-  if (!existingPending) return new Ok(undefined);
+  if (!existingPending) {
+    return new Ok(undefined);
+  }
   const result = await cancelPendingContract({ auth });
   if (result.isErr()) {
     return new Err(
@@ -606,10 +614,11 @@ async function cancelExistingPendingContract(
 // Ensure the workspace has a WorkOS organization for any paid tier.
 async function ensureWorkOSOrg(
   ownerLight: LightWorkspaceType,
-  pkgTier: MetronomePackageTier,
-  workspaceId: string
+  pkgTier: MetronomePackageTier
 ): Promise<Result<void, SwitchContractError>> {
-  if (pkgTier === "free") return new Ok(undefined);
+  if (pkgTier === "free") {
+    return new Ok(undefined);
+  }
   const result = await getOrCreateWorkOSOrganization(ownerLight);
   if (result.isErr()) {
     return new Err(
@@ -646,7 +655,7 @@ async function persistCreditConfig(
     if (result.isErr()) {
       return new Err(
         new SwitchContractError(
-          "payg_config_failed",
+          "credit_config_failed",
           `Failed to update credit configuration: ${result.error.message}`
         )
       );
@@ -659,7 +668,7 @@ async function persistCreditConfig(
     if (result.isErr()) {
       return new Err(
         new SwitchContractError(
-          "payg_config_failed",
+          "credit_config_failed",
           `Failed to create credit configuration: ${result.error.message}`
         )
       );
@@ -746,7 +755,9 @@ async function stepContractEdits({
 
   // Seat commitment commits and rate overrides.
   for (const seat of body.seats ?? []) {
-    if (!isMembershipSeatType(seat.seatType)) continue;
+    if (!isMembershipSeatType(seat.seatType)) {
+      continue;
+    }
     const pkgSeat = pkgSeatByType.get(seat.seatType);
     const billingFrequency = seat.seatType.endsWith("_yearly")
       ? "ANNUAL"
@@ -906,7 +917,9 @@ async function stepStripeCancellation({
   workspaceId,
   metronomeContractId,
 }: PostProvisionCtx): Promise<string | null> {
-  if (!stripeSubscriptionId) return null;
+  if (!stripeSubscriptionId) {
+    return null;
+  }
   const stripeCancelAt =
     alignedStart.getTime() > Date.now()
       ? alignedStart
@@ -1014,13 +1027,17 @@ export async function switchContract({
   // ─── Pre-provision ────────────────────────────────────────────────────────
 
   const eligibilityResult = await checkEligibility(auth);
-  if (eligibilityResult.isErr()) return new Err(eligibilityResult.error);
+  if (eligibilityResult.isErr()) {
+    return new Err(eligibilityResult.error);
+  }
 
   const creditConfig =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
 
   const stripeResult = await resolveStripeCustomer(body.stripeCustomerId);
-  if (stripeResult.isErr()) return new Err(stripeResult.error);
+  if (stripeResult.isErr()) {
+    return new Err(stripeResult.error);
+  }
   const { resolvedCurrency } = stripeResult.value;
 
   const customerResult = await resolveMetronomeCustomer({
@@ -1028,28 +1045,46 @@ export async function switchContract({
     stripeCustomerId: body.stripeCustomerId,
     stripeCollectionMethod: body.stripeCollectionMethod,
   });
-  if (customerResult.isErr()) return new Err(customerResult.error);
+  if (customerResult.isErr()) {
+    return new Err(customerResult.error);
+  }
   const { metronomeCustomerId } = customerResult.value;
 
   const packageResult = await resolveAndValidatePackage(body, resolvedCurrency);
-  if (packageResult.isErr()) return new Err(packageResult.error);
+  if (packageResult.isErr()) {
+    return new Err(packageResult.error);
+  }
   const { pkg, pkgSeatByType, packageAlias } = packageResult.value;
 
   const timingResult = resolveSwapTiming(body.startingAt);
-  if (timingResult.isErr()) return new Err(timingResult.error);
+  if (timingResult.isErr()) {
+    return new Err(timingResult.error);
+  }
   const { startingAtDate, swapAt } = timingResult.value;
 
-  const workosResult = await ensureWorkOSOrg(ownerLight, pkg.tier, owner.sId);
-  if (workosResult.isErr()) return new Err(workosResult.error);
+  const workosResult = await ensureWorkOSOrg(ownerLight, pkg.tier);
+  if (workosResult.isErr()) {
+    return new Err(workosResult.error);
+  }
 
   const seatFloorsResult = await persistSeatFloors(ownerLight, body);
-  if (seatFloorsResult.isErr()) return new Err(seatFloorsResult.error);
+  if (seatFloorsResult.isErr()) {
+    return new Err(seatFloorsResult.error);
+  }
 
-  const paygResult = await persistCreditConfig(auth, creditConfig, body);
-  if (paygResult.isErr()) return new Err(paygResult.error);
+  const creditsConfigResult = await persistCreditConfig(
+    auth,
+    creditConfig,
+    body
+  );
+  if (creditsConfigResult.isErr()) {
+    return new Err(creditsConfigResult.error);
+  }
 
   const cancelResult = await cancelExistingPendingContract(auth, owner.id);
-  if (cancelResult.isErr()) return new Err(cancelResult.error);
+  if (cancelResult.isErr()) {
+    return new Err(cancelResult.error);
+  }
 
   // ─── Provision ────────────────────────────────────────────────────────────
   // Disable the internal seat sync — switchContract always runs its own
@@ -1104,7 +1139,9 @@ export async function switchContract({
 
   const warnings: string[] = [];
   const warn = (w: string | null): void => {
-    if (w) warnings.push(w);
+    if (w) {
+      warnings.push(w);
+    }
   };
 
   warn(await stepContractEdits(ctx));

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -1,18 +1,16 @@
-import {
-  dispatchPaygDisabled,
-  dispatchPaygEnabled,
-} from "@app/lib/api/metronome/credit_state_dispatcher";
 import { cancelPendingContract } from "@app/lib/api/poke/cancel_pending_contract";
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import { metronomeAmount } from "@app/lib/metronome/amounts";
+import type { ContractEditParams } from "@metronome/sdk/resources/v2/contracts";
 import {
-  addPrepaidCommitToContract,
   ceilToHourISO,
   editMetronomeContract,
   floorToHourISO,
   listMetronomePackages,
+  type MetronomePackageSummary,
+  type PackageSeatConfig,
 } from "@app/lib/metronome/client";
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
@@ -26,10 +24,8 @@ import {
   HUBSPOT_DEAL_ID_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import {
-  applySeatRateOverrides,
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
-  type SeatRateOverride,
   syncContractQuantities,
 } from "@app/lib/metronome/contracts";
 import { remapMembershipSeatTypesForContract } from "@app/lib/metronome/seats";
@@ -51,9 +47,9 @@ import {
 } from "@app/lib/plans/stripe";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { LightWorkspaceType } from "@app/types/user";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import { isMembershipSeatType } from "@app/types/memberships";
@@ -150,6 +146,15 @@ export const SwitchContractBodySchema = z.object({
       })
     )
     .optional(),
+  // Credit usage configuration — written to credit_usage_configuration before
+  // provisioning so a failure aborts cleanly.
+  defaultDiscountPercent: z.number().int().min(0).max(100).default(0),
+  balanceThresholdCredits: z.number().int().min(0).optional(),
+  defaultPoolCapCredits: z.number().int().min(0).optional(),
+  programmaticMonthlyCapCredits: z.number().int().min(0).optional(),
+  autoSeatUpgradeEnabled: z.boolean().default(false),
+  topUpEnabled: z.boolean().default(false),
+  autoInvoiceFinalizationEnabled: z.boolean().default(true),
 });
 
 export type SwitchContractBody = z.infer<typeof SwitchContractBodySchema>;
@@ -159,11 +164,11 @@ export type SwitchContractErrorKind =
   | "invalid_request"
   // Metronome (or other upstream) API failure before any state was changed.
   | "metronome_api_error"
-  // Provisioned the Metronome contract but a follow-up step failed. Manual
-  // cleanup may be required; the message documents what's left to undo.
-  | "provision_inconsistent"
-  // PAYG configuration update/create failed after provisioning completed.
-  | "payg_config_failed";
+  // PAYG configuration update/create failed (pre-provision, clean abort).
+  | "payg_config_failed"
+  // Contract was provisioned but one or more post-provision steps failed.
+  // The contract is live; the operator must address each listed item manually.
+  | "provision_inconsistent";
 
 export class SwitchContractError extends Error {
   constructor(
@@ -341,40 +346,15 @@ function buildInvoiceScheduleItems({
   });
 }
 
-/**
- * Provision a Metronome contract for the workspace and align local state
- * (pending subscription, Stripe cancellation schedule, WorkOS org, PAYG
- * configuration, PAYG dispatcher).
- *
- * Side-effects that must succeed for the result to be `Ok`:
- *   - Ensure Metronome customer
- *   - Provision the Metronome contract
- *   - Create the pending local subscription
- *   - Schedule Stripe cancellation (if a Stripe sub exists)
- *   - PAYG configuration update / create (if applicable)
- *
- * Best-effort (failures are logged but do not fail the operation):
- *   - WorkOS organization provisioning
- *   - PAYG state dispatcher
- */
-export async function switchContract({
-  auth,
-  body,
-}: {
-  auth: Authenticator;
-  body: SwitchContractBody;
-}): Promise<Result<SwitchContractSuccess, SwitchContractError>> {
-  const owner = auth.getNonNullableWorkspace();
-  const currentSubscription = auth.subscriptionResource();
+// ─── Pre-provision helper functions ──────────────────────────────────────────
 
-  // Workspace must be Metronome-billed (current sub Metronome-only) or
-  // Metronome-eligible (Metronome billing enabled). Stripe-billed workspaces
-  // that have opted into Metronome billing land here too — their Stripe sub
-  // is scheduled to end at the swap time further down.
-  const isCurrentlyMetronomeOnlyBilled =
-    currentSubscription?.isMetronomeOnlyBilled ?? false;
-  const metronomeBillingEnabled = await isMetronomeBillingEnabled(auth);
-  if (!isCurrentlyMetronomeOnlyBilled && !metronomeBillingEnabled) {
+async function checkEligibility(
+  auth: Authenticator
+): Promise<Result<void, SwitchContractError>> {
+  const currentSubscription = auth.subscriptionResource();
+  const isMetronomeOnly = currentSubscription?.isMetronomeOnlyBilled ?? false;
+  const billingEnabled = await isMetronomeBillingEnabled(auth);
+  if (!isMetronomeOnly && !billingEnabled) {
     return new Err(
       new SwitchContractError(
         "invalid_request",
@@ -383,44 +363,67 @@ export async function switchContract({
       )
     );
   }
+  return new Ok(undefined);
+}
 
-  const creditConfig =
-    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
-
-  // Validate the Stripe customer exists before we touch Metronome.
-  // For free-tier switches the operator may omit the Stripe customer entirely
-  // — the contract is created without Stripe billing wired in.
-  let resolvedCurrency: SupportedCurrency | null = null;
-  if (body.stripeCustomerId) {
-    const stripeCustomer = await getStripeCustomer(body.stripeCustomerId);
-    if (!stripeCustomer) {
-      return new Err(
-        new SwitchContractError(
-          "invalid_request",
-          `Stripe customer not found: ${body.stripeCustomerId}.`
-        )
-      );
-    }
-    resolvedCurrency = resolveCurrencyFromStripe({ stripeCustomer });
-  }
-
-  // Resolve the Metronome customer.
-  const customerResult = await ensureMetronomeCustomerForWorkspace({
-    workspace: renderLightWorkspaceType({ workspace: owner }),
-    stripeCustomerId: body.stripeCustomerId,
-    stripeCollectionMethod: body.stripeCollectionMethod,
-  });
-  if (customerResult.isErr()) {
+async function resolveStripeCustomer(
+  stripeCustomerId: string | undefined
+): Promise<
+  Result<{ resolvedCurrency: SupportedCurrency | null }, SwitchContractError>
+> {
+  if (!stripeCustomerId) return new Ok({ resolvedCurrency: null });
+  const stripeCustomer = await getStripeCustomer(stripeCustomerId);
+  if (!stripeCustomer) {
     return new Err(
       new SwitchContractError(
-        "metronome_api_error",
-        `Failed to ensure Metronome customer: ${customerResult.error.message}`
+        "invalid_request",
+        `Stripe customer not found: ${stripeCustomerId}.`
       )
     );
   }
-  const { metronomeCustomerId } = customerResult.value;
+  return new Ok({
+    resolvedCurrency: resolveCurrencyFromStripe({ stripeCustomer }),
+  });
+}
 
-  // Resolve the package and classify its tier.
+async function resolveMetronomeCustomer({
+  ownerLight,
+  stripeCustomerId,
+  stripeCollectionMethod,
+}: {
+  ownerLight: LightWorkspaceType;
+  stripeCustomerId: string | undefined;
+  stripeCollectionMethod: "charge_automatically" | "send_invoice";
+}): Promise<Result<{ metronomeCustomerId: string }, SwitchContractError>> {
+  const result = await ensureMetronomeCustomerForWorkspace({
+    workspace: ownerLight,
+    stripeCustomerId,
+    stripeCollectionMethod,
+  });
+  if (result.isErr()) {
+    return new Err(
+      new SwitchContractError(
+        "metronome_api_error",
+        `Failed to ensure Metronome customer: ${result.error.message}`
+      )
+    );
+  }
+  return new Ok({ metronomeCustomerId: result.value.metronomeCustomerId });
+}
+
+async function resolveAndValidatePackage(
+  body: SwitchContractBody,
+  resolvedCurrency: SupportedCurrency | null
+): Promise<
+  Result<
+    {
+      pkg: MetronomePackageSummary;
+      pkgSeatByType: Map<string, PackageSeatConfig>;
+      packageAlias: string;
+    },
+    SwitchContractError
+  >
+> {
   const packagesResult = await listMetronomePackages();
   if (packagesResult.isErr()) {
     return new Err(
@@ -441,9 +444,6 @@ export async function switchContract({
       )
     );
   }
-  // Free packages are currency-agnostic (price is 0) — skip the currency
-  // match check. For paid tiers, the resolved Stripe currency must match the
-  // package's currency.
   if (
     pkg.tier !== "free" &&
     resolvedCurrency &&
@@ -458,36 +458,26 @@ export async function switchContract({
       )
     );
   }
-  // Plan ↔ package tier compatibility.
   const compat = validatePlanPackageCompat(body.planCode, pkg.tier);
   if (!compat.ok) {
     return new Err(new SwitchContractError("invalid_request", compat.message));
   }
-
   if (body.paygEnabled && !isPaygEligibleTier(pkg.tier)) {
     return new Err(
       new SwitchContractError(
         "invalid_request",
-        `Pay-as-you-go can only be enabled for ${PAYG_ELIGIBLE_TIERS.join(
-          " or "
-        )} contracts.`
+        `Pay-as-you-go can only be enabled for ${PAYG_ELIGIBLE_TIERS.join(" or ")} contracts.`
       )
     );
   }
-
-  // Initial credits are invoiced through the contract's Stripe billing config,
-  // so they require a Stripe customer (and therefore a resolved currency).
   if (body.initialCredits && !resolvedCurrency) {
     return new Err(
       new SwitchContractError(
         "invalid_request",
-        "Initial credits require a Stripe customer to invoice — provide a " +
-          "stripeCustomerId."
+        "Initial credits require a Stripe customer to invoice — provide a stripeCustomerId."
       )
     );
   }
-
-  // Seat commitments are invoiced as prepaid commits — same requirement.
   const hasSeatCommitment = (body.seats ?? []).some(
     (s) => s.commitmentPrice !== undefined && s.minSeats > 0 && s.rate > 0
   );
@@ -495,20 +485,13 @@ export async function switchContract({
     return new Err(
       new SwitchContractError(
         "invalid_request",
-        "Seat commitments require a Stripe customer to invoice — provide a " +
-          "stripeCustomerId."
+        "Seat commitments require a Stripe customer to invoice — provide a stripeCustomerId."
       )
     );
   }
-
-  // A seat the package does not entitle by default can be entitled here, but
-  // only at an explicit non-zero rate — except the free seat, which is allowed
-  // at rate 0. This guards against accidentally entitling a paid seat for free.
   const pkgSeatByType = new Map(pkg.seats.map((s) => [s.seatType, s]));
   for (const seat of body.seats ?? []) {
-    if (!isMembershipSeatType(seat.seatType)) {
-      continue;
-    }
+    if (!isMembershipSeatType(seat.seatType)) continue;
     const pkgSeat = pkgSeatByType.get(seat.seatType);
     if (
       seat.selected &&
@@ -526,33 +509,6 @@ export async function switchContract({
       );
     }
   }
-
-  // Resolve when the swap happens.
-  //  - startingAt provided: schedule at the requested moment, ceiled to the
-  //    next hour boundary. Any moment is accepted, including the past — the
-  //    operator is trusted to backdate a contract when reconciling.
-  //  - startingAt omitted: swap immediately at the current hour boundary
-  //    (supported for all tiers, including enterprise via the operator's
-  //    explicit "start immediately" opt-in).
-  let startingAtDate: Date;
-  let swapAt: "current-hour" | "next-hour";
-  if (body.startingAt) {
-    const requestedStartMs = Date.parse(body.startingAt);
-    if (Number.isNaN(requestedStartMs)) {
-      return new Err(
-        new SwitchContractError(
-          "invalid_request",
-          "startingAt is not a valid ISO timestamp."
-        )
-      );
-    }
-    startingAtDate = new Date(requestedStartMs);
-    swapAt = "next-hour";
-  } else {
-    startingAtDate = new Date();
-    swapAt = "current-hour";
-  }
-
   const packageAlias = pkg.aliases[0];
   if (!packageAlias) {
     return new Err(
@@ -562,64 +518,546 @@ export async function switchContract({
       )
     );
   }
+  return new Ok({ pkg, pkgSeatByType, packageAlias });
+}
 
-  // Persist the per-seat-type billing floors BEFORE provisioning. The
-  // provisioning sync (`syncContractQuantities` inside
-  // `provisionMetronomeContract`) clamps each seat's quantity up to its
-  // configured `minSeats`, so the floor must already be in
-  // `workspace_seat_limits` when that sync runs — otherwise the first sync
-  // bills the actual headcount and the floor only takes effect on a later sync.
-  // (The seat commitment + rate overrides run after provisioning, below, since
-  // they need the contract id.)
+function resolveSwapTiming(
+  startingAt: string | undefined
+): Result<
+  { startingAtDate: Date; swapAt: "current-hour" | "next-hour" },
+  SwitchContractError
+> {
+  if (!startingAt) {
+    return new Ok({ startingAtDate: new Date(), swapAt: "current-hour" });
+  }
+  const requestedStartMs = Date.parse(startingAt);
+  if (Number.isNaN(requestedStartMs)) {
+    return new Err(
+      new SwitchContractError(
+        "invalid_request",
+        "startingAt is not a valid ISO timestamp."
+      )
+    );
+  }
+  return new Ok({
+    startingAtDate: new Date(requestedStartMs),
+    swapAt: "next-hour",
+  });
+}
+
+// Persist the per-seat-type billing floors BEFORE provisioning. The
+// provisioning sync clamps each seat's quantity up to its configured
+// `minSeats`, so the floor must already be in `workspace_seat_limits` when
+// that sync runs.
+async function persistSeatFloors(
+  workspace: LightWorkspaceType,
+  body: SwitchContractBody
+): Promise<Result<void, SwitchContractError>> {
   for (const seat of body.seats ?? []) {
-    if (!isMembershipSeatType(seat.seatType)) {
-      continue;
-    }
-    // A deselected seat carries no billing floor — clear any existing one.
+    if (!isMembershipSeatType(seat.seatType)) continue;
     if (seat.selected && seat.minSeats > 0) {
-      const upsertResult = await WorkspaceSeatLimitResource.upsert({
-        workspace: owner,
+      const result = await WorkspaceSeatLimitResource.upsert({
+        workspace,
         seatType: seat.seatType,
         minSeats: seat.minSeats,
       });
-      if (upsertResult.isErr()) {
-        throw upsertResult.error;
+      if (result.isErr()) {
+        return new Err(
+          new SwitchContractError(
+            "metronome_api_error",
+            `Failed to persist seat floor for "${seat.seatType}": ${result.error.message}`
+          )
+        );
       }
     } else {
       await WorkspaceSeatLimitResource.remove({
-        workspace: owner,
+        workspace,
         seatType: seat.seatType,
       });
     }
   }
+  return new Ok(undefined);
+}
 
-  // If there's already a pending contract, cancel it before creating a new one.
-  // Metronome rejects a second transition from a contract that already has a
-  // RENEWAL successor, so we must archive the pending contract and restore the
-  // current one first.
+// If there's already a pending contract, cancel it before creating a new one.
+// Metronome rejects a second transition from a contract that already has a
+// RENEWAL successor, so we must archive the pending contract and restore the
+// current one first.
+async function cancelExistingPendingContract(
+  auth: Authenticator,
+  workspaceModelId: number
+): Promise<Result<void, SwitchContractError>> {
   const existingPending =
-    await SubscriptionResource.fetchPendingByWorkspaceModelId(owner.id);
-  if (existingPending) {
-    const cancelResult = await cancelPendingContract({ auth });
-    if (cancelResult.isErr()) {
+    await SubscriptionResource.fetchPendingByWorkspaceModelId(workspaceModelId);
+  if (!existingPending) return new Ok(undefined);
+  const result = await cancelPendingContract({ auth });
+  if (result.isErr()) {
+    return new Err(
+      new SwitchContractError(
+        "metronome_api_error",
+        `A pending contract already exists and could not be cancelled before ` +
+          `switching: ${result.error.message}`
+      )
+    );
+  }
+  return new Ok(undefined);
+}
+
+// Ensure the workspace has a WorkOS organization for any paid tier.
+async function ensureWorkOSOrg(
+  ownerLight: LightWorkspaceType,
+  pkgTier: MetronomePackageTier,
+  workspaceId: string
+): Promise<Result<void, SwitchContractError>> {
+  if (pkgTier === "free") return new Ok(undefined);
+  const result = await getOrCreateWorkOSOrganization(ownerLight);
+  if (result.isErr()) {
+    return new Err(
+      new SwitchContractError(
+        "metronome_api_error",
+        `Failed to provision WorkOS organization: ${result.error.message}`
+      )
+    );
+  }
+  return new Ok(undefined);
+}
+
+// Write all credit usage configuration fields before provisioning so a failure
+// aborts cleanly without any Metronome state to undo.
+async function persistCreditConfig(
+  auth: Authenticator,
+  creditConfig: CreditUsageConfigurationResource | null,
+  body: SwitchContractBody
+): Promise<Result<void, SwitchContractError>> {
+  const configBlob = {
+    defaultDiscountPercent: body.defaultDiscountPercent,
+    paygEnabled: body.paygEnabled,
+    usageCapCredits: body.usageCapCredits ?? null,
+    balanceThresholdAwuCredits: body.balanceThresholdCredits ?? null,
+    defaultPoolCapAwuCredits: body.defaultPoolCapCredits ?? null,
+    programmaticMonthlyCapAwuCredits:
+      body.programmaticMonthlyCapCredits ?? null,
+    autoSeatUpgradeEnabled: body.autoSeatUpgradeEnabled,
+    topUpEnabled: body.topUpEnabled,
+    autoInvoiceFinalizationEnabled: body.autoInvoiceFinalizationEnabled,
+  };
+  if (creditConfig) {
+    const result = await creditConfig.updateConfiguration(auth, configBlob);
+    if (result.isErr()) {
       return new Err(
         new SwitchContractError(
-          "metronome_api_error",
-          `A pending contract already exists and could not be cancelled before ` +
-            `switching: ${cancelResult.error.message}`
+          "payg_config_failed",
+          `Failed to update credit configuration: ${result.error.message}`
+        )
+      );
+    }
+  } else {
+    const result = await CreditUsageConfigurationResource.makeNew(
+      auth,
+      configBlob
+    );
+    if (result.isErr()) {
+      return new Err(
+        new SwitchContractError(
+          "payg_config_failed",
+          `Failed to create credit configuration: ${result.error.message}`
         )
       );
     }
   }
+  return new Ok(undefined);
+}
 
+// ─── Post-provision step context & step functions ────────────────────────────
+//
+// After the Metronome contract is provisioned, each step below is best-effort:
+// failures are returned as warning strings and collected by the caller;
+// they do NOT abort the switch. The operator must address each warning manually.
+
+type PostProvisionCtx = {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  alignedStart: Date;
+  ownerLight: LightWorkspaceType;
+  workspaceModelId: number;
+  workspaceId: string;
+  swapAt: "current-hour" | "next-hour";
+  resolvedCurrency: SupportedCurrency | null;
+  stripeSubscriptionId: string | null;
+  pkg: MetronomePackageSummary;
+  pkgSeatByType: Map<string, PackageSeatConfig>;
+  body: SwitchContractBody;
+};
+
+// Combine net payment terms, initial credits commit, seat commitment commits,
+// and seat rate overrides into a single v2.contracts.edit call.
+async function stepContractEdits({
+  metronomeCustomerId,
+  metronomeContractId,
+  alignedStart,
+  resolvedCurrency,
+  pkg,
+  pkgSeatByType,
+  body,
+}: PostProvisionCtx): Promise<string | null> {
+  const addCommits: NonNullable<ContractEditParams["add_commits"]> = [];
+  const addOverrides: NonNullable<ContractEditParams["add_overrides"]> = [];
+
+  // Initial credits prepaid commit.
+  if (body.initialCredits && resolvedCurrency) {
+    const invoiceAmountCents = Math.round(
+      body.initialCredits.invoiceAmount * 100
+    );
+    const scheduleItems = buildInvoiceScheduleItems({
+      invoiceAmountCents,
+      resolvedCurrency,
+      alignedStart,
+      paymentSchedule: body.initialCredits.paymentSchedule,
+    });
+    addCommits.push({
+      product_id: getProductPrepaidCommitId(),
+      type: "PREPAID",
+      name: `Initial credits: ${body.initialCredits.amountCredits.toLocaleString()} credits`,
+      priority: AWU_PRIORITY_PURCHASED_COMMIT,
+      applicable_product_tags: ["usage"],
+      custom_fields: {
+        [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: CARRY_ON_RENEWAL_FOREVER_VALUE,
+      },
+      access_schedule: {
+        credit_type_id: getCreditTypeAwuId(),
+        schedule_items: [
+          {
+            amount: body.initialCredits.amountCredits,
+            starting_at: floorToHourISO(alignedStart),
+            ending_before: floorToHourISO(FOREVER_ENDING_BEFORE),
+          },
+        ],
+      },
+      invoice_schedule: {
+        credit_type_id: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
+        schedule_items: scheduleItems.map((item) => ({
+          unit_price: item.unitPrice,
+          quantity: item.quantity,
+          timestamp: floorToHourISO(item.timestamp),
+        })),
+      },
+    });
+  }
+
+  // Seat commitment commits and rate overrides.
+  for (const seat of body.seats ?? []) {
+    if (!isMembershipSeatType(seat.seatType)) continue;
+    const pkgSeat = pkgSeatByType.get(seat.seatType);
+    const billingFrequency = seat.seatType.endsWith("_yearly")
+      ? "ANNUAL"
+      : "MONTHLY";
+    const rateNative = resolvedCurrency
+      ? metronomeAmount(Math.round(seat.rate * 100), resolvedCurrency)
+      : seat.rate;
+
+    if (
+      seat.selected &&
+      seat.commitmentPrice &&
+      seat.commitmentPrice > 0 &&
+      seat.minSeats > 0 &&
+      seat.rate > 0 &&
+      resolvedCurrency &&
+      pkgSeat
+    ) {
+      const fiatCreditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency];
+      const { fraction, periodEnd } = firstPeriodCommitment(
+        alignedStart,
+        billingFrequency,
+        pkg.billingAnchor
+      );
+      const accessAmountNative =
+        Math.round(seat.minSeats * rateNative * fraction * 100) / 100;
+      const seatScheduleItems = buildInvoiceScheduleItems({
+        invoiceAmountCents: Math.round(seat.commitmentPrice * 100),
+        resolvedCurrency,
+        alignedStart,
+        paymentSchedule: seat.paymentSchedule,
+      });
+      addCommits.push({
+        product_id: getProductSeatSubscriptionCommitId(),
+        type: "PREPAID",
+        name: `${pkgSeat.productName} commitment: ${seat.minSeats} seats`,
+        priority: AWU_PRIORITY_PURCHASED_COMMIT,
+        applicable_product_ids: [pkgSeat.productId],
+        access_schedule: {
+          credit_type_id: fiatCreditTypeId,
+          schedule_items: [
+            {
+              amount: accessAmountNative,
+              starting_at: floorToHourISO(alignedStart),
+              ending_before: floorToHourISO(periodEnd),
+            },
+          ],
+        },
+        invoice_schedule: {
+          credit_type_id: fiatCreditTypeId,
+          schedule_items: seatScheduleItems.map((item) => ({
+            unit_price: item.unitPrice,
+            quantity: item.quantity,
+            timestamp: floorToHourISO(item.timestamp),
+          })),
+        },
+      });
+    }
+
+    const needsEntitle = seat.selected && pkgSeat ? !pkgSeat.entitled : false;
+    const rateChanged =
+      seat.selected &&
+      pkgSeat != null &&
+      pkgSeat.entitled &&
+      seat.rate > 0 &&
+      rateNative !== pkgSeat.defaultRate;
+    const needsDisable = !seat.selected && pkgSeat != null && pkgSeat.entitled;
+    if (resolvedCurrency && pkgSeat && (needsEntitle || rateChanged)) {
+      addOverrides.push({
+        starting_at: alignedStart.toISOString(),
+        type: "OVERWRITE",
+        entitled: true,
+        override_specifiers: [
+          {
+            product_id: pkgSeat.productId,
+            billing_frequency: billingFrequency,
+          },
+        ],
+        overwrite_rate: {
+          rate_type: "FLAT",
+          price: rateNative,
+          credit_type_id: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
+        },
+      });
+    } else if (resolvedCurrency && pkgSeat && needsDisable) {
+      addOverrides.push({
+        starting_at: alignedStart.toISOString(),
+        type: "OVERWRITE",
+        entitled: false,
+        override_specifiers: [
+          {
+            product_id: pkgSeat.productId,
+            billing_frequency: billingFrequency,
+          },
+        ],
+        overwrite_rate: {
+          rate_type: "FLAT",
+          price: 0,
+          credit_type_id: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
+        },
+      });
+    }
+  }
+
+  const netPaymentTermsDays = body.netPaymentTermsDays;
+  if (
+    netPaymentTermsDays === undefined &&
+    addCommits.length === 0 &&
+    addOverrides.length === 0
+  ) {
+    return null;
+  }
+
+  const result = await editMetronomeContract({
+    customer_id: metronomeCustomerId,
+    contract_id: metronomeContractId,
+    ...(netPaymentTermsDays !== undefined
+      ? { update_net_payment_terms_days: netPaymentTermsDays }
+      : {}),
+    ...(addCommits.length > 0 ? { add_commits: addCommits } : {}),
+    ...(addOverrides.length > 0 ? { add_overrides: addOverrides } : {}),
+  });
+  if (result.isErr()) {
+    return `contract_edits: ${result.error.message}`;
+  }
+  return null;
+}
+
+// Persist the future-state subscription in `created_backend_only`; the
+// `contract.start` webhook flips it to `active` (and ends the current one).
+async function stepPendingSubscription({
+  workspaceModelId,
+  metronomeContractId,
+  alignedStart,
+  body,
+}: PostProvisionCtx): Promise<string | null> {
+  try {
+    await SubscriptionResource.createPendingMetronomeContract({
+      workspaceModelId,
+      planCode: body.planCode,
+      metronomeContractId,
+      startDate: alignedStart,
+      hubspotDealId: body.hubspotDealId,
+    });
+    return null;
+  } catch (err) {
+    return `pending_subscription: ${normalizeError(err).message}`;
+  }
+}
+
+// If the workspace is currently Stripe-billed, schedule the Stripe sub to
+// cancel at the swap moment so the two rails don't double-bill.
+// If the contract was backdated, alignedStart is already in the past and
+// Stripe rejects a past cancel_at — use now (+60s) in that case.
+async function stepStripeCancellation({
+  stripeSubscriptionId,
+  alignedStart,
+  workspaceId,
+  metronomeContractId,
+}: PostProvisionCtx): Promise<string | null> {
+  if (!stripeSubscriptionId) return null;
+  const stripeCancelAt =
+    alignedStart.getTime() > Date.now()
+      ? alignedStart
+      : new Date(Date.now() + 60_000);
+  try {
+    await scheduleSubscriptionCancellation({
+      stripeSubscriptionId,
+      cancelAt: stripeCancelAt,
+    });
+    return null;
+  } catch (err) {
+    logger.error(
+      {
+        workspaceId,
+        metronomeContractId,
+        stripeSubscriptionId,
+        err: normalizeError(err),
+      },
+      "[switch_contract] Failed to schedule Stripe subscription cancellation"
+    );
+    return (
+      `stripe_cancellation: failed to schedule cancellation of ${stripeSubscriptionId} ` +
+      `at ${stripeCancelAt.toISOString()} — ${normalizeError(err).message}. ` +
+      `URGENT: cancel the Stripe subscription manually to avoid double-billing.`
+    );
+  }
+}
+
+// Remap memberships and sync seat quantities against the final contract state
+// (all overrides already applied). This is the single authoritative seat sync
+// for switchContract — provisionMetronomeContract runs with enableSeatSync:false
+// to avoid an incorrect intermediate remap on package-default entitlements.
+async function stepSeatRemap({
+  metronomeCustomerId,
+  metronomeContractId,
+  ownerLight,
+  swapAt,
+  alignedStart,
+}: PostProvisionCtx): Promise<string | null> {
+  const result = await remapMembershipSeatTypesForContract({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+    workspace: ownerLight,
+    swapAt,
+    startingAt: alignedStart,
+  });
+  if (result.isErr()) {
+    return `seat_remap: ${result.error.message}`;
+  }
+  return null;
+}
+
+async function stepSeatSync({
+  metronomeCustomerId,
+  metronomeContractId,
+  ownerLight,
+  alignedStart,
+  body,
+}: PostProvisionCtx): Promise<string | null> {
+  const result = await syncContractQuantities(
+    metronomeCustomerId,
+    metronomeContractId,
+    ownerLight,
+    alignedStart.toISOString(),
+    body.planCode
+  );
+  if (result.isErr()) {
+    return `seat_sync: ${result.error.message}`;
+  }
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Provision a Metronome contract for the workspace and align local state
+ * (pending subscription, Stripe cancellation schedule, WorkOS org, PAYG
+ * configuration, PAYG dispatcher).
+ *
+ * Pre-provision (must succeed before the contract is created):
+ *   - Eligibility, Stripe customer, Metronome customer, package validation
+ *   - Seat billing floors, WorkOS org (soft), PAYG config (hard)
+ *   - Cancel any existing pending contract
+ *
+ * Provision: provisionMetronomeContract
+ *
+ * Post-provision (best-effort — failures collected as warnings):
+ *   - Net payment terms, initial credits, pending subscription
+ *   - Stripe cancellation schedule, seat configuration, seat remap/sync
+ *
+ * Best-effort fire-and-forget (failure logged, never surfaces):
+ *   - PAYG state dispatcher
+ */
+export async function switchContract({
+  auth,
+  body,
+}: {
+  auth: Authenticator;
+  body: SwitchContractBody;
+}): Promise<Result<SwitchContractSuccess, SwitchContractError>> {
+  const owner = auth.getNonNullableWorkspace();
+  const currentSubscription = auth.subscriptionResource();
+  const ownerLight = renderLightWorkspaceType({ workspace: owner });
+
+  // ─── Pre-provision ────────────────────────────────────────────────────────
+
+  const eligibilityResult = await checkEligibility(auth);
+  if (eligibilityResult.isErr()) return new Err(eligibilityResult.error);
+
+  const creditConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+  const stripeResult = await resolveStripeCustomer(body.stripeCustomerId);
+  if (stripeResult.isErr()) return new Err(stripeResult.error);
+  const { resolvedCurrency } = stripeResult.value;
+
+  const customerResult = await resolveMetronomeCustomer({
+    ownerLight,
+    stripeCustomerId: body.stripeCustomerId,
+    stripeCollectionMethod: body.stripeCollectionMethod,
+  });
+  if (customerResult.isErr()) return new Err(customerResult.error);
+  const { metronomeCustomerId } = customerResult.value;
+
+  const packageResult = await resolveAndValidatePackage(body, resolvedCurrency);
+  if (packageResult.isErr()) return new Err(packageResult.error);
+  const { pkg, pkgSeatByType, packageAlias } = packageResult.value;
+
+  const timingResult = resolveSwapTiming(body.startingAt);
+  if (timingResult.isErr()) return new Err(timingResult.error);
+  const { startingAtDate, swapAt } = timingResult.value;
+
+  const workosResult = await ensureWorkOSOrg(ownerLight, pkg.tier, owner.sId);
+  if (workosResult.isErr()) return new Err(workosResult.error);
+
+  const seatFloorsResult = await persistSeatFloors(ownerLight, body);
+  if (seatFloorsResult.isErr()) return new Err(seatFloorsResult.error);
+
+  const paygResult = await persistCreditConfig(auth, creditConfig, body);
+  if (paygResult.isErr()) return new Err(paygResult.error);
+
+  const cancelResult = await cancelExistingPendingContract(auth, owner.id);
+  if (cancelResult.isErr()) return new Err(cancelResult.error);
+
+  // ─── Provision ────────────────────────────────────────────────────────────
   // Disable the internal seat sync — switchContract always runs its own
   // remap + sync at the end (after seat-rate overrides), so the contract sees
-  // the final effective entitlements. Running the sync here first (on package
-  // defaults) then again after overrides would produce an incorrect intermediate
-  // remap that could briefly assign the wrong seat type to members.
+  // the final effective entitlements.
   const provisionResult = await provisionMetronomeContract({
     metronomeCustomerId,
-    workspace: renderLightWorkspaceType({ workspace: owner }),
+    workspace: ownerLight,
     packageAlias,
     startingAt: startingAtDate,
     swapAt,
@@ -641,382 +1079,49 @@ export async function switchContract({
   }
   const { metronomeContractId } = provisionResult.value;
 
-  // Net payment terms can't be passed at package-provision time (Metronome
-  // restricts the create payload when provisioning from a package), so apply
-  // it as a follow-up edit on the freshly created contract.
-  if (body.netPaymentTermsDays !== undefined) {
-    const netTermsResult = await editMetronomeContract({
-      contract_id: metronomeContractId,
-      customer_id: metronomeCustomerId,
-      update_net_payment_terms_days: body.netPaymentTermsDays,
-    });
-    if (netTermsResult.isErr()) {
-      return new Err(
-        new SwitchContractError(
-          "provision_inconsistent",
-          `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
-            `set net payment terms to ${body.netPaymentTermsDays} days: ` +
-            `${netTermsResult.error.message}. Manual cleanup may be required.`
-        )
-      );
-    }
-  }
-
-  // Match `provisionMetronomeContract`'s internal alignment so the pending
-  // subscription's startDate matches the Metronome contract's starting_at.
   const alignedStart = new Date(
     swapAt === "current-hour"
       ? floorToHourISO(startingAtDate)
       : ceilToHourISO(startingAtDate)
   );
 
-  // Optional one-off initial credits: a contract-level prepaid AWU commit
-  // starting with the contract. `invoiceAmount` is in the customer's currency
-  // major units; convert to Metronome fiat units (cents for USD, whole units
-  // for EUR) for the invoice unit price.
-  if (body.initialCredits && resolvedCurrency) {
-    const invoiceAmountCents = Math.round(
-      body.initialCredits.invoiceAmount * 100
-    );
-    const invoiceScheduleItems = buildInvoiceScheduleItems({
-      invoiceAmountCents,
-      resolvedCurrency,
-      alignedStart,
-      paymentSchedule: body.initialCredits.paymentSchedule,
-    });
+  // ─── Build context and run post-provision steps ───────────────────────────
 
-    const commitResult = await addPrepaidCommitToContract({
-      metronomeCustomerId,
-      metronomeContractId,
-      productId: getProductPrepaidCommitId(),
-      accessAmount: body.initialCredits.amountCredits,
-      accessCreditTypeId: getCreditTypeAwuId(),
-      accessStartingAt: alignedStart,
-      accessEndingBefore: FOREVER_ENDING_BEFORE,
-      invoiceScheduleItems,
-      invoiceCreditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
-      priority: AWU_PRIORITY_PURCHASED_COMMIT,
-      applicableProductTags: ["usage"],
-      name: `Initial credits: ${body.initialCredits.amountCredits.toLocaleString()} credits`,
-      // Scope the key to the freshly provisioned contract: a retroactive
-      // start can otherwise collide with a prior switch that shared the same
-      // workspace, start moment, and amount.
-      uniquenessKey: `initial-credits-${metronomeContractId}-${body.initialCredits.amountCredits}`,
-      customFields: {
-        [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: CARRY_ON_RENEWAL_FOREVER_VALUE,
-      },
-    });
-    if (commitResult.isErr()) {
-      return new Err(
-        new SwitchContractError(
-          "provision_inconsistent",
-          `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
-            `add the initial credits commit: ${commitResult.error.message}. ` +
-            "Manual cleanup may be required."
-        )
-      );
-    }
-  }
-
-  // Persist the future-state subscription in `created_backend_only`; the
-  // `contract.start` webhook flips it to `active` (and ends the current one).
-  // Any prior pending sub for this workspace is ended in the same txn.
-  try {
-    await SubscriptionResource.createPendingMetronomeContract({
-      workspaceModelId: owner.id,
-      planCode: body.planCode,
-      metronomeContractId,
-      startDate: alignedStart,
-      hubspotDealId: body.hubspotDealId,
-    });
-  } catch (err) {
-    return new Err(
-      new SwitchContractError(
-        "provision_inconsistent",
-        `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
-          `create pending subscription: ${normalizeError(err).message}. ` +
-          "Manual cleanup may be required."
-      )
-    );
-  }
-
-  // If the workspace is currently Stripe-billed (incl. shadow-Metronome),
-  // schedule the Stripe sub to cancel at the swap moment so the two rails
-  // don't double-bill.
-  const stripeSubscriptionIdToCancel =
-    currentSubscription?.stripeSubscriptionId ?? null;
-  if (stripeSubscriptionIdToCancel) {
-    try {
-      await scheduleSubscriptionCancellation({
-        stripeSubscriptionId: stripeSubscriptionIdToCancel,
-        cancelAt: alignedStart,
-      });
-    } catch (err) {
-      return new Err(
-        new SwitchContractError(
-          "provision_inconsistent",
-          `Provisioned Metronome contract ${metronomeContractId} and pending ` +
-            `subscription, but failed to schedule cancellation of Stripe ` +
-            `subscription ${stripeSubscriptionIdToCancel}: ` +
-            `${normalizeError(err).message}. ` +
-            `URGENT: cancel the Stripe subscription manually at ${alignedStart.toISOString()} ` +
-            "to avoid double-billing."
-        )
-      );
-    }
-  }
-
-  // Ensure the workspace has a WorkOS organization for any paid tier.
-  // Idempotent — `contract.start` webhook re-runs this as a safety net.
-  if (pkg.tier !== "free") {
-    const workosResult = await getOrCreateWorkOSOrganization(
-      renderLightWorkspaceType({ workspace: owner })
-    );
-    if (workosResult.isErr()) {
-      logger.error(
-        {
-          workspaceId: owner.sId,
-          metronomeContractId,
-          err: workosResult.error,
-        },
-        "[switch_contract] Failed to provision WorkOS organization"
-      );
-    }
-  }
-
-  // Per-seat-type settings: create a prepaid commit when a commitment price is
-  // set, and apply a rate override when the seat rate was changed. The billing
-  // floor (`minSeats`) was already persisted before provisioning (above) so the
-  // provisioning sync could clamp to it.
-  if (body.seats && body.seats.length > 0) {
-    // `pkgSeatByType` (built above) maps every seat type the package knows about
-    // to its config — used to target rate overrides, detect rate changes, and
-    // tell entitled seats apart from ones the operator is opting into.
-    const seatRateOverrides: SeatRateOverride[] = [];
-
-    for (const seat of body.seats) {
-      if (!isMembershipSeatType(seat.seatType)) {
-        continue;
-      }
-      const pkgSeat = pkgSeatByType.get(seat.seatType);
-      const billingFrequency = seat.seatType.endsWith("_yearly")
-        ? "ANNUAL"
-        : "MONTHLY";
-
-      // `rate` / `commitmentPrice` arrive in the currency's major units
-      // (dollars / euros). Convert to Metronome's fiat unit (cents for USD,
-      // whole units for EUR) — the unit `pkgSeat.defaultRate`, the rate-card
-      // override price, and the fiat credit type all use. No-op when there is
-      // no resolved currency (free / no-Stripe switch, where seat commits and
-      // overrides don't run anyway).
-      const rateNative = resolvedCurrency
-        ? metronomeAmount(Math.round(seat.rate * 100), resolvedCurrency)
-        : seat.rate;
-
-      // One-off seat commitment: grant `minSeats * rate` of contract credit
-      // (the list value of the committed seats), invoiced at the negotiated
-      // `commitmentPrice`. Not recurring — renegotiated at renewal.
-      // `rateNative`/`commitmentPriceNative` are already in the contract's fiat
-      // unit (matching the fiat credit type).
-      if (
-        seat.selected &&
-        seat.commitmentPrice &&
-        seat.commitmentPrice > 0 &&
-        seat.minSeats > 0 &&
-        seat.rate > 0 &&
-        resolvedCurrency &&
-        pkgSeat
-      ) {
-        const fiatCreditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency];
-        const { fraction, periodEnd } = firstPeriodCommitment(
-          alignedStart,
-          billingFrequency,
-          pkg.billingAnchor
-        );
-        // Access credit prorated by the billing anchor: full period for
-        // contract_start_date (fraction=1), partial stub for first_billing_period.
-        const accessAmountNative =
-          Math.round(seat.minSeats * rateNative * fraction * 100) / 100;
-        const seatInvoiceScheduleItems = buildInvoiceScheduleItems({
-          invoiceAmountCents: Math.round(seat.commitmentPrice * 100),
-          resolvedCurrency,
-          alignedStart,
-          paymentSchedule: seat.paymentSchedule,
-        });
-        const commitResult = await addPrepaidCommitToContract({
-          metronomeCustomerId,
-          metronomeContractId,
-          productId: getProductSeatSubscriptionCommitId(),
-          accessAmount: accessAmountNative,
-          accessCreditTypeId: fiatCreditTypeId,
-          accessStartingAt: alignedStart,
-          accessEndingBefore: periodEnd,
-          invoiceScheduleItems: seatInvoiceScheduleItems,
-          invoiceCreditTypeId: fiatCreditTypeId,
-          priority: AWU_PRIORITY_PURCHASED_COMMIT,
-          // Draw only against this seat's product, not all `usage`.
-          applicableProductIds: [pkgSeat.productId],
-          name: `${pkgSeat.productName} commitment: ${seat.minSeats} seats`,
-          // Scope the key to the freshly-provisioned contract so re-running the
-          // switch (which provisions a new contract) can't collide with a
-          // previous attempt's key (same workspace/seat/start time).
-          uniquenessKey: `seat-commitment-${metronomeContractId}-${seat.seatType}`,
-        });
-        if (commitResult.isErr()) {
-          return new Err(
-            new SwitchContractError(
-              "provision_inconsistent",
-              `Provisioned Metronome contract ${metronomeContractId} but failed ` +
-                `to add the ${seat.seatType} seat commitment: ` +
-                `${commitResult.error.message}. Manual cleanup may be required.`
-            )
-          );
-        }
-      }
-
-      // Seat override, applied as an OVERWRITE on the contract:
-      //  - selected + not entitled by the package → entitle it (the operator
-      //    opted in), or
-      //  - selected + entitled but the operator changed its rate from the
-      //    package default → set the new rate, or
-      //  - deselected but entitled by the package → disable it (`entitled:
-      //    false`, price 0) so the package's default seat is turned off.
-      // The free seat is allowed in at rate 0; paid seats are validated to a
-      // positive rate above before reaching this point.
-      const needsEntitle = seat.selected && pkgSeat ? !pkgSeat.entitled : false;
-      const rateChanged =
-        seat.selected &&
-        pkgSeat != null &&
-        pkgSeat.entitled &&
-        seat.rate > 0 &&
-        rateNative !== pkgSeat.defaultRate;
-      const needsDisable =
-        !seat.selected && pkgSeat != null && pkgSeat.entitled;
-      if (resolvedCurrency && pkgSeat && (needsEntitle || rateChanged)) {
-        seatRateOverrides.push({
-          productId: pkgSeat.productId,
-          billingFrequency,
-          priceNative: rateNative,
-          creditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
-          entitled: true,
-        });
-      } else if (resolvedCurrency && pkgSeat && needsDisable) {
-        seatRateOverrides.push({
-          productId: pkgSeat.productId,
-          billingFrequency,
-          priceNative: 0,
-          creditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
-          entitled: false,
-        });
-      }
-    }
-
-    const overridesResult = await applySeatRateOverrides({
-      metronomeCustomerId,
-      contractId: metronomeContractId,
-      startingAt: alignedStart.toISOString(),
-      overrides: seatRateOverrides,
-    });
-    if (overridesResult.isErr()) {
-      return new Err(
-        new SwitchContractError(
-          "provision_inconsistent",
-          `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
-            `apply seat rate overrides: ${overridesResult.error.message}. ` +
-            "Manual cleanup may be required."
-        )
-      );
-    }
-  }
-
-  // Remap memberships and sync seat quantities against the final contract state
-  // (all overrides already applied). This is the single authoritative seat sync
-  // for switchContract — provisionMetronomeContract runs with enableSeatSync:false
-  // to avoid an incorrect intermediate remap on package-default entitlements.
-  const ownerLight = renderLightWorkspaceType({ workspace: owner });
-  const remapResult = await remapMembershipSeatTypesForContract({
-    metronomeCustomerId,
-    contractId: metronomeContractId,
-    workspace: ownerLight,
-    swapAt,
-    startingAt: alignedStart,
-  });
-  if (remapResult.isErr()) {
-    return new Err(
-      new SwitchContractError(
-        "provision_inconsistent",
-        `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
-          `map membership seat types: ${remapResult.error.message}. Members may ` +
-          "remain on a seat type the new contract no longer bills. Manual " +
-          "reconciliation may be required."
-      )
-    );
-  }
-  const resyncResult = await syncContractQuantities(
+  const ctx: PostProvisionCtx = {
     metronomeCustomerId,
     metronomeContractId,
+    alignedStart,
     ownerLight,
-    alignedStart.toISOString(),
-    body.planCode
-  );
-  if (resyncResult.isErr()) {
+    workspaceModelId: owner.id,
+    workspaceId: owner.sId,
+    swapAt,
+    resolvedCurrency,
+    stripeSubscriptionId: currentSubscription?.stripeSubscriptionId ?? null,
+    pkg,
+    pkgSeatByType,
+    body,
+  };
+
+  const warnings: string[] = [];
+  const warn = (w: string | null): void => {
+    if (w) warnings.push(w);
+  };
+
+  warn(await stepContractEdits(ctx));
+  warn(await stepSeatRemap(ctx));
+  warn(await stepSeatSync(ctx));
+  warn(await stepPendingSubscription(ctx));
+  warn(await stepStripeCancellation(ctx));
+
+  if (warnings.length > 0) {
     return new Err(
       new SwitchContractError(
         "provision_inconsistent",
-        `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
-          `sync seat quantities: ${resyncResult.error.message}. Seats may bill ` +
-          "at incorrect quantities until the next sync. Manual reconciliation " +
-          "may be required."
+        `Contract ${metronomeContractId} was provisioned but some post-provision ` +
+          `steps failed and require manual attention:\n` +
+          warnings.map((w) => `  • ${w}`).join("\n")
       )
     );
-  }
-
-  // The operator supplies the AWU usage cap in credits directly — no fiat
-  // conversion. The value is written verbatim to
-  // `credit_usage_configuration.usageCapCredits` (see `MAX_USAGE_CAP_CREDITS`).
-  // `paygEnabled` and `usageCapCredits` are stored independently.
-  const usageCapCredits = body.usageCapCredits ?? null;
-  if (creditConfig) {
-    const updateResult = await creditConfig.updateConfiguration(auth, {
-      paygEnabled: body.paygEnabled,
-      usageCapCredits,
-    });
-    if (updateResult.isErr()) {
-      return new Err(
-        new SwitchContractError(
-          "payg_config_failed",
-          `Failed to update PAYG configuration: ${updateResult.error.message}`
-        )
-      );
-    }
-  } else if (body.paygEnabled || usageCapCredits !== null) {
-    const createResult = await CreditUsageConfigurationResource.makeNew(auth, {
-      defaultDiscountPercent: 0,
-      paygEnabled: body.paygEnabled,
-      usageCapCredits,
-    });
-    if (createResult.isErr()) {
-      return new Err(
-        new SwitchContractError(
-          "payg_config_failed",
-          `Failed to create PAYG configuration: ${createResult.error.message}`
-        )
-      );
-    }
-  }
-
-  // Note: the Metronome AWU PAYG cap alert is no longer synced from this
-  // endpoint. AWU concerns (discount, AWU PAYG cap) live on
-  // `credit_usage_configuration` and are managed via the
-  // "Manage Credit Usage Configuration" poke plugin.
-
-  const workspaceResource = await WorkspaceResource.fetchById(owner.sId);
-  if (workspaceResource) {
-    if (body.paygEnabled) {
-      await dispatchPaygEnabled({ workspace: workspaceResource });
-    } else {
-      await dispatchPaygDisabled({ workspace: workspaceResource });
-    }
   }
 
   return new Ok({ metronomeContractId });


### PR DESCRIPTION
## Description

Significant refactor and bug fixes to the `switch_contract` poke flow.

### `switch_contract.ts` — refactor

- **Extracted all steps into module-level functions**, split into two groups:
  - **Pre-provision** (hard failures, abort cleanly before any Metronome state exists): eligibility check, Stripe customer resolution, Metronome customer resolution, package validation, swap timing, seat billing floors, WorkOS org provisioning, PAYG/credit config persistence, cancel existing pending contract.
  - **Post-provision** (best-effort, failures collected as warnings): contract edits, seat remap, seat sync, pending subscription creation, Stripe cancellation scheduling.
- **Single Metronome edit call**: `stepNetPaymentTerms`, `stepInitialCredits`, and `stepSeatConfiguration` (commits + overrides) are merged into one `stepContractEdits` — a single `v2.contracts.edit` call instead of three.
- **`persistCreditConfig`** (renamed from `stepPaygConfig`): now writes all `CreditUsageConfigurationResource` fields (discount, PAYG, usage cap, balance threshold, pool cap, programmatic cap, auto-upgrade, top-up, invoice finalization) before provisioning.
- **Post-provision error handling**: all post-provision failures are collected as warnings; if any exist, returns `provision_inconsistent` with a bulleted list instead of `Ok`.
- **Stripe `cancel_at` fix**: backdated contracts have `alignedStart` in the past; Stripe rejects past `cancel_at`. Now uses `max(alignedStart, now + 60s)` so the subscription is cancelled as soon as possible.
- **Stripe cancellation is best-effort**: failure no longer rolls back the contract — it surfaces as a warning.
- Removed `provision_inconsistent` from pre-provision error paths (no Metronome state to roll back at that point). Removed dead `dispatchPaygEnabled/Disabled` calls (the `contract.start` webhook already calls `syncPoolCreditStateFromBalance`).

### `SwitchContractDialog.tsx` — UI improvements

<img width="829" height="735" alt="Screenshot 2026-06-25 at 10 58 21" src="https://github.com/user-attachments/assets/bb42fab1-97b3-49d0-80e6-2049edce639d" />

<img width="848" height="797" alt="Screenshot 2026-06-25 at 10 58 39" src="https://github.com/user-attachments/assets/2683b2c4-6ada-4554-8355-f4c348798ff8" />

- **Credit configuration section**: all `CreditUsageConfigurationResource` fields (previously only in the separate "Manage Credit Usage Configuration" plugin) are now inline at the end of the form.
- **Two-column grid layout** throughout: label left, field right — applied to the top fields, initial credits section, and credit configuration section.
- **Commitment price auto-fill**: if left blank, defaults to `minSeats × rate` on submit. The placeholder shows the calculated value dynamically.
- **Annual seat monthly hint**: for `_yearly` seat types, shows `≈ X/mo` below the rate field.
- **Period defaults on frequency change**: switching a payment schedule from one-time to monthly/quarterly/semi-annually/annually auto-fills the periods field (12/4/2/1). Uses `form.watch(callback)` for reliable per-field change detection (fixes a previous ref-based approach that didn't work).
- **Number field clear fix** (`fields.tsx`): clearing a `type="number"` input now emits `undefined` instead of `0`, so the placeholder reappears.

## Tests

Tested manually via the Switch Contract dialog in the poke UI.

## Risk

Low — changes are scoped to the operator poke interface (`switch_contract` endpoint + dialog). The Metronome contract provisioning logic is unchanged; only the surrounding orchestration and UI are affected.

Backdated `cancel_at` fix is new behavior: previously the whole switch failed on backdated contracts; now it succeeds and schedules Stripe cancellation at `now + 60s`.

## Deploy Plan

Standard deploy. No migration needed.