### PR TITLE
Add BM25 retrieval harness for MCP tool descriptions

### DIFF
--- a/front/scripts/mcp_bm25/README.md
+++ b/front/scripts/mcp_bm25/README.md
@@ -1,0 +1,54 @@
+# MCP tool-search BM25 harness
+
+A small diagnostic to check that internal MCP tool descriptions are
+**retrievable** by a lexical (BM25) tool-search index. When tools are deferred
+and surfaced on demand, a search matches the user's intent against each tool's
+**name + description + input schema** only (no server-level instructions). This
+harness scores realistic queries against the live tool metadata and reports
+whether the intended tool ranks first.
+
+## Run
+
+```sh
+# from front/
+npx tsx scripts/mcp_bm25/run.ts
+```
+
+Output is one row per query with the rank of the expected tool, a `<-- MISS`
+marker when it falls outside the allowed rank, and a top-1 summary.
+
+## Files
+
+- `bm25.ts` — BM25 ranker (k1=1.2, b=0.75) and the tokenizer.
+- `corpus.ts` — builds the document corpus from live server metadata. Each tool
+  becomes one document = name + description + every description / property key /
+  enum value in its input schema.
+- `queries.ts` — labeled queries (`query` -> server-qualified `expected` tool).
+- `run.ts` — wires the registered servers and queries together and prints the
+  report.
+
+## Adding a server
+
+1. Import its metadata in `run.ts` and add it to `SERVERS`.
+2. Add a block of realistic queries for it in `queries.ts`.
+
+## Reading the results
+
+A miss usually points to one of:
+
+- **Missing intent vocabulary** — the description uses one verb ("get") while
+  users type another ("read", "open"). BM25 has no synonyms, so add the words
+  people actually use.
+- **Sibling / cross-server collision** — two tools share too much wording (e.g.
+  two search tools, or `copy_file` in two servers). Give each tool its own
+  discriminating vocabulary and a platform token; avoid cross-referencing
+  another tool by name, which bleeds its keywords in.
+- **Oversized parameter descriptions** — a very long input schema (e.g. a query
+  field with pages of syntax help) dilutes the tool's term weights via BM25
+  length normalization and pushes it down the ranking.
+
+## Caveats
+
+The harness approximates a real index: it weights name, description, and input
+schema equally and uses crude singularization rather than full stemming.
+Treat the ranks as directional signal, not ground truth.

--- a/front/scripts/mcp_bm25/bm25.ts
+++ b/front/scripts/mcp_bm25/bm25.ts
@@ -1,0 +1,91 @@
+// Minimal BM25 ranker used to sanity-check that MCP tool descriptions are
+// retrievable by a lexical (BM25) tool-search index, which scores a query
+// against each tool's name, description, and input schema.
+//
+// Tokenizer: lowercase, split on non-alphanumeric, then a crude
+// singularization (strip one trailing "s" on tokens longer than 3 chars).
+// Product names such as OneDrive / SharePoint / PowerPoint are intentionally
+// kept whole so they match how users type them, and singularization
+// approximates stemming so doc~docs, file~files, sheet~sheets match. The same
+// tokenizer is applied to both the query and the documents.
+
+const K1 = 1.2;
+const B = 0.75;
+
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 0)
+    .map((t) => (t.length > 3 && t.endsWith("s") ? t.slice(0, -1) : t));
+}
+
+export interface Bm25Index {
+  tokenized: string[][];
+  avgdl: number;
+  idf: Map<string, number>;
+  names: string[];
+}
+
+export interface Document {
+  name: string;
+  text: string;
+}
+
+export function buildIndex(docs: Document[]): Bm25Index {
+  const tokenized = docs.map((d) => tokenize(d.text));
+  const n = docs.length;
+  const avgdl = tokenized.reduce((sum, t) => sum + t.length, 0) / n;
+
+  const df = new Map<string, number>();
+  for (const toks of tokenized) {
+    for (const t of new Set(toks)) {
+      df.set(t, (df.get(t) ?? 0) + 1);
+    }
+  }
+
+  const idf = new Map<string, number>();
+  for (const [t, count] of df) {
+    idf.set(t, Math.log(1 + (n - count + 0.5) / (count + 0.5)));
+  }
+
+  return { tokenized, avgdl, idf, names: docs.map((d) => d.name) };
+}
+
+function scoreDocument(
+  queryTokens: string[],
+  docTokens: string[],
+  idx: Bm25Index
+): number {
+  const tf = new Map<string, number>();
+  for (const t of docTokens) {
+    tf.set(t, (tf.get(t) ?? 0) + 1);
+  }
+
+  const dl = docTokens.length;
+  let score = 0;
+  for (const q of queryTokens) {
+    const f = tf.get(q);
+    if (!f) {
+      continue;
+    }
+    const idf = idx.idf.get(q) ?? 0;
+    score += (idf * (f * (K1 + 1))) / (f + K1 * (1 - B + B * (dl / idx.avgdl)));
+  }
+  return score;
+}
+
+export interface RankedDocument {
+  name: string;
+  score: number;
+}
+
+export function rank(query: string, idx: Bm25Index): RankedDocument[] {
+  const queryTokens = tokenize(query);
+  return idx.names
+    .map((name, i) => ({
+      name,
+      score: scoreDocument(queryTokens, idx.tokenized[i], idx),
+    }))
+    .sort((a, b) => b.score - a.score);
+}

--- a/front/scripts/mcp_bm25/corpus.ts
+++ b/front/scripts/mcp_bm25/corpus.ts
@@ -1,0 +1,74 @@
+// Builds the BM25 document corpus from live MCP server metadata, so the test
+// always reflects the descriptions actually shipped (no hand-maintained copy
+// that can drift). Each tool becomes one document whose text is the tool name,
+// its description, and every description / property key / enum value found in
+// its input schema (this mirrors what a tool-search index would index).
+
+import type { JSONSchema7, JSONSchema7Definition } from "json-schema";
+
+import type { Document } from "@app/scripts/mcp_bm25/bm25";
+
+export interface ServerEntry {
+  name: string;
+  tools: ReadonlyArray<{
+    name: string;
+    description: string;
+    inputSchema: JSONSchema7;
+  }>;
+}
+
+function collectSchemaText(def: JSONSchema7Definition | undefined): string[] {
+  if (def === undefined || typeof def === "boolean") {
+    return [];
+  }
+
+  const parts: string[] = [];
+
+  if (typeof def.description === "string") {
+    parts.push(def.description);
+  }
+  if (def.enum) {
+    parts.push(
+      def.enum.filter((e): e is string => typeof e === "string").join(" ")
+    );
+  }
+  if (def.properties) {
+    for (const [key, child] of Object.entries(def.properties)) {
+      parts.push(key);
+      parts.push(...collectSchemaText(child));
+    }
+  }
+  if (def.items) {
+    const items = Array.isArray(def.items) ? def.items : [def.items];
+    for (const item of items) {
+      parts.push(...collectSchemaText(item));
+    }
+  }
+  for (const branch of [def.anyOf, def.oneOf, def.allOf]) {
+    if (branch) {
+      for (const sub of branch) {
+        parts.push(...collectSchemaText(sub));
+      }
+    }
+  }
+
+  return parts;
+}
+
+export function buildDocs(servers: ServerEntry[]): Document[] {
+  const docs: Document[] = [];
+  for (const server of servers) {
+    for (const tool of server.tools) {
+      const parts = [
+        tool.name,
+        tool.description,
+        ...collectSchemaText(tool.inputSchema),
+      ];
+      docs.push({
+        name: `${server.name}.${tool.name}`,
+        text: parts.join(" "),
+      });
+    }
+  }
+  return docs;
+}

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1,0 +1,45 @@
+// Labeled retrieval queries: realistic user intents mapped to the tool that
+// should rank first. `expected` is server-qualified ("<server>.<tool>") because
+// several servers expose the same tool name (e.g. copy_file, get_file_content).
+// `maxRank` allows a query to pass when the expected tool is within the top N
+// (default 1); use it only for genuinely ambiguous intents.
+//
+// Add a server to run.ts and its queries here as each server is reviewed.
+
+export interface LabeledQuery {
+  query: string;
+  expected: string;
+  maxRank?: number;
+}
+
+export const QUERIES: LabeledQuery[] = [
+  // --- google_drive ---
+  { query: "search google drive for the Q3 report", expected: "google_drive.search_files" },
+  { query: "find my budget spreadsheet in google drive", expected: "google_drive.search_files" },
+  { query: "list all my google drives", expected: "google_drive.list_drives" },
+  { query: "read my google doc", expected: "google_drive.get_file_content" },
+  { query: "open a file from google drive", expected: "google_drive.get_file_content" },
+  { query: "clone this google doc", expected: "google_drive.copy_file" },
+  { query: "duplicate a google slides template", expected: "google_drive.copy_file" },
+  { query: "unshare a google drive file", expected: "google_drive.revoke_file_sharing" },
+  { query: "stop sharing a google doc with someone", expected: "google_drive.revoke_file_sharing" },
+  { query: "share a google doc with my colleague", expected: "google_drive.share_file" },
+  { query: "create a new google spreadsheet", expected: "google_drive.create_spreadsheet" },
+  { query: "make a new google slides deck", expected: "google_drive.create_presentation" },
+  { query: "who has access to this google drive file", expected: "google_drive.list_file_permissions" },
+  { query: "upload a file to google drive", expected: "google_drive.upload_file" },
+
+  // --- microsoft_drive ---
+  { query: "find my excel file in onedrive", expected: "microsoft_drive.search_drive_items" },
+  { query: "find the budget file in sharepoint", expected: "microsoft_drive.search_drive_items" },
+  { query: "what does my powerpoint in onedrive say about pricing", expected: "microsoft_drive.search_in_files" },
+  { query: "search inside my onedrive files for the refund policy", expected: "microsoft_drive.search_in_files" },
+  { query: "read my word doc in sharepoint", expected: "microsoft_drive.get_file_content" },
+  { query: "open an excel file from onedrive", expected: "microsoft_drive.get_file_content" },
+  { query: "edit my word document in onedrive", expected: "microsoft_drive.update_word_document" },
+  { query: "clone a file in sharepoint", expected: "microsoft_drive.copy_file" },
+  { query: "rename a folder in onedrive", expected: "microsoft_drive.rename_drive_item" },
+  { query: "upload a file to sharepoint", expected: "microsoft_drive.upload_file" },
+  { query: "list files in my onedrive folder", expected: "microsoft_drive.list_drive_items" },
+  { query: "browse my sharepoint site", expected: "microsoft_drive.list_drive_items" },
+];

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -1,0 +1,74 @@
+// Diagnostic: runs the BM25 retrieval check over the registered MCP servers and
+// the labeled query set, printing the rank of each expected tool, the queries
+// that miss (expected tool outside its allowed rank), and a top-1 summary.
+//
+// It reads descriptions from the live server metadata, so the numbers reflect
+// what a tool-search index would actually see (full input schema included).
+// A miss usually means a description lacks the intent vocabulary, collides with
+// a sibling/cross-server tool, or is diluted by an oversized parameter
+// description (BM25 length normalization). Always exits 0; it is a tool to guide
+// description work, not a CI gate.
+//
+// Usage: npx tsx scripts/mcp_bm25/run.ts   (from the front/ directory)
+
+import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
+import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
+import { buildIndex, rank } from "@app/scripts/mcp_bm25/bm25";
+import type { ServerEntry } from "@app/scripts/mcp_bm25/corpus";
+import { buildDocs } from "@app/scripts/mcp_bm25/corpus";
+import { QUERIES } from "@app/scripts/mcp_bm25/queries";
+
+const SERVERS: ServerEntry[] = [
+  { name: "google_drive", tools: GOOGLE_DRIVE_SERVER.tools },
+  { name: "microsoft_drive", tools: MICROSOFT_DRIVE_SERVER.tools },
+];
+
+function out(line: string): void {
+  process.stdout.write(line + "\n");
+}
+
+function main(): number {
+  const docs = buildDocs(SERVERS);
+  const idx = buildIndex(docs);
+
+  out(
+    `Corpus: ${docs.length} tools across ${SERVERS.length} servers, ${QUERIES.length} queries\n`
+  );
+  out(
+    "query".padEnd(54) +
+      "expected".padEnd(38) +
+      "rank".padStart(5) +
+      "  top hit"
+  );
+  out("-".repeat(130));
+
+  let passed = 0;
+  let top1 = 0;
+  for (const { query, expected, maxRank = 1 } of QUERIES) {
+    const ranked = rank(query, idx);
+    const pos = ranked.findIndex((r) => r.name === expected) + 1;
+    const ok = pos >= 1 && pos <= maxRank;
+    if (ok) {
+      passed++;
+    }
+    if (pos === 1) {
+      top1++;
+    }
+    const flag = ok ? "" : "  <-- MISS";
+    out(
+      query.padEnd(54) +
+        expected.padEnd(38) +
+        String(pos).padStart(5) +
+        "  " +
+        (ranked[0]?.name ?? "(none)") +
+        flag
+    );
+  }
+
+  out("-".repeat(130));
+  out(
+    `top-1: ${top1}/${QUERIES.length}  |  within maxRank: ${passed}/${QUERIES.length}`
+  );
+}
+
+main();


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The system prompt enumerated every MCP server and listed its tool names under per-server headings. That listing is redundant with the actual tool specifications the model already receives, and the per-server instructions it also carried have moved into the individual tool descriptions. It added prompt bloat and per-request entropy that hurt prompt-cache stability for no benefit.

This drops the listing block entirely. Tool availability is unchanged since tools are passed to the model through their full specifications independently of this prompt section.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
