### PR TITLE
Route conversation sandbox calls through conversations

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -22,7 +22,6 @@ import { ConversationForkResource } from "@app/lib/resources/conversation_fork_r
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import {
   ProjectTaskConversationModel,
   ProjectTaskSourceModel,
@@ -312,7 +311,7 @@ export async function destroyConversation(
     where: { workspaceId: owner.id, sourceId: conversation.sId },
   });
 
-  await SandboxResource.deleteByConversation(auth, conversation);
+  await conversation.deleteSandbox(auth);
 
   // TODO(2026-03-09 SANDBOX): Implement proper file deletion.
   // FileResource records associated with this conversation (via

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -2,7 +2,7 @@ import { Err, Ok, type Result } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  mockEnsureActive,
+  mockEnsureSandboxActive,
   mockEnsureSandboxEgressOnExec,
   mockGetSandboxImage,
   mockLoggerError,
@@ -17,7 +17,7 @@ const {
   const mockSetupSandboxMount = vi.fn();
   const mockRefreshSandboxMount = vi.fn();
   return {
-    mockEnsureActive: vi.fn(),
+    mockEnsureSandboxActive: vi.fn(),
     mockEnsureSandboxEgressOnExec: vi.fn(),
     mockGetSandboxImage: vi.fn(),
     mockLoggerError: vi.fn(),
@@ -50,9 +50,9 @@ vi.mock("@app/lib/api/sandbox/telemetry", () => ({
   startTelemetry: mockStartTelemetry,
 }));
 
-vi.mock("@app/lib/resources/sandbox_resource", () => ({
-  SandboxResource: {
-    ensureActive: mockEnsureActive,
+vi.mock("@app/lib/resources/conversation_resource", () => ({
+  ConversationResource: {
+    ensureSandboxActive: mockEnsureSandboxActive,
   },
 }));
 
@@ -92,7 +92,7 @@ describe("ensureSandboxReady", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockEnsureActive.mockResolvedValue(
+    mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: false, sandbox, wokeFromSleep: false })
     );
     mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Ok(undefined));
@@ -105,7 +105,7 @@ describe("ensureSandboxReady", () => {
   });
 
   it("preps egress, mounts files, and ensures egress on exec for freshly-created sandboxes", async () => {
-    mockEnsureActive.mockResolvedValue(
+    mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
     );
 
@@ -135,7 +135,7 @@ describe("ensureSandboxReady", () => {
   it("starts GCS mount before initial egress prep resolves", async () => {
     const prepStarted = createDeferred<void>();
     const prepResult = createDeferred<Result<void, Error>>();
-    mockEnsureActive.mockResolvedValue(
+    mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
     );
     mockPrepareSandboxEgressBeforeMount.mockImplementation(() => {
@@ -164,7 +164,7 @@ describe("ensureSandboxReady", () => {
   });
 
   it("only refreshes the token (no remount) when the sandbox woke from sleep", async () => {
-    mockEnsureActive.mockResolvedValue(
+    mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: false, sandbox, wokeFromSleep: true })
     );
 
@@ -220,7 +220,9 @@ describe("ensureSandboxReady", () => {
   });
 
   it("short-circuits when ensureActive fails", async () => {
-    mockEnsureActive.mockResolvedValue(new Err(new Error("ensure failed")));
+    mockEnsureSandboxActive.mockResolvedValue(
+      new Err(new Error("ensure failed"))
+    );
 
     const result = await ensureSandboxReady(
       auth as never,
@@ -234,7 +236,7 @@ describe("ensureSandboxReady", () => {
 
   it("returns the initial egress prep error after also running the GCS mount", async () => {
     const setupError = new Error("setup failed");
-    mockEnsureActive.mockResolvedValue(
+    mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
     );
     mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Err(setupError));
@@ -254,7 +256,7 @@ describe("ensureSandboxReady", () => {
 
   it("returns the initial egress prep error when both initial phases fail", async () => {
     const setupError = new Error("setup failed");
-    mockEnsureActive.mockResolvedValue(
+    mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
     );
     mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Err(setupError));
@@ -274,7 +276,7 @@ describe("ensureSandboxReady", () => {
   });
 
   it("short-circuits when mounting conversation files fails", async () => {
-    mockEnsureActive.mockResolvedValue(
+    mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
     );
     mockSetupSandboxMount.mockResolvedValue(new Err(new Error("mount failed")));
@@ -289,7 +291,7 @@ describe("ensureSandboxReady", () => {
   });
 
   it("short-circuits when DustFileSystem.forConversation fails", async () => {
-    mockEnsureActive.mockResolvedValue(
+    mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
     );
     mockForConversation.mockResolvedValue(

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -10,7 +10,8 @@ import {
 } from "@app/lib/api/sandbox/instrumentation";
 import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
 import type { Authenticator } from "@app/lib/auth";
-import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Ok, type Result } from "@app/types/shared/result";
@@ -21,7 +22,7 @@ export interface EnsureSandboxReadyResult {
 }
 
 // /!\ All sandbox-touching tools must use this helper rather than calling
-// SandboxResource.ensureActive directly, otherwise the GCS FUSE mount and
+// ConversationResource.ensureSandboxActive directly, otherwise the GCS FUSE mount and
 // egress forwarder bring-up will be skipped.
 export async function ensureSandboxReady(
   auth: Authenticator,
@@ -37,7 +38,7 @@ export async function ensureSandboxReady(
     return await traceSandboxStartupPhase("total", async () => {
       const ensureResult = await traceSandboxStartupPhase(
         "provider_ensure",
-        () => SandboxResource.ensureActive(auth, conversation)
+        () => ConversationResource.ensureSandboxActive(auth, conversation)
       );
       if (ensureResult.isErr()) {
         status = "error";

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -5,7 +5,7 @@ import {
 } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type {
@@ -58,7 +58,7 @@ export async function pauseSandboxBashForBlockedChild(
   // reconnects via execId. DB-first is the self-converging shape.
   await parentAction.updateStatus("blocked_child_action_input_required");
 
-  const pauseResult = await SandboxResource.pauseForApproval(
+  const pauseResult = await ConversationResource.pauseSandboxForApproval(
     auth,
     conversation
   );

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -23,6 +23,11 @@ import {
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
 import { RunResource } from "@app/lib/resources/run_resource";
+import {
+  type ConversationSandboxOwner,
+  type EnsureSandboxResult,
+  SandboxResource,
+} from "@app/lib/resources/sandbox_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
@@ -347,6 +352,79 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
 
     return conversations.map((c) => this.fromModel(c, null));
+  }
+
+  static async fetchSandbox(
+    auth: Authenticator,
+    conversation: ConversationSandboxOwner
+  ): Promise<SandboxResource | null> {
+    return SandboxResource.fetchByConversation(auth, conversation);
+  }
+
+  async fetchSandbox(auth: Authenticator): Promise<SandboxResource | null> {
+    return ConversationResource.fetchSandbox(auth, this);
+  }
+
+  static async ensureSandboxActive(
+    auth: Authenticator,
+    conversation: ConversationSandboxOwner
+  ): Promise<Result<EnsureSandboxResult, Error>> {
+    return SandboxResource.ensureActive(auth, conversation);
+  }
+
+  async ensureSandboxActive(
+    auth: Authenticator
+  ): Promise<Result<EnsureSandboxResult, Error>> {
+    return ConversationResource.ensureSandboxActive(auth, this);
+  }
+
+  static async pauseSandboxForApproval(
+    auth: Authenticator,
+    conversation: ConversationSandboxOwner
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.pauseForApproval(auth, conversation);
+  }
+
+  async pauseSandboxForApproval(
+    auth: Authenticator
+  ): Promise<Result<void, Error>> {
+    return ConversationResource.pauseSandboxForApproval(auth, this);
+  }
+
+  async deleteSandbox(auth: Authenticator): Promise<Result<void, Error>> {
+    return SandboxResource.deleteByConversation(auth, this);
+  }
+
+  async dangerouslySleepSandboxIfRunning(
+    auth: Authenticator
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslySleepIfRunning(auth, this);
+  }
+
+  async dangerouslySleepSandboxIfPendingApproval(
+    auth: Authenticator
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslySleepIfPendingApproval(auth, this);
+  }
+
+  async dangerouslyDestroySandboxIfSleeping(
+    auth: Authenticator
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslyDestroyIfSleeping(auth, this);
+  }
+
+  async dangerouslyDestroySandboxIfKillRequested(
+    auth: Authenticator
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslyDestroyIfKillRequested(auth, this);
+  }
+
+  static async dangerouslyFetchConversationModelIdsBySandboxes(
+    sandboxes: Pick<SandboxResource, "id" | "workspaceId">[]
+  ): Promise<Map<ModelId, ModelId>> {
+    return SandboxResource.dangerouslyFetchConversationModelIdsBySandboxes(
+      sandboxes
+    );
   }
 
   get forkingData(): ConversationForkingDataType | undefined {

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -42,11 +42,16 @@ import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
-interface EnsureSandboxResult {
+export interface EnsureSandboxResult {
   freshlyCreated: boolean;
   sandbox: SandboxResource;
   wokeFromSleep: boolean;
 }
+
+export type ConversationSandboxOwner = Pick<
+  ConversationWithoutContentType,
+  "id" | "sId"
+>;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SandboxResource extends ReadonlyAttributesType<SandboxModel> {}
@@ -229,7 +234,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
   static async fetchByConversation(
     auth: Authenticator,
-    conversation: ConversationWithoutContentType
+    conversation: ConversationSandboxOwner
   ): Promise<SandboxResource | null> {
     const link = await this.conversationSandboxModel.findOne({
       where: {
@@ -440,7 +445,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   // cannot shadow a system var like CONVERSATION_ID.
   private static async buildSandboxEnvVars(
     auth: Authenticator,
-    conversation: ConversationWithoutContentType,
+    conversation: ConversationSandboxOwner,
     imageEnvVars: Record<string, string> | undefined
   ): Promise<Result<Record<string, string>, Error>> {
     const workspaceEnvResult =
@@ -479,7 +484,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   static async ensureActive(
     auth: Authenticator,
-    conversation: ConversationWithoutContentType
+    conversation: ConversationSandboxOwner
   ): Promise<Result<EnsureSandboxResult, Error>> {
     assert(
       auth.getNonNullableWorkspace().id !== undefined,
@@ -726,7 +731,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   static async pauseForApproval(
     auth: Authenticator,
-    conversation: ConversationWithoutContentType
+    conversation: ConversationSandboxOwner
   ): Promise<Result<void, Error>> {
     return this.withLifecycleLock(conversation.sId, async (provider) => {
       const sandbox = await SandboxResource.fetchByConversation(

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -60,7 +60,7 @@ async function fetchConversationMap(
   sandboxes: SandboxResource[]
 ): Promise<ConversationMaps> {
   const conversationModelIdsBySandboxModelId =
-    await SandboxResource.dangerouslyFetchConversationModelIdsBySandboxes(
+    await ConversationResource.dangerouslyFetchConversationModelIdsBySandboxes(
       sandboxes
     );
   const conversationModelIds = [
@@ -92,8 +92,8 @@ async function fetchConversationMap(
 /**
  * Shared driver for every reaper phase: resolve the workspace auth and the
  * ConversationResource for each sandbox, then run `action` concurrently. The
- * lifecycle methods take the serialized conversation, so we pass
- * `conversation.toJSON()`.
+ * lifecycle methods run from the conversation resource so callers do not need
+ * to know the conversation-owned sandbox lookup details.
  */
 async function processSandboxes(
   sandboxes: SandboxResource[],
@@ -166,7 +166,7 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
     await processSandboxes(
       killRequestedSandboxes,
       (auth, conversation) =>
-        SandboxResource.dangerouslyDestroyIfKillRequested(auth, conversation),
+        conversation.dangerouslyDestroySandboxIfKillRequested(auth),
       "Reaper: failed to destroy kill-requested sandbox — continuing."
     );
   }
@@ -187,7 +187,7 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
     await processSandboxes(
       runningSandboxes,
       (auth, conversation) =>
-        SandboxResource.dangerouslySleepIfRunning(auth, conversation),
+        conversation.dangerouslySleepSandboxIfRunning(auth),
       "Reaper: failed to sleep sandbox — continuing."
     );
   }
@@ -208,7 +208,7 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
     await processSandboxes(
       pendingSandboxes,
       (auth, conversation) =>
-        SandboxResource.dangerouslySleepIfPendingApproval(auth, conversation),
+        conversation.dangerouslySleepSandboxIfPendingApproval(auth),
       "Reaper: failed to transition pending_approval sandbox — continuing."
     );
   }
@@ -229,7 +229,7 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
     await processSandboxes(
       sleepingSandboxes,
       (auth, conversation) =>
-        SandboxResource.dangerouslyDestroyIfSleeping(auth, conversation),
+        conversation.dangerouslyDestroySandboxIfSleeping(auth),
       "Reaper: failed to destroy sandbox — continuing."
     );
   }

--- a/front/temporal/sandbox_reaper/kill_requester/activities.test.ts
+++ b/front/temporal/sandbox_reaper/kill_requester/activities.test.ts
@@ -1,4 +1,4 @@
-import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { requestSandboxKillsActivity } from "@app/temporal/sandbox_reaper/kill_requester/activities";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -52,7 +52,7 @@ describe("requestSandboxKillsActivity", () => {
     });
 
     expect(hasMore).toBe(false);
-    const marked = await SandboxResource.fetchByConversation(authenticator, c1);
+    const marked = await ConversationResource.fetchSandbox(authenticator, c1);
     expect(marked?.killRequestedAt).not.toBeNull();
   });
 });

--- a/front/tests/utils/SandboxFactory.ts
+++ b/front/tests/utils/SandboxFactory.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
@@ -38,10 +39,7 @@ export class SandboxFactory {
       );
     }
 
-    const result = await SandboxResource.fetchByConversation(
-      auth,
-      conversation
-    );
+    const result = await ConversationResource.fetchSandbox(auth, conversation);
     if (!result) {
       throw new Error("Sandbox not found after creation");
     }


### PR DESCRIPTION
## Description

Route conversation-owned sandbox operations through `ConversationResource` instead of direct external calls to `SandboxResource`. This adds conversation-level methods for fetch, ensure active, pause for approval, deletion, and reaper lifecycle actions while keeping fleet-level sandbox scans on `SandboxResource`.

Also updates the sandbox lifecycle helper, sandbox-child blocking, conversation deletion, reaper activities, and test helpers to use the conversation boundary.

## Tests

- `npx biome check --write --error-on-warnings front/lib/api/assistant/conversation/destroy.ts front/lib/api/sandbox/lifecycle.test.ts front/lib/api/sandbox/lifecycle.ts front/lib/api/sandbox/sandbox_child_block.ts front/lib/resources/conversation_resource.ts front/lib/resources/sandbox_resource.ts front/temporal/sandbox_reaper/activities.ts front/temporal/sandbox_reaper/kill_requester/activities.test.ts front/tests/utils/SandboxFactory.ts`
- `cd front && NODE_ENV=test npm test -- lib/api/sandbox/lifecycle.test.ts temporal/sandbox_reaper/kill_requester/activities.test.ts lib/resources/sandbox_resource.test.ts lib/api/sandbox/sandbox_child_block.test.ts lib/resources/conversation_resource.test.ts`
- `cd front && NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit`
- GitHub CI is green on the latest commit.

## Risk

Low. This is a boundary refactor: behavior remains delegated to the existing sandbox resource implementation. The main risk is missing a call site, mitigated by search for direct conversation-owned `SandboxResource` calls plus focused lifecycle, reaper, and conversation resource tests.

## Deploy Plan

Standard deploy. No schema migration, data migration, feature flag, or backfill is required.