### PR TITLE
feat(seats): promote none-seat members into spare committed paid seats on contract switch

### DIFF
--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -4,6 +4,7 @@ import {
   computeSeatCreditTransfers,
   getSeatCreditNameForSeatType,
   hasContractSeatSubscription,
+  promoteNoneSeatTypesForContract,
   resolveRemappedSeatType,
 } from "@app/lib/metronome/seats";
 import {
@@ -303,6 +304,161 @@ describe("resolveRemappedSeatType — workspace-tier fallback for enterprise poo
     expect(resolveRemappedSeatType("pro_yearly", c, pt, { seatLimits })).toBe(
       "workspace_yearly"
     );
+  });
+});
+
+describe("promoteNoneSeatTypesForContract", () => {
+  const { contract, productSeatTypes } = makeContract({
+    seats: [{ seatType: "free" }, { seatType: "pro", awu: 8000 }],
+  });
+
+  it("promotes every none member when committed capacity covers them all", () => {
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["pro", { minSeats: 3, maxSeats: null }],
+    ]);
+    expect(
+      promoteNoneSeatTypesForContract({
+        contract,
+        productSeatTypes,
+        seatTypes: ["none", "none"],
+        seatLimits,
+      })
+    ).toEqual(["pro", "pro"]);
+  });
+
+  it("promotes none members when capacity exactly matches the none count", () => {
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["pro", { minSeats: 2, maxSeats: null }],
+    ]);
+    expect(
+      promoteNoneSeatTypesForContract({
+        contract,
+        productSeatTypes,
+        seatTypes: ["none", "none"],
+        seatLimits,
+      })
+    ).toEqual(["pro", "pro"]);
+  });
+
+  it("promotes no one (all-or-nothing) when capacity is short of the none count", () => {
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["pro", { minSeats: 2, maxSeats: null }],
+    ]);
+    expect(
+      promoteNoneSeatTypesForContract({
+        contract,
+        productSeatTypes,
+        seatTypes: ["none", "none", "none", "none"],
+        seatLimits,
+      })
+    ).toEqual(["none", "none", "none", "none"]);
+  });
+
+  it("counts seats already taken by non-none targets against capacity", () => {
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["pro", { minSeats: 3, maxSeats: null }],
+    ]);
+    expect(
+      promoteNoneSeatTypesForContract({
+        contract,
+        productSeatTypes,
+        seatTypes: ["pro", "pro", "none", "none"],
+        seatLimits,
+      })
+    ).toEqual(["pro", "pro", "none", "none"]);
+  });
+
+  it("does not promote when there is no committed paid seat", () => {
+    expect(
+      promoteNoneSeatTypesForContract({
+        contract,
+        productSeatTypes,
+        seatTypes: ["none", "none"],
+      })
+    ).toEqual(["none", "none"]);
+  });
+
+  it("never hands out the one-shot free tier on promotion", () => {
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["pro", { minSeats: 2, maxSeats: null }],
+    ]);
+    expect(
+      promoteNoneSeatTypesForContract({
+        contract,
+        productSeatTypes,
+        seatTypes: ["none", "none"],
+        seatLimits,
+      })
+    ).toEqual(["pro", "pro"]);
+  });
+
+  it("leaves non-none targets untouched", () => {
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["pro", { minSeats: 5, maxSeats: null }],
+    ]);
+    expect(
+      promoteNoneSeatTypesForContract({
+        contract,
+        productSeatTypes,
+        seatTypes: ["max", "pro_yearly", "free"],
+        seatLimits,
+      })
+    ).toEqual(["max", "pro_yearly", "free"]);
+  });
+
+  it("promotes into committed workspace tiers, not just pro", () => {
+    const { contract: c, productSeatTypes: pt } = makeContract({
+      seats: [{ seatType: "workspace_yearly", entitled: true }],
+    });
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["workspace_yearly", { minSeats: 25, maxSeats: null }],
+    ]);
+    expect(
+      promoteNoneSeatTypesForContract({
+        contract: c,
+        productSeatTypes: pt,
+        seatTypes: ["none", "none", "none"],
+        seatLimits,
+      })
+    ).toEqual(["workspace_yearly", "workspace_yearly", "workspace_yearly"]);
+  });
+
+  it("never auto-promotes into a committed max tier", () => {
+    const { contract: c, productSeatTypes: pt } = makeContract({
+      seats: [{ seatType: "max", awu: 40000, entitled: true }],
+    });
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["max", { minSeats: 10, maxSeats: null }],
+    ]);
+    expect(
+      promoteNoneSeatTypesForContract({
+        contract: c,
+        productSeatTypes: pt,
+        seatTypes: ["none", "none"],
+        seatLimits,
+      })
+    ).toEqual(["none", "none"]);
+  });
+
+  it("fills the lowest committed tier first when several are available", () => {
+    const { contract: c, productSeatTypes: pt } = makeContract({
+      seats: [
+        { seatType: "pro", awu: 8000, entitled: true },
+        { seatType: "workspace_yearly", entitled: true },
+      ],
+    });
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["pro", { minSeats: 1, maxSeats: null }],
+      ["workspace_yearly", { minSeats: 1, maxSeats: null }],
+    ]);
+    expect(
+      promoteNoneSeatTypesForContract({
+        contract: c,
+        productSeatTypes: pt,
+        seatTypes: ["none", "none"],
+        seatLimits,
+      })
+    ).toEqual(["pro", "workspace_yearly"]);
   });
 });
 

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -312,6 +312,71 @@ export function resolveRemappedSeatType(
   return "none";
 }
 
+const PROMOTABLE_SEAT_TYPES: ReadonlySet<MembershipSeatType> = new Set([
+  "pro",
+  "pro_yearly",
+  "workspace",
+  "workspace_yearly",
+]);
+
+export function promoteNoneSeatTypesForContract({
+  contract,
+  productSeatTypes,
+  seatTypes,
+  seatLimits,
+}: {
+  contract: CachedContract;
+  productSeatTypes: Map<string, MembershipSeatType>;
+  seatTypes: MembershipSeatType[];
+  seatLimits?: Map<MembershipSeatType, SeatLimit>;
+}): MembershipSeatType[] {
+  const committedPaidSeatTypes = [
+    ...getSeatSubscriptionsFromContract(contract, productSeatTypes).keys(),
+  ]
+    .filter(
+      (seatType) =>
+        PROMOTABLE_SEAT_TYPES.has(seatType) &&
+        (seatLimits?.get(seatType)?.minSeats ?? 0) > 0
+    )
+    .sort(
+      (a, b) => SEAT_TYPE_ORDER[a] - SEAT_TYPE_ORDER[b] || a.localeCompare(b)
+    );
+
+  const assignedBySeatType = new Map<MembershipSeatType, number>();
+  for (const seatType of seatTypes) {
+    if (seatType !== "none") {
+      assignedBySeatType.set(
+        seatType,
+        (assignedBySeatType.get(seatType) ?? 0) + 1
+      );
+    }
+  }
+  const remainingBySeatType = new Map<MembershipSeatType, number>();
+  for (const seatType of committedPaidSeatTypes) {
+    const minSeats = seatLimits?.get(seatType)?.minSeats ?? 0;
+    remainingBySeatType.set(
+      seatType,
+      Math.max(0, minSeats - (assignedBySeatType.get(seatType) ?? 0))
+    );
+  }
+
+  const result = [...seatTypes];
+  for (let i = 0; i < result.length; i++) {
+    if (result[i] !== "none") {
+      continue;
+    }
+    const target = committedPaidSeatTypes.find(
+      (seatType) => (remainingBySeatType.get(seatType) ?? 0) > 0
+    );
+    if (!target) {
+      return [...seatTypes];
+    }
+    remainingBySeatType.set(target, (remainingBySeatType.get(target) ?? 0) - 1);
+    result[i] = target;
+  }
+  return result;
+}
+
 /**
  * Remap existing memberships' seat types to the seat types billed by
  * `contract`, so that after a contract switch no membership ends up on a seat
@@ -326,6 +391,11 @@ export function resolveRemappedSeatType(
  *    keeps the old seat type (the current contract keeps billing correctly)
  *    and a future row flips at `startingAt`, which the seat sync picks up as a
  *    future segment on the new contract.
+ *
+ * Members landing on `none` are then promoted into any committed paid seat the
+ * new contract still has spare capacity for (see
+ * `promoteNoneSeatTypesForContract`): a committed seat is billed whether or not
+ * it is assigned, so filling it with an otherwise seat-less member adds no cost.
  *
  * No-op for memberships already on a covered seat type. A membership with no
  * resolvable `UserResource` is logged and skipped; a DB error while applying a
@@ -420,7 +490,7 @@ export async function remapMembershipSeatTypesForContract({
   const applyImmediately =
     swapAt === "current-hour" || startingAt.getTime() <= Date.now();
 
-  for (const membership of memberships) {
+  const remapTargets = memberships.flatMap((membership) => {
     const user = userByModelId.get(membership.userId);
     if (!user) {
       logger.warn(
@@ -431,15 +501,34 @@ export async function remapMembershipSeatTypesForContract({
         },
         "[Metronome][remap] No UserResource for membership — skipping"
       );
-      continue;
+      return [];
     }
+    return [
+      {
+        membership,
+        user,
+        baseTarget: resolveRemappedSeatType(
+          membership.seatType,
+          resolvedContract,
+          productSeatTypes,
+          { seatLimits }
+        ),
+      },
+    ];
+  });
 
-    const target = resolveRemappedSeatType(
-      membership.seatType,
-      resolvedContract,
-      productSeatTypes,
-      { seatLimits }
-    );
+  const promotedTargets = promoteNoneSeatTypesForContract({
+    contract: resolvedContract,
+    productSeatTypes,
+    seatTypes: remapTargets.map((t) => t.baseTarget),
+    seatLimits,
+  });
+
+  for (const [
+    index,
+    { membership, user, baseTarget },
+  ] of remapTargets.entries()) {
+    const target = promotedTargets[index];
     if (target === membership.seatType) {
       logger.info(
         {
@@ -460,6 +549,7 @@ export async function remapMembershipSeatTypesForContract({
         userId: user.sId,
         previousSeatType: membership.seatType,
         newSeatType: target,
+        promotedFromNone: baseTarget === "none" && target !== "none",
         mode: applyImmediately ? "immediate" : "scheduled",
         scheduledAt: applyImmediately ? null : startingAt.toISOString(),
       },


### PR DESCRIPTION
## Description

When a contract switch lands members on `none`, promote them into committed paid seats the new contract still has spare capacity for. Committed seats (minSeats > 0) are billed whether assigned or not, so filling otherwise-empty slots adds no cost and the seat can be reassigned to a new joiner later.

All-or-nothing: either there is enough committed capacity to seat every `none` member (all promoted) or none of them are.

Restrict auto-promotion to the committed pro and workspace tiers (and yearly variants) via PROMOTABLE_SEAT_TYPES. max is excluded: it's a premium seat an admin grants deliberately, and correcting an over-eager auto-grant is a downgrade that only takes effect at the next billing period. So we never auto-assign a seat the admin can't immediately walk back.

## Tests
Unit

## Risk

Low
## Deploy Plan

Front