### PR TITLE
[sparkle] add NewButton and NewInput (redesign, additive)

### DIFF
--- a/sparkle/src/components/NewButton.tsx
+++ b/sparkle/src/components/NewButton.tsx
@@ -71,7 +71,7 @@ const newButtonVariants = cva(
           "s-bg-gradient-to-b s-from-stone-700 s-to-stone-800",
           "s-text-white",
           SOLID_SHADOW("#364153"),
-          "hover:after:s-bg-white/10 active:after:s-bg-black/10",
+          "active:after:s-bg-black/10",
           "disabled:s-from-stone-300 disabled:s-to-stone-400 disabled:s-shadow-none",
           "dark:s-border dark:s-border-border-dark",
           "dark:s-from-white dark:s-to-stone-50 dark:s-text-muted-foreground",
@@ -84,7 +84,7 @@ const newButtonVariants = cva(
           "s-bg-gradient-to-b s-from-highlight-400 s-to-highlight-500",
           "s-text-white",
           SOLID_SHADOW("#4BABFF"),
-          "hover:after:s-bg-white/10 active:after:s-bg-black/10",
+          "active:after:s-bg-black/10",
           "disabled:s-from-highlight-200 disabled:s-to-highlight-300 disabled:s-shadow-none"
         ),
         warning: cn(
@@ -92,7 +92,7 @@ const newButtonVariants = cva(
           "s-bg-gradient-to-b s-from-red-400 s-to-red-500",
           "s-text-white",
           SOLID_SHADOW("#E76449"),
-          "hover:after:s-bg-white/10 active:after:s-bg-black/10",
+          "active:after:s-bg-black/10",
           "disabled:s-from-red-200 disabled:s-to-red-300 disabled:s-shadow-none"
         ),
         outline: cn(
@@ -105,7 +105,7 @@ const newButtonVariants = cva(
           "disabled:s-shadow-none disabled:s-text-faint",
           "dark:s-border-0 dark:s-from-stone-700 dark:s-to-stone-800 dark:s-text-white",
           DARK_SOLID_SHADOW,
-          "dark:hover:after:s-bg-white/10 dark:active:after:s-bg-black/10",
+          "dark:active:after:s-bg-black/10",
           "dark:disabled:s-from-stone-300 dark:disabled:s-to-stone-400 dark:disabled:s-text-white dark:disabled:s-shadow-none"
         ),
         ghost: cn(
@@ -163,6 +163,30 @@ const newButtonVariants = cva(
       { size: "xs", isIconOnly: true, className: "s-w-6 s-px-0" },
       { size: "sm", isIconOnly: true, className: "s-w-8 s-px-0" },
       { size: "md", isIconOnly: true, className: "s-w-10 s-px-0" },
+      // White hover overlay on solid variants: large buttons get a stronger
+      // tint (Figma uses white/0.2 at Large, white/0.1 at Small/Medium).
+      {
+        variant: ["primary", "highlight", "warning"],
+        size: ["xs", "sm"],
+        className: "hover:after:s-bg-white/10",
+      },
+      {
+        variant: ["primary", "highlight", "warning"],
+        size: "md",
+        className: "hover:after:s-bg-white/20",
+      },
+      // Outline renders as a dark solid in dark mode, so it follows the same
+      // size rule for its (dark-only) white hover overlay.
+      {
+        variant: "outline",
+        size: ["xs", "sm"],
+        className: "dark:hover:after:s-bg-white/10",
+      },
+      {
+        variant: "outline",
+        size: "md",
+        className: "dark:hover:after:s-bg-white/20",
+      },
     ],
     defaultVariants: {
       variant: "primary",

--- a/sparkle/src/components/NewButton.tsx
+++ b/sparkle/src/components/NewButton.tsx
@@ -269,8 +269,7 @@ const NewButton = React.forwardRef<HTMLButtonElement, NewButtonProps>(
     // trigger; isSelect is our chevron affordance. Tooltips don't, so they keep it.
     const isMenuTrigger = isSelect || props["aria-haspopup"] != null;
     const hasTextShadow =
-      variant != null &&
-      RAISED_VARIANTS.includes(variant as NewButtonVariantType);
+      variant != null && RAISED_VARIANTS.includes(variant);
     const iconShadow = hasTextShadow ? ICON_SHADOW : "";
 
     const renderIcon = (visual: NewButtonIconType, extraClass = "") => {

--- a/sparkle/src/components/NewButton.tsx
+++ b/sparkle/src/components/NewButton.tsx
@@ -1,0 +1,382 @@
+import { Slot } from "@radix-ui/react-slot";
+import { Counter } from "@sparkle/components/Counter";
+import { Icon } from "@sparkle/components/Icon";
+import {
+  LinkWrapper,
+  type LinkWrapperProps,
+} from "@sparkle/components/LinkWrapper";
+import { Spinner } from "@sparkle/components/Spinner";
+import { Tooltip } from "@sparkle/components/Tooltip";
+import { ChevronDown } from "@sparkle/icons/v2-stroke";
+import { cn } from "@sparkle/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+// Redesigned button, added alongside the existing Button (which is unchanged).
+// Sizes use a 24/32/40px scale. In dark mode, primary and outline swap (each
+// renders the other's light design); other variants are unchanged apart from
+// ghost text/hover tints, which flip via -night tokens.
+
+export const NEW_BUTTON_VARIANTS = [
+  "primary",
+  "highlight",
+  "outline",
+  "warning",
+  "ghost",
+  "ghost-secondary",
+  "highlight-ghost",
+  "warning-ghost",
+] as const;
+
+export type NewButtonVariantType = (typeof NEW_BUTTON_VARIANTS)[number];
+
+export const NEW_BUTTON_SIZES = ["xs", "sm", "md"] as const;
+export type NewButtonSizeType = (typeof NEW_BUTTON_SIZES)[number];
+
+// Per-variant shadow: tinted 0.5px outline + soft drop + faint inset highlight.
+// The outline hex is literal because arbitrary shadows can't use theme tokens.
+const SOLID_SHADOW = (outline: string) =>
+  `s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_${outline},0_1px_1.5px_0_rgba(0,0,0,0.10)]`;
+const OUTLINE_SHADOW =
+  "s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#DFE0E2,0_0.5px_1px_0_rgba(0,0,0,0.06)]";
+
+// Hover/active overlay for the raised variants. Per-variant (not in the base)
+// so ghost variants leave the ::after pseudo free for consumers (e.g. Tabs).
+const OVERLAY = cn(
+  "after:s-pointer-events-none after:s-absolute after:s-inset-0 after:s-rounded-[inherit]",
+  "after:s-transition-colors disabled:after:s-hidden"
+);
+
+// `dark:` shadow literals for the primary/outline swap, spelled out (not a
+// computed prefix) so Tailwind's JIT emits them.
+const DARK_OUTLINE_SHADOW =
+  "dark:s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#DFE0E2,0_0.5px_1px_0_rgba(0,0,0,0.06)]";
+const DARK_SOLID_SHADOW =
+  "dark:s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#44403b,0_1px_1.5px_0_rgba(0,0,0,0.10)]";
+
+const newButtonVariants = cva(
+  cn(
+    "s-relative s-isolate s-inline-flex s-shrink-0 s-select-none s-items-center s-justify-center s-whitespace-nowrap",
+    // `transform` stays in the transition list for the `press` scale.
+    "s-transition-[color,background-color,border-color,transform] s-duration-150 s-ease-out",
+    "motion-reduce:s-transition-none",
+    "focus-visible:s-outline-none focus-visible:s-ring-2 focus-visible:s-ring-ring focus-visible:s-ring-offset-0",
+    // Disabled styling is per-variant (below), not a blanket opacity.
+    "disabled:s-cursor-not-allowed"
+  ),
+  {
+    variants: {
+      variant: {
+        primary: cn(
+          OVERLAY,
+          "s-bg-gradient-to-b s-from-stone-700 s-to-stone-800",
+          "s-text-white",
+          SOLID_SHADOW("#44403b"),
+          "hover:after:s-bg-white/10 active:after:s-bg-black/10",
+          "disabled:s-from-stone-300 disabled:s-to-stone-400 disabled:s-shadow-none",
+          "dark:s-border dark:s-border-border-dark",
+          "dark:s-from-white dark:s-to-stone-50 dark:s-text-muted-foreground",
+          DARK_OUTLINE_SHADOW,
+          "dark:hover:after:s-bg-gray-950/[0.02] dark:active:after:s-bg-gray-950/[0.04]",
+          "dark:disabled:s-from-white dark:disabled:s-to-stone-50 dark:disabled:s-shadow-none dark:disabled:s-text-faint"
+        ),
+        highlight: cn(
+          OVERLAY,
+          "s-bg-gradient-to-b s-from-highlight-400 s-to-highlight-500",
+          "s-text-white",
+          SOLID_SHADOW("#4BABFF"),
+          "hover:after:s-bg-white/10 active:after:s-bg-black/10",
+          "disabled:s-from-highlight-200 disabled:s-to-highlight-300 disabled:s-shadow-none"
+        ),
+        warning: cn(
+          OVERLAY,
+          "s-bg-gradient-to-b s-from-red-400 s-to-red-500",
+          "s-text-white",
+          SOLID_SHADOW("#E76449"),
+          "hover:after:s-bg-white/10 active:after:s-bg-black/10",
+          "disabled:s-from-red-200 disabled:s-to-red-300 disabled:s-shadow-none"
+        ),
+        outline: cn(
+          OVERLAY,
+          "s-border s-border-border-dark",
+          "s-bg-gradient-to-b s-from-white s-to-stone-50",
+          "s-text-muted-foreground",
+          OUTLINE_SHADOW,
+          "hover:after:s-bg-gray-950/[0.02] active:after:s-bg-gray-950/[0.04]",
+          "disabled:s-shadow-none disabled:s-text-faint",
+          "dark:s-border-0 dark:s-from-stone-700 dark:s-to-stone-800 dark:s-text-white",
+          DARK_SOLID_SHADOW,
+          "dark:hover:after:s-bg-white/10 dark:active:after:s-bg-black/10",
+          "dark:disabled:s-from-stone-300 dark:disabled:s-to-stone-400 dark:disabled:s-text-white dark:disabled:s-shadow-none"
+        ),
+        ghost: cn(
+          "s-text-foreground dark:s-text-foreground-night",
+          "hover:s-bg-gray-950/[0.02] active:s-bg-gray-950/[0.04]",
+          "dark:hover:s-bg-white/[0.04] dark:active:s-bg-white/[0.08]",
+          "disabled:s-text-faint dark:disabled:s-text-faint-night",
+          "disabled:hover:s-bg-transparent dark:disabled:hover:s-bg-transparent"
+        ),
+        "ghost-secondary": cn(
+          "s-text-muted-foreground dark:s-text-muted-foreground-night",
+          "hover:s-bg-gray-950/[0.02] active:s-bg-gray-950/[0.04]",
+          "dark:hover:s-bg-white/[0.04] dark:active:s-bg-white/[0.08]",
+          "disabled:s-text-faint dark:disabled:s-text-faint-night",
+          "disabled:hover:s-bg-transparent dark:disabled:hover:s-bg-transparent"
+        ),
+        "highlight-ghost": cn(
+          "s-text-highlight-500 dark:s-text-highlight-500-night",
+          "hover:s-bg-highlight-50 active:s-bg-highlight-100",
+          "dark:hover:s-bg-highlight-50-night dark:active:s-bg-highlight-100-night",
+          "disabled:s-text-highlight-muted",
+          "disabled:hover:s-bg-transparent dark:disabled:hover:s-bg-transparent"
+        ),
+        "warning-ghost": cn(
+          "s-text-red-500",
+          "hover:s-bg-red-50 active:s-bg-red-100",
+          "dark:hover:s-bg-warning-50-night dark:active:s-bg-warning-100-night",
+          "disabled:s-text-red-300",
+          "disabled:hover:s-bg-transparent dark:disabled:hover:s-bg-transparent"
+        ),
+      },
+      size: {
+        xs: "s-h-6 s-gap-1.5 s-px-2 s-text-sm s-font-medium s-tracking-[-0.28px]",
+        sm: "s-h-8 s-gap-1.5 s-px-3 s-text-sm s-font-medium s-tracking-[-0.28px]",
+        md: "s-h-10 s-gap-1.5 s-px-4 s-text-base s-font-medium s-tracking-[-0.32px]",
+      },
+      // Separate from size: twMerge isn't configured for the s- prefix, so a
+      // size radius + rounded-full would both emit and let CSS order decide.
+      rounded: {
+        xs: "s-rounded-[9px]",
+        sm: "s-rounded-xl",
+        md: "s-rounded-[15px]",
+        full: "s-rounded-full",
+      },
+      isIconOnly: {
+        true: "",
+        false: "",
+      },
+      press: {
+        true: "active:s-scale-[0.97] motion-reduce:active:s-scale-100",
+        false: "",
+      },
+    },
+    compoundVariants: [
+      { size: "xs", isIconOnly: true, className: "s-w-6 s-px-0" },
+      { size: "sm", isIconOnly: true, className: "s-w-8 s-px-0" },
+      { size: "md", isIconOnly: true, className: "s-w-10 s-px-0" },
+    ],
+    defaultVariants: {
+      variant: "primary",
+      size: "sm",
+      rounded: "md",
+      isIconOnly: false,
+      press: true,
+    },
+  }
+);
+
+// Labels and icons carry a subtle shadow on raised (non-ghost) variants.
+const RAISED_VARIANTS: NewButtonVariantType[] = [
+  "primary",
+  "highlight",
+  "warning",
+  "outline",
+];
+const TEXT_SHADOW = "[text-shadow:0_1px_1.5px_rgba(0,0,0,0.08)]";
+const ICON_SHADOW = "s-drop-shadow-[0px_1px_0.75px_rgba(0,0,0,0.08)]";
+
+const ICON_SIZE_MAP: Record<NewButtonSizeType, "xs" | "sm"> = {
+  xs: "xs",
+  sm: "xs",
+  md: "sm",
+};
+
+const COUNTER_SIZE_MAP: Record<NewButtonSizeType, "xs" | "sm"> = {
+  xs: "xs",
+  sm: "xs",
+  md: "sm",
+};
+
+const chevronVariantMap: Record<NewButtonVariantType, string> = {
+  primary: "s-text-white/60",
+  highlight: "s-text-white/60",
+  warning: "s-text-white/60",
+  outline: "s-text-faint",
+  ghost: "s-text-faint",
+  "ghost-secondary": "s-text-faint",
+  "highlight-ghost": "s-text-highlight-400",
+  "warning-ghost": "s-text-warning-400",
+};
+
+export type NewButtonIconType = React.ComponentType | React.ReactElement;
+
+function isReactElement(
+  visual: NewButtonIconType
+): visual is React.ReactElement {
+  return React.isValidElement(visual);
+}
+
+export interface NewButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "size">,
+    Omit<LinkWrapperProps, "children" | "className">,
+    Pick<VariantProps<typeof newButtonVariants>, "variant"> {
+  size?: NewButtonSizeType;
+  label?: string;
+  icon?: NewButtonIconType;
+  iconRight?: NewButtonIconType;
+  isSelect?: boolean;
+  isLoading?: boolean;
+  isRounded?: boolean;
+  isCounter?: boolean;
+  counterValue?: string;
+  isPulsing?: boolean;
+  tooltip?: string;
+  tooltipShortcut?: string;
+}
+
+const NewButton = React.forwardRef<HTMLButtonElement, NewButtonProps>(
+  (
+    {
+      label,
+      icon,
+      iconRight,
+      className,
+      variant = "primary",
+      size = "sm",
+      isSelect = false,
+      isLoading = false,
+      isRounded = false,
+      isCounter = false,
+      counterValue,
+      isPulsing = false,
+      tooltip,
+      tooltipShortcut,
+      href,
+      target,
+      rel,
+      replace,
+      shallow,
+      "aria-label": ariaLabel,
+      ...props
+    },
+    ref
+  ) => {
+    const iconSize = ICON_SIZE_MAP[size];
+    const showCounter = isCounter && counterValue != null;
+    const isIconOnly = !label && !showCounter && !isSelect && !!icon;
+    // Menu triggers (dropdown/popover/select) skip the press scale, else the
+    // opening menu jumps with the anchor. Radix sets aria-haspopup on the
+    // trigger; isSelect is our chevron affordance. Tooltips don't, so they keep it.
+    const isMenuTrigger = isSelect || props["aria-haspopup"] != null;
+    const hasTextShadow =
+      variant != null &&
+      RAISED_VARIANTS.includes(variant as NewButtonVariantType);
+    const iconShadow = hasTextShadow ? ICON_SHADOW : "";
+
+    const renderIcon = (visual: NewButtonIconType, extraClass = "") => {
+      if (isReactElement(visual)) {
+        return <span className={cn("s-shrink-0", extraClass)}>{visual}</span>;
+      }
+      return <Icon visual={visual} size={iconSize} className={extraClass} />;
+    };
+
+    const content = (
+      <>
+        {isLoading ? (
+          <Spinner size="xs" variant="mono" />
+        ) : (
+          icon && renderIcon(icon, iconShadow)
+        )}
+        {label && (
+          <span className={cn(hasTextShadow && TEXT_SHADOW)}>{label}</span>
+        )}
+        {showCounter && (
+          <Counter
+            value={Number(counterValue)}
+            variant="primary"
+            size={COUNTER_SIZE_MAP[size]}
+            isInButton={true}
+          />
+        )}
+        {!isLoading && iconRight && renderIcon(iconRight, iconShadow)}
+        {isSelect && (
+          <Icon
+            visual={ChevronDown}
+            size={iconSize}
+            className={variant ? chevronVariantMap[variant] : ""}
+          />
+        )}
+      </>
+    );
+
+    const pointerEventProps = React.useMemo(() => {
+      if (isLoading || props.disabled) {
+        return {
+          onPointerDown: (e: React.PointerEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            e.stopPropagation();
+          },
+        };
+      }
+      return {};
+    }, [isLoading, props.disabled]);
+
+    // Disabled/loading buttons must not navigate: render a real <button> and
+    // skip the LinkWrapper below.
+    const isInteractive = !props.disabled && !isLoading;
+    const shouldUseSlot = !!href && isInteractive;
+    const Comp = shouldUseSlot ? Slot : "button";
+
+    const innerButton = (
+      <Comp
+        ref={ref}
+        className={cn(
+          newButtonVariants({
+            variant,
+            size,
+            rounded: isRounded ? "full" : size,
+            isIconOnly,
+            press: !isMenuTrigger,
+          }),
+          isPulsing && "s-animate-ring-pulse",
+          className
+        )}
+        disabled={isLoading || props.disabled}
+        aria-label={ariaLabel || tooltip || label}
+        {...props}
+        {...pointerEventProps}
+      >
+        {shouldUseSlot ? <span>{content}</span> : content}
+      </Comp>
+    );
+
+    const wrappedContent = tooltip ? (
+      <Tooltip
+        trigger={innerButton}
+        tooltipTriggerAsChild={true}
+        label={tooltip}
+        shortcut={tooltipShortcut}
+      />
+    ) : (
+      innerButton
+    );
+
+    return href && isInteractive ? (
+      <LinkWrapper
+        href={href}
+        target={target}
+        rel={rel}
+        replace={replace}
+        shallow={shallow}
+      >
+        {wrappedContent}
+      </LinkWrapper>
+    ) : (
+      wrappedContent
+    );
+  }
+);
+
+NewButton.displayName = "NewButton";
+
+export { NewButton, newButtonVariants };

--- a/sparkle/src/components/NewButton.tsx
+++ b/sparkle/src/components/NewButton.tsx
@@ -33,12 +33,11 @@ export type NewButtonVariantType = (typeof NEW_BUTTON_VARIANTS)[number];
 export const NEW_BUTTON_SIZES = ["xs", "sm", "md"] as const;
 export type NewButtonSizeType = (typeof NEW_BUTTON_SIZES)[number];
 
-// Per-variant shadow: tinted 0.5px outline + soft drop + faint inset highlight.
-// The outline hex is literal because arbitrary shadows can't use theme tokens.
+// The shadow shared by every raised button: a tinted 0.5px outline, a drop,
+// and a faint inset highlight. The outline hex is literal because arbitrary
+// shadows can't reference theme tokens.
 const SOLID_SHADOW = (outline: string) =>
   `s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_${outline},0_1px_1.5px_0_rgba(0,0,0,0.10)]`;
-const OUTLINE_SHADOW =
-  "s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#eeeeec,0_0.5px_1px_0_rgba(0,0,0,0.06)]";
 
 // Hover/active overlay for the raised variants. Per-variant (not in the base)
 // so ghost variants leave the ::after pseudo free for consumers (e.g. Tabs).
@@ -50,7 +49,7 @@ const OVERLAY = cn(
 // `dark:` shadow literals for the primary/outline swap, spelled out (not a
 // computed prefix) so Tailwind's JIT emits them.
 const DARK_OUTLINE_SHADOW =
-  "dark:s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#eeeeec,0_0.5px_1px_0_rgba(0,0,0,0.06)]";
+  "dark:s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#eeeeec,0_1px_1.5px_0_rgba(0,0,0,0.10)]";
 const DARK_SOLID_SHADOW =
   "dark:s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#364153,0_1px_1.5px_0_rgba(0,0,0,0.10)]";
 
@@ -101,7 +100,7 @@ const newButtonVariants = cva(
           "s-border s-border-border-dark",
           "s-bg-gradient-to-b s-from-white s-to-stone-50",
           "s-text-muted-foreground",
-          OUTLINE_SHADOW,
+          SOLID_SHADOW("#eeeeec"),
           "hover:after:s-bg-gray-950/[0.02] active:after:s-bg-gray-950/[0.04]",
           "disabled:s-shadow-none disabled:s-text-faint",
           "dark:s-border-0 dark:s-from-stone-700 dark:s-to-stone-800 dark:s-text-white",
@@ -111,14 +110,14 @@ const newButtonVariants = cva(
         ),
         ghost: cn(
           "s-text-foreground dark:s-text-foreground-night",
-          "hover:s-bg-gray-950/[0.02] active:s-bg-gray-950/[0.04]",
+          "hover:s-bg-black/[0.02] active:s-bg-black/[0.04]",
           "dark:hover:s-bg-white/[0.04] dark:active:s-bg-white/[0.08]",
           "disabled:s-text-faint dark:disabled:s-text-faint-night",
           "disabled:hover:s-bg-transparent dark:disabled:hover:s-bg-transparent"
         ),
         "ghost-secondary": cn(
           "s-text-muted-foreground dark:s-text-muted-foreground-night",
-          "hover:s-bg-gray-950/[0.02] active:s-bg-gray-950/[0.04]",
+          "hover:s-bg-black/[0.02] active:s-bg-black/[0.04]",
           "dark:hover:s-bg-white/[0.04] dark:active:s-bg-white/[0.08]",
           "disabled:s-text-faint dark:disabled:s-text-faint-night",
           "disabled:hover:s-bg-transparent dark:disabled:hover:s-bg-transparent"

--- a/sparkle/src/components/NewButton.tsx
+++ b/sparkle/src/components/NewButton.tsx
@@ -291,8 +291,7 @@ const NewButton = React.forwardRef<HTMLButtonElement, NewButtonProps>(
     // opening menu jumps with the anchor. Radix sets aria-haspopup on the
     // trigger; isSelect is our chevron affordance. Tooltips don't, so they keep it.
     const isMenuTrigger = isSelect || props["aria-haspopup"] != null;
-    const hasTextShadow =
-      variant != null && RAISED_VARIANTS.includes(variant);
+    const hasTextShadow = variant != null && RAISED_VARIANTS.includes(variant);
     const iconShadow = hasTextShadow ? ICON_SHADOW : "";
 
     const renderIcon = (visual: NewButtonIconType, extraClass = "") => {

--- a/sparkle/src/components/NewButton.tsx
+++ b/sparkle/src/components/NewButton.tsx
@@ -49,7 +49,7 @@ const OVERLAY = cn(
 // `dark:` shadow literals for the primary/outline swap, spelled out (not a
 // computed prefix) so Tailwind's JIT emits them.
 const DARK_OUTLINE_SHADOW =
-  "dark:s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#eeeeec,0_1px_1.5px_0_rgba(0,0,0,0.10)]";
+  "dark:s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#DFE0E2,0_1px_1.5px_0_rgba(0,0,0,0.10)]";
 const DARK_SOLID_SHADOW =
   "dark:s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#364153,0_1px_1.5px_0_rgba(0,0,0,0.10)]";
 
@@ -100,7 +100,7 @@ const newButtonVariants = cva(
           "s-border s-border-border-dark",
           "s-bg-gradient-to-b s-from-white s-to-stone-50",
           "s-text-muted-foreground",
-          SOLID_SHADOW("#eeeeec"),
+          SOLID_SHADOW("#DFE0E2"),
           "hover:after:s-bg-gray-950/[0.02] active:after:s-bg-gray-950/[0.04]",
           "disabled:s-shadow-none disabled:s-text-faint",
           "dark:s-border-0 dark:s-from-stone-700 dark:s-to-stone-800 dark:s-text-white",

--- a/sparkle/src/components/NewButton.tsx
+++ b/sparkle/src/components/NewButton.tsx
@@ -38,7 +38,7 @@ export type NewButtonSizeType = (typeof NEW_BUTTON_SIZES)[number];
 const SOLID_SHADOW = (outline: string) =>
   `s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_${outline},0_1px_1.5px_0_rgba(0,0,0,0.10)]`;
 const OUTLINE_SHADOW =
-  "s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#DFE0E2,0_0.5px_1px_0_rgba(0,0,0,0.06)]";
+  "s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#eeeeec,0_0.5px_1px_0_rgba(0,0,0,0.06)]";
 
 // Hover/active overlay for the raised variants. Per-variant (not in the base)
 // so ghost variants leave the ::after pseudo free for consumers (e.g. Tabs).
@@ -50,9 +50,9 @@ const OVERLAY = cn(
 // `dark:` shadow literals for the primary/outline swap, spelled out (not a
 // computed prefix) so Tailwind's JIT emits them.
 const DARK_OUTLINE_SHADOW =
-  "dark:s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#DFE0E2,0_0.5px_1px_0_rgba(0,0,0,0.06)]";
+  "dark:s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#eeeeec,0_0.5px_1px_0_rgba(0,0,0,0.06)]";
 const DARK_SOLID_SHADOW =
-  "dark:s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#44403b,0_1px_1.5px_0_rgba(0,0,0,0.10)]";
+  "dark:s-shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_#364153,0_1px_1.5px_0_rgba(0,0,0,0.10)]";
 
 const newButtonVariants = cva(
   cn(
@@ -71,7 +71,7 @@ const newButtonVariants = cva(
           OVERLAY,
           "s-bg-gradient-to-b s-from-stone-700 s-to-stone-800",
           "s-text-white",
-          SOLID_SHADOW("#44403b"),
+          SOLID_SHADOW("#364153"),
           "hover:after:s-bg-white/10 active:after:s-bg-black/10",
           "disabled:s-from-stone-300 disabled:s-to-stone-400 disabled:s-shadow-none",
           "dark:s-border dark:s-border-border-dark",
@@ -134,7 +134,7 @@ const newButtonVariants = cva(
           "s-text-red-500",
           "hover:s-bg-red-50 active:s-bg-red-100",
           "dark:hover:s-bg-warning-50-night dark:active:s-bg-warning-100-night",
-          "disabled:s-text-red-300",
+          "disabled:s-text-warning-muted",
           "disabled:hover:s-bg-transparent dark:disabled:hover:s-bg-transparent"
         ),
       },

--- a/sparkle/src/components/NewInput.tsx
+++ b/sparkle/src/components/NewInput.tsx
@@ -39,8 +39,8 @@ const fieldVariants = cva(
     variants: {
       size: {
         xs: "s-h-6 s-rounded-lg s-text-xs",
-        sm: "s-h-8 s-rounded-xl s-text-sm",
-        md: "s-h-10 s-rounded-[15px] s-text-sm",
+        sm: "s-h-8 s-rounded-xl s-text-sm s-tracking-[-0.28px]",
+        md: "s-h-10 s-rounded-[15px] s-text-sm s-tracking-[-0.28px]",
       },
       state: {
         default: cn(
@@ -68,7 +68,7 @@ const innerInputVariants = cva(
   cn(
     "s-h-full s-w-full s-min-w-0 s-flex-1 s-border-0 s-bg-transparent s-outline-none",
     // <input> does not inherit typography from its wrapper by default.
-    "s-font-sans s-text-inherit",
+    "s-font-sans s-font-medium s-text-inherit",
     "s-text-foreground dark:s-text-foreground-night",
     "placeholder:s-text-faint dark:placeholder:s-text-faint-night",
     "disabled:s-cursor-not-allowed disabled:s-text-faint dark:disabled:s-text-faint-night"
@@ -127,6 +127,13 @@ const ICON_CLASSES: Record<NewInputSizeType, string> = {
   xs: "s-h-3 s-w-3",
   sm: "s-h-3.5 s-w-3.5",
   md: "s-h-4 s-w-4",
+};
+
+// Inline icons sit at the same inset as the inner input's horizontal padding.
+const ICON_MARGIN: Record<NewInputSizeType, { left: string; right: string }> = {
+  xs: { left: "s-ml-2", right: "s-mr-2" },
+  sm: { left: "s-ml-3", right: "s-mr-3" },
+  md: { left: "s-ml-3", right: "s-mr-3" },
 };
 
 export interface NewInputProps
@@ -189,7 +196,8 @@ export const NewInput = forwardRef<HTMLInputElement, NewInputProps>(
             <Icon
               visual={icon}
               className={cn(
-                "s-ml-2 s-shrink-0 s-text-faint dark:s-text-faint-night",
+                "s-shrink-0 s-text-faint dark:s-text-faint-night",
+                ICON_MARGIN[size].left,
                 ICON_CLASSES[size]
               )}
             />
@@ -206,7 +214,8 @@ export const NewInput = forwardRef<HTMLInputElement, NewInputProps>(
             <Icon
               visual={iconRight}
               className={cn(
-                "s-mr-2 s-shrink-0 s-text-faint dark:s-text-faint-night",
+                "s-shrink-0 s-text-faint dark:s-text-faint-night",
+                ICON_MARGIN[size].right,
                 ICON_CLASSES[size]
               )}
             />
@@ -216,7 +225,7 @@ export const NewInput = forwardRef<HTMLInputElement, NewInputProps>(
         {message && (
           <div
             className={cn(
-              "s-flex s-items-center s-gap-1 s-text-xs",
+              "s-flex s-items-start s-gap-0.5 s-text-xs",
               messageVariant({ status: messageStatus })
             )}
           >

--- a/sparkle/src/components/NewInput.tsx
+++ b/sparkle/src/components/NewInput.tsx
@@ -1,0 +1,234 @@
+import { Icon } from "@sparkle/components/Icon";
+import { InfoCircle } from "@sparkle/icons/v2-stroke";
+import { cn } from "@sparkle/lib/utils";
+import { cva } from "class-variance-authority";
+import React, { forwardRef } from "react";
+
+// Redesigned input, added alongside the existing Input (which is unchanged).
+// xs/sm/md = 24/32/40px. The field is a wrapper around a transparent inner
+// <input> so slots and icons share one code path.
+
+const MESSAGE_STATUS = ["info", "default", "error"] as const;
+
+type MessageStatus = (typeof MESSAGE_STATUS)[number];
+
+export const NEW_INPUT_SIZES = ["xs", "sm", "md"] as const;
+export type NewInputSizeType = (typeof NEW_INPUT_SIZES)[number];
+
+const messageVariantStyles: Record<MessageStatus, string> = {
+  info: "s-text-muted-foreground dark:s-text-muted-foreground-night",
+  default: "s-text-muted-foreground dark:s-text-muted-foreground-night",
+  error: "s-text-foreground-warning dark:s-text-foreground-warning-night",
+};
+
+const messageVariant = cva("", {
+  variants: {
+    status: messageVariantStyles,
+  },
+  defaultVariants: {
+    status: "info",
+  },
+});
+
+const fieldVariants = cva(
+  cn(
+    "s-flex s-w-full s-items-center s-overflow-hidden s-border s-transition-colors",
+    "s-bg-background dark:s-bg-background-night"
+  ),
+  {
+    variants: {
+      size: {
+        xs: "s-h-6 s-rounded-lg s-text-xs",
+        sm: "s-h-8 s-rounded-xl s-text-sm",
+        md: "s-h-10 s-rounded-[15px] s-text-sm",
+      },
+      state: {
+        default: cn(
+          "s-border-border dark:s-border-border-night",
+          "focus-within:s-border-border-dark dark:focus-within:s-border-border-dark-night"
+        ),
+        error: cn(
+          "s-border-warning-300 dark:s-border-warning-300-night",
+          "focus-within:s-border-warning-400 dark:focus-within:s-border-warning-400-night"
+        ),
+        disabled: cn(
+          "s-cursor-not-allowed s-border-transparent",
+          "s-bg-muted dark:s-bg-muted-night"
+        ),
+      },
+    },
+    defaultVariants: {
+      size: "sm",
+      state: "default",
+    },
+  }
+);
+
+const innerInputVariants = cva(
+  cn(
+    "s-h-full s-w-full s-min-w-0 s-flex-1 s-border-0 s-bg-transparent s-outline-none",
+    // <input> does not inherit typography from its wrapper by default.
+    "s-font-sans s-text-inherit",
+    "s-text-foreground dark:s-text-foreground-night",
+    "placeholder:s-text-faint dark:placeholder:s-text-faint-night",
+    "disabled:s-cursor-not-allowed disabled:s-text-faint dark:disabled:s-text-faint-night"
+  ),
+  {
+    variants: {
+      size: {
+        xs: "s-px-2",
+        sm: "s-px-3",
+        md: "s-px-3",
+      },
+    },
+    defaultVariants: {
+      size: "sm",
+    },
+  }
+);
+
+const labelVariants = cva(
+  "s-pb-0.5 s-font-medium s-text-foreground dark:s-text-foreground-night",
+  {
+    variants: {
+      size: {
+        xs: "s-text-xs",
+        sm: "s-text-sm s-tracking-[-0.28px]",
+        md: "s-text-sm s-tracking-[-0.28px]",
+      },
+    },
+    defaultVariants: {
+      size: "sm",
+    },
+  }
+);
+
+// Full-height muted box flanking the field for a unit/currency (prefix/suffix).
+const slotBoxVariants = cva(
+  cn(
+    "s-flex s-h-full s-shrink-0 s-items-center s-justify-center",
+    "s-bg-muted dark:s-bg-muted-night"
+  ),
+  {
+    variants: {
+      size: {
+        xs: "s-w-6",
+        sm: "s-w-8",
+        md: "s-w-10",
+      },
+    },
+    defaultVariants: {
+      size: "sm",
+    },
+  }
+);
+
+const ICON_CLASSES: Record<NewInputSizeType, string> = {
+  xs: "s-h-3 s-w-3",
+  sm: "s-h-3.5 s-w-3.5",
+  md: "s-h-4 s-w-4",
+};
+
+export interface NewInputProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "value" | "size" | "prefix"
+  > {
+  size?: NewInputSizeType;
+  message?: string | null;
+  messageStatus?: MessageStatus;
+  value?: string | null;
+  isError?: boolean;
+  className?: string;
+  containerClassName?: string;
+  fieldClassName?: string;
+  label?: string;
+  icon?: React.ComponentType;
+  iconRight?: React.ComponentType;
+  prefix?: React.ReactNode;
+  suffix?: React.ReactNode;
+}
+
+export const NewInput = forwardRef<HTMLInputElement, NewInputProps>(
+  (
+    {
+      className,
+      containerClassName,
+      fieldClassName,
+      size = "sm",
+      message,
+      messageStatus,
+      value,
+      label,
+      isError,
+      disabled,
+      icon,
+      iconRight,
+      prefix,
+      suffix,
+      ...props
+    },
+    ref
+  ) => {
+    const state =
+      isError || (message && messageStatus === "error")
+        ? "error"
+        : disabled
+          ? "disabled"
+          : "default";
+    return (
+      <div className={cn("s-flex s-flex-col s-gap-1.5", containerClassName)}>
+        {label && (
+          <label htmlFor={props.name} className={labelVariants({ size })}>
+            {label}
+          </label>
+        )}
+        <div className={cn(fieldVariants({ size, state }), fieldClassName)}>
+          {prefix && <div className={slotBoxVariants({ size })}>{prefix}</div>}
+          {icon && (
+            <Icon
+              visual={icon}
+              className={cn(
+                "s-ml-2 s-shrink-0 s-text-faint dark:s-text-faint-night",
+                ICON_CLASSES[size]
+              )}
+            />
+          )}
+          <input
+            ref={ref}
+            className={cn(innerInputVariants({ size }), className)}
+            data-1p-ignore={props.type !== "password"}
+            value={value ?? undefined}
+            disabled={disabled}
+            {...props}
+          />
+          {iconRight && (
+            <Icon
+              visual={iconRight}
+              className={cn(
+                "s-mr-2 s-shrink-0 s-text-faint dark:s-text-faint-night",
+                ICON_CLASSES[size]
+              )}
+            />
+          )}
+          {suffix && <div className={slotBoxVariants({ size })}>{suffix}</div>}
+        </div>
+        {message && (
+          <div
+            className={cn(
+              "s-flex s-items-center s-gap-1 s-text-xs",
+              messageVariant({ status: messageStatus })
+            )}
+          >
+            {(messageStatus === "info" || messageStatus === "error") && (
+              <Icon visual={InfoCircle} size="xs" />
+            )}
+            {message}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+NewInput.displayName = "NewInput";

--- a/sparkle/src/components/NewInput.tsx
+++ b/sparkle/src/components/NewInput.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@sparkle/components/Icon";
-import { InfoCircle } from "@sparkle/icons/v2-stroke";
+import { AlertCircle } from "@sparkle/icons/v2-stroke";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
 import React, { forwardRef } from "react";
@@ -45,7 +45,13 @@ const fieldVariants = cva(
       state: {
         default: cn(
           "s-border-border dark:s-border-border-night",
-          "focus-within:s-border-border-dark dark:focus-within:s-border-border-dark-night"
+          "focus-within:s-border-border-dark dark:focus-within:s-border-border-dark-night",
+          // Filled (has a value): darker border, plus a muted fill while the
+          // field is not focused — matches Figma's "filled" state.
+          "has-[input:not(:placeholder-shown)]:s-border-border-dark",
+          "dark:has-[input:not(:placeholder-shown)]:s-border-border-dark-night",
+          "[&:has(input:not(:placeholder-shown)):not(:focus-within)]:s-bg-muted",
+          "dark:[&:has(input:not(:placeholder-shown)):not(:focus-within)]:s-bg-muted-night"
         ),
         error: cn(
           "s-border-warning-300 dark:s-border-warning-300-night",
@@ -230,7 +236,7 @@ export const NewInput = forwardRef<HTMLInputElement, NewInputProps>(
             )}
           >
             {(messageStatus === "info" || messageStatus === "error") && (
-              <Icon visual={InfoCircle} size="xs" />
+              <Icon visual={AlertCircle} size="xs" />
             )}
             {message}
           </div>

--- a/sparkle/src/components/NewInputWithSave.tsx
+++ b/sparkle/src/components/NewInputWithSave.tsx
@@ -1,0 +1,161 @@
+import { NewButton } from "@sparkle/components/NewButton";
+import { NewInput } from "@sparkle/components/NewInput";
+import { cn } from "@sparkle/lib/utils";
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+
+export interface NewInputWithSaveProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "value" | "onChange" | "size"
+  > {
+  value?: string | null;
+  unit?: string;
+  onSave: (value: string) => Promise<void> | void;
+  // Cleans each keystroke before it's passed to onSave (e.g. strip non-digits).
+  normalizeValue?: (value: string) => string;
+  // Formats the draft for display only (e.g. thousands separators); onSave still
+  // receives the normalized value.
+  formatValue?: (value: string) => string;
+  className?: string;
+}
+
+export const NewInputWithSave = forwardRef<
+  HTMLInputElement,
+  NewInputWithSaveProps
+>(
+  (
+    {
+      value,
+      unit,
+      onSave,
+      normalizeValue,
+      formatValue,
+      className,
+      disabled,
+      onFocus,
+      onBlur,
+      onKeyDown,
+      ...props
+    },
+    ref
+  ) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    useImperativeHandle(ref, () => inputRef.current!);
+
+    const [draftValue, setDraftValue] = useState("");
+    const [isEditing, setIsEditing] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+
+    const showSaveButton = isEditing || isSaving;
+
+    const handleSave = async () => {
+      if (isSaving) {
+        return;
+      }
+      setIsSaving(true);
+      try {
+        await onSave(draftValue);
+        setIsEditing(false);
+        inputRef.current?.blur();
+      } catch {
+        // Stay in editing state; error handling is the caller's responsibility.
+      } finally {
+        setIsSaving(false);
+      }
+    };
+
+    const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+      if (!isSaving && !isEditing) {
+        const raw = value ?? "";
+        setDraftValue(normalizeValue ? normalizeValue(raw) : raw);
+        setIsEditing(true);
+      }
+      onFocus?.(e);
+    };
+
+    const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+      // Revert to the value before the edit, unless a save is in flight.
+      if (!isSaving) {
+        setIsEditing(false);
+      }
+      onBlur?.(e);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        void handleSave();
+      } else if (e.key === "Escape") {
+        inputRef.current?.blur();
+      }
+      onKeyDown?.(e);
+    };
+
+    // Composes <NewInput> for the field and overlays the unit + Save button on the
+    // right (like SearchInput), so it can't drift from the NewInput design. The
+    // input reserves right padding so its value stays clear of the overlay.
+    const hasOverlay = Boolean(unit) || showSaveButton;
+
+    return (
+      <div className={cn("s-relative s-w-full", className)}>
+        <NewInput
+          ref={inputRef}
+          size="sm"
+          value={
+            showSaveButton
+              ? formatValue
+                ? formatValue(draftValue)
+                : draftValue
+              : (value ?? "")
+          }
+          onChange={(e) =>
+            setDraftValue(
+              normalizeValue ? normalizeValue(e.target.value) : e.target.value
+            )
+          }
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          readOnly={isSaving}
+          className={cn(showSaveButton ? "s-pr-20" : unit ? "s-pr-12" : null)}
+          {...props}
+        />
+        {hasOverlay && (
+          // pointer-events-none lets clicks fall through to the input (to
+          // focus it); the Save button re-enables them for itself.
+          <div className="s-pointer-events-none s-absolute s-inset-y-0 s-right-1 s-flex s-items-center s-gap-1.5">
+            {unit && (
+              <span className="s-shrink-0 s-text-sm s-text-faint dark:s-text-faint-night">
+                {unit}
+              </span>
+            )}
+            {showSaveButton && (
+              <NewButton
+                label="Save"
+                variant="highlight"
+                size="xs"
+                isLoading={isSaving}
+                className="s-pointer-events-auto"
+                // Prevent the input from blurring (which would revert the edit)
+                // before the click registers.
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void handleSave();
+                }}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+NewInputWithSave.displayName = "NewInputWithSave";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -205,6 +205,8 @@ export {
 } from "./NewButton";
 export type { NewInputProps, NewInputSizeType } from "./NewInput";
 export { NEW_INPUT_SIZES, NewInput } from "./NewInput";
+export type { NewInputWithSaveProps } from "./NewInputWithSave";
+export { NewInputWithSave } from "./NewInputWithSave";
 export type { NotificationType } from "./Notification";
 export { Notification, useSendNotification } from "./Notification";
 export { NotificationButton } from "./NotificationButton";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -191,6 +191,20 @@ export {
   NavTabPillList,
   NavTabPillTrigger,
 } from "./NavTabPill";
+export type {
+  NewButtonIconType,
+  NewButtonProps,
+  NewButtonSizeType,
+  NewButtonVariantType,
+} from "./NewButton";
+export {
+  NEW_BUTTON_SIZES,
+  NEW_BUTTON_VARIANTS,
+  NewButton,
+  newButtonVariants,
+} from "./NewButton";
+export type { NewInputProps, NewInputSizeType } from "./NewInput";
+export { NEW_INPUT_SIZES, NewInput } from "./NewInput";
 export type { NotificationType } from "./Notification";
 export { Notification, useSendNotification } from "./Notification";
 export { NotificationButton } from "./NotificationButton";

--- a/sparkle/src/stories/NewButton.stories.tsx
+++ b/sparkle/src/stories/NewButton.stories.tsx
@@ -1,0 +1,302 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import {
+  NEW_BUTTON_SIZES,
+  NEW_BUTTON_VARIANTS,
+  type NewButtonSizeType,
+  type NewButtonVariantType,
+} from "@sparkle/components/NewButton";
+
+import {
+  ArrowRight,
+  NewButton,
+  Plus,
+  Robot,
+  Separator,
+} from "../index_with_tw_base";
+
+const ICONS = {
+  none: null,
+  Plus: Plus,
+  Robot: Robot,
+} as const;
+
+const meta = {
+  title: "Actions/NewButton",
+  component: NewButton,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `Buttons let users trigger an action or event — submitting a form, opening a dialog, or confirming a choice. The button comes in several visual **variants** and three **sizes** (sm / md / lg), and supports a leading and/or trailing icon, loading and disabled states, an inline counter, a dropdown-chevron affordance (**isSelect**), and a fully-rounded shape (**isRounded**).
+
+**For design review:** the **Overview** story shows every variant in light and dark side by side; **Sizes** shows the S/M/L scale; **States** shows default / icon / loading / disabled. Press a button to see the 0.97 press animation (it's automatically suppressed on dropdown triggers).
+
+**Guidelines**
+- Use a single **highlight** button per view; use **outline** or a **ghost** variant for secondary actions.
+- Write concise, verb-first labels ("Save changes", not "OK").
+- An icon-only button (an **icon** with no **label**) should always have a **tooltip**.
+- Set **isLoading** during async work to communicate progress and prevent double submits.`,
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      description: "The visual style variant of the button",
+      options: NEW_BUTTON_VARIANTS,
+      control: { type: "select" },
+    },
+    size: {
+      description: "The size of the button",
+      options: NEW_BUTTON_SIZES,
+      control: { type: "select" },
+    },
+    icon: {
+      description: "Leading icon (omit the label for an icon-only button)",
+      options: Object.keys(ICONS),
+      mapping: ICONS,
+      control: { type: "select" },
+    },
+    iconRight: {
+      description: "Trailing icon",
+      options: Object.keys(ICONS),
+      mapping: ICONS,
+      control: { type: "select" },
+    },
+    label: {
+      description: "NewButton label (omit for an icon-only button)",
+      control: { type: "text" },
+    },
+    disabled: {
+      description: "Whether the button should be disabled",
+      control: "boolean",
+      defaultValue: false,
+    },
+    isLoading: {
+      description: "Whether the button should display a loading spinner",
+      control: "boolean",
+    },
+    isSelect: {
+      description: "Whether the button should display a dropdown chevron",
+      control: "boolean",
+    },
+    isRounded: {
+      description: "Whether the button is fully rounded (pill / circular)",
+      control: "boolean",
+    },
+    isPulsing: {
+      description: "Whether the button should have a pulsing ring animation",
+      control: "boolean",
+    },
+    isCounter: {
+      description: "Whether the button should display an inline counter",
+      control: "boolean",
+    },
+    counterValue: {
+      description: "Value to display in the counter (if isCounter is true)",
+      control: "text",
+      if: { arg: "isCounter", eq: true },
+    },
+    tooltip: {
+      description: "Optional tooltip text to display on hover",
+      control: "text",
+    },
+  },
+  render: (args) => <NewButton {...args} />,
+} satisfies Meta<typeof NewButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ---------------------------------------------------------------------------
+// Showcase helpers
+// ---------------------------------------------------------------------------
+
+const labelClass =
+  "s-text-xs s-font-medium s-text-muted-foreground dark:s-text-muted-foreground-night";
+
+// One variant row across its states.
+function VariantRow({
+  variant,
+  size,
+}: {
+  variant: NewButtonVariantType;
+  size: NewButtonSizeType;
+}) {
+  return (
+    <div className="s-flex s-items-center s-gap-3">
+      <div className={`s-w-32 s-shrink-0 ${labelClass}`}>{variant}</div>
+      <NewButton size={size} variant={variant} label="NewButton" />
+      <NewButton size={size} variant={variant} icon={Plus} label="NewButton" />
+      <NewButton
+        size={size}
+        variant={variant}
+        icon={Plus}
+        iconRight={ArrowRight}
+        label="NewButton"
+      />
+      <NewButton size={size} variant={variant} icon={Plus} tooltip="Add" />
+      <NewButton size={size} variant={variant} label="NewButton" isLoading />
+      <NewButton size={size} variant={variant} label="NewButton" disabled />
+    </div>
+  );
+}
+
+function ColumnLegend() {
+  return (
+    <div className={`s-flex s-items-center s-gap-3 ${labelClass}`}>
+      <div className="s-w-32 s-shrink-0">variant \ state</div>
+      <div className="s-w-[88px]">label</div>
+      <div className="s-w-[112px]">+ icon</div>
+      <div className="s-w-[132px]">+ both</div>
+      <div className="s-w-8">icon</div>
+      <div className="s-w-[100px]">loading</div>
+      <div>disabled</div>
+    </div>
+  );
+}
+
+function VariantGrid({ size = "md" }: { size?: NewButtonSizeType }) {
+  return (
+    <div className="s-flex s-flex-col s-gap-3">
+      <ColumnLegend />
+      {NEW_BUTTON_VARIANTS.map((variant) => (
+        <VariantRow key={variant} variant={variant} size={size} />
+      ))}
+    </div>
+  );
+}
+
+// A themed surface card. `dark` toggles the `.s-dark` ancestor (sparkle's
+// class-based dark mode) so every button inside renders its dark treatment.
+function Surface({
+  dark = false,
+  title,
+  caption,
+  children,
+}: {
+  dark?: boolean;
+  title: string;
+  caption?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={[
+        dark ? "s-dark s-bg-background-night s-border-border-night" : "",
+        !dark ? "s-bg-background s-border-border" : "",
+        "s-flex s-flex-col s-gap-4 s-rounded-2xl s-border s-p-6",
+      ].join(" ")}
+    >
+      <div>
+        <div className="s-text-sm s-font-semibold s-text-foreground dark:s-text-foreground-night">
+          {title}
+        </div>
+        {caption && <div className={`s-mt-0.5 ${labelClass}`}>{caption}</div>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/** Interactive single button — tweak any prop from the Controls panel. */
+export const Playground: Story = {
+  args: {
+    variant: "primary",
+    label: "NewButton",
+    size: "md",
+    isLoading: false,
+    isSelect: false,
+    isRounded: false,
+    isPulsing: false,
+    disabled: false,
+    isCounter: false,
+    counterValue: "1",
+  },
+};
+
+/**
+ * Every variant in light and dark, side by side — the main story for design
+ * review. Each row walks through the states: label, + icon, + both icons,
+ * icon-only, loading, disabled.
+ */
+export const Overview: Story = {
+  render: () => (
+    <div className="s-flex s-flex-col s-gap-6">
+      <Surface title="Light">
+        <VariantGrid size="md" />
+      </Surface>
+      <Surface
+        dark
+        title="Dark"
+        caption="Primary and outline swap in dark mode (designer spec); every other variant is unchanged — its tokens adapt on their own."
+      >
+        <VariantGrid size="md" />
+      </Surface>
+    </div>
+  ),
+};
+
+/** The S / M / L scale (24 / 32 / 40px) across all variants. */
+export const Sizes: Story = {
+  render: () => (
+    <div className="s-flex s-flex-col s-gap-6">
+      {NEW_BUTTON_SIZES.map((size) => (
+        <div key={size} className="s-flex s-flex-col s-gap-3">
+          <Separator />
+          <h3 className={labelClass}>{size.toUpperCase()}</h3>
+          <VariantGrid size={size} />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** Icon-only buttons across sizes, plus the fully-rounded shape. */
+export const IconButtons: Story = {
+  render: () => (
+    <div className="s-flex s-items-center s-gap-4">
+      <NewButton size="xs" variant="outline" icon={Plus} tooltip="Add" />
+      <NewButton size="sm" variant="outline" icon={Plus} tooltip="Add" />
+      <NewButton size="md" variant="outline" icon={Plus} tooltip="Add" />
+      <NewButton
+        size="md"
+        variant="highlight"
+        icon={Plus}
+        isRounded
+        tooltip="Add"
+      />
+      <NewButton size="md" variant="primary" icon={Robot} tooltip="Agent" />
+    </div>
+  ),
+};
+
+/** Dropdown affordance (isSelect), inline counter, rounded, and pulsing. */
+export const SpecialStates: Story = {
+  render: () => (
+    <div className="s-flex s-flex-col s-gap-4">
+      <div className="s-flex s-items-center s-gap-4">
+        <NewButton
+          variant="outline"
+          label="Select agent"
+          icon={Robot}
+          isSelect
+        />
+        <NewButton variant="primary" label="Filter" isSelect />
+        <NewButton
+          variant="outline"
+          label="Messages"
+          isCounter
+          counterValue="8"
+        />
+        <NewButton variant="highlight" label="New" icon={Plus} isRounded />
+        <NewButton variant="primary" label="Live" isPulsing />
+      </div>
+    </div>
+  ),
+};

--- a/sparkle/src/stories/NewInput.stories.tsx
+++ b/sparkle/src/stories/NewInput.stories.tsx
@@ -1,0 +1,240 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { NEW_INPUT_SIZES } from "@sparkle/components/NewInput";
+
+import { Image03, NewInput, SearchMd } from "../index_with_tw_base";
+
+const MESSAGE_STATUSES = ["info", "default", "error"] as const;
+
+const meta = {
+  title: "Forms & Inputs/NewInput",
+  component: NewInput,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `A single-line text field for short, freeform input such as a name, email, or search term. Inputs support an optional **label**, a helper or error **message** with status colouring, and the standard HTML input **type**s.
+
+**When to use**
+- To collect a short piece of text or a number from the user.
+- Inside forms, search bars, and settings panels.
+
+**Guidelines**
+- Always provide a **label** so the field is understandable and accessible; placeholders are examples, not labels.
+- Surface validation with **isError** and a **message** set to \`messageStatus="error"\`.
+- Use **messageStatus="info"** for neutral helper text (constraints, formats, hints).
+- For multi-line input use **TextArea**; for search-specific affordances use **SearchInput**.`,
+      },
+    },
+  },
+  argTypes: {
+    size: {
+      options: NEW_INPUT_SIZES,
+      control: { type: "select" },
+      description: "The size of the input (sm / md / lg)",
+    },
+    placeholder: {
+      control: "text",
+      description: "Placeholder text for the input",
+    },
+    value: {
+      control: "text",
+      description: "Current value of the input",
+    },
+    label: {
+      control: "text",
+      description: "Optional label above the input",
+    },
+    message: {
+      control: "text",
+      description: "Helper or error message below the input",
+    },
+    messageStatus: {
+      options: MESSAGE_STATUSES,
+      control: { type: "select" },
+      description: "Status/color of the message",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Whether the input is disabled",
+    },
+    isError: {
+      control: "boolean",
+      description: "Whether the input is in an error state",
+    },
+    type: {
+      control: "select",
+      options: ["text", "email", "password", "number", "tel", "url"],
+      description: "HTML input type",
+    },
+  },
+} satisfies Meta<typeof NewInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    size: "md",
+    placeholder: "Enter text...",
+    value: "",
+    label: "NewInput Label",
+    message: "This is a helper message",
+    messageStatus: "info",
+    disabled: false,
+    isError: false,
+    type: "text",
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="s-flex s-w-72 s-flex-col s-gap-4">
+      {NEW_INPUT_SIZES.map((size) => (
+        <NewInput key={size} size={size} placeholder={`Size ${size}`} />
+      ))}
+    </div>
+  ),
+};
+
+export const WithIcons: Story = {
+  render: () => (
+    <div className="s-flex s-w-72 s-flex-col s-gap-4">
+      <NewInput placeholder="Search…" icon={SearchMd} />
+      <NewInput placeholder="With trailing icon" iconRight={Image03} />
+      <NewInput placeholder="Both" icon={SearchMd} iconRight={Image03} />
+    </div>
+  ),
+};
+
+export const WithPrefixSuffix: Story = {
+  render: () => (
+    <div className="s-flex s-w-72 s-flex-col s-gap-4">
+      <NewInput
+        placeholder="0.00"
+        prefix={<span className="s-text-faint">$</span>}
+      />
+      <NewInput
+        placeholder="12,890"
+        suffix={<span className="s-text-faint">cr</span>}
+      />
+    </div>
+  ),
+};
+
+export const WithError: Story = {
+  args: {
+    placeholder: "Enter text...",
+    value: "Invalid value",
+    label: "Email",
+    message: "Please enter a valid email address",
+    messageStatus: "error",
+    isError: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: "Disabled input",
+    value: "Cannot edit",
+    label: "Disabled Field",
+    disabled: true,
+  },
+};
+
+export const WithInfoMessage: Story = {
+  args: {
+    placeholder: "Enter your name",
+    label: "Full Name",
+    message: "Name must be unique",
+    messageStatus: "info",
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="s-flex s-flex-col s-gap-20">
+      <div className="s-grid s-grid-cols-3 s-gap-4">
+        <NewInput
+          placeholder="placeholder"
+          name="input"
+          message="Name must be unique"
+          messageStatus="info"
+        />
+        <NewInput
+          placeholder="placeholder"
+          name="input"
+          value="value"
+          message="errored because it's a very long message"
+          messageStatus="error"
+        />
+        <NewInput
+          placeholder="placeholder"
+          name="input"
+          value="value"
+          message="Default message"
+        />
+        <NewInput
+          placeholder="placeholder"
+          name="input"
+          value="value"
+          message="errored because it's a very long message"
+          messageStatus="error"
+        />
+        <NewInput
+          placeholder="placeholder"
+          name="input"
+          value="disabled"
+          disabled
+          messageStatus="error"
+        />
+      </div>
+      <div className="s-grid s-grid-cols-3 s-gap-4">
+        <NewInput placeholder="placeholder" name="input" />
+        <NewInput
+          placeholder="placeholder"
+          name="input"
+          value="value"
+          message="errored because it's a very long message"
+          messageStatus="error"
+        />
+        <NewInput
+          placeholder="placeholder"
+          name="input"
+          value="value"
+          message="Default message"
+        />
+        <NewInput
+          placeholder="placeholder"
+          name="input"
+          value="value"
+          message="errored because it's a very long message"
+          messageStatus="error"
+        />
+        <NewInput
+          placeholder="placeholder"
+          name="input"
+          value="test"
+          messageStatus="error"
+        />
+      </div>
+      <div className="s-grid s-grid-cols-3 s-gap-4">
+        <NewInput
+          placeholder="placeholder"
+          name="input"
+          label="Firstname"
+          isError
+        />
+        <NewInput
+          placeholder="placeholder"
+          name="input"
+          label="Lastname"
+          message="NewInput your lastname"
+          messageStatus="info"
+          isError
+        />
+      </div>
+    </div>
+  ),
+};

--- a/sparkle/src/stories/NewInputWithSave.stories.tsx
+++ b/sparkle/src/stories/NewInputWithSave.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+
+import { NewInputWithSave } from "../index_with_tw_base";
+
+const meta = {
+  title: "Forms & Inputs/NewInputWithSave",
+  component: NewInputWithSave,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `A text field with an optional right-aligned **unit** and an inline save action. At rest it shows the value and unit; while editing, a Save button appears on the right. Clicking save (or pressing Enter) calls **onSave** and shows a spinner until the returned promise resolves; blurring without saving (or pressing Escape) reverts the edit.
+
+**When to use**
+- For a single value that is persisted on its own (e.g. a quota, a price, a limit), without a surrounding form.
+
+**Guidelines**
+- **onSave** receives the draft string and may return a promise; the spinner is shown until it settles.
+- The component reverts to the **value** prop when the edit is abandoned, so keep **value** in sync with the persisted state.`,
+      },
+    },
+  },
+  argTypes: {
+    value: {
+      description: "The persisted value shown at rest",
+      control: "text",
+    },
+    unit: {
+      description: "Optional unit displayed on the right of the input",
+      control: "text",
+    },
+    placeholder: {
+      description: "Placeholder text for the input",
+      control: "text",
+    },
+    disabled: {
+      description: "Whether the input is disabled",
+      control: "boolean",
+    },
+    onSave: {
+      description: "Callback when the save button is clicked",
+      action: "saved",
+    },
+  },
+} satisfies Meta<React.ComponentProps<typeof NewInputWithSave>>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ControlledInputWithSave({
+  initialValue,
+  unit,
+  placeholder,
+}: {
+  initialValue: string;
+  unit?: string;
+  placeholder?: string;
+}) {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <NewInputWithSave
+      value={value}
+      unit={unit}
+      placeholder={placeholder}
+      onSave={async (newValue) => {
+        // Simulate a network call.
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        setValue(newValue);
+      }}
+    />
+  );
+}
+
+export const ExampleInputWithSave: Story = {
+  args: {
+    value: "12,890",
+    unit: "Credits",
+    onSave: () => {},
+  },
+  render: (args) => (
+    <ControlledInputWithSave
+      initialValue={args.value ?? ""}
+      unit={args.unit}
+      placeholder={args.placeholder}
+    />
+  ),
+};
+
+export function InputWithSaveExamples() {
+  return (
+    <div className="s-flex s-max-w-md s-flex-col s-gap-4">
+      <ControlledInputWithSave initialValue="12,890" unit="Credits" />
+      <ControlledInputWithSave initialValue="49" unit="$" />
+      <ControlledInputWithSave
+        initialValue=""
+        unit="Credits"
+        placeholder="Enter an amount"
+      />
+      <ControlledInputWithSave initialValue="No unit here" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Adds the redesigned button and input as NewButton/NewInput alongside the existing Button/Input, which are left untouched. No consumers are migrated — this is purely additive so the new design can be adopted incrementally.

- NewButton: xs/sm/md scale, new variants/tokens, dark primary/outline swap
- NewInput: xs/sm/md scale, wrapper-around-inner-input with slots/icons

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
View local sparkle build
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, additive changes only so no live changes
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
