### PR TITLE
Fix: make compact bar UI more visible now with the optmimized scrolling, fix the live transcribe on mobile.

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -384,7 +384,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     context.projectSpaceName
   ) {
     return (
-      <div className="relative z-20 mx-auto flex w-full flex-col pt-4 pb-6 sm:w-full sm:max-w-conversation">
+      <div className="relative z-20 mx-auto flex w-full flex-col pt-4 pb-6 md:max-w-conversation">
         <PodJoinCTA
           owner={context.owner}
           podId={context.projectId}
@@ -461,7 +461,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
 
   if (context.projectId && context.isProjectArchived) {
     return (
-      <div className="mx-auto flex flex-col w-full py-4 sm:max-w-conversation">
+      <div className="mx-auto flex w-full flex-col py-4 md:max-w-conversation">
         <EmptyCTA
           message="This conversation belongs to an archived Pod. No new messages can be sent."
           action={null}
@@ -473,7 +473,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
   return (
     <div
       className={classNames(
-        "relative z-20 mx-auto flex w-full flex-col pt-4 pb-6 sm:w-full sm:max-w-conversation"
+        "relative z-20 mx-auto flex w-full flex-col pt-4 pb-6 md:max-w-conversation"
       )}
     >
       <div className="flex w-full justify-center gap-2">

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -273,7 +273,7 @@ export function ConversationContainerVirtuoso({
             className={classNames(
               "sticky bottom-0 z-20 flex max-h-dvh w-full",
               "pb-2",
-              "sm:w-full sm:max-w-conversation sm:pb-4"
+              "md:w-full md:max-w-conversation md:pb-4"
             )}
           >
             <InputBar

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -3,7 +3,6 @@ import { getWorkspaceLimitForSubmitError } from "@app/components/app/ReachedLimi
 import { ConversationViewerEmptyState } from "@app/components/assistant/ConversationViewerEmptyState";
 import { AgentInputBar } from "@app/components/assistant/conversation/AgentInputBar";
 import { ConversationBranchApprovalModal } from "@app/components/assistant/conversation/ConversationBranchApprovalModal";
-import { ConversationErrorDisplay } from "@app/components/assistant/conversation/ConversationError";
 import {
   parseDataAsMessageIdAndActionId,
   useConversationSidePanelContext,
@@ -103,6 +102,7 @@ import {
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { mutate } from "swr";
+import { ConversationErrorDisplay } from "./ConversationError";
 import { findFirstUnreadMessageIndex } from "./utils";
 
 const DEFAULT_PAGE_LIMIT = 50;
@@ -1526,7 +1526,7 @@ export const ConversationViewer = ({
           EmptyPlaceholder={ConversationViewerEmptyState}
           // Large buffer to avoid manipulating the dom too much when the user scrolls a bit.
           increaseViewportBy={8192}
-          enforceStickyFooterAtBottom={!isMobile}
+          enforceStickyFooterAtBottom
         />
       </VirtuosoMessageListLicense>
     </>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -440,7 +440,7 @@ export const InputBar = React.memo(function InputBar({
         }}
         className={classNames(
           isShaking && "animate-shake",
-          "relative flex flex-col items-stretch gap-0 sm:flex-row",
+          "relative flex flex-col items-stretch gap-0 md:flex-row",
           INPUT_BAR_COMPACT_MORPH_TRANSITION_CLASSES,
           !effectiveIsCompact && "w-full flex-1 self-stretch",
           effectiveIsCompact
@@ -454,13 +454,13 @@ export const InputBar = React.memo(function InputBar({
                 "bg-muted-background dark:bg-muted-background-night",
                 "border",
                 "border-border-dark dark:border-border-dark/10",
-                "sm:border-border-dark/50 sm:has-[.tiptap:focus]:border-border-dark",
-                "dark:has-[.tiptap:focus]:border-border-dark-night sm:has-[.tiptap:focus]:border-border-dark",
+                "md:border-border-dark/50 md:has-[.tiptap:focus]:border-border-dark",
+                "dark:has-[.tiptap:focus]:border-border-dark-night md:has-[.tiptap:focus]:border-border-dark",
                 isFloating
                   ? classNames(
                       "has-[.tiptap:focus]:ring-1 dark:has-[.tiptap:focus]:ring-1",
                       "dark:has-[.tiptap:focus]:ring-highlight/30-night has-[.tiptap:focus]:ring-highlight/30",
-                      "sm:has-[.tiptap:focus]:ring-2 dark:sm:has-[.tiptap:focus]:ring-2"
+                      "md:has-[.tiptap:focus]:ring-2 dark:md:has-[.tiptap:focus]:ring-2"
                     )
                   : classNames(
                       "has-[.tiptap:focus]:border-highlight-300",

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1315,7 +1315,7 @@ const InputBarContainer = ({
     "inline-block w-full",
     "border-0 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
     "whitespace-pre-wrap font-normal",
-    "px-3 sm:pl-4 pt-3 sm:pt-3.5"
+    "px-3 md:pl-4 pt-3 md:pt-3.5"
   );
 
   const isRecording = activeVoiceService.status === "recording";
@@ -1378,7 +1378,7 @@ const InputBarContainer = ({
           className={cn(
             INPUT_BAR_COMPACT_PILL_INNER_CLASSES,
             INPUT_BAR_COMPACT_CONTENT_ENTER_ANIMATION_CLASSES,
-            "relative min-w-0 w-full gap-1 px-1 sm:pt-0"
+            "relative min-w-0 w-full gap-1 px-1 md:pt-0"
           )}
         >
           {!isVoiceActive && (
@@ -1388,7 +1388,7 @@ const InputBarContainer = ({
                 INPUT_BAR_COMPACT_PREVIEW_CLASSES,
                 compactPreviewText
                   ? "text-foreground dark:text-foreground-night"
-                  : "text-faint dark:text-faint-night"
+                  : "text-muted-foreground dark:text-muted-foreground-night"
               )}
             >
               {compactPreviewText || compactDisplayPlaceholder}
@@ -1410,7 +1410,7 @@ const InputBarContainer = ({
                   elapsedSeconds={activeVoiceService.elapsedSeconds}
                   onRecordStart={activeVoiceService.startRecording}
                   onRecordStop={activeVoiceService.stopRecording}
-                  size="xs"
+                  size="sm"
                   compact
                   showStopLabel={false}
                   disabled={disableInput}
@@ -1422,7 +1422,7 @@ const InputBarContainer = ({
       <div
         id="InputBarContainer"
         className={cn(
-          "relative flex flex-1 cursor-text flex-row transition-opacity duration-200 sm:pt-0",
+          "relative flex flex-1 cursor-text flex-row transition-opacity duration-200 md:pt-0",
           isCompact &&
             "pointer-events-none absolute h-0 w-0 overflow-hidden opacity-0"
         )}
@@ -1444,7 +1444,7 @@ const InputBarContainer = ({
                 contentEditableClasses,
                 "scrollbar-hide",
                 "overflow-y-auto",
-                "max-h-[40vh] min-h-14 sm:min-h-16"
+                "max-h-[40vh] min-h-14 md:min-h-16"
               )}
             />
           </div>
@@ -1459,7 +1459,7 @@ const InputBarContainer = ({
             )}
           </BubbleMenu>
           <div
-            className={cn("flex w-full flex-col", "py-1.5 sm:pb-2")}
+            className={cn("flex w-full flex-col", "py-1.5 md:pb-2")}
             style={{
               transition: `padding ${COLLAPSE_TRANSITION}`,
             }}

--- a/front/components/assistant/conversation/input_bar/InputBarMessageNavigation.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarMessageNavigation.tsx
@@ -1,12 +1,13 @@
 import {
   INPUT_BAR_COMPACT_PILL_CLASSES,
   INPUT_BAR_COMPACT_PILL_INNER_CLASSES,
+  INPUT_BAR_SURFACE_CLASSES,
 } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
-import { classNames } from "@app/lib/utils";
 import {
   ArrowDown,
   ArrowUp,
   Button,
+  cn,
   IconButton,
   Stop,
   Zap,
@@ -56,7 +57,7 @@ export function InputBarMessageNavigation({
         <Button
           variant="ghost-secondary"
           icon={icon}
-          size="xs"
+          size="mini"
           onClick={onClick}
           disabled={disabled}
           aria-label={ariaLabel}
@@ -83,7 +84,7 @@ export function InputBarMessageNavigation({
         label={stopButtonLabel}
         onClick={onStopClick}
         disabled
-        size="xs"
+        size={variant === "compact" ? "mini" : "xs"}
       />
     ) : (
       <Button
@@ -93,7 +94,7 @@ export function InputBarMessageNavigation({
         aria-label={variant === "compact" ? stopButtonLabel : undefined}
         onClick={onStopClick}
         disabled={pendingAction !== null}
-        size="xs"
+        size={variant === "compact" ? "mini" : "xs"}
       />
     );
 
@@ -136,8 +137,9 @@ export function InputBarMessageNavigation({
 
   return (
     <div
-      className={classNames(
-        "flex items-center gap-1 rounded-xl border border-border bg-white p-1 dark:border-border-night dark:bg-muted-night"
+      className={cn(
+        "flex items-center gap-1 rounded-xl p-1",
+        INPUT_BAR_SURFACE_CLASSES
       )}
       style={{
         position: "absolute",

--- a/front/components/assistant/conversation/input_bar/inputBarCompactStyles.ts
+++ b/front/components/assistant/conversation/input_bar/inputBarCompactStyles.ts
@@ -1,11 +1,23 @@
-export const INPUT_BAR_COMPACT_PILL_CLASSES =
-  "min-w-0 w-full rounded-full border border-border/30 bg-muted-background/60 px-1 py-0.5 backdrop-blur-sm dark:border-border-night/30 dark:bg-muted-background-night/60";
+import { cn } from "@dust-tt/sparkle";
+
+/** Matches the expanded input bar surface (see InputBar.tsx). */
+export const INPUT_BAR_SURFACE_CLASSES =
+  "border border-border-dark bg-muted-background dark:border-border-dark/10 dark:bg-muted-background-night";
+
+/** Same hue as expanded, slightly translucent for compact overlay on scroll. */
+export const INPUT_BAR_COMPACT_SURFACE_CLASSES =
+  "border border-border-dark bg-muted-background/90 shadow-sm backdrop-blur-sm dark:border-border-dark/10 dark:bg-muted-background-night/90";
+
+export const INPUT_BAR_COMPACT_PILL_CLASSES = cn(
+  "min-w-0 w-full rounded-full px-2",
+  INPUT_BAR_COMPACT_SURFACE_CLASSES
+);
 
 export const INPUT_BAR_COMPACT_PILL_INNER_CLASSES =
-  "flex h-8 min-w-0 flex-row items-center gap-1";
+  "flex h-10 min-w-0 flex-row items-center gap-1.5";
 
 export const INPUT_BAR_COMPACT_PREVIEW_CLASSES =
-  "min-w-0 flex-1 truncate rounded-full px-2.5 copy-xs leading-8";
+  "min-w-0 flex-1 truncate rounded-full px-2.5 copy-md font-medium leading-10";
 
 export const INPUT_BAR_COMPACT_ENTER_ANIMATION_CLASSES =
   "motion-safe:origin-bottom motion-safe:animate-input-bar-compact-in";

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -26,6 +26,7 @@ import {
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
 import { extractFromEditorJSON } from "@app/lib/mentions/format";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { isMobile } from "@app/lib/utils";
 import type { RichMention } from "@app/types/assistant/mentions";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
@@ -47,7 +48,7 @@ function isLongTextPaste(text: string, maxCharThreshold?: number) {
   return text.length > maxChars;
 }
 
-const useEditorService = (editor: Editor | null) => {
+const useEditorService = (editor: Editor | null, isMobileViewport: boolean) => {
   return useMemo(() => {
     // Return the service object with utility functions.
     return {
@@ -65,6 +66,7 @@ const useEditorService = (editor: Editor | null) => {
         if (!editor) {
           return;
         }
+        const shouldFocus = !isMobileViewport;
         let partialPos: number | null = null;
         editor.state.doc.descendants((node, pos) => {
           if (node.type.name === "voicePartial" && partialPos === null) {
@@ -83,11 +85,17 @@ const useEditorService = (editor: Editor | null) => {
             })
             .run();
         } else {
-          editor
-            .chain()
-            .focus("end")
-            .insertContent({ type: "voicePartial", attrs: { text } })
-            .run();
+          const content = { type: "voicePartial", attrs: { text } };
+          if (shouldFocus) {
+            editor.chain().focus("end").insertContent(content).run();
+          } else {
+            editor
+              .chain()
+              .insertContentAt(editor.state.doc.content.size, content, {
+                updateSelection: false,
+              })
+              .run();
+          }
         }
       },
       // Replace the voicePartial node with the committed plain text.
@@ -96,6 +104,7 @@ const useEditorService = (editor: Editor | null) => {
         if (!editor) {
           return;
         }
+        const shouldFocus = !isMobileViewport;
         let found = false;
         editor.state.doc.descendants((node, pos) => {
           if (node.type.name === "voicePartial" && !found) {
@@ -121,7 +130,16 @@ const useEditorService = (editor: Editor | null) => {
           return true;
         });
         if (!found && committedText) {
-          editor.chain().focus("end").insertContent(committedText).run();
+          if (shouldFocus) {
+            editor.chain().focus("end").insertContent(committedText).run();
+          } else {
+            editor
+              .chain()
+              .insertContentAt(editor.state.doc.content.size, committedText, {
+                updateSelection: false,
+              })
+              .run();
+          }
         }
       },
       // Convert any pending voicePartial node to plain text in place.
@@ -269,7 +287,7 @@ const useEditorService = (editor: Editor | null) => {
         return editor?.setEditable(!loading);
       },
     };
-  }, [editor]);
+  }, [editor, isMobileViewport]);
 };
 
 export type EditorService = ReturnType<typeof useEditorService>;
@@ -552,7 +570,8 @@ const useCustomEditor = ({
     [conversationId, placeholderOverride]
   );
 
-  const editorService = useEditorService(editor);
+  const isMobileViewport = useIsMobile();
+  const editorService = useEditorService(editor, isMobileViewport);
   const lastSubmitTimestampMsRef = useRef(0);
 
   // Set keydown handler after editor is initialized to avoid synchronous updates during render.

--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -1,3 +1,4 @@
+import { INPUT_BAR_COMPACT_SURFACE_CLASSES } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
 import type { SidebarNavigation } from "@app/components/navigation/config";
 import {
   NavigationSidebar,
@@ -23,8 +24,8 @@ import type React from "react";
 import { useContext } from "react";
 
 const MOBILE_NAV_MENU_BUTTON_CLASSES = cn(
-  "border border-border/30 bg-muted-background/60 backdrop-blur-sm transition-none",
-  "dark:border-border-night/30 dark:bg-muted-background-night/60",
+  INPUT_BAR_COMPACT_SURFACE_CLASSES,
+  "transition-none",
   "hover:border-transparent hover:bg-hover hover:backdrop-blur-none",
   "dark:hover:bg-hover-night",
   "active:border-transparent active:bg-primary-300 active:backdrop-blur-none",

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -205,7 +205,7 @@ export function PodConversationsTab({
               )}
             </div>
             {podInfo.archivedAt ? (
-              <div className="mx-auto flex flex-col w-full py-4 sm:max-w-conversation">
+              <div className="mx-auto flex w-full flex-col py-4 md:max-w-conversation">
                 <EmptyCTA
                   message="This Pod is archived and no longer appears in your sidebar. You can still search for it and view past conversations, but you cannot start new ones."
                   action={null}

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -164,7 +164,7 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
                   >
                     <div
                       className={cn(
-                        "flex w-full grow flex-col px-4 sm:px-8",
+                        "flex w-full grow flex-col px-4 md:px-8",
                         contentWidth === "centered" && "max-w-4xl"
                       )}
                     >
@@ -205,7 +205,7 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
                     >
                       <div
                         className={cn(
-                          "flex w-full grow flex-col px-4 sm:px-8",
+                          "flex w-full grow flex-col px-4 md:px-8",
                           contentWidth === "centered" && "max-w-4xl"
                         )}
                       >


### PR DESCRIPTION
## Description

Two independent fixes, both stemming from the document-scroll mobile layout introduced in PR27960:

- **Compact bar visibility**: `inputBarCompactStyles.ts` bumps the pill to `h-10`, `copy-md font-medium` preview text, stronger `backdrop-blur-xl`/`backdrop-saturate-150`, and `bg-background/75` — making the floating compact bar clearly legible against the conversation background.
- **Live transcribe on mobile**: `useEditorService` now receives `isMobileViewport` and uses `insertContentAt(..., { updateSelection: false })` instead of `chain().focus("end")` when inserting `voicePartial`/committed text on mobile, preventing the editor from stealing focus mid-transcription.
- **`sm:` → `md:` breakpoint alignment**: All input bar and layout responsive classes updated to `md:` (768px) to match the `useIsMobile` threshold and prevent breakpoints from firing on mid-size mobile viewports.
- `enforceStickyFooterAtBottom` unconditionally enabled now that mobile scroll is handled at the document level.

## Tests

Tested locally on mobile viewport. Verified compact bar appearance and live transcription flow.

## Risk

Low. Pure front-end styling and focus-management changes. No data model or API changes. Safe to rollback.

## Deploy Plan

Deploy `front`.
