### PR TITLE
Add update_issue tool to GitHub MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -202,6 +202,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_organization_projects": "never_ask",
     "list_pull_requests": "never_ask",
     "search_advanced": "never_ask",
+    "update_issue": "medium",
   },
   "gmail": {
     "create_draft": "medium",

--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -31,6 +31,66 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       done: "Create GitHub issue",
     },
   },
+  update_issue: {
+    description:
+      "Update an existing issue on a GitHub repository: its title, body," +
+      " labels, assignees, milestone, and open/closed state (closing or" +
+      " reopening the issue). Only the provided fields are changed.",
+    schema: {
+      owner: z
+        .string()
+        .describe(
+          "The owner of the repository (account or organization name)."
+        ),
+      repo: z.string().describe("The name of the repository."),
+      issueNumber: z.number().describe("The number that identifies the issue."),
+      title: z.string().optional().describe("The new title of the issue."),
+      body: z
+        .string()
+        .optional()
+        .describe("The new contents of the issue (GitHub markdown)."),
+      state: z
+        .enum(["open", "closed"])
+        .optional()
+        .describe(
+          "The open or closed state of the issue. Set to 'closed' to close the" +
+            " issue, or 'open' to reopen it."
+        ),
+      stateReason: z
+        .enum(["completed", "not_planned", "reopened"])
+        .optional()
+        .describe(
+          "The reason for the state change. Ignored unless state is changed."
+        ),
+      assignees: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Logins for Users to assign to this issue. Replaces the current set" +
+            " of assignees; pass an empty array to clear all assignees."
+        ),
+      labels: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Labels to associate with this issue. Replaces the current set of" +
+            " labels; pass an empty array to clear all labels."
+        ),
+      milestone: z
+        .number()
+        .nullable()
+        .optional()
+        .describe(
+          "The number of the milestone to associate this issue with, or null" +
+            " to remove the current milestone."
+        ),
+    },
+    stake: "medium",
+    displayLabels: {
+      running: "Updating GitHub issue",
+      done: "Update GitHub issue",
+    },
+  },
   get_pull_request: {
     description:
       "Retrieve a pull request from a specified GitHub repository including" +

--- a/front/lib/api/actions/servers/github/tools/index.ts
+++ b/front/lib/api/actions/servers/github/tools/index.ts
@@ -370,6 +370,54 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
       }
     },
 
+    update_issue: async (
+      {
+        owner,
+        repo,
+        issueNumber,
+        title,
+        body,
+        state,
+        stateReason,
+        assignees,
+        labels,
+        milestone,
+      },
+      { authInfo }
+    ) => {
+      const octokit = await createOctokit(auth, {
+        accessToken: authInfo?.token,
+      });
+
+      try {
+        const { data: issue } = await octokit.request(
+          "PATCH /repos/{owner}/{repo}/issues/{issue_number}",
+          {
+            owner,
+            repo,
+            issue_number: issueNumber,
+            title,
+            body,
+            state,
+            state_reason: stateReason,
+            assignees,
+            labels,
+            milestone,
+          }
+        );
+
+        return new Ok([
+          { type: "text" as const, text: `Issue #${issue.number} updated` },
+        ]);
+      } catch (e) {
+        return new Err(
+          new MCPError(
+            `Error updating GitHub issue: ${normalizeError(e).message}`
+          )
+        );
+      }
+    },
+
     create_pull_request_review: async (
       { owner, repo, pullNumber, body, event, comments = [] },
       { authInfo }


### PR DESCRIPTION
## Description

Adds an update_issue tool to the internal GitHub MCP server. It lets agents edit an existing issue's title, body, labels, assignees and milestone, and close or reopen it via its state. Wraps PATCH /repos/{owner}/{repo}/issues/{issue_number}; only provided fields are changed.

fixes: [link](https://github.com/dust-tt/tasks/issues/9114)

## Tests

tested manually on front-edge

## Risk

Low. Additive change (new tool, existing tools untouched). Stake set to medium so the action requires user confirmation. Safe to rollback by removing the tool.

## Deploy Plan
