### PR TITLE
Improve Confluence tool descriptions for tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/confluence/metadata.ts
+++ b/front/lib/api/actions/servers/confluence/metadata.ts
@@ -9,7 +9,7 @@ export const CONFLUENCE_TOOL_NAME = "confluence" as const;
 export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
   get_current_user: {
     description:
-      "Get information about the currently authenticated Confluence user including account ID, display name, and email.",
+      "Get the currently authenticated Confluence user: who you are, your own account ID, display name, and email.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -29,7 +29,7 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
   },
   get_pages: {
     description:
-      "Search for Confluence pages using CQL (Confluence Query Language). Only returns page objects. " +
+      "Search Confluence to find and locate pages across spaces by keyword, title, label, or space, using CQL (Confluence Query Language). Use this to find a page when you only know its title or topic and not its ID. Only returns page objects. " +
       "Text matching operators: '~' contains, '!~' not contains, '=' exact match. " +
       "Common fields: title, text, space (use space key, not name), creator, label. " +
       "Examples: 'type=page AND space=DEV', 'type=page AND title~\"meeting\"', 'type=page AND label=important'",
@@ -56,7 +56,7 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
   },
   get_page: {
     description:
-      "Get a single Confluence page by its ID. Returns the page metadata and optionally the page body content.",
+      "Retrieve and read a single Confluence page by its ID, returning its metadata and body content. Use this when you already know the page ID.",
     schema: {
       pageId: z.string().describe("The ID of the page to retrieve"),
       includeBody: z
@@ -75,7 +75,7 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
   },
   create_page: {
     description:
-      "Create a new Confluence page in a specified space with optional content and parent page.",
+      "Create a new Confluence page in a space, optionally nested under a parent page.",
     schema: {
       spaceId: z
         .string()


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Part of https://github.com/dust-tt/tasks/issues/9168.

This sharpens the wording of the Confluence tools so the right one is surfaced when tool search ranks them by how well a user's phrasing matches each tool's name, description, and parameters. The main confusion was between searching for pages and reading one page by its identifier, which read almost identically and competed for the same intents. Searching now leads clearly with finding and locating a page by topic when you do not yet know its identifier, while reading leads with retrieving a single page once you already have its identifier. A second issue was that the current-user tool used a common word that pulled unrelated questions toward it; its wording now centres on telling you who you are, which also lets it answer that question directly. The create tool no longer borrows vocabulary that belonged to reading. No behaviour changes, only descriptions.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
