### PR TITLE
[front] jira/confluence: fix use of extra config with cloud_url

### DIFF
--- a/front/lib/api/actions/servers/confluence/helpers.ts
+++ b/front/lib/api/actions/servers/confluence/helpers.ts
@@ -19,6 +19,7 @@ import {
   CreatePagePayloadSchema,
 } from "@app/lib/api/actions/servers/confluence/types";
 import logger from "@app/logger/logger";
+import { normalizeAtlassianCloudUrl } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -113,9 +114,12 @@ async function getConfluenceBaseUrlAndResourceInfo(
     return null;
   }
 
-  const resource = !cloudUrl
+  const normalizedCloudUrl = cloudUrl
+    ? normalizeAtlassianCloudUrl(cloudUrl)
+    : null;
+  const resource = !normalizedCloudUrl
     ? resources[0]
-    : (resources.find((r) => r.url === cloudUrl) ?? null);
+    : (resources.find((r) => r.url === normalizedCloudUrl) ?? null);
 
   if (!resource) {
     return null;

--- a/front/lib/api/actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/api/actions/servers/jira/jira_api_helper.ts
@@ -43,6 +43,7 @@ import {
   SEARCH_USERS_MAX_RESULTS,
 } from "@app/lib/api/actions/servers/jira/types";
 import logger from "@app/logger/logger";
+import { normalizeAtlassianCloudUrl } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isTextExtractionSupportedContentType } from "@app/types/shared/text_extraction";
@@ -356,9 +357,12 @@ export async function getJiraBaseUrlAndResourceInfo(
     return null;
   }
 
-  const resource = !cloudUrl
+  const normalizedCloudUrl = cloudUrl
+    ? normalizeAtlassianCloudUrl(cloudUrl)
+    : null;
+  const resource = !normalizedCloudUrl
     ? resources[0]
-    : (resources.find((r) => r.url === cloudUrl) ?? null);
+    : (resources.find((r) => r.url === normalizedCloudUrl) ?? null);
 
   if (!resource) {
     return null;

--- a/front/lib/api/oauth/providers/confluence_tools.ts
+++ b/front/lib/api/oauth/providers/confluence_tools.ts
@@ -1,15 +1,19 @@
 import config from "@app/lib/api/config";
+import { getWorkspaceOAuthConnectionIdForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
 import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import type {
   ExtraConfigType,
   OAuthConnectionType,
   OAuthUseCase,
 } from "@app/types/oauth/lib";
 import { isValidAtlassianCloudUrlOrEmpty } from "@app/types/oauth/lib";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { ParsedUrlQuery } from "querystring";
 
 export class ConfluenceToolsOAuthProvider implements BaseOAuthStrategyProvider {
@@ -58,5 +62,48 @@ export class ConfluenceToolsOAuthProvider implements BaseOAuthStrategyProvider {
     }
     // confluence_cloud_url is optional — absent or empty means fall back to dynamic resolution.
     return isValidAtlassianCloudUrlOrEmpty(extraConfig.confluence_cloud_url);
+  }
+
+  async getUpdatedExtraConfig(
+    auth: Authenticator,
+    {
+      extraConfig,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<ExtraConfigType> {
+    if (useCase === "personal_actions") {
+      const { mcp_server_id, ...restConfig } = extraConfig;
+
+      if (mcp_server_id) {
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          throw new Error(oauthConnectionIdRes.error.message);
+        }
+
+        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthApi.getConnectionMetadata({
+          connectionId: oauthConnectionIdRes.value,
+        });
+        if (connectionRes.isErr()) {
+          throw new Error(
+            "Failed to get connection metadata: " + connectionRes.error.message
+          );
+        }
+        const connection = connectionRes.value.connection;
+
+        return {
+          ...restConfig,
+          ...(connection.metadata.confluence_cloud_url && {
+            confluence_cloud_url: connection.metadata.confluence_cloud_url,
+          }),
+        };
+      }
+    }
+
+    return extraConfig;
   }
 }

--- a/front/lib/api/oauth/providers/jira.ts
+++ b/front/lib/api/oauth/providers/jira.ts
@@ -1,15 +1,19 @@
 import config from "@app/lib/api/config";
+import { getWorkspaceOAuthConnectionIdForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
 import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import type {
   ExtraConfigType,
   OAuthConnectionType,
   OAuthUseCase,
 } from "@app/types/oauth/lib";
 import { isValidAtlassianCloudUrlOrEmpty } from "@app/types/oauth/lib";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { ParsedUrlQuery } from "querystring";
 
 export class JiraOAuthProvider implements BaseOAuthStrategyProvider {
@@ -68,5 +72,48 @@ export class JiraOAuthProvider implements BaseOAuthStrategyProvider {
     }
     // cloud_url is optional — absent or empty means fall back to dynamic resolution.
     return isValidAtlassianCloudUrlOrEmpty(extraConfig.jira_cloud_url);
+  }
+
+  async getUpdatedExtraConfig(
+    auth: Authenticator,
+    {
+      extraConfig,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<ExtraConfigType> {
+    if (useCase === "personal_actions") {
+      const { mcp_server_id, ...restConfig } = extraConfig;
+
+      if (mcp_server_id) {
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          throw new Error(oauthConnectionIdRes.error.message);
+        }
+
+        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthApi.getConnectionMetadata({
+          connectionId: oauthConnectionIdRes.value,
+        });
+        if (connectionRes.isErr()) {
+          throw new Error(
+            "Failed to get connection metadata: " + connectionRes.error.message
+          );
+        }
+        const connection = connectionRes.value.connection;
+
+        return {
+          ...restConfig,
+          ...(connection.metadata.jira_cloud_url && {
+            jira_cloud_url: connection.metadata.jira_cloud_url,
+          }),
+        };
+      }
+    }
+
+    return extraConfig;
   }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8932

* Add getUpdatedExtraConfig to the Jira and Confluence Tools OAuth providers: when a user authenticates via personal_actions with an mcp_server_id, the workspace connection metadata is fetched to populate jira_cloud_url / confluence_cloud_url in the extra config, enabling instance-specific API routing.
* Fix instance URL matching in the Jira and Confluence API helpers: the user-supplied cloud URL is now normalized (trailing slash stripped, https:// added if missing) before comparing it against Atlassian's accessible-resources API response, which always returns canonical URLs. Without this, a trailing slash in the stored URL would cause the find to miss and fall back to the wrong instance.

## Tests

Tested locally with an account that is not the admin that setup the tool => OK

## Risk

Low, jira/confluence only and improved personal connections

## Deploy Plan

Deploy front
