### PR TITLE
Introduce `runtimeToolStakeLevelOverride` for dynamic tool stake definition (based on plan for now)

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -36,7 +36,6 @@ import {
   getInternalMCPServerNameAndWorkspaceId,
   getInternalMCPServerToolStakes,
   INTERNAL_MCP_SERVERS,
-  type InternalMCPServerNameType,
   resolveInternalMCPServerToolStakeLevel,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { findMatchingSubSchemas } from "@app/lib/actions/mcp_internal_actions/input_configuration";
@@ -1264,16 +1263,10 @@ export async function buildToolConfigurationsFromRawTools(
   } = r.value;
 
   const availability = getAvailabilityOfInternalMCPServerById(mcpServerId);
-  const { serverType } = getServerTypeAndIdFromSId(mcpServerId);
-  let internalServerName: InternalMCPServerNameType | null = null;
-  if (serverType === "internal") {
-    const serverNameResult =
-      getInternalMCPServerNameAndWorkspaceId(mcpServerId);
-    if (serverNameResult.isErr()) {
-      return serverNameResult;
-    }
-    internalServerName = serverNameResult.value.name;
-  }
+  const serverNameResult = getInternalMCPServerNameAndWorkspaceId(mcpServerId);
+  const internalServerName = serverNameResult.isOk()
+    ? serverNameResult.value.name
+    : null;
 
   const toolsWithStakesRetryPoliciesAndTimeout = allToolsRaw
     .filter(({ name }) => !(toolsEnabled[name] === false)) // Include tools that are enabled (true) or not explicitly disabled (undefined).

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -36,6 +36,8 @@ import {
   getInternalMCPServerNameAndWorkspaceId,
   getInternalMCPServerToolStakes,
   INTERNAL_MCP_SERVERS,
+  type InternalMCPServerNameType,
+  resolveInternalMCPServerToolStakeLevel,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { findMatchingSubSchemas } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
@@ -1262,26 +1264,47 @@ export async function buildToolConfigurationsFromRawTools(
   } = r.value;
 
   const availability = getAvailabilityOfInternalMCPServerById(mcpServerId);
+  const { serverType } = getServerTypeAndIdFromSId(mcpServerId);
+  let internalServerName: InternalMCPServerNameType | null = null;
+  if (serverType === "internal") {
+    const serverNameResult =
+      getInternalMCPServerNameAndWorkspaceId(mcpServerId);
+    if (serverNameResult.isErr()) {
+      return serverNameResult;
+    }
+    internalServerName = serverNameResult.value.name;
+  }
 
   const toolsWithStakesRetryPoliciesAndTimeout = allToolsRaw
     .filter(({ name }) => !(toolsEnabled[name] === false)) // Include tools that are enabled (true) or not explicitly disabled (undefined).
-    .map((tool) => ({
-      ...tool,
-      stakeLevel:
+    .map((tool) => {
+      const configuredStakeLevel =
         toolsStakes[tool.name] ||
         (availability === "manual"
           ? FALLBACK_MCP_TOOL_STAKE_LEVEL
-          : FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL),
-      availability,
-      toolServerId: mcpServerId,
-      ...(serverTimeoutMs && { timeoutMs: serverTimeoutMs }),
-      retryPolicy:
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        toolsRetryPolicies?.[tool.name] ||
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        toolsRetryPolicies?.["default"] ||
-        DEFAULT_MCP_TOOL_RETRY_POLICY,
-    }));
+          : FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL);
+      const stakeLevel = internalServerName
+        ? resolveInternalMCPServerToolStakeLevel(internalServerName, {
+            toolName: tool.name,
+            plan: auth.plan(),
+            configuredStakeLevel,
+          })
+        : configuredStakeLevel;
+
+      return {
+        ...tool,
+        stakeLevel,
+        availability,
+        toolServerId: mcpServerId,
+        ...(serverTimeoutMs && { timeoutMs: serverTimeoutMs }),
+        retryPolicy:
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          toolsRetryPolicies?.[tool.name] ||
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          toolsRetryPolicies?.["default"] ||
+          DEFAULT_MCP_TOOL_RETRY_POLICY,
+      };
+    });
 
   const serverSideToolConfigs = makeServerSideMCPToolConfigurations(
     config,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1179,11 +1179,15 @@ type IsRestrictedCallback = (params: {
   isDeepDiveDisabled: boolean;
 }) => boolean;
 
-type RuntimeToolStakeLevelOverride = (params: {
+type RuntimeToolStakeLevelCallbackParams = {
   toolName: string;
   plan: PlanType | null;
   configuredStakeLevel: MCPToolStakeLevelType;
-}) => MCPToolStakeLevelType;
+};
+
+type RuntimeToolStakeLevelCallback = (
+  params: RuntimeToolStakeLevelCallbackParams
+) => MCPToolStakeLevelType;
 
 type InternalMCPServerEntryCommon = {
   id: number;
@@ -1191,7 +1195,7 @@ type InternalMCPServerEntryCommon = {
   allowMultipleInstances: boolean;
   isRestricted: IsRestrictedCallback | undefined;
   isPreview: boolean;
-  runtimeToolStakeLevelOverride?: RuntimeToolStakeLevelOverride;
+  runtimeToolStakeLevelCallback?: RuntimeToolStakeLevelCallback;
   // Defines which arguments require per-agent approval for "medium" stake tools.
   // When a tool has "medium" stake, the user must approve the specific combination
   // of (agent, tool, argument values) before the tool can execute.
@@ -1428,12 +1432,12 @@ export function getInternalMCPServerToolStakes(
 
 export function resolveInternalMCPServerToolStakeLevel(
   name: InternalMCPServerNameType,
-  params: Parameters<RuntimeToolStakeLevelOverride>[0]
+  params: RuntimeToolStakeLevelCallbackParams
 ): MCPToolStakeLevelType {
   const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
 
   return (
-    server.runtimeToolStakeLevelOverride?.(params) ??
+    server.runtimeToolStakeLevelCallback?.(params) ??
     params.configuredStakeLevel
   );
 }

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1179,12 +1179,19 @@ type IsRestrictedCallback = (params: {
   isDeepDiveDisabled: boolean;
 }) => boolean;
 
+type RuntimeToolStakeLevelOverride = (params: {
+  toolName: string;
+  plan: PlanType | null;
+  configuredStakeLevel: MCPToolStakeLevelType;
+}) => MCPToolStakeLevelType;
+
 type InternalMCPServerEntryCommon = {
   id: number;
   availability: MCPServerAvailability;
   allowMultipleInstances: boolean;
   isRestricted: IsRestrictedCallback | undefined;
   isPreview: boolean;
+  runtimeToolStakeLevelOverride?: RuntimeToolStakeLevelOverride;
   // Defines which arguments require per-agent approval for "medium" stake tools.
   // When a tool has "medium" stake, the user must approve the specific combination
   // of (agent, tool, argument values) before the tool can execute.
@@ -1417,6 +1424,18 @@ export function getInternalMCPServerToolStakes(
   const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
 
   return server.metadata.tools_stakes;
+}
+
+export function resolveInternalMCPServerToolStakeLevel(
+  name: InternalMCPServerNameType,
+  params: Parameters<RuntimeToolStakeLevelOverride>[0]
+): MCPToolStakeLevelType {
+  const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
+
+  return (
+    server.runtimeToolStakeLevelOverride?.(params) ??
+    params.configuredStakeLevel
+  );
 }
 
 export function getInternalMCPServerToolDisplayLabels<


### PR DESCRIPTION
## Description

Introduce `runtimeToolStakeLevelOverride` to enable dynamic runtime tool stake overrides (based on `PlanType` as an example).

Motivation is move wake-ups tool stake to low if the user is on a credit-based subscription.

## Tests

N/A will test locally with wake-ups in a follow-up PR. Tested non breaking locally.

## Risk

Low

## Deploy Plan

- deploy `front`