### PR TITLE
[front] enh: show enabled skill instructions in action details

### DIFF
--- a/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -1,15 +1,19 @@
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import { SkillInstructionsReadOnlyEditor } from "@app/components/skills/SkillInstructionsReadOnlyEditor";
 import {
   getOutputText,
   isResourceContentWithText,
   isTextContent,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isSkillEnableInputType } from "@app/lib/actions/mcp_internal_actions/types";
+import { getEnableSkillIdFromOutputBlock } from "@app/lib/api/actions/servers/skill_management/rendering";
 import { SKILL_ICON } from "@app/lib/skill";
-import { ContentMessage } from "@dust-tt/sparkle";
+import { useSkill } from "@app/lib/swr/skill_configurations";
+import { ContentMessage, Spinner } from "@dust-tt/sparkle";
 
 export function MCPSkillEnableActionDetails({
+  owner,
   displayContext,
   toolParams,
   toolOutput,
@@ -26,26 +30,75 @@ export function MCPSkillEnableActionDetails({
     ? toolOutput.filter((o) => isTextContent(o) || isResourceContentWithText(o))
     : [];
 
+  const enabledSkillId =
+    toolOutput
+      ?.map(getEnableSkillIdFromOutputBlock)
+      .find((skillId): skillId is string => skillId !== null) ?? null;
+  const shouldFetchSkill =
+    displayContext !== "conversation" && enabledSkillId !== null;
+  const { skill, isSkillLoading, isSkillError } = useSkill({
+    workspaceId: owner.sId,
+    skillId: enabledSkillId,
+    disabled: !shouldFetchSkill,
+  });
+
+  const instructions = skill?.instructions ?? "";
+  const hasInstructions = instructions.trim().length > 0;
+  const showInstructionsSection =
+    shouldFetchSkill && (isSkillLoading || isSkillError || hasInstructions);
+  const showSidebarDetails =
+    displayContext !== "conversation" &&
+    (showInstructionsSection || outputItems.length > 0);
+
   return (
     <ActionDetailsWrapper
       displayContext={displayContext}
       actionName={actionName}
       visual={SKILL_ICON}
     >
-      {displayContext !== "conversation" && outputItems.length > 0 && (
+      {showSidebarDetails && (
         <div className="dd-privacy-mask flex flex-col gap-4 py-4 pl-6">
-          <div>
-            <span className="font-medium text-foreground dark:text-foreground-night">
-              Output
-            </span>
-            <div className="my-2 flex flex-col gap-2">
-              {outputItems.map((o, index) => (
-                <ContentMessage key={index} variant="primary" size="lg">
-                  {getOutputText(o) ?? ""}
-                </ContentMessage>
-              ))}
+          {outputItems.length > 0 && (
+            <div>
+              <span className="font-medium text-foreground dark:text-foreground-night">
+                Output
+              </span>
+              <div className="my-2 flex flex-col gap-2">
+                {outputItems.map((o, index) => (
+                  <ContentMessage key={index} variant="primary" size="lg">
+                    {getOutputText(o) ?? ""}
+                  </ContentMessage>
+                ))}
+              </div>
             </div>
-          </div>
+          )}
+
+          {showInstructionsSection && (
+            <div>
+              <span className="font-medium text-foreground dark:text-foreground-night">
+                Instructions
+              </span>
+              <div className="my-2">
+                {isSkillLoading ? (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    <Spinner size="xs" />
+                    <span>Loading instructions...</span>
+                  </div>
+                ) : isSkillError ? (
+                  <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    Could not load the skill instructions.
+                  </div>
+                ) : hasInstructions ? (
+                  <SkillInstructionsReadOnlyEditor
+                    content={instructions}
+                    htmlContent={skill?.instructionsHtml ?? ""}
+                    owner={owner}
+                    className="max-h-[400px] overflow-y-auto"
+                  />
+                ) : null}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </ActionDetailsWrapper>

--- a/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -93,7 +93,7 @@ export function MCPSkillEnableActionDetails({
                     content={instructions}
                     htmlContent={skill?.instructionsHtml ?? ""}
                     owner={owner}
-                    className="max-h-[400px] overflow-y-auto"
+                    className="max-h-150 overflow-y-auto"
                   />
                 ) : null}
               </div>


### PR DESCRIPTION
## Description

This PR adds a skill instructions preview to the MCP `enable_skill` action details. The sidebar now resolves the enabled skill from the tool output, keeps the original message first (smth like "The tool was successfully enabled"), and renders the skill guidelines below it with the same readonly instructions editor used by the Skill info page.

Conversation inline details stay unchanged, and the instructions section is hidden when the skill has no instructions.

<img width="887" height="541" alt="image" src="https://github.com/user-attachments/assets/2a0e5958-88f5-48d5-af96-a7066023ab2b" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.

