### PR TITLE
Wake-ups: low stake for credit-based workspaces

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -15,6 +15,7 @@ import {
   autoInternalMCPServerNameToSId,
   internalMCPServerNameToSId,
 } from "@app/lib/actions/mcp_helper";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPConnectionParams } from "@app/lib/actions/mcp_metadata";
 import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
@@ -41,6 +42,7 @@ import type {
   UserMessageType,
 } from "@app/types/assistant/conversation";
 import { Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { assert, describe, expect, it, vi } from "vitest";
@@ -162,9 +164,14 @@ vi.mock("@app/lib/api/actions/servers/search/tools", async () => {
 });
 
 // Sets up test environment with workspace, auth, MCP server, client connection, and configuration.
-async function setupTest() {
+async function setupTest(
+  options: {
+    workspace?: WorkspaceType;
+    serverName?: InternalMCPServerNameType;
+  } = {}
+) {
   const user = await UserFactory.basic();
-  const workspace = await WorkspaceFactory.basic();
+  const workspace = options.workspace ?? (await WorkspaceFactory.basic());
   // Membership need to be set before auth.
   await MembershipFactory.associate(workspace, user, {
     role: "admin",
@@ -182,7 +189,7 @@ async function setupTest() {
   const internalMCPServer = await InternalMCPServerInMemoryResource.makeNew(
     auth,
     {
-      name: "google_calendar",
+      name: options.serverName ?? "google_calendar",
       useCase: null,
     }
   );
@@ -231,6 +238,53 @@ async function setupTest() {
 }
 
 describe("MCP Actions", () => {
+  it.each([
+    {
+      planType: "credit-priced",
+      createWorkspace: () => WorkspaceFactory.creditPriced(),
+      expectedStake: "low",
+    },
+    {
+      planType: "legacy",
+      createWorkspace: () => WorkspaceFactory.basic(),
+      expectedStake: "high",
+    },
+  ])("sets schedule_wakeup to $expectedStake stake for $planType plans", async ({
+    createWorkspace,
+    expectedStake,
+  }) => {
+    const workspace = await createWorkspace();
+    const { auth, connectionParams, mcpClient, config } = await setupTest({
+      workspace,
+      serverName: "wakeups",
+    });
+
+    const toolsResult = await listToolsForServerSideMCPServer(
+      auth,
+      connectionParams,
+      mcpClient,
+      config
+    );
+
+    assert(toolsResult.isOk());
+    expect(toolsResult.value).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "schedule_wakeup",
+          permission: expectedStake,
+        }),
+        expect.objectContaining({
+          name: "list_wakeups",
+          permission: "never_ask",
+        }),
+        expect.objectContaining({
+          name: "cancel_wakeup",
+          permission: "never_ask",
+        }),
+      ])
+    );
+  });
+
   it("should filter disabled tools and store metadata settings", async () => {
     const { auth, mcpServerId, connectionParams, mcpClient, config } =
       await setupTest();

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -93,6 +93,7 @@ import type {
   MCPToolRetryPolicyType,
   ToolDisplayLabels,
 } from "@app/lib/api/mcp";
+import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import type { PlanType } from "@app/types/plan";
 import {
@@ -1079,6 +1080,17 @@ export const INTERNAL_MCP_SERVERS = {
     allowMultipleInstances: false,
     isPreview: false,
     isRestricted: undefined,
+    runtimeToolStakeLevelCallback: ({
+      toolName,
+      plan,
+      configuredStakeLevel,
+    }) => {
+      if (toolName !== "schedule_wakeup") {
+        return configuredStakeLevel;
+      }
+
+      return plan && isCreditPricedPlanPrefix(plan.code) ? "low" : "high";
+    },
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -39,10 +39,8 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
             "If omitted, falls back to the user's timezone."
         ),
     },
-    // We want the wake-up creation high stake to ensure a human is in the loop to avoid agents
-    // scheduling themselves automatically for recurring wake-ups in an cascading way (we had an
-    // incident where an agent would wake-up itself every 2 minutes to process data in batch out of
-    // triggered conversations every hour creating a blowup of usage).
+    // This static default remains high to avoid cascading usage on legacy plans. At runtime,
+    // credit-priced subscriptions resolve this tool to low stake because usage is credit-limited.
     stake: "high",
     displayLabels: {
       running: "Scheduling wake-up",


### PR DESCRIPTION
## Description

Make wake-ups stake low if the workspace is credit-based. The credit-pooling applied to each user and alerting on the admin side about spending provide sufficient controls to allow low-stake Wake-Ups.

Based on https://github.com/dust-tt/dust/pull/27967

## Tests

Added a test. Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`