### PR TITLE
[front] feat: expose skill favorite APIs

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/favorite.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/favorite.ts
@@ -20,8 +20,7 @@ async function loadSkill(
   ctx: Context,
   sId: string
 ): Promise<
-  | { skill: SkillResource; sId: string }
-  | (Response & TypedResponse<APIErrorResponse>)
+  { skill: SkillResource } | (Response & TypedResponse<APIErrorResponse>)
 > {
   const auth = ctx.get("auth");
 
@@ -36,7 +35,7 @@ async function loadSkill(
     });
   }
 
-  return { skill, sId };
+  return { skill };
 }
 
 /** @ignoreswagger */

--- a/front-api/routes/w/[wId]/skills/[sId]/favorite.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/favorite.ts
@@ -1,0 +1,100 @@
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { APIErrorResponse } from "@app/types/error";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+import type { SuccessResponseBody } from "@front-api/routes/types";
+import type { Context, TypedResponse } from "hono";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  sId: z.string(),
+});
+
+// Mounted at /api/w/:wId/skills/:sId/favorite.
+const app = workspaceApp();
+
+async function loadSkill(
+  ctx: Context,
+  sId: string
+): Promise<
+  | { skill: SkillResource; sId: string }
+  | (Response & TypedResponse<APIErrorResponse>)
+> {
+  const auth = ctx.get("auth");
+
+  const skill = await SkillResource.fetchById(auth, sId);
+  if (!skill) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "skill_not_found",
+        message: "The skill you're trying to access was not found.",
+      },
+    });
+  }
+
+  return { skill, sId };
+}
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  withFeatureFlag("skill_favorites"),
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<SuccessResponseBody> => {
+    const auth = ctx.get("auth");
+    const { sId } = ctx.req.valid("param");
+    const loaded = await loadSkill(ctx, sId);
+    if (loaded instanceof Response) {
+      return loaded;
+    }
+    const { skill } = loaded;
+
+    const result = await skill.setFavorite(auth, true);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    return ctx.json({ success: true });
+  }
+);
+
+/** @ignoreswagger */
+app.delete(
+  "/",
+  withFeatureFlag("skill_favorites"),
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<SuccessResponseBody> => {
+    const auth = ctx.get("auth");
+    const { sId } = ctx.req.valid("param");
+    const loaded = await loadSkill(ctx, sId);
+    if (loaded instanceof Response) {
+      return loaded;
+    }
+    const { skill } = loaded;
+
+    const result = await skill.setFavorite(auth, false);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    return ctx.json({ success: true });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -6,6 +6,7 @@ import {
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -203,6 +203,40 @@ describe("GET /api/w/:wId/skills/:sId", () => {
     expect(data.skill.relations.usage.skills).toEqual([]);
   });
 
+  it("should not expose favorite state when the feature flag is disabled", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    const result = await skill.setFavorite(requestUserAuth, true);
+    expect(result.isOk()).toBe(true);
+
+    const response = await getSkill(workspace, skill.sId);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.skill).not.toHaveProperty("isFavorite");
+
+    const relationsResponse = await getSkillWithRelations(workspace, skill.sId);
+    expect(relationsResponse.status).toBe(200);
+    const relationsData = await relationsResponse.json();
+    expect(relationsData.skill).not.toHaveProperty("isFavorite");
+  });
+
+  it("should include favorite state when the feature flag is enabled", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+    await FeatureFlagFactory.basic(requestUserAuth, "skill_favorites");
+
+    const result = await skill.setFavorite(requestUserAuth, true);
+    expect(result.isOk()).toBe(true);
+
+    const response = await getSkill(workspace, skill.sId);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.skill.isFavorite).toBe(true);
+  });
+
   it("should return 404 for non-existent skill", async () => {
     const { workspace } = await setupTest();
 

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -15,6 +15,7 @@ import type {
   GetSkillResponseBody,
   GetSkillWithRelationsResponseBody,
   PatchSkillResponseBody,
+  SkillUserFavoriteState,
 } from "@app/types/api/skills";
 import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 import {
@@ -32,6 +33,7 @@ import uniq from "lodash/uniq";
 import { z } from "zod";
 
 import editors from "./editors";
+import favorite from "./favorite";
 import filesRoute from "./files/[fileId]/content";
 import history from "./history";
 import reinforcement from "./reinforcement";
@@ -93,6 +95,7 @@ const app = workspaceApp();
 
 // Sub-routes for this skill.
 app.route("/editors", editors);
+app.route("/favorite", favorite);
 app.route("/history", history);
 app.route("/reinforcement", reinforcement);
 app.route("/restore", restore);
@@ -117,6 +120,12 @@ app.get(
     const { skill } = loaded;
 
     const withRelations = ctx.req.query("withRelations");
+
+    let favoriteState: SkillUserFavoriteState = {};
+    if (await hasFeatureFlag(auth, "skill_favorites")) {
+      const isFavorite = await skill.isFavoriteForCurrentUser(auth);
+      favoriteState = { isFavorite };
+    }
 
     const serializedSkill = skill.toJSON(auth);
 
@@ -153,9 +162,13 @@ app.get(
         },
       };
 
-      return ctx.json({ skill: skillWithRelations });
+      return ctx.json({
+        skill: { ...skillWithRelations, ...favoriteState },
+      } satisfies GetSkillWithRelationsResponseBody);
     }
-    return ctx.json({ skill: serializedSkill });
+    return ctx.json({
+      skill: { ...serializedSkill, ...favoriteState },
+    } satisfies GetSkillResponseBody);
   }
 );
 

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -15,7 +15,6 @@ import type {
   GetSkillResponseBody,
   GetSkillWithRelationsResponseBody,
   PatchSkillResponseBody,
-  SkillUserFavoriteState,
 } from "@app/types/api/skills";
 import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 import {
@@ -121,7 +120,7 @@ app.get(
 
     const withRelations = ctx.req.query("withRelations");
 
-    let favoriteState: SkillUserFavoriteState = {};
+    let favoriteState: { isFavorite?: boolean } = {};
     if (await hasFeatureFlag(auth, "skill_favorites")) {
       const isFavorite = await skill.isFavoriteForCurrentUser(auth);
       favoriteState = { isFavorite };

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -3,6 +3,7 @@ import {
   getReferencedSkillSpaceModelIds,
   resolveAdditionalRequestedSpaceModelIds,
 } from "@app/lib/api/skills/space_requirements";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -120,8 +120,9 @@ app.get(
 
     const withRelations = ctx.req.query("withRelations");
 
+    const hasSkillFavorites = await hasFeatureFlag(auth, "skill_favorites");
     let favoriteState: { isFavorite?: boolean } = {};
-    if (await hasFeatureFlag(auth, "skill_favorites")) {
+    if (hasSkillFavorites) {
       const isFavorite = await skill.isFavoriteForCurrentUser(auth);
       favoriteState = { isFavorite };
     }

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -31,10 +31,6 @@ import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it, vi } from "vitest";
 
-type SkillListItemResponseType = GetSkillsResponseBody["skills"][number];
-type SkillListItemWithRelationsResponseType =
-  GetSkillsWithRelationsResponseBody["skills"][number];
-
 async function setupTest(role: MembershipRoleType = "builder") {
   return createPrivateApiMockRequest({ role });
 }
@@ -554,9 +550,10 @@ describe("GET /api/w/:wId/skills", () => {
 
     expect(response.status).toBe(200);
 
-    const skillWithoutInstructionsAndTools = (
-      await response.json()
-    ).skills.find((s: SkillListItemResponseType) => s.sId === skill.sId);
+    const responseBody: GetSkillsResponseBody = await response.json();
+    const skillWithoutInstructionsAndTools = responseBody.skills.find(
+      (s) => s.sId === skill.sId
+    );
 
     expect(skillWithoutInstructionsAndTools).toMatchObject({
       sId: skill.sId,
@@ -619,17 +616,18 @@ describe("GET /api/w/:wId/skills", () => {
 
     const response = await getSkills(workspace);
     expect(response.status).toBe(200);
-    const listedSkill = (await response.json()).skills.find(
-      (s: SkillListItemResponseType) => s.sId === skill.sId
-    );
+    const responseBody: GetSkillsResponseBody = await response.json();
+    const listedSkill = responseBody.skills.find((s) => s.sId === skill.sId);
     expect(listedSkill).not.toHaveProperty("isFavorite");
 
     const relationsResponse = await getSkills(workspace, {
       withRelations: "true",
     });
     expect(relationsResponse.status).toBe(200);
-    const relationsSkill = (await relationsResponse.json()).skills.find(
-      (s: SkillListItemWithRelationsResponseType) => s.sId === skill.sId
+    const relationsResponseBody: GetSkillsWithRelationsResponseBody =
+      await relationsResponse.json();
+    const relationsSkill = relationsResponseBody.skills.find(
+      (s) => s.sId === skill.sId
     );
     expect(relationsSkill).not.toHaveProperty("isFavorite");
 
@@ -656,8 +654,9 @@ describe("GET /api/w/:wId/skills", () => {
 
     const firstResponse = await getSkills(workspace);
     expect(firstResponse.status).toBe(200);
-    const firstSkill = (await firstResponse.json()).skills.find(
-      (s: SkillListItemResponseType) => s.sId === skill.sId
+    const firstResponseBody: GetSkillsResponseBody = await firstResponse.json();
+    const firstSkill = firstResponseBody.skills.find(
+      (s) => s.sId === skill.sId
     );
     expect(firstSkill?.isFavorite).toBe(false);
 
@@ -666,8 +665,10 @@ describe("GET /api/w/:wId/skills", () => {
 
     const secondResponse = await getSkills(workspace);
     expect(secondResponse.status).toBe(200);
-    const secondSkill = (await secondResponse.json()).skills.find(
-      (s: SkillListItemResponseType) => s.sId === skill.sId
+    const secondResponseBody: GetSkillsResponseBody =
+      await secondResponse.json();
+    const secondSkill = secondResponseBody.skills.find(
+      (s) => s.sId === skill.sId
     );
     expect(secondSkill?.isFavorite).toBe(true);
 
@@ -675,8 +676,10 @@ describe("GET /api/w/:wId/skills", () => {
       withRelations: "true",
     });
     expect(relationsResponse.status).toBe(200);
-    const relationsSkill = (await relationsResponse.json()).skills.find(
-      (s: SkillListItemWithRelationsResponseType) => s.sId === skill.sId
+    const relationsResponseBody: GetSkillsWithRelationsResponseBody =
+      await relationsResponse.json();
+    const relationsSkill = relationsResponseBody.skills.find(
+      (s) => s.sId === skill.sId
     );
     expect(relationsSkill?.isFavorite).toBe(true);
 
@@ -685,8 +688,9 @@ describe("GET /api/w/:wId/skills", () => {
 
     const thirdResponse = await getSkills(workspace);
     expect(thirdResponse.status).toBe(200);
-    const thirdSkill = (await thirdResponse.json()).skills.find(
-      (s: SkillListItemResponseType) => s.sId === skill.sId
+    const thirdResponseBody: GetSkillsResponseBody = await thirdResponse.json();
+    const thirdSkill = thirdResponseBody.skills.find(
+      (s) => s.sId === skill.sId
     );
     expect(thirdSkill?.isFavorite).toBe(false);
   });
@@ -700,9 +704,8 @@ describe("GET /api/w/:wId/skills", () => {
 
     const response = await getSkills(workspace);
     expect(response.status).toBe(200);
-    const framesSkill = (await response.json()).skills.find(
-      (s: SkillListItemResponseType) => s.sId === "frames"
-    );
+    const responseBody: GetSkillsResponseBody = await response.json();
+    const framesSkill = responseBody.skills.find((s) => s.sId === "frames");
     expect(framesSkill?.isFavorite).toBe(true);
   });
 

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -20,8 +20,8 @@ import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type {
-  SkillListItemResponseType,
-  SkillListItemWithRelationsResponseType,
+  GetSkillsResponseBody,
+  GetSkillsWithRelationsResponseBody,
 } from "@app/types/api/skills";
 import type {
   SkillWithoutInstructionsAndToolsType,
@@ -30,6 +30,10 @@ import type {
 import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it, vi } from "vitest";
+
+type SkillListItemResponseType = GetSkillsResponseBody["skills"][number];
+type SkillListItemWithRelationsResponseType =
+  GetSkillsWithRelationsResponseBody["skills"][number];
 
 async function setupTest(role: MembershipRoleType = "builder") {
   return createPrivateApiMockRequest({ role });

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -9,6 +9,7 @@ import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/system
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -20,6 +20,10 @@ import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type {
+  SkillListItemResponseType,
+  SkillListItemWithRelationsResponseType,
+} from "@app/types/api/skills";
+import type {
   SkillWithoutInstructionsAndToolsType,
   SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
@@ -69,6 +73,18 @@ function postSkill(workspace: { sId: string }, body: unknown) {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+  });
+}
+
+function favoriteSkill(workspace: { sId: string }, skillId: string) {
+  return honoApp.request(`/api/w/${workspace.sId}/skills/${skillId}/favorite`, {
+    method: "POST",
+  });
+}
+
+function unfavoriteSkill(workspace: { sId: string }, skillId: string) {
+  return honoApp.request(`/api/w/${workspace.sId}/skills/${skillId}/favorite`, {
+    method: "DELETE",
   });
 }
 
@@ -536,9 +552,7 @@ describe("GET /api/w/:wId/skills", () => {
 
     const skillWithoutInstructionsAndTools = (
       await response.json()
-    ).skills.find(
-      (s: SkillWithoutInstructionsAndToolsType) => s.sId === skill.sId
-    );
+    ).skills.find((s: SkillListItemResponseType) => s.sId === skill.sId);
 
     expect(skillWithoutInstructionsAndTools).toMatchObject({
       sId: skill.sId,
@@ -588,6 +602,132 @@ describe("GET /api/w/:wId/skills", () => {
     } finally {
       fetchInstructionsSpy.mockRestore();
     }
+  });
+
+  it("should not expose or mutate favorite state when the feature flag is disabled", async () => {
+    const { workspace, auth } = await setupTest();
+
+    const skill = await SkillFactory.create(auth, {
+      name: "Disabled Favorite Candidate",
+    });
+    const result = await skill.setFavorite(auth, true);
+    expect(result.isOk()).toBe(true);
+
+    const response = await getSkills(workspace);
+    expect(response.status).toBe(200);
+    const listedSkill = (await response.json()).skills.find(
+      (s: SkillListItemResponseType) => s.sId === skill.sId
+    );
+    expect(listedSkill).not.toHaveProperty("isFavorite");
+
+    const relationsResponse = await getSkills(workspace, {
+      withRelations: "true",
+    });
+    expect(relationsResponse.status).toBe(200);
+    const relationsSkill = (await relationsResponse.json()).skills.find(
+      (s: SkillListItemWithRelationsResponseType) => s.sId === skill.sId
+    );
+    expect(relationsSkill).not.toHaveProperty("isFavorite");
+
+    const favoriteResponse = await favoriteSkill(workspace, skill.sId);
+    expect(favoriteResponse.status).toBe(403);
+    expect((await favoriteResponse.json()).error.type).toBe(
+      "feature_flag_not_found"
+    );
+
+    const unfavoriteResponse = await unfavoriteSkill(workspace, skill.sId);
+    expect(unfavoriteResponse.status).toBe(403);
+    expect((await unfavoriteResponse.json()).error.type).toBe(
+      "feature_flag_not_found"
+    );
+  });
+
+  it("should include favorite state for custom skills", async () => {
+    const { workspace, auth } = await setupTest();
+    await FeatureFlagFactory.basic(auth, "skill_favorites");
+
+    const skill = await SkillFactory.create(auth, {
+      name: "Favorite Candidate",
+    });
+
+    const firstResponse = await getSkills(workspace);
+    expect(firstResponse.status).toBe(200);
+    const firstSkill = (await firstResponse.json()).skills.find(
+      (s: SkillListItemResponseType) => s.sId === skill.sId
+    );
+    expect(firstSkill?.isFavorite).toBe(false);
+
+    const favoriteResponse = await favoriteSkill(workspace, skill.sId);
+    expect(favoriteResponse.status).toBe(200);
+
+    const secondResponse = await getSkills(workspace);
+    expect(secondResponse.status).toBe(200);
+    const secondSkill = (await secondResponse.json()).skills.find(
+      (s: SkillListItemResponseType) => s.sId === skill.sId
+    );
+    expect(secondSkill?.isFavorite).toBe(true);
+
+    const relationsResponse = await getSkills(workspace, {
+      withRelations: "true",
+    });
+    expect(relationsResponse.status).toBe(200);
+    const relationsSkill = (await relationsResponse.json()).skills.find(
+      (s: SkillListItemWithRelationsResponseType) => s.sId === skill.sId
+    );
+    expect(relationsSkill?.isFavorite).toBe(true);
+
+    const unfavoriteResponse = await unfavoriteSkill(workspace, skill.sId);
+    expect(unfavoriteResponse.status).toBe(200);
+
+    const thirdResponse = await getSkills(workspace);
+    expect(thirdResponse.status).toBe(200);
+    const thirdSkill = (await thirdResponse.json()).skills.find(
+      (s: SkillListItemResponseType) => s.sId === skill.sId
+    );
+    expect(thirdSkill?.isFavorite).toBe(false);
+  });
+
+  it("should include favorite state for global skills", async () => {
+    const { workspace, auth } = await setupTest();
+    await FeatureFlagFactory.basic(auth, "skill_favorites");
+
+    const favoriteResponse = await favoriteSkill(workspace, "frames");
+    expect(favoriteResponse.status).toBe(200);
+
+    const response = await getSkills(workspace);
+    expect(response.status).toBe(200);
+    const framesSkill = (await response.json()).skills.find(
+      (s: SkillListItemResponseType) => s.sId === "frames"
+    );
+    expect(framesSkill?.isFavorite).toBe(true);
+  });
+
+  it("should not update favorite state for archived skills", async () => {
+    const { workspace, auth } = await setupTest();
+    await FeatureFlagFactory.basic(auth, "skill_favorites");
+
+    const skill = await SkillFactory.create(auth, {
+      name: "Archived Favorite Candidate",
+      status: "archived",
+    });
+
+    const favoriteResponse = await favoriteSkill(workspace, skill.sId);
+    expect(favoriteResponse.status).toBe(400);
+    expect(await favoriteResponse.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Only active skills can update favorite state.",
+      },
+    });
+
+    const unfavoriteResponse = await unfavoriteSkill(workspace, skill.sId);
+    expect(unfavoriteResponse.status).toBe(400);
+    expect(await unfavoriteResponse.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Only active skills can update favorite state.",
+      },
+    });
   });
 });
 

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -4,6 +4,7 @@ import {
   getReferencedSkillSpaceModelIds,
   resolveAdditionalRequestedSpaceModelIds,
 } from "@app/lib/api/skills/space_requirements";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -189,13 +189,12 @@ app.get(
       withFileAttachments: false,
     });
     const hasSkillFavorites = await hasFeatureFlag(auth, "skill_favorites");
-    const favoriteSkillIds = hasSkillFavorites
-      ? new Set(
-          (await SkillResource.listFavoritesForCurrentUser(auth)).map(
-            (skill) => skill.sId
-          )
-        )
-      : new Set<string>();
+    let favoriteSkillIds = new Set<string>();
+    if (hasSkillFavorites) {
+      const favoriteSkills =
+        await SkillResource.listFavoritesForCurrentUser(auth);
+      favoriteSkillIds = new Set(favoriteSkills.map((skill) => skill.sId));
+    }
 
     const canCreateSkill = await auth.hasWorkspacePermission("create", "skill");
 

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -13,9 +13,6 @@ import type {
   GetSkillsResponseBody,
   GetSkillsWithRelationsResponseBody,
   PostSkillResponseBody,
-  SkillListItemResponseType,
-  SkillListItemWithRelationsResponseType,
-  SkillUserFavoriteState,
 } from "@app/types/api/skills";
 import {
   availabilityFromIsDefault,
@@ -234,7 +231,7 @@ app.get(
       );
 
       const skillsWithRelations = skills.map((sc) => {
-        const favoriteState: SkillUserFavoriteState = hasSkillFavorites
+        const favoriteState: { isFavorite?: boolean } = hasSkillFavorites
           ? { isFavorite: favoriteSkillIds.has(sc.sId) }
           : {};
         const {
@@ -274,7 +271,7 @@ app.get(
             ),
           },
           ...favoriteState,
-        } satisfies SkillListItemWithRelationsResponseType;
+        } satisfies GetSkillsWithRelationsResponseBody["skills"][number];
       });
 
       return ctx.json({ skills: skillsWithRelations });
@@ -282,7 +279,7 @@ app.get(
 
     return ctx.json({
       skills: skills.map((sc) => {
-        const favoriteState: SkillUserFavoriteState = hasSkillFavorites
+        const favoriteState: { isFavorite?: boolean } = hasSkillFavorites
           ? { isFavorite: favoriteSkillIds.has(sc.sId) }
           : {};
         const {
@@ -295,7 +292,7 @@ app.get(
         return {
           ...skillWithoutInstructionsAndTools,
           ...favoriteState,
-        } satisfies SkillListItemResponseType;
+        } satisfies GetSkillsResponseBody["skills"][number];
       }),
     });
   }

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -13,6 +13,9 @@ import type {
   GetSkillsResponseBody,
   GetSkillsWithRelationsResponseBody,
   PostSkillResponseBody,
+  SkillListItemResponseType,
+  SkillListItemWithRelationsResponseType,
+  SkillUserFavoriteState,
 } from "@app/types/api/skills";
 import {
   availabilityFromIsDefault,
@@ -20,7 +23,6 @@ import {
   SKILL_AVAILABILITIES,
   SKILL_REINFORCEMENT_MODES,
   type SkillAvailability,
-  type SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
@@ -189,6 +191,14 @@ app.get(
       withTools: false,
       withFileAttachments: false,
     });
+    const hasSkillFavorites = await hasFeatureFlag(auth, "skill_favorites");
+    const favoriteSkillIds = hasSkillFavorites
+      ? new Set(
+          (await SkillResource.listFavoritesForCurrentUser(auth)).map(
+            (skill) => skill.sId
+          )
+        )
+      : new Set<string>();
 
     const canCreateSkill = await auth.hasWorkspacePermission("create", "skill");
 
@@ -224,6 +234,9 @@ app.get(
       );
 
       const skillsWithRelations = skills.map((sc) => {
+        const favoriteState: SkillUserFavoriteState = hasSkillFavorites
+          ? { isFavorite: favoriteSkillIds.has(sc.sId) }
+          : {};
         const {
           instructions,
           instructionsHtml,
@@ -260,7 +273,8 @@ app.get(
               }
             ),
           },
-        } satisfies SkillWithoutInstructionsAndToolsWithRelationsType;
+          ...favoriteState,
+        } satisfies SkillListItemWithRelationsResponseType;
       });
 
       return ctx.json({ skills: skillsWithRelations });
@@ -268,6 +282,9 @@ app.get(
 
     return ctx.json({
       skills: skills.map((sc) => {
+        const favoriteState: SkillUserFavoriteState = hasSkillFavorites
+          ? { isFavorite: favoriteSkillIds.has(sc.sId) }
+          : {};
         const {
           instructions,
           instructionsHtml,
@@ -275,7 +292,10 @@ app.get(
           ...skillWithoutInstructionsAndTools
         } = sc.toJSON(auth);
 
-        return skillWithoutInstructionsAndTools;
+        return {
+          ...skillWithoutInstructionsAndTools,
+          ...favoriteState,
+        } satisfies SkillListItemResponseType;
       }),
     });
   }

--- a/front/types/api/skills/index.ts
+++ b/front/types/api/skills/index.ts
@@ -5,12 +5,28 @@ import type {
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 
+// User-specific state appended only at the private skill API response boundary.
+export type SkillUserFavoriteState =
+  | { isFavorite: boolean }
+  | { isFavorite?: never };
+
+export type SkillResponseType = SkillType & SkillUserFavoriteState;
+
+export type SkillWithRelationsResponseType = SkillWithRelationsType &
+  SkillUserFavoriteState;
+
+export type SkillListItemResponseType = SkillWithoutInstructionsAndToolsType &
+  SkillUserFavoriteState;
+
+export type SkillListItemWithRelationsResponseType =
+  SkillWithoutInstructionsAndToolsWithRelationsType & SkillUserFavoriteState;
+
 export type GetSkillsResponseBody = {
-  skills: SkillWithoutInstructionsAndToolsType[];
+  skills: SkillListItemResponseType[];
 };
 
 export type GetSkillsWithRelationsResponseBody = {
-  skills: SkillWithoutInstructionsAndToolsWithRelationsType[];
+  skills: SkillListItemWithRelationsResponseType[];
 };
 
 export type PostSkillResponseBody = {
@@ -28,11 +44,11 @@ export type GetReinforcementDailySpendResponseBody = {
 };
 
 export type GetSkillResponseBody = {
-  skill: SkillType;
+  skill: SkillResponseType;
 };
 
 export type GetSkillWithRelationsResponseBody = {
-  skill: SkillWithRelationsType;
+  skill: SkillWithRelationsResponseType;
 };
 
 export type PatchSkillResponseBody = {

--- a/front/types/api/skills/index.ts
+++ b/front/types/api/skills/index.ts
@@ -6,17 +6,15 @@ import type {
 } from "@app/types/assistant/skill_configuration";
 
 export type GetSkillsResponseBody = {
-  skills: Array<
-    SkillWithoutInstructionsAndToolsType & { isFavorite?: boolean }
-  >;
+  skills: (SkillWithoutInstructionsAndToolsType & {
+    isFavorite?: boolean;
+  })[];
 };
 
 export type GetSkillsWithRelationsResponseBody = {
-  skills: Array<
-    SkillWithoutInstructionsAndToolsWithRelationsType & {
-      isFavorite?: boolean;
-    }
-  >;
+  skills: (SkillWithoutInstructionsAndToolsWithRelationsType & {
+    isFavorite?: boolean;
+  })[];
 };
 
 export type PostSkillResponseBody = {

--- a/front/types/api/skills/index.ts
+++ b/front/types/api/skills/index.ts
@@ -5,28 +5,18 @@ import type {
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 
-// User-specific state appended only at the private skill API response boundary.
-export type SkillUserFavoriteState =
-  | { isFavorite: boolean }
-  | { isFavorite?: never };
-
-export type SkillResponseType = SkillType & SkillUserFavoriteState;
-
-export type SkillWithRelationsResponseType = SkillWithRelationsType &
-  SkillUserFavoriteState;
-
-export type SkillListItemResponseType = SkillWithoutInstructionsAndToolsType &
-  SkillUserFavoriteState;
-
-export type SkillListItemWithRelationsResponseType =
-  SkillWithoutInstructionsAndToolsWithRelationsType & SkillUserFavoriteState;
-
 export type GetSkillsResponseBody = {
-  skills: SkillListItemResponseType[];
+  skills: Array<
+    SkillWithoutInstructionsAndToolsType & { isFavorite?: boolean }
+  >;
 };
 
 export type GetSkillsWithRelationsResponseBody = {
-  skills: SkillListItemWithRelationsResponseType[];
+  skills: Array<
+    SkillWithoutInstructionsAndToolsWithRelationsType & {
+      isFavorite?: boolean;
+    }
+  >;
 };
 
 export type PostSkillResponseBody = {
@@ -44,11 +34,11 @@ export type GetReinforcementDailySpendResponseBody = {
 };
 
 export type GetSkillResponseBody = {
-  skill: SkillResponseType;
+  skill: SkillType & { isFavorite?: boolean };
 };
 
 export type GetSkillWithRelationsResponseBody = {
-  skill: SkillWithRelationsResponseType;
+  skill: SkillWithRelationsType & { isFavorite?: boolean };
 };
 
 export type PatchSkillResponseBody = {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -237,6 +237,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable the Plan Mode skill: agents maintain a live plan.md for genuinely multi-step tasks, with an optional human-approval checkpoint.",
     stage: "dust_only",
   },
+  skill_favorites: {
+    description:
+      "Enable user favorites for skills, including favorite controls and runtime skill availability.",
+    stage: "dust_only",
+  },
   allow_old_notion_mcp: {
     description:
       "Allow individual workspaces to keep using the old internal Notion MCP server alongside the official one",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -774,6 +774,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "self_improvement_beta_tester"
   | "legacy_billing"
   | "plan_mode"
+  | "skill_favorites"
   | "poke_mcp"
   | "restricted_spaces_in_input_bar"
   | "salesforce_synced_queries"


### PR DESCRIPTION
## Description

This PR adds the private API for skill favorites. It just builds on top of the resource operations added in the previous PR. Authenticated users can favorite, unfavorite a skills through a new dedicated endpoint.

Skill lists and details expose whether the skill is favorited `isFavorite`, which will allow the UI to show a small visual hint to let the user know whether the skill has been favorited.

## Tests

- Added tests.

## Risk

- Low. Behind feature flag.

## Deploy Plan

- Deploy front.
