### PR TITLE
fix: disable reasoning for process data sources

### DIFF
--- a/front/lib/api/assistant/call_llm.ts
+++ b/front/lib/api/assistant/call_llm.ts
@@ -4,7 +4,10 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
-import type { ModelIdType } from "@app/types/assistant/models/types";
+import type {
+  ModelIdType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
@@ -14,6 +17,7 @@ export interface LLMConfig {
   modelId: ModelIdType;
   providerId: ModelProviderIdType;
   temperature?: number;
+  reasoningEffort?: ReasoningEffort | null;
   useCache?: boolean;
   useStream?: boolean;
 }
@@ -59,6 +63,7 @@ export async function runMultiActionsAgent(
     credentials,
     modelId: config.modelId,
     temperature: config.temperature,
+    reasoningEffort: config.reasoningEffort,
     context: options.context,
   });
 

--- a/front/lib/api/assistant/process_data_sources.ts
+++ b/front/lib/api/assistant/process_data_sources.ts
@@ -171,6 +171,7 @@ export async function processDataSources({
           modelId: model.modelId,
           providerId: model.providerId,
           temperature: model.temperature,
+          reasoningEffort: null,
           useCache: false,
         },
         {


### PR DESCRIPTION
## Description

Fixes a regression introduced by #27783, which changed the default `reasoningEffort` from `"none"` to `modelConfig.defaultReasoningEffort` when omitted.

`process_data_sources.ts` calls `runMultiActionsAgent` with `forceToolCall`. Claude models whose `defaultReasoningEffort` is non-null have thinking enabled by default, which Anthropic rejects when `tool_choice` forces a specific tool:

```
Invalid request to anthropic. 400 {"type":"error","error":{"type":"invalid_request_error","message":"Thinking may not be enabled when tool_choice forces tool use."}}
```

See logs [here](https://app.datadoghq.eu/logs?query=%40llmEventType%3Aerror%20%40modelId%3Aclaude-sonnet-4-6%20%40errorContent.originalError.error.error.message%3A%22Thinking%20may%20not%20be%20enabled%20when%20tool_choice%20forces%20tool%20use.%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=%40errorContent.type%2C%40context.conversationId%2C%40context.workspaceId&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1781081033340&to_ts=1782377033340&live=true)

This PR explicitly passes `reasoningEffort: null` in the `process_data_sources` call, restoring the previous behavior of no reasoning for this structured extraction path.

## Tests

## Risk

Low. This restores the behavior that existed before #27783 for this specific call site. No other callers are affected.

## Deploy Plan

Standard deployment.