### PR TITLE
[front] feat: add skill favorite UI

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -52,6 +52,7 @@ import { useEffect, useMemo, useState } from "react";
 interface CapabilityPickerItemBase extends CapabilitySearchIndexItem {
   description?: string;
   id: string;
+  isFavorite?: boolean;
   label: string;
 }
 
@@ -344,6 +345,7 @@ export function CapabilitiesPicker({
           kind: "skill",
           skill,
           id: `skills-picker-${skill.sId}`,
+          isFavorite: skill.isFavorite ?? false,
           label: skill.name,
           sortName: skill.name.toLowerCase(),
           description,

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -124,6 +124,18 @@ describe("searchCapabilityIndex ranking", () => {
     expect(result.map((item) => item.id)).toEqual(["a", "z"]);
   });
 
+  it("ranks favorite capabilities first when no query is provided", () => {
+    const result = searchCapabilityIndex({
+      query: "",
+      items: [
+        { id: "a", sortName: "asana" },
+        { id: "z", isFavorite: true, sortName: "zendesk" },
+      ],
+    });
+
+    expect(result.map((item) => item.id)).toEqual(["z", "a"]);
+  });
+
   it("ranks earlier substring matches first", () => {
     const result = searchCapabilityIndex({
       items: [
@@ -207,6 +219,25 @@ describe("searchCapabilityIndex ranking", () => {
     });
 
     expect(result.map((item) => item.id)).toEqual(["title-match", "desc-only"]);
+  });
+
+  it("ranks favorites first within the same query match class", () => {
+    const result = searchCapabilityIndex({
+      query: "docs",
+      items: [
+        {
+          id: "non-favorite",
+          sortName: "docs assistant",
+        },
+        {
+          id: "favorite",
+          sortName: "docs writer",
+          isFavorite: true,
+        },
+      ],
+    });
+
+    expect(result.map((item) => item.id)).toEqual(["favorite", "non-favorite"]);
   });
 });
 

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -6,8 +6,8 @@ import {
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
+import type { SkillListItemResponseType } from "@app/lib/swr/skill_configurations";
 import { compareForAutocompleteSort, subFilter } from "@app/lib/utils";
-import type { SkillListItemResponseType } from "@app/types/api/skills";
 import React from "react";
 
 export const SELECT_SKILL_SLASH_COMMAND_ACTION = "select-skill";

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -17,6 +17,7 @@ export const INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION = "insert-knowledge-node";
 export const MAX_RENDERED_CAPABILITY_ITEMS = 50;
 
 export interface CapabilitySearchIndexItem {
+  isFavorite?: boolean;
   normalizedDescription?: string;
   sortGroup?: number;
   sortName: string;
@@ -53,8 +54,15 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
       return groupComparison;
     }
 
+    const aIsFavorite = a.item.isFavorite ?? false;
+    const bIsFavorite = b.item.isFavorite ?? false;
+    const favoriteComparison =
+      aIsFavorite === bIsFavorite ? 0 : aIsFavorite ? -1 : 1;
+
     if (normalizedQuery.length === 0) {
-      return a.item.sortName.localeCompare(b.item.sortName);
+      return (
+        favoriteComparison || a.item.sortName.localeCompare(b.item.sortName)
+      );
     }
 
     if (a.titleMatches !== b.titleMatches) {
@@ -62,14 +70,17 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
     }
 
     if (a.titleMatches) {
-      return compareForAutocompleteSort(
-        normalizedQuery,
-        a.item.sortName,
-        b.item.sortName
+      return (
+        favoriteComparison ||
+        compareForAutocompleteSort(
+          normalizedQuery,
+          a.item.sortName,
+          b.item.sortName
+        )
       );
     }
 
-    return a.item.sortName.localeCompare(b.item.sortName);
+    return favoriteComparison || a.item.sortName.localeCompare(b.item.sortName);
   });
 
   return sortedMatches.slice(0, limit).map(({ item }) => item);
@@ -79,6 +90,7 @@ export type SlashCommandSkillSuggestion = Pick<
   SkillWithoutInstructionsAndToolsType,
   | "editedBy"
   | "icon"
+  | "isFavorite"
   | "name"
   | "requestedSpaceIds"
   | "sId"

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -7,7 +7,7 @@ import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { compareForAutocompleteSort, subFilter } from "@app/lib/utils";
-import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
+import type { SkillListItemResponseType } from "@app/types/api/skills";
 import React from "react";
 
 export const SELECT_SKILL_SLASH_COMMAND_ACTION = "select-skill";
@@ -87,7 +87,7 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
 }
 
 export type SlashCommandSkillSuggestion = Pick<
-  SkillWithoutInstructionsAndToolsType,
+  SkillListItemResponseType,
   | "editedBy"
   | "icon"
   | "isFavorite"

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -6,8 +6,8 @@ import {
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
-import type { SkillListItemResponseType } from "@app/lib/swr/skill_configurations";
 import { compareForAutocompleteSort, subFilter } from "@app/lib/utils";
+import type { GetSkillsResponseBody } from "@app/types/api/skills";
 import React from "react";
 
 export const SELECT_SKILL_SLASH_COMMAND_ACTION = "select-skill";
@@ -87,7 +87,7 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
 }
 
 export type SlashCommandSkillSuggestion = Pick<
-  SkillListItemResponseType,
+  GetSkillsResponseBody["skills"][number],
   | "editedBy"
   | "icon"
   | "isFavorite"

--- a/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
@@ -55,6 +55,7 @@ export function buildCapabilitySlashCommandItems<
         .filter((skill) => skill.sId !== excludeSkillId)
         .filter((skill) => skillFilter?.(skill) ?? true)
         .map((skill) => ({
+          isFavorite: skill.isFavorite ?? false,
           kind: "skill" as const,
           normalizedDescription: skill.userFacingDescription?.toLowerCase(),
           skill,

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -164,10 +164,7 @@ export function ManageSkillsPage() {
   );
 
   const skillsByTab = useMemo<
-    Record<
-      SkillManagerTabType,
-      SkillWithoutInstructionsAndToolsWithRelationsType[]
-    >
+    Record<SkillManagerTabType, SkillListItemWithRelationsResponseType[]>
   >(() => {
     const searchLower = skillSearch.toLowerCase();
     const editableByMeSkills = sortedActiveSkills.filter((s) =>

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -29,11 +29,16 @@ import {
 } from "@app/components/sparkle/AppLayoutContext";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useQueryParams } from "@app/hooks/useQueryParams";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { SKILL_ICON } from "@app/lib/skill";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import {
   useSkillsWithRelations,
+  useUpdateSkillFavorite,
   useUpdateSkillsAvailability,
 } from "@app/lib/swr/skill_configurations";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
@@ -68,7 +73,9 @@ export function ManageSkillsPage() {
   const owner = useWorkspace();
   const { user, isAdmin } = useAuth();
   const { hasPermission } = useWorkspacePermissions();
-  const [selectedSkill, setSelectedSkill] =
+  const { hasFeature } = useFeatureFlags();
+  const hasSkillFavorites = hasFeature("skill_favorites");
+  const [optimisticSelectedSkill, setOptimisticSelectedSkill] =
     useState<SkillWithoutInstructionsAndToolsWithRelationsType | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
@@ -102,6 +109,7 @@ export function ManageSkillsPage() {
   };
 
   const doUpdateAvailability = useUpdateSkillsAvailability({ owner });
+  const { updateSkillFavorite } = useUpdateSkillFavorite({ owner });
 
   const isSearchActive = !isEmptyString(skillSearch);
 
@@ -197,19 +205,9 @@ export function ManageSkillsPage() {
 
   const isLoading = isActiveLoading || isArchivedLoading || isSuggestedLoading;
 
-  // Open skill from hash param when skills are loaded.
-  useEffect(() => {
-    if (skillIdParam && !isActiveLoading && activeSkills.length > 0) {
-      const skillFromParam = activeSkills.find((s) => s.sId === skillIdParam);
-      if (skillFromParam && selectedSkill?.sId !== skillIdParam) {
-        setSelectedSkill(skillFromParam);
-      }
-    }
-  }, [skillIdParam, activeSkills, isActiveLoading, selectedSkill?.sId]);
-
   const handleSkillSelect = useCallback(
     (skill: SkillWithoutInstructionsAndToolsWithRelationsType | null) => {
-      setSelectedSkill(skill);
+      setOptimisticSelectedSkill(skill);
       setSkillIdParam(skill?.sId);
     },
     [setSkillIdParam]
@@ -256,6 +254,33 @@ export function ManageSkillsPage() {
     "skill"
   );
 
+  const handleFavoriteChange = useCallback(
+    async (
+      skill: SkillWithoutInstructionsAndToolsWithRelationsType,
+      isFavorite: boolean
+    ) => {
+      const didUpdate = await updateSkillFavorite(skill, isFavorite);
+      if (didUpdate) {
+        setOptimisticSelectedSkill((currentSkill) =>
+          currentSkill?.sId === skill.sId
+            ? { ...currentSkill, isFavorite }
+            : currentSkill
+        );
+      }
+    },
+    [updateSkillFavorite]
+  );
+
+  const handleFavoriteChangeClick = useCallback(
+    (
+      skill: SkillWithoutInstructionsAndToolsWithRelationsType,
+      isFavorite: boolean
+    ) => {
+      void handleFavoriteChange(skill, isFavorite);
+    },
+    [handleFavoriteChange]
+  );
+
   const knownSkillsById = useMemo(
     () =>
       new Map(
@@ -266,12 +291,25 @@ export function ManageSkillsPage() {
     [activeSkills, archivedSkills, suggestedSkills]
   );
 
+  const selectedSkill = useMemo(() => {
+    if (!skillIdParam) {
+      return null;
+    }
+
+    if (optimisticSelectedSkill?.sId === skillIdParam) {
+      return optimisticSelectedSkill;
+    }
+
+    return knownSkillsById.get(skillIdParam) ?? null;
+  }, [skillIdParam, knownSkillsById, optimisticSelectedSkill]);
+
   const handleUsedBySkillSelect = useCallback(
     (skillId: string) => {
       const skill = knownSkillsById.get(skillId);
       if (skill) {
         handleSkillSelect(skill);
       } else {
+        setOptimisticSelectedSkill(null);
         setSkillIdParam(skillId);
       }
     },
@@ -320,6 +358,7 @@ export function ManageSkillsPage() {
       <SkillDetailsSheet
         skill={selectedSkill}
         onClose={() => handleSkillSelect(null)}
+        onFavoriteChange={hasSkillFavorites ? handleFavoriteChange : undefined}
         user={user}
         owner={owner}
       />
@@ -476,9 +515,11 @@ export function ManageSkillsPage() {
                 <SkillsTable
                   owner={owner}
                   skills={skillsByTab[activeTab]}
+                  showFavoriteControls={hasSkillFavorites}
                   onSkillClick={handleSkillSelect}
                   onAgentClick={setAgentId}
                   onUsedBySkillClick={handleUsedBySkillSelect}
+                  onFavoriteChange={handleFavoriteChangeClick}
                   canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
                   {...(isBatchEditionAvailable && isBatchEditing
                     ? { rowSelection, setRowSelection }

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -73,7 +73,7 @@ export function ManageSkillsPage() {
   const { hasPermission } = useWorkspacePermissions();
   const { hasFeature } = useFeatureFlags();
   const hasSkillFavorites = hasFeature("skill_favorites");
-  const [optimisticSelectedSkill, setOptimisticSelectedSkill] = useState<
+  const [selectedSkillOverride, setSelectedSkillOverride] = useState<
     GetSkillsWithRelationsResponseBody["skills"][number] | null
   >(null);
   const [agentId, setAgentId] = useState<string | null>(null);
@@ -202,7 +202,7 @@ export function ManageSkillsPage() {
 
   const handleSkillSelect = useCallback(
     (skill: GetSkillsWithRelationsResponseBody["skills"][number] | null) => {
-      setOptimisticSelectedSkill(skill);
+      setSelectedSkillOverride(skill);
       setSkillIdParam(skill?.sId);
     },
     [setSkillIdParam]
@@ -256,7 +256,7 @@ export function ManageSkillsPage() {
     ) => {
       const didUpdate = await updateSkillFavorite(skill, isFavorite);
       if (didUpdate) {
-        setOptimisticSelectedSkill((currentSkill) =>
+        setSelectedSkillOverride((currentSkill) =>
           currentSkill?.sId === skill.sId
             ? { ...currentSkill, isFavorite }
             : currentSkill
@@ -291,12 +291,12 @@ export function ManageSkillsPage() {
       return null;
     }
 
-    if (optimisticSelectedSkill?.sId === skillIdParam) {
-      return optimisticSelectedSkill;
+    if (selectedSkillOverride?.sId === skillIdParam) {
+      return selectedSkillOverride;
     }
 
     return knownSkillsById.get(skillIdParam) ?? null;
-  }, [skillIdParam, knownSkillsById, optimisticSelectedSkill]);
+  }, [skillIdParam, knownSkillsById, selectedSkillOverride]);
 
   const handleUsedBySkillSelect = useCallback(
     (skillId: string) => {
@@ -304,7 +304,7 @@ export function ManageSkillsPage() {
       if (skill) {
         handleSkillSelect(skill);
       } else {
-        setOptimisticSelectedSkill(null);
+        setSelectedSkillOverride(null);
         setSkillIdParam(skillId);
       }
     },

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -37,12 +37,12 @@ import {
 import { SKILL_ICON } from "@app/lib/skill";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import {
-  type SkillListItemWithRelationsResponseType,
   useSkillsWithRelations,
   useUpdateSkillFavorite,
   useUpdateSkillsAvailability,
 } from "@app/lib/swr/skill_configurations";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
+import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
 import { isEmptyString } from "@app/types/shared/utils/general";
 import {
@@ -73,8 +73,9 @@ export function ManageSkillsPage() {
   const { hasPermission } = useWorkspacePermissions();
   const { hasFeature } = useFeatureFlags();
   const hasSkillFavorites = hasFeature("skill_favorites");
-  const [optimisticSelectedSkill, setOptimisticSelectedSkill] =
-    useState<SkillListItemWithRelationsResponseType | null>(null);
+  const [optimisticSelectedSkill, setOptimisticSelectedSkill] = useState<
+    GetSkillsWithRelationsResponseBody["skills"][number] | null
+  >(null);
   const [agentId, setAgentId] = useState<string | null>(null);
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
   const [selectedTab, setSelectedTab] = useHashParam("selectedTab", "active");
@@ -164,7 +165,7 @@ export function ManageSkillsPage() {
   );
 
   const skillsByTab = useMemo<
-    Record<SkillManagerTabType, SkillListItemWithRelationsResponseType[]>
+    Record<SkillManagerTabType, GetSkillsWithRelationsResponseBody["skills"]>
   >(() => {
     const searchLower = skillSearch.toLowerCase();
     const editableByMeSkills = sortedActiveSkills.filter((s) =>
@@ -200,7 +201,7 @@ export function ManageSkillsPage() {
   const isLoading = isActiveLoading || isArchivedLoading || isSuggestedLoading;
 
   const handleSkillSelect = useCallback(
-    (skill: SkillListItemWithRelationsResponseType | null) => {
+    (skill: GetSkillsWithRelationsResponseBody["skills"][number] | null) => {
       setOptimisticSelectedSkill(skill);
       setSkillIdParam(skill?.sId);
     },
@@ -250,7 +251,7 @@ export function ManageSkillsPage() {
 
   const handleFavoriteChange = useCallback(
     async (
-      skill: SkillListItemWithRelationsResponseType,
+      skill: GetSkillsWithRelationsResponseBody["skills"][number],
       isFavorite: boolean
     ) => {
       const didUpdate = await updateSkillFavorite(skill, isFavorite);
@@ -266,7 +267,10 @@ export function ManageSkillsPage() {
   );
 
   const handleFavoriteChangeClick = useCallback(
-    (skill: SkillListItemWithRelationsResponseType, isFavorite: boolean) => {
+    (
+      skill: GetSkillsWithRelationsResponseBody["skills"][number],
+      isFavorite: boolean
+    ) => {
       void handleFavoriteChange(skill, isFavorite);
     },
     [handleFavoriteChange]

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -37,12 +37,12 @@ import {
 import { SKILL_ICON } from "@app/lib/skill";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import {
+  type SkillListItemWithRelationsResponseType,
   useSkillsWithRelations,
   useUpdateSkillFavorite,
   useUpdateSkillsAvailability,
 } from "@app/lib/swr/skill_configurations";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
-import type { SkillListItemWithRelationsResponseType } from "@app/types/api/skills";
 import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
 import { isEmptyString } from "@app/types/shared/utils/general";
 import {

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -266,16 +266,6 @@ export function ManageSkillsPage() {
     [updateSkillFavorite]
   );
 
-  const handleFavoriteChangeClick = useCallback(
-    (
-      skill: GetSkillsWithRelationsResponseBody["skills"][number],
-      isFavorite: boolean
-    ) => {
-      void handleFavoriteChange(skill, isFavorite);
-    },
-    [handleFavoriteChange]
-  );
-
   const knownSkillsById = useMemo(
     () =>
       new Map(
@@ -510,11 +500,9 @@ export function ManageSkillsPage() {
                 <SkillsTable
                   owner={owner}
                   skills={skillsByTab[activeTab]}
-                  showFavoriteControls={hasSkillFavorites}
                   onSkillClick={handleSkillSelect}
                   onAgentClick={setAgentId}
                   onUsedBySkillClick={handleUsedBySkillSelect}
-                  onFavoriteChange={handleFavoriteChangeClick}
                   canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
                   {...(isBatchEditionAvailable && isBatchEditing
                     ? { rowSelection, setRowSelection }

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -42,10 +42,8 @@ import {
   useUpdateSkillsAvailability,
 } from "@app/lib/swr/skill_configurations";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
-import type {
-  SkillAvailability,
-  SkillWithoutInstructionsAndToolsWithRelationsType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillListItemWithRelationsResponseType } from "@app/types/api/skills";
+import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
 import { isEmptyString } from "@app/types/shared/utils/general";
 import {
   Button,
@@ -76,7 +74,7 @@ export function ManageSkillsPage() {
   const { hasFeature } = useFeatureFlags();
   const hasSkillFavorites = hasFeature("skill_favorites");
   const [optimisticSelectedSkill, setOptimisticSelectedSkill] =
-    useState<SkillWithoutInstructionsAndToolsWithRelationsType | null>(null);
+    useState<SkillListItemWithRelationsResponseType | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
   const [selectedTab, setSelectedTab] = useHashParam("selectedTab", "active");
@@ -172,7 +170,6 @@ export function ManageSkillsPage() {
     >
   >(() => {
     const searchLower = skillSearch.toLowerCase();
-
     const editableByMeSkills = sortedActiveSkills.filter((s) =>
       s.relations.editors?.some((e) => e.sId === user?.sId)
     );
@@ -206,7 +203,7 @@ export function ManageSkillsPage() {
   const isLoading = isActiveLoading || isArchivedLoading || isSuggestedLoading;
 
   const handleSkillSelect = useCallback(
-    (skill: SkillWithoutInstructionsAndToolsWithRelationsType | null) => {
+    (skill: SkillListItemWithRelationsResponseType | null) => {
       setOptimisticSelectedSkill(skill);
       setSkillIdParam(skill?.sId);
     },
@@ -256,7 +253,7 @@ export function ManageSkillsPage() {
 
   const handleFavoriteChange = useCallback(
     async (
-      skill: SkillWithoutInstructionsAndToolsWithRelationsType,
+      skill: SkillListItemWithRelationsResponseType,
       isFavorite: boolean
     ) => {
       const didUpdate = await updateSkillFavorite(skill, isFavorite);
@@ -272,10 +269,7 @@ export function ManageSkillsPage() {
   );
 
   const handleFavoriteChangeClick = useCallback(
-    (
-      skill: SkillWithoutInstructionsAndToolsWithRelationsType,
-      isFavorite: boolean
-    ) => {
+    (skill: SkillListItemWithRelationsResponseType, isFavorite: boolean) => {
       void handleFavoriteChange(skill, isFavorite);
     },
     [handleFavoriteChange]

--- a/front/components/pages/builder/skills/utils.ts
+++ b/front/components/pages/builder/skills/utils.ts
@@ -67,7 +67,7 @@ function getSkillSearchString(
 export function sortSkillsByName(
   skills: SkillWithoutInstructionsAndToolsWithRelationsType[]
 ) {
-  return [...skills].sort((a, b) => a.name.localeCompare(b.name));
+  return skills.toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 export function filterByAvailability(

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -1,7 +1,7 @@
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { SkillFavoriteButton } from "@app/components/skills/SkillFavoriteButton";
-import type { SkillListItemWithRelationsResponseType } from "@app/lib/swr/skill_configurations";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
+import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -16,12 +16,12 @@ import {
 import { useState } from "react";
 
 interface SkillDetailsButtonBarProps {
-  skill: SkillListItemWithRelationsResponseType;
+  skill: GetSkillsWithRelationsResponseBody["skills"][number];
   owner: WorkspaceType;
   onClose: () => void;
   replaceOnEdit?: boolean;
   onFavoriteChange?: (
-    skill: SkillListItemWithRelationsResponseType,
+    skill: GetSkillsWithRelationsResponseBody["skills"][number],
     isFavorite: boolean
   ) => void;
 }

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -1,7 +1,7 @@
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { SkillFavoriteButton } from "@app/components/skills/SkillFavoriteButton";
+import type { SkillListItemWithRelationsResponseType } from "@app/lib/swr/skill_configurations";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
-import type { SkillListItemWithRelationsResponseType } from "@app/types/api/skills";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -1,7 +1,7 @@
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { SkillFavoriteButton } from "@app/components/skills/SkillFavoriteButton";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
-import type { SkillWithoutInstructionsAndToolsWithRelationsType } from "@app/types/assistant/skill_configuration";
+import type { SkillListItemWithRelationsResponseType } from "@app/types/api/skills";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -16,12 +16,12 @@ import {
 import { useState } from "react";
 
 interface SkillDetailsButtonBarProps {
-  skill: SkillWithoutInstructionsAndToolsWithRelationsType;
+  skill: SkillListItemWithRelationsResponseType;
   owner: WorkspaceType;
   onClose: () => void;
   replaceOnEdit?: boolean;
   onFavoriteChange?: (
-    skill: SkillWithoutInstructionsAndToolsWithRelationsType,
+    skill: SkillListItemWithRelationsResponseType,
     isFavorite: boolean
   ) => void;
 }

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -55,6 +55,7 @@ export function SkillDetailsButtonBar({
           <SkillFavoriteButton
             isFavorite={skill.isFavorite ?? false}
             skill={skill}
+            variant="outline"
             onFavoriteChange={(isFavorite) =>
               onFavoriteChange(skill, isFavorite)
             }

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -1,4 +1,5 @@
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
+import { SkillFavoriteButton } from "@app/components/skills/SkillFavoriteButton";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { SkillWithoutInstructionsAndToolsWithRelationsType } from "@app/types/assistant/skill_configuration";
 import type { WorkspaceType } from "@app/types/user";
@@ -19,6 +20,10 @@ interface SkillDetailsButtonBarProps {
   owner: WorkspaceType;
   onClose: () => void;
   replaceOnEdit?: boolean;
+  onFavoriteChange?: (
+    skill: SkillWithoutInstructionsAndToolsWithRelationsType,
+    isFavorite: boolean
+  ) => void;
 }
 
 export function SkillDetailsButtonBar({
@@ -26,10 +31,11 @@ export function SkillDetailsButtonBar({
   owner,
   onClose,
   replaceOnEdit,
+  onFavoriteChange,
 }: SkillDetailsButtonBarProps) {
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
 
-  if (!skill.canAdministrate) {
+  if (!skill.canAdministrate && !onFavoriteChange) {
     return null;
   }
 
@@ -45,35 +51,48 @@ export function SkillDetailsButtonBar({
         }}
       />
       <div className="flex flex-row items-center gap-2 px-1.5">
-        <Button
-          size="sm"
-          tooltip="Edit skill"
-          href={getSkillBuilderRoute(owner.sId, skill.sId)}
-          replace={replaceOnEdit}
-          variant="outline"
-          icon={Edit04}
-        />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              icon={DotsHorizontal}
-              size="sm"
-              variant="ghost"
-              tooltip="Skill options"
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuItem
-              label="Archive"
-              icon={Trash01}
-              variant="warning"
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowArchiveDialog(true);
-              }}
-            />
-          </DropdownMenuContent>
-        </DropdownMenu>
+        {onFavoriteChange && (
+          <SkillFavoriteButton
+            isFavorite={skill.isFavorite ?? false}
+            skill={skill}
+            onFavoriteChange={(isFavorite) =>
+              onFavoriteChange(skill, isFavorite)
+            }
+          />
+        )}
+        {skill.canAdministrate && (
+          <Button
+            size="sm"
+            tooltip="Edit skill"
+            href={getSkillBuilderRoute(owner.sId, skill.sId)}
+            replace={replaceOnEdit}
+            variant="outline"
+            icon={Edit04}
+          />
+        )}
+        {skill.canAdministrate && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                icon={DotsHorizontal}
+                size="sm"
+                variant="ghost"
+                tooltip="Skill options"
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem
+                label="Archive"
+                icon={Trash01}
+                variant="warning"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowArchiveDialog(true);
+                }}
+              />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
     </>
   );

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -37,6 +37,10 @@ import { useState } from "react";
 type SkillDetailsProps = {
   skill: SkillWithoutInstructionsAndToolsWithRelationsType | null;
   onClose: () => void;
+  onFavoriteChange?: (
+    skill: SkillWithoutInstructionsAndToolsWithRelationsType,
+    isFavorite: boolean
+  ) => void;
   owner: WorkspaceType;
   user: UserType;
   replaceOnEdit?: boolean;
@@ -45,6 +49,7 @@ type SkillDetailsProps = {
 export function SkillDetailsSheet({
   skill,
   onClose,
+  onFavoriteChange,
   user,
   owner,
   replaceOnEdit,
@@ -71,6 +76,7 @@ export function SkillDetailsSheet({
                 owner={owner}
                 onClose={onClose}
                 replaceOnEdit={replaceOnEdit}
+                onFavoriteChange={onFavoriteChange}
               />
             </SheetHeader>
             <SheetContainer className="pb-4">
@@ -151,6 +157,10 @@ type DescriptionSectionProps = {
   owner: WorkspaceType;
   onClose: () => void;
   replaceOnEdit?: boolean;
+  onFavoriteChange?: (
+    skill: SkillWithoutInstructionsAndToolsWithRelationsType,
+    isFavorite: boolean
+  ) => void;
 };
 
 const DescriptionSection = ({
@@ -158,6 +168,7 @@ const DescriptionSection = ({
   owner,
   onClose,
   replaceOnEdit,
+  onFavoriteChange,
 }: DescriptionSectionProps) => {
   const [showRestoreModal, setShowRestoreModal] = useState(false);
   const { editedByUser } = skill.relations;
@@ -196,6 +207,7 @@ const DescriptionSection = ({
           skill={skill}
           onClose={onClose}
           replaceOnEdit={replaceOnEdit}
+          onFavoriteChange={onFavoriteChange}
         />
       )}
 

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -7,8 +7,10 @@ import {
   hasRelations,
   isDustProvidedSkill,
 } from "@app/lib/skill";
-import { useSkill } from "@app/lib/swr/skill_configurations";
-import type { SkillListItemWithRelationsResponseType } from "@app/types/api/skills";
+import {
+  type SkillListItemWithRelationsResponseType,
+  useSkill,
+} from "@app/lib/swr/skill_configurations";
 import type {
   SkillRelations,
   SkillType,

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -8,10 +8,10 @@ import {
   isDustProvidedSkill,
 } from "@app/lib/skill";
 import { useSkill } from "@app/lib/swr/skill_configurations";
+import type { SkillListItemWithRelationsResponseType } from "@app/types/api/skills";
 import type {
   SkillRelations,
   SkillType,
-  SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import {
@@ -35,10 +35,10 @@ import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useState } from "react";
 
 type SkillDetailsProps = {
-  skill: SkillWithoutInstructionsAndToolsWithRelationsType | null;
+  skill: SkillListItemWithRelationsResponseType | null;
   onClose: () => void;
   onFavoriteChange?: (
-    skill: SkillWithoutInstructionsAndToolsWithRelationsType,
+    skill: SkillListItemWithRelationsResponseType,
     isFavorite: boolean
   ) => void;
   owner: WorkspaceType;
@@ -153,12 +153,12 @@ function SkillDetailsSheetContent({
 }
 
 type DescriptionSectionProps = {
-  skill: SkillWithoutInstructionsAndToolsWithRelationsType;
+  skill: SkillListItemWithRelationsResponseType;
   owner: WorkspaceType;
   onClose: () => void;
   replaceOnEdit?: boolean;
   onFavoriteChange?: (
-    skill: SkillWithoutInstructionsAndToolsWithRelationsType,
+    skill: SkillListItemWithRelationsResponseType,
     isFavorite: boolean
   ) => void;
 };

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -7,10 +7,8 @@ import {
   hasRelations,
   isDustProvidedSkill,
 } from "@app/lib/skill";
-import {
-  type SkillListItemWithRelationsResponseType,
-  useSkill,
-} from "@app/lib/swr/skill_configurations";
+import { useSkill } from "@app/lib/swr/skill_configurations";
+import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import type {
   SkillRelations,
   SkillType,
@@ -37,10 +35,10 @@ import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useState } from "react";
 
 type SkillDetailsProps = {
-  skill: SkillListItemWithRelationsResponseType | null;
+  skill: GetSkillsWithRelationsResponseBody["skills"][number] | null;
   onClose: () => void;
   onFavoriteChange?: (
-    skill: SkillListItemWithRelationsResponseType,
+    skill: GetSkillsWithRelationsResponseBody["skills"][number],
     isFavorite: boolean
   ) => void;
   owner: WorkspaceType;
@@ -155,12 +153,12 @@ function SkillDetailsSheetContent({
 }
 
 type DescriptionSectionProps = {
-  skill: SkillListItemWithRelationsResponseType;
+  skill: GetSkillsWithRelationsResponseBody["skills"][number];
   owner: WorkspaceType;
   onClose: () => void;
   replaceOnEdit?: boolean;
   onFavoriteChange?: (
-    skill: SkillListItemWithRelationsResponseType,
+    skill: GetSkillsWithRelationsResponseBody["skills"][number],
     isFavorite: boolean
   ) => void;
 };

--- a/front/components/skills/SkillFavoriteButton.tsx
+++ b/front/components/skills/SkillFavoriteButton.tsx
@@ -1,0 +1,37 @@
+import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
+import { Button, Star01, StarFilled } from "@dust-tt/sparkle";
+import type { MouseEvent } from "react";
+
+type SkillFavoriteButtonProps = {
+  isFavorite: boolean;
+  onFavoriteChange: (isFavorite: boolean) => void;
+  skill: Pick<SkillWithoutInstructionsAndToolsType, "name">;
+  size?: "icon" | "icon-xs";
+};
+
+export function SkillFavoriteButton({
+  isFavorite,
+  onFavoriteChange,
+  skill,
+  size = "icon",
+}: SkillFavoriteButtonProps) {
+  const nextIsFavorite = !isFavorite;
+
+  return (
+    <Button
+      size={size}
+      variant="ghost-secondary"
+      icon={isFavorite ? StarFilled : Star01}
+      tooltip={`${nextIsFavorite ? "Favorite" : "Unfavorite"} ${skill.name}`}
+      className={
+        isFavorite
+          ? "text-warning dark:text-warning-night hover:text-warning dark:hover:text-warning-night"
+          : undefined
+      }
+      onClick={(event: MouseEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+        onFavoriteChange(nextIsFavorite);
+      }}
+    />
+  );
+}

--- a/front/components/skills/SkillFavoriteButton.tsx
+++ b/front/components/skills/SkillFavoriteButton.tsx
@@ -1,5 +1,10 @@
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
-import { Button, Star01, StarFilled } from "@dust-tt/sparkle";
+import {
+  Button,
+  type ButtonVariantType,
+  Star01,
+  StarFilled,
+} from "@dust-tt/sparkle";
 import type { MouseEvent } from "react";
 
 type SkillFavoriteButtonProps = {
@@ -7,6 +12,7 @@ type SkillFavoriteButtonProps = {
   onFavoriteChange: (isFavorite: boolean) => void;
   skill: SkillWithoutInstructionsAndToolsType;
   size?: "icon" | "icon-xs";
+  variant?: ButtonVariantType;
 };
 
 export function SkillFavoriteButton({
@@ -14,13 +20,14 @@ export function SkillFavoriteButton({
   onFavoriteChange,
   skill,
   size = "icon",
+  variant = "ghost-secondary",
 }: SkillFavoriteButtonProps) {
   const nextIsFavorite = !isFavorite;
 
   return (
     <Button
       size={size}
-      variant="ghost-secondary"
+      variant={variant}
       icon={isFavorite ? StarFilled : Star01}
       tooltip={`${nextIsFavorite ? "Favorite" : "Unfavorite"} ${skill.name}`}
       className={

--- a/front/components/skills/SkillFavoriteButton.tsx
+++ b/front/components/skills/SkillFavoriteButton.tsx
@@ -5,7 +5,7 @@ import type { MouseEvent } from "react";
 type SkillFavoriteButtonProps = {
   isFavorite: boolean;
   onFavoriteChange: (isFavorite: boolean) => void;
-  skill: Pick<SkillWithoutInstructionsAndToolsType, "name">;
+  skill: SkillWithoutInstructionsAndToolsType;
   size?: "icon" | "icon-xs";
 };
 

--- a/front/components/skills/SkillFavoriteButton.tsx
+++ b/front/components/skills/SkillFavoriteButton.tsx
@@ -30,11 +30,6 @@ export function SkillFavoriteButton({
       variant={variant}
       icon={isFavorite ? StarFilled : Star01}
       tooltip={`${nextIsFavorite ? "Favorite" : "Unfavorite"} ${skill.name}`}
-      className={
-        isFavorite
-          ? "text-warning dark:text-warning-night hover:text-warning dark:hover:text-warning-night"
-          : undefined
-      }
       onClick={(event: MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
         onFavoriteChange(nextIsFavorite);

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -11,6 +11,7 @@ import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import type {
   SkillAvailability,
   SkillUsageType,
+  SkillWithoutInstructionsAndToolsType,
 } from "@app/types/assistant/skill_configuration";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
@@ -32,6 +33,7 @@ import type {
 import { useMemo, useState } from "react";
 
 type RowData = {
+  skill: SkillWithoutInstructionsAndToolsType;
   sId: string;
   name: string;
   icon: string | null;
@@ -83,7 +85,7 @@ const nameColumn = {
             <SkillFavoriteButton
               size="icon-xs"
               isFavorite={info.row.original.isFavorite}
-              skill={{ name: info.getValue() }}
+              skill={info.row.original.skill}
               onFavoriteChange={info.row.original.onFavoriteChange}
             />
           )}
@@ -286,6 +288,7 @@ export function SkillsTable({
   const rows: RowData[] = useMemo(
     () =>
       skills.map((skill) => ({
+        skill,
         sId: skill.sId,
         name: skill.name,
         icon: skill.icon,

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -29,7 +29,7 @@ import type {
   Row,
   RowSelectionState,
 } from "@tanstack/react-table";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 
 type RowData = {
   sId: string;
@@ -263,10 +263,6 @@ export function SkillsTable({
   setRowSelection,
 }: SkillsTableProps) {
   const router = useAppRouter();
-  const routerRef = useRef(router);
-  useEffect(() => {
-    routerRef.current = router;
-  }, [router]);
   const { pagination, setPagination } = usePaginationFromUrl({});
   const [skillToArchive, setSkillToArchive] = useState<
     GetSkillsWithRelationsResponseBody["skills"][number] | null
@@ -286,7 +282,7 @@ export function SkillsTable({
     [onAgentClick, onUsedBySkillClick, isSelectionEnabled]
   );
 
-  // Keep row object identity stable for DataTable pagination: useAppRouter is not stable.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const rows: RowData[] = useMemo(
     () =>
       skills.map((skill) => ({
@@ -322,7 +318,7 @@ export function SkillsTable({
                   disabled: !skill.canAdministrate,
                   onClick: (e: React.MouseEvent) => {
                     e.stopPropagation();
-                    void routerRef.current.push(
+                    void router.push(
                       getSkillBuilderRoute(owner.sId, skill.sId)
                     );
                   },
@@ -351,6 +347,7 @@ export function SkillsTable({
               ].filter((item) => !item.disabled)
             : [],
       })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- router is not stable, mutating the skills list which prevent pagination to work
     [
       skills,
       onSkillClick,

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -29,7 +29,7 @@ import type {
   Row,
   RowSelectionState,
 } from "@tanstack/react-table";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type RowData = {
   sId: string;
@@ -262,7 +262,9 @@ export function SkillsTable({
 }: SkillsTableProps) {
   const router = useAppRouter();
   const routerRef = useRef(router);
-  routerRef.current = router;
+  useEffect(() => {
+    routerRef.current = router;
+  }, [router]);
   const { pagination, setPagination } = usePaginationFromUrl({});
   const [skillToArchive, setSkillToArchive] =
     useState<SkillListItemWithRelationsResponseType | null>(null);

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -298,9 +298,7 @@ export function SkillsTable({
         updatedAt: skill.updatedAt,
         createdAt: skill.createdAt,
         isFavorite: skill.isFavorite ?? false,
-        canToggleFavorite:
-          showFavoriteControls &&
-          (skill.status === "active" || (skill.isFavorite ?? false)),
+        canToggleFavorite: showFavoriteControls && skill.status === "active",
         onClick: () => {
           // During batch edition the DataTable itself toggles the row selection on
           // click; don't open the details panel on top of it.

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -4,9 +4,9 @@ import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useAppRouter } from "@app/lib/platform";
 import { getSkillAvatarIcon, isDustProvidedSkill } from "@app/lib/skill";
+import type { SkillListItemWithRelationsResponseType } from "@app/lib/swr/skill_configurations";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
-import type { SkillListItemWithRelationsResponseType } from "@app/types/api/skills";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import type {
   SkillAvailability,

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -1,5 +1,4 @@
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
-import { SkillFavoriteButton } from "@app/components/skills/SkillFavoriteButton";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useAppRouter } from "@app/lib/platform";
@@ -11,7 +10,6 @@ import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import type {
   SkillAvailability,
   SkillUsageType,
-  SkillWithoutInstructionsAndToolsType,
 } from "@app/types/assistant/skill_configuration";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
@@ -33,7 +31,6 @@ import type {
 import { useMemo, useState } from "react";
 
 type RowData = {
-  skill: SkillWithoutInstructionsAndToolsType;
   sId: string;
   name: string;
   icon: string | null;
@@ -44,10 +41,7 @@ type RowData = {
   usage: SkillUsageType;
   updatedAt: number | null;
   createdAt: number | null;
-  isFavorite: boolean;
-  canToggleFavorite: boolean;
   onClick: () => void;
-  onFavoriteChange: (isFavorite: boolean) => void;
   menuItems: MenuItem[];
 };
 
@@ -81,14 +75,6 @@ const nameColumn = {
     return (
       <DataTable.CellContent>
         <div className="flex flex-row items-center gap-2 py-3">
-          {info.row.original.canToggleFavorite && (
-            <SkillFavoriteButton
-              size="icon-xs"
-              isFavorite={info.row.original.isFavorite}
-              skill={info.row.original.skill}
-              onFavoriteChange={info.row.original.onFavoriteChange}
-            />
-          )}
           <div>
             <SkillAvatar />
           </div>
@@ -237,16 +223,11 @@ const getTableColumns = ({
 type SkillsTableProps = {
   skills: GetSkillsWithRelationsResponseBody["skills"];
   owner: LightWorkspaceType;
-  showFavoriteControls: boolean;
   onSkillClick: (
     skill: GetSkillsWithRelationsResponseBody["skills"][number]
   ) => void;
   onAgentClick: (agentId: string) => void;
   onUsedBySkillClick: (skillId: string) => void;
-  onFavoriteChange: (
-    skill: GetSkillsWithRelationsResponseBody["skills"][number],
-    isFavorite: boolean
-  ) => void;
   canMakeSkillAutoDiscoverable?: boolean;
   rowSelection?: RowSelectionState;
   setRowSelection?: (selection: RowSelectionState) => void;
@@ -255,11 +236,9 @@ type SkillsTableProps = {
 export function SkillsTable({
   skills,
   owner,
-  showFavoriteControls,
   onSkillClick,
   onAgentClick,
   onUsedBySkillClick,
-  onFavoriteChange,
   canMakeSkillAutoDiscoverable = false,
   rowSelection,
   setRowSelection,
@@ -288,7 +267,6 @@ export function SkillsTable({
   const rows: RowData[] = useMemo(
     () =>
       skills.map((skill) => ({
-        skill,
         sId: skill.sId,
         name: skill.name,
         icon: skill.icon,
@@ -299,8 +277,6 @@ export function SkillsTable({
         usage: skill.relations.usage,
         updatedAt: skill.updatedAt,
         createdAt: skill.createdAt,
-        isFavorite: skill.isFavorite ?? false,
-        canToggleFavorite: showFavoriteControls && skill.status === "active",
         onClick: () => {
           // During batch edition the DataTable itself toggles the row selection on
           // click; don't open the details panel on top of it.
@@ -308,9 +284,6 @@ export function SkillsTable({
             return;
           }
           onSkillClick(skill);
-        },
-        onFavoriteChange: (isFavorite: boolean) => {
-          onFavoriteChange(skill, isFavorite);
         },
         menuItems:
           skill.status !== "archived"
@@ -351,14 +324,7 @@ export function SkillsTable({
             : [],
       })),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is not stable, mutating the skills list which prevent pagination to work
-    [
-      skills,
-      onSkillClick,
-      onFavoriteChange,
-      owner.sId,
-      showFavoriteControls,
-      isSelectionEnabled,
-    ]
+    [skills, onSkillClick, owner.sId, isSelectionEnabled]
   );
 
   if (rows.length === 0) {

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -6,11 +6,11 @@ import { useAppRouter } from "@app/lib/platform";
 import { getSkillAvatarIcon, isDustProvidedSkill } from "@app/lib/skill";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
+import type { SkillListItemWithRelationsResponseType } from "@app/types/api/skills";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import type {
   SkillAvailability,
   SkillUsageType,
-  SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
@@ -233,16 +233,14 @@ const getTableColumns = ({
 };
 
 type SkillsTableProps = {
-  skills: SkillWithoutInstructionsAndToolsWithRelationsType[];
+  skills: SkillListItemWithRelationsResponseType[];
   owner: LightWorkspaceType;
   showFavoriteControls: boolean;
-  onSkillClick: (
-    skill: SkillWithoutInstructionsAndToolsWithRelationsType
-  ) => void;
+  onSkillClick: (skill: SkillListItemWithRelationsResponseType) => void;
   onAgentClick: (agentId: string) => void;
   onUsedBySkillClick: (skillId: string) => void;
   onFavoriteChange: (
-    skill: SkillWithoutInstructionsAndToolsWithRelationsType,
+    skill: SkillListItemWithRelationsResponseType,
     isFavorite: boolean
   ) => void;
   canMakeSkillAutoDiscoverable?: boolean;
@@ -267,7 +265,7 @@ export function SkillsTable({
   routerRef.current = router;
   const { pagination, setPagination } = usePaginationFromUrl({});
   const [skillToArchive, setSkillToArchive] =
-    useState<SkillWithoutInstructionsAndToolsWithRelationsType | null>(null);
+    useState<SkillListItemWithRelationsResponseType | null>(null);
 
   const isSelectionEnabled = rowSelection !== undefined;
 

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -1,4 +1,5 @@
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
+import { SkillFavoriteButton } from "@app/components/skills/SkillFavoriteButton";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useAppRouter } from "@app/lib/platform";
@@ -28,7 +29,7 @@ import type {
   Row,
   RowSelectionState,
 } from "@tanstack/react-table";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 type RowData = {
   sId: string;
@@ -41,7 +42,10 @@ type RowData = {
   usage: SkillUsageType;
   updatedAt: number | null;
   createdAt: number | null;
+  isFavorite: boolean;
+  canToggleFavorite: boolean;
   onClick: () => void;
+  onFavoriteChange: (isFavorite: boolean) => void;
   menuItems: MenuItem[];
 };
 
@@ -75,6 +79,14 @@ const nameColumn = {
     return (
       <DataTable.CellContent>
         <div className="flex flex-row items-center gap-2 py-3">
+          {info.row.original.canToggleFavorite && (
+            <SkillFavoriteButton
+              size="icon-xs"
+              isFavorite={info.row.original.isFavorite}
+              skill={{ name: info.getValue() }}
+              onFavoriteChange={info.row.original.onFavoriteChange}
+            />
+          )}
           <div>
             <SkillAvatar />
           </div>
@@ -223,11 +235,16 @@ const getTableColumns = ({
 type SkillsTableProps = {
   skills: SkillWithoutInstructionsAndToolsWithRelationsType[];
   owner: LightWorkspaceType;
+  showFavoriteControls: boolean;
   onSkillClick: (
     skill: SkillWithoutInstructionsAndToolsWithRelationsType
   ) => void;
   onAgentClick: (agentId: string) => void;
   onUsedBySkillClick: (skillId: string) => void;
+  onFavoriteChange: (
+    skill: SkillWithoutInstructionsAndToolsWithRelationsType,
+    isFavorite: boolean
+  ) => void;
   canMakeSkillAutoDiscoverable?: boolean;
   rowSelection?: RowSelectionState;
   setRowSelection?: (selection: RowSelectionState) => void;
@@ -236,14 +253,18 @@ type SkillsTableProps = {
 export function SkillsTable({
   skills,
   owner,
+  showFavoriteControls,
   onSkillClick,
   onAgentClick,
   onUsedBySkillClick,
+  onFavoriteChange,
   canMakeSkillAutoDiscoverable = false,
   rowSelection,
   setRowSelection,
 }: SkillsTableProps) {
   const router = useAppRouter();
+  const routerRef = useRef(router);
+  routerRef.current = router;
   const { pagination, setPagination } = usePaginationFromUrl({});
   const [skillToArchive, setSkillToArchive] =
     useState<SkillWithoutInstructionsAndToolsWithRelationsType | null>(null);
@@ -262,7 +283,7 @@ export function SkillsTable({
     [onAgentClick, onUsedBySkillClick, isSelectionEnabled]
   );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
+  // Keep row object identity stable for DataTable pagination: useAppRouter is not stable.
   const rows: RowData[] = useMemo(
     () =>
       skills.map((skill) => ({
@@ -276,6 +297,10 @@ export function SkillsTable({
         usage: skill.relations.usage,
         updatedAt: skill.updatedAt,
         createdAt: skill.createdAt,
+        isFavorite: skill.isFavorite ?? false,
+        canToggleFavorite:
+          showFavoriteControls &&
+          (skill.status === "active" || (skill.isFavorite ?? false)),
         onClick: () => {
           // During batch edition the DataTable itself toggles the row selection on
           // click; don't open the details panel on top of it.
@@ -283,6 +308,9 @@ export function SkillsTable({
             return;
           }
           onSkillClick(skill);
+        },
+        onFavoriteChange: (isFavorite: boolean) => {
+          onFavoriteChange(skill, isFavorite);
         },
         menuItems:
           skill.status !== "archived"
@@ -293,7 +321,7 @@ export function SkillsTable({
                   disabled: !skill.canAdministrate,
                   onClick: (e: React.MouseEvent) => {
                     e.stopPropagation();
-                    void router.push(
+                    void routerRef.current.push(
                       getSkillBuilderRoute(owner.sId, skill.sId)
                     );
                   },
@@ -322,8 +350,14 @@ export function SkillsTable({
               ].filter((item) => !item.disabled)
             : [],
       })),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- router is not stable, mutating the skills list which prevent pagination to work
-    [skills, onSkillClick, onUsedBySkillClick, owner.sId, isSelectionEnabled]
+    [
+      skills,
+      onSkillClick,
+      onFavoriteChange,
+      owner.sId,
+      showFavoriteControls,
+      isSelectionEnabled,
+    ]
   );
 
   if (rows.length === 0) {

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -4,9 +4,9 @@ import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useAppRouter } from "@app/lib/platform";
 import { getSkillAvatarIcon, isDustProvidedSkill } from "@app/lib/skill";
-import type { SkillListItemWithRelationsResponseType } from "@app/lib/swr/skill_configurations";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
+import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import type {
   SkillAvailability,
@@ -233,14 +233,16 @@ const getTableColumns = ({
 };
 
 type SkillsTableProps = {
-  skills: SkillListItemWithRelationsResponseType[];
+  skills: GetSkillsWithRelationsResponseBody["skills"];
   owner: LightWorkspaceType;
   showFavoriteControls: boolean;
-  onSkillClick: (skill: SkillListItemWithRelationsResponseType) => void;
+  onSkillClick: (
+    skill: GetSkillsWithRelationsResponseBody["skills"][number]
+  ) => void;
   onAgentClick: (agentId: string) => void;
   onUsedBySkillClick: (skillId: string) => void;
   onFavoriteChange: (
-    skill: SkillListItemWithRelationsResponseType,
+    skill: GetSkillsWithRelationsResponseBody["skills"][number],
     isFavorite: boolean
   ) => void;
   canMakeSkillAutoDiscoverable?: boolean;
@@ -266,8 +268,9 @@ export function SkillsTable({
     routerRef.current = router;
   }, [router]);
   const { pagination, setPagination } = usePaginationFromUrl({});
-  const [skillToArchive, setSkillToArchive] =
-    useState<SkillListItemWithRelationsResponseType | null>(null);
+  const [skillToArchive, setSkillToArchive] = useState<
+    GetSkillsWithRelationsResponseBody["skills"][number] | null
+  >(null);
 
   const isSelectionEnabled = rowSelection !== undefined;
 

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -341,6 +341,70 @@ export function useArchiveSkill({
   return doArchive;
 }
 
+export function useUpdateSkillFavorite({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const { fetcher } = useFetcher();
+  const sendNotification = useSendNotification();
+
+  const { mutateSkills: mutateActiveSkills } = useSkills({
+    owner,
+    status: "active",
+    disabled: true,
+  });
+  const { mutateSkillsWithRelations: mutateActiveSkillsWithRelations } =
+    useSkillsWithRelations({
+      owner,
+      status: "active",
+      disabled: true,
+    });
+  const { mutateSkillsWithRelations: mutateArchivedSkillsWithRelations } =
+    useSkillsWithRelations({
+      owner,
+      status: "archived",
+      disabled: true,
+    });
+
+  const updateSkillFavorite = useCallback(
+    async (
+      skill: Pick<SkillWithoutInstructionsAndToolsType, "name" | "sId">,
+      isFavorite: boolean
+    ) => {
+      try {
+        await fetcher(`/api/w/${owner.sId}/skills/${skill.sId}/favorite`, {
+          method: isFavorite ? "POST" : "DELETE",
+        });
+
+        void mutateActiveSkills();
+        void mutateActiveSkillsWithRelations();
+        void mutateArchivedSkillsWithRelations();
+        return true;
+      } catch (err) {
+        sendNotification({
+          type: "error",
+          title: `Failed to ${isFavorite ? "favorite" : "unfavorite"} ${skill.name}`,
+          description: isAPIErrorResponse(err)
+            ? err.error.message
+            : "An unexpected error occurred.",
+        });
+        return false;
+      }
+    },
+    [
+      fetcher,
+      mutateActiveSkills,
+      mutateActiveSkillsWithRelations,
+      mutateArchivedSkillsWithRelations,
+      owner.sId,
+      sendNotification,
+    ]
+  );
+
+  return { updateSkillFavorite };
+}
+
 type SkillReinforcementUpdate = {
   reinforcement?: SkillReinforcementMode;
   selfImprovementLock?: boolean;

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -22,6 +22,7 @@ import type {
   SkillStatus,
   SkillType,
   SkillWithoutInstructionsAndToolsType,
+  SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import { isAPIErrorResponse } from "@app/types/error";
 import { Ok } from "@app/types/shared/result";
@@ -40,7 +41,7 @@ export function useSkill(options: {
   withRelations: true;
   disabled?: boolean;
 }): {
-  skill: GetSkillWithRelationsResponseBody["skill"] | null;
+  skill: SkillWithRelationsType | null;
   isSkillLoading: boolean;
   isSkillError: boolean;
   mutateSkill: () => void;
@@ -51,7 +52,7 @@ export function useSkill(options: {
   withRelations?: false;
   disabled?: boolean;
 }): {
-  skill: GetSkillResponseBody["skill"] | null;
+  skill: SkillType | null;
   isSkillLoading: boolean;
   isSkillError: boolean;
   mutateSkill: () => void;
@@ -67,10 +68,7 @@ export function useSkill({
   withRelations?: boolean;
   disabled?: boolean;
 }): {
-  skill:
-    | GetSkillResponseBody["skill"]
-    | GetSkillWithRelationsResponseBody["skill"]
-    | null;
+  skill: SkillType | SkillWithRelationsType | null;
   isSkillLoading: boolean;
   isSkillError: boolean;
   mutateSkill: () => void;

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -14,9 +14,6 @@ import type {
   GetSkillsResponseBody,
   GetSkillsWithRelationsResponseBody,
   GetSkillWithRelationsResponseBody,
-  SkillListItemResponseType,
-  SkillResponseType,
-  SkillWithRelationsResponseType,
 } from "@app/types/api/skills";
 import type { GetSimilarSkillsResponseBody } from "@app/types/api/skills/existing_skill_checker";
 import type {
@@ -36,6 +33,13 @@ import type { SWRMutationConfiguration } from "swr/mutation";
 import useSWRMutation from "swr/mutation";
 
 const DETECT_SKILLS_DEBOUNCE_MS = 1_000;
+
+export type SkillResponseType = GetSkillResponseBody["skill"];
+export type SkillWithRelationsResponseType =
+  GetSkillWithRelationsResponseBody["skill"];
+export type SkillListItemResponseType = GetSkillsResponseBody["skills"][number];
+export type SkillListItemWithRelationsResponseType =
+  GetSkillsWithRelationsResponseBody["skills"][number];
 
 export function useSkill(options: {
   workspaceId: string;

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -360,12 +360,6 @@ export function useUpdateSkillFavorite({
       status: "active",
       disabled: true,
     });
-  const { mutateSkillsWithRelations: mutateArchivedSkillsWithRelations } =
-    useSkillsWithRelations({
-      owner,
-      status: "archived",
-      disabled: true,
-    });
 
   const updateSkillFavorite = useCallback(
     async (
@@ -379,7 +373,6 @@ export function useUpdateSkillFavorite({
 
         void mutateActiveSkills();
         void mutateActiveSkillsWithRelations();
-        void mutateArchivedSkillsWithRelations();
         return true;
       } catch (err) {
         sendNotification({
@@ -396,7 +389,6 @@ export function useUpdateSkillFavorite({
       fetcher,
       mutateActiveSkills,
       mutateActiveSkillsWithRelations,
-      mutateArchivedSkillsWithRelations,
       owner.sId,
       sendNotification,
     ]

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -34,20 +34,13 @@ import useSWRMutation from "swr/mutation";
 
 const DETECT_SKILLS_DEBOUNCE_MS = 1_000;
 
-export type SkillResponseType = GetSkillResponseBody["skill"];
-export type SkillWithRelationsResponseType =
-  GetSkillWithRelationsResponseBody["skill"];
-export type SkillListItemResponseType = GetSkillsResponseBody["skills"][number];
-export type SkillListItemWithRelationsResponseType =
-  GetSkillsWithRelationsResponseBody["skills"][number];
-
 export function useSkill(options: {
   workspaceId: string;
   skillId: string | null;
   withRelations: true;
   disabled?: boolean;
 }): {
-  skill: SkillWithRelationsResponseType | null;
+  skill: GetSkillWithRelationsResponseBody["skill"] | null;
   isSkillLoading: boolean;
   isSkillError: boolean;
   mutateSkill: () => void;
@@ -58,7 +51,7 @@ export function useSkill(options: {
   withRelations?: false;
   disabled?: boolean;
 }): {
-  skill: SkillResponseType | null;
+  skill: GetSkillResponseBody["skill"] | null;
   isSkillLoading: boolean;
   isSkillError: boolean;
   mutateSkill: () => void;
@@ -74,7 +67,10 @@ export function useSkill({
   withRelations?: boolean;
   disabled?: boolean;
 }): {
-  skill: SkillResponseType | SkillWithRelationsResponseType | null;
+  skill:
+    | GetSkillResponseBody["skill"]
+    | GetSkillWithRelationsResponseBody["skill"]
+    | null;
   isSkillLoading: boolean;
   isSkillError: boolean;
   mutateSkill: () => void;
@@ -121,7 +117,7 @@ export function useSkills({
   bypassEditorVisibility?: boolean;
   swrOptions?: SWRConfiguration;
 }): {
-  skills: SkillListItemResponseType[];
+  skills: GetSkillsResponseBody["skills"];
   isSkillsError: boolean;
   isSkillsLoading: boolean;
   mutateSkills: () => void;
@@ -156,7 +152,8 @@ export function useSkills({
   );
 
   return {
-    skills: data?.skills ?? emptyArray<SkillListItemResponseType>(),
+    skills:
+      data?.skills ?? emptyArray<GetSkillsResponseBody["skills"][number]>(),
     isSkillsError: !!error,
     isSkillsLoading: isLoading,
     mutateSkills: mutate,

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -368,7 +368,7 @@ export function useUpdateSkillFavorite({
 
   const updateSkillFavorite = useCallback(
     async (
-      skill: Pick<SkillWithoutInstructionsAndToolsType, "name" | "sId">,
+      skill: SkillWithoutInstructionsAndToolsType,
       isFavorite: boolean
     ) => {
       try {

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -11,8 +11,12 @@ import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetSkillHistoryResponseBody } from "@app/types/api/assistant/skills/history";
 import type {
   GetSkillResponseBody,
+  GetSkillsResponseBody,
   GetSkillsWithRelationsResponseBody,
   GetSkillWithRelationsResponseBody,
+  SkillListItemResponseType,
+  SkillResponseType,
+  SkillWithRelationsResponseType,
 } from "@app/types/api/skills";
 import type { GetSimilarSkillsResponseBody } from "@app/types/api/skills/existing_skill_checker";
 import type {
@@ -21,7 +25,6 @@ import type {
   SkillStatus,
   SkillType,
   SkillWithoutInstructionsAndToolsType,
-  SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import { isAPIErrorResponse } from "@app/types/error";
 import { Ok } from "@app/types/shared/result";
@@ -40,7 +43,7 @@ export function useSkill(options: {
   withRelations: true;
   disabled?: boolean;
 }): {
-  skill: SkillWithRelationsType | null;
+  skill: SkillWithRelationsResponseType | null;
   isSkillLoading: boolean;
   isSkillError: boolean;
   mutateSkill: () => void;
@@ -51,7 +54,7 @@ export function useSkill(options: {
   withRelations?: false;
   disabled?: boolean;
 }): {
-  skill: SkillType | null;
+  skill: SkillResponseType | null;
   isSkillLoading: boolean;
   isSkillError: boolean;
   mutateSkill: () => void;
@@ -67,7 +70,7 @@ export function useSkill({
   withRelations?: boolean;
   disabled?: boolean;
 }): {
-  skill: SkillType | SkillWithRelationsType | null;
+  skill: SkillResponseType | SkillWithRelationsResponseType | null;
   isSkillLoading: boolean;
   isSkillError: boolean;
   mutateSkill: () => void;
@@ -114,7 +117,7 @@ export function useSkills({
   bypassEditorVisibility?: boolean;
   swrOptions?: SWRConfiguration;
 }): {
-  skills: SkillWithoutInstructionsAndToolsType[];
+  skills: SkillListItemResponseType[];
   isSkillsError: boolean;
   isSkillsLoading: boolean;
   mutateSkills: () => void;
@@ -141,14 +144,15 @@ export function useSkills({
   }
   const queryString = queryParams.toString();
 
+  const skillsFetcher: Fetcher<GetSkillsResponseBody> = fetcher;
   const { data, error, isLoading, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/skills${queryString ? `?${queryString}` : ""}`,
-    fetcher,
+    skillsFetcher,
     { ...swrOptions, disabled }
   );
 
   return {
-    skills: data?.skills ?? emptyArray<SkillWithoutInstructionsAndToolsType>(),
+    skills: data?.skills ?? emptyArray<SkillListItemResponseType>(),
     isSkillsError: !!error,
     isSkillsLoading: isLoading,
     mutateSkills: mutate,


### PR DESCRIPTION
## Description

Adds favorite controls to active skills in Manage Skills and the skill details sheet behind `skill_favorites`. Favorite updates refresh both active skill caches so the table, details sheet, and other skill consumers stay synchronized.

Favorites are ranked first in the slash-command capability dropdown and the input-bar Capabilities picker. Manage Skills keeps its existing tabs and list ordering, and archived skills do not expose favorite controls.

Some polish is planned for the future, the goal here is to have a working version.

## Tests

- Added coverage for favorite-first capability sorting.

## Risk

- Low. Behind feature flag.

## Deploy Plan

- Deploy front.
