### PR TITLE
fix: sandbox timeout errors

### DIFF
--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -13,6 +13,15 @@ export const SANDBOX_TOOL_NAME = "sandbox" as const;
 export const SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS = 60000;
 export const SANDBOX_MAX_COMMAND_TIMEOUT_MS = 120000;
 
+// Extra time we add on top of a command's in-container timeout to set the
+// timeout we give the sandbox provider. The in-container `timeout`
+// wrapper stops the command and returns whatever output it has; this extra
+// time lets that finish and reach us before the provider gives up. A few
+// seconds is plenty (it only covers stopping the command and sending its
+// output back). It must stay small enough that the provider timeout
+// (max command timeout + this) stays under SANDBOX_MCP_REQUEST_TIMEOUT_MS.
+export const SANDBOX_EXEC_TIMEOUT_BUFFER_MS = 10000;
+
 // Outer MCP request deadline for the sandbox server. It must be strictly
 // greater than the max in-container command timeout so the graceful
 // in-container timeout (which returns partial output) always fires before the

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -11,6 +11,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isSandboxResumeState } from "@app/lib/actions/types";
 import {
   SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS,
+  SANDBOX_EXEC_TIMEOUT_BUFFER_MS,
   SANDBOX_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/sandbox/metadata";
 import {
@@ -365,9 +366,13 @@ export async function runSandboxBashTool(
   const startMs = performance.now();
 
   const providerId = agentConfiguration.model.providerId;
-  const timeoutSec = Math.ceil(
-    (timeoutMs ?? SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS) / 1000
-  );
+  const commandTimeoutMs = timeoutMs ?? SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS;
+  const timeoutSec = Math.ceil(commandTimeoutMs / 1000);
+  // Give the provider a slightly longer timeout than the in-container one, so
+  // the in-container `timeout` wrapper always stops the command first and we
+  // get its partial output, instead of the provider cutting the call short
+  // with no output.
+  const execTimeoutMs = commandTimeoutMs + SANDBOX_EXEC_TIMEOUT_BUFFER_MS;
   const commandToRun = isResumeMode
     ? buildWaitAndCollectCommand(execId)
     : wrapCommandWithCapture(command, execId, providerId, { timeoutSec });
@@ -383,6 +388,7 @@ export async function runSandboxBashTool(
       DUST_SANDBOX_TOKEN: sandboxToken,
       DUST_API_URL: `${sandboxAPIBase}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
     },
+    timeoutMs: execTimeoutMs,
     user: "agent-proxied",
   });
 


### PR DESCRIPTION
## Description

This PR fixes sandbox timeout errors by explicitly passing a `timeoutMs` to the provider, with a small buffer on top of the in-container command timeout.

- Before this fix, `timeoutMs` was not passed to the provider at all, causing E2B to use its own default timeout which could cut the call short before the in-container `timeout` wrapper had a chance to return partial output.
- Introduces `SANDBOX_EXEC_TIMEOUT_BUFFER_MS` (10s) as the extra time given to the provider on top of the command timeout, ensuring the in-container timeout always fires first.

Example error log https://app.datadoghq.eu/logs?query=status%3Aerror%20%40dd.env%3Aprod%20service%3Afront-agent-loop-worker%20%40toolName%3Asandbox&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ8EgrvsnAOm1gAAABhBWjhFZ3NBMEFBQXpZZ0FSaHRQQmxnQWQAAAAkMDE5ZjA0ODMtMDI4Yi00YjQ4LTgyNDEtNzVmNTVmMDMxMGQ3AABpTQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1782478801933&to_ts=1782482401933&live=true

## Tests

Manually.

## Risk

Low.

## Deploy Plan

Standard deployment.