### PR TITLE
[front] fix: align MarkdownFilePreview tests with double-click handler

### DIFF
--- a/front/components/file_explorer/MarkdownFilePreview.test.tsx
+++ b/front/components/file_explorer/MarkdownFilePreview.test.tsx
@@ -72,7 +72,7 @@ describe("MarkdownFilePreview", () => {
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
-  it("switches to edit mode when clicking preview content", () => {
+  it("switches to edit mode when double-clicking preview content", () => {
     const onViewModeChange = vi.fn();
 
     render(
@@ -84,12 +84,12 @@ describe("MarkdownFilePreview", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("heading", { name: "Hello" }));
+    fireEvent.doubleClick(screen.getByRole("heading", { name: "Hello" }));
 
     expect(onViewModeChange).toHaveBeenCalledWith("edit");
   });
 
-  it("does not switch to edit mode when clicking a link", () => {
+  it("does not switch to edit mode when double-clicking a link", () => {
     const onViewModeChange = vi.fn();
 
     render(
@@ -101,7 +101,7 @@ describe("MarkdownFilePreview", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("link", { name: "Dust" }));
+    fireEvent.doubleClick(screen.getByRole("link", { name: "Dust" }));
 
     expect(onViewModeChange).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Problem

The "switches to edit mode when clicking preview content" test was failing:

```
AssertionError: expected "vi.fn()" to be called with arguments: [ 'edit' ]
Number of calls: 0
```

Root cause: `MarkdownFilePreview` binds its edit-mode handler to `onDoubleClick`, but the test fired a single `click`, so the handler never ran. The sibling "does not switch to edit mode when clicking a link" test was passing vacuously for the same reason — a single click can never trigger edit mode.

## Fix

Fire `doubleClick` in both tests (and rename them to "double-clicking") to match the component's intentional double-click behavior. The link test now genuinely verifies that double-clicking a link does not switch to edit mode.

## Test plan

- [x] `NODE_ENV=test npm run test -- components/file_explorer/MarkdownFilePreview.test.tsx` — 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)