### PR TITLE
db: add dustAPIDataSourceId index on data_sources table

### DIFF
--- a/front/lib/resources/storage/models/data_source.ts
+++ b/front/lib/resources/storage/models/data_source.ts
@@ -94,6 +94,11 @@ DataSourceModel.init(
         name: "data_sources_conversation_id",
         concurrently: true,
       },
+      {
+        fields: ["dustAPIDataSourceId"],
+        name: "data_sources_dust_api_data_source_id",
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/migrations/pre-deploy/20260625171717_add_dust_api_data_source_id_index_to_data_sources.sql
+++ b/front/migrations/pre-deploy/20260625171717_add_dust_api_data_source_id_index_to_data_sources.sql
@@ -1,0 +1,7 @@
+/*
+Statement 0
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY data_sources_dust_api_data_source_id ON public.data_sources USING btree ("dustAPIDataSourceId");


### PR DESCRIPTION
## Description

This PR adds an index on the `dustAPIDataSourceId` column of the `data_sources` table. This is motivated by [this](https://app.pganalyze.com/databases/-642267629/queries/12127590052?t=6h) query, a `SELECT` on `data_sources` filtering by `dustAPIDataSourceId` averaging ~300ms at 0.42 calls/min.

## Tests

## Risks
Low. Might increase db load while creating the index.

## Deploy Plan
No special considerations. Run the migration.
