### PR TITLE
Derive sandbox MCP request timeout from max command timeout plus buffer

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -64,7 +64,10 @@ import { RUN_AGENT_SERVER } from "@app/lib/api/actions/servers/run_agent/metadat
 import { RUN_DUST_APP_SERVER } from "@app/lib/api/actions/servers/run_dust_app/metadata";
 import { SALESFORCE_SERVER } from "@app/lib/api/actions/servers/salesforce/metadata";
 import { SALESLOFT_SERVER } from "@app/lib/api/actions/servers/salesloft/metadata";
-import { SANDBOX_SERVER } from "@app/lib/api/actions/servers/sandbox/metadata";
+import {
+  SANDBOX_MCP_REQUEST_TIMEOUT_MS,
+  SANDBOX_SERVER,
+} from "@app/lib/api/actions/servers/sandbox/metadata";
 import { SCHEDULES_MANAGEMENT_SERVER } from "@app/lib/api/actions/servers/schedules_management/metadata";
 import { SEARCH_SERVER } from "@app/lib/api/actions/servers/search/metadata";
 import { SKILL_AUTHORING_SERVER } from "@app/lib/api/actions/servers/skill_authoring/metadata";
@@ -1038,7 +1041,9 @@ export const INTERNAL_MCP_SERVERS = {
     metadata: SANDBOX_SERVER,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
-    timeoutMs: 120000, // 2 minutes for command execution
+    // Derived from the max command timeout plus a buffer so the in-container
+    // timeout returns captured output before this MCP deadline aborts the call.
+    timeoutMs: SANDBOX_MCP_REQUEST_TIMEOUT_MS,
   },
   user_mentions: {
     id: 1026,

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -6,6 +6,22 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const SANDBOX_TOOL_NAME = "sandbox" as const;
 
+// Default and maximum timeout the model can request for a single bash command.
+// The value is enforced in-container by the `timeout` wrapper (see
+// `wrapCommandWithCapture`), which kills the command and returns the captured
+// output when it overruns.
+export const SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS = 60000;
+export const SANDBOX_MAX_COMMAND_TIMEOUT_MS = 120000;
+
+// Outer MCP request deadline for the sandbox server. It must be strictly
+// greater than the max in-container command timeout so the graceful
+// in-container timeout (which returns partial output) always fires before the
+// MCP layer hard-aborts the call. The buffer covers process teardown, output
+// flushing, and the host round-trip.
+const SANDBOX_MCP_TIMEOUT_BUFFER_MS = 30000;
+export const SANDBOX_MCP_REQUEST_TIMEOUT_MS =
+  SANDBOX_MAX_COMMAND_TIMEOUT_MS + SANDBOX_MCP_TIMEOUT_BUFFER_MS;
+
 export const SANDBOX_TOOLS_METADATA = createToolsRecord({
   bash: {
     description:
@@ -31,10 +47,10 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         .describe("Working directory for command execution. Defaults to /tmp."),
       timeoutMs: z
         .number()
-        .max(120000)
+        .max(SANDBOX_MAX_COMMAND_TIMEOUT_MS)
         .optional()
         .describe(
-          "Timeout in milliseconds for command execution. Defaults to 60000, max 120000."
+          `Timeout in milliseconds for command execution. Defaults to ${SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS}, max ${SANDBOX_MAX_COMMAND_TIMEOUT_MS}.`
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -9,7 +9,10 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isSandboxResumeState } from "@app/lib/actions/types";
-import { SANDBOX_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox/metadata";
+import {
+  SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS,
+  SANDBOX_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/sandbox/metadata";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
@@ -362,7 +365,9 @@ export async function runSandboxBashTool(
   const startMs = performance.now();
 
   const providerId = agentConfiguration.model.providerId;
-  const timeoutSec = timeoutMs ? Math.ceil(timeoutMs / 1000) : 60;
+  const timeoutSec = Math.ceil(
+    (timeoutMs ?? SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS) / 1000
+  );
   const commandToRun = isResumeMode
     ? buildWaitAndCollectCommand(execId)
     : wrapCommandWithCapture(command, execId, providerId, { timeoutSec });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The sandbox bash tool enforces a command timeout inside the container, returning captured output when the limit is reached. The MCP layer applies its own hard deadline to the whole tool call. Both were hardcoded to the same two minute value, so when the model requested the maximum command timeout the two deadlines fired at the same moment. Because the in-container path needs extra time to tear down the process, flush output, and round-trip to the host, the MCP deadline tended to win and abort the call before the graceful timeout could return its partial output, surfacing a hard error instead of a clean result.

This introduces a single source of truth for the default and maximum command timeouts and derives the MCP deadline from the maximum plus a buffer, so the in-container timeout always resolves first and the MCP deadline acts purely as an outer backstop. Raising the maximum command timeout now moves the MCP ceiling with it.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
