### PR TITLE
fix(poke): raise negotiated free credits cap to $5,000

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -27,7 +27,7 @@ import assert from "assert";
 import type Stripe from "stripe";
 import { z } from "zod";
 
-export const MAX_FREE_CREDITS_DOLLARS = 2_000;
+export const MAX_FREE_CREDITS_DOLLARS = 5_000;
 export const MAX_PAYG_CAP_DOLLARS = 20_000;
 export const MAX_DAILY_CAP_DOLLARS = 10_000;
 const MIN_DAILY_CAP_DOLLARS = 100;


### PR DESCRIPTION
## Description

Bump MAX_FREE_CREDITS_DOLLARS from $2,000 to $5,000 so contracts with higher monthly API credit allowances can be provisioned via the Poke Upgrade/Downgrade flow.

Ticket: https://github.com/dust-tt/tasks/issues/9220

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
