### PR TITLE
Fix: poke spa broke.

### DIFF
--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -3,7 +3,6 @@ import {
   InputField,
   SelectField,
 } from "@app/components/poke/shadcn/ui/form/fields";
-import { CreditUsageConfigurationSchema } from "@app/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration";
 import type { SwitchContractBodySchema } from "@app/lib/api/poke/switch_contract";
 import { clientFetch } from "@app/lib/egress/client";
 import { amountCents } from "@app/lib/metronome/amounts";
@@ -24,6 +23,7 @@ import {
 import assert from "@app/lib/utils/assert";
 import { usePokePluginAsyncArgs } from "@app/poke/swr/plugins";
 import { isCreditPricedPlan } from "@app/types/plan";
+import { CreditUsageConfigurationSchema } from "@app/types/poke/credit_usage_configuration";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,

--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -18,50 +18,15 @@ import {
   DEFAULT_TOP_UP_ENABLED,
 } from "@app/lib/resources/storage/models/credit_usage_configurations";
 import { isCreditPricedPlan } from "@app/types/plan";
+import {
+  CreditUsageConfigurationSchema,
+  MAX_AWU_USAGE_CAP_CREDITS,
+} from "@app/types/poke/credit_usage_configuration";
 import { Err, Ok } from "@app/types/shared/result";
-import { z } from "zod";
 
-export const MAX_AWU_USAGE_CAP_CREDITS = 2_000_000;
+export { MAX_AWU_USAGE_CAP_CREDITS } from "@app/types/poke/credit_usage_configuration";
+
 const POKE_AUDIT_CONTEXT = { location: "poke" };
-
-export const CreditUsageConfigurationSchema = z.object({
-  defaultDiscountPercent: z
-    .number()
-    .min(0, "Discount percentage must be at least 0")
-    .max(
-      MAX_AWU_DISCOUNT_PERCENT,
-      `Discount cannot exceed ${MAX_AWU_DISCOUNT_PERCENT}% for AWU credit purchases`
-    )
-    .default(0),
-  paygEnabled: z.boolean(),
-  usageCapCredits: z
-    .number()
-    .int("AWU usage cap must be an integer number of credits")
-    .min(0, "AWU usage cap must be non-negative")
-    .max(
-      MAX_AWU_USAGE_CAP_CREDITS,
-      `AWU usage cap cannot exceed ${MAX_AWU_USAGE_CAP_CREDITS.toLocaleString()} credits`
-    )
-    .default(0),
-  balanceThresholdCredits: z
-    .number()
-    .int("Balance threshold must be an integer number of credits")
-    .min(0, "Balance threshold must be non-negative")
-    .default(0),
-  defaultPoolCapCredits: z
-    .number()
-    .int("Default pool cap must be an integer number of credits")
-    .min(0, "Default pool cap must be non-negative")
-    .default(0),
-  programmaticMonthlyCapCredits: z
-    .number()
-    .int("Programmatic monthly cap must be an integer number of credits")
-    .min(0, "Programmatic monthly cap must be non-negative")
-    .default(0),
-  autoSeatUpgradeEnabled: z.boolean().default(false),
-  topUpEnabled: z.boolean().default(false),
-  autoInvoiceFinalizationEnabled: z.boolean().default(true),
-});
 
 export const manageCreditUsageConfigurationPlugin = createPlugin({
   manifest: {

--- a/front/types/poke/credit_usage_configuration.ts
+++ b/front/types/poke/credit_usage_configuration.ts
@@ -1,0 +1,49 @@
+import { MAX_AWU_DISCOUNT_PERCENT } from "@app/lib/credits/awu_purchase_constants";
+import { z } from "zod";
+
+export const MAX_AWU_USAGE_CAP_CREDITS = 2_000_000;
+
+// Shared between the manage-credit-usage-configuration poke plugin and SPA
+// forms (e.g. SwitchContractDialog) that pre-populate credit config fields.
+export const CreditUsageConfigurationSchema = z.object({
+  defaultDiscountPercent: z
+    .number()
+    .min(0, "Discount percentage must be at least 0")
+    .max(
+      MAX_AWU_DISCOUNT_PERCENT,
+      `Discount cannot exceed ${MAX_AWU_DISCOUNT_PERCENT}% for AWU credit purchases`
+    )
+    .default(0),
+  paygEnabled: z.boolean(),
+  usageCapCredits: z
+    .number()
+    .int("AWU usage cap must be an integer number of credits")
+    .min(0, "AWU usage cap must be non-negative")
+    .max(
+      MAX_AWU_USAGE_CAP_CREDITS,
+      `AWU usage cap cannot exceed ${MAX_AWU_USAGE_CAP_CREDITS.toLocaleString()} credits`
+    )
+    .default(0),
+  balanceThresholdCredits: z
+    .number()
+    .int("Balance threshold must be an integer number of credits")
+    .min(0, "Balance threshold must be non-negative")
+    .default(0),
+  defaultPoolCapCredits: z
+    .number()
+    .int("Default pool cap must be an integer number of credits")
+    .min(0, "Default pool cap must be non-negative")
+    .default(0),
+  programmaticMonthlyCapCredits: z
+    .number()
+    .int("Programmatic monthly cap must be an integer number of credits")
+    .min(0, "Programmatic monthly cap must be non-negative")
+    .default(0),
+  autoSeatUpgradeEnabled: z.boolean().default(false),
+  topUpEnabled: z.boolean().default(false),
+  autoInvoiceFinalizationEnabled: z.boolean().default(true),
+});
+
+export type CreditUsageConfigurationFormValues = z.infer<
+  typeof CreditUsageConfigurationSchema
+>;


### PR DESCRIPTION
## Description

`SwitchContractDialog` was importing `CreditUsageConfigurationSchema` directly from the poke plugin module (`manage_credit_usage_configuration.ts`), which caused a circular dependency that broke the Poke SPA. Extracted `CreditUsageConfigurationSchema`, `MAX_AWU_USAGE_CAP_CREDITS`, and the derived `CreditUsageConfigurationFormValues` type into a new shared module at `front/types/poke/credit_usage_configuration.ts`. The plugin re-exports `MAX_AWU_USAGE_CAP_CREDITS` for backward compatibility with any existing consumers.

## Tests

Tested locally — Poke SPA loads correctly after the fix.

## Risk

Low. Pure refactor: no logic change, schema definition is identical, and the re-export in the plugin preserves any existing imports.

## Deploy Plan

Deploy front.
