### PR TITLE
fix(front): keep credit cost visible with loader while fetching

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -27,7 +27,10 @@ import {
   isUserMessage,
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
-import { useCreditCostMenuItem } from "@app/components/assistant/conversation/useCreditCostMenuItem";
+import {
+  CREDIT_COST_ITEM_CLASS_NAME,
+  useCreditCostMenuItem,
+} from "@app/components/assistant/conversation/useCreditCostMenuItem";
 import { ConfirmContext } from "@app/components/Confirm";
 import {
   CitationsContext,
@@ -248,6 +251,13 @@ export function AgentMessage({
   >([]);
   const [isCopied, copy] = useCopyToClipboard();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  // Latches to true the first time the menu opens. We use this rather than
+  // `isMenuOpen` to gate the cost fetch so the query stays enabled after the
+  // menu closes: otherwise disabling it nulls the SWR key, dropping
+  // `refreshedMessage` back to the prop values (which never carry
+  // `subAgentCostCredits`) and flickering the displayed total during the close
+  // animation.
+  const [hasOpenedMenu, setHasOpenedMenu] = useState(false);
   // Re-fetch (on menu open) only if a cost we want to show is still missing:
   // - Own cost: null until the agentic loop finishes; absent while streaming/listed.
   // - Sub-agent cost: only aggregated by the single-message fetch, and only exists
@@ -257,22 +267,26 @@ export function AgentMessage({
     agentMessage.costCredits == null ||
     (hasMessageSpawnedSubAgent(agentMessage) &&
       agentMessage.subAgentCostCredits == null);
-  const { message: refreshedMessage } = useConversationMessage({
-    conversationId,
-    workspaceId: owner.sId,
-    messageId: agentMessage.sId,
-    options: {
-      disabled: !isMenuOpen || !needsCostFetch,
-    },
-  });
+  const { message: refreshedMessage, isMessageLoading } =
+    useConversationMessage({
+      conversationId,
+      workspaceId: owner.sId,
+      messageId: agentMessage.sId,
+      options: {
+        disabled: !hasOpenedMenu || !needsCostFetch,
+      },
+    });
   const refreshedAgentMessage =
     refreshedMessage?.type === "agent_message" ? refreshedMessage : null;
-  const creditCostItem = useCreditCostMenuItem({
+  const { creditCostItem, isCreditPriced } = useCreditCostMenuItem({
     credits: refreshedAgentMessage?.costCredits ?? agentMessage.costCredits,
     subAgentCredits:
       refreshedAgentMessage?.subAgentCostCredits ??
       agentMessage.subAgentCostCredits,
   });
+  // On a credit-priced plan, keep the cost section visible while the fetch is
+  // in flight (showing a loader) rather than popping it in once it resolves.
+  const isCreditCostLoading = needsCostFetch && isMessageLoading;
   const sendNotification = useSendNotification();
   const confirm = useContext(ConfirmContext);
 
@@ -874,7 +888,14 @@ export function AgentMessage({
           icon={isCopied ? ClipboardCheck : Clipboard}
           className="text-muted-foreground dark:text-muted-foreground-night"
         />
-        <DropdownMenu onOpenChange={setIsMenuOpen}>
+        <DropdownMenu
+          onOpenChange={(open) => {
+            setIsMenuOpen(open);
+            if (open) {
+              setHasOpenedMenu(true);
+            }
+          }}
+        >
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
@@ -884,9 +905,20 @@ export function AgentMessage({
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            {creditCostItem && (
+            {isCreditPriced && (creditCostItem || isCreditCostLoading) && (
               <>
-                <DropdownMenuItem {...creditCostItem} />
+                {creditCostItem ? (
+                  <DropdownMenuItem {...creditCostItem} />
+                ) : (
+                  <DropdownMenuItem
+                    label="Credit cost"
+                    endComponent={
+                      <div className="h-3 w-8 animate-pulse rounded bg-muted-foreground/20" />
+                    }
+                    className={CREDIT_COST_ITEM_CLASS_NAME}
+                    onSelect={(e) => e.preventDefault()}
+                  />
+                )}
                 <DropdownMenuSeparator />
               </>
             )}

--- a/front/components/assistant/conversation/useCreditCostMenuItem.ts
+++ b/front/components/assistant/conversation/useCreditCostMenuItem.ts
@@ -6,7 +6,7 @@ import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
 const BEGINNING_AGENT_TOOLTIP =
   "Credits used for this message (tokens and actions).";
 
-const ITEM_CLASS_NAME =
+export const CREDIT_COST_ITEM_CLASS_NAME =
   "cursor-default font-normal text-muted-foreground hover:bg-transparent focus:bg-transparent dark:text-muted-foreground-night dark:hover:bg-transparent dark:focus:bg-transparent";
 
 interface UseCreditCostMenuItemProps {
@@ -14,14 +14,22 @@ interface UseCreditCostMenuItemProps {
   subAgentCredits: number | null | undefined;
 }
 
+interface UseCreditCostMenuItemResult {
+  creditCostItem: DropdownMenuItemProps | null;
+  // Whether the current plan bills with credits. Gates whether the menu
+  // section should be shown at all: on a credit-priced plan we keep it visible
+  // (with a loader) while the cost is still being fetched.
+  isCreditPriced: boolean;
+}
+
 export function useCreditCostMenuItem({
   credits,
   subAgentCredits,
-}: UseCreditCostMenuItemProps): DropdownMenuItemProps | null {
+}: UseCreditCostMenuItemProps): UseCreditCostMenuItemResult {
   const { subscription } = useAuth();
 
   if (!isCreditPricedPlan(subscription.plan)) {
-    return null;
+    return { creditCostItem: null, isCreditPriced: false };
   }
 
   const ownCredits = credits ?? 0;
@@ -29,7 +37,7 @@ export function useCreditCostMenuItem({
   const totalCredits = ownCredits + subCredits;
 
   if (totalCredits <= 0) {
-    return null;
+    return { creditCostItem: null, isCreditPriced: true };
   }
 
   const tooltip =
@@ -39,10 +47,13 @@ export function useCreditCostMenuItem({
       : "");
 
   return {
-    label: "Credit cost",
-    endComponent: formatCredits(totalCredits),
-    tooltip,
-    className: ITEM_CLASS_NAME,
-    onSelect: (e) => e.preventDefault(),
+    creditCostItem: {
+      label: "Credit cost",
+      endComponent: formatCredits(totalCredits),
+      tooltip,
+      className: CREDIT_COST_ITEM_CLASS_NAME,
+      onSelect: (e) => e.preventDefault(),
+    },
+    isCreditPriced: true,
   };
 }


### PR DESCRIPTION
## Description

On credit-priced plans, the "Credit cost" item in the agent message menu could flicker or pop in late while the per-message cost was still being fetched.

Two fixes:

- Latch the menu-open state (`hasOpenedMenu`) and use it — instead of the live `isMenuOpen` — to gate the cost fetch. This keeps the SWR query enabled after the menu closes, so `refreshedMessage` (which carries `subAgentCostCredits`) isn't dropped back to the prop values during the close animation, removing a flicker of the displayed total.
- Keep the cost section visible with a loading placeholder while the fetch is in flight, rather than having it pop in once the value resolves. `useCreditCostMenuItem` now returns `{ creditCostItem, isCreditPriced }` so the menu can decide to render the section (with a loader) on credit-priced plans even before the cost is available.

Only affects credit-priced plans; no behavior change for other plans (`isCreditPriced` is `false`, section stays hidden).
