### PR TITLE
Fixed contract switching after cancelling pending contract

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1374,6 +1374,17 @@ export async function processMetronomeWebhook({
         );
       }
 
+      // The contract was archived (cancelled) after the start webhook was
+      // enqueued but before it was delivered — skip to avoid swapping the
+      // active subscription onto a dead contract.
+      if (contractResult.value.archived_at) {
+        logger.info(
+          { contractId, workspaceId: workspace.sId },
+          "[Metronome Webhook] contract.start: contract is archived, skipping"
+        );
+        break;
+      }
+
       const renewalTransition = contractResult.value.transitions?.find(
         (t) => t.to_contract_id === contractId
       );


### PR DESCRIPTION
## Description

When a pending contract switch was cancelled, Metronome could still deliver the stale `contract.start` webhook for the archived contract after the cancellation completed. With the `created_backend_only` subscription row already deleted by the cancel, the webhook's legacy fallback path ran and swapped the active subscription onto the now-archived contract — leaving the workspace with an active DB subscription pointing to a dead Metronome contract.

Fix: skip all subscription mutation in `contract.start` when the contract is already archived.

## Tests

Covered by manual reproduction: switch contract → cancel pending → observe stale webhook no longer mutates the subscription.

## Risk

Low. The guard is a no-op for healthy webhooks (active contracts). It only fires for a webhook that arrives after the contract was explicitly cancelled, which was already a broken path.

## Deploy Plan

Deploy `front` / `front-api`. No migration, no feature flag.