### PR TITLE
Skip pending subscription if already started

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -455,7 +455,11 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
 
-    const response = await postSwitchContract(workspace.sId, proBody());
+    // Future startingAt: pending row is created and waits for contract.start.
+    const response = await postSwitchContract(
+      workspace.sId,
+      proBody({ startingAt: futureIso(2) })
+    );
 
     expect(response.status).toBe(200);
 
@@ -477,8 +481,11 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
 
-    // First schedule → pending P1.
-    const firstResponse = await postSwitchContract(workspace.sId, proBody());
+    // Future startingAt: pending row is created and waits for contract.start.
+    const firstResponse = await postSwitchContract(
+      workspace.sId,
+      proBody({ startingAt: futureIso(2) })
+    );
     expect(firstResponse.status).toBe(200);
 
     const workspaceModelId = (await WorkspaceResource.fetchById(workspace.sId))!
@@ -497,7 +504,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
     );
     const secondResponse = await postSwitchContract(
       workspace.sId,
-      businessBody()
+      businessBody({ startingAt: futureIso(2) })
     );
     expect(secondResponse.status).toBe(200);
 

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -891,12 +891,18 @@ async function stepContractEdits({
 
 // Persist the future-state subscription in `created_backend_only`; the
 // `contract.start` webhook flips it to `active` (and ends the current one).
+// Skip entirely when alignedStart is in the past: Metronome fires contract.start
+// immediately for backdated contracts, so the contract.start handler handles the
+// swap — there is no window for a pending row to be useful.
 async function stepPendingSubscription({
   workspaceModelId,
   metronomeContractId,
   alignedStart,
   body,
 }: PostProvisionCtx): Promise<string | null> {
+  if (alignedStart.getTime() <= Date.now()) {
+    return null;
+  }
   try {
     await SubscriptionResource.createPendingMetronomeContract({
       workspaceModelId,


### PR DESCRIPTION
## Description

When using switch-contract with a backdated start date, Metronome fires `contract.start` immediately upon contract creation (the start is already in the past). This caused a race with `stepPendingSubscription`, which runs after provisioning: the webhook arrived before the `created_backend_only` row was inserted, fell through to the `swapMetronomeContract` path, and created an `active` subscription. Then `stepPendingSubscription` inserted a second `created_backend_only` row — two subscriptions pointing at the same contract.

**Fix:** skip `stepPendingSubscription` entirely when `alignedStart <= now`. The pending row only makes sense for future-dated contracts where the webhook will arrive later. For past (or immediate) contracts the webhook fires right away and the `contract.start` handler handles the transition — there is no window where a pending row is useful.

**Detection query** for existing broken workspaces (two subs on the same contract):
```sql
SELECT s1."workspaceId", s1."sId" AS active_sid, s2."sId" AS pending_sid, s1."metronomeContractId"
FROM subscriptions s1
JOIN subscriptions s2
  ON  s1."workspaceId"         = s2."workspaceId"
  AND s1."metronomeContractId" = s2."metronomeContractId"
WHERE s1.status = 'active'
  AND s2.status = 'created_backend_only';
```

## Tests

Manually verified the query above identifies the affected workspace. The fix is a one-line guard with no new code paths for the happy case.

## Risk

Low. Only affects the backdated-contract path in switch-contract. Future-dated contracts are unchanged. The `contract.start` webhook handler already handles pilot → paid transitions correctly.

## Deploy Plan

Standard deploy. No migration needed.