### PR TITLE
Remove legacy sandbox ownership fallback

### DIFF
--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -235,6 +235,39 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
     );
     expect(reloaded?.status).toBe("deleted");
   });
+
+  it("does not fall back to the legacy conversationId column when ownership is missing", async () => {
+    const sandbox = await SandboxFactory.create(
+      authenticator,
+      conversationResource.toJSON(),
+      {
+        status: "sleeping",
+      }
+    );
+
+    await ConversationSandboxModel.destroy({
+      where: {
+        sandboxId: sandbox.id,
+        workspaceId: authenticator.getNonNullableWorkspace().id,
+      },
+    });
+
+    const result = await SandboxResource.dangerouslyDestroyIfSleeping(
+      authenticator,
+      conversationResource
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockProviderDestroy).not.toHaveBeenCalled();
+
+    const row = await SandboxModel.findOne({
+      where: {
+        id: sandbox.id,
+        workspaceId: authenticator.getNonNullableWorkspace().id,
+      },
+    });
+    expect(row?.status).toBe("sleeping");
+  });
 });
 
 describe("SandboxResource.dangerouslyDestroyIfKillRequested", () => {
@@ -552,7 +585,7 @@ describe("SandboxResource.fetchByConversation", () => {
     });
   }
 
-  it("reads from conversation_sandboxes before the legacy conversationId column", async () => {
+  it("reads from conversation_sandboxes even when the legacy conversationId column disagrees", async () => {
     const conversation = await makeConversation();
     const otherConversation = await makeConversation();
     const sandbox = await SandboxFactory.create(authenticator, conversation);
@@ -570,7 +603,7 @@ describe("SandboxResource.fetchByConversation", () => {
     expect(fetched?.id).toBe(sandbox.id);
   });
 
-  it("falls back to the legacy conversationId column when no ownership row exists", async () => {
+  it("returns null when no ownership row exists", async () => {
     const conversation = await makeConversation();
     const sandbox = await SandboxFactory.create(authenticator, conversation);
 
@@ -586,7 +619,7 @@ describe("SandboxResource.fetchByConversation", () => {
       conversation
     );
 
-    expect(fetched?.id).toBe(sandbox.id);
+    expect(fetched).toBeNull();
   });
 
   it("loads conversation ownership mappings by sandboxes", async () => {

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -224,14 +224,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       }
     }
 
-    const row = await this.model.findOne({
-      where: {
-        conversationId: conversation.id,
-        workspaceId: conversation.workspaceId,
-      },
-    });
-
-    return row ? new this(this.model, row.get()) : null;
+    return null;
   }
 
   static async fetchByConversation(
@@ -257,17 +250,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       }
     }
 
-    const sandboxes = await this.baseFetch(auth, {
-      where: {
-        conversationId: conversation.id,
-      },
-    });
-
-    if (sandboxes.length === 0) {
-      return null;
-    }
-
-    return sandboxes[0];
+    return null;
   }
 
   /**

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -64,13 +64,7 @@ async function fetchConversationMap(
       sandboxes
     );
   const conversationModelIds = [
-    ...new Set(
-      sandboxes.map(
-        (sandbox) =>
-          conversationModelIdsBySandboxModelId.get(sandbox.id) ??
-          sandbox.conversationId
-      )
-    ),
+    ...new Set(conversationModelIdsBySandboxModelId.values()),
   ];
   const conversations =
     await ConversationResource.dangerouslyFetchByModelIds(conversationModelIds);
@@ -80,9 +74,13 @@ async function fetchConversationMap(
     conversationModelIdsBySandboxModelId,
     conversationsBySandboxModelId: new Map(
       sandboxes.flatMap((sandbox) => {
-        const conversationModelId =
-          conversationModelIdsBySandboxModelId.get(sandbox.id) ??
-          sandbox.conversationId;
+        const conversationModelId = conversationModelIdsBySandboxModelId.get(
+          sandbox.id
+        );
+        if (!conversationModelId) {
+          return [];
+        }
+
         const conversation = conversationsById.get(conversationModelId);
 
         return conversation ? [[sandbox.id, conversation] as const] : [];
@@ -119,7 +117,6 @@ async function processSandboxes(
       if (!auth || !conversation) {
         logger.warn(
           {
-            legacyConversationModelId: sandbox.conversationId,
             ownershipConversationModelId:
               conversationMaps.conversationModelIdsBySandboxModelId.get(
                 sandbox.id
@@ -136,7 +133,7 @@ async function processSandboxes(
       if (result.isErr()) {
         logger.error(
           {
-            conversationModelId: sandbox.conversationId,
+            conversationModelId: conversation.id,
             error: result.error.message,
           },
           errorMessage


### PR DESCRIPTION
Follow up of #27494 and #27916.

## Description

Remove the remaining sandbox ownership read fallback to the legacy `sandboxes.conversationId` column. Conversation sandbox reads and reaper ownership resolution now depend on `conversation_sandboxes` only, while writes still keep the legacy column populated until the later drop-column PR.

## Tests

Tested locally with explicit Biome on the changed files, `NODE_ENV=test npm test -- lib/resources/sandbox_resource.test.ts`, and `nvm use && NODE_OPTIONS=\"--max-old-space-size=8192\" npx tsc --noEmit` in `front`.

## Risk

A sandbox missing its `conversation_sandboxes` row will no longer be resolved from the legacy column. Safe to rollback by reverting this PR while the legacy column still exists.

## Deploy Plan

- [ ] Before deploying this PR, verify `conversation_sandboxes` is ISO with `sandboxes.conversationId` in prod (`missing=0`, `extra=0`) using `front/migrations/20260624_backfill_conversation_sandboxes.ts`.
- [ ] Deploy front.
- [ ] Monitor sandbox lifecycle/reaper errors.