### PR TITLE
Add missing indices

### DIFF
--- a/front/lib/models/agent/actions/conversation_mcp_server_view.ts
+++ b/front/lib/models/agent/actions/conversation_mcp_server_view.ts
@@ -105,6 +105,10 @@ ConversationMCPServerViewModel.init(
         name: "conversation_mcp_server_views_conversation_id",
         concurrently: true,
       },
+      {
+        fields: ["mcpServerViewId"],
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -112,6 +112,7 @@ ConversationModel.init(
       {
         fields: ["workspaceId", "spaceId"],
       },
+      { fields: ["spaceId"], concurrently: true },
       {
         fields: ["workspaceId", "createdAt"],
         name: "conversations_workspace_id_created_at_idx",

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -286,6 +286,10 @@ SkillMCPServerConfigurationModel.init(
         fields: ["workspaceId", "skillConfigurationId"],
         name: "idx_skill_mcp_server_config_workspace_skill_config",
       },
+      {
+        fields: ["mcpServerViewId"],
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/migrations/pre-deploy/20260625114824_add_index_conversations_space_id.sql
+++ b/front/migrations/pre-deploy/20260625114824_add_index_conversations_space_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY conversations_space_id ON public.conversations USING btree ("spaceId");

--- a/front/migrations/pre-deploy/20260625115702_add_indices_for_delete_mcp_server_views.sql
+++ b/front/migrations/pre-deploy/20260625115702_add_indices_for_delete_mcp_server_views.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY conversation_mcp_server_views_mcp_server_view_id ON public.conversation_mcp_server_views USING btree ("mcpServerViewId");
+CREATE INDEX CONCURRENTLY skill_mcp_server_configurations_mcp_server_view_id ON public.skill_mcp_server_configurations USING btree ("mcpServerViewId");


### PR DESCRIPTION
## Summary

Add missing leading-field indexes on FK columns that were causing `deleteSpacesActivity` to take 10+ minutes in production.

**Root cause:** `DELETE FROM vaults WHERE id = ?` and `DELETE FROM mcp_server_views WHERE workspaceId = ? AND id = ?` each triggered Postgres FK constraint scans on referencing tables that lacked a leading-field index on the FK column — forcing full sequential scans even after all rows had already been cleaned up.

**Slow queries observed in APM (4–8s each):**
- `DELETE FROM vaults` → Postgres scanned `conversations` (14M rows) to verify `spaceId` FK — only had `(workspaceId, spaceId)`, not usable for `WHERE spaceId = ?`
- `DELETE FROM mcp_server_views` → Postgres scanned `conversation_mcp_server_views` and `skill_mcp_server_configurations` on `mcpServerViewId` — no index at all

**Fixes:**
- `conversations.spaceId` — new index (14M rows, built `CONCURRENTLY`)
- `conversation_mcp_server_views.mcpServerViewId` — new index (`CONCURRENTLY`)
- `skill_mcp_server_configurations.mcpServerViewId` — new index (`CONCURRENTLY`)

## Deploy Plan

Pre-deploy migrations only. All three indexes use `CONCURRENTLY` so no table locks.