### PR TITLE
[front] Poke: show MCP tool schema in a click-to-open pane

### DIFF
--- a/front/components/poke/mcp_server_views/tools_config.tsx
+++ b/front/components/poke/mcp_server_views/tools_config.tsx
@@ -11,8 +11,23 @@ import {
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { PokeMCPServerViewType } from "@app/types/poke";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
-import { Chip } from "@dust-tt/sparkle";
-import { useMemo } from "react";
+import {
+  Button,
+  Chip,
+  Clipboard,
+  ClipboardCheck,
+  CodeBlock,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  useCopyToClipboard,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+type ToolType = PokeMCPServerViewType["server"]["tools"][number];
 
 const STAKE_LABELS: Record<MCPToolStakeLevelType, string> = {
   high: "High",
@@ -31,6 +46,7 @@ const STAKE_COLORS = {
 interface ToolConfigRow {
   name: string;
   description: string;
+  inputSchema: ToolType["inputSchema"];
   enabled: boolean;
   permission: MCPToolStakeLevelType;
   defaultPermission: MCPToolStakeLevelType;
@@ -53,11 +69,108 @@ function StakeChip({ permission, className }: StakeChipProps) {
   );
 }
 
+interface ToolDetailsSheetProps {
+  tool: ToolConfigRow | null;
+  onClose: () => void;
+}
+
+function ToolDetailsSheet({ tool, onClose }: ToolDetailsSheetProps) {
+  const [isCopied, copyToClipboard] = useCopyToClipboard();
+
+  const schemaString = tool?.inputSchema
+    ? JSON.stringify(tool.inputSchema, null, 2)
+    : null;
+
+  return (
+    <Sheet
+      open={tool !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <SheetContent size="lg">
+        {tool && (
+          <>
+            <SheetHeader>
+              <SheetTitle>{asDisplayName(tool.name)}</SheetTitle>
+              <SheetDescription>
+                <span className="flex items-center gap-1.5">
+                  {!tool.enabled && (
+                    <Chip size="xs" color="warning" label="Disabled by admin" />
+                  )}
+                  {tool.stakeOverridden && (
+                    <>
+                      <StakeChip
+                        permission={tool.defaultPermission}
+                        className="line-through opacity-60"
+                      />
+                      →
+                    </>
+                  )}
+                  <StakeChip permission={tool.permission} />
+                </span>
+              </SheetDescription>
+            </SheetHeader>
+            <SheetContainer>
+              <div className="flex flex-col gap-4">
+                <div>
+                  <span className="font-medium text-foreground dark:text-foreground-night">
+                    Description
+                  </span>
+                  <p className="py-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    {tool.description || "No description."}
+                  </p>
+                </div>
+                <div>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium text-foreground dark:text-foreground-night">
+                      Input schema
+                    </span>
+                    {schemaString && (
+                      <Button
+                        variant="outline"
+                        size="xs"
+                        icon={isCopied ? ClipboardCheck : Clipboard}
+                        label={isCopied ? "Copied!" : "Copy"}
+                        onClick={() => {
+                          void copyToClipboard(schemaString);
+                        }}
+                      />
+                    )}
+                  </div>
+                  <div className="py-2">
+                    {schemaString ? (
+                      <CodeBlock
+                        className="language-json max-h-96 overflow-y-auto"
+                        wrapLongLines={true}
+                      >
+                        {schemaString}
+                      </CodeBlock>
+                    ) : (
+                      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                        No input schema.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </SheetContainer>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
 interface ToolsConfigTableProps {
   mcpServerView: PokeMCPServerViewType;
 }
 
 export function ToolsConfigTable({ mcpServerView }: ToolsConfigTableProps) {
+  const [selectedToolName, setSelectedToolName] = useState<string | null>(null);
+
   const rows = useMemo<ToolConfigRow[]>(() => {
     const overridesByName = new Map(
       (mcpServerView.toolsMetadata ?? []).map((m) => [m.toolName, m])
@@ -74,6 +187,7 @@ export function ToolsConfigTable({ mcpServerView }: ToolsConfigTableProps) {
       return {
         name: tool.name,
         description: tool.description,
+        inputSchema: tool.inputSchema,
         enabled: override?.enabled ?? true,
         permission,
         defaultPermission,
@@ -81,6 +195,9 @@ export function ToolsConfigTable({ mcpServerView }: ToolsConfigTableProps) {
       };
     });
   }, [mcpServerView.server, mcpServerView.toolsMetadata]);
+
+  const selectedTool =
+    rows.find((row) => row.name === selectedToolName) ?? null;
 
   return (
     <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
@@ -99,43 +216,31 @@ export function ToolsConfigTable({ mcpServerView }: ToolsConfigTableProps) {
           </PokeTableHeader>
           <PokeTableBody>
             {rows.map((row) => (
-              <PokeTableRow key={row.name}>
+              <PokeTableRow
+                key={row.name}
+                className="cursor-pointer"
+                onClick={() => setSelectedToolName(row.name)}
+              >
                 <PokeTableCell>
-                  <div className="flex flex-col gap-1">
-                    <div className="flex items-center gap-2">
-                      <span
-                        className={cn(
-                          "font-medium",
-                          !row.enabled &&
-                            "text-muted-foreground line-through dark:text-muted-foreground-night"
-                        )}
-                      >
-                        {asDisplayName(row.name)}
-                      </span>
-                      {!row.enabled && (
-                        <Chip
-                          size="xs"
-                          color="warning"
-                          label="Disabled by admin"
-                        />
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        "font-medium",
+                        !row.enabled &&
+                          "text-muted-foreground line-through dark:text-muted-foreground-night"
                       )}
-                      {row.stakeOverridden && (
-                        <Chip
-                          size="xs"
-                          color="warning"
-                          label="Edited by admin"
-                        />
-                      )}
-                    </div>
-                    {row.description && (
-                      <span
-                        className={cn(
-                          "text-sm text-muted-foreground dark:text-muted-foreground-night",
-                          !row.enabled && "line-through"
-                        )}
-                      >
-                        {row.description}
-                      </span>
+                    >
+                      {asDisplayName(row.name)}
+                    </span>
+                    {!row.enabled && (
+                      <Chip
+                        size="xs"
+                        color="warning"
+                        label="Disabled by admin"
+                      />
+                    )}
+                    {row.stakeOverridden && (
+                      <Chip size="xs" color="warning" label="Edited by admin" />
                     )}
                   </div>
                 </PokeTableCell>
@@ -166,6 +271,10 @@ export function ToolsConfigTable({ mcpServerView }: ToolsConfigTableProps) {
           </PokeTableBody>
         </PokeTable>
       )}
+      <ToolDetailsSheet
+        tool={selectedTool}
+        onClose={() => setSelectedToolName(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What

On the Poke MCP server view page (`/poke/[wId]/spaces/[spaceId]/mcp_server_views/[svId]`), the **Tools configuration** table previously showed each tool's full description inline and never exposed the input schema.

This PR makes the table a short list and moves the details behind a click:

- Rows now show only the tool name, the "Disabled by admin" / "Edited by admin" chips, and the **Stake** column.
- Rows are clickable; clicking a tool opens a side **Sheet** showing:
  - the tool's full **description**,
  - its **input schema** as pretty-printed JSON (`CodeBlock`), with a **copy-to-clipboard** button,
  - the stake chips repeated for context.
- Tools with no `inputSchema` show "No input schema."

No API/data change was needed — `inputSchema` is already serialized into `PokeMCPServerViewType`.

<img width="1236" height="803" alt="Screenshot 2026-06-26 at 10 54 24" src="https://github.com/user-attachments/assets/07f5c932-3f42-4db5-8eeb-68b645875905" />


## Test plan

- `npx tsgo --noEmit` clean.
- `biome check` clean.
- Manually: open a Poke MCP server view, confirm the list is short, clicking a tool opens the pane with description + schema, and the copy button copies the JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)