### PR TITLE
revert: roll back reasoning effort default changes

### DIFF
--- a/front/lib/api/assistant/call_llm.ts
+++ b/front/lib/api/assistant/call_llm.ts
@@ -4,10 +4,7 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
-import type {
-  ModelIdType,
-  ReasoningEffort,
-} from "@app/types/assistant/models/types";
+import type { ModelIdType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
@@ -17,7 +14,6 @@ export interface LLMConfig {
   modelId: ModelIdType;
   providerId: ModelProviderIdType;
   temperature?: number;
-  reasoningEffort?: ReasoningEffort | null;
   useCache?: boolean;
   useStream?: boolean;
 }
@@ -63,7 +59,6 @@ export async function runMultiActionsAgent(
     credentials,
     modelId: config.modelId,
     temperature: config.temperature,
-    reasoningEffort: config.reasoningEffort,
     context: options.context,
   });
 

--- a/front/lib/api/assistant/process_data_sources.ts
+++ b/front/lib/api/assistant/process_data_sources.ts
@@ -171,7 +171,6 @@ export async function processDataSources({
           modelId: model.modelId,
           providerId: model.providerId,
           temperature: model.temperature,
-          reasoningEffort: null,
           useCache: false,
         },
         {

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -64,7 +64,7 @@ export abstract class LLM<TPayload = unknown> {
       context,
       getTraceOutput,
       modelId,
-      reasoningEffort,
+      reasoningEffort = "none",
       responseFormat = null,
       temperature = AGENT_CREATIVITY_LEVEL_TEMPERATURES.balanced,
     }: LLMParameters
@@ -79,8 +79,7 @@ export abstract class LLM<TPayload = unknown> {
     }
     this.modelConfig = modelConfig;
     this.temperature = temperature;
-    this.reasoningEffort =
-      reasoningEffort ?? modelConfig.defaultReasoningEffort;
+    this.reasoningEffort = reasoningEffort;
     this.responseFormat = responseFormat;
     this.bypassFeatureFlag = bypassFeatureFlag;
     this.metadata = {

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -80,9 +80,7 @@ export abstract class LLM<TPayload = unknown> {
     this.modelConfig = modelConfig;
     this.temperature = temperature;
     this.reasoningEffort =
-      reasoningEffort !== undefined
-        ? reasoningEffort
-        : modelConfig.defaultReasoningEffort;
+      reasoningEffort ?? modelConfig.defaultReasoningEffort;
     this.responseFormat = responseFormat;
     this.bypassFeatureFlag = bypassFeatureFlag;
     this.metadata = {


### PR DESCRIPTION
## Description

Reverts the following three commits related to reasoning effort defaults:

- #27952 — fix: disable reasoning for process data sources
- #27880 — fix: preserve null reasoningEffort overwrites
- #27783 — fix(llm): default reasoning effort to the model default instead of "none"

The real fix lands in #27971, which supersedes this line of changes.

## Tests

Reverts applied cleanly with no conflicts.

## Risk

Low — straight revert of recent commits. Safe to roll back if needed.

## Deploy Plan

Standard deploy.