### PR TITLE
Surface document size and nudge toward grep in the company data cat tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -211,20 +211,24 @@ export const DataSourceFilesystemCatInputSchema = z.object({
     .optional()
     .describe(
       "The character position to start reading from (0-based). If not provided, starts from " +
-        "the beginning."
+        "the beginning. The tool output reports the total document size and, when more content " +
+        "remains, the offset to use to continue reading."
     ),
   limit: z
     .number()
     .optional()
     .describe(
-      "The maximum number of characters to read. If not provided, reads all characters."
+      "The maximum number of characters to read. If not provided, reads all characters. For " +
+        "large documents, do not page through the whole document by repeatedly incrementing " +
+        "offset (this exhausts the context window). Prefer grep to extract only the relevant content."
     ),
   grep: z
     .string()
     .optional()
     .describe(
       "A regular expression to filter lines. Applied after offset/limit slicing. Only lines " +
-        "matching this pattern will be returned."
+        "matching this pattern will be returned. Prefer this over reading a large document in " +
+        "full when you are looking for specific content."
     ),
 });
 

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -26,9 +26,11 @@ export const FILESYSTEM_LIST_TOOL_NAME = "list";
 export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
   [FILESYSTEM_CAT_TOOL_NAME]: {
     description:
-      "Read and retrieve the full text content of a document or page by its nodeId (like 'cat' in Unix). " +
+      "Read and retrieve the text content of a document or page by its nodeId (like 'cat' in Unix). " +
       `Use to open, view, or read a specific file after locating it via '${FILESYSTEM_FIND_TOOL_NAME}', '${FILESYSTEM_LIST_TOOL_NAME}', or '${FILESYSTEM_SEARCH_TOOL_NAME}'. ` +
-      "The nodeId is the unique identifier exposed in the output of all navigation and search tools in this server.",
+      "The nodeId is the unique identifier exposed in the output of all navigation and search tools in this server. " +
+      "The output reports the document's total size; for large documents, use 'grep' to extract only the relevant " +
+      "content rather than paging through the whole document by incrementing 'offset', which exhausts the context window.",
     schema: DataSourceFilesystemCatInputSchema.shape,
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -29,7 +29,7 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
       "Read and retrieve the text content of a document or page by its nodeId (like 'cat' in Unix). " +
       `Use to open, view, or read a specific file after locating it via '${FILESYSTEM_FIND_TOOL_NAME}', '${FILESYSTEM_LIST_TOOL_NAME}', or '${FILESYSTEM_SEARCH_TOOL_NAME}'. ` +
       "The nodeId is the unique identifier exposed in the output of all navigation and search tools in this server. " +
-      "The output reports the document's total size; for large documents, use 'grep' to extract only the relevant " +
+      "The output reports the document's total size. For large documents, use 'grep' to extract only the relevant " +
       "content rather than paging through the whole document by incrementing 'offset', which exhausts the context window.",
     schema: DataSourceFilesystemCatInputSchema.shape,
     stake: "never_ask",

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
@@ -15,6 +15,50 @@ import { CoreAPI } from "@app/types/core/core_api";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
+// Above this size we nudge the model to use `grep` rather than reading the whole
+// document linearly page by page, which can quickly exhaust the context window.
+const LARGE_DOCUMENT_CHARS = 50_000;
+
+// Builds a footer appended to the returned text so the model knows the total
+// document size and whether more content remains, instead of blindly looping on
+// `offset`. `grep` is applied by Core after offset/limit slicing, so the window
+// is computed from offset/limit/total rather than from the (possibly filtered)
+// returned text length.
+function makeCatFooter({
+  totalCharacters,
+  offset,
+  limit,
+}: {
+  totalCharacters: number;
+  offset: number | null;
+  limit: number | null;
+}): string {
+  const effectiveOffset = offset ?? 0;
+  const sliceEnd =
+    limit !== null
+      ? Math.min(effectiveOffset + limit, totalCharacters)
+      : totalCharacters;
+  const charsRemaining = Math.max(0, totalCharacters - sliceEnd);
+
+  if (charsRemaining > 0) {
+    const grepHint =
+      totalCharacters >= LARGE_DOCUMENT_CHARS
+        ? " This document is large. Prefer `grep` to extract specific content instead of reading it all page by page."
+        : "";
+    return (
+      `\n\n[Showing characters ${effectiveOffset}-${sliceEnd} of ${totalCharacters}.` +
+      `${grepHint} Use offset=${sliceEnd} to continue reading.]`
+    );
+  }
+
+  // Whole document returned in a single unbounded call: no footer needed.
+  if (effectiveOffset === 0 && limit === null) {
+    return "";
+  }
+
+  return `\n\n[End of document reached (${totalCharacters} characters total).]`;
+}
+
 export async function cat(
   {
     dataSources,
@@ -135,13 +179,19 @@ export async function cat(
 
   const ref = getRefs()[citationsOffset];
 
+  const footer = makeCatFooter({
+    totalCharacters: readResult.value.total_characters,
+    offset: readResult.value.offset,
+    limit: readResult.value.limit,
+  });
+
   return new Ok([
     {
       type: "resource" as const,
       resource: {
         mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_NODE_CONTENT,
         uri: node.source_url ?? "",
-        text: readResult.value.text,
+        text: readResult.value.text + footer,
         metadata: renderNode(node, dataSourceIdToConnectorMap),
         ref: ref,
       },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR aims at fixing (to some extend) https://github.com/dust-tt/tasks/issues/9245.

When an agent reads a document through the company data cat tool, it previously received only the raw text with no indication of how large the document was or whether more content remained. The result was a common failure mode where the agent would keep paginating by incrementing the offset to pull the rest of a large document, accumulating every page in its context and exhausting the window for no good reason.

This change appends a short footer to the returned text so the agent always knows the total size of the document and, when content remains, exactly where to continue from. Once the agent has paged to the end, it now gets an explicit end of document marker so a looping read stops deterministically instead of nudging the offset indefinitely. For documents above a large threshold the footer also steers the agent toward filtering with a regular expression rather than reading everything linearly. The total size and offset values were already returned by core but had been discarded, so no new backend work is required, and the window is computed from the offset and limit rather than the returned text length so it stays correct even when a regular expression filter is applied after slicing.

The tool and parameter descriptions were updated to match, telling the model that the output reports total size and continuation offset and that filtering is preferred over paging a large document to exhaustion. The behavior change is purely additive: a bracketed footer in the text plus richer descriptions, with no change to the API contract.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
