### PR TITLE
Upg: do not wait between events fetch if we are paginating history.

### DIFF
--- a/front-api/lib/api/sse/conversation_events.ts
+++ b/front-api/lib/api/sse/conversation_events.ts
@@ -52,5 +52,6 @@ export async function streamConversationEventsForRoute(
         signal,
       }),
     transform: (event) => opts.transformEvent(auth, event),
+    writeDoneSentinel: true,
   });
 }

--- a/front-api/lib/api/sse/message_events.ts
+++ b/front-api/lib/api/sse/message_events.ts
@@ -71,5 +71,6 @@ export async function streamMessageEventsForRoute(
     iterator: (signal) =>
       getMessagesEvents(auth, { messageId, lastEventId, signal }),
     transform: (event) => opts.transformEvent(auth, event),
+    writeDoneSentinel: true,
   });
 }

--- a/front-api/lib/api/sse/stream_events.ts
+++ b/front-api/lib/api/sse/stream_events.ts
@@ -24,9 +24,10 @@ type StreamEventsParams<TIn> = {
   // Returning `null` skips the event without writing anything. May be
   // sync or async — the helper always awaits.
   transform?: (event: TIn) => unknown | null | Promise<unknown | null>;
-  // Only MCP requests opts in. Conversation/message events rely on EOF
-  // alone — the SDK already filters "done" before JSON-parsing, so no
-  // consumer treats it as a terminator.
+  // When true, writes `data: done` after the iterator completes. Clients treat
+  // this as an immediate reconnect signal (history pagination, idle timeout).
+  // MCP requests also opt in; conversation/message routes use it for the same
+  // pagination handoff after Redis history replay.
   writeDoneSentinel?: boolean;
 };
 

--- a/front-api/tests/utils/sse.ts
+++ b/front-api/tests/utils/sse.ts
@@ -1,5 +1,7 @@
 import { expect } from "vitest";
 
+export const SSE_DONE_SENTINEL = "done";
+
 // eslint-disable-next-line require-yield
 export async function* emptyAsyncIterator<T>(): AsyncGenerator<T, void> {
   return;
@@ -25,18 +27,20 @@ export function throwingAsyncIterator<T>(events: T[], error: Error) {
   };
 }
 
-// Extracts the `data:` payloads from an SSE response body.
+// Extracts JSON `data:` payloads from an SSE response body, excluding the
+// reconnect sentinel written by routes that opt into writeDoneSentinel.
 export function parseSseDataPayloads(body: string): string[] {
   return body
     .split("\n\n")
     .map((chunk) => chunk.trim())
     .filter((chunk) => chunk.startsWith("data:"))
-    .map((chunk) => chunk.slice("data:".length).trim());
+    .map((chunk) => chunk.slice("data:".length).trim())
+    .filter((payload) => payload !== SSE_DONE_SENTINEL);
 }
 
 export async function expectEmptySseStream(
   response: Response,
-  { expectDoneSentinel = false }: { expectDoneSentinel?: boolean } = {}
+  { expectDoneSentinel = true }: { expectDoneSentinel?: boolean } = {}
 ) {
   expect(response.status).toBe(200);
   expect(response.headers.get("content-type")).toBe("text/event-stream");

--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -146,7 +146,9 @@ export function useEventSource(
         if (event.data === "done") {
           source.close();
 
-          // Reconnect to the stream right away.
+          // Reconnect to the stream right away. The server sends "done" after
+          // each paginated history batch and on idle timeout so clients resume
+          // with lastEventId without waiting on the error backoff.
           setReconnectCounter((c) => c + 1);
           return;
         }

--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -363,6 +363,7 @@ class RedisHybridManager {
 
           if (historyHasMore) {
             // Force the client to re-subscribe with the latest event id it had in order to get more events from history.
+            // SSE routes use writeDoneSentinel so the stream ends with "done" and clients reconnect immediately.
             callback("close");
           }
         }


### PR DESCRIPTION
## Description

`streamConversationEventsForRoute` and `streamMessageEventsForRoute` now opt in to `writeDoneSentinel: true`, enabling the server to send `data: done` after each Redis history pagination batch (and on idle timeout). Previously these routes did not send the sentinel, so when `RedisHybridManager` triggered a reconnect via `callback("close")` during history replay, clients saw it as a connection error and applied backoff before retrying. Now `useEventSource` catches `done` and reconnects immediately, draining paginated history as fast as possible.

## Tests

Tested locally by observing SSE reconnect behaviour during history pagination — no backoff delay between pages.

## Risk

Low. `writeDoneSentinel` was already used by MCP routes with no issues. The `done` sentinel is already filtered by the SDK before JSON-parsing; `useEventSource` was already handling it. No consumer treats it as a data event.

## Deploy Plan

Deploy front.
