### PR TITLE
[front] chore: remove internal MCP server instructions field

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -22,9 +22,7 @@ export function makeInternalMCPServer(
 ): McpServer {
   const serverInfo = getInternalMCPServerInfo(name);
 
-  return new McpServer(serverInfo, {
-    instructions: serverInfo.instructions ?? undefined,
-  });
+  return new McpServer(serverInfo);
 }
 
 // Returns an MCPError when the caller is not a workspace admin, null otherwise.

--- a/front/lib/api/actions/servers/agent_memory/metadata.ts
+++ b/front/lib/api/actions/servers/agent_memory/metadata.ts
@@ -103,7 +103,6 @@ export const AGENT_MEMORY_SERVER = {
     authorization: null,
     icon: "ActionLightbulbIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(AGENT_MEMORY_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/agent_router/metadata.ts
+++ b/front/lib/api/actions/servers/agent_router/metadata.ts
@@ -53,7 +53,6 @@ export const AGENT_ROUTER_SERVER = {
     authorization: null,
     icon: "ActionRobotIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(AGENT_ROUTER_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
@@ -25,7 +25,6 @@ export const AGENT_SIDEKICK_AGENT_STATE_SERVER_INFO = {
   authorization: null,
   icon: "ActionRobotIcon" as const,
   documentationUrl: null,
-  instructions: null,
 };
 
 export const AGENT_SIDEKICK_AGENT_STATE_SERVER = {

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -553,7 +553,6 @@ export const AGENT_SIDEKICK_CONTEXT_SERVER = {
     authorization: null,
     icon: "ActionRobotIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -247,7 +247,6 @@ export const ASHBY_SERVER = {
     authorization: null,
     icon: "AshbyLogo",
     documentationUrl: "https://docs.dust.tt/docs/ashby-mcp",
-    instructions: null,
   },
   tools: Object.values(ASHBY_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -49,7 +49,6 @@ export const ASK_USER_QUESTION_SERVER = {
     icon: "ActionChatBubbleThoughtIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(ASK_USER_QUESTION_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/clari_copilot/metadata.ts
+++ b/front/lib/api/actions/servers/clari_copilot/metadata.ts
@@ -92,7 +92,6 @@ export const CLARI_COPILOT_SERVER = {
     authorization: null,
     icon: "ClariLogo",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(CLARI_COPILOT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/common_utilities/metadata.ts
+++ b/front/lib/api/actions/servers/common_utilities/metadata.ts
@@ -113,7 +113,6 @@ export const COMMON_UTILITIES_SERVER = {
     icon: "ActionAtomIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(COMMON_UTILITIES_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/confluence/metadata.ts
+++ b/front/lib/api/actions/servers/confluence/metadata.ts
@@ -170,7 +170,6 @@ export const CONFLUENCE_SERVER = {
     },
     icon: "ConfluenceLogo",
     documentationUrl: "https://docs.dust.tt/docs/confluence-tool",
-    instructions: null,
   },
   tools: Object.values(CONFLUENCE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -117,7 +117,6 @@ export const CONVERSATION_FILES_SERVER = {
     icon: "ActionDocumentTextIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: ALL_CONVERSATION_FILES_TOOLS.map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -142,7 +142,6 @@ export const DATA_SOURCES_FILE_SYSTEM_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -168,7 +168,6 @@ export const DATA_WAREHOUSES_SERVER = {
     authorization: null,
     icon: "ActionTableIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(DATA_WAREHOUSES_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/databricks/metadata.ts
+++ b/front/lib/api/actions/servers/databricks/metadata.ts
@@ -28,7 +28,6 @@ export const DATABRICKS_SERVER = {
     },
     icon: "ActionTableIcon",
     documentationUrl: "https://docs.dust.tt/docs/databricks",
-    instructions: null,
   },
   tools: Object.values(DATABRICKS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/exa/metadata.ts
+++ b/front/lib/api/actions/servers/exa/metadata.ts
@@ -88,7 +88,6 @@ export const EXA_SERVER = {
     authorization: null,
     icon: "ActionMagnifyingGlassIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(EXA_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/extract_data/metadata.ts
+++ b/front/lib/api/actions/servers/extract_data/metadata.ts
@@ -129,7 +129,6 @@ export const EXTRACT_DATA_SERVER = {
     icon: "ActionScanIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(EXTRACT_DATA_BASE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/fathom/metadata.ts
+++ b/front/lib/api/actions/servers/fathom/metadata.ts
@@ -112,7 +112,6 @@ export const FATHOM_SERVER = {
     },
     icon: "FathomLogo",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(FATHOM_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/file_generation/metadata.ts
+++ b/front/lib/api/actions/servers/file_generation/metadata.ts
@@ -116,7 +116,6 @@ export const FILE_GENERATION_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(FILE_GENERATION_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -365,7 +365,6 @@ export const FILES_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(FILES_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -695,7 +695,6 @@ export const FRESHSERVICE_SERVER = {
     },
     icon: "FreshserviceLogo",
     documentationUrl: "https://docs.dust.tt/docs/freshservice",
-    instructions: null,
   },
   tools: Object.values(FRESHSERVICE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -311,7 +311,6 @@ export const FRONT_SERVER = {
     authorization: null,
     icon: "FrontLogo",
     documentationUrl: "https://docs.dust.tt/docs/front-mcp",
-    instructions: null,
   },
   tools: Object.values(FRONT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -498,7 +498,6 @@ export const GITHUB_SERVER = {
     },
     icon: "GithubLogo",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(GITHUB_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -292,7 +292,6 @@ export const GMAIL_SERVER = {
     },
     icon: "GmailLogo",
     documentationUrl: "https://docs.dust.tt/docs/gmail",
-    instructions: null,
   },
   tools: Object.values(GMAIL_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/gong/metadata.ts
+++ b/front/lib/api/actions/servers/gong/metadata.ts
@@ -80,7 +80,6 @@ export const GONG_SERVER = {
     },
     icon: "GongLogo",
     documentationUrl: "https://docs.dust.tt/update/docs/gong-mcp",
-    instructions: null,
   },
   tools: Object.values(GONG_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -308,7 +308,6 @@ export const GOOGLE_CALENDAR_SERVER = {
     },
     icon: "GcalLogo",
     documentationUrl: "https://docs.dust.tt/docs/google-calendar",
-    instructions: null,
   },
   tools: Object.values(GOOGLE_CALENDAR_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -629,7 +629,6 @@ export function getGoogleDriveServerMetadata() {
       },
       icon: "DriveLogo",
       documentationUrl: "https://docs.dust.tt/docs/google-drive",
-      instructions: null,
     },
     tools: Object.values(ALL_TOOLS_METADATA).map((t) => ({
       name: t.name,

--- a/front/lib/api/actions/servers/google_sheets/metadata.ts
+++ b/front/lib/api/actions/servers/google_sheets/metadata.ts
@@ -305,7 +305,6 @@ export const GOOGLE_SHEETS_SERVER = {
     },
     icon: "GoogleSpreadsheetLogo",
     documentationUrl: "https://docs.dust.tt/docs/google-sheets",
-    instructions: null,
   },
   tools: Object.values(GOOGLE_SHEETS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/http_client/metadata.ts
+++ b/front/lib/api/actions/servers/http_client/metadata.ts
@@ -75,7 +75,6 @@ export const HTTP_CLIENT_SERVER = {
     authorization: null,
     icon: "ActionGlobeAltIcon" as const,
     documentationUrl: null,
-    instructions: null,
     developerSecretSelection: "optional" as const,
     developerSecretSelectionDescription:
       "This is optional. If set, this secret will be used as a default Bearer token (Authorization header) for HTTP requests.",

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -781,7 +781,6 @@ export const HUBSPOT_SERVER = {
     },
     icon: "HubspotLogo",
     documentationUrl: "https://docs.dust.tt/docs/hubspot",
-    instructions: null,
   },
   tools: Object.values(HUBSPOT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -90,7 +90,6 @@ export const IMAGE_GENERATION_SERVER = {
     authorization: null,
     icon: "ActionImageIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(IMAGE_GENERATION_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -66,7 +66,6 @@ export const INCLUDE_DATA_SERVER = {
     icon: "ActionTimeIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(INCLUDE_DATA_BASE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -267,7 +267,6 @@ export const INTERACTIVE_CONTENT_SERVER = {
     authorization: null,
     icon: "ActionFrameIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(INTERACTIVE_CONTENT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -389,7 +389,6 @@ export const JIRA_SERVER = {
     },
     icon: "JiraLogo",
     documentationUrl: "https://docs.dust.tt/docs/jira",
-    instructions: null,
   },
   tools: Object.values(JIRA_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/jit_testing/metadata.ts
+++ b/front/lib/api/actions/servers/jit_testing/metadata.ts
@@ -80,7 +80,6 @@ export const JIT_TESTING_SERVER = {
     icon: "ActionEmotionLaughIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(JIT_TESTING_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/luma/metadata.ts
+++ b/front/lib/api/actions/servers/luma/metadata.ts
@@ -316,7 +316,6 @@ export const LUMA_SERVER = {
     authorization: null,
     icon: "LumaLogo",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(LUMA_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -327,7 +327,6 @@ export const MICROSOFT_DRIVE_SERVER = {
       ],
     },
     documentationUrl: "https://docs.dust.tt/docs/microsoft-drive-tool-setup",
-    instructions: null,
   },
   tools: Object.values(MICROSOFT_DRIVE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -235,7 +235,6 @@ export const MICROSOFT_EXCEL_SERVER = {
       ],
     },
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(MICROSOFT_EXCEL_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -349,7 +349,6 @@ export const MICROSOFT_TEAMS_SERVER = {
       ],
     },
     documentationUrl: "https://docs.dust.tt/docs/microsoft-teams-tool-setup",
-    instructions: null,
   },
   tools: Object.values(MICROSOFT_TEAMS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/missing_action_catcher/metadata.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/metadata.ts
@@ -12,7 +12,6 @@ export const MISSING_ACTION_CATCHER_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,
-    instructions: null,
   },
   // Tools are created dynamically at runtime based on the agentLoopContext.
   tools: [],

--- a/front/lib/api/actions/servers/monday/metadata.ts
+++ b/front/lib/api/actions/servers/monday/metadata.ts
@@ -489,7 +489,6 @@ export const MONDAY_SERVER = {
     },
     icon: "MondayLogo",
     documentationUrl: "https://docs.dust.tt/docs/monday",
-    instructions: null,
   },
   tools: Object.values(MONDAY_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/notion/metadata.ts
+++ b/front/lib/api/actions/servers/notion/metadata.ts
@@ -533,7 +533,6 @@ export const NOTION_SERVER = {
     },
     icon: "NotionLogo",
     documentationUrl: "https://docs.dust.tt/docs/notion-mcp",
-    instructions: null,
   },
   tools: Object.values(NOTION_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/openai_usage/metadata.ts
+++ b/front/lib/api/actions/servers/openai_usage/metadata.ts
@@ -132,7 +132,6 @@ export const OPENAI_USAGE_SERVER = {
     authorization: null,
     icon: "OpenaiLogo",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(OPENAI_USAGE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/outlook/calendar_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_metadata.ts
@@ -362,7 +362,6 @@ export const OUTLOOK_CALENDAR_SERVER = {
     },
     icon: "MicrosoftOutlookLogo",
     documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",
-    instructions: null,
   },
   tools: Object.values(OUTLOOK_CALENDAR_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -598,7 +598,6 @@ export const OUTLOOK_MAIL_SERVER = {
     },
     icon: "MicrosoftOutlookLogo",
     documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",
-    instructions: null,
   },
   tools: Object.values(OUTLOOK_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -107,7 +107,6 @@ export const PLAN_MODE_SERVER = {
     icon: "ActionDocumentTextIcon" as const,
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(PLAN_MODE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -441,7 +441,6 @@ export const POD_MANAGER_SERVER = {
     icon: "ActionDocumentTextIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(POD_MANAGER_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/pod_tasks/metadata.ts
+++ b/front/lib/api/actions/servers/pod_tasks/metadata.ts
@@ -120,7 +120,6 @@ export const POD_TASKS_SERVER = {
     icon: "ActionCheckCircleIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(POD_TASKS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -357,7 +357,6 @@ export const POKE_SERVER = {
     authorization: null,
     icon: "ActionLightbulbIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(POKE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
@@ -110,7 +110,6 @@ export const PRIMITIVE_TYPES_DEBUGGER_SERVER = {
     icon: "ActionEmotionLaughIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -381,7 +381,6 @@ export const PRODUCTBOARD_SERVER = {
     },
     icon: "ProductboardLogo",
     documentationUrl: "https://docs.dust.tt/docs/productboard",
-    instructions: null,
   },
   tools: Object.values(PRODUCTBOARD_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -102,7 +102,6 @@ export const QUERY_TABLES_V2_SERVER = {
     icon: "ActionTableIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(QUERY_TABLES_V2_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -111,7 +111,6 @@ export const RUN_AGENT_SERVER = {
     authorization: null,
     icon: "ActionRobotIcon",
     documentationUrl: null,
-    instructions: null,
   },
   // The actual tool name is dynamic, but we need a placeholder tool
   // with the configurable properties schema so that the UI can detect that this server

--- a/front/lib/api/actions/servers/run_dust_app/metadata.ts
+++ b/front/lib/api/actions/servers/run_dust_app/metadata.ts
@@ -36,7 +36,6 @@ export const RUN_DUST_APP_SERVER = {
     icon: "CommandLineIcon" as const,
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(RUN_DUST_APP_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -144,7 +144,6 @@ export const SALESFORCE_SERVER = {
     },
     icon: "SalesforceLogo",
     documentationUrl: "https://docs.dust.tt/docs/salesforce",
-    instructions: null,
   },
   tools: Object.values(SALESFORCE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/salesloft/metadata.ts
+++ b/front/lib/api/actions/servers/salesloft/metadata.ts
@@ -40,7 +40,6 @@ export const SALESLOFT_SERVER = {
     authorization: null,
     icon: "SalesloftLogo",
     documentationUrl: "https://docs.dust.tt/docs/salesloft-mcp",
-    instructions: null,
   },
   tools: Object.values(SALESLOFT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -123,7 +123,6 @@ export const SANDBOX_SERVER = {
     authorization: null,
     icon: "CommandLineIcon",
     documentationUrl: null,
-    instructions: null,
   },
   // Note: The `as JSONSchema` cast is standard pattern across all metadata files.
   // zodToJsonSchema returns a compatible type but TypeScript can't verify it statically.

--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -75,7 +75,6 @@ export const SCHEDULES_MANAGEMENT_SERVER = {
     authorization: null,
     icon: "ActionTimeIcon" as const,
     documentationUrl: null,
-    instructions: null,
   },
   tools: (
     Object.keys(

--- a/front/lib/api/actions/servers/search/metadata.ts
+++ b/front/lib/api/actions/servers/search/metadata.ts
@@ -67,7 +67,6 @@ export const SEARCH_SERVER = {
     icon: "ActionMagnifyingGlassIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(SEARCH_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -133,7 +133,6 @@ export const SKILL_AUTHORING_SERVER = {
     authorization: null,
     icon: "ActionListCheckIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(SKILL_AUTHORING_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/skill_management/metadata.ts
+++ b/front/lib/api/actions/servers/skill_management/metadata.ts
@@ -31,7 +31,6 @@ export const SKILL_MANAGEMENT_SERVER = {
     authorization: null,
     icon: "PuzzleIcon" as const,
     documentationUrl: null,
-    instructions: null,
   },
   tools: (
     Object.keys(SKILL_MANAGEMENT_TOOLS_METADATA) as SkillManagementToolKey[]

--- a/front/lib/api/actions/servers/slab/metadata.ts
+++ b/front/lib/api/actions/servers/slab/metadata.ts
@@ -110,7 +110,6 @@ export const SLAB_SERVER = {
     authorization: null,
     icon: "SlabLogo",
     documentationUrl: "https://docs.dust.tt/docs/slab-mcp",
-    instructions: null,
   },
   tools: Object.values(SLAB_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -227,7 +227,6 @@ export const SLACK_BOT_SERVER = {
     },
     icon: "SlackLogo",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(SLACK_BOT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -508,7 +508,6 @@ export const SLACK_PERSONAL_SERVER = {
     },
     icon: "SlackLogo",
     documentationUrl: "https://docs.dust.tt/docs/slack-mcp",
-    instructions: null,
   },
   tools: Object.values(SLACK_PERSONAL_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -130,7 +130,6 @@ export const SNOWFLAKE_SERVER = {
     },
     icon: "SnowflakeLogo",
     documentationUrl: "https://docs.dust.tt/docs/snowflake-tool",
-    instructions: null,
   },
   tools: Object.values(SNOWFLAKE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/sound_studio/metadata.ts
+++ b/front/lib/api/actions/servers/sound_studio/metadata.ts
@@ -54,7 +54,6 @@ export const SOUND_STUDIO_SERVER = {
     authorization: null,
     icon: "ActionNoiseIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(SOUND_STUDIO_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -240,7 +240,6 @@ export const SPEECH_GENERATOR_SERVER = {
     authorization: null,
     icon: "ActionSpeakIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(SPEECH_GENERATOR_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/statuspage/metadata.ts
+++ b/front/lib/api/actions/servers/statuspage/metadata.ts
@@ -172,7 +172,6 @@ export const STATUSPAGE_SERVER = {
     authorization: null,
     icon: "StatuspageLogo",
     documentationUrl: "https://docs.dust.tt/docs/statuspage-mcp",
-    instructions: null,
   },
   tools: Object.values(STATUSPAGE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/toolsets/metadata.ts
+++ b/front/lib/api/actions/servers/toolsets/metadata.ts
@@ -36,7 +36,6 @@ export const TOOLSETS_SERVER = {
     authorization: null,
     icon: "ActionLightbulbIcon",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(TOOLSETS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/ukg_ready/metadata.ts
+++ b/front/lib/api/actions/servers/ukg_ready/metadata.ts
@@ -196,7 +196,6 @@ export const UKG_READY_SERVER = {
     },
     icon: "UkgLogo",
     documentationUrl: "https://docs.dust.tt/docs/ukg-ready",
-    instructions: null,
   },
   tools: Object.values(UKG_READY_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/user_mentions/metadata.ts
+++ b/front/lib/api/actions/servers/user_mentions/metadata.ts
@@ -53,7 +53,6 @@ export const USER_MENTIONS_SERVER = {
     icon: "ActionMegaphoneIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(USER_MENTIONS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/val_town/metadata.ts
+++ b/front/lib/api/actions/servers/val_town/metadata.ts
@@ -268,7 +268,6 @@ export const VAL_TOWN_SERVER = {
     authorization: null,
     icon: "ValTownLogo",
     documentationUrl: "https://docs.dust.tt/docs/val-town",
-    instructions: null,
     developerSecretSelection: "required",
   },
   tools: Object.values(VAL_TOWN_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/vanta/metadata.ts
+++ b/front/lib/api/actions/servers/vanta/metadata.ts
@@ -325,7 +325,6 @@ export const VANTA_SERVER = {
     },
     icon: "VantaLogo",
     documentationUrl: "https://docs.dust.tt/docs/vanta",
-    instructions: null,
   },
   tools: Object.values(VANTA_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -86,7 +86,6 @@ export const WAKEUPS_SERVER = {
     authorization: null,
     icon: "ActionTimeIcon",
     documentationUrl: null,
-    instructions: null,
     displayedAs: "agent",
   },
   tools: Object.values(WAKEUPS_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -45,7 +45,6 @@ export const WEB_SEARCH_BROWSE_SERVER = {
     authorization: null,
     icon: "ActionGlobeAltIcon" as const,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(WEB_SEARCH_BROWSE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -265,7 +265,6 @@ export const WORKSPACE_ANALYTICS_SERVER = {
     icon: "ActionPieChartIcon",
     authorization: null,
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(WORKSPACE_ANALYTICS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -156,7 +156,6 @@ export const ZENDESK_SERVER = {
     },
     icon: "ZendeskLogo",
     documentationUrl: null,
-    instructions: null,
   },
   tools: Object.values(ZENDESK_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -150,8 +150,6 @@ type InternalMCPServerType = MCPServerType & {
   name: InternalMCPServerNameType;
   // We enforce that we pass an icon here.
   icon: InternalAllowedIconType;
-  // Instructions that are appended to the overall prompt.
-  instructions: string | null;
   // Whether the server's actions are framed as the agent acting (e.g. "Allow
   // @agent to schedule a wake-up?") or as the server acting (default, e.g.
   // "Allow Linear to create an issue?"). Use "agent" for self-contained agent


### PR DESCRIPTION
## Description

- This PR removes the unused `instructions` field from internal MCP server definitions.
- Internal MCP servers no longer pass server-level instructions, and the `instructions: null` boilerplate is removed from internal server metadata.
- Remote MCP server instructions are unchanged.

## Tests

- Covered by existing tests + typecheck.

## Risk

- Low.

## Deploy Plan

- Deploy front.
