### PR TITLE
[front] chore: tweak Salesforce tool descriptions for tool search recall

### DIFF
--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -8,6 +8,7 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
   execute_read_query: {
     description:
       "Run a read-only SOQL query on Salesforce to retrieve or discover data. It never writes. " +
+      "Use this for SOQL SELECT queries that search, filter, count, or retrieve Salesforce records, such as querying Salesforce Accounts by Industry. " +
       "The usual flow is list_objects to find an object name, then describe_object to learn its exact fields and relationships, then this tool. " +
       "Custom objects and fields end in `__c` and custom relationships end in `__r`. " +
       "Use dot notation for child-to-parent (e.g. SELECT Account.Name FROM Contact) and a subquery for parent-to-child (e.g. SELECT Name, (SELECT LastName FROM Contacts) FROM Account). " +
@@ -24,7 +25,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
   },
   list_objects: {
     description:
-      "List Salesforce objects (standard, custom, or all). Use it to find an object's exact API name before describing or querying it.",
+      "List Salesforce objects (standard, custom, or all). Use it to find an object's exact API name before describing or querying it. " +
+      "Use this to discover which objects exist and to see object labels before creating or updating records.",
     schema: {
       filter: z
         .enum(["all", "standard", "custom"])
@@ -41,7 +43,9 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
   describe_object: {
     description:
       "Get detailed metadata for a Salesforce object from its API name (e.g. Account, Lead, MyCustomObject__c): fields with names, labels, types, and other properties; child relationship names for subqueries; record types; and other object-level properties. " +
-      "This is the reliable way to confirm field and relationship names before an execute_read_query.",
+      "This is the reliable way to confirm field and relationship names before an execute_read_query. " +
+      "Use this when asking what fields exist on an object, or to discover picklist values and " +
+      "required/createable/updateable flags before querying or writing records.",
     schema: {
       objectName: z.string().describe("The name of the object to describe"),
     },
@@ -52,7 +56,9 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_object: {
-    description: "Create one or more records in Salesforce",
+    description:
+      "Create one or more records in Salesforce. " +
+      "Use this to insert or add new records for an object such as Account, Contact, Lead, Opportunity, or a custom object; not to update existing records.",
     schema: {
       objectName: z
         .string()
@@ -76,7 +82,9 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     },
   },
   update_object: {
-    description: "Update one or more records in Salesforce",
+    description:
+      "Update one or more records in Salesforce. " +
+      "Use this to edit or modify existing records by Id for an object such as Account, Contact, Lead, Opportunity, or a custom object; not to create new records.",
     schema: {
       objectName: z
         .string()
@@ -106,7 +114,9 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     },
   },
   list_attachments: {
-    description: "List all attachments and files for a Salesforce record.",
+    description:
+      "List all attachments and files for a Salesforce record. " +
+      "Use this to find attachment IDs, file IDs, filenames, and metadata before reading or downloading a PDF, document, image, or uploaded file.",
     schema: {
       recordId: z.string().describe("The Salesforce record ID"),
     },
@@ -118,7 +128,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
   },
   read_attachment: {
     description:
-      "Read content from any attachment or file on a Salesforce record.",
+      "Read content from any attachment or file on a Salesforce record. " +
+      "Use this after list_attachments when you know the attachment ID or file ID and need to read or download its text or binary file.",
     schema: {
       recordId: z.string().describe("The Salesforce record ID"),
       attachmentId: z

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -528,6 +528,48 @@ export const QUERIES: LabeledQuery[] = [
     expected: "hubspot.get_email_campaign",
   },
 
+  // --- salesforce ---
+  {
+    query: "run a soql query in salesforce",
+    expected: "salesforce.execute_read_query",
+  },
+  {
+    query: "query salesforce accounts by industry",
+    expected: "salesforce.execute_read_query",
+  },
+  {
+    query: "list salesforce custom objects",
+    expected: "salesforce.list_objects",
+  },
+  {
+    query: "find the exact api name for a salesforce object",
+    expected: "salesforce.list_objects",
+  },
+  {
+    query: "what fields exist on salesforce account",
+    expected: "salesforce.describe_object",
+  },
+  {
+    query: "describe the salesforce lead object metadata",
+    expected: "salesforce.describe_object",
+  },
+  {
+    query: "create a salesforce account record",
+    expected: "salesforce.create_object",
+  },
+  {
+    query: "update a salesforce contact record",
+    expected: "salesforce.update_object",
+  },
+  {
+    query: "list files attached to a salesforce opportunity",
+    expected: "salesforce.list_attachments",
+  },
+  {
+    query: "read a salesforce attachment file",
+    expected: "salesforce.read_attachment",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -19,6 +19,7 @@ import { HUBSPOT_SERVER } from "@app/lib/api/actions/servers/hubspot/metadata";
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
+import { SALESFORCE_SERVER } from "@app/lib/api/actions/servers/salesforce/metadata";
 import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadata";
 import { SLACK_PERSONAL_SERVER } from "@app/lib/api/actions/servers/slack_personal/metadata";
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
@@ -39,6 +40,7 @@ const SERVERS: ServerEntry[] = [
   { name: "microsoft_teams", tools: MICROSOFT_TEAMS_SERVER.tools },
   { name: "confluence", tools: CONFLUENCE_SERVER.tools },
   { name: "hubspot", tools: HUBSPOT_SERVER.tools },
+  { name: "salesforce", tools: SALESFORCE_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9162.

This PR tweaks the Salesforce MCP tool descriptions so BM25 tool search separates the main Salesforce intents more reliably: SOQL record querying, object discovery, schema/field discovery, record creation/update, and attachment listing/reading.

It also registers Salesforce in the BM25 harness and adds labeled Salesforce queries covering those intents. The Salesforce samples all rank top-1 in the full mixed corpus.

## Tests

- Added cases in the existing harness script.

## Risk

- Low.

## Deploy Plan

- Deploy front.
