### PR TITLE
Avoid passing non garbage collectable composite signal to tool call

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -9,6 +9,7 @@ import {
   getToolExtraFields,
   listToolsForServerSideMCPServer,
   postProcessMCPToolResult,
+  runToolCallWithDetachedSignal,
   tryCallMCPTool,
 } from "@app/lib/actions/mcp_actions";
 import {
@@ -823,5 +824,114 @@ describe("postProcessMCPToolResult - structuredContent", () => {
     );
 
     expect(result.content).toHaveLength(0);
+  });
+});
+
+// Counts active "abort" listeners on a signal by spying on add/remove. We can't
+// read the listener list directly, so we track the delta ourselves.
+function trackAbortListeners(signal: AbortSignal): { count: () => number } {
+  let count = 0;
+  const add = signal.addEventListener.bind(signal);
+  const remove = signal.removeEventListener.bind(signal);
+  vi.spyOn(signal, "addEventListener").mockImplementation((type, ...rest) => {
+    if (type === "abort") {
+      count += 1;
+    }
+    return add(type, ...rest);
+  });
+  vi.spyOn(signal, "removeEventListener").mockImplementation(
+    (type, ...rest) => {
+      if (type === "abort") {
+        count -= 1;
+      }
+      return remove(type, ...rest);
+    }
+  );
+  return { count: () => count };
+}
+
+describe("runToolCallWithDetachedSignal", () => {
+  it("leaves no listener on the source after the call resolves", async () => {
+    const source = new AbortController().signal;
+    const tracker = trackAbortListeners(source);
+
+    const result = await runToolCallWithDetachedSignal(
+      source,
+      async () => "ok"
+    );
+
+    expect(result).toBe("ok");
+    expect(tracker.count()).toBe(0);
+  });
+
+  it("leaves no listener on the source after the call rejects", async () => {
+    const source = new AbortController().signal;
+    const tracker = trackAbortListeners(source);
+
+    await expect(
+      runToolCallWithDetachedSignal(source, async () => {
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+
+    expect(tracker.count()).toBe(0);
+  });
+
+  it("does not retain a listener even if the SDK leaks one on its signal", async () => {
+    // Simulates the MCP SDK: the callee attaches an abort listener it never
+    // removes. The leak must land on the throwaway signal, not on `source`.
+    const source = new AbortController().signal;
+    const tracker = trackAbortListeners(source);
+
+    await runToolCallWithDetachedSignal(source, async (signal) => {
+      signal.addEventListener("abort", () => {});
+    });
+
+    expect(tracker.count()).toBe(0);
+  });
+
+  it("forwards aborts from the source to the throwaway signal", async () => {
+    const controller = new AbortController();
+
+    let inner: AbortSignal | undefined;
+    const pending = runToolCallWithDetachedSignal(
+      controller.signal,
+      async (signal) => {
+        inner = signal;
+        return new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve());
+        });
+      }
+    );
+
+    controller.abort(new Error("cancelled"));
+    await pending;
+
+    expect(inner?.aborted).toBe(true);
+    expect((inner?.reason as Error)?.message).toBe("cancelled");
+  });
+
+  it("propagates an already-aborted source immediately", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("already gone"));
+
+    const seen = await runToolCallWithDetachedSignal(
+      controller.signal,
+      async (signal) => signal.aborted
+    );
+
+    expect(seen).toBe(true);
+  });
+
+  it("runs without a source signal", async () => {
+    const seen = await runToolCallWithDetachedSignal(
+      undefined,
+      async (signal) => {
+        expect(signal).toBeInstanceOf(AbortSignal);
+        return signal.aborted;
+      }
+    );
+
+    expect(seen).toBe(false);
   });
 });

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -292,6 +292,42 @@ function generateRemoteContentMetadata(content: CallToolResult["content"]): {
 }
 
 /**
+ * Runs `callTool` with a throwaway per-call signal so `compositeSignal` retains
+ * nothing once the call settles.
+ *
+ * The MCP SDK (v1.x) adds an `abort` listener to the signal we pass and never
+ * removes it. Since `compositeSignal` is pod-lifetime (composed with the shutdown
+ * signal in `temporal/agent_loop/activities/run_tool.ts`), that listener would pin
+ * every tool result until the pod dies — an OOM over thousands of calls.
+ *
+ * We bridge aborts onto a fresh controller and detach the bridge in `finally`, so
+ * the SDK's dangling listener hangs off a collectable per-call signal instead.
+ */
+export async function runToolCallWithDetachedSignal<T>(
+  compositeSignal: AbortSignal | undefined,
+  callTool: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  const perToolCallController = new AbortController();
+
+  if (!compositeSignal) {
+    return callTool(perToolCallController.signal);
+  }
+
+  if (compositeSignal.aborted) {
+    perToolCallController.abort(compositeSignal.reason);
+    return callTool(perToolCallController.signal);
+  }
+
+  const onAbort = () => perToolCallController.abort(compositeSignal.reason);
+  compositeSignal.addEventListener("abort", onAbort, { once: true });
+  try {
+    return await callTool(perToolCallController.signal);
+  } finally {
+    compositeSignal.removeEventListener("abort", onAbort);
+  }
+}
+
+/**
  * Try to call an MCP tool.
  *
  * May fail when connecting to remote/client-side servers.
@@ -457,21 +493,27 @@ export async function* tryCallMCPTool(
       "mcp.tool.call",
       { resource: toolConfiguration.originalName },
       async () =>
-        client.callTool(
-          {
-            name: toolConfiguration.originalName,
-            arguments: inputs,
-            _meta: {
-              ...toolConfiguration.meta,
-              progressToken,
+        // Hand the SDK a throwaway per-call signal instead of `abortSignal`.
+        // The SDK attaches an `abort` listener it never removes; `abortSignal`
+        // is composed with the pod-lifetime shutdown signal, so that listener
+        // would pin the tool result until the pod dies.
+        runToolCallWithDetachedSignal(abortSignal, (signal) =>
+          client.callTool(
+            {
+              name: toolConfiguration.originalName,
+              arguments: inputs,
+              _meta: {
+                ...toolConfiguration.meta,
+                progressToken,
+              },
             },
-          },
-          CallToolResultSchema,
-          {
-            timeout:
-              toolConfiguration.timeoutMs ?? DEFAULT_MCP_REQUEST_TIMEOUT_MS,
-            signal: abortSignal,
-          }
+            CallToolResultSchema,
+            {
+              timeout:
+                toolConfiguration.timeoutMs ?? DEFAULT_MCP_REQUEST_TIMEOUT_MS,
+              signal,
+            }
+          )
         )
     );
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -315,6 +315,9 @@ export async function runToolCallWithDetachedSignal<T>(
   }
 
   if (compositeSignal.aborted) {
+    // Even if it's already aborted we still make a tool call
+    // so it runs its normal abort path (which rejects the call) rather
+    // than us inventing a separate error.
     perToolCallController.abort(compositeSignal.reason);
     return callTool(perToolCallController.signal);
   }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -298,10 +298,11 @@ function generateRemoteContentMetadata(content: CallToolResult["content"]): {
  * The MCP SDK (v1.x) adds an `abort` listener to the signal we pass and never
  * removes it. Since `compositeSignal` is pod-lifetime (composed with the shutdown
  * signal in `temporal/agent_loop/activities/run_tool.ts`), that listener would pin
- * every tool result until the pod dies — an OOM over thousands of calls.
+ * every tool result until the pod dies.
  *
  * We bridge aborts onto a fresh controller and detach the bridge in `finally`, so
  * the SDK's dangling listener hangs off a collectable per-call signal instead.
+ * We can remove this once we upgrade to v2 when it's stable.
  */
 export async function runToolCallWithDetachedSignal<T>(
   compositeSignal: AbortSignal | undefined,


### PR DESCRIPTION
## Description
This PR is my attempt to fix memory leak in agent loop worker. 

I have multiple snapshots from agent loop worker, and most of them are retained by `gcPersistentSignals`. For example in one of my snapshots:
```
- Total heap self-size: ~1856 MB
- Retained by gcPersistentSignals: ~753 MB (40.6%)
```

Below is Yuka's current understanding of what is happening, I might be wrong so be extra careful when you read it 🫡

<details>
<summary>What is an AbortController/AbortSignal?</summary>

`AbortController` is the way to cancel fetch requests or other asynchronous operations.

For example, the following fetch will be cancelled if it doesn't finish within 5000ms: 
```
const controller = new AbortController();
const signal = controller.signal;

setTimeout(() => controller.abort(), 5000);

fetch(url, { signal }).then(response => {
    return response.text();
}).then(text => {
    console.log(text);
});
```
(note: you can now also use AbortSignal.timeout instead of setTimeout:  `await fetch(url, { signal: AbortSignal.timeout(5000) })`)

You can attach an event listener to the signal:
```
signal.addEventListener('abort', () => {
    console.log(signal.aborted); // logs true
});
```
</details>

--- 

<details open>

<summary>Why there is a memory leak and what is gcPersistentSignals?</summary>

There is a bug in MCP sdk, they attach an event listener to the abort signal but never remove it, and also it doesn't have `{ once: true }` (meaning that even if it's aborted the listener will not be removed, you can read more about `once` [here](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#once_)).

https://github.com/modelcontextprotocol/typescript-sdk/blob/v1.27.1/src/shared/protocol.ts#L1202-L1204
```
            options?.signal?.addEventListener('abort', () => {
                cancel(options?.signal?.reason);
            });
```

The event listener they attach captures `cancel`, which carries [a reject function](https://github.com/modelcontextprotocol/typescript-sdk/blob/v1.27.1/src/shared/protocol.ts#L1177) and it is a closure that points back at the whole Promise. A settled promise retains its fulfillment value `([[PromiseResult]])` in V8, because the abort listener is never removed, reject stays reachable indefinitely, and the result of every past tool call accumulates in memory for the lifetime of the pod.
 
This bug is fixed in v2 alpha version but not in v1. If you use a single abort signal and it's garbage collectable, this bug is harmless, because once V8 cannot reach the abort signal, everything (the listener, handler, and its closure) will be garbage collected.  

However, the problem is we pass a composite signal and one of them is non garbage collectable: 

https://github.com/dust-tt/dust/blob/main/front/temporal/agent_loop/activities/run_tool.ts#L210-L214
```
  const abortSignal = AbortSignal.any([
    Context.current().cancellationSignal,
    getShutdownSignal(),
  ]);
```
 
`getShutdownSignal` is a singleton that is [declared at module level](https://github.com/dust-tt/dust/blob/main/front/lib/shutdown_signal.ts#L47-L49) which will never be garbaged collected during the entire pod lifecycle.  


When you call `AbortSignal.any([toolCallSignal, getShutdownSignal()])`, Node.js wires up two pointers between each source and the composite signal:
```
        ┌──────────── WeakRef ───────────►┐
   source signal                      composite signal
        ◄─────────── WeakRef ────────────┘
```

It's a [WeakRef](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef), so even if one of the sources is still alive, the composite signal can be garbage collected once nothing strongly references it.

However, if you add an event listener to a composite signal, you don't want the signal to be garbage collected (otherwise nothing happens when abort is fired). So Node.js will add a composite signal to `gcPersistentSignals` while it has an abort listener AND still has at least one live source. This will strongly reference the signal:

https://github.com/nodejs/node/blob/ccdfb374383a3b0126693089780314f967881d20/lib/internal/abort_controller.js#L238-L252

```
  [kNewListener](size, type, listener, once, capture, passive, weak) {
    super[kNewListener](size, type, listener, once, capture, passive, weak);
    const isTimeoutOrNonEmptyCompositeSignal = this[kTimeout] || (this[kComposite] && this[kSourceSignals]?.size);
    if (isTimeoutOrNonEmptyCompositeSignal &&
        type === 'abort' &&
        !this.aborted &&
        !weak &&
        size === 1) {
      // If this is a timeout signal, or a non-empty composite signal, and we're adding a non-weak abort
      // listener, then we don't want it to be gc'd while the listener
      // is attached and the timer still hasn't fired. So, we retain a
      // strong ref that is held for as long as the listener is registered.
      gcPersistentSignals.add(this);
    }
  }
```

It will be removed from `gcPersistentSignals` only when the listener count drops back to 0 or both sources are gone. It will never happen in our case because sdk doesn't remove the listener when it's completed or aborted, and one of sources is alive forever.

So the retention chain is:
```gcPersistentSignals → composite signal → abort listener → cancel closure → reject → Promise → [[PromiseResult]] ```
</details>

<details open>
<summary>How can we fix it?</summary>
The MCP SDK attaches an abort listener that we have no way to remove. So instead of handing it the composite signal, we hand it a signal from a locally scoped AbortController. Because that signal is a non-composite signal, Node.js never adds it to `gcPersistentSignals` and because it's only referenced locally, it is garbage collected once the tool call ends (along with the SDK's listener and the retained tool result). if the composite signal receives an abort event (pod shutdown or workflow cancellation), our bridge listener forwards the abort, with its reason, to the per-call AbortController, so the in-flight tool call is still cancellable (I think??).

</details> 


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
