### PR TITLE
feat(front): sound notification when an agent requires manual action

### DIFF
--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -2,6 +2,7 @@ import { agentMessageFeedbackWorkflow } from "@app/lib/notifications/workflows/a
 import { agentSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import { balanceThresholdReachedWorkflow } from "@app/lib/notifications/workflows/balance-threshold-reached";
 import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/conversation-unread";
+import { manualActionRequiredWorkflow } from "@app/lib/notifications/workflows/manual-action-required";
 import { podAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/pod-added-as-member";
 import { programmaticCapReachedWorkflow } from "@app/lib/notifications/workflows/programmatic-cap-reached";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
@@ -72,6 +73,7 @@ const options: ServeHandlerOptions = {
     programmaticCapReachedWorkflow,
     upgradeRequestCreatedWorkflow,
     seatAutoUpgradedWorkflow,
+    manualActionRequiredWorkflow,
   ],
 };
 

--- a/front/hooks/useSetupNotifications.ts
+++ b/front/hooks/useSetupNotifications.ts
@@ -1,21 +1,29 @@
 import { useBrowserNotification } from "@app/hooks/useBrowserNotification";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useNovuClient } from "@app/hooks/useNovuClient";
+import { useSoundNotification } from "@app/hooks/useSoundNotification";
 import config from "@app/lib/api/config";
 import { ConversationsUpdatedEvent } from "@app/lib/notifications/events";
 import { useAppRouter } from "@app/lib/platform";
 import { workspaceAuthContextUrl } from "@app/lib/swr/workspaces";
-import { PROVIDER_CREDENTIALS_HEALTH_UPDATED_TAG } from "@app/types/notification_preferences";
+import {
+  MANUAL_ACTION_REQUIRED_TAG,
+  PROVIDER_CREDENTIALS_HEALTH_UPDATED_TAG,
+} from "@app/types/notification_preferences";
 import { isString } from "@app/types/shared/utils/general";
 import type { Novu } from "@novu/js";
 import { useEffect } from "react";
 import { mutate } from "swr";
+
+const isActivelyViewing = (isOnConversationPage: boolean): boolean =>
+  isOnConversationPage && window.document.hasFocus();
 
 export const useSetupNotifications = () => {
   const { push } = useAppRouter();
   const { novuClient } = useNovuClient();
   const sendNotification = useSendNotification();
   const { allowBrowserNotification, notify } = useBrowserNotification();
+  const { requestManualActionSound } = useSoundNotification();
 
   useEffect(() => {
     const setupNotifications = async (novuClient: Novu) => {
@@ -41,13 +49,35 @@ export const useSetupNotifications = () => {
           }
 
           if (
+            notification.result.tags?.includes(MANUAL_ACTION_REQUIRED_TAG) &&
+            window !== undefined
+          ) {
+            const conversationId = notification.result.data?.conversationId;
+            if (isString(conversationId)) {
+              if (
+                !isActivelyViewing(
+                  window.location.pathname.includes(conversationId)
+                )
+              ) {
+                requestManualActionSound();
+              }
+              window.dispatchEvent(new ConversationsUpdatedEvent());
+            }
+            void novuClient.notifications.delete({
+              notificationId: notification.result.id,
+            });
+            return;
+          }
+
+          if (
             notification.result.tags?.includes("conversations") &&
             window !== undefined
           ) {
             if (
-              window.location.pathname !==
-                notification.result.primaryAction?.redirect?.url ||
-              !window.document.hasFocus()
+              !isActivelyViewing(
+                window.location.pathname ===
+                  notification.result.primaryAction?.redirect?.url
+              )
             ) {
               // If we are not already on the conversation page, dispatch the event to update the conversations list.
               window.dispatchEvent(new ConversationsUpdatedEvent());
@@ -112,5 +142,12 @@ export const useSetupNotifications = () => {
         console.error("Failed to setup notifications", { error });
       }
     }
-  }, [allowBrowserNotification, notify, novuClient, push, sendNotification]);
+  }, [
+    allowBrowserNotification,
+    notify,
+    novuClient,
+    push,
+    requestManualActionSound,
+    sendNotification,
+  ]);
 };

--- a/front/hooks/useSoundNotification.ts
+++ b/front/hooks/useSoundNotification.ts
@@ -1,0 +1,155 @@
+import { useUserMetadata } from "@app/lib/swr/user";
+import {
+  DEFAULT_SOUND_NOTIFICATION,
+  isSoundNotificationType,
+  SOUND_NOTIFICATION_METADATA_KEYS,
+} from "@app/types/notification_preferences";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const MANUAL_ACTION_SOUND_DEBOUNCE_MS = 1000;
+const MANUAL_ACTION_SOUND_LAST_CHIME_KEY =
+  "dust:manual-action-sound:last-chime-ms";
+const MANUAL_ACTION_SOUND_LOCK_NAME = "dust:manual-action-sound";
+
+function showNotification(): void {
+  if (Notification.permission === "granted") {
+    new Notification("Dust — Action required", {
+      body: "A manual action requires your approval.",
+      icon: "/favicon.ico",
+    });
+  }
+}
+
+function claimChimeFromStorage(nowMs: number): boolean {
+  try {
+    const lastChimeAtMs = Number(
+      window.localStorage.getItem(MANUAL_ACTION_SOUND_LAST_CHIME_KEY)
+    );
+    if (
+      lastChimeAtMs &&
+      nowMs - lastChimeAtMs < MANUAL_ACTION_SOUND_DEBOUNCE_MS
+    ) {
+      return false;
+    }
+    window.localStorage.setItem(
+      MANUAL_ACTION_SOUND_LAST_CHIME_KEY,
+      String(nowMs)
+    );
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+async function canChimeManualActionSound(nowMs: number): Promise<boolean> {
+  if (!("locks" in navigator)) {
+    return claimChimeFromStorage(nowMs);
+  }
+  return navigator.locks.request(MANUAL_ACTION_SOUND_LOCK_NAME, () =>
+    claimChimeFromStorage(nowMs)
+  );
+}
+
+export function useSoundNotification() {
+  const { metadata: enabledMetadata, isMetadataLoading: isEnabledLoading } =
+    useUserMetadata(SOUND_NOTIFICATION_METADATA_KEYS.enabled);
+  const { metadata: soundMetadata, isMetadataLoading: isSoundLoading } =
+    useUserMetadata(SOUND_NOTIFICATION_METADATA_KEYS.sound);
+
+  const [pendingSound, setPendingSound] = useState(false);
+
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const audioBufferCacheRef = useRef<Map<string, AudioBuffer>>(new Map());
+
+  const getAudioContext = useCallback(() => {
+    if (
+      !audioContextRef.current ||
+      audioContextRef.current.state === "closed"
+    ) {
+      audioContextRef.current = new AudioContext();
+    }
+    return audioContextRef.current;
+  }, []);
+
+  useEffect(() => {
+    const unlock = () => {
+      const ctx = getAudioContext();
+      if (ctx.state === "suspended") {
+        void ctx.resume();
+      }
+    };
+
+    window.addEventListener("click", unlock);
+    window.addEventListener("keydown", unlock);
+    return () => {
+      window.removeEventListener("click", unlock);
+      window.removeEventListener("keydown", unlock);
+    };
+  }, [getAudioContext]);
+
+  const playSound = useCallback(
+    async (soundName: string) => {
+      try {
+        const ctx = getAudioContext();
+        if (ctx.state === "suspended") {
+          await ctx.resume();
+        }
+        if (ctx.state !== "running") {
+          throw new Error("AudioContext could not resume — no user gesture");
+        }
+
+        let buffer = audioBufferCacheRef.current.get(soundName);
+        if (!buffer) {
+          const response = await fetch(
+            `/sounds/${encodeURIComponent(soundName)}.mp3`
+          );
+          if (!response.ok) {
+            throw new Error(`Failed to fetch sound: ${response.status}`);
+          }
+          const arrayBuffer = await response.arrayBuffer();
+          buffer = await ctx.decodeAudioData(arrayBuffer);
+          audioBufferCacheRef.current.set(soundName, buffer);
+        }
+
+        const source = ctx.createBufferSource();
+        source.buffer = buffer;
+        source.connect(ctx.destination);
+        source.start(0);
+      } catch {
+        showNotification();
+      }
+    },
+    [getAudioContext]
+  );
+
+  const requestManualActionSound = useCallback(() => {
+    void canChimeManualActionSound(Date.now()).then((canChime) => {
+      if (canChime) {
+        setPendingSound(true);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!pendingSound || isEnabledLoading || isSoundLoading) {
+      return;
+    }
+    if (enabledMetadata?.value === "true") {
+      const sound =
+        soundMetadata?.value && isSoundNotificationType(soundMetadata.value)
+          ? soundMetadata.value
+          : DEFAULT_SOUND_NOTIFICATION;
+      void playSound(sound);
+    }
+    setPendingSound(false);
+  }, [
+    pendingSound,
+    enabledMetadata,
+    isEnabledLoading,
+    soundMetadata,
+    isSoundLoading,
+    playSound,
+  ]);
+
+  return { requestManualActionSound };
+}

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -21,6 +21,7 @@ import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
 import { pauseSandboxBashForBlockedChild } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
+import { notifyManualActionRequired } from "@app/lib/notifications/workflows/manual-action-required";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -249,6 +250,13 @@ export async function createSandboxChildAction(
     });
 
     await ConversationResource.markAsActionRequired(auth, { conversation });
+
+    if (!conversation.actionRequired) {
+      notifyManualActionRequired(auth, {
+        conversationId: conversation.sId,
+        actionId: action.sId,
+      });
+    }
 
     // Hand the sandbox pause back to the caller instead of pausing here.
     // `pauseSandboxBashForBlockedChild` freezes the whole sandbox via

--- a/front/lib/notifications/workflows/manual-action-required.ts
+++ b/front/lib/notifications/workflows/manual-action-required.ts
@@ -1,0 +1,129 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { DustError } from "@app/lib/error";
+import { getNovuClient } from "@app/lib/notifications/novu-client";
+import logger from "@app/logger/logger";
+import {
+  MANUAL_ACTION_REQUIRED_TAG,
+  MANUAL_ACTION_REQUIRED_TRIGGER_ID,
+  SOUND_NOTIFICATION_METADATA_KEYS,
+} from "@app/types/notification_preferences";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { workflow } from "@novu/framework";
+import z from "zod";
+
+const ManualActionRequiredPayloadSchema = z.object({
+  workspaceId: z.string(),
+  conversationId: z.string(),
+  actionId: z.string().optional(),
+});
+
+type ManualActionRequiredPayloadType = z.infer<
+  typeof ManualActionRequiredPayloadSchema
+>;
+
+export const manualActionRequiredWorkflow = workflow(
+  MANUAL_ACTION_REQUIRED_TRIGGER_ID,
+  async ({ step, payload }) => {
+    await step.inApp("manual-action-required-in-app", async () => {
+      return {
+        subject: "Action required",
+        body: "A manual action requires your approval.",
+        data: {
+          autoDelete: true,
+          conversationId: payload.conversationId,
+          actionId: payload.actionId,
+        },
+      };
+    });
+  },
+  {
+    payloadSchema: ManualActionRequiredPayloadSchema,
+    tags: [MANUAL_ACTION_REQUIRED_TAG],
+  }
+);
+
+export const triggerManualActionRequiredNotification = async (
+  auth: Authenticator,
+  { conversationId, actionId }: { conversationId: string; actionId?: string }
+): Promise<Result<void, DustError<"internal_error">>> => {
+  const user = auth.user();
+  if (!user) {
+    return new Ok(undefined);
+  }
+
+  const soundEnabled = await user.getMetadata(
+    SOUND_NOTIFICATION_METADATA_KEYS.enabled
+  );
+  if (soundEnabled?.value !== "true") {
+    return new Ok(undefined);
+  }
+
+  const novuPayload: ManualActionRequiredPayloadType = {
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    conversationId,
+    actionId,
+  };
+
+  try {
+    const novuClient = await getNovuClient();
+
+    const r = await novuClient.triggerBulk({
+      events: [
+        {
+          workflowId: MANUAL_ACTION_REQUIRED_TRIGGER_ID,
+          to: {
+            subscriberId: user.sId,
+            email: user.email,
+            firstName: user.firstName ?? undefined,
+            lastName: user.lastName ?? undefined,
+          },
+          payload: novuPayload,
+        },
+      ],
+    });
+
+    if (r.result.some((res) => !!res.error?.length)) {
+      const eventErrors = r.result
+        .filter((res) => !!res.error?.length)
+        .map(({ error }) => error?.join("; "))
+        .join("; ");
+      return new Err({
+        name: "dust_error",
+        code: "internal_error",
+        message: `Failed to trigger manual action required notification: ${eventErrors}`,
+      });
+    }
+  } catch (err) {
+    return new Err({
+      name: "dust_error",
+      code: "internal_error",
+      message: "Failed to trigger manual action required notification",
+      cause: normalizeError(err),
+    });
+  }
+
+  return new Ok(undefined);
+};
+
+export function notifyManualActionRequired(
+  auth: Authenticator,
+  { conversationId, actionId }: { conversationId: string; actionId?: string }
+): void {
+  void triggerManualActionRequiredNotification(auth, {
+    conversationId,
+    actionId,
+  }).then((notifRes) => {
+    if (notifRes.isErr()) {
+      logger.error(
+        {
+          error: notifRes.error,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          conversationId,
+        },
+        "Failed to trigger manual action required notification"
+      );
+    }
+  });
+}

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -5,6 +5,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { DurationRecorder } from "@app/lib/duration_recorder";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import { notifyManualActionRequired } from "@app/lib/notifications/workflows/manual-action-required";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
@@ -292,6 +293,12 @@ async function _runModelAndCreateActionsActivity({
     await ConversationResource.markAsActionRequired(auth, {
       conversation: runAgentData.conversation,
     });
+
+    if (!runAgentData.conversation.actionRequired) {
+      notifyManualActionRequired(auth, {
+        conversationId: runAgentData.conversation.sId,
+      });
+    }
   }
 
   return {

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -7,6 +7,7 @@ import {
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
+import { notifyManualActionRequired } from "@app/lib/notifications/workflows/manual-action-required";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -395,6 +396,13 @@ async function executeToolStreaming(
         await ConversationResource.markAsActionRequired(auth, {
           conversation,
         });
+
+        if (!conversation.actionRequired) {
+          notifyManualActionRequired(auth, {
+            conversationId: conversation.sId,
+            actionId: action.sId,
+          });
+        }
 
         return { deferredEvents };
 

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -125,6 +125,10 @@ export const UPGRADE_REQUEST_CREATED_TAG = "upgrade-request-created" as const;
 export const SEAT_AUTO_UPGRADED_TRIGGER_ID = "seat-auto-upgraded" as const;
 export const SEAT_AUTO_UPGRADED_TAG = "seat-auto-upgraded" as const;
 
+export const MANUAL_ACTION_REQUIRED_TRIGGER_ID =
+  "manual-action-required" as const;
+export const MANUAL_ACTION_REQUIRED_TAG = "manual-action-required" as const;
+
 export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
   | typeof POD_ADDED_AS_MEMBER_TRIGGER_ID
@@ -135,7 +139,8 @@ export type WorkflowTriggerId =
   | typeof BALANCE_THRESHOLD_REACHED_TRIGGER_ID
   | typeof PROGRAMMATIC_CAP_REACHED_TRIGGER_ID
   | typeof UPGRADE_REQUEST_CREATED_TRIGGER_ID
-  | typeof SEAT_AUTO_UPGRADED_TRIGGER_ID;
+  | typeof SEAT_AUTO_UPGRADED_TRIGGER_ID
+  | typeof MANUAL_ACTION_REQUIRED_TRIGGER_ID;
 
 export const SOUND_NOTIFICATION_OPTIONS = [
   "Pluck",


### PR DESCRIPTION
## Description

Plays a sound notification when an agent pauses and requires a manual action (tool approval / decline), so the user is alerted even when they're not looking at the conversation.

Follow-up to #27793, which added the user preference (enable + sound choice) and the `sound_notification` feature flag. This PR adds :

- New Novu `manual-action-required` workflow (silent in-app signal, intercepted client-side by tag) + `notifyManualActionRequired` helper, registered on the  front-api Novu bridge.
- Fires at the three points where a conversation is marked action-required: sandbox child action, `run_tool`, and the run-model wrapper.
- Client: `useSoundNotification` hook + `useSetupNotifications` plays the user's configured sound when the notification arrives and they aren't already viewing that conversation.

Gated behind the `sound_notification` feature flag. 

## Tests

Manual testing locally using Novu bridge to test notifications.

## Risk
Low. Entirely gated behind the `sound_notification` flag (off by default).

## Deploy Plan

