### PR TITLE
Improve inline file preview links

### DIFF
--- a/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
@@ -117,16 +117,19 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
           <AgentMessageMarkdown
             owner={mockOwner}
             content={
-              'Preview\n:preview_file{path="conversation-c1/booklet.pdf" title="booklet.pdf" contentType="application/pdf"}'
+              'Open :preview_file{path="conversation-c1/booklet.pdf" title="booklet.pdf" contentType="application/pdf"} for the details.'
             }
           />
         </FilePreviewProvider>
       );
 
-      expect(screen.getByText("booklet.pdf")).toBeInTheDocument();
+      const fileLink = screen.getByRole("button", { name: "booklet.pdf" });
+      expect(fileLink.parentElement).toHaveTextContent(
+        "Open booklet.pdf for the details."
+      );
       expect(container.querySelector("a[href*='download=1']")).toBeNull();
 
-      fireEvent.click(screen.getByText("booklet.pdf"));
+      fireEvent.click(fileLink);
 
       expect(await screen.findByRole("dialog")).toBeInTheDocument();
       expect(

--- a/front/components/assistant/conversation/attachment/PreviewableCitation.tsx
+++ b/front/components/assistant/conversation/attachment/PreviewableCitation.tsx
@@ -6,7 +6,13 @@ import { FileCitationCard } from "@app/components/assistant/conversation/attachm
 import { useFilePreviewContext } from "@app/components/assistant/conversation/FilePreviewContext";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import { isSupportedImageContentType } from "@app/types/files";
-import { Citation, CitationImage, Tooltip } from "@dust-tt/sparkle";
+import {
+  Citation,
+  CitationImage,
+  Hoverable,
+  Icon,
+  Tooltip,
+} from "@dust-tt/sparkle";
 import type React from "react";
 
 interface PreviewableCitationProps {
@@ -26,6 +32,7 @@ interface PreviewableCitationProps {
   thumbnailUrl?: string;
   title: string;
   tooltipLabel?: React.ReactNode;
+  variant?: "card" | "inline";
 }
 
 export function PreviewableCitation({
@@ -43,11 +50,51 @@ export function PreviewableCitation({
   thumbnailUrl,
   title,
   tooltipLabel,
+  variant = "card",
 }: PreviewableCitationProps) {
   const { openFilePreview } = useFilePreviewContext();
 
   const handleClick = () =>
     openFilePreview({ fileId, filePath, title, contentType });
+
+  if (variant === "inline") {
+    const FileIcon = getFileTypeIcon(contentType, title);
+    const inlineTooltipLabel =
+      tooltipLabel ??
+      (description ? (
+        <div className="flex flex-col gap-0.5">
+          <div>{title}</div>
+          <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            {description}
+          </div>
+        </div>
+      ) : (
+        title
+      ));
+
+    return (
+      <Tooltip
+        tooltipTriggerAsChild
+        trigger={
+          <Hoverable variant="highlight" asChild>
+            <button
+              type="button"
+              onClick={handleClick}
+              className="inline-flex max-w-full items-baseline gap-1 align-baseline"
+            >
+              <Icon
+                visual={FileIcon}
+                size="xs"
+                className="shrink-0 self-center"
+              />
+              <span className="truncate">{title}</span>
+            </button>
+          </Hoverable>
+        }
+        label={inlineTooltipLabel}
+      />
+    );
+  }
 
   if (isSupportedImageContentType(contentType) && thumbnailUrl) {
     return (

--- a/front/components/markdown/FilePreviewBlock.test.tsx
+++ b/front/components/markdown/FilePreviewBlock.test.tsx
@@ -130,8 +130,9 @@ describe("getFilePreviewPlugin", () => {
 
     expect(screen.getByText("report final.pdf")).toBeInTheDocument();
     expect(container.querySelector("a[href*='download=1']")).toBeNull();
+    expect(container.querySelector("button button")).toBeNull();
 
-    fireEvent.click(screen.getByText("report final.pdf"));
+    fireEvent.click(screen.getByRole("button", { name: "report final.pdf" }));
 
     expect(
       await screen.findByRole("dialog", { name: "report final.pdf" })

--- a/front/components/markdown/FilePreviewBlock.tsx
+++ b/front/components/markdown/FilePreviewBlock.tsx
@@ -63,7 +63,7 @@ export function FilePreviewBlock({
       contentType={fileContentType}
       title={fileName}
       description={typeLabel}
-      size="xs"
+      variant="inline"
     />
   );
 }

--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -4,6 +4,7 @@ import { copyHandler } from "@app/lib/api/actions/servers/files/tools/copy";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { getFilePreviewDirectiveInstruction } from "@app/lib/markdown/file_preview";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
@@ -72,10 +73,11 @@ describe("copyHandler", () => {
       type: "text",
       text:
         `Copied \`conversation-${conversation.sId}/report.pdf\` to \`pod-${spaceId}/report.pdf\`. ` +
-        `To show a previewable file citation in your response, output this markdown directive exactly on its own line:\n` +
-        `:preview_file{path="pod-${spaceId}/report.pdf" title="report.pdf" contentType="text/plain"}\n` +
-        "The rendered citation opens the file preview, where the user can download the file. " +
-        "Do not invent a URL for this file.",
+        getFilePreviewDirectiveInstruction({
+          contentType: "text/plain",
+          path: `pod-${spaceId}/report.pdf`,
+          title: "report.pdf",
+        }),
     });
     expect(result.value[1]).toMatchObject({
       type: "resource",

--- a/front/lib/api/actions/servers/files/tools/move.test.ts
+++ b/front/lib/api/actions/servers/files/tools/move.test.ts
@@ -3,6 +3,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { moveHandler } from "@app/lib/api/actions/servers/files/tools/move";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
+import { getFilePreviewDirectiveInstruction } from "@app/lib/markdown/file_preview";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -77,10 +78,11 @@ describe("moveHandler", () => {
       type: "text",
       text:
         `Moved \`conversation-${conversation.sId}/report.pdf\` to \`pod-${spaceId}/report.pdf\`. ` +
-        `To show a previewable file citation in your response, output this markdown directive exactly on its own line:\n` +
-        `:preview_file{path="pod-${spaceId}/report.pdf" title="report.pdf" contentType="text/plain"}\n` +
-        "The rendered citation opens the file preview, where the user can download the file. " +
-        "Do not invent a URL for this file.",
+        getFilePreviewDirectiveInstruction({
+          contentType: "text/plain",
+          path: `pod-${spaceId}/report.pdf`,
+          title: "report.pdf",
+        }),
     });
   });
 

--- a/front/lib/markdown/file_preview.test.ts
+++ b/front/lib/markdown/file_preview.test.ts
@@ -2,10 +2,29 @@ import { describe, expect, it } from "vitest";
 
 import {
   getFilePreviewContentType,
+  getFilePreviewDirectiveInstruction,
   getFilePreviewMarkdownDirective,
   getFilePreviewTypeLabel,
   parseFilePreviewMarkdownDirective,
 } from "./file_preview";
+
+describe("getFilePreviewDirectiveInstruction", () => {
+  it("instructs the agent to place the file link inline", () => {
+    const instruction = getFilePreviewDirectiveInstruction({
+      path: "conversation-c1/report.pdf",
+    });
+
+    expect(instruction).toContain(
+      "Always place the previewable file directive inline within the sentence"
+    );
+    expect(instruction).toContain(
+      "rather than as a standalone element at the end of the response"
+    );
+    expect(instruction).toContain(
+      'Here is your file :preview_file{path="conversation-c1/report.pdf"'
+    );
+  });
+});
 
 describe("getFilePreviewMarkdownDirective", () => {
   it("infers the title from the scoped path", () => {

--- a/front/lib/markdown/file_preview.ts
+++ b/front/lib/markdown/file_preview.ts
@@ -219,9 +219,10 @@ export function getFilePreviewDirectiveInstruction({
   title?: string;
 }): string {
   return (
-    "To show a previewable file citation in your response, output this markdown directive exactly on its own line:\n" +
-    `${getFilePreviewMarkdownDirective({ contentType, path, title })}\n` +
-    "The rendered citation opens the file preview, where the user can download the file. " +
+    "Always place the previewable file directive inline within the sentence that mentions the file, " +
+    "rather than as a standalone element at the end of the response. " +
+    `For example: "Here is your file ${getFilePreviewMarkdownDirective({ contentType, path, title })}"\n` +
+    "The rendered link opens the file preview, where the user can download the file. " +
     "Do not invent a URL for this file."
   );
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This updates `:preview_file` directives to render as themed inline file links while preserving the preview dialog and tooltip behavior. It also fixes alignment with surrounding text, prevents nested buttons, and instructs agents to place file directives naturally within sentences.

<img width="881" height="224" alt="image" src="https://github.com/user-attachments/assets/824210f2-ba08-4360-a1ad-dbcdeca48942" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
