### PR TITLE
[front] chore: tweak HubSpot tool descriptions for tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -145,7 +145,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_contact: {
-    description: "Retrieves a Hubspot contact by its ID.",
+    description:
+      "Open a single HubSpot contact record by its ID and read its properties.",
     schema: {
       contactId: z.string().describe("The ID of the contact to retrieve."),
     },
@@ -157,7 +158,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   get_company: {
     description:
-      "Retrieves a Hubspot company by its ID. Returns default properties plus any additional properties specified.",
+      "Open a single HubSpot company record by its ID and read its properties. " +
+      "Returns default properties plus any additional properties specified.",
     schema: {
       companyId: z.string().describe("The ID of the company to retrieve."),
       extraProperties: z
@@ -175,7 +177,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   get_deal: {
     description:
-      "Retrieves a Hubspot deal by its ID. Returns default properties plus any additional properties specified.",
+      "Open a single HubSpot deal record by its ID and read its properties. " +
+      "Returns default properties plus any additional properties specified.",
     schema: {
       dealId: z.string().describe("The ID of the deal to retrieve."),
       extraProperties: z
@@ -232,9 +235,11 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   search_crm_objects: {
     description:
-      "Comprehensive search tool for ALL HubSpot object types including contacts, companies, deals, " +
-      "and ALL engagement types (tasks, notes, meetings, calls, emails). Supports advanced filtering by properties, " +
-      "date ranges, owners, and free-text queries. Enhanced to support owner filtering across all engagement types. " +
+      "Find HubSpot contacts, companies, deals, and activity records when " +
+      "you do not know the object ID. " +
+      "Use this to find contacts at a company, search deals by close date, " +
+      "or locate tasks, notes, meetings, calls, and emails. " +
+      "Supports advanced filtering by properties, date ranges, owners, and free-text queries. " +
       "IMPORTANT: For enumeration properties (like industry), always use get_object_properties first to discover the exact values. " +
       "Use this for specific searches, or use get_user_activity for comprehensive user activity across all types.",
     schema: {
@@ -329,7 +334,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   get_current_user_id: {
     description:
-      "Gets the current authenticated user's HubSpot owner ID and profile information. " +
+      "Identify who you are in HubSpot: get the current authenticated user's " +
+      "HubSpot owner ID and profile information. " +
       "Essential first step for getting your own activity data. Returns user_id (needed for get_user_activity), " +
       "user details, and hub_id. Use this before calling get_user_activity with your own data.",
     schema: {},
@@ -508,7 +514,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   get_email_campaign: {
     description:
-      "Retrieves detailed information about a specific email campaign, including name, subject, type, " +
+      "Open and read a detailed HubSpot email campaign report by campaign ID, " +
+      "including name, subject, type, " +
       "and deliverability counters (sent, delivered, open, click, bounce, unsubscribe, etc.).",
     schema: {
       campaignId: z

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -466,6 +466,68 @@ export const QUERIES: LabeledQuery[] = [
     expected: "confluence.get_current_user",
   },
 
+  // --- hubspot ---
+  {
+    query: "find a hubspot contact by email address",
+    expected: "hubspot.get_object_by_email",
+  },
+  {
+    query: "read hubspot contact 123",
+    expected: "hubspot.get_contact",
+  },
+  {
+    query: "open a hubspot company record",
+    expected: "hubspot.get_company",
+  },
+  {
+    query: "read a hubspot deal by id",
+    expected: "hubspot.get_deal",
+  },
+  {
+    query: "search hubspot deals by close date",
+    expected: "hubspot.search_crm_objects",
+  },
+  {
+    query: "find contacts at acme in hubspot",
+    expected: "hubspot.search_crm_objects",
+  },
+  {
+    query: "export hubspot contacts to csv",
+    expected: "hubspot.export_crm_objects_csv",
+  },
+  {
+    query: "who am i in hubspot",
+    expected: "hubspot.get_current_user_id",
+  },
+  {
+    query: "show my hubspot activity last week",
+    expected: "hubspot.get_user_activity",
+  },
+  {
+    query: "find a hubspot owner by name",
+    expected: "hubspot.search_owners",
+  },
+  {
+    query: "create a hubspot note on a contact",
+    expected: "hubspot.create_note",
+  },
+  {
+    query: "list contacts associated with a hubspot company",
+    expected: "hubspot.list_associations",
+  },
+  {
+    query: "get my hubspot portal id",
+    expected: "hubspot.get_hubspot_portal_id",
+  },
+  {
+    query: "list hubspot marketing emails",
+    expected: "hubspot.list_marketing_emails",
+  },
+  {
+    query: "read hubspot email campaign report",
+    expected: "hubspot.get_email_campaign",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -15,6 +15,7 @@ import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metad
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
+import { HUBSPOT_SERVER } from "@app/lib/api/actions/servers/hubspot/metadata";
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
@@ -37,6 +38,7 @@ const SERVERS: ServerEntry[] = [
   { name: "slack_bot", tools: SLACK_BOT_SERVER.tools },
   { name: "microsoft_teams", tools: MICROSOFT_TEAMS_SERVER.tools },
   { name: "confluence", tools: CONFLUENCE_SERVER.tools },
+  { name: "hubspot", tools: HUBSPOT_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9162.

This PR follows up on the BM25 MCP tool-search harness by adding HubSpot to the covered servers and tightening HubSpot tool descriptions for common retrieval intents.

Direct CRM record reads now include read/open/retrieve vocabulary, broad CRM search owns find/search intents for contacts and deals, current-user lookup owns “who am I”, and email campaign details own campaign report wording. This is metadata and diagnostic coverage only; no change in the tool callbacks.

## Tests

- Added cases in the existing harness tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
