### PR TITLE
Move sandbox lifecycle ownership to conversations

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -24,9 +24,10 @@ import {
 } from "@app/lib/resources/permission_utils";
 import { RunResource } from "@app/lib/resources/run_resource";
 import {
-  type ConversationSandboxOwner,
   type EnsureSandboxResult,
   type SandboxCreateBlob,
+  type SandboxDeleteOwner,
+  type SandboxLifecycleOwner,
   SandboxResource,
 } from "@app/lib/resources/sandbox_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -89,6 +90,11 @@ import type {
   WhereOptions,
 } from "sequelize";
 import { col, fn, literal, Op, QueryTypes, Sequelize, where } from "sequelize";
+
+type ConversationSandboxOwner = Pick<
+  ConversationWithoutContentType,
+  "id" | "sId"
+>;
 
 export type FetchConversationOptions = {
   includeDeleted?: boolean;
@@ -356,11 +362,43 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return conversations.map((c) => this.fromModel(c, null));
   }
 
-  static async fetchSandbox(
+  private static async fetchSandboxByConversation(
     auth: Authenticator,
     conversation: ConversationSandboxOwner
   ): Promise<SandboxResource | null> {
-    return SandboxResource.fetchByConversation(auth, conversation);
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const link = await SandboxOwnerModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: workspaceModelId,
+      },
+    });
+
+    if (!link) {
+      return null;
+    }
+
+    return SandboxResource.fetchByModelIdForWorkspace(auth, link.sandboxId);
+  }
+
+  private static async dangerouslyFetchSandboxByConversation(
+    conversation: Pick<ConversationResource, "id" | "workspaceId">
+  ): Promise<SandboxResource | null> {
+    const link = await SandboxOwnerModel.findOne({
+      where: {
+        workspaceId: conversation.workspaceId,
+        conversationId: conversation.id,
+      },
+    });
+
+    if (!link) {
+      return null;
+    }
+
+    return SandboxResource.dangerouslyFetchByModelIdForWorkspace({
+      sandboxModelId: link.sandboxId,
+      workspaceModelId: conversation.workspaceId,
+    });
   }
 
   private static async createSandboxRecordForConversation(
@@ -386,6 +424,43 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
       return sandbox;
     });
+  }
+
+  private static toSandboxLifecycleOwner(
+    conversation: ConversationResource
+  ): SandboxLifecycleOwner {
+    return {
+      lockKey: conversation.sId,
+      fetchSandbox: () =>
+        this.dangerouslyFetchSandboxByConversation(conversation),
+    };
+  }
+
+  private static toSandboxDeleteOwner(
+    auth: Authenticator,
+    conversation: ConversationResource
+  ): SandboxDeleteOwner {
+    return {
+      lockKey: conversation.sId,
+      fetchSandbox: () => this.fetchSandboxByConversation(auth, conversation),
+      deleteSandbox: async (sandbox, transaction) => {
+        await SandboxOwnerModel.destroy({
+          where: {
+            conversationId: conversation.id,
+            sandboxId: sandbox.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+          transaction,
+        });
+      },
+    };
+  }
+
+  static async fetchSandbox(
+    auth: Authenticator,
+    conversation: ConversationSandboxOwner
+  ): Promise<SandboxResource | null> {
+    return this.fetchSandboxByConversation(auth, conversation);
   }
 
   async fetchSandbox(auth: Authenticator): Promise<SandboxResource | null> {
@@ -416,7 +491,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     auth: Authenticator,
     conversation: ConversationSandboxOwner
   ): Promise<Result<void, Error>> {
-    return SandboxResource.pauseForApproval(auth, conversation);
+    return SandboxResource.pauseForApproval(auth, {
+      lockKey: conversation.sId,
+      fetchSandbox: () => this.fetchSandboxByConversation(auth, conversation),
+    });
   }
 
   async pauseSandboxForApproval(
@@ -426,31 +504,46 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   }
 
   async deleteSandbox(auth: Authenticator): Promise<Result<void, Error>> {
-    return SandboxResource.deleteByConversation(auth, this);
+    return SandboxResource.deleteByOwner(
+      auth,
+      ConversationResource.toSandboxDeleteOwner(auth, this)
+    );
   }
 
   async dangerouslySleepSandboxIfRunning(
     auth: Authenticator
   ): Promise<Result<void, Error>> {
-    return SandboxResource.dangerouslySleepIfRunning(auth, this);
+    return SandboxResource.dangerouslySleepIfRunning(
+      auth,
+      ConversationResource.toSandboxLifecycleOwner(this)
+    );
   }
 
   async dangerouslySleepSandboxIfPendingApproval(
     auth: Authenticator
   ): Promise<Result<void, Error>> {
-    return SandboxResource.dangerouslySleepIfPendingApproval(auth, this);
+    return SandboxResource.dangerouslySleepIfPendingApproval(
+      auth,
+      ConversationResource.toSandboxLifecycleOwner(this)
+    );
   }
 
   async dangerouslyDestroySandboxIfSleeping(
     auth: Authenticator
   ): Promise<Result<void, Error>> {
-    return SandboxResource.dangerouslyDestroyIfSleeping(auth, this);
+    return SandboxResource.dangerouslyDestroyIfSleeping(
+      auth,
+      ConversationResource.toSandboxLifecycleOwner(this)
+    );
   }
 
   async dangerouslyDestroySandboxIfKillRequested(
     auth: Authenticator
   ): Promise<Result<void, Error>> {
-    return SandboxResource.dangerouslyDestroyIfKillRequested(auth, this);
+    return SandboxResource.dangerouslyDestroyIfKillRequested(
+      auth,
+      ConversationResource.toSandboxLifecycleOwner(this)
+    );
   }
 
   static async dangerouslyFetchConversationModelIdsBySandboxes(

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -175,7 +175,7 @@ describe("SandboxResource.updateStatus", () => {
   });
 });
 
-describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
+describe("ConversationResource.dangerouslyDestroySandboxIfSleeping", () => {
   let authenticator: Authenticator;
   let conversationResource: ConversationResource;
 
@@ -219,10 +219,10 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
       }
     );
 
-    const result = await SandboxResource.dangerouslyDestroyIfSleeping(
-      authenticator,
-      conversationResource
-    );
+    const result =
+      await conversationResource.dangerouslyDestroySandboxIfSleeping(
+        authenticator
+      );
 
     expect(result.isOk()).toBe(true);
     expect(mockProviderDestroy).toHaveBeenCalledWith(sandbox.providerId, {
@@ -252,10 +252,10 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
     };
     await SandboxOwnerModel.destroy({ where });
 
-    const result = await SandboxResource.dangerouslyDestroyIfSleeping(
-      authenticator,
-      conversationResource
-    );
+    const result =
+      await conversationResource.dangerouslyDestroySandboxIfSleeping(
+        authenticator
+      );
 
     expect(result.isOk()).toBe(true);
     expect(mockProviderDestroy).not.toHaveBeenCalled();
@@ -268,9 +268,34 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
     });
     expect(row?.status).toBe("sleeping");
   });
+
+  it("deleteSandbox deletes the owner link and sandbox row", async () => {
+    const sandbox = await SandboxFactory.create(
+      authenticator,
+      conversationResource.toJSON()
+    );
+    const workspaceModelId = authenticator.getNonNullableWorkspace().id;
+
+    const result = await conversationResource.deleteSandbox(authenticator);
+
+    expect(result.isOk()).toBe(true);
+    const [linkCount, sandboxCount] = await Promise.all([
+      SandboxOwnerModel.count({
+        where: {
+          conversationId: conversationResource.id,
+          sandboxId: sandbox.id,
+          workspaceId: workspaceModelId,
+        },
+      }),
+      SandboxModel.count({
+        where: { id: sandbox.id, workspaceId: workspaceModelId },
+      }),
+    ]);
+    expect([linkCount, sandboxCount]).toEqual([0, 0]);
+  });
 });
 
-describe("SandboxResource.dangerouslyDestroyIfKillRequested", () => {
+describe("ConversationResource.dangerouslyDestroySandboxIfKillRequested", () => {
   let authenticator: Authenticator;
   let conversationResource: ConversationResource;
 
@@ -319,10 +344,10 @@ describe("SandboxResource.dangerouslyDestroyIfKillRequested", () => {
       }
     );
 
-    const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
-      authenticator,
-      conversationResource
-    );
+    const result =
+      await conversationResource.dangerouslyDestroySandboxIfKillRequested(
+        authenticator
+      );
 
     expect(result.isOk()).toBe(true);
     expect(mockProviderDestroy).toHaveBeenCalledWith(sandbox.providerId, {
@@ -341,10 +366,10 @@ describe("SandboxResource.dangerouslyDestroyIfKillRequested", () => {
       status: "running",
     });
 
-    const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
-      authenticator,
-      conversationResource
-    );
+    const result =
+      await conversationResource.dangerouslyDestroySandboxIfKillRequested(
+        authenticator
+      );
 
     expect(result.isOk()).toBe(true);
     expect(mockProviderDestroy).not.toHaveBeenCalled();
@@ -362,10 +387,10 @@ describe("SandboxResource.dangerouslyDestroyIfKillRequested", () => {
       killRequestedAt: new Date(),
     });
 
-    const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
-      authenticator,
-      conversationResource
-    );
+    const result =
+      await conversationResource.dangerouslyDestroySandboxIfKillRequested(
+        authenticator
+      );
 
     expect(result.isOk()).toBe(true);
     expect(mockProviderDestroy).not.toHaveBeenCalled();

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -19,7 +19,6 @@ import { SANDBOX_TRUST_ENV_VARS } from "@app/lib/api/sandbox/trust_env";
 import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import {
   SandboxModel,
@@ -62,6 +61,8 @@ export type SandboxCreateBlob = {
 
 export type SandboxLifecycleOwner = {
   lockKey: string;
+  // Must return a sandbox scoped to the same workspace as the Authenticator
+  // passed to the lifecycle operation.
   fetchSandbox: () => Promise<SandboxResource | null>;
 };
 
@@ -69,6 +70,13 @@ export type SandboxCreateOwner = SandboxLifecycleOwner & {
   createSandbox: (blob: SandboxCreateBlob) => Promise<SandboxResource>;
   envVars: Record<string, string>;
   logLabel: string;
+};
+
+export type SandboxDeleteOwner = SandboxLifecycleOwner & {
+  deleteSandbox: (
+    sandbox: SandboxResource,
+    transaction: Transaction
+  ) => Promise<void>;
 };
 
 // Owner identity env vars are reserved for owner adapters. SandboxResource
@@ -135,6 +143,33 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     workspaceId: ModelId;
   }): string {
     return makeSId("sandbox", { id, workspaceId });
+  }
+
+  static async fetchByModelIdForWorkspace(
+    auth: Authenticator,
+    sandboxModelId: ModelId
+  ): Promise<SandboxResource | null> {
+    return this.dangerouslyFetchByModelIdForWorkspace({
+      sandboxModelId,
+      workspaceModelId: auth.getNonNullableWorkspace().id,
+    });
+  }
+
+  static async dangerouslyFetchByModelIdForWorkspace({
+    sandboxModelId,
+    workspaceModelId,
+  }: {
+    sandboxModelId: ModelId;
+    workspaceModelId: ModelId;
+  }): Promise<SandboxResource | null> {
+    const sandbox = await this.model.findOne({
+      where: {
+        id: sandboxModelId,
+        workspaceId: workspaceModelId,
+      },
+    });
+
+    return sandbox ? new this(this.model, sandbox.get()) : null;
   }
 
   static async makeNew(
@@ -212,37 +247,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     return rows.map((r) => new this(this.model, r.get()));
   }
 
-  /**
-   * Fetch the sandbox for a conversation without an Authenticator. Only used by
-   * the reaper inside the lifecycle lock. Every query remains scoped to the
-   * conversation workspace.
-   */
-  private static async dangerouslyFetchByConversation(
-    conversation: ConversationResource
-  ): Promise<SandboxResource | null> {
-    const owner = await this.sandboxOwnerModel.findOne({
-      where: {
-        workspaceId: conversation.workspaceId,
-        conversationId: conversation.id,
-      },
-    });
-
-    if (owner) {
-      const sandbox = await this.model.findOne({
-        where: {
-          id: owner.sandboxId,
-          workspaceId: conversation.workspaceId,
-        },
-      });
-
-      if (sandbox) {
-        return new this(this.model, sandbox.get());
-      }
-    }
-
-    return null;
-  }
-
   static async fetchByConversation(
     auth: Authenticator,
     conversation: ConversationSandboxOwner
@@ -270,11 +274,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     return null;
   }
 
-  /**
-   * Fetch conversation owners for sandbox rows touched by the reaper. Queries
-   * are grouped by workspace so every lookup remains workspace-scoped without
-   * issuing unbounded parallel DB queries.
-   */
   static async dangerouslyFetchConversationModelIdsBySandboxes(
     sandboxes: Pick<SandboxResource, "id" | "workspaceId">[]
   ): Promise<Map<ModelId, ModelId>> {
@@ -389,17 +388,14 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
   /**
    * Full cleanup under the lifecycle lock: best-effort destroy at the provider,
-   * then delete the DB row.
+   * then delete the owner link and DB row.
    */
-  static async deleteByConversation(
+  static async deleteByOwner(
     auth: Authenticator,
-    conversation: ConversationResource
+    owner: SandboxDeleteOwner
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(conversation.sId, async (provider) => {
-      const sandbox = await SandboxResource.fetchByConversation(
-        auth,
-        conversation.toJSON()
-      );
+    return this.withLifecycleLock(owner.lockKey, async (provider) => {
+      const sandbox = await owner.fetchSandbox();
       if (!sandbox) {
         return new Ok(undefined);
       }
@@ -420,14 +416,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       }
 
       await withTransaction(async (transaction) => {
-        await SandboxOwnerModel.destroy({
-          where: {
-            sandboxId: sandbox.id,
-            workspaceId: auth.getNonNullableWorkspace().id,
-          },
-          transaction,
-        });
-
+        await owner.deleteSandbox(sandbox, transaction);
         await SandboxModel.destroy({
           where: {
             id: sandbox.id,
@@ -446,7 +435,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   // ---------------------------------------------------------------------------
 
   private static async withLifecycleLock<T>(
-    ownerLockKey: string,
+    lockKey: string,
     fn: (provider: SandboxProvider) => Promise<Result<T, Error>>
   ): Promise<Result<T, Error>> {
     const provider = getSandboxProvider();
@@ -455,7 +444,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     }
 
     return executeWithLock(
-      `sandbox:lifecycle:${ownerLockKey}`,
+      `sandbox:lifecycle:${lockKey}`,
       () => fn(provider),
       undefined,
       { traceAcquireResource: "sandbox:lifecycle" }
@@ -717,17 +706,16 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   }
 
   /**
-   * Sleep a running sandbox for the given conversation. Acquires the lifecycle
-   * lock, re-fetches the sandbox inside it, and only sleeps if still running.
-   * If the provider reports the sandbox as gone, marks it deleted instead.
+   * Sleep a running sandbox for the given owner. Acquires the lifecycle lock,
+   * re-fetches the sandbox inside it, and only sleeps if still running. If the
+   * provider reports the sandbox as gone, marks it deleted instead.
    */
   static async dangerouslySleepIfRunning(
     auth: Authenticator,
-    conversation: ConversationResource
+    owner: SandboxLifecycleOwner
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(conversation.sId, async (provider) => {
-      const sandbox =
-        await SandboxResource.dangerouslyFetchByConversation(conversation);
+    return this.withLifecycleLock(owner.lockKey, async (provider) => {
+      const sandbox = await owner.fetchSandbox();
       if (!sandbox || sandbox.status !== "running") {
         return new Ok(undefined);
       }
@@ -762,13 +750,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   static async pauseForApproval(
     auth: Authenticator,
-    conversation: ConversationSandboxOwner
+    owner: SandboxLifecycleOwner
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(conversation.sId, async (provider) => {
-      const sandbox = await SandboxResource.fetchByConversation(
-        auth,
-        conversation
-      );
+    return this.withLifecycleLock(owner.lockKey, async (provider) => {
+      const sandbox = await owner.fetchSandbox();
       if (!sandbox || sandbox.status !== "running") {
         return new Ok(undefined);
       }
@@ -812,11 +797,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   static async dangerouslySleepIfPendingApproval(
     auth: Authenticator,
-    conversation: ConversationResource
+    owner: SandboxLifecycleOwner
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(conversation.sId, async () => {
-      const sandbox =
-        await SandboxResource.dangerouslyFetchByConversation(conversation);
+    return this.withLifecycleLock(owner.lockKey, async () => {
+      const sandbox = await owner.fetchSandbox();
       if (!sandbox || sandbox.status !== "pending_approval") {
         return new Ok(undefined);
       }
@@ -832,18 +816,16 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   }
 
   /**
-   * Destroy a sleeping sandbox for the given conversation. Acquires the
-   * lifecycle lock, re-fetches the sandbox inside it, and only destroys if
-   * still sleeping. If the provider reports the sandbox as gone, marks it
-   * deleted anyway.
+   * Destroy a sleeping sandbox for the given owner. Acquires the lifecycle lock,
+   * re-fetches the sandbox inside it, and only destroys if still sleeping. If
+   * the provider reports the sandbox as gone, marks it deleted anyway.
    */
   static async dangerouslyDestroyIfSleeping(
     auth: Authenticator,
-    conversation: ConversationResource
+    owner: SandboxLifecycleOwner
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(conversation.sId, async (provider) => {
-      const sandbox =
-        await SandboxResource.dangerouslyFetchByConversation(conversation);
+    return this.withLifecycleLock(owner.lockKey, async (provider) => {
+      const sandbox = await owner.fetchSandbox();
       if (!sandbox || sandbox.status !== "sleeping") {
         return new Ok(undefined);
       }
@@ -967,11 +949,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   static async dangerouslyDestroyIfKillRequested(
     auth: Authenticator,
-    conversation: ConversationResource
+    owner: SandboxLifecycleOwner
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(conversation.sId, async (provider) => {
-      const sandbox =
-        await SandboxResource.dangerouslyFetchByConversation(conversation);
+    return this.withLifecycleLock(owner.lockKey, async (provider) => {
+      const sandbox = await owner.fetchSandbox();
       if (
         !sandbox ||
         sandbox.status === "deleted" ||


### PR DESCRIPTION
## Description

No UI changes.

Based on `main` after #28037, which has merged. This PR moves conversation-specific sandbox lifecycle and delete ownership into `ConversationResource` owner adapters.

What changes here:
- `SandboxResource` lifecycle methods now operate on generic owner fetch/delete callbacks.
- `ConversationResource` owns the conversation `sandbox_owners` lookup and deletion wiring.
- `SandboxResource` stays responsible for provider lifecycle operations and the sandbox row.
- Normal sandbox model fetches now go through `SandboxResource.fetchByModelIdForWorkspace(auth, sandboxModelId)` so workspace scoping comes from `Authenticator`.
- The raw workspace-id lookup is explicitly named `dangerouslyFetchByModelIdForWorkspace` and is only used by the no-auth reaper/conversation path.

Current stack after #28037:
- #28040: generic lifecycle and delete owner adapters for conversations.
- #28041: remove remaining public conversation fetch wrappers from `SandboxResource`.
- #28047: add pod sandbox resource methods.
- #28048: wire pod sandbox owners into the reaper.

## Tests

Latest local verification on the rewritten stack:

- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && npx biome check front/lib/resources/conversation_resource.ts front/lib/resources/pod_sandbox_resource.ts front/lib/resources/sandbox_resource.ts front/lib/resources/sandbox_resource.test.ts front/lib/resources/pod_sandbox_resource.test.ts front/temporal/sandbox_reaper/activities.test.ts front/lib/api/sandbox/access_tokens.test.ts`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_ENV=test npm test -- ./lib/resources/sandbox_resource.test.ts ./lib/resources/pod_sandbox_resource.test.ts ./temporal/sandbox_reaper/activities.test.ts ./lib/api/sandbox/access_tokens.test.ts`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && npm -w front run tsgo`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && npm -w front-api run tsgo`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && npm -w front-spa run tsgo`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && npm -w extension run tsgo`

## Risk

Medium-low. Conversation sandbox lifecycle calls still use the same provider operations and `sandbox_owners` rows, but ownership lookup now goes through `ConversationResource` adapters before calling `SandboxResource`.

The raw workspace-id sandbox lookup is now explicitly dangerous. Normal fetch paths are auth-scoped, reducing the chance of accidental cross-workspace reads.

Rollback is code-only: revert this PR. There is no schema or data migration in this PR.

## Deploy Plan

- [x] #28037 has merged into `main`.
- [ ] Merge this PR after CI and review are green.
- [ ] Deploy normally as app code only.
- [ ] No schema migration, data migration, or backfill is required for this PR.
