### PR TITLE
 enh(analytics) show real names for space-restricted agents

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -338,9 +338,13 @@ export async function getAgentConfigurations<V extends AgentFetchVariant>(
         auth,
         agentModels
       );
-      workspaceAgents = await enrichAgentConfigurations(auth, allowedAgentModels, {
-        variant,
-      });
+      workspaceAgents = await enrichAgentConfigurations(
+        auth,
+        allowedAgentModels,
+        {
+          variant,
+        }
+      );
     }
 
     const agents = [...globalAgents, ...workspaceAgents];

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -6,6 +6,7 @@ import {
 import { createAgentActionConfiguration } from "@app/lib/api/assistant/configuration/actions";
 import {
   enrichAgentConfigurations,
+  getModelForAgentConfiguration,
   isSelfHostedImageWithValidContentType,
 } from "@app/lib/api/assistant/configuration/helpers";
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
@@ -252,6 +253,43 @@ export async function listsAgentConfigurationVersions<
     : LightAgentConfigurationType[];
 }
 
+async function fetchLatestWorkspaceAgentModels(
+  auth: Authenticator,
+  workspaceAgentIds: string[]
+): Promise<AgentConfigurationModel[]> {
+  if (workspaceAgentIds.length === 0) {
+    return [];
+  }
+  // Use window function for optimal performance - single query, single pass
+  const query = `
+    SELECT *
+    FROM (
+      SELECT *,
+              ROW_NUMBER() OVER (
+                PARTITION BY "sId"
+                ORDER BY version DESC
+              ) as rn
+      FROM agent_configurations
+      WHERE "workspaceId" = :workspaceId
+        AND "sId" IN (:agentIds)
+    ) ranked_agents
+    WHERE rn = 1
+    ORDER BY version DESC
+  `;
+
+  return (
+    (await AgentConfigurationModel.sequelize?.query(query, {
+      type: QueryTypes.SELECT,
+      replacements: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        agentIds: workspaceAgentIds,
+      },
+      model: AgentConfigurationModel,
+      mapToModel: true,
+    })) ?? []
+  );
+}
+
 /**
  * Get the latest versions of multiple agents.
  */
@@ -291,43 +329,18 @@ export async function getAgentConfigurations<V extends AgentFetchVariant>(
 
     let workspaceAgents: AgentConfigurationType[] = [];
     if (workspaceAgentIds.length > 0) {
-      // Use window function for optimal performance - single query, single pass
-      const query = `
-        SELECT *
-        FROM (
-          SELECT *,
-                  ROW_NUMBER() OVER (
-                    PARTITION BY "sId"
-                    ORDER BY version DESC
-                  ) as rn
-          FROM agent_configurations
-          WHERE "workspaceId" = :workspaceId
-            AND "sId" IN (:agentIds)
-        ) ranked_agents
-        WHERE rn = 1
-        ORDER BY version DESC
-      `;
-
-      const agentModels =
-        (await AgentConfigurationModel.sequelize?.query(query, {
-          type: QueryTypes.SELECT,
-          replacements: {
-            workspaceId: owner.id,
-            agentIds: workspaceAgentIds,
-          },
-          model: AgentConfigurationModel,
-          mapToModel: true,
-        })) ?? [];
+      const agentModels = await fetchLatestWorkspaceAgentModels(
+        auth,
+        workspaceAgentIds
+      );
 
       const allowedAgentModels = await filterAgentsByRequestedSpaces(
         auth,
         agentModels
       );
-      workspaceAgents = await enrichAgentConfigurations(
-        auth,
-        allowedAgentModels,
-        { variant }
-      );
+      workspaceAgents = await enrichAgentConfigurations(auth, allowedAgentModels, {
+        variant,
+      });
     }
 
     const agents = [...globalAgents, ...workspaceAgents];
@@ -384,6 +397,35 @@ export async function getAgentConfiguration<V extends AgentFetchVariant>(
         : AgentConfigurationType) || null
     );
   });
+}
+
+export type AgentLabel = {
+  sId: string;
+  name: string;
+  pictureUrl: string | null;
+  model: AgentModelConfigurationType;
+};
+
+export async function getAgentLabelsByIds(
+  auth: Authenticator,
+  agentIds: string[]
+): Promise<AgentLabel[]> {
+  if (!auth.hasPermission("workspace:view_analytics")) {
+    return [];
+  }
+
+  const workspaceAgentIds = agentIds.filter((id) => !isGlobalAgentId(id));
+  const agentModels = await fetchLatestWorkspaceAgentModels(
+    auth,
+    workspaceAgentIds
+  );
+
+  return agentModels.map((agent) => ({
+    sId: agent.sId,
+    name: agent.name,
+    pictureUrl: agent.pictureUrl,
+    model: getModelForAgentConfiguration(agent),
+  }));
 }
 
 /**

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -16,7 +16,7 @@ import type {
 } from "@app/types/assistant/agent";
 import type { ModelId } from "@app/types/shared/model_id";
 
-function getModelForAgentConfiguration(
+export function getModelForAgentConfiguration(
   agent: AgentConfigurationModel
 ): AgentModelConfigurationType {
   const model: AgentModelConfigurationType = {

--- a/front/lib/api/assistant/observability/agent_labels.ts
+++ b/front/lib/api/assistant/observability/agent_labels.ts
@@ -1,4 +1,7 @@
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import {
+  getAgentConfigurations,
+  getAgentLabelsByIds,
+} from "@app/lib/api/assistant/configuration/agent";
 import { getAgentModelDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import type { Authenticator } from "@app/lib/auth";
 
@@ -28,27 +31,50 @@ export async function resolveAnalyticsAgentLabels(
 
   const agents = await getAgentConfigurations(auth, {
     agentIds,
-    variant: "light",
+    variant: "extra_light",
   });
   const agentsById = new Map(agents.map((agent) => [agent.sId, agent]));
+
+  const missingAgentIds = agentIds.filter((id) => !agentsById.has(id));
+  const fallbackLabels =
+    missingAgentIds.length > 0
+      ? await getAgentLabelsByIds(auth, missingAgentIds)
+      : [];
+  const fallbackById = new Map(
+    fallbackLabels.map((label) => [label.sId, label])
+  );
 
   return new Map(
     agentIds.map((agentId) => {
       const agent = agentsById.get(agentId);
-      if (!agent) {
-        return [agentId, UNKNOWN_AGENT_LABEL];
+      if (agent) {
+        return [
+          agentId,
+          {
+            name: agent.name,
+            pictureUrl: agent.pictureUrl,
+            modelDisplayName: getAgentModelDisplayName(agent.model),
+            description: agent.canRead
+              ? agent.description
+              : PRIVATE_AGENT_DESCRIPTION
+          },
+        ];
       }
-      return [
-        agentId,
-        {
-          name: agent.name,
-          pictureUrl: agent.pictureUrl,
-          modelDisplayName: getAgentModelDisplayName(agent.model),
-          description: agent.canRead
-            ? agent.description
-            : PRIVATE_AGENT_DESCRIPTION,
-        },
-      ];
+
+      const fallback = fallbackById.get(agentId);
+      if (fallback) {
+        return [
+          agentId,
+          {
+            name: fallback.name,
+            pictureUrl: fallback.pictureUrl,
+            modelDisplayName: getAgentModelDisplayName(fallback.model),
+            description: PRIVATE_AGENT_DESCRIPTION,
+          },
+        ];
+      }
+
+      return [agentId, UNKNOWN_AGENT_LABEL];
     })
   );
 }

--- a/front/lib/api/assistant/observability/agent_labels.ts
+++ b/front/lib/api/assistant/observability/agent_labels.ts
@@ -56,7 +56,7 @@ export async function resolveAnalyticsAgentLabels(
             modelDisplayName: getAgentModelDisplayName(agent.model),
             description: agent.canRead
               ? agent.description
-              : PRIVATE_AGENT_DESCRIPTION
+              : PRIVATE_AGENT_DESCRIPTION,
           },
         ];
       }

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -1,5 +1,5 @@
 import { sourceLabelForOrigin } from "@app/lib/api/analytics/source_labels";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
 import { buildCreditsScopeQuery } from "@app/lib/api/assistant/observability/utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import {
@@ -139,11 +139,10 @@ async function resolveGroupNames(
   }
   switch (groupBy) {
     case "agent": {
-      const agents = await getAgentConfigurations(auth, {
-        agentIds: ids,
-        variant: "extra_light",
-      });
-      return new Map(agents.map((agent) => [agent.sId, agent.name]));
+      const labels = await resolveAnalyticsAgentLabels(auth, ids);
+      return new Map(
+        Array.from(labels, ([agentId, label]) => [agentId, label.name])
+      );
     }
     case "user": {
       const users = await UserResource.fetchByIds(ids);

--- a/front/lib/api/assistant/observability/top_agents.ts
+++ b/front/lib/api/assistant/observability/top_agents.ts
@@ -1,4 +1,7 @@
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import {
+  resolveAnalyticsAgentLabels,
+  UNKNOWN_AGENT_LABEL,
+} from "@app/lib/api/assistant/observability/agent_labels";
 import {
   fetchAgentCostStats,
   getAgentCostStats,
@@ -91,10 +94,7 @@ export async function fetchTopAgents(
   }
 
   const [agents, costStatsResult] = await Promise.all([
-    getAgentConfigurations(auth, {
-      agentIds: bucketAgentIds,
-      variant: "extra_light",
-    }),
+    resolveAnalyticsAgentLabels(auth, bucketAgentIds),
     fetchAgentCostStats(auth, {
       agentIds: bucketAgentIds,
       days,
@@ -108,15 +108,13 @@ export async function fetchTopAgents(
   }
   const costStatsMap = costStatsResult.value;
 
-  const agentsById = new Map(agents.map((agent) => [agent.sId, agent]));
-
   const rows = buckets.map((bucket) => {
     const agentId = String(bucket.key);
-    const agent = agentsById.get(agentId);
+    const label = agents.get(agentId) ?? UNKNOWN_AGENT_LABEL;
     return {
       agentId,
-      name: agent?.name ?? "Unknown agent",
-      pictureUrl: agent?.pictureUrl ?? null,
+      name: label.name,
+      pictureUrl: label.pictureUrl,
       messageCount: bucket.doc_count ?? 0,
       userCount: Math.round(bucket.unique_users?.value ?? 0),
       totalCostCredits: getAgentCostStats(costStatsMap, agentId)


### PR DESCRIPTION
## Description

Analytics surfaces previously rendered "Unknown agent" for agents in spaces the viewer cannot access. Add getAgentLabelsByIds, a permission-gated, label-only lookup (name/picture/model, never description/instructions) that bypasses space-access filtering, and wire it into resolveAnalyticsAgentLabels as a fallback for ids dropped by getAgentConfigurations. The credit tables, credit usage chart, and top-agents surfaces now show the real name with the description still masked.


## Tests

Local

## Risk

Low
## Deploy Plan

Front