### PR TITLE
refactor(analytics) extract shared agent-label helper for credit tables

### DIFF
--- a/front/lib/api/assistant/observability/agent_credits.ts
+++ b/front/lib/api/assistant/observability/agent_credits.ts
@@ -1,12 +1,10 @@
-import {
-  getAgentConfigurations,
-  searchAgentConfigurationsByName,
-} from "@app/lib/api/assistant/configuration/agent";
+import { searchAgentConfigurationsByName } from "@app/lib/api/assistant/configuration/agent";
 import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
 import {
-  getAgentModelDisplayName,
-  getUserDisplayName,
-} from "@app/lib/api/assistant/observability/credit_labels";
+  resolveAnalyticsAgentLabels,
+  UNKNOWN_AGENT_LABEL,
+} from "@app/lib/api/assistant/observability/agent_labels";
+import { getUserDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import {
   buildCreditsScopeQuery,
   daysToInstantRange,
@@ -171,22 +169,21 @@ export async function fetchAgentCreditBreakdown(
     )
   );
 
-  const [agents, users, skills] = await Promise.all([
-    getAgentConfigurations(auth, { agentIds, variant: "light" }),
+  const [agentLabels, users, skills] = await Promise.all([
+    resolveAnalyticsAgentLabels(auth, agentIds),
     userIds.length > 0 ? UserResource.fetchByIds(userIds) : Promise.resolve([]),
     skillIds.length > 0
       ? SkillResource.fetchByIds(auth, skillIds)
       : Promise.resolve([]),
   ]);
 
-  const agentsById = new Map(agents.map((agent) => [agent.sId, agent]));
   const usersById = new Map(users.map((user) => [user.sId, user]));
   // fetchByIds only returns skills the admin can read; others get no description.
   const skillsById = new Map(skills.map((skill) => [skill.sId, skill]));
 
   const rows: AgentCreditRow[] = buckets.map((bucket) => {
     const agentId = String(bucket.key);
-    const agent = agentsById.get(agentId);
+    const label = agentLabels.get(agentId) ?? UNKNOWN_AGENT_LABEL;
 
     const topUsers: AgentCreditUser[] = bucketsToArray<SubBucket>(
       bucket.top_users?.buckets
@@ -216,15 +213,10 @@ export async function fetchAgentCreditBreakdown(
 
     return {
       agentId,
-      name: agent?.name ?? "Unknown agent",
-      pictureUrl: agent?.pictureUrl ?? null,
-      modelDisplayName: getAgentModelDisplayName(agent?.model),
-      // Only surface the description for agents this admin can read; private
-      // agents owned by others appear in usage but their description must not.
-      description:
-        agent && !agent.canRead
-          ? "Private agent: description unavailable"
-          : (agent?.description ?? ""),
+      name: label.name,
+      pictureUrl: label.pictureUrl,
+      modelDisplayName: label.modelDisplayName,
+      description: label.description,
       credits: Math.round(bucket.credits?.value ?? 0),
       topUsers,
       topSkills,

--- a/front/lib/api/assistant/observability/agent_labels.ts
+++ b/front/lib/api/assistant/observability/agent_labels.ts
@@ -1,0 +1,54 @@
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { getAgentModelDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
+import type { Authenticator } from "@app/lib/auth";
+
+export type AnalyticsAgentLabel = {
+  name: string;
+  pictureUrl: string | null;
+  modelDisplayName: string;
+  description: string;
+};
+
+const PRIVATE_AGENT_DESCRIPTION = "Private agent: description unavailable";
+
+export const UNKNOWN_AGENT_LABEL: AnalyticsAgentLabel = {
+  name: "Unknown agent",
+  pictureUrl: null,
+  modelDisplayName: getAgentModelDisplayName(undefined),
+  description: "",
+};
+
+export async function resolveAnalyticsAgentLabels(
+  auth: Authenticator,
+  agentIds: string[]
+): Promise<Map<string, AnalyticsAgentLabel>> {
+  if (agentIds.length === 0) {
+    return new Map();
+  }
+
+  const agents = await getAgentConfigurations(auth, {
+    agentIds,
+    variant: "light",
+  });
+  const agentsById = new Map(agents.map((agent) => [agent.sId, agent]));
+
+  return new Map(
+    agentIds.map((agentId) => {
+      const agent = agentsById.get(agentId);
+      if (!agent) {
+        return [agentId, UNKNOWN_AGENT_LABEL];
+      }
+      return [
+        agentId,
+        {
+          name: agent.name,
+          pictureUrl: agent.pictureUrl,
+          modelDisplayName: getAgentModelDisplayName(agent.model),
+          description: agent.canRead
+            ? agent.description
+            : PRIVATE_AGENT_DESCRIPTION,
+        },
+      ];
+    })
+  );
+}

--- a/front/lib/api/assistant/observability/user_credits.ts
+++ b/front/lib/api/assistant/observability/user_credits.ts
@@ -1,8 +1,8 @@
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import {
-  getAgentModelDisplayName,
-  getUserDisplayName,
-} from "@app/lib/api/assistant/observability/credit_labels";
+  resolveAnalyticsAgentLabels,
+  UNKNOWN_AGENT_LABEL,
+} from "@app/lib/api/assistant/observability/agent_labels";
+import { getUserDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import {
   buildCreditsScopeQuery,
   daysToInstantRange,
@@ -127,15 +127,12 @@ export async function fetchUserCreditBreakdown(
     )
   );
 
-  const [users, agents] = await Promise.all([
+  const [users, agentLabels] = await Promise.all([
     UserResource.fetchByIds(userIds),
-    agentIds.length > 0
-      ? getAgentConfigurations(auth, { agentIds, variant: "light" })
-      : Promise.resolve([]),
+    resolveAnalyticsAgentLabels(auth, agentIds),
   ]);
 
   const usersById = new Map(users.map((user) => [user.sId, user]));
-  const agentsById = new Map(agents.map((agent) => [agent.sId, agent]));
 
   const rows: UserCreditRow[] = buckets.map((bucket) => {
     const userId = String(bucket.key);
@@ -145,16 +142,13 @@ export async function fetchUserCreditBreakdown(
       bucket.top_agents?.buckets
     ).map((agentBucket) => {
       const agentId = String(agentBucket.key);
-      const agent = agentsById.get(agentId);
+      const label = agentLabels.get(agentId) ?? UNKNOWN_AGENT_LABEL;
       return {
         agentId,
-        name: agent?.name ?? "Unknown agent",
-        pictureUrl: agent?.pictureUrl ?? null,
-        modelDisplayName: getAgentModelDisplayName(agent?.model),
-        description:
-          agent && !agent.canRead
-            ? "Private agent: description unavailable"
-            : (agent?.description ?? ""),
+        name: label.name,
+        pictureUrl: label.pictureUrl,
+        modelDisplayName: label.modelDisplayName,
+        description: label.description,
       };
     });
 


### PR DESCRIPTION
## Description

Consolidate the agent name/picture/model/description labeling rule used by the "Agents by credits" and "Users by credits" tables into a single resolveAnalyticsAgentLabels helper. Private agents the admin cannot read keep their masked description.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
