### PR TITLE
[front] enh: Display code-defined skills instructions

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -6,6 +6,7 @@ import {
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -139,6 +140,40 @@ describe("GET /api/w/:wId/skills/:sId", () => {
     expect(data).toHaveProperty("skill");
     expect(data.skill.sId).toBe(skill.sId);
     expect(data.skill.name).toBe("Test Skill");
+  });
+
+  it("should hide instructions for a code-defined skill that has not opted in", async () => {
+    // Code-defined skills hide their prompt from the front-end by default; only
+    // skills that set exposeInstructions (e.g. docs/pptx/xlsx) surface it. Frames
+    // is intentionally kept opaque.
+    const { workspace } = await setupTest({ requestUserRole: "admin" });
+
+    const response = await getSkill(workspace, "frames");
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.skill.sId).toBe("frames");
+    expect(data.skill.instructions).toBeNull();
+    expect(data.skill.instructionsHtml).toBeNull();
+  });
+
+  it("should expose instructions for an opted-in code-defined skill", async () => {
+    // pptx sets exposeInstructions: true, so its prompt is surfaced on the detail
+    // fetch as plain markdown (instructionsHtml stays null). The skill is gated
+    // behind the computer feature, so enable it first.
+    const { workspace, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+    await FeatureFlagFactory.basic(requestUserAuth, "sandbox_tools");
+
+    const response = await getSkill(workspace, "pptx");
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.skill.sId).toBe("pptx");
+    expect(typeof data.skill.instructions).toBe("string");
+    expect(data.skill.instructions.length).toBeGreaterThan(0);
+    expect(data.skill.instructionsHtml).toBeNull();
   });
 
   it("should return child skills", async () => {

--- a/front/lib/resources/skill/code_defined/docx.ts
+++ b/front/lib/resources/skill/code_defined/docx.ts
@@ -130,6 +130,7 @@ export const docxSkill = {
   agentFacingDescription:
     "Work with .docx and .doc files in the sandbox using python-docx.",
   instructions: DOCX_SKILL_INSTRUCTIONS,
+  exposeInstructions: true,
   mcpServers: [{ name: "sandbox" }],
   version: 1,
   icon: "ActionDocumentTextIcon",

--- a/front/lib/resources/skill/code_defined/pptx.ts
+++ b/front/lib/resources/skill/code_defined/pptx.ts
@@ -342,6 +342,7 @@ export const pptxSkill = {
     "text, charts, tables, media) so existing decks can be adapted in place " +
     "via python-pptx rather than rebuilt from scratch with pptxgenjs.",
   instructions: PPTX_SKILL_INSTRUCTIONS,
+  exposeInstructions: true,
   mcpServers: [{ name: "sandbox" }],
   version: 1,
   icon: "ActionSlideshowIcon",

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -23,6 +23,11 @@ interface BaseSkillDefinition {
   readonly icon: string;
   readonly mcpServers?: MCPServerDefinition[];
   readonly inheritAgentConfigurationDataSources?: boolean;
+  // When true, the skill's instructions are exposed to the front-end so builders
+  // can read them in the skill details panel and build on top of the skill.
+  // Defaults to false: code-defined skill instructions are hidden by default and
+  // opted in per skill (e.g. docs/pptx/xlsx). System skills stay hidden.
+  readonly exposeInstructions?: boolean;
   readonly isRestricted?: (auth: Authenticator) => Promise<boolean>;
   // Optional callback to auto-equip a code-defined skill for an agent loop (subject to
   // isRestricted), without enabling it. Return true to make the skill available through

--- a/front/lib/resources/skill/code_defined/xlsx.ts
+++ b/front/lib/resources/skill/code_defined/xlsx.ts
@@ -132,6 +132,7 @@ export const xlsxSkill = {
     "(sheets, formulas, cached values, formatting) so templates can be " +
     "adapted in place rather than rewritten.",
   instructions: XLSX_SKILL_INSTRUCTIONS,
+  exposeInstructions: true,
   mcpServers: [{ name: "sandbox" }],
   version: 2,
   icon: "ActionTableIcon",

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -122,6 +122,8 @@ type SkillResourceConstructorOptions =
       // For global skills, there is no editor group.
       dataSourceConfigurations: SkillDataSourceConfigurationModel[];
       editorGroup?: undefined;
+      // When true, the global skill's instructions are exposed to the front-end.
+      exposeInstructions?: boolean;
       fileAttachments: FileResource[];
       globalSId: string;
       mcpServerConfigurations: SkillMCPServerConfiguration[];
@@ -130,6 +132,8 @@ type SkillResourceConstructorOptions =
   | {
       dataSourceConfigurations: SkillDataSourceConfigurationModel[];
       editorGroup?: GroupResource;
+      // Custom skills always expose their own instructions; this flag is unused.
+      exposeInstructions?: undefined;
       fileAttachments: FileResource[];
       globalSId?: undefined;
       mcpServerConfigurations: SkillMCPServerConfiguration[];
@@ -228,6 +232,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   readonly version: number | null = null;
 
   private readonly globalSId: string | null;
+  // Only meaningful for global skills: whether their instructions may be
+  // serialized to the front-end. Custom skills always expose their own.
+  private readonly exposeInstructions: boolean;
 
   private _mcpServerConfigurations: SkillMCPServerConfiguration[];
 
@@ -236,6 +243,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     blob: Attributes<SkillConfigurationModel>,
     {
       dataSourceConfigurations,
+      exposeInstructions,
       fileAttachments,
       globalSId,
       mcpServerConfigurations,
@@ -247,6 +255,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     this.dataSourceConfigurations = dataSourceConfigurations;
     this.editorGroup = editorGroup ?? null;
+    this.exposeInstructions = exposeInstructions ?? false;
     this.fileAttachments = fileAttachments ?? [];
     this.globalSId = globalSId ?? null;
     this._mcpServerConfigurations = mcpServerConfigurations;
@@ -1755,6 +1764,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       {
         // Global skills do not have data source configurations.
         dataSourceConfigurations: [],
+        exposeInstructions: def.exposeInstructions,
         globalSId: def.sId,
         mcpServerConfigurations,
         fileAttachments: [],
@@ -3633,6 +3643,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       })
     );
 
+    // Code-defined (global) skills hide their instructions from the front-end by
+    // default; a skill opts in via `exposeInstructions` in its definition (e.g.
+    // docs/pptx/xlsx) so builders can read and build on top of it. System skills
+    // and the rest stay opaque. Custom skills always expose their own
+    // instructions. The list endpoints strip instructions/tools regardless, and
+    // the public v1 API only returns custom skills, so this only surfaces on the
+    // single-skill detail fetch.
+    const hideInstructions =
+      this.globalSId !== null && !this.exposeInstructions;
+
     return {
       id: this.id,
       sId: this.sId,
@@ -3643,9 +3663,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       name: this.name,
       agentFacingDescription: this.agentFacingDescription,
       userFacingDescription: this.userFacingDescription,
-      // We don't want to expose global skills instructions to the front-end.
-      instructions: this.globalSId ? null : this.instructions,
-      instructionsHtml: this.globalSId ? null : this.instructionsHtml,
+      instructions: hideInstructions ? null : this.instructions,
+      instructionsHtml: hideInstructions ? null : this.instructionsHtml,
       requestedSpaceIds,
       icon: this.icon ?? null,
       reinforcement: this.reinforcement,


### PR DESCRIPTION
## Description

In a skills in skills world, we might want people to start building on top of the code-defined, dust-curated skills (at least in my case for pptx).

Right now, you can't look at their instructions (except if you look at our code)

This is a 80/20 fix for that.

Not strongly held on the solution, somewhat held on the necessity to do it though.


## Tests

Tested locally

## Risk

Low

## Deploy Plan

Deploy front