### PR TITLE
fix: do not retry trigger workflow when no seat available

### DIFF
--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -300,7 +300,8 @@ export async function runTriggeredAgentsActivity({
       errorType === "model_disabled" ||
       errorType === "invalid_request_error" ||
       errorType === "agent_inaccessible" ||
-      errorType === "webhook_storage_error";
+      errorType === "webhook_storage_error" ||
+      errorType === "no_seat";
 
     if (isNonRetryable) {
       logger.info(


### PR DESCRIPTION
## Description

This PR fixes the trigger workflow to not retry when a user has no available seat, by adding `"no_seat"` to the list of non-retryable error types.

There are some temporal activities failing because the user has no seat https://app.datadoghq.eu/logs?query=%40workflowId%3Aagent-schedule-%2A%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1782211149324&to_ts=1782383949324&live=true

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.
