### PR TITLE
chore(mcp): sharpen ticketing tool descriptions for BM25 tool search

### DIFF
--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -57,13 +57,13 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   get_ticket: {
     description:
-      "Gets a specific Freshservice ticket by its ID. By default returns essential fields for performance; pass the fields parameter to request others.",
+      "Gets a specific Freshservice ticket by its ID. By default returns essential fields for performance. Pass the fields parameter to request others.",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       fields: z
         .array(FreshserviceTicketSchema.keyof())
         .optional()
-        .describe("Optional fields to include; defaults to essential fields."),
+        .describe("Optional fields to include. Defaults to essential fields."),
       include: z
         .array(z.enum(ALLOWED_TICKET_INCLUDES))
         .optional()
@@ -102,7 +102,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   create_ticket: {
     description:
-      "Creates a new Freshservice ticket — for example to log an incident, submit an IT support request, or report a problem. Required fields vary by ticket type; pass them in custom_fields.",
+      "Creates a new Freshservice ticket. For example to log an incident, submit an IT support request, or report a problem. Required fields vary by ticket type. Pass them in custom_fields.",
     schema: {
       email: z.string().describe("Requester email address"),
       subject: z.string().describe("Ticket subject"),
@@ -537,7 +537,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   list_solution_articles: {
     description:
-      "Lists the Freshservice knowledge base articles (solution articles) in a folder. Returns metadata only; fetch an article by id for its full content.",
+      "Lists the Freshservice knowledge base articles (solution articles) in a folder. Returns metadata only. Fetch an article by id for its full content.",
     schema: {
       folder_id: z
         .number()

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -21,7 +21,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   // Ticket operations
   list_tickets: {
     description:
-      "Lists tickets with optional filtering and pagination. By default returns minimal fields (id, subject, status) for performance.",
+      "Lists or shows Freshservice tickets, with optional filtering (e.g. by status, requester, or update time) and pagination. Returns minimal fields (id, subject, status) by default for performance.",
     schema: {
       filter: z
         .object({
@@ -57,21 +57,17 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   get_ticket: {
     description:
-      "Gets detailed information about a specific ticket. By default returns essential fields for performance, but you can specify specific fields.",
+      "Gets a specific Freshservice ticket by its ID. By default returns essential fields for performance; pass the fields parameter to request others.",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       fields: z
         .array(FreshserviceTicketSchema.keyof())
         .optional()
-        .describe(
-          "Optional list of fields to include. Defaults to essential fields (id, subject, description_text, priority, status, requester_id, responder_id, department_id, group_id, type, created_at, updated_at, due_by) for performance."
-        ),
+        .describe("Optional fields to include; defaults to essential fields."),
       include: z
         .array(z.enum(ALLOWED_TICKET_INCLUDES))
         .optional()
-        .describe(
-          "Additional information to include (e.g., conversations, requester, stats, problem, assets, changes, related_tickets, onboarding_context, offboarding_context)."
-        ),
+        .describe("Additional related data to include."),
     },
     stake: "never_ask",
     displayLabels: {
@@ -81,7 +77,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   get_ticket_read_fields: {
     description:
-      "Lists available Freshservice ticket field ids for use in the get_ticket.fields parameter (read-time).",
+      "Lists the field ids available when reading a Freshservice ticket. Use only to discover field names.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -91,7 +87,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   get_ticket_write_fields: {
     description:
-      "Lists all available ticket fields including standard and custom fields. Use this to discover what fields are available for use in create_ticket, update_ticket, and other operations.",
+      "Lists all Freshservice ticket fields (standard and custom) available when creating or updating a ticket. Use only to discover field names.",
     schema: {
       search: z
         .string()
@@ -106,7 +102,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   create_ticket: {
     description:
-      "Creates a new ticket in Freshservice. You MUST call get_ticket_write_fields first to get required fields, then provide all required field values in the custom_fields parameter.",
+      "Creates a new Freshservice ticket — for example to log an incident, submit an IT support request, or report a problem. Required fields vary by ticket type; pass them in custom_fields.",
     schema: {
       email: z.string().describe("Requester email address"),
       subject: z.string().describe("Ticket subject"),
@@ -133,7 +129,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   update_ticket: {
-    description: "Updates an existing ticket in Freshservice",
+    description: "Updates an existing Freshservice ticket.",
     schema: {
       ticket_id: z.string().describe("Ticket ID to update"),
       subject: z.string().optional().describe("Updated ticket subject"),
@@ -159,7 +155,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   add_ticket_note: {
-    description: "Adds a note to an existing ticket",
+    description:
+      "Adds a private or public note to an existing Freshservice ticket.",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       body: z.string().describe("Content of the note in HTML format"),
@@ -176,7 +173,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   add_ticket_reply: {
-    description: "Adds a reply to a ticket conversation",
+    description: "Adds a reply to a Freshservice ticket conversation.",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       body: z.string().describe("Content of the note in HTML format"),
@@ -228,7 +225,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   create_ticket_task: {
     description:
-      "Creates a new task on a ticket. Tasks help break down complex tickets into manageable subtasks.",
+      "Adds a new task or subtask to a Freshservice ticket, to break the ticket into smaller pieces of work.",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       title: z.string().describe("Task title"),
@@ -236,20 +233,14 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       status: z
         .enum(["1", "2", "3"])
         .optional()
-        .describe("Status: 1=Open, 2=In Progress, 3=Completed"),
-      due_date: z.string().optional().describe("Due date in ISO 8601 format"),
+        .describe("1=Open, 2=In Progress, 3=Completed"),
+      due_date: z.string().optional().describe("Due date (ISO 8601)."),
       notify_before: z
         .number()
         .optional()
-        .describe("Number of hours before due date to send notification"),
-      agent_id: z
-        .number()
-        .optional()
-        .describe("Agent ID to assign the task to"),
-      group_id: z
-        .number()
-        .optional()
-        .describe("Group ID to assign the task to"),
+        .describe("Hours before the due date to notify."),
+      agent_id: z.number().optional().describe("Agent to assign the task to."),
+      group_id: z.number().optional().describe("Group to assign the task to."),
     },
     stake: "low",
     displayLabels: {
@@ -546,7 +537,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   list_solution_articles: {
     description:
-      "Lists solution articles within a specific folder (returns metadata only, use get_solution_article for full content). To get folder_id: 1) Use list_solution_categories to get category IDs, 2) Use list_solution_folders with category_id to get folder IDs, 3) Use the folder_id here.",
+      "Lists the Freshservice knowledge base articles (solution articles) in a folder. Returns metadata only; fetch an article by id for its full content.",
     schema: {
       folder_id: z
         .number()
@@ -568,7 +559,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   get_solution_article: {
     description:
-      "Gets detailed information about a specific solution article including its full content",
+      "Gets a Freshservice knowledge base article (also called a solution article), including its full content.",
     schema: {
       article_id: z.number().describe("The ID of the solution article"),
     },
@@ -604,7 +595,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
 
   // Requesters
   list_requesters: {
-    description: "Lists requesters",
+    description:
+      "Lists Freshservice requesters: the person or people who submitted a ticket (the end users who report issues). Filter by email, phone, or mobile.",
     schema: {
       email: z.string().optional().describe("Filter by email"),
       mobile: z.string().optional().describe("Filter by mobile"),

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -7,14 +7,12 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const FRONT_TOOLS_METADATA = createToolsRecord({
   search_conversations: {
     description:
-      "Search conversations in Front by keywords, customer email, tags, status, or other criteria. " +
-      "Returns matching conversations with their details.",
+      "Search or find conversations in the Front inbox by keywords, customer email, tags, status, or other criteria. Returns matching conversations with their details.",
     schema: {
       q: z
         .string()
         .describe(
-          "Search query. Can include keywords, email addresses (e.g., 'customer@example.com'), " +
-            "status filters (e.g., 'is:open', 'is:archived'), tag filters (e.g., 'tag:bug'), etc."
+          "Search query: keywords, customer email, status (is:open, is:archived), or tags (tag:bug)."
         ),
       limit: z
         .number()
@@ -101,7 +99,7 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
   },
   get_customer_history: {
     description:
-      "Retrieve past conversations with a specific customer by their email address.",
+      "Retrieve a customer's past conversations in Front, by their email address.",
     schema: {
       customer_email: z
         .string()
@@ -218,7 +216,7 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
   },
   add_comment: {
     description:
-      "Add an internal comment/note to a conversation (only visible to team).",
+      "Add an internal comment or note to a Front conversation, visible only to your team.",
     schema: {
       conversation_id: z.string().describe("The unique ID of the conversation"),
       body: z.string().describe("The comment content"),
@@ -250,7 +248,7 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
   },
   send_message: {
     description:
-      "Send a reply or internal comment to a conversation. Can send as email reply or internal note.",
+      "Reply or respond to a customer on a Front conversation. Sends a customer-facing email by default; can also post an internal note.",
     schema: {
       conversation_id: z.string().describe("The unique ID of the conversation"),
       body: z.string().describe("The message content (supports markdown)"),
@@ -275,7 +273,7 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
   },
   update_conversation_status: {
     description:
-      "Update the status of a conversation (archive, reopen, delete, spam, trash).",
+      "Update the status of a Front conversation: archive (close), reopen, delete, mark as spam, or move to trash.",
     schema: {
       conversation_id: z.string().describe("The unique ID of the conversation"),
       status: z

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -248,7 +248,7 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
   },
   send_message: {
     description:
-      "Reply or respond to a customer on a Front conversation. Sends a customer-facing email by default; can also post an internal note.",
+      "Reply or respond to a customer on a Front conversation. Sends a customer-facing email by default. Can also post an internal note.",
     schema: {
       conversation_id: z.string().describe("The unique ID of the conversation"),
       body: z.string().describe("The message content (supports markdown)"),

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -16,7 +16,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   // Read operations
   get_issue_read_fields: {
     description:
-      "Lists available Jira field keys/ids and names for use in the get_issue.fields parameter (read-time).",
+      "Lists the field keys, ids, and names that can be requested when reading an issue.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -26,9 +26,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_issue: {
     description:
-      "Retrieves a single JIRA issue by its key (e.g., 'PROJ-123'). " +
-      "By default it returns a minimal set of fields for performance: summary, issuetype, priority, assignee, reporter, labels, duedate, parent, project, status. " +
-      "To request others, pass them in the fields parameter using the key for built-in fields (e.g. summary) and the id for custom fields (e.g. customfield_10020), which you can discover with get_issue_read_fields.",
+      "Looks up and retrieves a single Jira issue (ticket) by its key (e.g., 'PROJ-123'). Returns a minimal set of fields by default; pass the fields parameter to request others.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       fields: z
@@ -45,7 +43,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_projects: {
-    description: "Retrieves a list of JIRA projects.",
+    description: "Retrieves all Jira projects (the full list).",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -54,7 +52,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_project: {
-    description: "Retrieves a single JIRA project by its key (e.g., 'PROJ').",
+    description: "Retrieves a single Jira project by its key (e.g., 'PROJ').",
     schema: {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
     },
@@ -78,7 +76,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_transitions: {
     description:
-      "Gets available transitions for a JIRA issue based on its current status and workflow.",
+      "Lists which status changes a Jira issue is currently allowed to make.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
     },
@@ -90,7 +88,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_issues: {
     description:
-      "Search issues using one or more filters (e.g., status, priority, labels, assignee, fixVersion, customField, dueDate, created, resolved). Use exact matching by default, or fuzzy matching for approximate/partial matches on summary field. For custom fields, use field 'customField' with customFieldName parameter. For date fields (dueDate, created, resolved), use operator parameter with '<', '>', '=', etc. and date format '2023-07-03' or relative '-25d', '7d', '2w', '1M', etc. Results can be sorted using the sortBy parameter with field and direction (ASC/DESC). When referring to the user, use the get_connection_info tool. When referring to unknown create/update fields, use get_issue_create_fields or get_issue_types to discover the field names.",
+      "Search or list Jira issues (tickets, bugs) by filters: status (open, in progress, done), priority, labels, who they are assigned to, fixVersion, or dates. Supports fuzzy matching and sorting — use it to browse the backlog or find issues by criteria.",
     schema: {
       filters: z
         .array(JiraSearchFilterSchema)
@@ -112,7 +110,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_issues_using_jql: {
     description:
-      "Search JIRA issues using a custom JQL (Jira Query Language) query. This tool allows for advanced search capabilities beyond the filtered search. Examples: 'project = PROJ AND status = Open', 'assignee = currentUser() AND priority = High', 'created >= -30d AND labels = bug'.",
+      "Search Jira issues using a raw JQL (Jira Query Language) query string. Use only when you already have a JQL expression.",
     schema: {
       jql: z.string().describe("The JQL (Jira Query Language) query string"),
       maxResults: z
@@ -153,7 +151,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_issue_create_fields: {
     description:
-      "Create/update-time field metadata for a specific project and issue type. Returns only fields available on the Create/Update screens (subset). Use get_issue_types to get the issue type ID.",
+      "Lists the field metadata (names and ids) on the screens used to create or update an issue, for a given project and issue type. Use it to discover valid field names beforehand.",
     schema: {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
       issueTypeId: z
@@ -187,21 +185,16 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_users: {
-    description:
-      "Search for JIRA users. Provide emailAddress for exact email match, or name for display name contains. If neither is provided, returns the first maxResults users. Use startAt for pagination (pass the previous result's nextStartAt).",
+    description: "Search for Jira users by email address or display name.",
     schema: {
       emailAddress: z
         .string()
         .optional()
-        .describe(
-          "Exact email address (e.g., 'john.doe@company.com'). If provided, only exact matches are returned."
-        ),
+        .describe("Exact email address to match."),
       name: z
         .string()
         .optional()
-        .describe(
-          "Display name filter (e.g., 'John Doe'). Case-insensitive contains match."
-        ),
+        .describe("Display name to match (case-insensitive contains)."),
       maxResults: z
         .number()
         .min(1)
@@ -209,16 +202,14 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
         .optional()
         .default(SEARCH_USERS_MAX_RESULTS)
         .describe(
-          `Maximum number of users to return when searching by name (default: ${SEARCH_USERS_MAX_RESULTS}, max: ${SEARCH_USERS_MAX_RESULTS})`
+          `Maximum number of users to return (default and max: ${SEARCH_USERS_MAX_RESULTS}).`
         ),
       startAt: z
         .number()
         .int()
         .min(0)
         .optional()
-        .describe(
-          "Pagination offset. Pass the previous response's nextStartAt to fetch the next page."
-        ),
+        .describe("Pagination offset (use the previous nextStartAt)."),
     },
     stake: "never_ask",
     displayLabels: {
@@ -240,7 +231,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   read_attachment: {
     description:
-      "Read content from any attachment on a Jira issue. For text-based files (PDF, Word, Excel, CSV, plain text), extracts and returns the text content. For other files (images, documents), returns the file for upload. Supports text extraction with OCR for scanned documents.",
+      "Read the content of an attachment on a Jira issue. Extracts text from PDF, Word, Excel, CSV, and plain-text files (with OCR for scans); other files are returned as-is.",
     schema: {
       issueKey: z.string().describe("The Jira issue key (e.g., 'PROJ-123')"),
       attachmentId: z.string().describe("The ID of the attachment to read"),
@@ -255,7 +246,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   // Write operations
   create_comment: {
     description:
-      "Adds a comment to an existing JIRA issue. Accepts either plain text string or rich Atlassian Document Format (ADF).",
+      "Adds a comment or note to an existing Jira issue. Accepts plain text or rich ADF formatting.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       comment: z
@@ -280,7 +271,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   transition_issue: {
     description:
-      "Transitions a JIRA issue to a different status/workflow state.",
+      "Moves or changes a Jira issue (ticket) to a different status — e.g. to In Progress or Done. Performs a workflow transition.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       transitionId: z.string().describe("The ID of the transition to perform"),
@@ -293,7 +284,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   create_issue: {
     description:
-      "Creates a new JIRA issue with the specified details. For textarea fields (like description), you can use either plain text or rich ADF format. Note: Available fields vary by project and issue type. Use get_issue_create_fields to check which fields are required and available.",
+      "Creates a new Jira issue — also called a ticket — in a project; use it to log a bug, raise a request, or open a task or story. Description fields accept plain text or rich ADF; required fields vary by project and issue type.",
     schema: {
       issueData: JiraCreateIssueRequestSchema.describe(
         "The description of the issue"
@@ -307,7 +298,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   update_issue: {
     description:
-      "Updates an existing JIRA issue with new field values (e.g., summary, description, priority, assignee). For textarea fields (like description), you can use either plain text or rich ADF format. Use get_issue_create_fields to discover which fields are available for the project and issue type, including which ones are textarea fields. Note: Issue links, attachments, and some system fields require separate APIs and are not supported.",
+      "Updates or changes field values on an existing Jira issue, such as its summary, description, priority, or assignee. Description accepts plain text or rich ADF. Issue links and attachments are not changed here.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       updateData: JiraCreateIssueRequestSchema.partial().describe(
@@ -322,7 +313,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   create_issue_link: {
     description:
-      "Creates a link between two JIRA issues with a specified relationship type (e.g., 'Blocks', 'Relates', 'Duplicates').",
+      "Links or marks two Jira issues as related, with a relationship type such as blocks, relates to, or duplicates.",
     schema: {
       linkData: JiraCreateIssueLinkRequestSchema.describe(
         "Link configuration including type and issues to link"
@@ -347,7 +338,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   upload_attachment: {
     description:
-      "Upload a file attachment to a Jira issue. Supports two types of file sources: conversation files (from current Dust conversation) and external files (base64 encoded). The attachment must specify its type and corresponding fields. IMPORTANT: The 'type' field must be exactly 'conversation_file' or 'external_file', not a MIME type like 'image/png'.",
+      "Attach a file to a Jira issue (upload). The file can come from the current Dust conversation or be provided as base64 data.",
     schema: {
       issueKey: z.string().describe("The Jira issue key (e.g., 'PROJ-123')"),
       attachment: z.union([

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -26,7 +26,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_issue: {
     description:
-      "Looks up and retrieves a single Jira issue (ticket) by its key (e.g., 'PROJ-123'). Returns a minimal set of fields by default; pass the fields parameter to request others.",
+      "Looks up and retrieves a single Jira issue (ticket) by its key (e.g., 'PROJ-123'). Returns a minimal set of fields by default. Pass the fields parameter to request others.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       fields: z
@@ -88,7 +88,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_issues: {
     description:
-      "Search or list Jira issues (tickets, bugs) by filters: status (open, in progress, done), priority, labels, who they are assigned to, fixVersion, or dates. Supports fuzzy matching and sorting — use it to browse the backlog or find issues by criteria.",
+      "Search or list Jira issues (tickets, bugs) by filters: status (open, in progress, done), priority, labels, who they are assigned to, fixVersion, or dates. Supports fuzzy matching and sorting. Use it to browse the backlog or find issues by criteria.",
     schema: {
       filters: z
         .array(JiraSearchFilterSchema)
@@ -231,7 +231,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   read_attachment: {
     description:
-      "Read the content of an attachment on a Jira issue. Extracts text from PDF, Word, Excel, CSV, and plain-text files (with OCR for scans); other files are returned as-is.",
+      "Read the content of an attachment on a Jira issue. Extracts text from PDF, Word, Excel, CSV, and plain-text files (with OCR for scans). Other files are returned as-is.",
     schema: {
       issueKey: z.string().describe("The Jira issue key (e.g., 'PROJ-123')"),
       attachmentId: z.string().describe("The ID of the attachment to read"),
@@ -271,7 +271,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   transition_issue: {
     description:
-      "Moves or changes a Jira issue (ticket) to a different status — e.g. to In Progress or Done. Performs a workflow transition.",
+      "Moves or changes a Jira issue (ticket) to a different status (e.g. to In Progress or Done). Performs a workflow transition.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       transitionId: z.string().describe("The ID of the transition to perform"),
@@ -284,7 +284,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   create_issue: {
     description:
-      "Creates a new Jira issue — also called a ticket — in a project; use it to log a bug, raise a request, or open a task or story. Description fields accept plain text or rich ADF; required fields vary by project and issue type.",
+      "Creates a new Jira issue, or ticket, in a project. Use it to log a bug, raise a request, or open a task or story. Description fields accept plain text or rich ADF. Required fields vary by project and issue type.",
     schema: {
       issueData: JiraCreateIssueRequestSchema.describe(
         "The description of the issue"

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -65,7 +65,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   },
   list_ticket_fields: {
     description:
-      "Lists Zendesk ticket field definitions — both built-in fields (Subject, Priority, Status) and custom fields — with their id, title, type, and active state.",
+      "Lists Zendesk ticket field definitions. Both built-in fields (Subject, Priority, Status) and custom fields. With their id, title, type, and active state.",
     schema: {
       includeInactive: z
         .boolean()
@@ -116,7 +116,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   },
   update_ticket_tags: {
     description:
-      "Add tags to a Zendesk ticket, or replace all of its tags. By default (override=false) the provided tags are added to the existing ones; with override=true they replace the full list (omitted tags are removed).",
+      "Add tags to a Zendesk ticket, or replace all of its tags. By default (override=false) the provided tags are added to the existing ones. With override=true they replace the full list (omitted tags are removed).",
     schema: {
       ticketId: z
         .number()

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -7,10 +7,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   get_ticket: {
     description:
-      "Retrieve a Zendesk ticket by its ID. Returns the ticket details including subject, " +
-      "description, status, priority, assignee, and other metadata. Optionally include ticket metrics " +
-      "such as resolution times, wait times, and reply counts. Optionally include the full conversation " +
-      "with all comments. Optionally download and include file attachments from comments.",
+      "Look up and retrieve a Zendesk support ticket by its ID. Returns subject, description, status, priority, assignee, and other metadata. Optionally include ticket metrics, the full conversation of comments, and file attachments.",
     schema: {
       ticketId: z
         .number()
@@ -21,20 +18,18 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether to include ticket metrics (resolution times, wait times, reopens, replies, etc.). Defaults to false."
+          "Include ticket metrics (resolution/wait times, replies). Defaults to false."
         ),
       includeConversation: z
         .boolean()
         .optional()
         .describe(
-          "Whether to include the full conversation (all comments) for the ticket. Defaults to false."
+          "Include the full conversation (all comments). Defaults to false."
         ),
       includeAttachments: z
         .boolean()
         .optional()
-        .describe(
-          "Whether to download and include the content of file attachments from ticket comments."
-        ),
+        .describe("Include file attachments from ticket comments."),
     },
     stake: "never_ask",
     displayLabels: {
@@ -44,17 +39,12 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   },
   search_tickets: {
     description:
-      "Search for Zendesk tickets using query syntax. Returns up to 1,000 matching tickets with their details. " +
-      "Supports filtering by status, priority, type, assignee, tags, custom fields, dates, and text fields. " +
-      'Custom fields use syntax: custom_field_{id}:"exact_value". Tags are simple labels; business-specific data ' +
-      "are typically stored in custom fields. Use list_ticket_fields to discover available custom field IDs.",
+      "Search for Zendesk tickets using query syntax. Returns matching tickets with their details. Filter by status (e.g. open, pending, solved), priority, type, assignee, tags, custom fields, dates, and text fields.",
     schema: {
       query: z
         .string()
         .describe(
-          "Search query using Zendesk query syntax. Supports field:value pairs for status, priority, type, assignee, tags, " +
-            'and custom_field_{id}:"value" for custom fields. Multiple conditions are combined with AND logic. ' +
-            "Do not include 'type:ticket' as it is automatically added."
+          "Zendesk search query. Supports field:value pairs (status, priority, type, assignee, tags) and custom_field_{id}:\"value\". Do not include 'type:ticket'."
         ),
       sortBy: z
         .enum(["updated_at", "created_at", "priority", "status", "ticket_type"])
@@ -75,9 +65,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   },
   list_ticket_fields: {
     description:
-      "Lists ticket field definitions with their ID, title, type, and whether they are active. " +
-      "Includes built-in fields (Subject, Priority, Status) and custom fields. " +
-      "Returns active fields by default. Set includeInactive=true for all fields.",
+      "Lists Zendesk ticket field definitions — both built-in fields (Subject, Priority, Status) and custom fields — with their id, title, type, and active state.",
     schema: {
       includeInactive: z
         .boolean()
@@ -111,7 +99,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   },
   post_reply: {
     description:
-      "Post a public reply to a Zendesk ticket. The reply will be visible to the end user.",
+      "Post or send a public reply (response) on a Zendesk ticket, visible to the end user (the customer).",
     schema: {
       ticketId: z
         .number()
@@ -128,11 +116,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   },
   update_ticket_tags: {
     description:
-      "Add tags to a Zendesk ticket or completely replace its tags. " +
-      "By default (override=false), adds the provided tags to the existing ones without affecting them. " +
-      "When override=true, all existing tags on the ticket are replaced by the provided list — " +
-      "any tag not included in the list will be permanently removed. " +
-      "To remove a tag: first retrieve the current tags on the ticket, then call this tool with override=true, omitting the tag to remove from the list.",
+      "Add tags to a Zendesk ticket, or replace all of its tags. By default (override=false) the provided tags are added to the existing ones; with override=true they replace the full list (omitted tags are removed).",
     schema: {
       ticketId: z
         .number()


### PR DESCRIPTION
## Description

Part of #9163. Once deferred behind tool search, tools in `jira`, `zendesk`, `front`, and `freshservice` are only surfaced when a BM25 index matches user intent against tool name, description, and input schema. All four are ticketing systems, so "ticket"/"reply"/"fields" collide across servers and the platform name is the only discriminator.

- **Platform tokens:** tools that lacked them now name their platform (mostly `freshservice` e.g. `add_ticket_reply`, `get_ticket`, `list_requesters`). Without this, `reply to a freshservice ticket` routed to `zendesk.post_reply`.
- **De-bleeding:** removed cross-references to sibling tool names in descriptions/params (`Use get_issue_create_fields…`, `Use list_ticket_fields…`, `get_ticket.fields`) that leaked the wrong tool's keywords.
- **Length:** trimmed oversized parameter prose (jira `get_users`, zendesk `get_ticket`/`search_tickets`, front `search_conversations`, freshservice `get_ticket`) so BM25 length-normalization stops sinking them.
- **Synonyms:** added the words users actually type, like "ticket" for jira issues, "knowledge base", "look up", "subtask", "person who submitted".

Result: top-1 routing **28/57 → 50/57** (52/57 within top-2). Remaining non-firsts rank the right tool within its own server's top results and trace to BM25 penalizing tools with large input schemas (ADF on jira writes, the field enum on `freshservice.get_ticket`).

## Tests

No behavior change. The edits are tool name/description/parameter text only. Validated with the BM25 harness (not committed here, it lives on the harness branch).

## Risk

Low.

## Deploy Plan

Standard.