### PR TITLE
fix(analytics) stop get_agent_details leaking private agent details

### DIFF
--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -234,6 +234,21 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       ]);
     }
 
+    if (!agent.canRead) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text:
+            `Agent ${agent.name} [${agent.sId}]\n` +
+            `- Description: (private agent - not available)\n` +
+            `- Scope: ${agent.scope}\n` +
+            `- Model: ${agent.model.providerId}/${agent.model.modelId}\n\n` +
+            "Instructions, skills, and tools are not available for private " +
+            "agents you do not have access to.",
+        },
+      ]);
+    }
+
     const toolNames = agent.actions.map((action) => action.name).join(", ");
     const skillNames = (agent.skills ?? []).join(", ");
 


### PR DESCRIPTION
## Description

The get_agent_details workspace analytics tool printed the description and full instructions of agents the admin cannot read (hidden-scope agents returned by getAgentConfigurations with canRead false). Return a redacted view for those agents: name, scope, and model only, with the description masked and instructions/skills/tools withheld. Readable agents are unchanged.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
