### PR TITLE
feat: enable alerting for sandbox tool

### DIFF
--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -58,6 +58,7 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       running: "Executing command",
       done: "Execute command in the Computer",
     },
+    enableAlerting: true,
   },
   describe_toolset: {
     description:


### PR DESCRIPTION
## Description

Enables `enableAlerting` on the sandbox `bash` tool so that infrastructure-level errors are picked up by the tool datadog monitors.

Notice that bash command failures are returned as successful results with the output, not as tracked errors. Tracked errors should only fire on infrastructure failures (sandbox not starting, lifecycle issues, etc.) which are the kind of errors that should be surfaced on the monitors.

Yesterday's incident revealed that sandbox errors were going undetected because no monitor was wired up.

## Tests

## Risk

Low. Only adds signal, doesn't change behavior.

## Deploy Plan

Standard deployment.