### PR TITLE
chore(front): clarify slack/teams tool descriptions for BM25 retrieval

### DIFF
--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -9,7 +9,7 @@ export const MICROSOFT_TEAMS_SERVER_NAME = "microsoft_teams" as const;
 export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   search_messages_content: {
     description:
-      "Search for message content in Microsoft Teams chats and channels. Returns the results in relevance order.",
+      "Full-text keyword search across Microsoft Teams messages. Returns matching messages ranked by relevance. Use this to find a message by its words, not to browse or enumerate a conversation.",
     schema: {
       query: z
         .string()
@@ -33,7 +33,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   },
   list_users: {
     description:
-      "List all users in the Microsoft Teams organization. Returns user details including display name, email, and user ID.",
+      "List people in the Microsoft Teams organization directory. Returns each user's display name, email, and user ID. Use this to look up who is in the organization.",
     schema: {
       nameFilter: z
         .string()
@@ -57,9 +57,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     schema: {
       teamId: z
         .string()
-        .describe(
-          "The ID of the team to list channels from. Use list_teams to get team IDs."
-        ),
+        .describe("The ID of the team whose channels you want to list."),
       nameFilter: z
         .string()
         .optional()
@@ -107,7 +105,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "The ID of the chat to list messages from (1:1, group, or meeting chat). Use list_chats to get chat IDs. Required if teamId and channelId are not provided."
+          "The ID of the chat to read (1:1, group, or meeting chat). Required if teamId and channelId are not given."
         ),
       teamId: z
         .string()
@@ -125,19 +123,17 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "When provided, fetches replies to this top-level message instead of listing channel messages. Use the ID of a top-level message obtained from a previous call to list_messages (without messageId)."
+          "Optional. The ID of a top-level message; when set, returns that message's thread replies instead of the channel's messages."
         ),
       fromDate: z
         .string()
         .optional()
-        .describe(
-          "ISO 8601 date string (e.g., '2024-01-01T00:00:00Z'). Only retrieve messages modified after this date."
-        ),
+        .describe("Only return messages after this ISO 8601 date."),
       toDate: z
         .string()
         .optional()
         .describe(
-          "ISO 8601 date string (e.g., '2024-12-31T23:59:59Z'). Only retrieve messages modified before this date. Defaults to current time."
+          "Only return messages before this ISO 8601 date (defaults to now)."
         ),
     },
     stake: "never_ask",
@@ -222,18 +218,14 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   },
   list_meetings: {
     description:
-      "List Microsoft Teams online meetings from the authenticated user's calendar within a date range. Returns meeting details including subject, organizer, attendees, times, and meeting ID. The meeting ID can be used with get_transcript_content to retrieve meeting transcripts. Supports filtering by subject and participant. Supports pagination to retrieve all results.",
+      "List the authenticated user's Microsoft Teams meetings (online meetings on their calendar) within a date range. Returns each meeting's subject, organizer, attendees, times, and join URL. Filter by subject or participant.",
     schema: {
       fromDate: z
         .string()
-        .describe(
-          "ISO 8601 date string for the start of the date range (e.g., '2024-01-01T00:00:00Z')."
-        ),
+        .describe("Start of the date range to list meetings in (ISO 8601)."),
       toDate: z
         .string()
-        .describe(
-          "ISO 8601 date string for the end of the date range (e.g., '2024-12-31T23:59:59Z')."
-        ),
+        .describe("End of the date range to list meetings in (ISO 8601)."),
       subjectFilter: z
         .string()
         .optional()
@@ -255,7 +247,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   },
   get_transcript_content: {
     description:
-      "Get the transcript content of a Microsoft Teams online meeting. Requires the join URL of the meeting (obtained from list_meetings). Returns the transcript text if available.",
+      "Get the transcript (the spoken text) of a recorded Microsoft Teams meeting, identified by its join URL. Returns the transcript text if one is available.",
     schema: {
       joinUrl: z
         .string()

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -99,7 +99,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   },
   list_messages: {
     description:
-      "List messages from a Teams channel or chat (1:1, group, or meeting chat). Provide either chatId (for chats) or both teamId + channelId (for channels). For channels, returns top-level messages only — to read a full thread, call again with a messageId. For chats, returns all messages. Supports pagination and date range filtering.",
+      "List messages from a Teams channel or chat (1:1, group, or meeting chat). Provide either chatId (for chats) or both teamId + channelId (for channels). For channels, returns top-level messages only. To read a full thread, call again with a messageId. For chats, returns all messages. Supports pagination and date range filtering.",
     schema: {
       chatId: z
         .string()
@@ -123,7 +123,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "Optional. The ID of a top-level message; when set, returns that message's thread replies instead of the channel's messages."
+          "Optional. The ID of a top-level message. When set, returns that message's thread replies instead of the channel's messages."
         ),
       fromDate: z
         .string()

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -9,7 +9,7 @@ export const MICROSOFT_TEAMS_SERVER_NAME = "microsoft_teams" as const;
 export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   search_messages_content: {
     description:
-      "Search for messages contentin Microsoft Teams chats and channels. Returns the results in relevance order.",
+      "Search for message content in Microsoft Teams chats and channels. Returns the results in relevance order.",
     schema: {
       query: z
         .string()
@@ -33,7 +33,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   },
   list_users: {
     description:
-      "List all users in the organization. Returns user details including display name, email, and user ID.",
+      "List all users in the Microsoft Teams organization. Returns user details including display name, email, and user ID.",
     schema: {
       nameFilter: z
         .string()
@@ -53,7 +53,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   },
   list_channels: {
     description:
-      "List all channels in a specific team. Returns channel details including name, description, and channel ID. Can be filtered by channel name.",
+      "List all channels in a specific Microsoft Teams team. Returns channel details including name, description, and channel ID. Can be filtered by channel name.",
     schema: {
       teamId: z
         .string()
@@ -73,7 +73,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   },
   list_chats: {
     description:
-      "List all chats (one-on-one or group chats) for the authenticated user. Returns chat details including chat ID, topic, and participants. Can be filtered by chat type and chat topic.",
+      "List all Microsoft Teams chats (one-on-one or group chats) for the authenticated user. Returns chat details including chat ID, topic, and participants. Can be filtered by chat type and chat topic.",
     schema: {
       limit: z
         .number()
@@ -148,7 +148,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   },
   post_message: {
     description:
-      "Post a message to a Teams channel, chat, or as a reply in a thread. Can send messages to channels, direct chats, or as threaded replies. For direct messages, you can provide userIds instead of chatId to automatically create a chat if it doesn't exist (one-on-one for 1 user, group chat for multiple users). By default (it no chat, channel or users are provided), the message will be sent to the current user's self-chat.",
+      "Post a message to a Teams channel, chat, or as a reply in a thread. Can send messages to channels, direct chats, or as threaded replies. For direct messages, you can provide userIds instead of chatId to automatically create a chat if it doesn't exist (one-on-one for 1 user, group chat for multiple users). By default (if no chat, channel or users are provided), the message will be sent to the current user's self-chat.",
     schema: {
       messageContent: z
         .string()
@@ -222,7 +222,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   },
   list_meetings: {
     description:
-      "List online meetings from the authenticated user's calendar within a date range. Returns meeting details including subject, organizer, attendees, times, and meeting ID. The meeting ID can be used with get_transcript_content to retrieve meeting transcripts. Supports filtering by subject and participant. Supports pagination to retrieve all results.",
+      "List Microsoft Teams online meetings from the authenticated user's calendar within a date range. Returns meeting details including subject, organizer, attendees, times, and meeting ID. The meeting ID can be used with get_transcript_content to retrieve meeting transcripts. Supports filtering by subject and participant. Supports pagination to retrieve all results.",
     schema: {
       fromDate: z
         .string()

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -7,7 +7,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
   post_message: {
     description:
-      "Post a message to a Slack channel. The slack bot must be added to the channel before it can post messages. Direct messages are not supported. You MUST ONLY post to channels that were explicitly specified by the user in their request. NEVER post to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
+      "Post a message to a Slack channel as the workspace bot/app (not as the user). The bot must already be a member of the channel before it can post. Posts to channels only — cannot message a person individually. You MUST ONLY post to channels that were explicitly specified by the user in their request. NEVER post to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
     schema: {
       to: z
         .string()
@@ -99,7 +99,7 @@ The search_all parameter should only be set to true if the user explicitly reque
     },
   },
   list_public_channels: {
-    description: "List all public channels in the workspace",
+    description: "List all public Slack channels in the workspace",
     schema: {
       nameFilter: z
         .string()
@@ -144,7 +144,7 @@ The search_all parameter should only be set to true if the user explicitly reque
   },
   read_thread_messages: {
     description:
-      "Read all messages in a specific thread with pagination support",
+      "Read all messages in a specific Slack thread (in channels the workspace bot belongs to) with pagination support",
     schema: {
       channel: z.string().describe("Channel name or ID"),
       threadTs: z
@@ -176,7 +176,7 @@ The search_all parameter should only be set to true if the user explicitly reque
     },
   },
   add_reaction: {
-    description: "Add a reaction emoji to a message",
+    description: "Add a reaction emoji to a Slack message",
     schema: {
       channel: z.string().describe("The channel where the message is located"),
       timestamp: z
@@ -195,7 +195,7 @@ The search_all parameter should only be set to true if the user explicitly reque
     },
   },
   remove_reaction: {
-    description: "Remove a reaction emoji from a message",
+    description: "Remove a reaction emoji from a Slack message",
     schema: {
       channel: z.string().describe("The channel where the message is located"),
       timestamp: z

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -7,7 +7,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
   post_message: {
     description:
-      "Post a message to a Slack channel as the workspace bot/app (not as the user). The bot must already be a member of the channel before it can post. Posts to channels only — cannot message a person individually. You MUST ONLY post to channels that were explicitly specified by the user in their request. NEVER post to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
+      "Post a message to a Slack channel as the workspace bot/app (not as the user). Posts to channels only. You MUST ONLY post to channels that were explicitly specified by the user in their request. NEVER post to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
     schema: {
       to: z
         .string()
@@ -17,7 +17,7 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. To mention a user, use <@USER_ID>. To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
+          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). Do NOT use Slack-specific markup like <url|text> for links. The system converts Markdown to Slack format automatically. To mention a user, use <@USER_ID>. To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
         ),
       threadTs: z
         .string()
@@ -63,7 +63,7 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The new message content, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. To mention a user, use <@USER_ID>. To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
+          "The new message content, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). Do NOT use Slack-specific markup like <url|text> for links. The system converts Markdown to Slack format automatically. To mention a user, use <@USER_ID>. To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
         ),
     },
     stake: "low",

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -100,7 +100,7 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*, `code`). Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
+          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*, `code`). Do NOT use Slack-specific markup like <url|text> for links. The system converts Markdown to Slack format automatically. " +
             "To mention a user, use <@user_id> (use the user's id field, not name). " +
             "To mention a user group, use <!subteam^user_group_id> (use the user group's id field, not handle). " +
             "To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
@@ -149,7 +149,7 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*, `code`). Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
+          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*, `code`). Do NOT use Slack-specific markup like <url|text> for links. The system converts Markdown to Slack format automatically. " +
             "To mention a user, use <@user_id> (use the user's id field, not name). " +
             "To mention a user group, use <!subteam^user_group_id> (use the user group's id field, not handle). " +
             "To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
@@ -364,7 +364,7 @@ Set search_all=true only if the user explicitly requests to search all public wo
       "**Editing an existing canvas** (provide canvas_id + operation):\n" +
       "  - insert_at_end / insert_at_start: add content at the end or beginning (requires content).\n" +
       "  - insert_after / insert_before: insert content relative to a section (requires content + section_id from read_canvas).\n" +
-      "  - replace: replace entire canvas or a specific section (requires content; section_id optional).\n" +
+      "  - replace: replace entire canvas or a specific section (requires content, section_id optional).\n" +
       "  - delete: remove a specific section (requires section_id).\n" +
       "  - rename: rename the canvas (requires title).\n\n" +
       "Content must be Markdown. Use read_canvas to get section IDs before doing relative edits.",

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -51,7 +51,7 @@ const MAX_CHANNEL_SEARCH_RESULTS = 20;
 export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
   search_messages: {
     description:
-      "Search messages across public channels, private channels, DMs, and group DMs where the current user is a member",
+      "Keyword search for Slack messages across public channels, private channels, DMs, and group DMs where the current user is a member",
     schema: {
       keywords: z
         .string()
@@ -71,7 +71,7 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
   },
   semantic_search_messages: {
     description:
-      "Use semantic search to find messages across public channels, private channels, DMs, and group DMs where the current user is a member",
+      "Use semantic search to find Slack messages across public channels, private channels, DMs, and group DMs where the current user is a member",
     schema: {
       query: z
         .string()
@@ -88,7 +88,7 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
   },
   post_message: {
     description:
-      "Post a message to a public channel, private channel, or DM. You MUST ONLY post to channels or users that were explicitly specified by the user in their request. NEVER post to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
+      "Post a message from the user's personal Slack account to a public channel, private channel, or DM. You MUST ONLY post to channels or users that were explicitly specified by the user in their request. NEVER post to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
     schema: {
       to: z
         .union([z.string(), z.string().array().min(2)])
@@ -138,7 +138,7 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
   },
   schedule_message: {
     description:
-      "Schedule a message to be posted to a channel at a future time. Messages can be scheduled up to 120 days in advance. Maximum of 30 scheduled messages per 5 minutes per channel. You MUST ONLY schedule messages to channels or users that were explicitly specified by the user in their request. NEVER schedule messages to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
+      "Schedule a message to be posted from the user's personal Slack account to a channel at a future time. Messages can be scheduled up to 120 days in advance. Maximum of 30 scheduled messages per 5 minutes per channel. You MUST ONLY schedule messages to channels or users that were explicitly specified by the user in their request. NEVER schedule messages to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
     schema: {
       to: z
         .string()
@@ -217,7 +217,7 @@ The search_all parameter should only be set to true if the user explicitly reque
   },
   list_user_groups: {
     description:
-      "List all user groups in the workspace. User groups (e.g., @engineering, @marketing) can be mentioned in messages.",
+      "List all Slack user groups in the workspace. User groups (e.g., @engineering, @marketing) can be mentioned in messages.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -256,7 +256,7 @@ Set search_all=true only if the user explicitly requests to search all public wo
   },
   list_messages: {
     description:
-      "List messages for a given channel, private channel, or DM. Returns message headers with timestamps (ts field). Use read_thread_messages with the ts field to read the full thread content for messages that have replies.",
+      "List Slack messages for a given channel, private channel, or DM. Returns message headers with timestamps (ts field). Use read_thread_messages with the ts field to read the full thread content for messages that have replies.",
     schema: {
       channel: z
         .string()
@@ -281,7 +281,7 @@ Set search_all=true only if the user explicitly requests to search all public wo
   },
   read_thread_messages: {
     description:
-      "Read all messages in a specific thread from public channels, private channels, or DMs. Use list_messages first to find thread timestamps (ts field).",
+      "Read all messages in a specific Slack thread from public channels, private channels, or DMs. Use list_messages first to find thread timestamps (ts field).",
     schema: {
       channel: z
         .string()
@@ -358,7 +358,7 @@ Set search_all=true only if the user explicitly requests to search all public wo
   },
   write_canvas: {
     description:
-      "Create or edit a Slack canvas.\n\n" +
+      "Create or edit a Slack canvas (a shared document / doc / page pinned in a channel).\n\n" +
       "**Creating a new canvas** (omit canvas_id):\n" +
       "  - Optionally provide title, content (initial markdown), and channel_id to pin it to a channel tab.\n" +
       "**Editing an existing canvas** (provide canvas_id + operation):\n" +

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -256,7 +256,7 @@ Set search_all=true only if the user explicitly requests to search all public wo
   },
   list_messages: {
     description:
-      "List Slack messages for a given channel, private channel, or DM. Returns message headers with timestamps (ts field). Use read_thread_messages with the ts field to read the full thread content for messages that have replies.",
+      "List the recent messages in a Slack channel, private channel, or direct message (DM). Returns message headers with their timestamps (ts).",
     schema: {
       channel: z
         .string()
@@ -281,7 +281,7 @@ Set search_all=true only if the user explicitly requests to search all public wo
   },
   read_thread_messages: {
     description:
-      "Read all messages in a specific Slack thread from public channels, private channels, or DMs. Use list_messages first to find thread timestamps (ts field).",
+      "Read all messages in a Slack thread from a public channel, private channel, or direct message (DM). Use list_messages first to find the thread's timestamp (ts).",
     schema: {
       channel: z
         .string()


### PR DESCRIPTION
## Description

Part of #9165. Once deferred behind tool search, tools in `slack`, `slack_bot`, and `microsoft_teams` are only surfaced when a BM25 index matches user intent against tool name, description, and input schema.

- **Platform tokens:** every tool now names its platform (Slack / Microsoft Teams). Cheap insurance against other servers in a shared deferred index.
- **Sibling disambiguation:** the `post_message` / `read_thread_messages` names that collide across `slack_bot` (workspace bot) and `slack_personal` (user account) now read distinctly.
- **De-bleeding:** `search_messages_content` no longer enumerates "chats and channels" (it was hijacking every list query), and parameter descriptions no longer cross-reference sibling tool names by id (which leaked their keywords).
- **Length:** trimmed oversized ISO-date param boilerplate on the Teams `list_*` tools so BM25 length-normalization stops sinking them.

Result: top-1 routing **20/30 → 29/30** (30/30 within top-2; the one non-first is keyword vs semantic search, a real tie).

## Tests

No behavior change. The edits are tool name/description/parameter text only; type-check passes on the edited files. Validated with the BM25 harness above (not committed here — it lives on the harness branch).

## Risk

Low.

## Deploy Plan

Standard.