### PR TITLE
Dump the raw body for debug

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -147,6 +147,7 @@ app.post(
         {
           message: "conversations/index",
           body: ctx.req.valid("json"),
+          rawBody: await ctx.req.text(),
         },
         "conversations/index"
       );


### PR DESCRIPTION
## Description

Adds `rawBody: await ctx.req.text()` to the existing `logger.info` call in `front-api/routes/v1/w/[wId]/assistant/conversations/index.ts`. The validated JSON body is already logged; this surfaces the raw request body alongside it for debugging purposes — useful when validation strips or transforms fields unexpectedly.

⚠️ Temporary debug change — must be reverted before or shortly after merging.

## Tests

Tested manually — verified the raw body appears in logs on the `conversations/index` route.

## Risk

Low. Additive log-only change with no business logic impact. Note: raw body may contain user-provided data; avoid leaving this in production logs longer than needed. No rollback concern.

## Deploy Plan

Deploy `front-api`.
