### PR TITLE
Add sandbox owners transition

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -123,6 +123,7 @@ import {
 import {
   ConversationSandboxModel,
   SandboxModel,
+  SandboxOwnerModel,
 } from "@app/lib/resources/storage/models/sandbox";
 import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
@@ -258,6 +259,7 @@ export function loadAllModels() {
     AcademyChapterVisitModel,
     SandboxModel,
     ConversationSandboxModel,
+    SandboxOwnerModel,
     ConversationBranchModel,
     ConversationForkModel,
     ProjectTaskModel,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -6844,6 +6844,7 @@ const KNOWN_CONVERSATION_RELATED_MODELS = [
   "message",
   "project_todo_conversation",
   "sandbox",
+  "sandbox_owner",
   // skill_suggestion.notificationConversationId is ON DELETE SET NULL, so no
   // explicit cleanup is needed in destroyConversation — the DB clears it.
   "skill_suggestion",

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -55,6 +55,7 @@ import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import {
   ConversationSandboxModel,
   SandboxModel,
+  SandboxOwnerModel,
 } from "@app/lib/resources/storage/models/sandbox";
 import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -64,6 +65,7 @@ import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Ok } from "@app/types/shared/result";
 import { encrypt } from "@app/types/shared/utils/encryption";
+import type { WhereOptions } from "sequelize";
 
 describe("SandboxResource.updateStatus", () => {
   let authenticator: Authenticator;
@@ -245,12 +247,12 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
       }
     );
 
-    await ConversationSandboxModel.destroy({
-      where: {
-        sandboxId: sandbox.id,
-        workspaceId: authenticator.getNonNullableWorkspace().id,
-      },
-    });
+    const where: WhereOptions = {
+      sandboxId: sandbox.id,
+      workspaceId: authenticator.getNonNullableWorkspace().id,
+    };
+    await SandboxOwnerModel.destroy({ where });
+    await ConversationSandboxModel.destroy({ where });
 
     const result = await SandboxResource.dangerouslyDestroyIfSleeping(
       authenticator,
@@ -603,15 +605,49 @@ describe("SandboxResource.fetchByConversation", () => {
     expect(fetched?.id).toBe(sandbox.id);
   });
 
-  it("returns null when no ownership row exists", async () => {
+  it("writes both ownership tables", async () => {
+    const conversation = await makeConversation();
+    const sandbox = await SandboxFactory.create(authenticator, conversation);
+    const where = {
+      sandboxId: sandbox.id,
+      workspaceId: authenticator.getNonNullableWorkspace().id,
+    };
+
+    await expect(ConversationSandboxModel.count({ where })).resolves.toBe(1);
+    await expect(SandboxOwnerModel.count({ where })).resolves.toBe(1);
+  });
+
+  it("falls back to conversation_sandboxes during the migration window", async () => {
     const conversation = await makeConversation();
     const sandbox = await SandboxFactory.create(authenticator, conversation);
 
-    await ConversationSandboxModel.destroy({
+    await SandboxOwnerModel.destroy({
       where: {
         sandboxId: sandbox.id,
         workspaceId: authenticator.getNonNullableWorkspace().id,
       },
+    });
+
+    const fetched = await SandboxResource.fetchByConversation(
+      authenticator,
+      conversation
+    );
+
+    expect(fetched?.id).toBe(sandbox.id);
+  });
+
+  it("returns null when no ownership row exists", async () => {
+    const conversation = await makeConversation();
+    const sandbox = await SandboxFactory.create(authenticator, conversation);
+    const where = {
+      sandboxId: sandbox.id,
+      workspaceId: authenticator.getNonNullableWorkspace().id,
+    };
+
+    await SandboxOwnerModel.destroy({ where });
+
+    await ConversationSandboxModel.destroy({
+      where,
     });
 
     const fetched = await SandboxResource.fetchByConversation(

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -24,6 +24,7 @@ import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import {
   ConversationSandboxModel,
   SandboxModel,
+  SandboxOwnerModel,
 } from "@app/lib/resources/storage/models/sandbox";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -60,6 +61,8 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   static model: ModelStaticWorkspaceAware<SandboxModel> = SandboxModel;
   private static conversationSandboxModel: ModelStaticWorkspaceAware<ConversationSandboxModel> =
     ConversationSandboxModel;
+  private static sandboxOwnerModel: ModelStaticWorkspaceAware<SandboxOwnerModel> =
+    SandboxOwnerModel;
 
   private static deleteEgressPolicyAfterDestroy(
     sandbox: SandboxResource
@@ -146,6 +149,15 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         { transaction: t }
       );
 
+      await SandboxOwnerModel.create(
+        {
+          workspaceId,
+          conversationId: blob.conversationId,
+          sandboxId: sandbox.id,
+        },
+        { transaction: t }
+      );
+
       return sandbox;
     };
 
@@ -210,12 +222,22 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   private static async dangerouslyFetchByConversation(
     conversation: ConversationResource
   ): Promise<SandboxResource | null> {
-    const link = await this.conversationSandboxModel.findOne({
+    const owner = await this.sandboxOwnerModel.findOne({
       where: {
         workspaceId: conversation.workspaceId,
         conversationId: conversation.id,
       },
     });
+
+    const link =
+      owner ??
+      (await this.conversationSandboxModel.findOne({
+        where: {
+          workspaceId: conversation.workspaceId,
+          conversationId: conversation.id,
+        },
+      }));
+
     if (link) {
       const sandbox = await this.model.findOne({
         where: {
@@ -236,12 +258,22 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     auth: Authenticator,
     conversation: ConversationSandboxOwner
   ): Promise<SandboxResource | null> {
-    const link = await this.conversationSandboxModel.findOne({
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const owner = await this.sandboxOwnerModel.findOne({
       where: {
         conversationId: conversation.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId,
       },
     });
+
+    const link =
+      owner ??
+      (await this.conversationSandboxModel.findOne({
+        where: {
+          conversationId: conversation.id,
+          workspaceId,
+        },
+      }));
 
     if (link) {
       const sandboxes = await this.baseFetch(auth, {
@@ -281,12 +313,25 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       );
     }
 
-    const rows: ConversationSandboxModel[] = [];
+    const conversationModelIdsBySandboxModelId = new Map<ModelId, ModelId>();
     for (const [
       workspaceModelId,
       sandboxModelIds,
     ] of sandboxModelIdsByWorkspaceModelId.entries()) {
-      const workspaceRows = await this.conversationSandboxModel.findAll({
+      const ownerRows = await this.sandboxOwnerModel.findAll({
+        where: {
+          workspaceId: workspaceModelId,
+          conversationId: {
+            [Op.ne]: null,
+          },
+          sandboxId: {
+            [Op.in]: sandboxModelIds,
+          },
+        },
+        attributes: ["sandboxId", "conversationId"],
+      });
+
+      const conversationRows = await this.conversationSandboxModel.findAll({
         where: {
           workspaceId: workspaceModelId,
           sandboxId: {
@@ -295,10 +340,24 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         },
         attributes: ["sandboxId", "conversationId"],
       });
-      rows.push(...workspaceRows);
+
+      for (const row of conversationRows) {
+        conversationModelIdsBySandboxModelId.set(
+          row.sandboxId,
+          row.conversationId
+        );
+      }
+      for (const row of ownerRows) {
+        if (row.conversationId !== null) {
+          conversationModelIdsBySandboxModelId.set(
+            row.sandboxId,
+            row.conversationId
+          );
+        }
+      }
     }
 
-    return new Map(rows.map((r) => [r.sandboxId, r.conversationId]));
+    return conversationModelIdsBySandboxModelId;
   }
 
   async updateStatus(
@@ -342,6 +401,14 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   ): Promise<Result<number, Error>> {
     const workspaceId = auth.getNonNullableWorkspace().id;
     const deleteSandbox = async (t: Transaction) => {
+      await SandboxOwnerModel.destroy({
+        where: {
+          sandboxId: this.id,
+          workspaceId,
+        },
+        transaction: t,
+      });
+
       await ConversationSandboxModel.destroy({
         where: {
           sandboxId: this.id,
@@ -397,6 +464,14 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       }
 
       await withTransaction(async (transaction) => {
+        await SandboxOwnerModel.destroy({
+          where: {
+            sandboxId: sandbox.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+          transaction,
+        });
+
         await ConversationSandboxModel.destroy({
           where: {
             conversationId: conversation.id,

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1746,6 +1746,7 @@ const KNOWN_SPACE_RELATED_MODELS = [
   "group_vaults",
   "mcp_server_view",
   "sandbox_function",
+  "sandbox_owner",
   "project_metadata",
   "project_todo",
   "project_todo_state",

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -11,6 +11,7 @@ import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticSoftDeletable } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -621,6 +622,16 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           transaction,
         }
       );
+    }
+
+    if (hardDelete) {
+      await SandboxOwnerModel.destroy({
+        where: {
+          spaceId: this.id,
+          workspaceId,
+        },
+        transaction,
+      });
     }
 
     await SpaceModel.destroy({

--- a/front/lib/resources/storage/models/sandbox.ts
+++ b/front/lib/resources/storage/models/sandbox.ts
@@ -1,6 +1,7 @@
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 
@@ -15,8 +16,8 @@ export class SandboxModel extends WorkspaceAwareModel<SandboxModel> {
   declare updatedAt: CreationOptional<Date>;
 
   // TODO(2026-06-17 SANDBOX): Drop this legacy owner column once
-  // conversation_sandboxes fully replaces it.
-  declare conversationId: ForeignKey<ConversationModel["id"]>;
+  // sandbox_owners fully replaces it.
+  declare conversationId: ForeignKey<ConversationModel["id"]> | null;
   declare providerId: string;
   declare status: SandboxStatus;
   declare statusChangedAt: CreationOptional<Date>;
@@ -43,7 +44,7 @@ SandboxModel.init(
     },
     conversationId: {
       type: DataTypes.BIGINT,
-      allowNull: false,
+      allowNull: true,
       references: {
         model: ConversationModel,
         key: "id",
@@ -192,4 +193,118 @@ ConversationSandboxModel.belongsTo(SandboxModel, {
 SandboxModel.hasOne(ConversationSandboxModel, {
   foreignKey: { name: "sandboxId", allowNull: false },
   as: "conversationLink",
+});
+
+export class SandboxOwnerModel extends WorkspaceAwareModel<SandboxOwnerModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare conversationId: ForeignKey<ConversationModel["id"]> | null;
+  declare spaceId: ForeignKey<SpaceModel["id"]> | null;
+  declare sandboxId: ForeignKey<SandboxModel["id"]>;
+
+  declare conversation: NonAttribute<ConversationModel>;
+  declare space: NonAttribute<SpaceModel>;
+  declare sandbox: NonAttribute<SandboxModel>;
+}
+
+SandboxOwnerModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    conversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
+    spaceId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
+    sandboxId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "sandbox_owner",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        unique: true,
+        fields: ["workspaceId", "sandboxId"],
+        name: "sandbox_owners_workspace_sandbox_idx",
+        concurrently: true,
+      },
+      {
+        unique: true,
+        fields: ["workspaceId", "conversationId"],
+        name: "sandbox_owners_workspace_conversation_idx",
+        where: { conversationId: { [Op.ne]: null } },
+        concurrently: true,
+      },
+      {
+        unique: true,
+        fields: ["workspaceId", "spaceId"],
+        name: "sandbox_owners_workspace_space_idx",
+        where: { spaceId: { [Op.ne]: null } },
+        concurrently: true,
+      },
+      {
+        fields: ["conversationId"],
+        name: "sandbox_owners_conversation_id_idx",
+        concurrently: true,
+      },
+      {
+        fields: ["spaceId"],
+        name: "sandbox_owners_space_id_idx",
+        concurrently: true,
+      },
+      {
+        fields: ["sandboxId"],
+        name: "sandbox_owners_sandbox_id_idx",
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+SandboxOwnerModel.belongsTo(ConversationModel, {
+  foreignKey: { name: "conversationId", allowNull: true },
+  onDelete: "RESTRICT",
+  as: "conversation",
+});
+
+ConversationModel.hasMany(SandboxOwnerModel, {
+  foreignKey: { name: "conversationId", allowNull: true },
+  as: "sandboxOwnerLinks",
+});
+
+SandboxOwnerModel.belongsTo(SpaceModel, {
+  foreignKey: { name: "spaceId", allowNull: true },
+  onDelete: "RESTRICT",
+  as: "space",
+});
+
+SpaceModel.hasMany(SandboxOwnerModel, {
+  foreignKey: { name: "spaceId", allowNull: true },
+  as: "sandboxOwnerLinks",
+});
+
+SandboxOwnerModel.belongsTo(SandboxModel, {
+  foreignKey: { name: "sandboxId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "sandbox",
+});
+
+SandboxModel.hasOne(SandboxOwnerModel, {
+  foreignKey: { name: "sandboxId", allowNull: false },
+  as: "ownerLink",
 });

--- a/front/migrations/20260627_backfill_sandbox_owners.ts
+++ b/front/migrations/20260627_backfill_sandbox_owners.ts
@@ -1,0 +1,80 @@
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { makeScript } from "@app/scripts/helpers";
+
+type CountRow = { count: number };
+
+async function countRows(sql: string): Promise<number> {
+  const [{ count }] = await frontSequelize.query<CountRow>(sql, {
+    type: QueryTypes.SELECT,
+  });
+  return count;
+}
+
+async function countMissingSandboxOwners(): Promise<number> {
+  return countRows(`
+    SELECT COUNT(*)::int AS "count"
+    FROM "conversation_sandboxes" cs
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "sandbox_owners" so
+      WHERE so."workspaceId" = cs."workspaceId"
+        AND so."conversationId" = cs."conversationId"
+        AND so."sandboxId" = cs."sandboxId"
+    )
+  `);
+}
+
+async function countExtraSandboxOwners(): Promise<number> {
+  return countRows(`
+    SELECT COUNT(*)::int AS "count"
+    FROM "sandbox_owners" so
+    WHERE so."conversationId" IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM "conversation_sandboxes" cs
+        WHERE cs."workspaceId" = so."workspaceId"
+          AND cs."conversationId" = so."conversationId"
+          AND cs."sandboxId" = so."sandboxId"
+      )
+  `);
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  const missingBefore = await countMissingSandboxOwners();
+  const extraBefore = await countExtraSandboxOwners();
+
+  logger.info({ missingBefore, extraBefore }, "Checked sandbox owner drift");
+
+  if (execute) {
+    await countRows(`
+      WITH inserted AS (
+        INSERT INTO "sandbox_owners"
+          ("createdAt", "updatedAt", "conversationId", "sandboxId", "workspaceId")
+        SELECT
+          cs."createdAt",
+          NOW(),
+          cs."conversationId",
+          cs."sandboxId",
+          cs."workspaceId"
+        FROM "conversation_sandboxes" cs
+        WHERE NOT EXISTS (
+          SELECT 1 FROM "sandbox_owners" so
+          WHERE so."workspaceId" = cs."workspaceId"
+            AND so."conversationId" = cs."conversationId"
+            AND so."sandboxId" = cs."sandboxId"
+        )
+        ON CONFLICT DO NOTHING RETURNING 1
+      )
+      SELECT COUNT(*)::int AS "count" FROM inserted
+    `);
+  }
+
+  const missingAfter = await countMissingSandboxOwners();
+  const extraAfter = await countExtraSandboxOwners();
+
+  if (execute && (missingAfter > 0 || extraAfter > 0)) {
+    throw new Error(
+      `sandbox_owners is not ISO with conversation_sandboxes: missing=${missingAfter} extra=${extraAfter}`
+    );
+  }
+});

--- a/front/migrations/pre-deploy/20260627103000_create_sandbox_owners.sql
+++ b/front/migrations/pre-deploy/20260627103000_create_sandbox_owners.sql
@@ -1,0 +1,36 @@
+-- Add the generic sandbox ownership table.
+SET lock_timeout = '5s';
+
+ALTER TABLE "public"."sandboxes"
+  ALTER COLUMN "conversationId" DROP NOT NULL;
+
+CREATE TABLE "public"."sandbox_owners"
+(
+  "createdAt"      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedAt"      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "conversationId" BIGINT REFERENCES "public"."conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "spaceId"        BIGINT REFERENCES "public"."vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "sandboxId"      BIGINT                   NOT NULL REFERENCES "public"."sandboxes" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "workspaceId"    BIGINT                   NOT NULL REFERENCES "public"."workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "id"             BIGSERIAL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "sandbox_owners_exactly_one_owner_check"
+    CHECK (num_nonnulls("conversationId", "spaceId") = 1)
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY "sandbox_owners_workspace_sandbox_idx"
+  ON "public"."sandbox_owners" ("workspaceId", "sandboxId");
+
+CREATE UNIQUE INDEX CONCURRENTLY "sandbox_owners_workspace_conversation_idx"
+  ON "public"."sandbox_owners" ("workspaceId", "conversationId")
+  WHERE "conversationId" IS NOT NULL;
+
+CREATE UNIQUE INDEX CONCURRENTLY "sandbox_owners_workspace_space_idx"
+  ON "public"."sandbox_owners" ("workspaceId", "spaceId")
+  WHERE "spaceId" IS NOT NULL;
+
+CREATE INDEX CONCURRENTLY "sandbox_owners_conversation_id_idx" ON "public"."sandbox_owners" ("conversationId");
+
+CREATE INDEX CONCURRENTLY "sandbox_owners_space_id_idx" ON "public"."sandbox_owners" ("spaceId");
+
+CREATE INDEX CONCURRENTLY "sandbox_owners_sandbox_id_idx" ON "public"."sandbox_owners" ("sandboxId");


### PR DESCRIPTION
## Description

Follow up of #28006. Adds the generic `sandbox_owners` table so sandbox ownership can move from conversation-only links to either a conversation or a space.

This keeps `conversation_sandboxes` alive during the transition. Conversation sandbox creation/deletion writes both tables, and reads prefer `sandbox_owners` with `conversation_sandboxes` as the migration fallback. The separate backfill script copies existing conversation owners into `sandbox_owners` and checks both tables are ISO after execution.

Stack:
- PR 1: create `sandbox_owners`, dual write/read, and add the data migration script.
- PR 2: remove runtime reads/writes from `conversation_sandboxes`.
- PR 3: cleanup the legacy `conversation_sandboxes` table.
- Follow-ups: rebase the conversation boundary, space sandbox resource, and reaper PRs on top.

## Tests

- `source \"$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh\" && psql \"$TEST_FRONT_DATABASE_URI\" -v ON_ERROR_STOP=1 -f front/migrations/pre-deploy/20260627103000_create_sandbox_owners.sql`
- `source \"$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh\" && NODE_ENV=test npm test -- lib/resources/sandbox_resource.test.ts`
- `source \"$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh\" && NODE_OPTIONS=\"--max-old-space-size=8192\" npx tsc --noEmit`

## Risk

Medium. The app reads and writes both ownership tables while the data migration runs, so rollback is safe before later cleanup PRs. Worst case, `sandbox_owners` backfill drift is detected by the script and the next PR stays blocked.

## Deploy Plan

- [ ] Apply `front/migrations/pre-deploy/20260627103000_create_sandbox_owners.sql` in both regions.
- [ ] Deploy front with dual writes and dual reads.
- [ ] Run `cd front && npx tsx migrations/20260627_backfill_sandbox_owners.ts` as a dry run.
- [ ] Run `cd front && npx tsx migrations/20260627_backfill_sandbox_owners.ts --execute` in both regions.
- [ ] Confirm the script reports `missing=0` and `extra=0` after execution.

!