### PR TITLE
Load single seatId balance when needed

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -3462,15 +3462,18 @@ export async function adjustSeatCreditBalances({
  * Uses a raw fetch because the Metronome SDK does not yet expose this endpoint.
  * Returns one entry per seat_id (user sId), with balance (remaining) and
  * starting_balance (full allocation for the period).
+ * Pass `seatIds` to restrict the query to specific seats (no pagination needed).
  */
 export async function listMetronomeSeatBalances({
   metronomeCustomerId,
   metronomeContractId,
   coveringDate = new Date(),
+  seatId,
 }: {
   metronomeCustomerId: string;
   metronomeContractId: string;
   coveringDate?: Date;
+  seatId?: string;
 }): Promise<Result<MetronomeSeatBalance[], Error>> {
   if (!config.getMetronomeApiKey()) {
     return new Ok([]);
@@ -3497,6 +3500,7 @@ export async function listMetronomeSeatBalances({
               include_credits_and_commits: true,
               covering_date: coveringDate.toISOString(),
               limit: 100,
+              ...(seatId ? { seat_ids: [seatId] } : {}),
               ...(nextPage ? { cursor: nextPage } : {}),
             },
           }

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -22,7 +22,10 @@ import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import type { MetronomeSeatBalance } from "@app/lib/metronome/types";
 import type { MembershipSeatType } from "@app/types/memberships";
-import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
+import {
+  isSeatBased,
+  normalizeToPoolLimitSeatType,
+} from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -111,10 +114,11 @@ export async function fetchLiveUserCreditInputs({
       seatBalanceAwu = credit.balanceAwu;
       seatStartingBalanceAwu = credit.startingBalanceAwu;
     }
-  } else if (metronomeContractId) {
+  } else if (isSeatBased(seatType) && metronomeContractId) {
     const seatBalancesResult = await listMetronomeSeatBalances({
       metronomeCustomerId,
       metronomeContractId,
+      seatId: userId,
     });
     if (seatBalancesResult.isErr()) {
       return new Err(


### PR DESCRIPTION
## Description

When trying to get user state, only load seat balance of the user - previously, we were iterating on all seat balances of all users (with multiple paginated requests)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

deploy front
