### PR TITLE
Fix: better scroll handling on mobile for main page and conversations.

### DIFF
--- a/front/components/actions/ActionDetailsWrapper.tsx
+++ b/front/components/actions/ActionDetailsWrapper.tsx
@@ -106,7 +106,7 @@ function DurationLabel({ durationMs, isRunning, size }: DurationLabelProps) {
   return (
     <span
       className={cn(
-        "text-muted-foreground dark:text-muted-foreground-night",
+        "shrink-0 text-muted-foreground dark:text-muted-foreground-night",
         size === "xs" ? "text-xs" : "text-sm"
       )}
     >
@@ -140,11 +140,16 @@ export function ActionDetailsWrapper({
         <div
           className={cn(
             "text-foreground dark:text-foreground-night",
-            "flex flex-grow flex-row items-center gap-x-2"
+            "flex min-w-0 flex-grow flex-row items-center gap-x-2"
           )}
         >
-          <Icon visual={visual} size="xs" />
-          <span className="heading-sm font-medium">{actionName}</span>
+          <Icon visual={visual} size="xs" className="shrink-0" />
+          <span
+            className="heading-sm min-w-0 flex-1 truncate font-medium"
+            title={actionName}
+          >
+            {actionName}
+          </span>
           {hasDuration && (
             <DurationLabel
               durationMs={displayedDurationMs}
@@ -169,11 +174,16 @@ export function ActionDetailsWrapper({
       <div
         className={cn(
           "text-foreground dark:text-foreground-night",
-          "flex flex-row items-center gap-x-2"
+          "flex min-w-0 flex-row items-center gap-x-2"
         )}
       >
-        <Icon visual={visual} />
-        <span className="heading-base">{actionName}</span>
+        <Icon visual={visual} className="shrink-0" />
+        <span
+          className="heading-base min-w-0 flex-1 truncate"
+          title={actionName}
+        >
+          {actionName}
+        </span>
         {hasDuration && (
           <DurationLabel
             durationMs={displayedDurationMs}
@@ -181,7 +191,6 @@ export function ActionDetailsWrapper({
             size="sm"
           />
         )}
-        <span className="flex-grow"></span>
         {headerAction}
       </div>
       {children}

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -17,6 +17,7 @@ import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
 import { classNames } from "@app/lib/utils";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -238,6 +239,7 @@ export function ConversationContainerVirtuoso({
   }, [user]);
 
   const { startConversationRef } = useWelcomeTourGuide();
+  const isMobile = useIsMobile();
 
   // Forces a full remount of ConversationViewer (Virtuoso list, messages, InputBar)
   // when switching conversations.
@@ -337,6 +339,8 @@ export function ConversationContainerVirtuoso({
   // when there is no active conversation
   return activeConversationId ? (
     body
+  ) : isMobile ? (
+    <div className="px-4">{body}</div>
   ) : (
     <ScrollArea className="px-4 md:px-8">{body}</ScrollArea>
   );

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -21,6 +21,7 @@ import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { ONBOARDING_CONVERSATION_ENABLED } from "@app/lib/onboarding";
 import { useAppRouter } from "@app/lib/platform";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type {
   ConversationError,
   ConversationWithoutContentType,
@@ -150,36 +151,50 @@ function ConversationInnerLayout({
   conversationError,
   activeConversationId,
 }: ConversationInnerLayoutProps) {
+  const isMobile = useIsMobile();
+
+  const conversationMain = (
+    <>
+      {activeConversationId && !conversationError && (
+        <ConversationTitle owner={owner} />
+      )}
+      {conversationError ? (
+        <ConversationErrorDisplay error={conversationError} />
+      ) : (
+        <FileDropProvider>
+          <GenerationContextProvider>{children}</GenerationContextProvider>
+        </FileDropProvider>
+      )}
+    </>
+  );
+
   return (
     <ErrorBoundary fallback={<UncaughtConversationErrorFallback />}>
-      <div className="flex h-full w-full flex-col">
-        <ResizablePanelGroup
-          direction="horizontal"
-          className="flex h-full w-full flex-1"
-        >
-          <ResizablePanel defaultSize={100}>
-            <div className="flex flex-col h-panel">
-              {activeConversationId && !conversationError && (
-                <ConversationTitle owner={owner} />
-              )}
-              {conversationError ? (
-                <ConversationErrorDisplay error={conversationError} />
-              ) : (
-                <FileDropProvider>
-                  <GenerationContextProvider>
-                    {children}
-                  </GenerationContextProvider>
-                </FileDropProvider>
-              )}
-            </div>
-          </ResizablePanel>
-
+      {isMobile ? (
+        <div className="relative flex w-full flex-col">
+          {conversationMain}
           <ConversationSidePanelContainer
             owner={owner}
             conversation={conversation}
           />
-        </ResizablePanelGroup>
-      </div>
+        </div>
+      ) : (
+        <div className="flex h-full w-full flex-col">
+          <ResizablePanelGroup
+            direction="horizontal"
+            className="flex h-full w-full flex-1"
+          >
+            <ResizablePanel defaultSize={100}>
+              <div className="flex h-panel flex-col">{conversationMain}</div>
+            </ResizablePanel>
+
+            <ConversationSidePanelContainer
+              owner={owner}
+              conversation={conversation}
+            />
+          </ResizablePanelGroup>
+        </div>
+      )}
     </ErrorBoundary>
   );
 }

--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -28,23 +28,44 @@ export default function ConversationSidePanelContainer({
   const isMobile = useIsMobile();
 
   useEffect(() => {
+    if (isMobile) {
+      setPanelRef(null);
+      return;
+    }
+
     setPanelRef(panelRef.current);
-  }, [setPanelRef]);
+  }, [isMobile, setPanelRef]);
 
   useEffect(() => {
-    if (!currentPanel || !panelRef.current) {
+    if (isMobile || !currentPanel || !panelRef.current) {
       return;
     }
 
     panelRef.current?.expand(DEFAULT_RIGHT_PANEL_SIZE);
-  }, [currentPanel]);
+  }, [currentPanel, isMobile]);
+
+  if (isMobile) {
+    if (!currentPanel || !conversation) {
+      return null;
+    }
+
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col overflow-hidden bg-panel-background dark:bg-panel-background-night">
+        <ConversationSidePanelContent
+          conversation={conversation}
+          owner={owner}
+          currentPanel={currentPanel}
+        />
+      </div>
+    );
+  }
 
   return (
     <>
       {!!conversation && (
         <ResizableHandle
-          withHandle={currentPanel && !isMobile && !isFullScreen}
-          disabled={!currentPanel || isMobile || isFullScreen}
+          withHandle={currentPanel && !isFullScreen}
+          disabled={!currentPanel || isFullScreen}
           className="z-50"
         />
       )}

--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -2,6 +2,7 @@ import ConversationSidePanelContent from "@app/components/assistant/conversation
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { DEFAULT_RIGHT_PANEL_SIZE } from "@app/components/assistant/conversation/constant";
 import { useHashParam } from "@app/hooks/useHashParams";
+import { useLockDocumentScroll } from "@app/hooks/useLockDocumentScroll";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { FULL_SCREEN_HASH_PARAM } from "@app/types/conversation_side_panel";
@@ -26,6 +27,9 @@ export default function ConversationSidePanelContainer({
   const isFullScreen = fullScreenHash === "true";
 
   const isMobile = useIsMobile();
+  const isMobilePanelOpen = isMobile && !!currentPanel;
+
+  useLockDocumentScroll(isMobilePanelOpen);
 
   useEffect(() => {
     if (isMobile) {
@@ -50,12 +54,14 @@ export default function ConversationSidePanelContainer({
     }
 
     return (
-      <div className="fixed inset-0 z-50 flex flex-col overflow-hidden bg-panel-background dark:bg-panel-background-night">
-        <ConversationSidePanelContent
-          conversation={conversation}
-          owner={owner}
-          currentPanel={currentPanel}
-        />
+      <div className="fixed inset-0 z-50 flex flex-col overflow-hidden overscroll-none bg-panel-background dark:bg-panel-background-night">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain">
+          <ConversationSidePanelContent
+            conversation={conversation}
+            owner={owner}
+            currentPanel={currentPanel}
+          />
+        </div>
       </div>
     );
   }

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -336,6 +336,11 @@ export const ConversationViewer = ({
     useRef<
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
+  const isMobile = useIsMobile();
+  const isMobileRef = useRef(isMobile);
+  useEffect(() => {
+    isMobileRef.current = isMobile;
+  }, [isMobile]);
   const isAutoScrollEnabledRef = useRef(true);
   const prevScrollLocationRef = useRef({
     scrollHeight: 0,
@@ -738,12 +743,6 @@ export const ConversationViewer = ({
   useEffect(() => {
     currentPanelRef.current = currentPanel;
   }, [currentPanel]);
-
-  const isMobile = useIsMobile();
-  const isMobileRef = useRef(isMobile);
-  useEffect(() => {
-    isMobileRef.current = isMobile;
-  }, [isMobile]);
 
   // Only conversation related events are handled here.
   const onEventCallback = useCallback(
@@ -1498,6 +1497,7 @@ export const ConversationViewer = ({
         <VirtuosoMessageList<VirtuosoMessage, VirtuosoMessageListContext>
           onRenderedDataChange={onRenderedDataChange}
           StickyHeader={ConversationBranchApprovalModal}
+          useWindowScroll={isMobile}
           data={{
             data: initialListData,
             scrollModifier: {
@@ -1518,8 +1518,8 @@ export const ConversationViewer = ({
             "dd-privacy-mask",
             "@container/conversation",
             "touch-pan-y",
-            "overscroll-contain",
-            "h-full w-full px-5",
+            "w-full px-5",
+            !isMobile && "overscroll-contain h-full",
             !agentBuilderContext && "md:px-8"
           )}
           shortSizeAlign="top"
@@ -1530,7 +1530,7 @@ export const ConversationViewer = ({
           EmptyPlaceholder={ConversationViewerEmptyState}
           // Large buffer to avoid manipulating the dom too much when the user scrolls a bit.
           increaseViewportBy={8192}
-          enforceStickyFooterAtBottom
+          enforceStickyFooterAtBottom={!isMobile}
         />
       </VirtuosoMessageListLicense>
     </>

--- a/front/components/misc/DropzoneContainer.tsx
+++ b/front/components/misc/DropzoneContainer.tsx
@@ -1,5 +1,7 @@
 import { useFileDrop } from "@app/components/assistant/conversation/FileUploaderContext";
-import { DropzoneOverlay } from "@dust-tt/sparkle";
+import { MOBILE_DOCUMENT_SCROLL_CLASSES } from "@app/lib/documentScrollLayoutClasses";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
+import { cn, DropzoneOverlay } from "@dust-tt/sparkle";
 import { useDropzone } from "react-dropzone";
 
 interface DropzoneContainerProps {
@@ -15,6 +17,7 @@ export function DropzoneContainer({
   title,
   disabled,
 }: DropzoneContainerProps) {
+  const isMobile = useIsMobile();
   const { setDroppedFiles } = useFileDrop();
 
   const onDrop = (acceptedFiles: File[]) => {
@@ -54,7 +57,12 @@ export function DropzoneContainer({
   return (
     <div
       {...getRootProps()}
-      className="dropzone-container flex min-h-0 h-panel w-full flex-col items-center"
+      className={cn(
+        "flex w-full flex-col items-center",
+        isMobile
+          ? MOBILE_DOCUMENT_SCROLL_CLASSES.dropzoneContainer
+          : "min-h-0 h-panel"
+      )}
       onPaste={onPaste}
     >
       <DropzoneOverlay

--- a/front/components/misc/DropzoneContainer.tsx
+++ b/front/components/misc/DropzoneContainer.tsx
@@ -54,7 +54,7 @@ export function DropzoneContainer({
   return (
     <div
       {...getRootProps()}
-      className="flex min-h-0 w-full flex-col items-center h-panel"
+      className="dropzone-container flex min-h-0 h-panel w-full flex-col items-center"
       onPaste={onPaste}
     >
       <DropzoneOverlay

--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -22,6 +22,15 @@ import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import type React from "react";
 import { useContext } from "react";
 
+const MOBILE_NAV_MENU_BUTTON_CLASSES = cn(
+  "border border-border/30 bg-muted-background/60 backdrop-blur-sm transition-none",
+  "dark:border-border-night/30 dark:bg-muted-background-night/60",
+  "hover:border-transparent hover:bg-hover hover:backdrop-blur-none",
+  "dark:hover:bg-hover-night",
+  "active:border-transparent active:bg-primary-300 active:backdrop-blur-none",
+  "dark:active:bg-hover-night"
+);
+
 interface NavigationProps {
   hideSidebar: boolean;
   owner: WorkspaceType;
@@ -63,12 +72,14 @@ export function Navigation({
     >
       {isMobile ? (
         <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-          <div className="fixed left-0 top-0 z-40 flex h-12 shrink-0 items-center gap-x-4 px-2">
+          <div className="fixed left-0 top-0 z-40 flex shrink-0 items-center px-2 pt-2">
             <SheetTrigger asChild>
               <Button
                 variant="ghost"
                 icon={Menu01}
+                className={MOBILE_NAV_MENU_BUTTON_CLASSES}
                 onClick={() => setSidebarOpen(true)}
+                aria-label="Open navigation"
               />
             </SheetTrigger>
           </div>

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -6,6 +6,7 @@ import { SubscriptionEndBanner } from "@app/components/navigation/TrialBanner";
 import { useAppLayout } from "@app/components/sparkle/AppLayoutContext";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useAppKeyboardShortcuts } from "@app/hooks/useAppKeyboardShortcuts";
+import { useDocumentScrollMode } from "@app/hooks/useDocumentScrollMode";
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
@@ -46,11 +47,7 @@ function AppContentInnerWrapper({
   children,
 }: AppContentInnerWrapperProps) {
   if (isMobile) {
-    return (
-      <div className="bg-panel-background dark:bg-panel-background-night">
-        {children}
-      </div>
-    );
+    return children;
   }
 
   return (
@@ -95,14 +92,16 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
   const { isNavigationBarOpen, setIsNavigationBarOpen } =
     useDesktopNavigation();
 
+  useDocumentScrollMode(isMobile);
+
   return (
-    <div className="flex h-dvh flex-col">
+    <div className="app-content-root flex h-dvh flex-col">
       <SubscriptionEndBanner
         isAdmin={isAdmin(owner)}
         owner={owner}
         subscription={subscription}
       />
-      <div className="flex min-h-0 flex-1 flex-row">
+      <div className="app-content-row flex min-h-0 flex-1 flex-row">
         <Navigation
           hideSidebar={hideSidebar}
           isNavigationBarOpen={isNavigationBarOpen}
@@ -116,7 +115,7 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
         />
         <div
           className={cn(
-            "relative flex h-full w-full flex-1 flex-col overflow-x-hidden",
+            "app-content-main relative flex h-full w-full flex-1 flex-col overflow-x-hidden",
             "bg-app-background text-foreground",
             "dark:bg-app-background-night dark:text-foreground-night"
           )}
@@ -129,12 +128,12 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
             {/* Temporary measure to preserve title existence on smaller screens.
              * Page has no title, prepend empty AppLayoutTitle. */}
             {!hasTitleBar && (
-              <div className="flex min-h-0 flex-1 flex-col h-panel overflow-y-auto">
+              <div className="app-content-pane flex min-h-0 flex-1 flex-col h-panel overflow-y-auto">
                 <AppLayoutTitle />
                 {contentWidth ? (
                   <div
                     className={cn(
-                      "flex h-full w-full flex-col items-center overflow-y-auto",
+                      "app-content-scroll flex h-full w-full flex-col items-center overflow-y-auto",
                       contentWidth === "centered" ? "pt-4" : "pt-8",
                       contentClassName
                     )}
@@ -154,13 +153,13 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
               </div>
             )}
             {hasTitleBar && (
-              <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+              <div className="app-content-pane flex min-h-0 flex-1 flex-col overflow-y-auto">
                 {contentWidth ? (
                   <>
                     {title}
                     <div
                       className={cn(
-                        "flex w-full flex-col items-center overflow-y-auto",
+                        "app-content-scroll flex w-full flex-col items-center overflow-y-auto",
                         contentWidth === "centered"
                           ? cn(
                               title ? "h-[calc(100vh-3.5rem)]" : "h-full",

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -10,6 +10,7 @@ import { useDocumentScrollMode } from "@app/hooks/useDocumentScrollMode";
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { MOBILE_DOCUMENT_SCROLL_CLASSES } from "@app/lib/documentScrollLayoutClasses";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { FULL_SCREEN_HASH_PARAM } from "@app/types/conversation_side_panel";
 import { isAdmin } from "@app/types/user";
@@ -95,13 +96,25 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
   useDocumentScrollMode(isMobile);
 
   return (
-    <div className="app-content-root flex h-dvh flex-col">
+    <div
+      className={cn(
+        "flex flex-col",
+        isMobile ? MOBILE_DOCUMENT_SCROLL_CLASSES.contentRoot : "h-dvh"
+      )}
+    >
       <SubscriptionEndBanner
         isAdmin={isAdmin(owner)}
         owner={owner}
         subscription={subscription}
       />
-      <div className="app-content-row flex min-h-0 flex-1 flex-row">
+      <div
+        className={cn(
+          "flex flex-row",
+          isMobile
+            ? MOBILE_DOCUMENT_SCROLL_CLASSES.contentRow
+            : "min-h-0 flex-1"
+        )}
+      >
         <Navigation
           hideSidebar={hideSidebar}
           isNavigationBarOpen={isNavigationBarOpen}
@@ -115,9 +128,10 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
         />
         <div
           className={cn(
-            "app-content-main relative flex h-full w-full flex-1 flex-col overflow-x-hidden",
-            "bg-app-background text-foreground",
-            "dark:bg-app-background-night dark:text-foreground-night"
+            "relative flex w-full flex-1 flex-col text-foreground dark:text-foreground-night",
+            isMobile
+              ? MOBILE_DOCUMENT_SCROLL_CLASSES.contentMain
+              : "h-full overflow-x-hidden bg-app-background dark:bg-app-background-night"
           )}
         >
           <AppContentInnerWrapper
@@ -128,12 +142,22 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
             {/* Temporary measure to preserve title existence on smaller screens.
              * Page has no title, prepend empty AppLayoutTitle. */}
             {!hasTitleBar && (
-              <div className="app-content-pane flex min-h-0 flex-1 flex-col h-panel overflow-y-auto">
+              <div
+                className={cn(
+                  "flex flex-1 flex-col",
+                  isMobile
+                    ? MOBILE_DOCUMENT_SCROLL_CLASSES.contentArea
+                    : "min-h-0 h-panel overflow-y-auto"
+                )}
+              >
                 <AppLayoutTitle />
                 {contentWidth ? (
                   <div
                     className={cn(
-                      "app-content-scroll flex h-full w-full flex-col items-center overflow-y-auto",
+                      "flex w-full flex-col items-center",
+                      isMobile
+                        ? MOBILE_DOCUMENT_SCROLL_CLASSES.contentArea
+                        : "h-full overflow-y-auto",
                       contentWidth === "centered" ? "pt-4" : "pt-8",
                       contentClassName
                     )}
@@ -153,13 +177,23 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
               </div>
             )}
             {hasTitleBar && (
-              <div className="app-content-pane flex min-h-0 flex-1 flex-col overflow-y-auto">
+              <div
+                className={cn(
+                  "flex flex-1 flex-col",
+                  isMobile
+                    ? MOBILE_DOCUMENT_SCROLL_CLASSES.contentArea
+                    : "min-h-0 overflow-y-auto"
+                )}
+              >
                 {contentWidth ? (
                   <>
                     {title}
                     <div
                       className={cn(
-                        "app-content-scroll flex w-full flex-col items-center overflow-y-auto",
+                        "flex w-full flex-col items-center",
+                        isMobile
+                          ? MOBILE_DOCUMENT_SCROLL_CLASSES.contentArea
+                          : "overflow-y-auto",
                         contentWidth === "centered"
                           ? cn(
                               title ? "h-[calc(100vh-3.5rem)]" : "h-full",

--- a/front/hooks/useDocumentScrollMode.ts
+++ b/front/hooks/useDocumentScrollMode.ts
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+
+/** Mobile-only: toggles `document-scroll-mode` on `<body>`. See global.css. */
+export function useDocumentScrollMode(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    document.body.classList.add("document-scroll-mode");
+
+    return () => {
+      document.body.classList.remove("document-scroll-mode");
+    };
+  }, [enabled]);
+}

--- a/front/hooks/useDocumentScrollMode.ts
+++ b/front/hooks/useDocumentScrollMode.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-/** Mobile-only: toggles `document-scroll-mode` on `<body>`. See global.css. */
+/** Mobile-only: toggles `document-scroll-mode` on `<body>`. See global.css + MOBILE_DOCUMENT_SCROLL_CLASSES. */
 export function useDocumentScrollMode(enabled: boolean) {
   useEffect(() => {
     if (!enabled) {

--- a/front/hooks/useLockDocumentScroll.ts
+++ b/front/hooks/useLockDocumentScroll.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Prevents window/document scroll while `enabled` (e.g. mobile full-screen overlay).
+ * Uses position:fixed on body so iOS Safari does not chain scroll to content behind.
+ */
+export function useLockDocumentScroll(enabled: boolean) {
+  const scrollYRef = useRef(0);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    scrollYRef.current = window.scrollY;
+    const { style } = document.body;
+    const previous = {
+      position: style.position,
+      top: style.top,
+      width: style.width,
+      overflow: style.overflow,
+    };
+
+    style.position = "fixed";
+    style.top = `-${scrollYRef.current}px`;
+    style.width = "100%";
+    style.overflow = "hidden";
+
+    return () => {
+      style.position = previous.position;
+      style.top = previous.top;
+      style.width = previous.width;
+      style.overflow = previous.overflow;
+      window.scrollTo(0, scrollYRef.current);
+    };
+  }, [enabled]);
+}

--- a/front/lib/documentScrollLayoutClasses.ts
+++ b/front/lib/documentScrollLayoutClasses.ts
@@ -1,0 +1,10 @@
+/** Mobile document scroll layout overrides. Paired with body.document-scroll-mode. */
+export const MOBILE_DOCUMENT_SCROLL_CLASSES = {
+  dropzoneContainer: "h-auto min-h-0",
+  contentRoot: "h-auto min-h-dvh w-full",
+  contentRow: "min-h-0 flex-[0_1_auto] w-full max-w-full overflow-x-clip",
+  contentMain:
+    "h-auto min-h-[var(--panel-height)] flex-[0_1_auto] w-full max-w-full overflow-x-clip bg-transparent",
+  contentArea:
+    "h-auto flex-[0_1_auto] w-full max-w-full overflow-x-clip overflow-y-visible",
+} as const;

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -64,11 +64,11 @@ body {
 
 /*
  * Mobile document scroll (body.document-scroll-mode via useDocumentScrollMode).
- * Unlocks height chain, document/window scroll, panel background through full range.
+ * Top-level height chain + panel background. Component layout overrides live in
+ * MOBILE_DOCUMENT_SCROLL_CLASSES (see AppContentLayout, DropzoneContainer).
  */
 html:has(body.document-scroll-mode),
 html:has(body.document-scroll-mode) body,
-html:has(body.document-scroll-mode) #__next,
 html:has(body.document-scroll-mode) #root {
   height: auto;
   min-height: 100dvh;
@@ -102,36 +102,6 @@ body.document-scroll-mode #root {
   width: 100%;
 }
 
-body.document-scroll-mode .dropzone-container {
-  height: auto;
-  min-height: 0;
-}
-
-body.document-scroll-mode .app-content-root {
-  height: auto;
-  min-height: 100dvh;
-  width: 100%;
-}
-
-body.document-scroll-mode .app-content-row {
-  flex: 0 1 auto;
-  min-height: auto;
-  width: 100%;
-  max-width: 100%;
-  overflow-x: clip;
-}
-
-body.document-scroll-mode .app-content-main {
-  height: auto;
-  min-height: var(--panel-height);
-  flex: 0 1 auto;
-  width: 100%;
-  max-width: 100%;
-  /* Contain wide message content; table scroll is handled via #BlockWrapper rules below */
-  overflow-x: clip;
-  background-color: transparent;
-}
-
 /*
  * Markdown tables (TableBlock) use ScrollArea (overflow-hidden) + sticky copy
  * actions (ContentBlockWrapper). Nested scroll + sticky inside document scroll
@@ -150,16 +120,6 @@ body.document-scroll-mode #BlockWrapper .s-overflow-hidden {
 body.document-scroll-mode #BlockWrapper .s-sticky {
   position: relative;
   top: auto;
-}
-
-body.document-scroll-mode .app-content-pane,
-body.document-scroll-mode .app-content-scroll {
-  height: auto;
-  flex: 0 1 auto;
-  width: 100%;
-  max-width: 100%;
-  overflow-x: clip;
-  overflow-y: visible;
 }
 
 #__next {

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -62,6 +62,106 @@ body {
   overscroll-behavior: none;
 }
 
+/*
+ * Mobile document scroll (body.document-scroll-mode via useDocumentScrollMode).
+ * Unlocks height chain, document/window scroll, panel background through full range.
+ */
+html:has(body.document-scroll-mode),
+html:has(body.document-scroll-mode) body,
+html:has(body.document-scroll-mode) #__next,
+html:has(body.document-scroll-mode) #root {
+  height: auto;
+  min-height: 100dvh;
+}
+
+html:has(body.document-scroll-mode),
+html:has(body.document-scroll-mode) #__next,
+body.document-scroll-mode,
+body.document-scroll-mode #root {
+  @apply bg-panel-background;
+}
+
+html.dark:has(body.document-scroll-mode),
+html.dark:has(body.document-scroll-mode) #__next,
+.dark body.document-scroll-mode,
+.dark body.document-scroll-mode #root {
+  @apply bg-panel-background-night;
+}
+
+body.document-scroll-mode {
+  display: flex;
+  flex-direction: column;
+  overflow-y: visible;
+  overscroll-behavior: auto;
+}
+
+body.document-scroll-mode #root {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+body.document-scroll-mode .dropzone-container {
+  height: auto;
+  min-height: 0;
+}
+
+body.document-scroll-mode .app-content-root {
+  height: auto;
+  min-height: 100dvh;
+  width: 100%;
+}
+
+body.document-scroll-mode .app-content-row {
+  flex: 0 1 auto;
+  min-height: auto;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: clip;
+}
+
+body.document-scroll-mode .app-content-main {
+  height: auto;
+  min-height: var(--panel-height);
+  flex: 0 1 auto;
+  width: 100%;
+  max-width: 100%;
+  /* Contain wide message content; table scroll is handled via #BlockWrapper rules below */
+  overflow-x: clip;
+  background-color: transparent;
+}
+
+/*
+ * Markdown tables (TableBlock) use ScrollArea (overflow-hidden) + sticky copy
+ * actions (ContentBlockWrapper). Nested scroll + sticky inside document scroll
+ * clips content and breaks iOS window scroll once the table leaves the viewport.
+ */
+body.document-scroll-mode #BlockWrapper {
+  max-width: 100%;
+  min-width: 0;
+}
+
+body.document-scroll-mode #BlockWrapper .s-overflow-hidden {
+  overflow-x: auto;
+  overflow-y: visible;
+}
+
+body.document-scroll-mode #BlockWrapper .s-sticky {
+  position: relative;
+  top: auto;
+}
+
+body.document-scroll-mode .app-content-pane,
+body.document-scroll-mode .app-content-scroll {
+  height: auto;
+  flex: 0 1 auto;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: clip;
+  overflow-y: visible;
+}
+
 #__next {
   @apply h-full;
 }

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -102,26 +102,6 @@ body.document-scroll-mode #root {
   width: 100%;
 }
 
-/*
- * Markdown tables (TableBlock) use ScrollArea (overflow-hidden) + sticky copy
- * actions (ContentBlockWrapper). Nested scroll + sticky inside document scroll
- * clips content and breaks iOS window scroll once the table leaves the viewport.
- */
-body.document-scroll-mode #BlockWrapper {
-  max-width: 100%;
-  min-width: 0;
-}
-
-body.document-scroll-mode #BlockWrapper .s-overflow-hidden {
-  overflow-x: auto;
-  overflow-y: visible;
-}
-
-body.document-scroll-mode #BlockWrapper .s-sticky {
-  position: relative;
-  top: auto;
-}
-
 #__next {
   @apply h-full;
 }

--- a/sparkle/src/components/ScrollArea.tsx
+++ b/sparkle/src/components/ScrollArea.tsx
@@ -7,6 +7,8 @@ interface ScrollAreaProps
   extends React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> {
   hideScrollBar?: boolean;
   orientation?: "vertical" | "horizontal";
+  /** Horizontal: clip x-axis only so a parent/window can scroll vertically. */
+  scrollContainment?: "default" | "horizontal";
   scrollBarClassName?: string;
   viewportClassName?: string;
   viewportRef?: React.Ref<HTMLDivElement>;
@@ -22,6 +24,7 @@ const ScrollArea = React.forwardRef<
       children,
       hideScrollBar = false,
       orientation = "vertical",
+      scrollContainment = "default",
       scrollBarClassName,
       viewportClassName,
       viewportRef,
@@ -47,7 +50,13 @@ const ScrollArea = React.forwardRef<
     return (
       <ScrollAreaPrimitive.Root
         ref={ref}
-        className={cn("s-relative s-z-20 s-overflow-hidden", className)}
+        className={cn(
+          "s-relative s-z-20",
+          scrollContainment === "horizontal"
+            ? "s-overflow-x-auto s-overflow-y-visible"
+            : "s-overflow-hidden",
+          className
+        )}
         {...props}
       >
         <ScrollAreaPrimitive.Viewport

--- a/sparkle/src/components/markdown/ContentBlockWrapper.tsx
+++ b/sparkle/src/components/markdown/ContentBlockWrapper.tsx
@@ -16,29 +16,20 @@ const contentTypeExtensions: Record<SupportedContentType, string> = {
   "text/csv": ".csv",
 };
 
-const wrapperVariants = cva("s-group s-relative s-w-full !s-overflow-visible", {
-  variants: {
-    buttonDisplay: {
-      inside: "s-mt-0",
-      outside: "s-mt-11",
+const wrapperVariants = cva(
+  "s-group s-relative s-w-full s-max-w-full s-min-w-0 !s-overflow-visible",
+  {
+    variants: {
+      buttonDisplay: {
+        inside: "s-mt-0",
+        outside: "s-mt-11",
+      },
     },
-  },
-  defaultVariants: {
-    buttonDisplay: "outside",
-  },
-});
-
-const stickyContainerVariants = cva("s-sticky s-z-[1] s-h-0", {
-  variants: {
-    buttonDisplay: {
-      inside: "s-top-0",
-      outside: "s-top-11",
+    defaultVariants: {
+      buttonDisplay: "outside",
     },
-  },
-  defaultVariants: {
-    buttonDisplay: "outside",
-  },
-});
+  }
+);
 
 const actionsVariants = cva(
   "s-absolute s-right-2 s-flex s-items-center s-gap-1 s-py-2",
@@ -147,12 +138,9 @@ export function ContentBlockWrapper({
   );
 
   return (
-    <div
-      id="BlockWrapper"
-      className={cn(wrapperVariants({ buttonDisplay }), className)}
-    >
+    <div className={cn(wrapperVariants({ buttonDisplay }), className)}>
       {buttonDisplay !== null && (
-        <div className={stickyContainerVariants({ buttonDisplay })}>
+        <div className="s-relative s-z-[1] s-h-0">
           <div
             id="BlockActions"
             className={actionsVariants({ buttonDisplay, displayActions })}
@@ -179,7 +167,9 @@ export function ContentBlockWrapper({
           </div>
         </div>
       )}
-      <div className={cn("s-z-0 s-w-full", innerClassName)}>{children}</div>
+      <div className={cn("s-z-0 s-w-full s-min-w-0", innerClassName)}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/sparkle/src/components/markdown/PrettyJsonViewer.tsx
+++ b/sparkle/src/components/markdown/PrettyJsonViewer.tsx
@@ -400,8 +400,9 @@ export function PrettyJsonViewer({ data, className }: JsonViewerProps) {
   return (
     <div
       className={cn(
+        "s-max-w-full s-min-w-0 s-overflow-x-auto s-overflow-y-visible",
         "s-bg-structure-50 dark:s-bg-structure-50-night",
-        "s-overflow-hidden s-rounded-lg s-px-4 s-py-4 s-text-base",
+        "s-rounded-lg s-px-4 s-py-4 s-text-base",
         className
       )}
     >

--- a/sparkle/src/components/markdown/TableBlock.tsx
+++ b/sparkle/src/components/markdown/TableBlock.tsx
@@ -77,7 +77,10 @@ export const TableBlock = memo(
         innerClassName="s-relative s-my-2 s-w-full s-border s-border-border dark:s-border-border-night s-rounded-2xl"
         content={tableData}
       >
-        <ScrollArea className="s-w-full s-rounded-2xl">
+        <ScrollArea
+          scrollContainment="horizontal"
+          className="s-w-full s-rounded-2xl"
+        >
           <table className="s-w-full">{children}</table>
           <ScrollBar orientation="horizontal" />
         </ScrollArea>


### PR DESCRIPTION
## Description

**Everything is scoped to mobile only.**

Fixes mobile scroll by switching from a fixed-height viewport model to native document/window scroll on mobile. Updated only the main and conversation pages, can extends the approach.

Notice below how the content uses the whole screen.

Before

https://github.com/user-attachments/assets/f4bdc8fa-3eed-4c36-a821-3d2c74fd08b3

After

https://github.com/user-attachments/assets/cf5197a4-8cec-4328-af7a-d24fbfc95683

## Tests

Tested manually on mobile. No automated tests — pure layout/scroll behaviour change.

## Risk

Low. All changes are gated on `isMobile` (`useIsMobile` hook) and the `document-scroll-mode` CSS class, leaving desktop layout untouched. Rollback is a single front deploy revert.

## Deploy Plan

Deploy `front`.
