### PR TITLE
[front] billing: expire contract commits/credits one year after start

### DIFF
--- a/front/lib/api/checkout/business_activation.test.ts
+++ b/front/lib/api/checkout/business_activation.test.ts
@@ -153,9 +153,12 @@ vi.mock("@app/lib/metronome/constants", () => ({
   PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY: "DUST_PAYMENT_GATE_TYPE",
   PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION: "subscription_activation",
   CURRENCY_TO_CREDIT_TYPE_ID: { usd: "usd-credit", eur: "eur-credit" },
-  FOREVER_ENDING_BEFORE: "9999-12-31T00:00:00.000Z",
   CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY: "CARRY_ON_RENEWAL",
-  CARRY_ON_RENEWAL_FOREVER_VALUE: "forever",
+  oneYearAfter: (start: Date) => {
+    const end = new Date(start);
+    end.setUTCFullYear(end.getUTCFullYear() + 1);
+    return end;
+  },
   SEAT_PRIORITY_SUBSCRIPTION_COMMIT: 100,
   getProductSeatSubscriptionCommitId: () => "seat-commit-product",
 }));

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -24,10 +24,9 @@ import {
 } from "@app/lib/metronome/client";
 import {
   CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
-  CARRY_ON_RENEWAL_FOREVER_VALUE,
   CURRENCY_TO_CREDIT_TYPE_ID,
-  FOREVER_ENDING_BEFORE,
   getProductSeatSubscriptionCommitId,
+  oneYearAfter,
   PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY,
   PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION,
   SEAT_PRIORITY_SUBSCRIPTION_COMMIT,
@@ -300,6 +299,8 @@ export async function createPaymentGatedBusinessActivation({
   const fiatCreditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[currency];
   const amountNative = metronomeAmount(effectiveAmountCents, currency);
 
+  const accessEndingBefore = oneYearAfter(now);
+
   const commitResult = await addPaymentGatedCommitToContract({
     metronomeCustomerId,
     metronomeContractId,
@@ -307,7 +308,7 @@ export async function createPaymentGatedBusinessActivation({
     accessAmount: amountNative,
     accessCreditTypeId: fiatCreditTypeId,
     accessStartingAt: now,
-    accessEndingBefore: FOREVER_ENDING_BEFORE,
+    accessEndingBefore,
     invoiceUnitPrice: amountNative,
     invoiceQuantity: 1,
     invoiceCreditTypeId: fiatCreditTypeId,
@@ -317,7 +318,7 @@ export async function createPaymentGatedBusinessActivation({
     name: `Business subscription activation (${seatType} ${billingPeriod})`,
     uniquenessKey,
     customFields: {
-      [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: CARRY_ON_RENEWAL_FOREVER_VALUE,
+      [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: floorToHourISO(accessEndingBefore),
     },
     stripeInvoiceMetadata: {
       subscription_activation: "true",

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -14,13 +14,12 @@ import {
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
   CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
-  CARRY_ON_RENEWAL_FOREVER_VALUE,
   CURRENCY_TO_CREDIT_TYPE_ID,
-  FOREVER_ENDING_BEFORE,
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
   getProductSeatSubscriptionCommitId,
   HUBSPOT_DEAL_ID_CUSTOM_FIELD_KEY,
+  oneYearAfter,
 } from "@app/lib/metronome/constants";
 import {
   ensureMetronomeCustomerForWorkspace,
@@ -725,6 +724,9 @@ async function stepContractEdits({
       alignedStart,
       paymentSchedule: body.initialCredits.paymentSchedule,
     });
+    const initialCreditsEndingBefore = floorToHourISO(
+      oneYearAfter(alignedStart)
+    );
     addCommits.push({
       product_id: getProductPrepaidCommitId(),
       type: "PREPAID",
@@ -732,7 +734,7 @@ async function stepContractEdits({
       priority: AWU_PRIORITY_PURCHASED_COMMIT,
       applicable_product_tags: ["usage"],
       custom_fields: {
-        [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: CARRY_ON_RENEWAL_FOREVER_VALUE,
+        [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: initialCreditsEndingBefore,
       },
       access_schedule: {
         credit_type_id: getCreditTypeAwuId(),
@@ -740,7 +742,7 @@ async function stepContractEdits({
           {
             amount: body.initialCredits.amountCredits,
             starting_at: floorToHourISO(alignedStart),
-            ending_before: floorToHourISO(FOREVER_ENDING_BEFORE),
+            ending_before: initialCreditsEndingBefore,
           },
         ],
       },

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -11,16 +11,16 @@ import {
 } from "@app/lib/credits/awu_purchase_status";
 import {
   addPaymentGatedCommitToContract,
+  floorToHourISO,
   getMetronomeCustomerStripeCustomerId,
 } from "@app/lib/metronome/client";
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
   CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
-  CARRY_ON_RENEWAL_FOREVER_VALUE,
   CURRENCY_TO_CREDIT_TYPE_ID,
-  FOREVER_ENDING_BEFORE,
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
+  oneYearAfter,
 } from "@app/lib/metronome/constants";
 import { USAGE_TAG } from "@app/lib/metronome/setup_common";
 import { isEnterprisePlanPrefix } from "@app/lib/plans/plan_codes";
@@ -335,6 +335,8 @@ export async function purchaseAwuCredits(
     amountCredits,
   });
 
+  const accessEndingBefore = oneYearAfter(now);
+
   const editResult = await addPaymentGatedCommitToContract({
     metronomeCustomerId,
     metronomeContractId,
@@ -342,7 +344,7 @@ export async function purchaseAwuCredits(
     accessAmount: amountCredits,
     accessCreditTypeId: getCreditTypeAwuId(),
     accessStartingAt: now,
-    accessEndingBefore: FOREVER_ENDING_BEFORE,
+    accessEndingBefore,
     invoiceUnitPrice,
     invoiceQuantity: 1,
     invoiceCreditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[currency],
@@ -355,7 +357,7 @@ export async function purchaseAwuCredits(
         : `Credit top-up: ${amountCredits.toLocaleString()} credits`,
     uniquenessKey,
     customFields: {
-      [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: CARRY_ON_RENEWAL_FOREVER_VALUE,
+      [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: floorToHourISO(accessEndingBefore),
     },
     // Stamped on the Stripe invoice Metronome pushes downstream so the
     // existing eligibility check (`isAwuPurchaseInvoice`) still recognises

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -139,12 +139,14 @@ export type ContractCreditType =
 // the balance left at the transition from their expiration ledger entry, and
 // re-grants it on the successor contract (see `carryOverContractBalancesOnRenewal`).
 //
-// The field VALUE is either `CARRY_ON_RENEWAL_FOREVER_VALUE` (the entry never
-// expires and carries indefinitely) or an ISO timestamp (a finite expiry).
-// Metronome clamps a commit's live access window to the contract end when a
-// RENEWAL ends the source, so by the time the webhook runs the original expiry
-// is gone — we stamp it here so it survives. The carried grant re-stamps the
-// same value, preserving the policy across any number of renewals.
+// The field VALUE is an ISO timestamp (the entry's absolute expiry, one year
+// after its start — see `oneYearAfter`). Legacy entries may instead carry
+// `CARRY_ON_RENEWAL_FOREVER_VALUE` (never expires); the carry-over reader treats
+// any non-date value as forever. Metronome clamps a commit's live access window
+// to the contract end when a RENEWAL ends the source, so by the time the webhook
+// runs the original expiry is gone — we stamp it here so it survives. The
+// carried grant re-stamps the same value, preserving the expiry across any
+// number of renewals.
 //
 // This replaces Metronome's `rollover_fraction`: a rolled-over commit becomes a
 // "rollover" commit, and Metronome consumes rollover commits before all prepaid
@@ -158,6 +160,12 @@ export const CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY = "DUST_CARRY_ON_RENEWAL";
 export const CARRY_ON_RENEWAL_FOREVER_VALUE = "forever";
 
 export const FOREVER_ENDING_BEFORE = new Date("2999-01-01T00:00:00.000Z");
+
+export function oneYearAfter(start: Date): Date {
+  const end = new Date(start);
+  end.setUTCFullYear(end.getUTCFullYear() + 1);
+  return end;
+}
 
 // Custom field stamped on a per-user (free) seat credit, carrying the seat's
 // user sId. Metronome alerts can filter on custom fields but not on a credit's

--- a/front/scripts/backfill_contract_credit_expiry.ts
+++ b/front/scripts/backfill_contract_credit_expiry.ts
@@ -1,0 +1,339 @@
+/**
+ * Backfill a one-year expiry onto contract commits and credits that were granted
+ * a far-future (2999) "forever" access window.
+ *
+ * The initial-credits, AWU top-up and business-activation seat commits used to be
+ * created with `ending_before = 2999-01-01` and `DUST_CARRY_ON_RENEWAL=forever`,
+ * so they never expired and carried their full balance forever across renewals.
+ * We now grant them a one-year window instead. This rewrites the existing forever
+ * entries to expire one year after they start, and stamps the same absolute date
+ * on `DUST_CARRY_ON_RENEWAL` so the expiry is preserved (not reset) when a balance
+ * is carried onto a renewed contract.
+ *
+ * Targets only contract entries flagged `DUST_CARRY_ON_RENEWAL` whose access
+ * window is far-future. Idempotent: entries whose window is already finite are
+ * skipped.
+ *
+ * NOTE: an entry that started more than a year ago resolves to a past expiry and
+ * is expired retroactively. The dry run (default) logs every entry and its
+ * computed new end (flagging the retroactive ones) so you can review before
+ * passing --execute.
+ *
+ * Run with: npx tsx scripts/backfill_contract_credit_expiry.ts [--execute] [--workspaceId <sId>]
+ */
+
+import {
+  floorToHourISO,
+  getMetronomeClient,
+  listMetronomeCustomerCommits,
+  listMetronomeCustomerCredits,
+  setMetronomeCommitCustomFields,
+  setMetronomeContractCreditCustomFields,
+} from "@app/lib/metronome/client";
+import {
+  CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
+  FOREVER_ENDING_BEFORE,
+  oneYearAfter,
+} from "@app/lib/metronome/constants";
+import type {
+  MetronomeCommit,
+  MetronomeCredit,
+} from "@app/lib/metronome/types";
+import type { Logger } from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
+
+const FOREVER_MS = FOREVER_ENDING_BEFORE.getTime();
+
+type Entry = MetronomeCommit | MetronomeCredit;
+
+// Rewrite the access-schedule end date of a single commit/credit schedule item.
+// Inlined here (rather than added to `lib/metronome/client.ts`) because it is a
+// one-shot need for this disposable backfill; the rest of the codebase has no
+// reason to edit a contract entry's access window.
+async function updateAccessEndDate({
+  kind,
+  metronomeCustomerId,
+  contractId,
+  entryId,
+  segmentId,
+  endingBefore,
+}: {
+  kind: "commit" | "credit";
+  metronomeCustomerId: string;
+  contractId: string;
+  entryId: string;
+  segmentId: string;
+  endingBefore: string;
+}): Promise<Result<void, Error>> {
+  const accessSchedule = {
+    update_schedule_items: [{ id: segmentId, ending_before: endingBefore }],
+  };
+  try {
+    await getMetronomeClient().v2.contracts.edit({
+      customer_id: metronomeCustomerId,
+      contract_id: contractId,
+      ...(kind === "commit"
+        ? {
+            update_commits: [
+              { commit_id: entryId, access_schedule: accessSchedule },
+            ],
+          }
+        : {
+            update_credits: [
+              { credit_id: entryId, access_schedule: accessSchedule },
+            ],
+          }),
+    });
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+function isForeverEndingBefore(endingBefore: string): boolean {
+  const ms = Date.parse(endingBefore);
+  return !Number.isNaN(ms) && ms >= FOREVER_MS;
+}
+
+type EntryPlan = {
+  contractId: string;
+  segmentUpdates: Array<{ segmentId: string; endingBefore: string }>;
+  carryValue: string;
+};
+
+function planForEntry(entry: Entry): EntryPlan | null {
+  const carry = entry.custom_fields?.[CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY];
+  if (carry === undefined) {
+    return null;
+  }
+  const contractId = entry.contract?.id;
+  if (!contractId) {
+    return null;
+  }
+  const items = entry.access_schedule?.schedule_items ?? [];
+  const foreverItems = items.filter((it) =>
+    isForeverEndingBefore(it.ending_before)
+  );
+  if (foreverItems.length === 0) {
+    return null;
+  }
+  const segmentUpdates = foreverItems.map((it) => ({
+    segmentId: it.id,
+    endingBefore: floorToHourISO(oneYearAfter(new Date(it.starting_at))),
+  }));
+  // The carry-on-renewal value is the entry's absolute expiry: one year after
+  // its earliest start. With a single schedule item it matches the new window.
+  const earliestStartMs = Math.min(
+    ...items.map((it) => Date.parse(it.starting_at))
+  );
+  const carryValue = floorToHourISO(oneYearAfter(new Date(earliestStartMs)));
+  return { contractId, segmentUpdates, carryValue };
+}
+
+async function processEntries({
+  kind,
+  entries,
+  workspace,
+  execute,
+  logger,
+  updateEndDate,
+  setCarryCustomField,
+}: {
+  kind: "commit" | "credit";
+  entries: Entry[];
+  workspace: LightWorkspaceType;
+  execute: boolean;
+  logger: Logger;
+  updateEndDate: (args: {
+    contractId: string;
+    entryId: string;
+    segmentId: string;
+    endingBefore: string;
+  }) => Promise<Result<void, Error>>;
+  setCarryCustomField: (args: {
+    entryId: string;
+    value: string;
+  }) => Promise<Result<void, Error>>;
+}): Promise<void> {
+  const nowMs = Date.now();
+  for (const entry of entries) {
+    const plan = planForEntry(entry);
+    if (!plan) {
+      continue;
+    }
+    const retroactive = Date.parse(plan.carryValue) <= nowMs;
+
+    if (!execute) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          kind,
+          entryId: entry.id,
+          name: entry.name,
+          contractId: plan.contractId,
+          newEndingBefore: plan.carryValue,
+          retroactive,
+        },
+        "[Backfill contract expiry] [DRY RUN] Would set one-year expiry"
+      );
+      continue;
+    }
+
+    let failed = false;
+    for (const seg of plan.segmentUpdates) {
+      const result = await updateEndDate({
+        contractId: plan.contractId,
+        entryId: entry.id,
+        segmentId: seg.segmentId,
+        endingBefore: seg.endingBefore,
+      });
+      if (result.isErr()) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            kind,
+            entryId: entry.id,
+            segmentId: seg.segmentId,
+            error: result.error,
+          },
+          "[Backfill contract expiry] Failed to update access end date"
+        );
+        failed = true;
+        break;
+      }
+    }
+    if (failed) {
+      continue;
+    }
+
+    const carryResult = await setCarryCustomField({
+      entryId: entry.id,
+      value: plan.carryValue,
+    });
+    if (carryResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          kind,
+          entryId: entry.id,
+          error: carryResult.error,
+        },
+        "[Backfill contract expiry] Failed to update carry-on-renewal field"
+      );
+      continue;
+    }
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        kind,
+        entryId: entry.id,
+        newEndingBefore: plan.carryValue,
+        retroactive,
+      },
+      "[Backfill contract expiry] Set one-year expiry"
+    );
+  }
+}
+
+async function backfillForWorkspace(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return; // Workspace not provisioned in Metronome — skip.
+  }
+
+  const commitsResult = await listMetronomeCustomerCommits({
+    metronomeCustomerId,
+    includeContractCommits: true,
+  });
+  if (commitsResult.isErr()) {
+    logger.error(
+      { workspaceId: workspace.sId, error: commitsResult.error },
+      "[Backfill contract expiry] Failed to list commits"
+    );
+  } else {
+    await processEntries({
+      kind: "commit",
+      entries: commitsResult.value,
+      workspace,
+      execute,
+      logger,
+      updateEndDate: ({ contractId, entryId, segmentId, endingBefore }) =>
+        updateAccessEndDate({
+          kind: "commit",
+          metronomeCustomerId,
+          contractId,
+          entryId,
+          segmentId,
+          endingBefore,
+        }),
+      setCarryCustomField: ({ entryId, value }) =>
+        setMetronomeCommitCustomFields({
+          commitId: entryId,
+          customFields: { [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: value },
+        }),
+    });
+  }
+
+  const creditsResult = await listMetronomeCustomerCredits({
+    metronomeCustomerId,
+    includeContractCredits: true,
+  });
+  if (creditsResult.isErr()) {
+    logger.error(
+      { workspaceId: workspace.sId, error: creditsResult.error },
+      "[Backfill contract expiry] Failed to list credits"
+    );
+  } else {
+    await processEntries({
+      kind: "credit",
+      entries: creditsResult.value,
+      workspace,
+      execute,
+      logger,
+      updateEndDate: ({ contractId, entryId, segmentId, endingBefore }) =>
+        updateAccessEndDate({
+          kind: "credit",
+          metronomeCustomerId,
+          contractId,
+          entryId,
+          segmentId,
+          endingBefore,
+        }),
+      setCarryCustomField: ({ entryId, value }) =>
+        setMetronomeContractCreditCustomFields({
+          creditId: entryId,
+          customFields: { [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: value },
+        }),
+    });
+  }
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string" as const,
+      description:
+        "Optional workspace sId to process (processes all if omitted)",
+      required: false,
+    },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await backfillForWorkspace(workspace, execute, logger);
+      },
+      { concurrency: 4, wId: workspaceId }
+    );
+  }
+);


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9225

Contract commits and credits (initial credits, AWU top-ups, business-activation seat prepayment) were granted a far-future (2999) "forever" access window and a `DUST_CARRY_ON_RENEWAL=forever` custom field, so they never expired and carried their full balance forever across renewals.

Grant them a one-year window instead:
- add `oneYearAfter(start)` and use it at the three creation sites for both the Metronome access `ending_before` and the `DUST_CARRY_ON_RENEWAL` value, so the expiry is absolute (one year from the original start) and preserved — not reset — when a balance is carried onto a renewed contract.
- add `scripts/backfill_contract_credit_expiry.ts` to rewrite existing forever entries to expire one year after they start (dry-run by default; flags retroactively-expired entries before --execute).
## Tests

Local

## Risk

Low
## Deploy Plan

Run `cd front && npx tsx scripts/backfill_contract_credit_expiry.ts --execute`