### PR TITLE
[front] feat: equip favorite skills at runtime

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -8,7 +8,10 @@ import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
-import { renderAvailableSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
+import {
+  renderEquippedSkillsUserMessage,
+  renderFavoriteSkillsUserMessage,
+} from "@app/lib/api/assistant/skills_rendering";
 import { getStreamEndpointFromLegacyModelId } from "@app/lib/api/llm/selectPreferredEndpointForWorkspace";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
@@ -236,8 +239,8 @@ app.post(
     });
     const prompt = systemPromptToText(promptSections);
     const leadingMessages = removeNulls([
-      renderAvailableSkillsUserMessage(equippedSkills, "system"),
-      renderAvailableSkillsUserMessage(favoriteSkills, "user"),
+      renderEquippedSkillsUserMessage(equippedSkills),
+      renderFavoriteSkillsUserMessage(favoriteSkills),
     ]);
 
     const specifications = availableActions.map((t) =>

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -8,7 +8,7 @@ import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
-import { renderEquippedSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
+import { renderAvailableSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
 import { getStreamEndpointFromLegacyModelId } from "@app/lib/api/llm/selectPreferredEndpointForWorkspace";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
@@ -145,6 +145,7 @@ app.post(
       enabledSkills,
       systemSkills,
       equippedSkills,
+      favoriteSkills,
       hasSelectedSpacesOutsideAgentScope,
     } = await SkillResource.listForAgentLoop(auth, {
       agentConfiguration,
@@ -235,7 +236,8 @@ app.post(
     });
     const prompt = systemPromptToText(promptSections);
     const leadingMessages = removeNulls([
-      renderEquippedSkillsUserMessage(equippedSkills),
+      renderAvailableSkillsUserMessage(equippedSkills, "system"),
+      renderAvailableSkillsUserMessage(favoriteSkills, "user"),
     ]);
 
     const specifications = availableActions.map((t) =>

--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -85,6 +85,7 @@ describe("skill_management enable_skill tool", () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [],
       equippedSkills: [skill],
+      favoriteSkills: [],
       systemSkills: [],
     });
     mockBatchFetchUsedBySkills.mockResolvedValue(new Map());
@@ -167,6 +168,23 @@ describe("skill_management enable_skill tool", () => {
     expect(mockLoadSkillFilesToConversation).not.toHaveBeenCalled();
   });
 
+  it("enables a favorite-only skill", async () => {
+    mockListForAgentLoop.mockResolvedValue({
+      enabledSkills: [],
+      equippedSkills: [],
+      favoriteSkills: [skill],
+      systemSkills: [],
+    });
+
+    const result = await getTool().handler(
+      { skillName: "commit" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockEnableForAgent).toHaveBeenCalled();
+  });
+
   it("reports file load failures without failing the tool", async () => {
     mockLoadSkillFilesToConversation.mockResolvedValue(
       new Err(new Error("GCS copy failed"))
@@ -192,6 +210,7 @@ describe("skill_management enable_skill tool", () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [skill],
       equippedSkills: [],
+      favoriteSkills: [],
       systemSkills: [],
     });
 
@@ -208,6 +227,7 @@ describe("skill_management enable_skill tool", () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [],
       equippedSkills: [],
+      favoriteSkills: [],
       systemSkills: [],
     });
 
@@ -225,6 +245,7 @@ describe("skill_management enable_skill tool", () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [],
       equippedSkills: [parentSkill],
+      favoriteSkills: [],
       systemSkills: [],
     });
     mockFetchByName.mockResolvedValue(skill);
@@ -262,6 +283,7 @@ describe("skill_management enable_skill tool", () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [parentSkill],
       equippedSkills: [],
+      favoriteSkills: [],
       systemSkills: [],
     });
     mockFetchByName.mockResolvedValue(skill);
@@ -291,6 +313,7 @@ describe("skill_management enable_skill tool", () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [],
       equippedSkills: [unavailableParentSkill],
+      favoriteSkills: [],
       systemSkills: [],
     });
     mockFetchByName.mockResolvedValue(skill);
@@ -322,6 +345,7 @@ describe("skill_management enable_skill tool", () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [],
       equippedSkills: [],
+      favoriteSkills: [],
       systemSkills: [],
     });
     mockFetchByIds.mockResolvedValue([parentSkill]);
@@ -357,6 +381,7 @@ describe("skill_management enable_skill tool", () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [],
       equippedSkills: [],
+      favoriteSkills: [],
       systemSkills: [],
     });
     mockFetchByIds.mockResolvedValue([skill]);
@@ -395,6 +420,7 @@ describe("skill_management enable_skill tool", () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [],
       equippedSkills: [],
+      favoriteSkills: [],
       systemSkills: [],
     });
     mockFetchByIds.mockResolvedValue([skill]);
@@ -440,6 +466,7 @@ describe("skill_management enable_skill tool", () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [],
       equippedSkills: [],
+      favoriteSkills: [],
       systemSkills: [],
     });
     mockFetchByIds.mockResolvedValue([skill]);
@@ -478,6 +505,7 @@ describe("skill_management enable_skill tool", () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [],
       equippedSkills: [],
+      favoriteSkills: [],
       systemSkills: [],
     });
 

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -48,8 +48,13 @@ async function findAvailableSkillForAgentLoop({
   agentLoopData: AgentLoopExecutionData;
   skillName: string;
 }): Promise<SkillResource | null> {
-  const { effectiveSpaceIds, enabledSkills, equippedSkills, systemSkills } =
-    await SkillResource.listForAgentLoop(auth, agentLoopData);
+  const {
+    effectiveSpaceIds,
+    enabledSkills,
+    equippedSkills,
+    favoriteSkills,
+    systemSkills,
+  } = await SkillResource.listForAgentLoop(auth, agentLoopData);
   const userMessageSkills = await SkillResource.fetchByIds(
     auth,
     extractSkillIdsFromConversationMessages(agentLoopData),
@@ -58,6 +63,7 @@ async function findAvailableSkillForAgentLoop({
   const directlyAllowedSkills = [
     ...enabledSkills,
     ...equippedSkills,
+    ...favoriteSkills,
     ...userMessageSkills,
   ];
 
@@ -69,10 +75,12 @@ async function findAvailableSkillForAgentLoop({
   }
 
   const parentSkillById = new Map(
-    [...systemSkills, ...enabledSkills, ...equippedSkills].map((skill) => [
-      skill.sId,
-      skill,
-    ])
+    [
+      ...systemSkills,
+      ...enabledSkills,
+      ...equippedSkills,
+      ...favoriteSkills,
+    ].map((skill) => [skill.sId, skill])
   );
   const candidate = await SkillResource.fetchByName(auth, skillName, {
     agentLoopData,

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -1,5 +1,8 @@
 import { makeEnableSkillResultOutput } from "@app/lib/api/actions/servers/skill_management/rendering";
-import { renderEquippedSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
+import {
+  renderEquippedSkillsUserMessage,
+  renderFavoriteSkillsUserMessage,
+} from "@app/lib/api/assistant/skills_rendering";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -225,6 +228,25 @@ Pass \`skillName\` exactly as written between backticks above, character for cha
 </dust_system>`,
         },
       ],
+    });
+  });
+
+  it("renders favorite skills as a separate non-cacheable user message", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const favoriteSkill = await SkillFactory.create(authenticator, {
+      name: "favorite-skill",
+      agentFacingDescription: "Use my favorite skill.",
+    });
+
+    const message = renderFavoriteSkillsUserMessage([favoriteSkill]);
+
+    expect(message).toMatchObject({
+      role: "user",
+      name: "user",
+    });
+    expect(message?.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("`favorite-skill`"),
     });
   });
 

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -1,5 +1,8 @@
 import { makeEnableSkillResultOutput } from "@app/lib/api/actions/servers/skill_management/rendering";
-import { renderAvailableSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
+import {
+  renderEquippedSkillsUserMessage,
+  renderFavoriteSkillsUserMessage,
+} from "@app/lib/api/assistant/skills_rendering";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -204,10 +207,10 @@ describe("skill rendering helpers", () => {
         "Review a pull request for code quality and correctness.",
     });
 
-    const message = renderAvailableSkillsUserMessage(
-      [commitSkill, reviewPrSkill],
-      "system"
-    );
+    const message = renderEquippedSkillsUserMessage([
+      commitSkill,
+      reviewPrSkill,
+    ]);
 
     expect(message).toEqual({
       role: "user",
@@ -235,15 +238,23 @@ Pass \`skillName\` exactly as written between backticks above, character for cha
       agentFacingDescription: "Use my favorite skill.",
     });
 
-    const message = renderAvailableSkillsUserMessage([favoriteSkill], "user");
+    const message = renderFavoriteSkillsUserMessage([favoriteSkill]);
 
-    expect(message).toMatchObject({
+    expect(message).toEqual({
       role: "user",
       name: "user",
-    });
-    expect(message?.content[0]).toMatchObject({
-      type: "text",
-      text: expect.stringContaining("`favorite-skill`"),
+      content: [
+        {
+          type: "text",
+          text: `<dust_system>
+The following skills were set as favorites by the user and are available for use with the skill_management__enable_skill tool:
+
+- \`favorite-skill\`: Use my favorite skill.
+
+Pass \`skillName\` exactly as written between backticks above, character for character: same case, same spacing, same punctuation, same prefixes and suffixes. Copy the name rather than retyping it, and do not adjust it to match how other skills in the list are named. Names are matched exactly, so a modified name will not be found.
+</dust_system>`,
+        },
+      ],
     });
   });
 

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -1,8 +1,5 @@
 import { makeEnableSkillResultOutput } from "@app/lib/api/actions/servers/skill_management/rendering";
-import {
-  renderEquippedSkillsUserMessage,
-  renderFavoriteSkillsUserMessage,
-} from "@app/lib/api/assistant/skills_rendering";
+import { renderAvailableSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -207,10 +204,10 @@ describe("skill rendering helpers", () => {
         "Review a pull request for code quality and correctness.",
     });
 
-    const message = renderEquippedSkillsUserMessage([
-      commitSkill,
-      reviewPrSkill,
-    ]);
+    const message = renderAvailableSkillsUserMessage(
+      [commitSkill, reviewPrSkill],
+      "system"
+    );
 
     expect(message).toEqual({
       role: "user",
@@ -238,7 +235,7 @@ Pass \`skillName\` exactly as written between backticks above, character for cha
       agentFacingDescription: "Use my favorite skill.",
     });
 
-    const message = renderFavoriteSkillsUserMessage([favoriteSkill]);
+    const message = renderAvailableSkillsUserMessage([favoriteSkill], "user");
 
     expect(message).toMatchObject({
       role: "user",

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -247,11 +247,9 @@ Pass \`skillName\` exactly as written between backticks above, character for cha
         {
           type: "text",
           text: `<dust_system>
-The following skills were set as favorites by the user and are available for use with the skill_management__enable_skill tool:
+The following skills were set as favorites by the user and are also available for use with the skill_management__enable_skill tool:
 
 - \`favorite-skill\`: Use my favorite skill.
-
-Pass \`skillName\` exactly as written between backticks above, character for character: same case, same spacing, same punctuation, same prefixes and suffixes. Copy the name rather than retyping it, and do not adjust it to match how other skills in the list are named. Names are matched exactly, so a modified name will not be found.
 </dust_system>`,
         },
       ],

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -207,10 +207,30 @@ describe("getJITServers", () => {
       });
 
       it("does not equip favorite skills when the feature flag is disabled", async () => {
-        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+        await SkillFactory.linkGlobalSkillToAgent(auth, {
+          globalSkillId: "discover_skills",
+          agentConfigurationId: agentConfig.id,
+        });
 
         const skill = await SkillFactory.create(auth, {
           name: "Disabled Favorite Skill",
+        });
+        const favoriteResult = await skill.setFavorite(auth, true);
+        expect(favoriteResult.isOk()).toBe(true);
+
+        const { equippedSkills } = await SkillResource.listForAgentLoop(auth, {
+          agentConfiguration: agentConfig,
+          conversation: { ...conversation, spaceId: conversationsSpace.sId },
+        });
+        expect(equippedSkills.map((s) => s.sId)).not.toContain(skill.sId);
+      });
+
+      it("does not equip favorite skills without discover_skills", async () => {
+        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+        await FeatureFlagFactory.basic(auth, "skill_favorites");
+
+        const skill = await SkillFactory.create(auth, {
+          name: "Favorite Skill Without Discovery",
         });
         const favoriteResult = await skill.setFavorite(auth, true);
         expect(favoriteResult.isOk()).toBe(true);
@@ -232,9 +252,13 @@ describe("getJITServers", () => {
         ).toBe(false);
       });
 
-      it("equips favorite skills and includes skill_management without configured skills", async () => {
+      it("equips favorite skills when discovery and favorites are enabled", async () => {
         await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
         await FeatureFlagFactory.basic(auth, "skill_favorites");
+        await SkillFactory.linkGlobalSkillToAgent(auth, {
+          globalSkillId: "discover_skills",
+          agentConfigurationId: agentConfig.id,
+        });
 
         const skill = await SkillFactory.create(auth, {
           name: "Favorite Skill",

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -231,7 +231,6 @@ describe("getJITServers", () => {
       });
 
       it("does not equip favorite skills without discover_skills", async () => {
-        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
         await FeatureFlagFactory.basic(auth, "skill_favorites");
 
         const skill = await SkillFactory.create(auth, {
@@ -250,16 +249,6 @@ describe("getJITServers", () => {
           });
         expect(equippedSkills.map((s) => s.sId)).not.toContain(skill.sId);
         expect(favoriteSkills.map((s) => s.sId)).not.toContain(skill.sId);
-
-        const jitServers = await getJITServers(auth, {
-          agentConfiguration: agentConfig,
-          conversation: { ...conversation, spaceId: conversationsSpace.sId },
-          attachments: [],
-        });
-
-        expect(
-          jitServers.some((server) => server.name === "skill_management")
-        ).toBe(false);
       });
 
       it("equips favorite skills when discovery and favorites are enabled", async () => {

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -217,13 +217,13 @@ describe("getJITServers", () => {
 
         const { equippedSkills } = await SkillResource.listForAgentLoop(auth, {
           agentConfiguration: agentConfig,
-          conversation,
+          conversation: { ...conversation, spaceId: conversationsSpace.sId },
         });
         expect(equippedSkills.map((s) => s.sId)).not.toContain(skill.sId);
 
         const jitServers = await getJITServers(auth, {
           agentConfiguration: agentConfig,
-          conversation,
+          conversation: { ...conversation, spaceId: conversationsSpace.sId },
           attachments: [],
         });
 
@@ -244,13 +244,13 @@ describe("getJITServers", () => {
 
         const { equippedSkills } = await SkillResource.listForAgentLoop(auth, {
           agentConfiguration: agentConfig,
-          conversation,
+          conversation: { ...conversation, spaceId: conversationsSpace.sId },
         });
         expect(equippedSkills.map((s) => s.sId)).toContain(skill.sId);
 
         const jitServers = await getJITServers(auth, {
           agentConfiguration: agentConfig,
-          conversation,
+          conversation: { ...conversation, spaceId: conversationsSpace.sId },
           attachments: [],
         });
 

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -205,6 +205,59 @@ describe("getJITServers", () => {
 
         expect(skillManagementServer).toBeDefined();
       });
+
+      it("does not equip favorite skills when the feature flag is disabled", async () => {
+        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+        const skill = await SkillFactory.create(auth, {
+          name: "Disabled Favorite Skill",
+        });
+        const favoriteResult = await skill.setFavorite(auth, true);
+        expect(favoriteResult.isOk()).toBe(true);
+
+        const { equippedSkills } = await SkillResource.listForAgentLoop(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+        });
+        expect(equippedSkills.map((s) => s.sId)).not.toContain(skill.sId);
+
+        const jitServers = await getJITServers(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+          attachments: [],
+        });
+
+        expect(
+          jitServers.some((server) => server.name === "skill_management")
+        ).toBe(false);
+      });
+
+      it("equips favorite skills and includes skill_management without configured skills", async () => {
+        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+        await FeatureFlagFactory.basic(auth, "skill_favorites");
+
+        const skill = await SkillFactory.create(auth, {
+          name: "Favorite Skill",
+        });
+        const favoriteResult = await skill.setFavorite(auth, true);
+        expect(favoriteResult.isOk()).toBe(true);
+
+        const { equippedSkills } = await SkillResource.listForAgentLoop(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+        });
+        expect(equippedSkills.map((s) => s.sId)).toContain(skill.sId);
+
+        const jitServers = await getJITServers(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+          attachments: [],
+        });
+
+        expect(
+          jitServers.some((server) => server.name === "skill_management")
+        ).toBe(true);
+      });
     });
 
     it("keeps configured custom skills equipped after enabling them, but not system skills", async () => {

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -218,11 +218,16 @@ describe("getJITServers", () => {
         const favoriteResult = await skill.setFavorite(auth, true);
         expect(favoriteResult.isOk()).toBe(true);
 
-        const { equippedSkills } = await SkillResource.listForAgentLoop(auth, {
-          agentConfiguration: agentConfig,
-          conversation: { ...conversation, spaceId: conversationsSpace.sId },
-        });
+        const { equippedSkills, favoriteSkills } =
+          await SkillResource.listForAgentLoop(auth, {
+            agentConfiguration: agentConfig,
+            conversation: {
+              ...conversation,
+              spaceId: conversationsSpace.sId,
+            },
+          });
         expect(equippedSkills.map((s) => s.sId)).not.toContain(skill.sId);
+        expect(favoriteSkills.map((s) => s.sId)).not.toContain(skill.sId);
       });
 
       it("does not equip favorite skills without discover_skills", async () => {
@@ -235,11 +240,16 @@ describe("getJITServers", () => {
         const favoriteResult = await skill.setFavorite(auth, true);
         expect(favoriteResult.isOk()).toBe(true);
 
-        const { equippedSkills } = await SkillResource.listForAgentLoop(auth, {
-          agentConfiguration: agentConfig,
-          conversation: { ...conversation, spaceId: conversationsSpace.sId },
-        });
+        const { equippedSkills, favoriteSkills } =
+          await SkillResource.listForAgentLoop(auth, {
+            agentConfiguration: agentConfig,
+            conversation: {
+              ...conversation,
+              spaceId: conversationsSpace.sId,
+            },
+          });
         expect(equippedSkills.map((s) => s.sId)).not.toContain(skill.sId);
+        expect(favoriteSkills.map((s) => s.sId)).not.toContain(skill.sId);
 
         const jitServers = await getJITServers(auth, {
           agentConfiguration: agentConfig,
@@ -266,11 +276,16 @@ describe("getJITServers", () => {
         const favoriteResult = await skill.setFavorite(auth, true);
         expect(favoriteResult.isOk()).toBe(true);
 
-        const { equippedSkills } = await SkillResource.listForAgentLoop(auth, {
-          agentConfiguration: agentConfig,
-          conversation: { ...conversation, spaceId: conversationsSpace.sId },
-        });
-        expect(equippedSkills.map((s) => s.sId)).toContain(skill.sId);
+        const { equippedSkills, favoriteSkills } =
+          await SkillResource.listForAgentLoop(auth, {
+            agentConfiguration: agentConfig,
+            conversation: {
+              ...conversation,
+              spaceId: conversationsSpace.sId,
+            },
+          });
+        expect(equippedSkills.map((s) => s.sId)).not.toContain(skill.sId);
+        expect(favoriteSkills.map((s) => s.sId)).toContain(skill.sId);
 
         const jitServers = await getJITServers(auth, {
           agentConfiguration: agentConfig,
@@ -281,6 +296,33 @@ describe("getJITServers", () => {
         expect(
           jitServers.some((server) => server.name === "skill_management")
         ).toBe(true);
+      });
+
+      it("keeps discoverable favorites in the shared equipped skills", async () => {
+        await FeatureFlagFactory.basic(auth, "skill_favorites");
+        await SkillFactory.linkGlobalSkillToAgent(auth, {
+          globalSkillId: "discover_skills",
+          agentConfigurationId: agentConfig.id,
+        });
+
+        const skill = await SkillFactory.create(auth, {
+          name: "Discoverable Favorite Skill",
+          availability: "users_and_agents",
+        });
+        const favoriteResult = await skill.setFavorite(auth, true);
+        expect(favoriteResult.isOk()).toBe(true);
+
+        const { equippedSkills, favoriteSkills } =
+          await SkillResource.listForAgentLoop(auth, {
+            agentConfiguration: agentConfig,
+            conversation: {
+              ...conversation,
+              spaceId: conversationsSpace.sId,
+            },
+          });
+
+        expect(equippedSkills.map((s) => s.sId)).toContain(skill.sId);
+        expect(favoriteSkills.map((s) => s.sId)).not.toContain(skill.sId);
       });
     });
 

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -37,7 +37,7 @@ export function getEnabledSkillInstructions(
   return `<${skill.name}>\n${modelInstructions}\n</${skill.name}>`;
 }
 
-function renderAvailableSkillsUserMessage(
+export function renderAvailableSkillsUserMessage(
   skills: Pick<SkillResource, "name" | "agentFacingDescription">[],
   name: "system" | "user"
 ): UserMessageTypeModel | null {
@@ -66,19 +66,6 @@ function renderAvailableSkillsUserMessage(
       `</dust_system>`,
     name
   );
-}
-
-export function renderEquippedSkillsUserMessage(
-  equippedSkills: SkillResource[]
-): UserMessageTypeModel | null {
-  return renderAvailableSkillsUserMessage(equippedSkills, "system");
-}
-
-export function renderFavoriteSkillsUserMessage(
-  favoriteSkills: SkillResource[]
-): UserMessageTypeModel | null {
-  // Only a leading name: "system" message receives the skills cache breakpoint.
-  return renderAvailableSkillsUserMessage(favoriteSkills, "user");
 }
 
 export function renderEnabledSkillUserMessageFromInstructions({

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -38,6 +38,10 @@ export function getEnabledSkillInstructions(
 }
 
 function renderSkillList(skills: SkillResource[]): string {
+  // Names are rendered as code literals rather than bold text: `skillName` is matched exactly, and
+  // a literal is copied verbatim far more reliably than prose. Workspaces tend to develop their own
+  // naming conventions, and models otherwise regenerate names to fit the pattern they infer from
+  // the list instead of copying them, which never resolves.
   return skills
     .map(
       ({ name, agentFacingDescription }) =>
@@ -46,10 +50,6 @@ function renderSkillList(skills: SkillResource[]): string {
     .join("\n");
 }
 
-// Names are rendered as code literals rather than bold text: `skillName` is matched exactly, and
-// a literal is copied verbatim far more reliably than prose. Workspaces tend to develop their own
-// naming conventions, and models otherwise regenerate names to fit the pattern they infer from
-// the list instead of copying them, which never resolves.
 const EXACT_SKILL_NAME_INSTRUCTION =
   `Pass \`skillName\` exactly as written between backticks above, character for character: ` +
   `same case, same spacing, same punctuation, same prefixes and suffixes. Copy the name ` +

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -86,9 +86,8 @@ export function renderFavoriteSkillsUserMessage(
 
   return renderSkillMessage(
     `<dust_system>\n` +
-      `The following skills were set as favorites by the user and are available for use with the ${enableSkillToolName} tool:\n\n` +
-      `${renderSkillList(favoriteSkills)}\n\n` +
-      `${EXACT_SKILL_NAME_INSTRUCTION}\n` +
+      `The following skills were set as favorites by the user and are also available for use with the ${enableSkillToolName} tool:\n\n` +
+      `${renderSkillList(favoriteSkills)}\n` +
       `</dust_system>`,
     "user"
   );

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -38,7 +38,7 @@ export function getEnabledSkillInstructions(
 }
 
 export function renderAvailableSkillsUserMessage(
-  skills: Pick<SkillResource, "name" | "agentFacingDescription">[],
+  skills: SkillResource[],
   name: "system" | "user"
 ): UserMessageTypeModel | null {
   if (skills.length === 0) {

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -10,10 +10,13 @@ import type { UserMessageTypeModel } from "@app/types/assistant/generation";
 
 export type EnabledSkill = SkillResource;
 
-function renderSystemSkillMessage(text: string): UserMessageTypeModel {
+function renderSkillMessage(
+  text: string,
+  name: "system" | "user"
+): UserMessageTypeModel {
   return {
     role: "user",
-    name: "system",
+    name,
     content: [{ type: "text", text }],
   };
 }
@@ -34,10 +37,11 @@ export function getEnabledSkillInstructions(
   return `<${skill.name}>\n${modelInstructions}\n</${skill.name}>`;
 }
 
-export function renderEquippedSkillsUserMessage(
-  equippedSkills: SkillResource[]
+function renderAvailableSkillsUserMessage(
+  skills: Pick<SkillResource, "name" | "agentFacingDescription">[],
+  name: "system" | "user"
 ): UserMessageTypeModel | null {
-  if (equippedSkills.length === 0) {
+  if (skills.length === 0) {
     return null;
   }
 
@@ -46,12 +50,12 @@ export function renderEquippedSkillsUserMessage(
   // a literal is copied verbatim far more reliably than prose. Workspaces tend to develop their own
   // naming conventions, and models otherwise regenerate names to fit the pattern they infer from
   // the list instead of copying them, which never resolves.
-  const lines = equippedSkills.map(
+  const lines = skills.map(
     ({ name, agentFacingDescription }) =>
       `- \`${name}\`: ${agentFacingDescription.replaceAll("\n", "\n  ")}`
   );
 
-  return renderSystemSkillMessage(
+  return renderSkillMessage(
     `<dust_system>\n` +
       `The following skills are available for use with the ${enableSkillToolName} tool:\n\n` +
       `${lines.join("\n")}\n\n` +
@@ -59,8 +63,22 @@ export function renderEquippedSkillsUserMessage(
       `same case, same spacing, same punctuation, same prefixes and suffixes. Copy the name ` +
       `rather than retyping it, and do not adjust it to match how other skills in the list are ` +
       `named. Names are matched exactly, so a modified name will not be found.\n` +
-      `</dust_system>`
+      `</dust_system>`,
+    name
   );
+}
+
+export function renderEquippedSkillsUserMessage(
+  equippedSkills: SkillResource[]
+): UserMessageTypeModel | null {
+  return renderAvailableSkillsUserMessage(equippedSkills, "system");
+}
+
+export function renderFavoriteSkillsUserMessage(
+  favoriteSkills: SkillResource[]
+): UserMessageTypeModel | null {
+  // Only a leading name: "system" message receives the skills cache breakpoint.
+  return renderAvailableSkillsUserMessage(favoriteSkills, "user");
 }
 
 export function renderEnabledSkillUserMessageFromInstructions({
@@ -70,7 +88,8 @@ export function renderEnabledSkillUserMessageFromInstructions({
 }): UserMessageTypeModel {
   const skillInstructions = getEnabledSkillInstructions(skill);
 
-  return renderSystemSkillMessage(
-    `<dust_system>\n${skillInstructions}\n</dust_system>`
+  return renderSkillMessage(
+    `<dust_system>\n${skillInstructions}\n</dust_system>`,
+    "system"
   );
 }

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -12,7 +12,7 @@ export type EnabledSkill = SkillResource;
 
 function renderSkillMessage(
   text: string,
-  name: "system" | "user"
+  { name }: { name: "system" | "user" }
 ): UserMessageTypeModel {
   return {
     role: "user",
@@ -38,10 +38,6 @@ export function getEnabledSkillInstructions(
 }
 
 function renderSkillList(skills: SkillResource[]): string {
-  // Names are rendered as code literals rather than bold text: `skillName` is matched exactly, and
-  // a literal is copied verbatim far more reliably than prose. Workspaces tend to develop their own
-  // naming conventions, and models otherwise regenerate names to fit the pattern they infer from
-  // the list instead of copying them, which never resolves.
   return skills
     .map(
       ({ name, agentFacingDescription }) =>
@@ -50,6 +46,10 @@ function renderSkillList(skills: SkillResource[]): string {
     .join("\n");
 }
 
+// Names are rendered as code literals rather than bold text: `skillName` is matched exactly, and
+// a literal is copied verbatim far more reliably than prose. Workspaces tend to develop their own
+// naming conventions, and models otherwise regenerate names to fit the pattern they infer from
+// the list instead of copying them, which never resolves.
 const EXACT_SKILL_NAME_INSTRUCTION =
   `Pass \`skillName\` exactly as written between backticks above, character for character: ` +
   `same case, same spacing, same punctuation, same prefixes and suffixes. Copy the name ` +
@@ -71,7 +71,7 @@ export function renderEquippedSkillsUserMessage(
       `${renderSkillList(equippedSkills)}\n\n` +
       `${EXACT_SKILL_NAME_INSTRUCTION}\n` +
       `</dust_system>`,
-    "system"
+    { name: "system" }
   );
 }
 
@@ -89,7 +89,7 @@ export function renderFavoriteSkillsUserMessage(
       `The following skills were set as favorites by the user and are also available for use with the ${enableSkillToolName} tool:\n\n` +
       `${renderSkillList(favoriteSkills)}\n` +
       `</dust_system>`,
-    "user"
+    { name: "user" }
   );
 }
 
@@ -102,6 +102,6 @@ export function renderEnabledSkillUserMessageFromInstructions({
 
   return renderSkillMessage(
     `<dust_system>\n${skillInstructions}\n</dust_system>`,
-    "system"
+    { name: "system" }
   );
 }

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -37,34 +37,60 @@ export function getEnabledSkillInstructions(
   return `<${skill.name}>\n${modelInstructions}\n</${skill.name}>`;
 }
 
-export function renderAvailableSkillsUserMessage(
-  skills: SkillResource[],
-  name: "system" | "user"
-): UserMessageTypeModel | null {
-  if (skills.length === 0) {
-    return null;
-  }
-
-  const enableSkillToolName = `${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}`;
+function renderSkillList(skills: SkillResource[]): string {
   // Names are rendered as code literals rather than bold text: `skillName` is matched exactly, and
   // a literal is copied verbatim far more reliably than prose. Workspaces tend to develop their own
   // naming conventions, and models otherwise regenerate names to fit the pattern they infer from
   // the list instead of copying them, which never resolves.
-  const lines = skills.map(
-    ({ name, agentFacingDescription }) =>
-      `- \`${name}\`: ${agentFacingDescription.replaceAll("\n", "\n  ")}`
-  );
+  return skills
+    .map(
+      ({ name, agentFacingDescription }) =>
+        `- \`${name}\`: ${agentFacingDescription.replaceAll("\n", "\n  ")}`
+    )
+    .join("\n");
+}
+
+const EXACT_SKILL_NAME_INSTRUCTION =
+  `Pass \`skillName\` exactly as written between backticks above, character for character: ` +
+  `same case, same spacing, same punctuation, same prefixes and suffixes. Copy the name ` +
+  `rather than retyping it, and do not adjust it to match how other skills in the list are ` +
+  `named. Names are matched exactly, so a modified name will not be found.`;
+
+export function renderEquippedSkillsUserMessage(
+  equippedSkills: SkillResource[]
+): UserMessageTypeModel | null {
+  if (equippedSkills.length === 0) {
+    return null;
+  }
+
+  const enableSkillToolName = `${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}`;
 
   return renderSkillMessage(
     `<dust_system>\n` +
       `The following skills are available for use with the ${enableSkillToolName} tool:\n\n` +
-      `${lines.join("\n")}\n\n` +
-      `Pass \`skillName\` exactly as written between backticks above, character for character: ` +
-      `same case, same spacing, same punctuation, same prefixes and suffixes. Copy the name ` +
-      `rather than retyping it, and do not adjust it to match how other skills in the list are ` +
-      `named. Names are matched exactly, so a modified name will not be found.\n` +
+      `${renderSkillList(equippedSkills)}\n\n` +
+      `${EXACT_SKILL_NAME_INSTRUCTION}\n` +
       `</dust_system>`,
-    name
+    "system"
+  );
+}
+
+export function renderFavoriteSkillsUserMessage(
+  favoriteSkills: SkillResource[]
+): UserMessageTypeModel | null {
+  if (favoriteSkills.length === 0) {
+    return null;
+  }
+
+  const enableSkillToolName = `${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}`;
+
+  return renderSkillMessage(
+    `<dust_system>\n` +
+      `The following skills were set as favorites by the user and are available for use with the ${enableSkillToolName} tool:\n\n` +
+      `${renderSkillList(favoriteSkills)}\n\n` +
+      `${EXACT_SKILL_NAME_INSTRUCTION}\n` +
+      `</dust_system>`,
+    "user"
   );
 }
 

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -3,7 +3,7 @@ import { renderConversationForModel } from "@app/lib/api/assistant/conversation_
 import { categorizeConversationRenderErrorMessage } from "@app/lib/api/assistant/errors";
 import {
   type EnabledSkill,
-  renderEquippedSkillsUserMessage,
+  renderAvailableSkillsUserMessage,
 } from "@app/lib/api/assistant/skills_rendering";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
@@ -338,7 +338,9 @@ export async function sendBatchCallToLlm(
     const { enabledSkills, equippedSkills } = input;
 
     const leadingMessages = equippedSkills
-      ? removeNulls([renderEquippedSkillsUserMessage(equippedSkills)])
+      ? removeNulls([
+          renderAvailableSkillsUserMessage(equippedSkills, "system"),
+        ])
       : [];
 
     const modelConversationRes = await renderConversationForModel(auth, {

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -3,7 +3,7 @@ import { renderConversationForModel } from "@app/lib/api/assistant/conversation_
 import { categorizeConversationRenderErrorMessage } from "@app/lib/api/assistant/errors";
 import {
   type EnabledSkill,
-  renderAvailableSkillsUserMessage,
+  renderEquippedSkillsUserMessage,
 } from "@app/lib/api/assistant/skills_rendering";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
@@ -338,9 +338,7 @@ export async function sendBatchCallToLlm(
     const { enabledSkills, equippedSkills } = input;
 
     const leadingMessages = equippedSkills
-      ? removeNulls([
-          renderAvailableSkillsUserMessage(equippedSkills, "system"),
-        ])
+      ? removeNulls([renderEquippedSkillsUserMessage(equippedSkills)])
       : [];
 
     const modelConversationRes = await renderConversationForModel(auth, {

--- a/front/lib/api/llm/transitionLLM.test.ts
+++ b/front/lib/api/llm/transitionLLM.test.ts
@@ -175,6 +175,58 @@ describe("withMessageCacheBreakpoints", () => {
     expect(cacheOf(result[1])).toBeUndefined();
   });
 
+  it("preserves the full message shape and places cache breakpoints around favorite skills", () => {
+    const conversation: ModelMessageTypeMultiActionsWithoutContentFragment[] = [
+      equippedSkillsMessage,
+      {
+        role: "user",
+        name: "user",
+        content: [{ type: "text", text: "favorite skills" }],
+      },
+      {
+        role: "assistant",
+        name: "agent",
+        contents: [{ type: "text_content", value: "hello" }],
+      },
+      {
+        role: "user",
+        name: "user",
+        content: [{ type: "text", text: "latest turn" }],
+      },
+    ];
+
+    const result = withMessageCacheBreakpoints(
+      conversation.flatMap(toBaseMessages),
+      conversation[0],
+      { explicitTailBreakpoint: true }
+    );
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        type: "text",
+        content: { value: "equipped skills" },
+        cache: "short",
+      },
+      {
+        role: "user",
+        type: "text",
+        content: { value: "favorite skills" },
+      },
+      {
+        role: "assistant",
+        type: "text",
+        content: { value: "hello" },
+      },
+      {
+        role: "user",
+        type: "text",
+        content: { value: "latest turn" },
+        cache: "short",
+      },
+    ]);
+  });
+
   it("does not cache favorite skills when there is no shared equipped prefix", () => {
     const favoriteSkillsMessage: ModelMessageTypeMultiActionsWithoutContentFragment =
       {

--- a/front/lib/api/llm/transitionLLM.test.ts
+++ b/front/lib/api/llm/transitionLLM.test.ts
@@ -160,16 +160,34 @@ describe("withMessageCacheBreakpoints", () => {
     expect(cacheOf(result[2])).toBe("short");
   });
 
-  it("skips the equipped-skills breakpoint when the first message is not the name:system block", () => {
-    const firstUserTurn: ModelMessageTypeMultiActionsWithoutContentFragment = {
-      role: "user",
-      name: "user",
-      content: [{ type: "text", text: "hi" }],
-    };
+  it("leaves a favorite skills message after the shared prefix unmarked", () => {
+    const result = withMessageCacheBreakpoints(
+      [
+        messages[0],
+        { role: "user", type: "text", content: { value: "favorite skills" } },
+        ...messages.slice(1),
+      ],
+      equippedSkillsMessage,
+      { explicitTailBreakpoint: false }
+    );
 
-    const result = withMessageCacheBreakpoints(messages, firstUserTurn, {
-      explicitTailBreakpoint: false,
-    });
+    expect(cacheOf(result[0])).toBe("short");
+    expect(cacheOf(result[1])).toBeUndefined();
+  });
+
+  it("does not cache favorite skills when there is no shared equipped prefix", () => {
+    const favoriteSkillsMessage: ModelMessageTypeMultiActionsWithoutContentFragment =
+      {
+        role: "user",
+        name: "user",
+        content: [{ type: "text", text: "favorite skills" }],
+      };
+
+    const result = withMessageCacheBreakpoints(
+      messages,
+      favoriteSkillsMessage,
+      { explicitTailBreakpoint: false }
+    );
 
     expect(result.every((m) => cacheOf(m) === undefined)).toBe(true);
   });

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -303,12 +303,13 @@ export function toBaseMessages(
 
 // Places provider user-message cache breakpoints at the same boundaries as the
 // legacy Anthropic router. Returns a new array; does not mutate its input.
-//   - Equipped-skills prefix: always. When the first message is the
+//   - Shared equipped-skills prefix: always. When the first message is the
 //     `name: "system"` user block (the stable per agent+workspace skills list),
 //     its last content block is cached for cross-conversation reuse. Mirrors the
 //     legacy `isFirst && message.name === "system"` breakpoint. `toBaseMessages`
 //     emits one BaseMessage per user content item, so messages[0]'s last block
-//     sits at index (content.length - 1).
+//     sits at index (content.length - 1). A following user-specific favorites
+//     message uses `name: "user"` and is intentionally left unmarked.
 //   - Conversation tail: only when `explicitTailBreakpoint` is set — i.e. on
 //     surfaces without the request-level automatic cache_control (Vertex/
 //     agent-platform). The last user message is cached, mirroring legacy's

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -10,6 +10,7 @@ import {
   hasSharedMembership,
 } from "@app/lib/api/user";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { hasAll } from "@app/lib/matcher/operators/array";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1791,6 +1791,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         effectiveSpaceIds,
       });
     }
+    const favoriteSkills = (await hasFeatureFlag(auth, "skill_favorites"))
+      ? await this.listFavoritesForCurrentUser(auth, {
+          agentLoopData,
+        })
+      : [];
 
     const sortByName = (a: SkillResource, b: SkillResource) =>
       a.name.localeCompare(b.name);
@@ -1864,12 +1869,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     // Equipped skills are the enable-able candidates shown to the model. They
     // come from the agent configuration, context auto-equipping, Pod defaults,
-    // and discoverable skills. System prompt skills are never enable-able.
+    // favorite skills, and discoverable skills. System prompt skills are never enable-able.
     const equippedSkillsById = new Map<string, SkillResource>();
     for (const skill of [
       ...autoEquippedSkills,
       ...discoverableSkills,
       ...podDefaultSkills,
+      ...favoriteSkills,
       ...allAgentSkills,
     ]) {
       if (

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1750,6 +1750,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     enabledSkills: SkillResource[];
     systemSkills: SkillResource[];
     equippedSkills: SkillResource[];
+    favoriteSkills: SkillResource[];
   }> {
     const { agentConfiguration, conversation } = params;
     // Light type-guard to check whether we have a full AgentLoopExecutionData.
@@ -1869,15 +1870,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     ];
     const systemSkillIds = new Set(systemSkills.map((skill) => skill.sId));
 
-    // Equipped skills are the enable-able candidates shown to the model. They
-    // come from the agent configuration, context auto-equipping, Pod defaults,
-    // favorite skills, and discoverable skills. System prompt skills are never enable-able.
+    // Equipped skills are the workspace-shared enable-able candidates shown to
+    // the model. User-specific favorites are returned separately so they don't
+    // invalidate the shared prompt cache prefix.
     const equippedSkillsById = new Map<string, SkillResource>();
     for (const skill of [
       ...autoEquippedSkills,
       ...discoverableSkills,
       ...podDefaultSkills,
-      ...favoriteSkills,
       ...allAgentSkills,
     ]) {
       if (
@@ -1896,6 +1896,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         .filter((s) => !systemSkillIds.has(s.sId))
         .sort(sortByName),
       equippedSkills: [...equippedSkillsById.values()].sort(sortByName),
+      favoriteSkills: favoriteSkills
+        .filter(
+          (skill) =>
+            !systemSkillIds.has(skill.sId) && !equippedSkillsById.has(skill.sId)
+        )
+        .sort(sortByName),
     };
   }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1785,17 +1785,18 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
 
     let discoverableSkills: SkillResource[] = [];
+    let favoriteSkills: SkillResource[] = [];
     if (allAgentSkills.some((s) => s.globalSId === "discover_skills")) {
       discoverableSkills = await this.listDiscoverable(auth, {
         agentLoopData,
         effectiveSpaceIds,
       });
+      favoriteSkills = (await hasFeatureFlag(auth, "skill_favorites"))
+        ? await this.listFavoritesForCurrentUser(auth, {
+            agentLoopData,
+          })
+        : [];
     }
-    const favoriteSkills = (await hasFeatureFlag(auth, "skill_favorites"))
-      ? await this.listFavoritesForCurrentUser(auth, {
-          agentLoopData,
-        })
-      : [];
 
     const sortByName = (a: SkillResource, b: SkillResource) =>
       a.name.localeCompare(b.name);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1791,11 +1791,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         agentLoopData,
         effectiveSpaceIds,
       });
-      favoriteSkills = (await hasFeatureFlag(auth, "skill_favorites"))
-        ? await this.listFavoritesForCurrentUser(auth, {
-            agentLoopData,
-          })
-        : [];
+      const hasSkillFavorites = await hasFeatureFlag(auth, "skill_favorites");
+      if (hasSkillFavorites) {
+        favoriteSkills = await this.listFavoritesForCurrentUser(auth, {
+          agentLoopData,
+        });
+      }
     }
 
     const sortByName = (a: SkillResource, b: SkillResource) =>

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -8,7 +8,10 @@ import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
-import { renderEquippedSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
+import {
+  renderEquippedSkillsUserMessage,
+  renderFavoriteSkillsUserMessage,
+} from "@app/lib/api/assistant/skills_rendering";
 import { legacyModelIdToModel } from "@app/lib/api/llm";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import { Authenticator } from "@app/lib/auth";
@@ -117,6 +120,7 @@ makeScript(
       enabledSkills,
       systemSkills,
       equippedSkills,
+      favoriteSkills,
       hasSelectedSpacesOutsideAgentScope,
     } = await SkillResource.listForAgentLoop(auth, {
       agentConfiguration,
@@ -211,6 +215,7 @@ makeScript(
     const prompt = systemPromptToText(promptSections);
     const leadingMessages = removeNulls([
       renderEquippedSkillsUserMessage(equippedSkills),
+      renderFavoriteSkillsUserMessage(favoriteSkills),
     ]);
 
     const specifications = availableActions.map((t) =>

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -8,7 +8,10 @@ import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
-import { renderAvailableSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
+import {
+  renderEquippedSkillsUserMessage,
+  renderFavoriteSkillsUserMessage,
+} from "@app/lib/api/assistant/skills_rendering";
 import { legacyModelIdToModel } from "@app/lib/api/llm";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import { Authenticator } from "@app/lib/auth";
@@ -211,8 +214,8 @@ makeScript(
     });
     const prompt = systemPromptToText(promptSections);
     const leadingMessages = removeNulls([
-      renderAvailableSkillsUserMessage(equippedSkills, "system"),
-      renderAvailableSkillsUserMessage(favoriteSkills, "user"),
+      renderEquippedSkillsUserMessage(equippedSkills),
+      renderFavoriteSkillsUserMessage(favoriteSkills),
     ]);
 
     const specifications = availableActions.map((t) =>

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -8,10 +8,7 @@ import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
-import {
-  renderEquippedSkillsUserMessage,
-  renderFavoriteSkillsUserMessage,
-} from "@app/lib/api/assistant/skills_rendering";
+import { renderAvailableSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
 import { legacyModelIdToModel } from "@app/lib/api/llm";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import { Authenticator } from "@app/lib/auth";
@@ -214,8 +211,8 @@ makeScript(
     });
     const prompt = systemPromptToText(promptSections);
     const leadingMessages = removeNulls([
-      renderEquippedSkillsUserMessage(equippedSkills),
-      renderFavoriteSkillsUserMessage(favoriteSkills),
+      renderAvailableSkillsUserMessage(equippedSkills, "system"),
+      renderAvailableSkillsUserMessage(favoriteSkills, "user"),
     ]);
 
     const specifications = availableActions.map((t) =>

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -34,7 +34,10 @@ import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
-import { renderEquippedSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
+import {
+  renderEquippedSkillsUserMessage,
+  renderFavoriteSkillsUserMessage,
+} from "@app/lib/api/assistant/skills_rendering";
 import {
   buildAuditLogTarget,
   emitAuditLogEventDirect,
@@ -488,6 +491,7 @@ export async function runModel(
     enabledSkills,
     systemSkills,
     equippedSkills,
+    favoriteSkills,
     serverToolsAndInstructions: mcpActions,
     hasSelectedSpacesOutsideAgentScope,
   } = await startActiveObservation("resolve-tools", async () => {
@@ -513,6 +517,7 @@ export async function runModel(
       enabledSkills,
       systemSkills,
       equippedSkills,
+      favoriteSkills,
       hasSelectedSpacesOutsideAgentScope,
     } = await SkillResource.listForAgentLoop(auth, runAgentData);
 
@@ -542,6 +547,7 @@ export async function runModel(
       hasSelectedSpacesOutsideAgentScope,
       enabledSkills,
       equippedSkills,
+      favoriteSkills,
       systemSkills,
       serverToolsAndInstructions,
     };
@@ -642,6 +648,7 @@ export async function runModel(
   });
   const leadingMessages = removeNulls([
     renderEquippedSkillsUserMessage(equippedSkills),
+    renderFavoriteSkillsUserMessage(favoriteSkills),
   ]);
 
   const modelConfig = modelInfo.endpoint.modelConfig;

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -34,7 +34,10 @@ import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
-import { renderAvailableSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
+import {
+  renderEquippedSkillsUserMessage,
+  renderFavoriteSkillsUserMessage,
+} from "@app/lib/api/assistant/skills_rendering";
 import {
   buildAuditLogTarget,
   emitAuditLogEventDirect,
@@ -645,8 +648,8 @@ export async function runModel(
   });
   // Only the shared skills message receives the leading skills cache breakpoint.
   const leadingMessages = removeNulls([
-    renderAvailableSkillsUserMessage(equippedSkills, "system"),
-    renderAvailableSkillsUserMessage(favoriteSkills, "user"),
+    renderEquippedSkillsUserMessage(equippedSkills),
+    renderFavoriteSkillsUserMessage(favoriteSkills),
   ]);
 
   const modelConfig = modelInfo.endpoint.modelConfig;

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -34,10 +34,7 @@ import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
-import {
-  renderEquippedSkillsUserMessage,
-  renderFavoriteSkillsUserMessage,
-} from "@app/lib/api/assistant/skills_rendering";
+import { renderAvailableSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
 import {
   buildAuditLogTarget,
   emitAuditLogEventDirect,
@@ -646,9 +643,10 @@ export async function runModel(
     disableFormattingPrompt,
     hasSelectedSpacesOutsideAgentScope,
   });
+  // Only the shared skills message receives the leading skills cache breakpoint.
   const leadingMessages = removeNulls([
-    renderEquippedSkillsUserMessage(equippedSkills),
-    renderFavoriteSkillsUserMessage(favoriteSkills),
+    renderAvailableSkillsUserMessage(equippedSkills, "system"),
+    renderAvailableSkillsUserMessage(favoriteSkills, "user"),
   ]);
 
   const modelConfig = modelInfo.endpoint.modelConfig;


### PR DESCRIPTION
## Description

This PR exposes the descriptions of the user's favorite skills to the model, only for agents agent that have `discover_skills`.

These skills are exposed in a separate user message, to identify them clearly and to keep a cache breakpoint on the part that is shared across the workspace.

## Tests

- Added tests.
- Tested locally.

## Risk

- Low. Behind feature flag.

## Deploy Plan

- Deploy front.
