### PR TITLE
Ultra temporary debug log.

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -27,6 +27,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import {
   isContentFragmentInput,
   isContentFragmentInputWithContentNode,
@@ -53,7 +54,6 @@ import { publicApiApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-
 import conversation from "./[cId]";
 
 // Mounted at /api/v1/w/:wId/assistant/conversations.
@@ -140,6 +140,17 @@ app.post(
       blocking,
       spaceId,
     } = ctx.req.valid("json");
+
+    // Extremely temporary debug.
+    if (auth.getNonNullableWorkspace().sId === "ba367d3014") {
+      logger.info(
+        {
+          message: "conversations/index",
+          body: ctx.req.valid("json"),
+        },
+        "conversations/index"
+      );
+    }
 
     const origin = message?.context.origin ?? "api";
 


### PR DESCRIPTION
## Description

Adds a temporary `logger.info` call in the `POST /api/v1/w/:wId/assistant/conversations` handler, gated on workspace sId `ba367d3014`. Logs the full validated request body to help debug an issue on that specific workspace. Must be reverted once the investigation is done.

## Tests

Targeted debug log — no automated tests. Verified manually that the guard sId prevents any impact on other workspaces.

## Risk

Low. Entirely gated behind a hardcoded workspace sId check; no behavior change for any other workspace. Log output may include request body content, so should not stay in prod longer than needed.

## Deploy Plan

Deploy front. Revert and redeploy once debugging is complete.
