### PR TITLE
[front] fix: map "none" reasoning effort to "minimal" for gpt-5 models

### DIFF
--- a/front/lib/model_constructors/providers/openai/models/gpt_five.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five.ts
@@ -12,15 +12,25 @@ const CONTEXT_SIZE = 400_000;
 const MAX_OUTPUT_TOKENS = 128_000;
 const DEFAULT_REASONING_EFFORT = "medium";
 
-// gpt-5 accepts minimal/low/medium/high. Unlike gpt-5.5 it does NOT support
-// "none" or "xhigh"; the universal "maximal" (maps to xhigh) is unsupported
-// too. They all surface as an input configuration error.
-const GPT_5_REASONING_EFFORTS = ["minimal", "low", "medium", "high"] as const;
+// gpt-5 accepts minimal/low/medium/high. It has no "none"; we accept it and map
+// it to the nearest supported effort ("minimal"). "xhigh" and the universal
+// "maximal" (mapped to "xhigh") remain unsupported and surface as an input
+// configuration error.
+const GPT_5_REASONING_EFFORTS = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+] as const;
 
 const configSchema = inputConfigSchema.extend({
   reasoning: z
     .object({ effort: z.enum(GPT_5_REASONING_EFFORTS) })
-    .default({ effort: DEFAULT_REASONING_EFFORT }),
+    .default({ effort: DEFAULT_REASONING_EFFORT })
+    .transform(({ effort }) => ({
+      effort: effort === "none" ? "minimal" : effort,
+    })),
   // gpt-5 rejects any explicit temperature; reasoning is always on.
   temperature: temperatureSchema.optional().transform(() => undefined),
 });

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_mini.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_mini.ts
@@ -12,10 +12,12 @@ const CONTEXT_SIZE = 400_000;
 const MAX_OUTPUT_TOKENS = 128_000;
 const DEFAULT_REASONING_EFFORT = "medium";
 
-// gpt-5-mini accepts minimal/low/medium/high. Unlike gpt-5.5 it rejects "none"
-// and "xhigh"; the universal "maximal" (mapped to "xhigh") is also unsupported.
-// All three surface as an input configuration error.
+// gpt-5-mini accepts minimal/low/medium/high. It has no "none"; we accept it
+// and map it to the nearest supported effort ("minimal"). "xhigh" and the
+// universal "maximal" (mapped to "xhigh") remain unsupported and surface as an
+// input configuration error.
 const GPT_5_MINI_REASONING_EFFORTS = [
+  "none",
   "minimal",
   "low",
   "medium",
@@ -27,7 +29,10 @@ const GPT_5_MINI_REASONING_EFFORTS = [
 const configSchema = inputConfigSchema.extend({
   reasoning: z
     .object({ effort: z.enum(GPT_5_MINI_REASONING_EFFORTS) })
-    .default({ effort: DEFAULT_REASONING_EFFORT }),
+    .default({ effort: DEFAULT_REASONING_EFFORT })
+    .transform(({ effort }) => ({
+      effort: effort === "none" ? "minimal" : effort,
+    })),
   temperature: temperatureSchema.optional().transform(() => undefined),
 });
 

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_nano.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_nano.ts
@@ -12,10 +12,12 @@ const CONTEXT_SIZE = 400_000;
 const MAX_OUTPUT_TOKENS = 128_000;
 const DEFAULT_REASONING_EFFORT = "medium";
 
-// gpt-5-nano accepts minimal/low/medium/high. Unlike gpt-5.5 it does NOT
-// support "none" or "xhigh". The universal "maximal" is unsupported too; all of
-// these surface as an input configuration error.
+// gpt-5-nano accepts minimal/low/medium/high. It has no "none"; we accept it
+// and map it to the nearest supported effort ("minimal"). "xhigh" and the
+// universal "maximal" (mapped to "xhigh") remain unsupported and surface as an
+// input configuration error.
 const GPT_5_NANO_REASONING_EFFORTS = [
+  "none",
   "minimal",
   "low",
   "medium",
@@ -25,7 +27,10 @@ const GPT_5_NANO_REASONING_EFFORTS = [
 const configSchema = inputConfigSchema.extend({
   reasoning: z
     .object({ effort: z.enum(GPT_5_NANO_REASONING_EFFORTS) })
-    .default({ effort: DEFAULT_REASONING_EFFORT }),
+    .default({ effort: DEFAULT_REASONING_EFFORT })
+    .transform(({ effort }) => ({
+      effort: effort === "none" ? "minimal" : effort,
+    })),
   // The Responses API rejects an explicit temperature while reasoning is on.
   temperature: temperatureSchema.optional().transform(() => undefined),
 });

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test.ts
@@ -13,19 +13,20 @@ const setup: StreamSetup = {
   // `null` runs the case with its default checkers; a checker array overrides
   // them. Every case always runs.
   tests: {
-    // gpt-5 does not support reasoning "none" nor the universal "maximal"
-    // (it maps to "xhigh", also unsupported). Both are rejected locally.
-    "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
+    // gpt-5 maps reasoning "none" to "minimal", so it runs normally. The
+    // universal "maximal" (mapped to the unsupported "xhigh") remains an input
+    // config error.
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-none": null,
     "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
-    "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
-    "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-none/force-tool": null,
+    "reasoning/no-tools/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-none": null,
 
     "simple/no-tools/t-default/r-default": null,
     "simple/no-tools/t-default/r-minimal": null,

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_mini.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_mini.test.ts
@@ -13,12 +13,13 @@ const setup: StreamSetup = {
   // `null` runs the case with its default checkers; a checker array overrides
   // them. Every case always runs.
   tests: {
-    // gpt-5-mini rejects reasoning "none" (unlike gpt-5.5) and the universal
-    // "maximal" (mapped to the unsupported "xhigh"); both are input config errors.
-    "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
+    // gpt-5-mini maps reasoning "none" to "minimal", so it runs normally. The
+    // universal "maximal" (mapped to the unsupported "xhigh") remains an input
+    // config error.
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-none": null,
     "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
@@ -51,13 +52,13 @@ const setup: StreamSetup = {
 
     "calc/calc/t-default/r-default/force-tool-default": null,
     "calc/calc/t-default/r-default/force-tool": null,
-    // Reasoning "none" is unsupported, so the forced tool call is an input error.
-    "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
+    // Reasoning "none" maps to "minimal", so the forced tool call runs normally.
+    "calc/calc/t-default/r-none/force-tool": null,
 
-    "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-none": null,
     "reasoning/no-tools/t-default/r-low": null,
 
-    "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-none": null,
     "output-format/json-schema/t-default/r-high": null,
 
     "following/no-tools/t-default/r-default": null,

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_nano.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_nano.test.ts
@@ -18,8 +18,8 @@ const setup: StreamSetup = {
     "simple/no-tools/t-0/r-minimal": null,
     "simple/no-tools/t-0.1/r-minimal": null,
     "simple/no-tools/t-1/r-minimal": null,
-    // "none" and "maximal" (→ xhigh) reasoning efforts are not supported by the
-    // model; the mixin's enum rejects them locally.
+    // "none" maps to "minimal", so it runs normally. "maximal" (→ xhigh) is
+    // unsupported and rejected locally.
     "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
@@ -29,22 +29,22 @@ const setup: StreamSetup = {
     "calc/calc/t-default/r-default/force-tool": null,
 
     "simple/no-tools/t-default/r-default": null,
-    "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-none": null,
     "simple/no-tools/t-default/r-low": null,
     "simple/no-tools/t-default/r-medium": null,
     "simple/no-tools/t-default/r-high": null,
     "simple/no-tools/t-0/r-default": null,
-    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-none": null,
     "simple/no-tools/t-0/r-low": null,
     "simple/no-tools/t-0/r-medium": null,
     "simple/no-tools/t-0/r-high": null,
     "simple/no-tools/t-0.1/r-default": null,
-    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-none": null,
     "simple/no-tools/t-0.1/r-low": null,
     "simple/no-tools/t-0.1/r-medium": null,
     "simple/no-tools/t-0.1/r-high": null,
     "simple/no-tools/t-1/r-default": null,
-    "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-none": null,
     "simple/no-tools/t-1/r-low": null,
     "simple/no-tools/t-1/r-medium": null,
     "simple/no-tools/t-1/r-high": null,
@@ -54,12 +54,12 @@ const setup: StreamSetup = {
     "calc/calc/t-0.1/r-medium": null,
 
     "calc/calc/t-default/r-default/force-tool-default": null,
-    "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-none/force-tool": null,
 
-    "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-none": null,
     "reasoning/no-tools/t-default/r-low": null,
 
-    "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-none": null,
     "output-format/json-schema/t-default/r-high": null,
 
     "following/no-tools/t-default/r-default": null,


### PR DESCRIPTION
## Description

When running behind `use_new_llm_router`, the per-model reasoning schemas for `gpt-5`, `gpt-5-mini` and `gpt-5-nano` rejected a `"none"` reasoning effort outright, throwing a raw `ZodError`:

```
ZodError: reasoning.effort received "none", expected 'minimal' | 'low' | 'medium' | 'high'
```

This crashes any agent that carries a `"none"` effort into one of these models — most commonly a stale value left over from a model swap (an agent previously on a `none`-supporting model, then switched without clearing the effort). The old router never hit this because it mapped `none -> minimal` per-model; the new router validated strictly instead.

These three models' API has no `"none"` level (the next-lowest is `"minimal"`). They are exactly the three models that previously declared a `none -> minimal` mapping, so this PR restores that behavior in the new router: each model now accepts `"none"` as input and maps it to `"minimal"` in its config schema, leaving every other supported effort untouched. `"xhigh"` and the universal `"maximal"` remain input configuration errors.

## Tests

Updated the live endpoint tests for all three models so the `r-none` cases now expect a normal run (mapped to `minimal`) instead of an input configuration error; `r-maximal` stays an input error.

Ran the live suites against the OpenAI API for all three:

```
RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js \
  lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test.ts \
  lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_nano.test.ts \
  lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_mini.test.ts
```

All `r-none` cases pass (including forced-tool and json-schema variants).

## Risk

Low. Scoped to three model config schemas in the new router; no change for any effort other than `none`. Worst case, agents that sent `none` to these models run at `minimal` instead of erroring. Safe to rollback.

## Deploy Plan

- [ ] Deploy `front`