### PR TITLE
[front] metronome: paginate listMetronomeCustomerCommits/Credits

### DIFF
--- a/front/lib/metronome/client.test.ts
+++ b/front/lib/metronome/client.test.ts
@@ -145,9 +145,9 @@ describe("createMetronomeCredit", () => {
 
   it("on ConflictError, looks up the existing credit and returns its id", async () => {
     mockCreate.mockRejectedValueOnce(new MockConflictError("conflict"));
-    mockList.mockResolvedValue({
-      data: [{ id: "existing-id", uniqueness_key: BASE_PARAMS.idempotencyKey }],
-    });
+    mockList.mockReturnValue([
+      { id: "existing-id", uniqueness_key: BASE_PARAMS.idempotencyKey },
+    ]);
 
     const result = await createMetronomeCredit(BASE_PARAMS);
 
@@ -156,7 +156,7 @@ describe("createMetronomeCredit", () => {
 
   it("on ConflictError with no matching credit in list, returns Ok(null)", async () => {
     mockCreate.mockRejectedValueOnce(new MockConflictError("conflict"));
-    mockList.mockResolvedValue({ data: [] });
+    mockList.mockReturnValue([]);
 
     const result = await createMetronomeCredit(BASE_PARAMS);
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -3028,14 +3028,17 @@ export async function listMetronomeCustomerCredits({
   coveringDate?: string;
 }): Promise<Result<Credit[], Error>> {
   try {
-    const page = await getMetronomeClient().v1.customers.credits.list({
+    const credits: Credit[] = [];
+    for await (const entry of getMetronomeClient().v1.customers.credits.list({
       customer_id: metronomeCustomerId,
       ...(creditId ? { credit_id: creditId } : {}),
       ...(coveringDate ? { covering_date: coveringDate } : {}),
       include_contract_credits: includeContractCredits,
       include_balance: includeBalance,
-    });
-    return new Ok(page.data);
+    })) {
+      credits.push(entry);
+    }
+    return new Ok(credits);
   } catch (err) {
     const error = normalizeError(err);
     logger.error(
@@ -3064,14 +3067,17 @@ export async function listMetronomeCustomerCommits({
   coveringDate?: string;
 }): Promise<Result<Commit[], Error>> {
   try {
-    const page = await getMetronomeClient().v1.customers.commits.list({
+    const commits: Commit[] = [];
+    for await (const entry of getMetronomeClient().v1.customers.commits.list({
       customer_id: metronomeCustomerId,
       ...(commitId ? { commit_id: commitId } : {}),
       ...(coveringDate ? { covering_date: coveringDate } : {}),
       include_contract_commits: includeContractCommits,
       include_balance: includeBalance,
-    });
-    return new Ok(page.data);
+    })) {
+      commits.push(entry);
+    }
+    return new Ok(commits);
   } catch (err) {
     const error = normalizeError(err);
     logger.error(


### PR DESCRIPTION
## Description

`listMetronomeCustomerCommits` and `listMetronomeCustomerCredits` returned only `page.data` from a single `v1.customers.*.list(...)` call, silently dropping every entry past the first page. Iterate the SDK's async-paginated result instead so callers see the full set.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
