### PR TITLE
[front] Poke plugin to grant free credits to a member + free-seat allowance fixes

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -230,6 +230,7 @@ function UsageSection({ owner, onClose }: UsageSectionProps) {
                     }
                     consumedFromPool={myUsage?.consumedFromPoolAwuCredits ?? 0}
                     memberUsageLimit={myUsage?.memberUsageLimit ?? null}
+                    seatBalanceAwu={myUsage?.seatBalanceAwu ?? null}
                     effectiveLimit={myUsage?.spendLimitAwuCredits ?? 0}
                     seatType={myUsage?.seatType ?? null}
                     isTotalAllowedUsagePending={false}

--- a/front/components/poke/credits/GrantFreeCreditsButton.tsx
+++ b/front/components/poke/credits/GrantFreeCreditsButton.tsx
@@ -1,0 +1,135 @@
+import { PokeForm } from "@app/components/poke/shadcn/ui/form";
+import { InputField } from "@app/components/poke/shadcn/ui/form/fields";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useRunPokePlugin } from "@app/poke/swr/plugins";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+const GRANT_USER_FREE_CREDITS_PLUGIN_ID = "grant-user-free-credits";
+
+const GrantFreeCreditsFormSchema = z.object({
+  amountCredits: z
+    .number({ invalid_type_error: "Enter a number of credits" })
+    .int("Amount must be a whole number of credits")
+    .positive("Amount must be greater than 0"),
+});
+
+type GrantFreeCreditsFormType = z.infer<typeof GrantFreeCreditsFormSchema>;
+
+interface GrantFreeCreditsButtonProps {
+  owner: WorkspaceType;
+  userId: string;
+  memberName: string;
+  // Called after a successful grant so callers can refresh their data.
+  onGranted?: () => void;
+}
+
+export function GrantFreeCreditsButton({
+  owner,
+  userId,
+  memberName,
+  onGranted,
+}: GrantFreeCreditsButtonProps) {
+  const sendNotification = useSendNotification();
+  const [open, setOpen] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
+
+  const form = useForm<GrantFreeCreditsFormType>({
+    resolver: zodResolver(GrantFreeCreditsFormSchema),
+    defaultValues: { amountCredits: undefined },
+  });
+
+  const { doRunPlugin } = useRunPokePlugin({
+    pluginId: GRANT_USER_FREE_CREDITS_PLUGIN_ID,
+    pluginResourceTarget: {
+      resourceType: "workspaces",
+      resourceId: owner.sId,
+      workspace: owner,
+    },
+  });
+
+  const onSubmit = async (values: GrantFreeCreditsFormType) => {
+    setIsRunning(true);
+    const result = await doRunPlugin({
+      userId,
+      amountCredits: values.amountCredits,
+      confirm: true,
+    });
+    setIsRunning(false);
+
+    if (result.isErr()) {
+      sendNotification({
+        type: "error",
+        title: "Failed to grant free credits",
+        description: result.error,
+      });
+      return;
+    }
+
+    sendNotification({
+      type: "success",
+      title: "Free credits granted",
+      description:
+        result.value.display === "text"
+          ? result.value.value
+          : `Granted free credits to ${memberName}.`,
+    });
+    form.reset();
+    setOpen(false);
+    onGranted?.();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="xs" label="Free credits" />
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>Grant free credits</DialogTitle>
+          <DialogDescription>
+            Add free AWU credits to {memberName}'s free-seat balance. No invoice
+            is generated.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          <PokeForm {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+              <InputField
+                control={form.control}
+                name="amountCredits"
+                title="Amount (AWU credits)"
+                type="number"
+                min="1"
+                step={1}
+                placeholder="e.g. 500"
+              />
+              <DialogFooter>
+                <Button
+                  type="submit"
+                  variant="warning"
+                  label="Grant"
+                  isLoading={isRunning}
+                />
+              </DialogFooter>
+            </form>
+          </PokeForm>
+        </DialogContainer>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -1,5 +1,6 @@
 import { AlertChip } from "@app/components/poke/credits/AlertChip";
 import { CreditStateLogsLink } from "@app/components/poke/credits/CreditStateLogsLink";
+import { GrantFreeCreditsButton } from "@app/components/poke/credits/GrantFreeCreditsButton";
 import { ReconcileCreditStateButton } from "@app/components/poke/credits/ReconcileCreditStateButton";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
@@ -241,12 +242,22 @@ function makeColumns({
       header: () => null,
       enableSorting: false,
       cell: ({ row }) => (
-        <ReconcileCreditStateButton
-          owner={owner}
-          target="user"
-          userId={row.original.sId}
-          onReconciled={onReconciled}
-        />
+        <div className="flex items-center justify-end gap-2">
+          {row.original.seatType === "free" && (
+            <GrantFreeCreditsButton
+              owner={owner}
+              userId={row.original.sId}
+              memberName={row.original.name}
+              onGranted={onReconciled}
+            />
+          )}
+          <ReconcileCreditStateButton
+            owner={owner}
+            target="user"
+            userId={row.original.sId}
+            onReconciled={onReconciled}
+          />
+        </div>
       ),
     },
   ];

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -138,7 +138,7 @@ export function AwuUsageBar({
   // For free seats: use lifetime consumed (derived from the live Metronome
   // balance) instead of period spend, so the bar reflects remaining credit.
   const isFreeWithBalance =
-    seatType === "free" && seatBalanceAwu !== null && memberUsageLimit !== null;
+    seatType === "free" && seatBalanceAwu != null && memberUsageLimit !== null;
   const lifetimeConsumed = isFreeWithBalance
     ? Math.max(0, memberUsageLimit - seatBalanceAwu!)
     : null;

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -138,7 +138,9 @@ export function AwuUsageBar({
   // For free seats: use lifetime consumed (derived from the live Metronome
   // balance) instead of period spend, so the bar reflects remaining credit.
   const isFreeWithBalance =
-    seatType === "free" && seatBalanceAwu != null && memberUsageLimit !== null;
+    seatType === "free" &&
+    typeof seatBalanceAwu === "number" &&
+    typeof memberUsageLimit === "number";
   const lifetimeConsumed = isFreeWithBalance
     ? Math.max(0, memberUsageLimit - seatBalanceAwu!)
     : null;

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -497,7 +497,13 @@ export function MembersUsageTable({
                 },
               ]
             : []),
-          ...(showSpendLimit
+          // Only paid, message-sending seats have a spend limit to edit. Free
+          // seats have no pool (their cap is just the fixed free allowance), and
+          // "none"/seatless members can't send anything — so the option hides.
+          ...(showSpendLimit &&
+          m.seatType &&
+          m.seatType !== "free" &&
+          m.seatType !== "none"
             ? [
                 {
                   kind: "item" as const,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -20,7 +20,6 @@ import {
 } from "@app/lib/metronome/client";
 import {
   CONTRACT_CREDIT_TYPE_FREE_SEAT,
-  FREE_SEAT_LIFETIME_AWU_CREDITS,
   getCreditTypeAwuId,
   toFreeMetronomeUserId,
 } from "@app/lib/metronome/constants";
@@ -863,9 +862,36 @@ export async function getMemberUsage({
   const seatData = seatDataByUserId.get(userId);
   const awuAllocation = seatData?.awuAllocation ?? 0;
 
+  // Free seats draw from a per-user credit whose granted total a Dust rep can
+  // raise (see the `grant-user-free-credits` poke plugin). Read the live balance
+  // and granted total so the "Your Credits" bar reflects the member's real
+  // allowance and lifetime usage rather than the fixed seat-type constant.
+  // Degrades to the constant on read failure.
+  let freeSeatBalanceAwu: number | null = null;
+  let freeSeatAllowanceAwu: number | null = null;
+  if (membership.seatType === "free" && metronomeCustomerId) {
+    const balances = await listCustomerPerUserCreditBalances({
+      metronomeCustomerId,
+      contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
+    });
+    if (balances.isOk()) {
+      const entry = balances.value.get(userId);
+      if (entry) {
+        freeSeatBalanceAwu = entry.balanceAwu;
+        freeSeatAllowanceAwu = entry.startingBalanceAwu;
+      }
+    } else {
+      logger.warn(
+        { err: balances.error, workspaceId: workspace.sId, userId },
+        "[MembersUsage] Failed to fetch free-seat credit for member usage"
+      );
+    }
+  }
+  const effectiveAllocationAwu = freeSeatAllowanceAwu ?? awuAllocation;
+
   const consumedFromAllowanceAwuCredits = Math.min(
     totalConsumedCredits,
-    awuAllocation
+    effectiveAllocationAwu
   );
   const consumedFromPoolAwuCredits =
     totalConsumedCredits - consumedFromAllowanceAwuCredits;
@@ -887,10 +913,10 @@ export async function getMemberUsage({
   // allowance (allowance + 0 pool) — like every other seat the cap includes the
   // allowance, it just has no pool headroom on top. There's no default cap alert
   // for free (normalizeToPoolLimitSeatType is null), so we supply it explicitly.
+  // Use the member's real free-credit total (which a rep may have raised) rather
+  // than the constant.
   const effectiveDefaultAwuCredits =
-    membership.seatType === "free"
-      ? FREE_SEAT_LIFETIME_AWU_CREDITS
-      : defaultAwuCredits;
+    membership.seatType === "free" ? effectiveAllocationAwu : defaultAwuCredits;
 
   const spendLimitSource = resolveEffectiveSpendLimitSource({
     overrideAwuCredits,
@@ -904,8 +930,9 @@ export async function getMemberUsage({
       email: userResource.email ?? null,
       image: userResource.imageUrl ?? null,
       seatType: membership.seatType ?? null,
-      memberUsageLimit: awuAllocation > 0 ? awuAllocation : null,
-      seatBalanceAwu: null,
+      memberUsageLimit:
+        effectiveAllocationAwu > 0 ? effectiveAllocationAwu : null,
+      seatBalanceAwu: freeSeatBalanceAwu,
       consumedAwuCredits: totalConsumedCredits,
       consumedFromAllowanceAwuCredits,
       consumedFromPoolAwuCredits,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -425,38 +425,31 @@ async function fetchSeatDataForMembersTable({
   }
 }
 
-// Live per-seat AWU balance remaining (`balanceByUserId`), plus, for free seats,
-// the granted total of the per-user free-seat credit (`freeStartingByUserId`).
-// Free-seat allowances are not a fixed constant — a Dust rep can raise a single
-// member's grant (see the `grant-user-free-credits` poke plugin) — so the table
-// reads each free member's real allowance from their credit rather than the
-// seat-type default. Degrades to empty maps on any read failure so the table
-// still renders (the column just shows "-").
+// Live per-seat AWU balance remaining for paid (seat-managed) seats, keyed by
+// userId. This is the expensive read (`listMetronomeSeatBalances`) gated to poke
+// — free seats are handled separately by `fetchFreeSeatCreditsForMembersTable`.
+// Degrades to an empty map on any read failure so the table still renders.
 async function fetchSeatBalancesForMembersTable({
   metronomeCustomerId,
   metronomeContractId,
 }: {
   metronomeCustomerId: string | null;
   metronomeContractId: string | null;
-}): Promise<{
-  balanceByUserId: Map<string, number>;
-  freeStartingByUserId: Map<string, number>;
-}> {
+}): Promise<Map<string, number>> {
   if (!metronomeCustomerId || !metronomeContractId) {
-    return { balanceByUserId: new Map(), freeStartingByUserId: new Map() };
+    return new Map();
   }
   const result = await listMetronomeSeatBalances({
     metronomeCustomerId,
     metronomeContractId,
   });
   const balanceByUserId = new Map<string, number>();
-  const freeStartingByUserId = new Map<string, number>();
   if (result.isErr()) {
     logger.warn(
       { err: result.error, metronomeCustomerId },
       "[MembersUsage] Failed to fetch seat balances, degrading to empty map"
     );
-    return { balanceByUserId, freeStartingByUserId };
+    return balanceByUserId;
   }
   const awuCreditTypeId = getCreditTypeAwuId();
   for (const seat of result.value) {
@@ -465,14 +458,30 @@ async function fetchSeatBalancesForMembersTable({
       balanceByUserId.set(seat.seat_id, awu.balance);
     }
   }
+  return balanceByUserId;
+}
 
-  // Free seats hold a per-user contract credit rather than a seat balance, so
-  // they're absent from `listMetronomeSeatBalances`. Fill their remaining
-  // balance in from the per-user credits — but only when the user has no seat
-  // balance: a user who switched free → pro/max still has a leftover free
-  // credit, and it must not overwrite their (real) pro/max seat balance. Also
-  // surface each free-seat credit's granted total so the table can show the
-  // member's real allowance. Degrades silently on read failure.
+// Per-user free-seat credit data, keyed by userId: live remaining balance
+// (`freeBalanceByUserId`) and granted total (`freeStartingByUserId`). Free seats
+// hold a per-user customer credit rather than a seat balance, and a Dust rep can
+// raise a single member's grant (see the `grant-user-free-credits` poke plugin),
+// so every surface reads each free member's real allowance/balance from their
+// credit rather than the fixed seat-type constant. This is a single
+// `credits.list` read, so — unlike the paid-seat balances above — it runs on the
+// customer usage page too, not just poke. Degrades to empty maps on read failure.
+async function fetchFreeSeatCreditsForMembersTable({
+  metronomeCustomerId,
+}: {
+  metronomeCustomerId: string | null;
+}): Promise<{
+  freeBalanceByUserId: Map<string, number>;
+  freeStartingByUserId: Map<string, number>;
+}> {
+  const freeBalanceByUserId = new Map<string, number>();
+  const freeStartingByUserId = new Map<string, number>();
+  if (!metronomeCustomerId) {
+    return { freeBalanceByUserId, freeStartingByUserId };
+  }
   const perUserCreditBalances = await listCustomerPerUserCreditBalances({
     metronomeCustomerId,
     contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
@@ -482,9 +491,7 @@ async function fetchSeatBalancesForMembersTable({
       userId,
       { balanceAwu, startingBalanceAwu },
     ] of perUserCreditBalances.value) {
-      if (!balanceByUserId.has(userId)) {
-        balanceByUserId.set(userId, balanceAwu);
-      }
+      freeBalanceByUserId.set(userId, balanceAwu);
       freeStartingByUserId.set(userId, startingBalanceAwu);
     }
   } else {
@@ -493,8 +500,7 @@ async function fetchSeatBalancesForMembersTable({
       "[MembersUsage] Failed to fetch per-user credit balances, skipping"
     );
   }
-
-  return { balanceByUserId, freeStartingByUserId };
+  return { freeBalanceByUserId, freeStartingByUserId };
 }
 
 async function fetchPerUserCapAlertIdsUncached({
@@ -1147,7 +1153,8 @@ export async function getMembersUsage({
   const [
     perUserTotalConsumedCredits,
     seatDataByUserId,
-    { balanceByUserId: seatBalanceByUserId, freeStartingByUserId },
+    seatBalanceByUserId,
+    { freeBalanceByUserId, freeStartingByUserId },
     perUserSpendLimits,
     freeCreditAlertIdsByUserId,
   ] = await Promise.all([
@@ -1160,13 +1167,22 @@ export async function getMembersUsage({
       metronomeCustomerId: metronomeCustomerId ?? null,
       metronomeContractId,
     }),
+    // Paid (seat-managed) live balances — the expensive read, poke-only.
     includeSeatBalance
       ? fetchSeatBalancesForMembersTable({
           metronomeCustomerId: metronomeCustomerId ?? null,
           metronomeContractId,
         })
+      : Promise.resolve(new Map<string, number>()),
+    // Free-seat per-user credit balance + granted total. Needed on every surface
+    // (customer usage page included) to show the member's real allowance, so it
+    // runs whenever the page has free seats — independent of `includeSeatBalance`.
+    freeSeatUserIds.length > 0
+      ? fetchFreeSeatCreditsForMembersTable({
+          metronomeCustomerId: metronomeCustomerId ?? null,
+        })
       : Promise.resolve({
-          balanceByUserId: new Map<string, number>(),
+          freeBalanceByUserId: new Map<string, number>(),
           freeStartingByUserId: new Map<string, number>(),
         }),
     fetchEffectivePerUserSpendLimits({
@@ -1319,10 +1335,11 @@ export async function getMembersUsage({
         memberUsageLimit:
           effectiveAllocationAwu > 0 ? effectiveAllocationAwu : null,
         seatBalanceAwu:
-          effectiveAllocationAwu > 0
-            ? (seatBalanceByUserId.get(userId) ??
-              (membership.seatType === "free" ? 0 : null))
-            : null,
+          membership.seatType === "free"
+            ? (freeBalanceByUserId.get(userId) ?? 0)
+            : effectiveAllocationAwu > 0
+              ? (seatBalanceByUserId.get(userId) ?? null)
+              : null,
         consumedAwuCredits: totalConsumedCredits,
         consumedFromAllowanceAwuCredits,
         consumedFromPoolAwuCredits,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -426,32 +426,40 @@ async function fetchSeatDataForMembersTable({
   }
 }
 
-// Live per-seat AWU balance remaining, keyed by userId. Degrades to an empty
-// map on any read failure so the members table still renders (the column just
-// shows "-"). Mirrors how the seat-balance alerts read the same source.
+// Live per-seat AWU balance remaining (`balanceByUserId`), plus, for free seats,
+// the granted total of the per-user free-seat credit (`freeStartingByUserId`).
+// Free-seat allowances are not a fixed constant — a Dust rep can raise a single
+// member's grant (see the `grant-user-free-credits` poke plugin) — so the table
+// reads each free member's real allowance from their credit rather than the
+// seat-type default. Degrades to empty maps on any read failure so the table
+// still renders (the column just shows "-").
 async function fetchSeatBalancesForMembersTable({
   metronomeCustomerId,
   metronomeContractId,
 }: {
   metronomeCustomerId: string | null;
   metronomeContractId: string | null;
-}): Promise<Map<string, number>> {
+}): Promise<{
+  balanceByUserId: Map<string, number>;
+  freeStartingByUserId: Map<string, number>;
+}> {
   if (!metronomeCustomerId || !metronomeContractId) {
-    return new Map();
+    return { balanceByUserId: new Map(), freeStartingByUserId: new Map() };
   }
   const result = await listMetronomeSeatBalances({
     metronomeCustomerId,
     metronomeContractId,
   });
+  const balanceByUserId = new Map<string, number>();
+  const freeStartingByUserId = new Map<string, number>();
   if (result.isErr()) {
     logger.warn(
       { err: result.error, metronomeCustomerId },
       "[MembersUsage] Failed to fetch seat balances, degrading to empty map"
     );
-    return new Map();
+    return { balanceByUserId, freeStartingByUserId };
   }
   const awuCreditTypeId = getCreditTypeAwuId();
-  const balanceByUserId = new Map<string, number>();
   for (const seat of result.value) {
     const awu = seat.balances.find((b) => b.credit_type_id === awuCreditTypeId);
     if (awu) {
@@ -463,17 +471,22 @@ async function fetchSeatBalancesForMembersTable({
   // they're absent from `listMetronomeSeatBalances`. Fill their remaining
   // balance in from the per-user credits — but only when the user has no seat
   // balance: a user who switched free → pro/max still has a leftover free
-  // credit, and it must not overwrite their (real) pro/max seat balance.
-  // Degrades silently on read failure.
+  // credit, and it must not overwrite their (real) pro/max seat balance. Also
+  // surface each free-seat credit's granted total so the table can show the
+  // member's real allowance. Degrades silently on read failure.
   const perUserCreditBalances = await listCustomerPerUserCreditBalances({
     metronomeCustomerId,
     contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
   });
   if (perUserCreditBalances.isOk()) {
-    for (const [userId, { balanceAwu }] of perUserCreditBalances.value) {
+    for (const [
+      userId,
+      { balanceAwu, startingBalanceAwu },
+    ] of perUserCreditBalances.value) {
       if (!balanceByUserId.has(userId)) {
         balanceByUserId.set(userId, balanceAwu);
       }
+      freeStartingByUserId.set(userId, startingBalanceAwu);
     }
   } else {
     logger.warn(
@@ -482,7 +495,7 @@ async function fetchSeatBalancesForMembersTable({
     );
   }
 
-  return balanceByUserId;
+  return { balanceByUserId, freeStartingByUserId };
 }
 
 async function fetchPerUserCapAlertIdsUncached({
@@ -1107,7 +1120,7 @@ export async function getMembersUsage({
   const [
     perUserTotalConsumedCredits,
     seatDataByUserId,
-    seatBalanceByUserId,
+    { balanceByUserId: seatBalanceByUserId, freeStartingByUserId },
     perUserSpendLimits,
     freeCreditAlertIdsByUserId,
   ] = await Promise.all([
@@ -1125,7 +1138,10 @@ export async function getMembersUsage({
           metronomeCustomerId: metronomeCustomerId ?? null,
           metronomeContractId,
         })
-      : Promise.resolve(new Map<string, number>()),
+      : Promise.resolve({
+          balanceByUserId: new Map<string, number>(),
+          freeStartingByUserId: new Map<string, number>(),
+        }),
     fetchEffectivePerUserSpendLimits({
       metronomeCustomerId: metronomeCustomerId ?? null,
       workspaceId: workspace.sId,
@@ -1190,12 +1206,23 @@ export async function getMembersUsage({
     const awuAllocation = seatData?.awuAllocation ?? 0;
     const scheduled = scheduledByUserId.get(membership.userId);
 
+    // For free seats, the real allowance is the granted total of the member's
+    // per-user free-seat credit (a Dust rep can raise it via the
+    // `grant-user-free-credits` poke plugin), not the fixed seat-type constant.
+    // Only available when seat balances were fetched (poke); elsewhere fall back
+    // to the seat-type allocation.
+    const freeStartingBalanceAwu =
+      membership.seatType === "free"
+        ? (freeStartingByUserId.get(userId) ?? null)
+        : null;
+    const effectiveAllocationAwu = freeStartingBalanceAwu ?? awuAllocation;
+
     // Credits drain seat-allowance-first, then the workspace pool, so the
     // allowance covers up to the user's seat allocation and the remainder
     // overflows to the pool.
     const consumedFromAllowanceAwuCredits = Math.min(
       totalConsumedCredits,
-      awuAllocation
+      effectiveAllocationAwu
     );
     const consumedFromPoolAwuCredits =
       totalConsumedCredits - consumedFromAllowanceAwuCredits;
@@ -1221,10 +1248,11 @@ export async function getMembersUsage({
         : null;
     // Free seats have no pool, so their total spend cap is just the seat
     // allowance (allowance + 0 pool) — the cap includes the allowance like every
-    // other seat, it just has no pool headroom on top.
+    // other seat, it just has no pool headroom on top. Use the member's real
+    // free-credit total (which a rep may have raised) rather than the constant.
     const effectiveDefaultAwuCredits =
       membership.seatType === "free"
-        ? FREE_SEAT_LIFETIME_AWU_CREDITS
+        ? effectiveAllocationAwu
         : defaultAwuCredits;
 
     const spendLimitSource = resolveEffectiveSpendLimitSource({
@@ -1261,9 +1289,10 @@ export async function getMembersUsage({
         email: u.email ?? null,
         image: u.imageUrl ?? null,
         seatType: membership.seatType ?? null,
-        memberUsageLimit: awuAllocation > 0 ? awuAllocation : null,
+        memberUsageLimit:
+          effectiveAllocationAwu > 0 ? effectiveAllocationAwu : null,
         seatBalanceAwu:
-          awuAllocation > 0
+          effectiveAllocationAwu > 0
             ? (seatBalanceByUserId.get(userId) ??
               (membership.seatType === "free" ? 0 : null))
             : null,

--- a/front/lib/api/poke/plugins/workspaces/grant_user_free_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/grant_user_free_credits.ts
@@ -1,7 +1,7 @@
 import { createPlugin } from "@app/lib/api/poke/types";
 import { upsertPerUserCreditBalanceAlerts } from "@app/lib/metronome/alerts/per_user_credit_balance";
 import {
-  adjustCustomerCreditBalance,
+  editCustomerCreditSegmentAmount,
   findPerUserCustomerCreditSegment,
 } from "@app/lib/metronome/client";
 import {
@@ -38,8 +38,8 @@ export const grantUserFreeCreditsPlugin = createPlugin({
     name: "Grant Free Credits to Member",
     description:
       "Grant additional free AWU credits to a specific workspace member on a " +
-      "free seat. Tops up the member's existing per-user free-seat credit via a " +
-      "Metronome ledger entry (no invoice, no second credit) and refreshes their " +
+      "free seat. Raises the granted amount of the member's existing per-user " +
+      "free-seat credit (no invoice, no second credit) and refreshes their " +
       "balance alerts.",
     resourceTypes: ["workspaces"],
     args: {
@@ -120,8 +120,9 @@ export const grantUserFreeCreditsPlugin = createPlugin({
 
     // The free-seat per-user credit is keyed by the free-prefixed Metronome user
     // id (usage for free-seat members is emitted under "free-<sId>"). A member
-    // holds exactly one such credit; we top it up with a manual ledger entry
-    // rather than creating a second credit.
+    // holds exactly one such credit; we raise its granted amount by editing the
+    // access-schedule segment (not a ledger entry), so the credit's *total* — and
+    // every display derived from it — reflects the new allowance.
     const metronomeUserId = toFreeMetronomeUserId(userId);
 
     const segmentResult = await findPerUserCustomerCreditSegment({
@@ -140,30 +141,30 @@ export const grantUserFreeCreditsPlugin = createPlugin({
         )
       );
     }
-    const { creditId, segmentId, startingBalanceAwu } = segmentResult.value;
+    const { creditId, segmentId, segmentAmountAwu, startingBalanceAwu } =
+      segmentResult.value;
 
-    const adjustResult = await adjustCustomerCreditBalance({
+    const newAllowanceAwu = startingBalanceAwu + amountCredits;
+
+    const editResult = await editCustomerCreditSegmentAmount({
       metronomeCustomerId,
       creditId,
       segmentId,
-      amount: amountCredits,
-      reason: `Free credits granted by Dust representative (poke): +${amountCredits} AWU`,
+      amount: segmentAmountAwu + amountCredits,
     });
-    if (adjustResult.isErr()) {
+    if (editResult.isErr()) {
       logger.error(
         {
           workspaceId: workspace.sId,
           userId,
           creditId,
           amountCredits,
-          error: adjustResult.error.message,
+          error: editResult.error.message,
         },
         "[Poke Plugin] Failed to grant free credits to member"
       );
-      return new Err(adjustResult.error);
+      return new Err(editResult.error);
     }
-
-    const newAllowanceAwu = startingBalanceAwu + amountCredits;
 
     // Best-effort: refresh the per-user balance alerts so the low-balance
     // threshold tracks the new total allowance. A failure here does not undo the

--- a/front/lib/api/poke/plugins/workspaces/grant_user_free_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/grant_user_free_credits.ts
@@ -10,7 +10,6 @@ import {
 } from "@app/lib/metronome/constants";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
@@ -79,12 +78,7 @@ export const grantUserFreeCreditsPlugin = createPlugin({
     }
     const { userId, amountCredits } = validationResult.data;
 
-    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
-    if (!workspaceResource) {
-      return new Err(new Error(`Workspace not found: wId='${workspace.sId}'`));
-    }
-
-    const { metronomeCustomerId } = workspaceResource;
+    const { metronomeCustomerId } = workspace;
     if (!metronomeCustomerId) {
       return new Err(
         new Error(

--- a/front/lib/api/poke/plugins/workspaces/grant_user_free_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/grant_user_free_credits.ts
@@ -1,0 +1,193 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { upsertPerUserCreditBalanceAlerts } from "@app/lib/metronome/alerts/per_user_credit_balance";
+import {
+  adjustCustomerCreditBalance,
+  findPerUserCustomerCreditSegment,
+} from "@app/lib/metronome/client";
+import {
+  CONTRACT_CREDIT_TYPE_FREE_SEAT,
+  toFreeMetronomeUserId,
+} from "@app/lib/metronome/constants";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import logger from "@app/logger/logger";
+import { isCreditPricedPlan } from "@app/types/plan";
+import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const GrantUserFreeCreditsArgsSchema = z
+  .object({
+    userId: z.string().min(1, "User sId is required"),
+    amountCredits: z
+      .number()
+      .int("Amount must be a whole number of credits")
+      .positive("Amount must be greater than 0")
+      .finite("Amount must be a valid number"),
+    confirm: z.boolean(),
+  })
+  .refine((data) => data.confirm === true, {
+    message: "Please confirm by checking the confirmation box",
+    path: ["confirm"],
+  });
+
+export const grantUserFreeCreditsPlugin = createPlugin({
+  manifest: {
+    id: "grant-user-free-credits",
+    name: "Grant Free Credits to Member",
+    description:
+      "Grant additional free AWU credits to a specific workspace member on a " +
+      "free seat. Tops up the member's existing per-user free-seat credit via a " +
+      "Metronome ledger entry (no invoice, no second credit) and refreshes their " +
+      "balance alerts.",
+    resourceTypes: ["workspaces"],
+    args: {
+      userId: {
+        type: "string",
+        label: "User sId",
+        description: "The sId of the member to grant free credits to.",
+      },
+      amountCredits: {
+        type: "number",
+        variant: "text",
+        label: "Amount (AWU credits)",
+        description: "Number of free AWU credits to add to the member.",
+      },
+      confirm: {
+        type: "boolean",
+        label: "⚠️ Confirm grant",
+        description:
+          "I confirm that I want to grant these free credits to the member. " +
+          "Free credits are given for free (no invoice).",
+      },
+    },
+    requiredRoles: ["billing"],
+  },
+  isApplicableTo: (auth) => {
+    const plan = auth.plan();
+    return plan !== null && isCreditPricedPlan(plan);
+  },
+  execute: async (auth, workspace, args) => {
+    if (!workspace) {
+      return new Err(new Error("Cannot find workspace."));
+    }
+
+    const validationResult = GrantUserFreeCreditsArgsSchema.safeParse(args);
+    if (!validationResult.success) {
+      return new Err(new Error(fromError(validationResult.error).toString()));
+    }
+    const { userId, amountCredits } = validationResult.data;
+
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    if (!workspaceResource) {
+      return new Err(new Error(`Workspace not found: wId='${workspace.sId}'`));
+    }
+
+    const { metronomeCustomerId } = workspaceResource;
+    if (!metronomeCustomerId) {
+      return new Err(
+        new Error(
+          `Workspace "${workspace.name}" is not provisioned in Metronome.`
+        )
+      );
+    }
+
+    const user = await UserResource.fetchById(userId);
+    if (!user) {
+      return new Err(new Error(`User not found: userId='${userId}'`));
+    }
+
+    const { memberships } = await MembershipResource.getActiveMemberships({
+      workspace,
+      users: [user],
+    });
+    const membership = memberships.find((m) => m.userId === user.id);
+    if (!membership) {
+      return new Err(
+        new Error(
+          `User "${user.email ?? userId}" is not an active member of "${workspace.name}".`
+        )
+      );
+    }
+    if (membership.seatType !== "free") {
+      return new Err(
+        new Error(
+          `Free credits only apply to free seats; "${user.email ?? userId}" is on a "${membership.seatType ?? "none"}" seat.`
+        )
+      );
+    }
+
+    // The free-seat per-user credit is keyed by the free-prefixed Metronome user
+    // id (usage for free-seat members is emitted under "free-<sId>"). A member
+    // holds exactly one such credit; we top it up with a manual ledger entry
+    // rather than creating a second credit.
+    const metronomeUserId = toFreeMetronomeUserId(userId);
+
+    const segmentResult = await findPerUserCustomerCreditSegment({
+      metronomeCustomerId,
+      contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
+      userId: metronomeUserId,
+    });
+    if (segmentResult.isErr()) {
+      return new Err(segmentResult.error);
+    }
+    if (!segmentResult.value) {
+      return new Err(
+        new Error(
+          `No active free-seat credit found for "${user.email ?? userId}". ` +
+            "Reconcile the workspace seats first so the member's free credit exists."
+        )
+      );
+    }
+    const { creditId, segmentId, startingBalanceAwu } = segmentResult.value;
+
+    const adjustResult = await adjustCustomerCreditBalance({
+      metronomeCustomerId,
+      creditId,
+      segmentId,
+      amount: amountCredits,
+      reason: `Free credits granted by Dust representative (poke): +${amountCredits} AWU`,
+    });
+    if (adjustResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          userId,
+          creditId,
+          amountCredits,
+          error: adjustResult.error.message,
+        },
+        "[Poke Plugin] Failed to grant free credits to member"
+      );
+      return new Err(adjustResult.error);
+    }
+
+    const newAllowanceAwu = startingBalanceAwu + amountCredits;
+
+    // Best-effort: refresh the per-user balance alerts so the low-balance
+    // threshold tracks the new total allowance. A failure here does not undo the
+    // grant.
+    const alertResult = await upsertPerUserCreditBalanceAlerts({
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+      userId: metronomeUserId,
+      allowanceAwu: newAllowanceAwu,
+    });
+    if (alertResult.isErr()) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          userId,
+          error: alertResult.error.message,
+        },
+        "[Poke Plugin] Granted free credits but failed to refresh balance alerts"
+      );
+    }
+
+    return new Ok({
+      display: "text",
+      value: `Granted ${amountCredits.toLocaleString()} free AWU credits to ${user.email ?? userId}. New total free allowance: ${newAllowanceAwu.toLocaleString()} credits.`,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -16,6 +16,7 @@ export * from "./disable_sso_enforcement";
 export * from "./extend_trial";
 export * from "./extension_blacklist_domains";
 export * from "./grant_awu_credits";
+export * from "./grant_user_free_credits";
 export * from "./insert_verified_workspace_verification_attempt";
 export * from "./invite_user";
 export * from "./manage_audit_logs_kill_switch";

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -2709,6 +2709,129 @@ export async function listCustomerPerUserCreditBalances({
 }
 
 /**
+ * Find a member's per-user customer credit (e.g. the free-seat credit) and the
+ * access-schedule segment active at `coveringDate`, plus its starting balance
+ * (sum of the credit's schedule-item amounts). Returns the
+ * `{ creditId, segmentId }` pair required to post a manual ledger entry via
+ * `adjustCustomerCreditBalance`. `userId` is the value stored in the per-user
+ * custom field — the free-prefixed Metronome user id ("free-<sId>") for free
+ * seats. Skips contract-scoped credits (these are standalone customer credits)
+ * and archived ones (we only adjust the active credit). Returns null when no
+ * matching active segment is found.
+ */
+export async function findPerUserCustomerCreditSegment({
+  metronomeCustomerId,
+  contractCreditType,
+  userId,
+  coveringDate = new Date(),
+}: {
+  metronomeCustomerId: string;
+  contractCreditType: ContractCreditType;
+  userId: string;
+  coveringDate?: Date;
+}): Promise<
+  Result<
+    { creditId: string; segmentId: string; startingBalanceAwu: number } | null,
+    Error
+  >
+> {
+  if (!config.getMetronomeApiKey()) {
+    return new Ok(null);
+  }
+
+  const client = getMetronomeClient();
+  const coveringMs = coveringDate.getTime();
+
+  try {
+    for await (const entry of client.v1.customers.credits.list({
+      customer_id: metronomeCustomerId,
+      include_balance: false,
+    })) {
+      if (entry.contract) {
+        continue;
+      }
+      if (
+        entry.custom_fields?.[PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY] !==
+          userId ||
+        entry.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY] !==
+          contractCreditType
+      ) {
+        continue;
+      }
+      const scheduleItems = entry.access_schedule?.schedule_items ?? [];
+      const segment = scheduleItems.find((item) => {
+        const startMs = new Date(item.starting_at).getTime();
+        const endMs = new Date(item.ending_before).getTime();
+        return startMs <= coveringMs && coveringMs < endMs;
+      });
+      if (segment) {
+        return new Ok({
+          creditId: entry.id,
+          segmentId: segment.id,
+          startingBalanceAwu: scheduleItems.reduce(
+            (sum, item) => sum + item.amount,
+            0
+          ),
+        });
+      }
+    }
+    return new Ok(null);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, userId },
+      "[Metronome] Failed to find per-user customer credit segment"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Post a manual ledger entry against a customer-level credit (no contract), such
+ * as a free-seat per-user credit. A positive amount tops the balance up, a
+ * negative one draws it down. This is the customer-level counterpart of
+ * `adjustSeatCreditBalances` (which targets seat-managed contract credit pools):
+ * `contract_id` is left blank so Metronome updates the customer-level balance,
+ * and the `reason` is recorded on the credit's ledger. `timestamp` defaults to
+ * the start of the segment.
+ */
+export async function adjustCustomerCreditBalance({
+  metronomeCustomerId,
+  creditId,
+  segmentId,
+  amount,
+  reason,
+}: {
+  metronomeCustomerId: string;
+  creditId: string;
+  segmentId: string;
+  amount: number;
+  reason: string;
+}): Promise<Result<void, Error>> {
+  try {
+    await getMetronomeClient().v1.contracts.addManualBalanceEntry({
+      id: creditId,
+      customer_id: metronomeCustomerId,
+      segment_id: segmentId,
+      amount,
+      reason,
+    });
+    logger.info(
+      { metronomeCustomerId, creditId, segmentId, amount },
+      "[Metronome] Customer credit manual ledger entry applied"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, creditId, segmentId, amount },
+      "[Metronome] Failed to apply customer credit manual ledger entry"
+    );
+    return new Err(error);
+  }
+}
+
+/**
  * Revoke a per-user customer credit by setting its end date to the next round
  * hour. Metronome requires hour-aligned timestamps; ceiling to the next hour is
  * safe here because the credit is keyed on the free-seat Metronome user id

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -2731,7 +2731,12 @@ export async function findPerUserCustomerCreditSegment({
   coveringDate?: Date;
 }): Promise<
   Result<
-    { creditId: string; segmentId: string; startingBalanceAwu: number } | null,
+    {
+      creditId: string;
+      segmentId: string;
+      segmentAmountAwu: number;
+      startingBalanceAwu: number;
+    } | null,
     Error
   >
 > {
@@ -2768,6 +2773,7 @@ export async function findPerUserCustomerCreditSegment({
         return new Ok({
           creditId: entry.id,
           segmentId: segment.id,
+          segmentAmountAwu: segment.amount,
           startingBalanceAwu: scheduleItems.reduce(
             (sum, item) => sum + item.amount,
             0
@@ -2787,45 +2793,43 @@ export async function findPerUserCustomerCreditSegment({
 }
 
 /**
- * Post a manual ledger entry against a customer-level credit (no contract), such
- * as a free-seat per-user credit. A positive amount tops the balance up, a
- * negative one draws it down. This is the customer-level counterpart of
- * `adjustSeatCreditBalances` (which targets seat-managed contract credit pools):
- * `contract_id` is left blank so Metronome updates the customer-level balance,
- * and the `reason` is recorded on the credit's ledger. `timestamp` defaults to
- * the start of the segment.
+ * Edit the granted amount of a customer credit's access-schedule segment via the
+ * v2 "edit a credit" endpoint. Unlike a manual ledger entry (which only moves the
+ * running balance and leaves the credit's granted total untouched), this rewrites
+ * the segment amount so the credit's *total* changes and the balance recomputes
+ * against it. `editCredit` takes no `contract_id`, so it works on contract-less
+ * customer credits such as free-seat per-user credits. `amount` is the new
+ * absolute segment amount.
  */
-export async function adjustCustomerCreditBalance({
+export async function editCustomerCreditSegmentAmount({
   metronomeCustomerId,
   creditId,
   segmentId,
   amount,
-  reason,
 }: {
   metronomeCustomerId: string;
   creditId: string;
   segmentId: string;
   amount: number;
-  reason: string;
 }): Promise<Result<void, Error>> {
   try {
-    await getMetronomeClient().v1.contracts.addManualBalanceEntry({
-      id: creditId,
+    await getMetronomeClient().v2.contracts.editCredit({
+      credit_id: creditId,
       customer_id: metronomeCustomerId,
-      segment_id: segmentId,
-      amount,
-      reason,
+      access_schedule: {
+        update_schedule_items: [{ id: segmentId, amount }],
+      },
     });
     logger.info(
       { metronomeCustomerId, creditId, segmentId, amount },
-      "[Metronome] Customer credit manual ledger entry applied"
+      "[Metronome] Customer credit segment amount edited"
     );
     return new Ok(undefined);
   } catch (err) {
     const error = normalizeError(err);
     logger.error(
       { error, metronomeCustomerId, creditId, segmentId, amount },
-      "[Metronome] Failed to apply customer credit manual ledger entry"
+      "[Metronome] Failed to edit customer credit segment amount"
     );
     return new Err(error);
   }


### PR DESCRIPTION
## Description

Adds a "Grant Free Credits to Member" poke plugin, invokable per-row from the members table in a workspace's Usage tab (free seats only): it raises the member's existing per-user free-seat credit's granted amount in Metronome via `v2.contracts.editCredit` (no invoice, no second credit) and refreshes their balance alerts. Because free-seat allowances had been a fixed `FREE_SEAT_LIFETIME_AWU_CREDITS` constant in several places, the poke members table, the customer usage-page "Credits usage" column, and the personal-settings "Your Credits" bar now all read each free member's real allowance/balance from their per-user credit (fixing displays like `1798/500`, `500/500`, and `NaN/500` → `2/1800`). Also hardens `AwuUsageBar` against a missing balance (`!= null`) and hides the "Edit spend limit" row action for free/none/seatless members, who have no pool to cap.

## Tests

Manual testing in poke and the customer Usage/Settings surfaces (grant flow, balance + allowance/cap consistency across all three gauges, menu visibility per seat type); type-check (`tsgo`) and biome pass.

## Risk

Low and free-seat-scoped: paid/none seat rows produce byte-identical display output, the plugin and its Metronome helpers only run for free-seat credits, and the only broader change is one extra `credits.list` read on the customer usage page when free seats are present (skipped otherwise). Safe to roll back (revert the branch).

## Deploy Plan

Standard front deploy, no migrations or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)