### PR TITLE
Preserve Snowflake selections on read-only failures

### DIFF
--- a/connectors/src/connectors/snowflake/temporal/activities.ts
+++ b/connectors/src/connectors/snowflake/temporal/activities.ts
@@ -4,14 +4,13 @@ import {
   isConnectionReadonly,
   useWarehouse,
 } from "@connectors/connectors/snowflake/lib/snowflake_api";
-import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import {
+  ExternalOAuthTokenError,
+  RemoteDatabaseConnectionNotReadonlyError,
+} from "@connectors/lib/error";
 import { sync } from "@connectors/lib/remote_databases/activities";
 import { getConnectorAndCredentials } from "@connectors/lib/remote_databases/utils";
-import {
-  syncFailed,
-  syncStarted,
-  syncSucceeded,
-} from "@connectors/lib/sync_status";
+import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
 import type { ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES, isSnowflakeCredentials } from "@connectors/types";
@@ -66,11 +65,14 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
     await sync({
       mimeTypes: INTERNAL_MIME_TYPES.SNOWFLAKE,
       connector,
+      preserveSelectedPermissions: true,
       tags: [],
     });
 
-    // ... and we mark the connector as errored.
-    await syncFailed(connectorId, "remote_database_connection_not_readonly");
+    // ... and we pause the connector until an admin fixes the Snowflake grants.
+    throw new RemoteDatabaseConnectionNotReadonlyError(
+      readonlyConnectionCheck.error
+    );
   } else {
     localLogger.info("Fetching tree from Snowflake");
     const treeRes = await fetchTree(

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -105,6 +105,16 @@ export class ExternalOAuthTokenError extends Error {
   }
 }
 
+export class RemoteDatabaseConnectionNotReadonlyError extends Error {
+  declare cause?: Error;
+
+  constructor(readonly innerError?: Error) {
+    super(innerError?.message);
+    this.cause = innerError;
+    this.name = "RemoteDatabaseConnectionNotReadonlyError";
+  }
+}
+
 export class WorkspaceQuotaExceededError extends Error {
   constructor() {
     super(

--- a/connectors/src/lib/remote_databases/activities.test.ts
+++ b/connectors/src/lib/remote_databases/activities.test.ts
@@ -1,5 +1,6 @@
 import {
   deleteDataSourceFolder,
+  deleteDataSourceTable,
   upsertDataSourceFolder,
   upsertDataSourceRemoteTable,
 } from "@connectors/lib/data_sources";
@@ -23,6 +24,7 @@ vi.mock(import("@connectors/lib/data_sources"), async (importOriginal) => {
     upsertDataSourceFolder: vi.fn(),
     upsertDataSourceRemoteTable: vi.fn(),
     deleteDataSourceFolder: vi.fn(),
+    deleteDataSourceTable: vi.fn(),
   };
 });
 
@@ -369,6 +371,91 @@ describe("sync remote databases", async () => {
     expect(deleteDataSourceFolder).not.toHaveBeenCalled();
     expect(upsertDataSourceFolder).not.toHaveBeenCalled();
     expect(upsertDataSourceRemoteTable).not.toHaveBeenCalled();
+  });
+
+  it("should preserve selected permissions when garbage collecting without a tree", async () => {
+    const dataSourceConfig: DataSourceConfig = {
+      workspaceId: "test-workspace-id",
+      workspaceAPIKey: "test-workspace-api-key",
+      dataSourceId: "test-data-source-id",
+    };
+
+    const connector = await ConnectorResource.makeNew(
+      "bigquery",
+      {
+        connectionId: "test-connection-id",
+        workspaceId: dataSourceConfig.workspaceId,
+        dataSourceId: dataSourceConfig.dataSourceId,
+        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+      },
+      {
+        useMetadataForDBML: false,
+      }
+    );
+
+    const lastUpsertedAt = new Date();
+    await RemoteDatabaseModel.create({
+      internalId: "selected-db",
+      name: "selected-db",
+      permission: "selected",
+      lastUpsertedAt,
+      connectorId: connector.id,
+    });
+    await RemoteSchemaModel.create({
+      internalId: "selected-db.selected-schema",
+      name: "selected-schema",
+      databaseName: "selected-db",
+      permission: "selected",
+      lastUpsertedAt,
+      connectorId: connector.id,
+    });
+    await RemoteTableModel.create({
+      internalId: "selected-db.selected-schema.selected-table",
+      name: "selected-table",
+      databaseName: "selected-db",
+      schemaName: "selected-schema",
+      permission: "selected",
+      lastUpsertedAt,
+      connectorId: connector.id,
+    });
+
+    await sync({
+      remoteDBTree: undefined,
+      connector,
+      mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
+      preserveSelectedPermissions: true,
+      tags: [],
+    });
+
+    expect(deleteDataSourceFolder).toHaveBeenCalledWith({
+      dataSourceConfig,
+      folderId: "selected-db",
+    });
+    expect(deleteDataSourceFolder).toHaveBeenCalledWith({
+      dataSourceConfig,
+      folderId: "selected-db.selected-schema",
+    });
+    expect(deleteDataSourceTable).toHaveBeenCalledWith({
+      dataSourceConfig,
+      tableId: "selected-db.selected-schema.selected-table",
+    });
+
+    const remoteDb = await RemoteDatabaseModel.findOne({
+      where: { internalId: "selected-db" },
+    });
+    const remoteSchema = await RemoteSchemaModel.findOne({
+      where: { internalId: "selected-db.selected-schema" },
+    });
+    const remoteTable = await RemoteTableModel.findOne({
+      where: { internalId: "selected-db.selected-schema.selected-table" },
+    });
+
+    expect(remoteDb?.permission).toBe("selected");
+    expect(remoteDb?.lastUpsertedAt).toBeNull();
+    expect(remoteSchema?.permission).toBe("selected");
+    expect(remoteSchema?.lastUpsertedAt).toBeNull();
+    expect(remoteTable?.permission).toBe("selected");
+    expect(remoteTable?.lastUpsertedAt).toBeNull();
   });
 
   it("should correctly handle dots in database, schema, and table names", async () => {

--- a/connectors/src/lib/remote_databases/activities.ts
+++ b/connectors/src/lib/remote_databases/activities.ts
@@ -21,6 +21,17 @@ import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig, INTERNAL_MIME_TYPES } from "@connectors/types";
 
+type RemoteDatabaseHierarchyModel =
+  | RemoteDatabaseModel
+  | RemoteSchemaModel
+  | RemoteTableModel;
+
+type CleanupUnusedRemoteDatabaseHierarchyModel = {
+  destroy: () => Promise<unknown>;
+  permission: RemoteDatabaseHierarchyModel["permission"];
+  update: (fields: { lastUpsertedAt: null }) => Promise<unknown>;
+};
+
 const isDatabaseReadGranted = ({
   readGrantedInternalIds,
   internalId,
@@ -343,6 +354,22 @@ const createTableAndHierarchy = async ({
   return { newDatabase, newSchema, newTable, usedInternalIds };
 };
 
+async function cleanupUnusedRemoteDatabaseHierarchyModel({
+  model,
+  preserveSelectedPermissions,
+}: {
+  model: CleanupUnusedRemoteDatabaseHierarchyModel;
+  preserveSelectedPermissions: boolean;
+}) {
+  if (model.permission === "selected" && preserveSelectedPermissions) {
+    await model.update({
+      lastUpsertedAt: null,
+    });
+  } else {
+    await model.destroy();
+  }
+}
+
 export async function sync({
   remoteDBTree,
   connector,
@@ -585,14 +612,10 @@ export async function sync({
       dataSourceConfig,
       folderId: unusedDb.internalId,
     });
-
-    if (unusedDb.permission === "selected" && preserveSelectedPermissions) {
-      await unusedDb.update({
-        lastUpsertedAt: null,
-      });
-    } else {
-      await unusedDb.destroy();
-    }
+    await cleanupUnusedRemoteDatabaseHierarchyModel({
+      model: unusedDb,
+      preserveSelectedPermissions,
+    });
 
     if (unusedDb.permission === "selected" && !preserveSelectedPermissions) {
       localLogger.error(
@@ -611,14 +634,10 @@ export async function sync({
       dataSourceConfig,
       folderId: unusedSchema.internalId,
     });
-
-    if (unusedSchema.permission === "selected" && preserveSelectedPermissions) {
-      await unusedSchema.update({
-        lastUpsertedAt: null,
-      });
-    } else {
-      await unusedSchema.destroy();
-    }
+    await cleanupUnusedRemoteDatabaseHierarchyModel({
+      model: unusedSchema,
+      preserveSelectedPermissions,
+    });
 
     if (
       unusedSchema.permission === "selected" &&
@@ -640,14 +659,10 @@ export async function sync({
       dataSourceConfig,
       tableId: unusedTable.internalId,
     });
-
-    if (unusedTable.permission === "selected" && preserveSelectedPermissions) {
-      await unusedTable.update({
-        lastUpsertedAt: null,
-      });
-    } else {
-      await unusedTable.destroy();
-    }
+    await cleanupUnusedRemoteDatabaseHierarchyModel({
+      model: unusedTable,
+      preserveSelectedPermissions,
+    });
 
     if (unusedTable.permission === "selected" && !preserveSelectedPermissions) {
       localLogger.error(

--- a/connectors/src/lib/remote_databases/activities.ts
+++ b/connectors/src/lib/remote_databases/activities.ts
@@ -348,6 +348,7 @@ export async function sync({
   connector,
   mimeTypes,
   internalTableIdToRemoteTableId = (internalTableId: string) => internalTableId,
+  preserveSelectedPermissions = false,
   tags,
 }: {
   remoteDBTree?: RemoteDBTree;
@@ -357,6 +358,7 @@ export async function sync({
     | typeof INTERNAL_MIME_TYPES.SNOWFLAKE
     | typeof INTERNAL_MIME_TYPES.SALESFORCE;
   internalTableIdToRemoteTableId?: (internalTableId: string) => string;
+  preserveSelectedPermissions?: boolean;
   tags: string[];
 }) {
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
@@ -583,9 +585,16 @@ export async function sync({
       dataSourceConfig,
       folderId: unusedDb.internalId,
     });
-    await unusedDb.destroy();
 
-    if (unusedDb.permission === "selected") {
+    if (unusedDb.permission === "selected" && preserveSelectedPermissions) {
+      await unusedDb.update({
+        lastUpsertedAt: null,
+      });
+    } else {
+      await unusedDb.destroy();
+    }
+
+    if (unusedDb.permission === "selected" && !preserveSelectedPermissions) {
       localLogger.error(
         {
           databaseInternalId: unusedDb.internalId,
@@ -602,9 +611,16 @@ export async function sync({
       dataSourceConfig,
       folderId: unusedSchema.internalId,
     });
-    await unusedSchema.destroy();
 
-    if (unusedSchema.permission === "selected") {
+    if (unusedSchema.permission === "selected" && preserveSelectedPermissions) {
+      await unusedSchema.update({
+        lastUpsertedAt: null,
+      });
+    } else {
+      await unusedSchema.destroy();
+    }
+
+    if (unusedSchema.permission === "selected" && !preserveSelectedPermissions) {
       localLogger.error(
         {
           schemaInternalId: unusedSchema.internalId,
@@ -621,9 +637,16 @@ export async function sync({
       dataSourceConfig,
       tableId: unusedTable.internalId,
     });
-    await unusedTable.destroy();
 
-    if (unusedTable.permission === "selected") {
+    if (unusedTable.permission === "selected" && preserveSelectedPermissions) {
+      await unusedTable.update({
+        lastUpsertedAt: null,
+      });
+    } else {
+      await unusedTable.destroy();
+    }
+
+    if (unusedTable.permission === "selected" && !preserveSelectedPermissions) {
       localLogger.error(
         {
           tableInternalId: unusedTable.internalId,

--- a/connectors/src/lib/remote_databases/activities.ts
+++ b/connectors/src/lib/remote_databases/activities.ts
@@ -620,7 +620,10 @@ export async function sync({
       await unusedSchema.destroy();
     }
 
-    if (unusedSchema.permission === "selected" && !preserveSelectedPermissions) {
+    if (
+      unusedSchema.permission === "selected" &&
+      !preserveSelectedPermissions
+    ) {
       localLogger.error(
         {
           schemaInternalId: unusedSchema.internalId,

--- a/connectors/src/lib/temporal_monitoring.test.ts
+++ b/connectors/src/lib/temporal_monitoring.test.ts
@@ -1,0 +1,160 @@
+import { Context, type Info } from "@temporalio/activity";
+import {
+  noopMetricMeter,
+  type Logger as TemporalLogger,
+} from "@temporalio/common";
+import type {
+  ActivityExecuteInput,
+  ActivityInboundCallsInterceptor,
+  Next,
+} from "@temporalio/worker";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  fetchById: vi.fn(),
+  getConnectorId: vi.fn(),
+  getConnectorManager: vi.fn(),
+  info: vi.fn(),
+  pauseAndStop: vi.fn(),
+  statsDIncrement: vi.fn(),
+  syncFailed: vi.fn(),
+  trace: vi.fn(),
+}));
+
+vi.mock("@connectors/connectors", () => ({
+  getConnectorManager: mocks.getConnectorManager,
+}));
+
+vi.mock("@connectors/lib/sync_status", () => ({
+  syncFailed: mocks.syncFailed,
+}));
+
+vi.mock("@connectors/lib/temporal", () => ({
+  getConnectorId: mocks.getConnectorId,
+}));
+
+vi.mock("@connectors/logger/logger", () => ({
+  default: {
+    child: vi.fn(() => ({
+      error: mocks.error,
+      info: mocks.info,
+    })),
+  },
+}));
+
+vi.mock("@connectors/logger/withlogging", () => ({
+  statsDClient: {
+    increment: mocks.statsDIncrement,
+  },
+}));
+
+vi.mock("@connectors/resources/connector_resource", () => ({
+  ConnectorResource: {
+    fetchById: mocks.fetchById,
+  },
+}));
+
+vi.mock("dd-trace", () => ({
+  default: {
+    trace: mocks.trace,
+  },
+}));
+
+import logger from "@connectors/logger/logger";
+
+import { RemoteDatabaseConnectionNotReadonlyError } from "./error";
+import { ActivityInboundLogInterceptor } from "./temporal_monitoring";
+
+const temporalLogger = {
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  log: vi.fn(),
+  trace: vi.fn(),
+  warn: vi.fn(),
+} satisfies TemporalLogger;
+
+function makeActivityContext() {
+  const info = {
+    activityId: "activity-id",
+    activityNamespace: "default",
+    activityType: "checkPermissions",
+    attempt: 1,
+    base64TaskToken: "",
+    currentAttemptScheduledTimestampMs: 0,
+    heartbeatDetails: undefined,
+    isLocal: false,
+    scheduledTimestampMs: 0,
+    scheduleToCloseTimeoutMs: 60_000,
+    startToCloseTimeoutMs: 60_000,
+    taskQueue: "task-queue",
+    taskToken: new Uint8Array(),
+    workflowExecution: {
+      runId: "run-id",
+      workflowId: "workflow-id",
+    },
+    workflowNamespace: "default",
+    workflowType: "snowflakeSyncWorkflow",
+  } satisfies Info;
+
+  return new Context(
+    info,
+    new Promise<never>(() => undefined),
+    new AbortController().signal,
+    () => undefined,
+    undefined,
+    temporalLogger,
+    noopMetricMeter,
+    {}
+  );
+}
+
+describe("ActivityInboundLogInterceptor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchById.mockResolvedValue({
+      dataSourceId: "data-source-id",
+      id: 42,
+      type: "snowflake",
+      workspaceId: "workspace-id",
+    });
+    mocks.getConnectorId.mockResolvedValue(42);
+    mocks.getConnectorManager.mockReturnValue({
+      pauseAndStop: mocks.pauseAndStop,
+    });
+    mocks.trace.mockImplementation((_name, _options, next) =>
+      next({
+        setTag: vi.fn(),
+      })
+    );
+  });
+
+  it("marks Snowflake read-only failures and pauses the connector", async () => {
+    const interceptor = new ActivityInboundLogInterceptor(
+      makeActivityContext(),
+      logger,
+      "snowflake"
+    );
+    const error = new RemoteDatabaseConnectionNotReadonlyError(
+      new Error("Connection is not read-only")
+    );
+    const input = {
+      args: [],
+      headers: {},
+    } satisfies ActivityExecuteInput;
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(interceptor.execute(input, next)).rejects.toBe(error);
+
+    expect(mocks.syncFailed).toHaveBeenCalledWith(
+      42,
+      "remote_database_connection_not_readonly"
+    );
+    expect(mocks.pauseAndStop).toHaveBeenCalledWith({
+      reason: "Stopped on RemoteDatabaseConnectionNotReadonlyError",
+    });
+  });
+});

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -18,6 +18,7 @@ import {
   DustConnectorWorkflowError,
   ExternalOAuthTokenError,
   ProviderTransientError,
+  RemoteDatabaseConnectionNotReadonlyError,
   WorkspaceQuotaExceededError,
 } from "./error";
 import { syncFailed } from "./sync_status";
@@ -209,9 +210,11 @@ export class ActivityInboundLogInterceptor
 
       if (
         err instanceof ExternalOAuthTokenError ||
+        err instanceof RemoteDatabaseConnectionNotReadonlyError ||
         err instanceof WorkspaceQuotaExceededError
       ) {
-        // We have a connector working on an expired token, we need to cancel the workflow.
+        // The connector cannot make progress without a human action, so pause it
+        // and stop its workflow.
         if (connectorId) {
           if (!connector) {
             throw new Error(
@@ -229,6 +232,20 @@ export class ActivityInboundLogInterceptor
                 workspaceId,
               },
               `Stopping connector manager because of expired token.`
+            );
+          } else if (err instanceof RemoteDatabaseConnectionNotReadonlyError) {
+            await syncFailed(
+              connectorId,
+              "remote_database_connection_not_readonly"
+            );
+            this.logger.info(
+              {
+                connectorId,
+                dataSourceId,
+                error: err,
+                workspaceId,
+              },
+              `Stopping connector manager because the remote database connection is not read-only.`
             );
           } else {
             await syncFailed(connectorId, "workspace_quota_exceeded");


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9137.

Snowflake `NOT_READONLY` failures used the remote database garbage collector with an empty tree, which removed both Core-visible tables and the connector rows storing admin selections. This keeps the cleanup of Core content, preserves selected DB/schema/table rows for the next successful sync, and pauses the connector with `remote_database_connection_not_readonly` until grants are fixed.

## Tests

Added regression coverage for preserving selected permissions during no-tree garbage collection and for pausing Snowflake connectors on read-only failures.

Ran locally:
- `NODE_ENV=test CONNECTORS_DATABASE_URI=postgres://test:test@localhost:5433/dust_connectors_test_issue_9137_20260625 npx vitest run src/lib/remote_databases/activities.test.ts src/lib/temporal_monitoring.test.ts`
- `npx tsgo --noEmit`

## Risk

Worst case, selected Snowflake permissions are retained when the remote object was intentionally removed. The next successful sync still reconciles the catalog and recreates only selected reachable content. This does not restore selections that were already deleted before this deploy; those still need backup/log-based recovery or manual reselection. Safe to rollback.

## Deploy Plan

Standard deploy.
