### PR TITLE
Fix blank-line/blank-list-item artifacts in suggestion diff preview

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -569,6 +569,244 @@ describe("InstructionSuggestionExtension", () => {
     });
   });
 
+  describe("diff rendering artifacts (blank line / blank list item)", () => {
+    // Addition widgets should render inline content; a block-level element
+    // (<p>, <li>) inside one means a wrapper leaked and renders as a phantom
+    // line/row. These helpers detect that.
+    function getAdditionWidgets(editor: Editor) {
+      return Array.from(
+        editor.view.dom.querySelectorAll(
+          ".suggestion-addition.ProseMirror-widget"
+        )
+      );
+    }
+
+    function getBlockLevelAdditions(editor: Editor) {
+      return Array.from(
+        editor.view.dom.querySelectorAll(".suggestion-addition")
+      ).filter((el) => ["P", "LI", "DIV"].includes(el.tagName));
+    }
+
+    it("renders a smart-quote swap inline without a phantom line", () => {
+      const { schema } = editor.state;
+
+      // A multi-paragraph block (instructionBlock content is `block+`).
+      const makeBlock = (apostrophe: string) =>
+        schema.node("instructionBlock", { type: "rules" }, [
+          schema.node("paragraph", null, [schema.text("First line stays")]),
+          schema.node("paragraph", null, [
+            schema.text(`Don${apostrophe}t change me`),
+          ]),
+        ]);
+
+      // Only the apostrophe (U+0027 -> U+2019) changes: exactly one inline change.
+      const changes = diffBlockContent(makeBlock("'"), makeBlock("’"), schema);
+      expect(changes).toHaveLength(1);
+
+      // Render it through the extension.
+      editor.commands.setContent(
+        ["<rules>", "First line stays", "", "Don't change me", "</rules>"].join(
+          "\n"
+        ),
+        { contentType: "markdown" }
+      );
+
+      let blockId: string | null = null;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === "instructionBlock") {
+          blockId = node.attrs[BLOCK_ID_ATTRIBUTE];
+          return false;
+        }
+        return true;
+      });
+      expect(blockId).not.toBeNull();
+
+      editor.commands.applySuggestion({
+        id: "smart-quote",
+        targetBlockId: blockId!,
+        content: `<div data-type="instruction-block" data-instruction-type="rules"><p>First line stays</p><p>Don’t change me</p></div>`,
+      });
+
+      // The straight quote is struck through inline.
+      const deletions = getDeletions(editor);
+      expect(deletions).toHaveLength(1);
+      expect(deletions[0].text).toBe("'");
+
+      // The curly quote is added inline — no phantom block (<p>) on its own line.
+      expect(getBlockLevelAdditions(editor)).toHaveLength(0);
+
+      const widgets = getAdditionWidgets(editor);
+      expect(widgets).toHaveLength(1);
+      expect(widgets[0].textContent).toBe("’");
+    });
+
+    it("edits one item in an ordered list without rendering a blank list item", () => {
+      editor.commands.setContent("1. Keep this\n2. Second item", {
+        contentType: "markdown",
+      });
+
+      let listBlockId: string | null = null;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === "orderedList") {
+          listBlockId = node.attrs[BLOCK_ID_ATTRIBUTE];
+          return false;
+        }
+        return true;
+      });
+      expect(listBlockId).not.toBeNull();
+
+      // Edit only the second item ("item" -> "task"); the first is untouched.
+      editor.commands.applySuggestion({
+        id: "list-one",
+        targetBlockId: listBlockId!,
+        content:
+          "<ol><li><p>Keep this</p></li><li><p>Second task</p></li></ol>",
+      });
+
+      // No empty list item is rendered.
+      const emptyListItems = Array.from(
+        editor.view.dom.querySelectorAll("li")
+      ).filter((li) => (li.textContent ?? "").trim() === "");
+      expect(emptyListItems).toHaveLength(0);
+
+      // The addition stays inline (no <li>/<p> block leaked into the preview).
+      expect(getBlockLevelAdditions(editor)).toHaveLength(0);
+
+      // One genuinely changed item -> one addition widget.
+      const widgets = getAdditionWidgets(editor);
+      expect(widgets).toHaveLength(1);
+      expect(widgets[0].textContent).toBe("task");
+    });
+
+    it("edits multiple list items without rendering blank list items", () => {
+      editor.commands.setContent("1. First item\n2. Second item", {
+        contentType: "markdown",
+      });
+
+      let listBlockId: string | null = null;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === "orderedList") {
+          listBlockId = node.attrs[BLOCK_ID_ATTRIBUTE];
+          return false;
+        }
+        return true;
+      });
+      expect(listBlockId).not.toBeNull();
+
+      // Append a distinct suffix to each item -> exactly one addition per item.
+      editor.commands.applySuggestion({
+        id: "list-both",
+        targetBlockId: listBlockId!,
+        content:
+          "<ol><li><p>First item one</p></li><li><p>Second item two</p></li></ol>",
+      });
+
+      const emptyListItems = Array.from(
+        editor.view.dom.querySelectorAll("li")
+      ).filter((li) => (li.textContent ?? "").trim() === "");
+      expect(emptyListItems).toHaveLength(0);
+
+      expect(getBlockLevelAdditions(editor)).toHaveLength(0);
+
+      // Two changed items -> two addition widgets.
+      const widgets = getAdditionWidgets(editor);
+      expect(widgets).toHaveLength(2);
+      expect(widgets.map((w) => w.textContent)).toEqual([" one", " two"]);
+    });
+
+    it("inserts an empty paragraph as a single blank widget, not two", () => {
+      // A blank line inserted between two paragraphs renders as one blank widget.
+      editor.commands.setContent(
+        ["<rules>", "First", "", "Last", "</rules>"].join("\n"),
+        { contentType: "markdown" }
+      );
+
+      let blockId: string | null = null;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === "instructionBlock") {
+          blockId = node.attrs[BLOCK_ID_ATTRIBUTE];
+          return false;
+        }
+        return true;
+      });
+      expect(blockId).not.toBeNull();
+
+      editor.commands.applySuggestion({
+        id: "blank-line",
+        targetBlockId: blockId!,
+        content: `<div data-type="instruction-block" data-instruction-type="rules"><p>First</p><p></p><p>Last</p></div>`,
+      });
+
+      // Exactly one (empty) addition widget for the single inserted blank line.
+      const widgets = getAdditionWidgets(editor);
+      expect(widgets).toHaveLength(1);
+      const emptyParagraphAdditions = widgets[0].querySelectorAll("p");
+      expect(emptyParagraphAdditions).toHaveLength(1);
+    });
+
+    it("edits a list item's first word inline (change touches the item start)", () => {
+      // The change starts at the item's first character, so its slice touches
+      // the list-item boundary — it must still render inline, not as a row.
+      editor.commands.setContent("1. First item\n2. Second item", {
+        contentType: "markdown",
+      });
+
+      let listBlockId: string | null = null;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === "orderedList") {
+          listBlockId = node.attrs[BLOCK_ID_ATTRIBUTE];
+          return false;
+        }
+        return true;
+      });
+      expect(listBlockId).not.toBeNull();
+
+      editor.commands.applySuggestion({
+        id: "first-word",
+        targetBlockId: listBlockId!,
+        content:
+          "<ol><li><p>First item</p></li><li><p>Renamed item</p></li></ol>",
+      });
+
+      const emptyListItems = Array.from(
+        editor.view.dom.querySelectorAll("li")
+      ).filter((li) => (li.textContent ?? "").trim() === "");
+      expect(emptyListItems).toHaveLength(0);
+      expect(getBlockLevelAdditions(editor)).toHaveLength(0);
+      expect(getAdditionWidgets(editor).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("renders an inserted empty list item as a single blank row, not doubled", () => {
+      editor.commands.setContent("1. A\n2. B\n3. C", {
+        contentType: "markdown",
+      });
+
+      let listBlockId: string | null = null;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === "orderedList") {
+          listBlockId = node.attrs[BLOCK_ID_ATTRIBUTE];
+          return false;
+        }
+        return true;
+      });
+      expect(listBlockId).not.toBeNull();
+
+      // An empty list item is `listItem > paragraph()` — non-zero size, so the
+      // shallow size check would let two copies through.
+      editor.commands.applySuggestion({
+        id: "empty-item",
+        targetBlockId: listBlockId!,
+        content:
+          "<ol><li><p>A</p></li><li><p>B</p></li><li><p></p></li><li><p>C</p></li></ol>",
+      });
+
+      const emptyListItems = Array.from(
+        editor.view.dom.querySelectorAll("li")
+      ).filter((li) => (li.textContent ?? "").trim() === "");
+      expect(emptyListItems).toHaveLength(1);
+    });
+  });
+
   describe("markdown parsing resilience", () => {
     it("should handle angle-bracketed non-HTML tokens like <URL>", () => {
       const escaped = preprocessMarkdownForEditor("Test <URL>");

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -2,7 +2,7 @@ import { BLOCK_ID_ATTRIBUTE } from "@app/components/editor/extensions/instructio
 import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import { Extension } from "@tiptap/core";
-import type { Node as PMNode, Schema } from "@tiptap/pm/model";
+import type { Node as PMNode, Schema, Slice } from "@tiptap/pm/model";
 import {
   DOMSerializer,
   Fragment,
@@ -173,6 +173,42 @@ function findBlockByBlockId(
   return result;
 }
 
+// Returns the content to render in an addition widget for an inserted slice.
+// Diff ranges include nested block boundaries, so a slice can wrap an
+// inline-level change in its containing block(s). When the change stays within
+// one text block, the slice is open on both ends and forms a single block chain
+// — drill down to the inline content so it renders inline rather than as a
+// phantom <p>/<li>. A genuine new block comes through closed (open depth 0) or
+// as multiple children, so it keeps its structure. Each level peeled reduces the
+// open depth by one (an open boundary always cuts through a non-leaf node, so
+// firstChild is safe to descend into).
+function inlineContentForInsertion(slice: Slice): Fragment {
+  let { content } = slice;
+  let { openStart, openEnd } = slice;
+
+  while (
+    openStart > 0 &&
+    openEnd > 0 &&
+    content.childCount === 1 &&
+    !content.firstChild!.isInline
+  ) {
+    content = content.firstChild!.content;
+    openStart -= 1;
+    openEnd -= 1;
+  }
+
+  // Drop empty leading blocks so an inserted blank line or empty list item
+  // doesn't render as extra blank widgets. `textContent` (not content.size)
+  // catches empty wrappers like listItem > paragraph(), whose size is non-zero.
+  // The childCount guard keeps the node when the whole insertion is one empty
+  // block, so a single inserted blank line still shows one widget.
+  while (content.childCount > 1 && content.firstChild!.textContent === "") {
+    content = content.cut(content.firstChild!.nodeSize);
+  }
+
+  return content;
+}
+
 // Create inline diff decorations for a single block (deletion + addition widgets).
 function buildBlockDecorations({
   applyBlockHighlight,
@@ -221,7 +257,6 @@ function buildBlockDecorations({
     }
 
     if (change.fromB !== change.toB) {
-      const insertedSlice = newNode.content.cut(change.fromB, change.toB);
       const isCrossType = oldNode.type !== newNode.type;
       // When old block is a different type, place the addition after it so the new content doesn't render inside the old block's container.
       const widgetPos = isCrossType
@@ -247,7 +282,10 @@ function buildBlockDecorations({
               const blockEl = serializer.serializeNode(newNode, {});
               span.appendChild(blockEl);
             } else {
-              serializer.serializeFragment(insertedSlice, {}, span);
+              const insertedContent = inlineContentForInsertion(
+                newNode.slice(change.fromB, change.toB)
+              );
+              serializer.serializeFragment(insertedContent, {}, span);
             }
 
             // Apply styling to all child elements to ensure visibility in nested structures (e.g., list items)


### PR DESCRIPTION
fix https://github.com/dust-tt/tasks/issues/9219
## Description
The suggestion diff preview rendered spurious blank lines and blank list items: swapping a straight apostrophe for a curly one added a phantom line, and editing a list item rendered an empty row before the change. The accepted content was always correct — this was purely a decoration rendering artifact.

Root cause: diffBlockContent() returns change ranges in the block's full content space, which includes the open/close tokens of nested blocks (paragraphs, list items). buildBlockDecorations then cut newNode at those positions and serialized the result, so an inline-level change inside a block-with-block-children got re-wrapped in its containing <p>/<li> and rendered inline as a phantom block.

Fix: take a real Slice and unwrap single-chain block wrappers when the change is contained within one text block (open on both ends), and drop a leading empty block left by an empty-paragraph insertion. Genuine cross-block / new-block additions keep their structure. acceptSuggestion semantics are unchanged.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
Before:
<img width="1888" height="444" alt="Screenshot 2026-06-25 at 3 19 15 PM" src="https://github.com/user-attachments/assets/0839dc89-6bfe-4df5-a474-0f19e3e08af6" />

After:
<img width="888" height="262" alt="Screenshot 2026-06-25 at 3 07 28 PM" src="https://github.com/user-attachments/assets/32d7ea98-e95f-478b-b20e-90de96ef5a40" />


<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
