### PR TITLE
[Migration] Store default skills in an array for the default skills in pods feature

### DIFF
--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -23,6 +23,7 @@ export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataMod
   declare pinnedFramePath: CreationOptional<string | null>;
   /** sId of the agent pre-selected for new conversations in this pod. Null = @dust. */
   declare defaultAgentId: CreationOptional<string | null>;
+  declare defaultSkillsIds: CreationOptional<string[] | null>;
 }
 
 ProjectMetadataModel.init(
@@ -67,6 +68,12 @@ ProjectMetadataModel.init(
       allowNull: true,
       defaultValue: null,
       field: "defaultAgentSId",
+    },
+    defaultSkillsIds: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
+      defaultValue: null,
+      field: "defaultSkillsIds",
     },
   },
   {

--- a/front/migrations/pre-deploy/20260626160000_add_default_skills_array_to_project_metadata.sql
+++ b/front/migrations/pre-deploy/20260626160000_add_default_skills_array_to_project_metadata.sql
@@ -1,0 +1,9 @@
+/*
+Add the pod default-skill sId array to project_metadata. Nullable, no default data: the pods default-skills feature is not yet
+released, so there is nothing to backfill.
+
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."project_metadata" ADD COLUMN "defaultSkillsIds" character varying(255)[] DEFAULT NULL::character varying[];


### PR DESCRIPTION
## Description
After the [discussion](https://dust4ai.slack.com/archives/C050SM8NSPK/p1782391809362389) we have decided to store the default skill ids as a string array column in the current project_metadata table.

## Tests
Manual tests

## Risk
Low risk, nothing depends on this column yet.

## Deploy Plan
1. Deploy migration
2. Deploy pod default skills feature to prod
3. Ensure that nothing relies on the project_default_skills table that is now obsolete
4. Drop the table in another PR