### PR TITLE
Fix plan card and panel not refreshing after close then recreate

### DIFF
--- a/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
+++ b/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
@@ -15,14 +15,14 @@ export const AgentMessageCompletionStatus = ({
   agentMessage: LightAgentMessageType | LightAgentMessageWithActionsType;
   onClick?: () => void;
 }) => {
-  const { openPanel, data } = useConversationSidePanelContext();
+  const { togglePanel, data } = useConversationSidePanelContext();
 
   const handleClick = () => {
     if (onClick) {
       onClick();
       return;
     }
-    openPanel({
+    togglePanel({
       type: "actions",
       messageId: agentMessage.sId,
     });

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_RIGHT_PANEL_SIZE } from "@app/components/assistant/conversation/constant";
 import type { AgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useHashParam } from "@app/hooks/useHashParams";
@@ -44,6 +45,7 @@ const isSupportedPanelType = (
 interface ConversationSidePanelContextType {
   currentPanel: ConversationSidePanelType;
   openPanel: (params: OpenPanelParams) => void;
+  togglePanel: (params: OpenPanelParams) => void;
   closePanel: () => void;
   onPanelClosed: () => void;
   setPanelRef: (ref: ImperativePanelHandle | null) => void;
@@ -125,8 +127,9 @@ export function ConversationSidePanelProvider({
     }
   }, [panelRef, onPanelClosed]);
 
-  const openPanel = useCallback(
-    (params: OpenPanelParams) => {
+  // Shared selection; `toggle` decides whether re-selecting the shown panel closes it.
+  const applyPanel = useCallback(
+    (params: OpenPanelParams, { toggle }: { toggle: boolean }) => {
       setCurrentPanel(params.type);
 
       switch (params.type) {
@@ -135,11 +138,8 @@ export function ConversationSidePanelProvider({
             ? `${params.messageId}@${params.actionId}`
             : params.messageId;
 
-          /**
-           * If the panel is already open for the same data,
-           * we close it.
-           */
-          if (newData === data) {
+          // A different message/action switches content; only the same data toggles closed.
+          if (toggle && newData === data) {
             closePanel();
             return;
           }
@@ -156,8 +156,7 @@ export function ConversationSidePanelProvider({
           break;
 
         case FILES_SIDE_PANEL_TYPE:
-          // Toggle: if already open, close it.
-          if (currentPanel === FILES_SIDE_PANEL_TYPE) {
+          if (toggle && currentPanel === FILES_SIDE_PANEL_TYPE) {
             closePanel();
             return;
           }
@@ -165,8 +164,7 @@ export function ConversationSidePanelProvider({
           break;
 
         case PLAN_SIDE_PANEL_TYPE:
-          // Toggle: if already open, close it.
-          if (currentPanel === PLAN_SIDE_PANEL_TYPE) {
+          if (toggle && currentPanel === PLAN_SIDE_PANEL_TYPE) {
             closePanel();
             return;
           }
@@ -176,8 +174,25 @@ export function ConversationSidePanelProvider({
         default:
           assertNever(params);
       }
+
+      // Re-expand imperatively: the container's expand effect only fires when `currentPanel`
+      // changes, so a close→reopen race (same value) wouldn't re-run it. No-op on mobile.
+      panelRef.current?.expand(DEFAULT_RIGHT_PANEL_SIZE);
     },
     [setCurrentPanel, setData, data, closePanel, currentPanel]
+  );
+
+  // Idempotent open for programmatic callers: a toggle could mis-close during a close→reopen
+  // transition where `currentPanel` still reads the old value.
+  const openPanel = useCallback(
+    (params: OpenPanelParams) => applyPanel(params, { toggle: false }),
+    [applyPanel]
+  );
+
+  // Toggle for user-controlled buttons: re-selecting the shown panel closes it.
+  const togglePanel = useCallback(
+    (params: OpenPanelParams) => applyPanel(params, { toggle: true }),
+    [applyPanel]
   );
 
   // Close the panel when switching conversations: the provider stays mounted
@@ -213,6 +228,7 @@ export function ConversationSidePanelProvider({
         ? currentPanel
         : undefined,
       openPanel,
+      togglePanel,
       closePanel,
       onPanelClosed,
       setPanelRef,
@@ -224,6 +240,7 @@ export function ConversationSidePanelProvider({
     [
       currentPanel,
       openPanel,
+      togglePanel,
       closePanel,
       onPanelClosed,
       setPanelRef,

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -35,7 +35,7 @@ const MOBILE_FORKED_TITLE_TRUNCATE_LENGTH = 35;
 export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const activeConversationId = useActiveConversationId();
   const { user } = useAuth();
-  const { openPanel } = useConversationSidePanelContext();
+  const { togglePanel } = useConversationSidePanelContext();
   const { conversation } = useConversation({
     conversationId: activeConversationId,
     workspaceId: owner.sId,
@@ -174,7 +174,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
             label={isMobile ? undefined : "Files"}
             icon={Folder}
             variant="ghost"
-            onClick={() => openPanel({ type: "files" })}
+            onClick={() => togglePanel({ type: "files" })}
           />
           <ConversationMenu
             activeConversationId={activeConversationId}

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -18,6 +18,7 @@ import {
   createPlaceholderUserMessage,
 } from "@app/components/assistant/conversation/lib";
 import { MessageItem } from "@app/components/assistant/conversation/MessageItem";
+import { handlePlanUpdatedEvent } from "@app/components/assistant/conversation/plan_mode/handle_plan_updated";
 import type {
   ConversationForkNotice,
   VirtuosoMessage,
@@ -65,6 +66,7 @@ import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
 import { getNextWakeUpFireAtFromScheduleConfig } from "@app/lib/utils/wakeup_description";
 import logger from "@app/logger/logger";
+import type { GetConversationPlanModeResponseBody } from "@app/types/api/assistant/plan_mode";
 import {
   type ConversationForkedChildType,
   type ConversationListItemType,
@@ -1056,20 +1058,26 @@ export const ConversationViewer = ({
             window.dispatchEvent(new CompactionCompletedEvent());
             break;
           case "plan_updated": {
-            if (event.isClosed) {
-              if (currentPanelRef.current === "plan") {
-                closePanel();
-              }
-            } else if (!planAutoOpenedRef.current && !isMobileRef.current) {
-              planAutoOpenedRef.current = true;
-              openPanel({ type: "plan" });
-            }
-            void mutate(
-              planFileKey({
-                workspaceId: owner.sId,
-                conversationId: event.conversationId,
-              })
-            );
+            const planKey = planFileKey({
+              workspaceId: owner.sId,
+              conversationId: event.conversationId,
+            });
+            void handlePlanUpdatedEvent(event, {
+              isMobile: isMobileRef.current,
+              isPlanPanelOpen: currentPanelRef.current === "plan",
+              autoOpenedRef: planAutoOpenedRef,
+              // Cache-only write (revalidate: false): resolves without a fetch, cannot reject.
+              writeClosedToCache: () =>
+                void mutate<GetConversationPlanModeResponseBody>(
+                  planKey,
+                  { content: null },
+                  { revalidate: false }
+                ),
+              revalidate: () =>
+                mutate<GetConversationPlanModeResponseBody>(planKey),
+              openPlanPanel: () => openPanel({ type: "plan" }),
+              closePanel,
+            });
             break;
           }
           case "wake_up_updated": {

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -72,7 +72,7 @@ export function InlineActivitySteps({
   const actions = isAgentMessageWithActions ? agentMessage.actions : [];
   const chainOfThought = agentMessage.chainOfThought ?? "";
 
-  const { openPanel } = useConversationSidePanelContext();
+  const { togglePanel } = useConversationSidePanelContext();
 
   const isDone =
     lastAgentStateClassification === "done" ||
@@ -84,7 +84,7 @@ export function InlineActivitySteps({
       onOpenDetails(agentMessage.sId);
       return;
     }
-    openPanel({
+    togglePanel({
       type: "actions",
       messageId: agentMessage.sId,
       actionId,

--- a/front/components/assistant/conversation/plan_mode/PlanCard.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanCard.tsx
@@ -47,7 +47,7 @@ export const PlanCard = React.memo(function PlanCard({
     conversationId: isPlanModeEnabled ? conversationId : null,
     workspaceId,
   });
-  const { openPanel } = useConversationSidePanelContext();
+  const { togglePanel } = useConversationSidePanelContext();
   const { closePlan, isClosing } = useClosePlan({
     workspaceId,
     conversationId,
@@ -69,7 +69,7 @@ export const PlanCard = React.memo(function PlanCard({
     >
       <button
         type="button"
-        onClick={() => openPanel({ type: "plan" })}
+        onClick={() => togglePanel({ type: "plan" })}
         className="flex w-full min-w-0 items-center gap-2 text-left"
       >
         <span className="min-w-0 truncate text-foreground dark:text-foreground-night">

--- a/front/components/assistant/conversation/plan_mode/handle_plan_updated.test.ts
+++ b/front/components/assistant/conversation/plan_mode/handle_plan_updated.test.ts
@@ -1,0 +1,120 @@
+import type { PlanUpdatedDeps } from "@app/components/assistant/conversation/plan_mode/handle_plan_updated";
+import { handlePlanUpdatedEvent } from "@app/components/assistant/conversation/plan_mode/handle_plan_updated";
+import type { PlanUpdatedEvent } from "@app/types/assistant/conversation";
+import { describe, expect, it, vi } from "vitest";
+
+function makeEvent(isClosed: boolean): PlanUpdatedEvent {
+  return {
+    type: "plan_updated",
+    created: 0,
+    conversationId: "c_test",
+    isClosed,
+  };
+}
+
+function makeDeps(overrides: Partial<PlanUpdatedDeps> = {}): PlanUpdatedDeps {
+  return {
+    isMobile: false,
+    isPlanPanelOpen: false,
+    autoOpenedRef: { current: false },
+    writeClosedToCache: vi.fn(),
+    revalidate: vi.fn().mockResolvedValue({ content: "# Plan" }),
+    openPlanPanel: vi.fn(),
+    closePanel: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("handlePlanUpdatedEvent", () => {
+  it("on close, drops the cache, closes the plan panel, and re-arms auto-open", async () => {
+    const deps = makeDeps({
+      isPlanPanelOpen: true,
+      autoOpenedRef: { current: true },
+    });
+
+    await handlePlanUpdatedEvent(makeEvent(true), deps);
+
+    expect(deps.writeClosedToCache).toHaveBeenCalledTimes(1);
+    expect(deps.closePanel).toHaveBeenCalledTimes(1);
+    expect(deps.autoOpenedRef.current).toBe(false);
+    expect(deps.revalidate).not.toHaveBeenCalled();
+    expect(deps.openPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("on close, leaves the panel alone when the plan panel is not open", async () => {
+    const deps = makeDeps({ isPlanPanelOpen: false });
+
+    await handlePlanUpdatedEvent(makeEvent(true), deps);
+
+    expect(deps.writeClosedToCache).toHaveBeenCalledTimes(1);
+    expect(deps.closePanel).not.toHaveBeenCalled();
+  });
+
+  it("on create, revalidates and opens the plan panel once content arrives", async () => {
+    const deps = makeDeps();
+
+    await handlePlanUpdatedEvent(makeEvent(false), deps);
+
+    expect(deps.revalidate).toHaveBeenCalledTimes(1);
+    expect(deps.openPlanPanel).toHaveBeenCalledTimes(1);
+    expect(deps.autoOpenedRef.current).toBe(true);
+  });
+
+  it("on edit (already auto-opened), refreshes but does not reopen the panel", async () => {
+    const deps = makeDeps({ autoOpenedRef: { current: true } });
+
+    await handlePlanUpdatedEvent(makeEvent(false), deps);
+
+    expect(deps.revalidate).toHaveBeenCalledTimes(1);
+    expect(deps.openPlanPanel).not.toHaveBeenCalled();
+    expect(deps.autoOpenedRef.current).toBe(true);
+  });
+
+  it("on create, does not auto-open on mobile", async () => {
+    const deps = makeDeps({ isMobile: true });
+
+    await handlePlanUpdatedEvent(makeEvent(false), deps);
+
+    expect(deps.openPlanPanel).not.toHaveBeenCalled();
+    expect(deps.autoOpenedRef.current).toBe(false);
+  });
+
+  it("on create, releases the latch when the fetch returns no content", async () => {
+    const deps = makeDeps({
+      revalidate: vi.fn().mockResolvedValue({ content: null }),
+    });
+
+    await handlePlanUpdatedEvent(makeEvent(false), deps);
+
+    expect(deps.openPlanPanel).not.toHaveBeenCalled();
+    expect(deps.autoOpenedRef.current).toBe(false);
+  });
+
+  it("on create, does not reopen when a close reset the latch mid-revalidation", async () => {
+    const autoOpenedRef = { current: false };
+    const deps = makeDeps({
+      autoOpenedRef,
+      // Simulate a close event landing (resetting the latch) while the revalidation is in flight,
+      // then this stale revalidation resolving with content.
+      revalidate: vi.fn().mockImplementation(async () => {
+        autoOpenedRef.current = false;
+        return { content: "# Plan" };
+      }),
+    });
+
+    await handlePlanUpdatedEvent(makeEvent(false), deps);
+
+    expect(deps.openPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("on create, releases the latch when the fetch fails", async () => {
+    const deps = makeDeps({
+      revalidate: vi.fn().mockRejectedValue(new Error("boom")),
+    });
+
+    await handlePlanUpdatedEvent(makeEvent(false), deps);
+
+    expect(deps.openPlanPanel).not.toHaveBeenCalled();
+    expect(deps.autoOpenedRef.current).toBe(false);
+  });
+});

--- a/front/components/assistant/conversation/plan_mode/handle_plan_updated.ts
+++ b/front/components/assistant/conversation/plan_mode/handle_plan_updated.ts
@@ -1,0 +1,62 @@
+import type { GetConversationPlanModeResponseBody } from "@app/types/api/assistant/plan_mode";
+import type { PlanUpdatedEvent } from "@app/types/assistant/conversation";
+
+export interface PlanUpdatedDeps {
+  isMobile: boolean;
+  isPlanPanelOpen: boolean;
+  // Latch: true once the panel has auto-opened for the current plan, so edits don't reopen it.
+  autoOpenedRef: { current: boolean };
+  // Drop the cached plan to null without revalidating.
+  writeClosedToCache: () => void;
+  // Revalidate the plan and resolve with the fresh body.
+  revalidate: () => Promise<GetConversationPlanModeResponseBody | undefined>;
+  openPlanPanel: () => void;
+  closePanel: () => void;
+}
+
+// Decides how the UI reacts to a `plan_updated` event. Pulled out of ConversationViewer so the
+// close→reopen behavior this guards is unit-testable without rendering the conversation. Never
+// rejects (the create path catches), so callers can `void` it.
+export async function handlePlanUpdatedEvent(
+  event: PlanUpdatedEvent,
+  deps: PlanUpdatedDeps
+): Promise<void> {
+  if (event.isClosed) {
+    // Authoritative close: drop the cache to null (no refetch, which could race a quick subsequent
+    // create) and re-arm auto-open for the next plan.
+    deps.autoOpenedRef.current = false;
+    deps.writeClosedToCache();
+    if (deps.isPlanPanelOpen) {
+      deps.closePanel();
+    }
+    return;
+  }
+
+  // Create/edit: claim auto-open synchronously so rapid edits don't double-open; release it if the
+  // fetch is empty or fails so a later update can still open.
+  const shouldAutoOpen = !deps.autoOpenedRef.current && !deps.isMobile;
+  if (shouldAutoOpen) {
+    deps.autoOpenedRef.current = true;
+  }
+  try {
+    const data = await deps.revalidate();
+    if (!shouldAutoOpen) {
+      return;
+    }
+    // A close that landed while this revalidation was in flight resets the latch; bail so a stale
+    // result can't reopen the panel for a plan that is no longer active. (SWR already discards the
+    // stale revalidation's cache write, so the card stays closed too.)
+    if (!deps.autoOpenedRef.current) {
+      return;
+    }
+    if (data?.content) {
+      deps.openPlanPanel();
+    } else {
+      deps.autoOpenedRef.current = false;
+    }
+  } catch {
+    if (shouldAutoOpen && deps.autoOpenedRef.current) {
+      deps.autoOpenedRef.current = false;
+    }
+  }
+}

--- a/front/hooks/conversations/usePlanFile.test.ts
+++ b/front/hooks/conversations/usePlanFile.test.ts
@@ -1,0 +1,75 @@
+import {
+  planFileKey,
+  useClosePlan,
+} from "@app/hooks/conversations/usePlanFile";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockClientFetch = vi.fn();
+vi.mock("@app/lib/egress/client", () => ({
+  clientFetch: (...args: unknown[]) => mockClientFetch(...args),
+}));
+
+const mockSendNotification = vi.fn();
+vi.mock("@app/hooks/useNotification", () => ({
+  useSendNotification: () => mockSendNotification,
+}));
+
+const mockMutate = vi.fn();
+vi.mock("swr", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("swr")>()),
+  useSWRConfig: () => ({ mutate: mockMutate }),
+}));
+
+describe("useClosePlan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("writes { content: null } to the cache without revalidating on a successful close", async () => {
+    mockClientFetch.mockResolvedValue(new Response(null, { status: 200 }));
+
+    const { result } = renderHook(() =>
+      useClosePlan({ workspaceId: "w_test", conversationId: "c_test" })
+    );
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.closePlan();
+    });
+
+    const key = planFileKey({
+      workspaceId: "w_test",
+      conversationId: "c_test",
+    });
+    expect(ok).toBe(true);
+    expect(mockClientFetch).toHaveBeenCalledWith(key, { method: "DELETE" });
+    // Authoritative local cache write, not a refetch: avoids racing a quick subsequent create.
+    expect(mockMutate).toHaveBeenCalledWith(
+      key,
+      { content: null },
+      { revalidate: false }
+    );
+  });
+
+  it("does not touch the cache and notifies on a failed close", async () => {
+    mockClientFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "nope" } }), {
+        status: 500,
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useClosePlan({ workspaceId: "w_test", conversationId: "c_test" })
+    );
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.closePlan();
+    });
+
+    expect(ok).toBe(false);
+    expect(mockMutate).not.toHaveBeenCalled();
+    expect(mockSendNotification).toHaveBeenCalled();
+  });
+});

--- a/front/hooks/conversations/usePlanFile.ts
+++ b/front/hooks/conversations/usePlanFile.ts
@@ -72,7 +72,9 @@ export function useClosePlan({
         return false;
       }
 
-      await mutate(key);
+      // Write the cache directly instead of refetching: a refetch could race a quick subsequent
+      // create and leave a stale null.
+      await mutate(key, { content: null }, { revalidate: false });
       return true;
     } finally {
       setIsClosing(false);


### PR DESCRIPTION
## Problem

Plan card + panel sometimes didn't refresh after closing a plan then asking for a new one (needed a page reload).

**Root cause:** three things; openPanel was a toggle so a programmatic open from the SSE handler could mis-close (made worse by the handler being bound once with a stale currentPanel); the auto-open latch was never reset on close; and close did a refetch that a quick create could dedupe onto, leaving a stale null.

**What this does**: splits openPanel (idempotent) from togglePanel (clicks); close writes { content: null } directly instead of refetching; create/edit does one revalidation with a race-safe single auto-open.

## Tests

`usePlanFile.test.ts` covers the close cache write contract (writes `{ content: null }` with `revalidate: false` on success, no cache write and a notification on failure). `plan_mode.test.ts` still green.

## Deploy plan

Deploy front. 