### PR TITLE
Remove available-tool-servers listing from the system prompt

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -164,38 +164,6 @@ function constructToolsSection({
 
   toolsSection += toolUseDirectives;
 
-  // The following section provides the model with a high-level overview of available external servers
-  // (groups of tools) and their general purpose (if server instructions are provided).
-  // It lists the names of tools available under each server to give context about tool groupings.
-  // Note: Actual tool callability, including detailed descriptions and parameters for each tool,
-  // is determined by the comprehensive tool specifications provided to the model separately.
-  // All discovered tools from all servers are made available for the agent to call, regardless of
-  // whether their server has explicit instructions or is detailed in this specific prompt overview.
-  let toolServersPrompt = "";
-
-  if (serverToolsAndInstructions && serverToolsAndInstructions.length > 0) {
-    toolServersPrompt = "\n## AVAILABLE TOOL SERVERS\n";
-    toolServersPrompt +=
-      "Each server provides a list of tools made available to the agent.\n";
-    for (const serverData of serverToolsAndInstructions) {
-      toolServersPrompt += `\n### SERVER NAME: ${serverData.serverName}\n`;
-      if (serverData.instructions) {
-        toolServersPrompt += `Server instructions: ${serverData.instructions}\n`;
-      }
-      if (serverData.tools && serverData.tools.length > 0) {
-        toolServersPrompt += `Tools available on this server (names only):\n`;
-        for (const tool of serverData.tools) {
-          toolServersPrompt += `  - ${tool.name}\n`;
-        }
-      } else {
-        toolServersPrompt += `  (No tools reported by this server or tool listing failed.)\n`;
-      }
-    }
-    toolServersPrompt += "\n";
-  }
-
-  toolsSection += toolServersPrompt;
-
   return toolsSection;
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The system prompt enumerated every MCP server and listed its tool names under per-server headings. That listing is redundant with the actual tool specifications the model already receives, and the per-server instructions it also carried have moved into the individual tool descriptions. It added prompt bloat and per-request entropy that hurt prompt-cache stability for no benefit.

This drops the listing block entirely. Tool availability is unchanged since tools are passed to the model through their full specifications independently of this prompt section.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Could break model understanding of server and connection between tools. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
