### PR TITLE
Decouple sandbox creation from conversation ownership

### DIFF
--- a/front/lib/api/sandbox/access_tokens.test.ts
+++ b/front/lib/api/sandbox/access_tokens.test.ts
@@ -43,7 +43,6 @@ async function setupTest() {
   });
 
   const sandbox = await SandboxResource.makeNew(auth, {
-    conversationId: conversation.id,
     providerId: "test-provider-id",
     status: "running",
     baseImage: "dust-base",

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -26,11 +26,13 @@ import { RunResource } from "@app/lib/resources/run_resource";
 import {
   type ConversationSandboxOwner,
   type EnsureSandboxResult,
+  type SandboxCreateBlob,
   SandboxResource,
 } from "@app/lib/resources/sandbox_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -361,6 +363,31 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return SandboxResource.fetchByConversation(auth, conversation);
   }
 
+  private static async createSandboxRecordForConversation(
+    auth: Authenticator,
+    conversation: ConversationSandboxOwner,
+    blob: SandboxCreateBlob
+  ): Promise<SandboxResource> {
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+
+    return withTransaction(async (transaction) => {
+      const sandbox = await SandboxResource.makeNew(auth, blob, {
+        transaction,
+      });
+
+      await SandboxOwnerModel.create(
+        {
+          workspaceId: workspaceModelId,
+          conversationId: conversation.id,
+          sandboxId: sandbox.id,
+        },
+        { transaction }
+      );
+
+      return sandbox;
+    });
+  }
+
   async fetchSandbox(auth: Authenticator): Promise<SandboxResource | null> {
     return ConversationResource.fetchSandbox(auth, this);
   }
@@ -369,7 +396,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     auth: Authenticator,
     conversation: ConversationSandboxOwner
   ): Promise<Result<EnsureSandboxResult, Error>> {
-    return SandboxResource.ensureActive(auth, conversation);
+    return SandboxResource.ensureActive(auth, {
+      lockKey: conversation.sId,
+      envVars: { CONVERSATION_ID: conversation.sId },
+      logLabel: "conversation",
+      fetchSandbox: () => this.fetchSandbox(auth, conversation),
+      createSandbox: (blob) =>
+        this.createSandboxRecordForConversation(auth, conversation, blob),
+    });
   }
 
   async ensureSandboxActive(

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -678,6 +678,7 @@ describe("SandboxResource.ensureActive", () => {
           imageId: { imageName: "test-image", tag: "0.0.1" },
           envVars: {
             DST_API_TOKEN: "image-token",
+            POD_ID: "image-pod-id",
             WORKSPACE_ID: "image-workspace-id",
           },
           network: { egress: "restricted" },
@@ -758,7 +759,7 @@ describe("SandboxResource.ensureActive", () => {
       },
     ]);
 
-    const result = await SandboxResource.ensureActive(
+    const result = await ConversationResource.ensureSandboxActive(
       authenticator,
       conversation
     );
@@ -793,11 +794,14 @@ describe("SandboxResource.ensureActive", () => {
     expect(mockProviderCreate.mock.calls[0]?.[0].envVars).not.toHaveProperty(
       "DD_HOST"
     );
+    expect(mockProviderCreate.mock.calls[0]?.[0].envVars).not.toHaveProperty(
+      "POD_ID"
+    );
     expect(mockProviderExec).not.toHaveBeenCalled();
   });
 
   it("records baseImage and version from the registered image on fresh create", async () => {
-    const result = await SandboxResource.ensureActive(
+    const result = await ConversationResource.ensureSandboxActive(
       authenticator,
       conversation
     );
@@ -827,7 +831,7 @@ describe("SandboxResource.ensureActive", () => {
       version: "0.0.0-old",
     });
 
-    const result = await SandboxResource.ensureActive(
+    const result = await ConversationResource.ensureSandboxActive(
       authenticator,
       conversation
     );
@@ -852,7 +856,7 @@ describe("SandboxResource.ensureActive", () => {
       killRequestedAt: new Date(),
     });
 
-    const result = await SandboxResource.ensureActive(
+    const result = await ConversationResource.ensureSandboxActive(
       authenticator,
       conversation
     );

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -53,6 +53,31 @@ export type ConversationSandboxOwner = Pick<
   "id" | "sId"
 >;
 
+export type SandboxCreateBlob = {
+  providerId: string;
+  status: SandboxStatus;
+  baseImage: string;
+  version: string;
+};
+
+export type SandboxLifecycleOwner = {
+  lockKey: string;
+  fetchSandbox: () => Promise<SandboxResource | null>;
+};
+
+export type SandboxCreateOwner = SandboxLifecycleOwner & {
+  createSandbox: (blob: SandboxCreateBlob) => Promise<SandboxResource>;
+  envVars: Record<string, string>;
+  logLabel: string;
+};
+
+// Owner identity env vars are reserved for owner adapters. SandboxResource
+// only enforces the env contract and does not interpret owner types.
+const SANDBOX_OWNER_ENV_VAR_CONTRACT_NAMES = new Set([
+  "CONVERSATION_ID",
+  "POD_ID",
+]);
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SandboxResource extends ReadonlyAttributesType<SandboxModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -114,35 +139,19 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
   static async makeNew(
     auth: Authenticator,
-    blob: {
-      conversationId: number;
-      providerId: string;
-      status: SandboxStatus;
-      baseImage: string;
-      version: string;
-    },
+    blob: SandboxCreateBlob,
     { transaction }: { transaction?: Transaction } = {}
   ) {
     const now = new Date();
     const workspaceId = auth.getNonNullableWorkspace().id;
-    const { conversationId, ...sandboxBlob } = blob;
 
     const createSandbox = async (t: Transaction) => {
       const sandbox = await this.model.create(
         {
-          ...sandboxBlob,
+          ...blob,
           workspaceId,
           lastActivityAt: now,
           statusChangedAt: now,
-        },
-        { transaction: t }
-      );
-
-      await SandboxOwnerModel.create(
-        {
-          workspaceId,
-          conversationId,
-          sandboxId: sandbox.id,
         },
         { transaction: t }
       );
@@ -437,7 +446,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   // ---------------------------------------------------------------------------
 
   private static async withLifecycleLock<T>(
-    conversationId: string,
+    ownerLockKey: string,
     fn: (provider: SandboxProvider) => Promise<Result<T, Error>>
   ): Promise<Result<T, Error>> {
     const provider = getSandboxProvider();
@@ -446,7 +455,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     }
 
     return executeWithLock(
-      `sandbox:lifecycle:${conversationId}`,
+      `sandbox:lifecycle:${ownerLockKey}`,
       () => fn(provider),
       undefined,
       { traceAcquireResource: "sandbox:lifecycle" }
@@ -454,12 +463,13 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   }
 
   // Compose the env vars passed to provider.create. Precedence (lowest →
-  // highest): workspace env vars → image runEnv → system vars. The image and
-  // system layers always win, so even if a row slips past suffix validation it
-  // cannot shadow a system var like CONVERSATION_ID.
+  // highest): workspace env vars → image runEnv → owner vars → system vars.
+  // Owner and system layers always win, so even if a row slips past suffix
+  // validation it cannot shadow owner/system vars like CONVERSATION_ID or
+  // WORKSPACE_ID.
   private static async buildSandboxEnvVars(
     auth: Authenticator,
-    conversation: ConversationSandboxOwner,
+    ownerEnvVars: Record<string, string>,
     imageEnvVars: Record<string, string> | undefined
   ): Promise<Result<Record<string, string>, Error>> {
     const workspaceEnvResult =
@@ -481,37 +491,45 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     // processes started directly from the sandbox runtime. The key set is
     // canonical in trust_env.ts so dsbx's `env -u` strip list can't drift.
 
-    return new Ok({
+    const envVars = {
       ...workspaceEnvResult.value,
       ...httpsSecretEnvResult.value,
       ...imageEnvVars,
       ...SANDBOX_TRUST_ENV_VARS,
-      CONVERSATION_ID: conversation.sId,
+    };
+    const scopedEnvVars = Object.fromEntries(
+      Object.entries(envVars).filter(
+        ([name]) =>
+          !SANDBOX_OWNER_ENV_VAR_CONTRACT_NAMES.has(name) ||
+          name in ownerEnvVars
+      )
+    );
+
+    return new Ok({
+      ...scopedEnvVars,
+      ...ownerEnvVars,
       WORKSPACE_ID: auth.getNonNullableWorkspace().sId,
     });
   }
 
   /**
-   * Ensure a running sandbox exists for the given conversation.
+   * Ensure a running sandbox exists for the given owner.
    *
    * The provider is resolved internally — callers never touch it.
    */
   static async ensureActive(
     auth: Authenticator,
-    conversation: ConversationSandboxOwner
+    owner: SandboxCreateOwner
   ): Promise<Result<EnsureSandboxResult, Error>> {
     assert(
       auth.getNonNullableWorkspace().id !== undefined,
       "Cannot ensure sandbox without a workspace"
     );
 
-    return this.withLifecycleLock(conversation.sId, async (provider) => {
+    return this.withLifecycleLock(owner.lockKey, async (provider) => {
       const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
       const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
-      const existing = await SandboxResource.fetchByConversation(
-        auth,
-        conversation
-      );
+      const existing = await owner.fetchSandbox();
 
       if (!existing) {
         const imageResult = getSandboxImage(auth);
@@ -522,7 +540,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         const createConfig = imageResult.value.toCreateConfig();
         const envVarsResult = await this.buildSandboxEnvVars(
           auth,
-          conversation,
+          owner.envVars,
           createConfig.envVars
         );
         if (envVarsResult.isErr()) {
@@ -540,8 +558,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           return createResult;
         }
 
-        const sandbox = await SandboxResource.makeNew(auth, {
-          conversationId: conversation.id,
+        const sandbox = await owner.createSandbox({
           providerId: createResult.value.providerId,
           status: "running",
           baseImage: createConfig.imageId.imageName,
@@ -549,8 +566,8 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         });
 
         logger.info(
-          { sandbox: sandbox.toLogJSON() },
-          "Created new sandbox for conversation"
+          { owner: owner.logLabel, sandbox: sandbox.toLogJSON() },
+          "Created new sandbox for owner"
         );
 
         return new Ok({ sandbox, freshlyCreated: true, wokeFromSleep: false });
@@ -647,7 +664,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           const createConfig = imageResult.value.toCreateConfig();
           const envVarsResult = await this.buildSandboxEnvVars(
             auth,
-            conversation,
+            owner.envVars,
             createConfig.envVars
           );
           if (envVarsResult.isErr()) {

--- a/front/tests/utils/SandboxFactory.ts
+++ b/front/tests/utils/SandboxFactory.ts
@@ -2,7 +2,10 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
-import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
+import {
+  SandboxModel,
+  SandboxOwnerModel,
+} from "@app/lib/resources/storage/models/sandbox";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 
 export class SandboxFactory {
@@ -18,11 +21,16 @@ export class SandboxFactory {
     }
   ): Promise<SandboxResource> {
     const sandbox = await SandboxResource.makeNew(auth, {
-      conversationId: conversation.id,
       providerId: `test-provider-${Date.now()}`,
       status: opts?.status ?? "running",
       baseImage: opts?.baseImage ?? "dust-base",
       version: opts?.version ?? "0.0.0-test",
+    });
+
+    await SandboxOwnerModel.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      conversationId: conversation.id,
+      sandboxId: sandbox.id,
     });
 
     if (opts?.statusChangedAt !== undefined) {


### PR DESCRIPTION
## Description

No UI changes.

Based on `main` after #28078, which has already merged and been applied. This PR decouples sandbox row creation from conversation ownership writes so `SandboxResource` can be reused by non-conversation owners in the follow-up PRs.

What changes here:
- `SandboxResource.makeNew` now only persists the `sandboxes` row. It no longer receives a conversation id and no longer writes the ownership link itself.
- `SandboxResource.ensureActive` now accepts a small generic owner adapter: lifecycle lock key, owner env vars, fetch callback, create callback, and log label.
- `ConversationResource.ensureSandboxActive` maps a conversation to that adapter inline.
- Conversation-specific DB persistence lives in `createSandboxRecordForConversation`, which creates the sandbox row and the `sandbox_owners` link in one transaction.
- Owner identity env vars are handled as owner adapter inputs, so workspace/image env vars cannot accidentally provide reserved owner ids like `CONVERSATION_ID` or `POD_ID` unless the owner adapter provides them.

Current stack after #28078:
- #28037: decouple sandbox creation from conversation ownership.
- #28040: move lifecycle/delete ownership boundaries to `ConversationResource`.
- #28041: remove conversation-specific fetch wrappers from `SandboxResource`.
- #28047: add pod sandbox resource methods.
- #28048: wire pod sandbox owners into the reaper.

## Tests

Latest local verification on the rewritten stack:

- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && npx biome check front/lib/resources/conversation_resource.ts front/lib/resources/pod_sandbox_resource.ts front/lib/resources/sandbox_resource.ts front/lib/resources/sandbox_resource.test.ts front/lib/resources/pod_sandbox_resource.test.ts front/temporal/sandbox_reaper/activities.test.ts front/lib/api/sandbox/access_tokens.test.ts`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_ENV=test npm test -- ./lib/resources/sandbox_resource.test.ts ./lib/resources/pod_sandbox_resource.test.ts ./temporal/sandbox_reaper/activities.test.ts ./lib/api/sandbox/access_tokens.test.ts`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && npm -w front run tsgo`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && npm -w front-api run tsgo`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && npm -w front-spa run tsgo`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && npm -w extension run tsgo`

## Risk

Low. Conversation sandbox creation still creates one sandbox row and one `sandbox_owners` link in a single transaction. Existing read/lifecycle behavior remains conversation-scoped in this PR; the generic owner adapter only moves where conversation-specific persistence is wired.

Rollback is code-only: revert this PR. There is no schema or data migration in this PR.

## Deploy Plan

- [x] #28078 merged and its migration/drop has been applied.
- [ ] Merge this PR after CI and review are green.
- [ ] Deploy normally as app code only.
- [ ] No schema migration, data migration, or backfill is required for this PR.
