### PR TITLE
Remove conversation fetch wrappers from sandbox resource

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
@@ -1,6 +1,5 @@
 import type { GetConversationSandboxResponseBody } from "@app/lib/api/assistant/conversation/sandbox";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -33,10 +32,7 @@ app.get(
       });
     }
 
-    const sandbox = await SandboxResource.fetchByConversation(
-      auth,
-      conversation.toJSON()
-    );
+    const sandbox = await ConversationResource.fetchSandbox(auth, conversation);
 
     return ctx.json({
       sandboxStatus: sandbox?.status ?? null,

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -106,6 +106,8 @@ export type FetchConversationOptions = {
 
 type SpaceConversationsFilter = "all" | "group" | "with_me";
 
+const SANDBOX_OWNER_LOOKUP_CONCURRENCY = 4;
+
 interface UserParticipation {
   actionRequired: boolean;
   updated: number;
@@ -549,9 +551,52 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   static async dangerouslyFetchConversationModelIdsBySandboxes(
     sandboxes: Pick<SandboxResource, "id" | "workspaceId">[]
   ): Promise<Map<ModelId, ModelId>> {
-    return SandboxResource.dangerouslyFetchConversationModelIdsBySandboxes(
-      sandboxes
-    );
+    if (sandboxes.length === 0) {
+      return new Map();
+    }
+
+    const sandboxModelIdsByWorkspaceModelId = new Map<ModelId, ModelId[]>();
+    for (const sandbox of sandboxes) {
+      const sandboxModelIds =
+        sandboxModelIdsByWorkspaceModelId.get(sandbox.workspaceId) ?? [];
+      sandboxModelIds.push(sandbox.id);
+      sandboxModelIdsByWorkspaceModelId.set(
+        sandbox.workspaceId,
+        sandboxModelIds
+      );
+    }
+
+    const rows = (
+      await concurrentExecutor(
+        [...sandboxModelIdsByWorkspaceModelId.entries()],
+        async ([workspaceModelId, sandboxModelIds]) =>
+          SandboxOwnerModel.findAll({
+            where: {
+              workspaceId: workspaceModelId,
+              conversationId: {
+                [Op.ne]: null,
+              },
+              sandboxId: {
+                [Op.in]: sandboxModelIds,
+              },
+            },
+            attributes: ["sandboxId", "conversationId"],
+          }),
+        { concurrency: SANDBOX_OWNER_LOOKUP_CONCURRENCY }
+      )
+    ).flat();
+
+    const conversationModelIdsBySandboxModelId = new Map<ModelId, ModelId>();
+    for (const row of rows) {
+      if (row.conversationId !== null) {
+        conversationModelIdsBySandboxModelId.set(
+          row.sandboxId,
+          row.conversationId
+        );
+      }
+    }
+
+    return conversationModelIdsBySandboxModelId;
   }
 
   get forkingData(): ConversationForkingDataType | undefined {

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -140,7 +140,7 @@ describe("SandboxResource.updateStatus", () => {
 
     expect(mockDistribution).not.toHaveBeenCalled();
 
-    const reloaded = await SandboxResource.fetchByConversation(
+    const reloaded = await ConversationResource.fetchSandbox(
       authenticator,
       conversation
     );
@@ -161,7 +161,7 @@ describe("SandboxResource.updateStatus", () => {
     await sandbox.updateStatus("sleeping", { ctx });
     const afterTransition = Date.now();
 
-    const reloaded = await SandboxResource.fetchByConversation(
+    const reloaded = await ConversationResource.fetchSandbox(
       authenticator,
       conversation
     );
@@ -230,7 +230,7 @@ describe("ConversationResource.dangerouslyDestroySandboxIfSleeping", () => {
     });
     expect(mockDeleteSandboxPolicy).toHaveBeenCalledWith(sandbox.providerId);
 
-    const reloaded = await SandboxResource.fetchByConversation(
+    const reloaded = await ConversationResource.fetchSandbox(
       authenticator,
       conversationResource.toJSON()
     );
@@ -354,7 +354,7 @@ describe("ConversationResource.dangerouslyDestroySandboxIfKillRequested", () => 
       workspaceId: authenticator.getNonNullableWorkspace().sId,
     });
 
-    const reloaded = await SandboxResource.fetchByConversation(
+    const reloaded = await ConversationResource.fetchSandbox(
       authenticator,
       conversationResource.toJSON()
     );
@@ -374,7 +374,7 @@ describe("ConversationResource.dangerouslyDestroySandboxIfKillRequested", () => 
     expect(result.isOk()).toBe(true);
     expect(mockProviderDestroy).not.toHaveBeenCalled();
 
-    const reloaded = await SandboxResource.fetchByConversation(
+    const reloaded = await ConversationResource.fetchSandbox(
       authenticator,
       conversationResource.toJSON()
     );
@@ -498,7 +498,7 @@ describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
     });
 
     expect(affected).toBe(2);
-    const stillUnmarked = await SandboxResource.fetchByConversation(
+    const stillUnmarked = await ConversationResource.fetchSandbox(
       authenticator,
       other
     );
@@ -535,7 +535,7 @@ describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
     });
 
     expect(affected).toBe(2);
-    const matched = await SandboxResource.fetchByConversation(
+    const matched = await ConversationResource.fetchSandbox(
       authenticator,
       cMatch
     );
@@ -565,7 +565,7 @@ describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
     });
 
     expect(affected).toBe(1);
-    const alreadyMarked = await SandboxResource.fetchByConversation(
+    const alreadyMarked = await ConversationResource.fetchSandbox(
       authenticator,
       cAlreadyMarked
     );
@@ -589,7 +589,7 @@ describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
   });
 });
 
-describe("SandboxResource.fetchByConversation", () => {
+describe("ConversationResource.fetchSandbox", () => {
   let authenticator: Authenticator;
   let agentConfigId: string;
 
@@ -614,7 +614,7 @@ describe("SandboxResource.fetchByConversation", () => {
     const conversation = await makeConversation();
     const sandbox = await SandboxFactory.create(authenticator, conversation);
 
-    const fetched = await SandboxResource.fetchByConversation(
+    const fetched = await ConversationResource.fetchSandbox(
       authenticator,
       conversation
     );
@@ -643,7 +643,7 @@ describe("SandboxResource.fetchByConversation", () => {
 
     await SandboxOwnerModel.destroy({ where });
 
-    const fetched = await SandboxResource.fetchByConversation(
+    const fetched = await ConversationResource.fetchSandbox(
       authenticator,
       conversation
     );
@@ -656,9 +656,9 @@ describe("SandboxResource.fetchByConversation", () => {
     const sandbox = await SandboxFactory.create(authenticator, conversation);
 
     const conversationModelIdsBySandboxModelId =
-      await SandboxResource.dangerouslyFetchConversationModelIdsBySandboxes([
-        sandbox,
-      ]);
+      await ConversationResource.dangerouslyFetchConversationModelIdsBySandboxes(
+        [sandbox]
+      );
 
     expect(conversationModelIdsBySandboxModelId.get(sandbox.id)).toBe(
       conversation.id
@@ -670,12 +670,14 @@ describe("SandboxResource.fetchByConversation", () => {
     const sandbox = await SandboxFactory.create(authenticator, conversation);
 
     const conversationModelIdsBySandboxModelId =
-      await SandboxResource.dangerouslyFetchConversationModelIdsBySandboxes([
-        {
-          id: sandbox.id,
-          workspaceId: sandbox.workspaceId + 1,
-        },
-      ]);
+      await ConversationResource.dangerouslyFetchConversationModelIdsBySandboxes(
+        [
+          {
+            id: sandbox.id,
+            workspaceId: sandbox.workspaceId + 1,
+          },
+        ]
+      );
 
     expect(
       conversationModelIdsBySandboxModelId.get(sandbox.id)
@@ -833,7 +835,7 @@ describe("SandboxResource.ensureActive", () => {
 
     expect(result.isOk()).toBe(true);
 
-    const persisted = await SandboxResource.fetchByConversation(
+    const persisted = await ConversationResource.fetchSandbox(
       authenticator,
       conversation
     );
@@ -863,7 +865,7 @@ describe("SandboxResource.ensureActive", () => {
 
     expect(result.isOk()).toBe(true);
 
-    const persisted = await SandboxResource.fetchByConversation(
+    const persisted = await ConversationResource.fetchSandbox(
       authenticator,
       conversation
     );
@@ -892,7 +894,7 @@ describe("SandboxResource.ensureActive", () => {
     });
     expect(mockProviderCreate).toHaveBeenCalled();
 
-    const persisted = await SandboxResource.fetchByConversation(
+    const persisted = await ConversationResource.fetchSandbox(
       authenticator,
       conversation
     );

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -31,7 +31,6 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -46,11 +45,6 @@ export interface EnsureSandboxResult {
   sandbox: SandboxResource;
   wokeFromSleep: boolean;
 }
-
-export type ConversationSandboxOwner = Pick<
-  ConversationWithoutContentType,
-  "id" | "sId"
->;
 
 export type SandboxCreateBlob = {
   providerId: string;
@@ -91,8 +85,6 @@ export interface SandboxResource extends ReadonlyAttributesType<SandboxModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SandboxResource extends BaseResource<SandboxModel> {
   static model: ModelStaticWorkspaceAware<SandboxModel> = SandboxModel;
-  private static sandboxOwnerModel: ModelStaticWorkspaceAware<SandboxOwnerModel> =
-    SandboxOwnerModel;
 
   private static deleteEgressPolicyAfterDestroy(
     sandbox: SandboxResource
@@ -245,82 +237,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     });
 
     return rows.map((r) => new this(this.model, r.get()));
-  }
-
-  static async fetchByConversation(
-    auth: Authenticator,
-    conversation: ConversationSandboxOwner
-  ): Promise<SandboxResource | null> {
-    const workspaceId = auth.getNonNullableWorkspace().id;
-    const owner = await this.sandboxOwnerModel.findOne({
-      where: {
-        conversationId: conversation.id,
-        workspaceId,
-      },
-    });
-
-    if (owner) {
-      const sandboxes = await this.baseFetch(auth, {
-        where: {
-          id: owner.sandboxId,
-        },
-      });
-
-      if (sandboxes[0]) {
-        return sandboxes[0];
-      }
-    }
-
-    return null;
-  }
-
-  static async dangerouslyFetchConversationModelIdsBySandboxes(
-    sandboxes: Pick<SandboxResource, "id" | "workspaceId">[]
-  ): Promise<Map<ModelId, ModelId>> {
-    if (sandboxes.length === 0) {
-      return new Map();
-    }
-
-    const sandboxModelIdsByWorkspaceModelId = new Map<ModelId, ModelId[]>();
-    for (const sandbox of sandboxes) {
-      const sandboxModelIds =
-        sandboxModelIdsByWorkspaceModelId.get(sandbox.workspaceId) ?? [];
-      sandboxModelIds.push(sandbox.id);
-      sandboxModelIdsByWorkspaceModelId.set(
-        sandbox.workspaceId,
-        sandboxModelIds
-      );
-    }
-
-    const conversationModelIdsBySandboxModelId = new Map<ModelId, ModelId>();
-    for (const [
-      workspaceModelId,
-      sandboxModelIds,
-    ] of sandboxModelIdsByWorkspaceModelId.entries()) {
-      const ownerRows = await this.sandboxOwnerModel.findAll({
-        where: {
-          workspaceId: workspaceModelId,
-          conversationId: {
-            [Op.ne]: null,
-          },
-          sandboxId: {
-            [Op.in]: sandboxModelIds,
-          },
-        },
-        attributes: ["sandboxId", "conversationId"],
-      });
-
-      for (const row of ownerRows) {
-        if (row.conversationId !== null) {
-          conversationModelIdsBySandboxModelId.set(
-            row.sandboxId,
-            row.conversationId
-          );
-        }
-      }
-    }
-
-    return conversationModelIdsBySandboxModelId;
   }
 
   async updateStatus(


### PR DESCRIPTION
## Description

No UI changes.

Based on `main` after #28040, which has merged. This PR removes the remaining public conversation fetch and ownership mapping wrappers from `SandboxResource`.

What changes here:
- Conversation sandbox reads and reaper owner mapping now live behind `ConversationResource`, using `sandbox_owners` internally.
- External callers no longer reach through `SandboxResource` for conversation-owned sandboxes.
- Conversation sandbox owner lookups are grouped by workspace and run through `concurrentExecutor` with a low concurrency cap.

Current open stack after #28040:
- #28041: remove remaining public conversation fetch wrappers from `SandboxResource`.
- #28047: add pod sandbox resource methods.
- #28048: wire pod sandbox owners into the reaper.

## Tests

Latest local verification on the rewritten stack:

- `npm exec -- biome check front/lib/resources/conversation_resource.ts front/lib/resources/pod_sandbox_resource.ts front/lib/resources/sandbox_resource.ts front/lib/resources/sandbox_resource.test.ts front/lib/resources/pod_sandbox_resource.test.ts front/temporal/sandbox_reaper/activities.test.ts front/lib/api/sandbox/access_tokens.test.ts`
- `cd front && source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_ENV=test npm test -- ./lib/resources/sandbox_resource.test.ts ./lib/resources/pod_sandbox_resource.test.ts ./temporal/sandbox_reaper/activities.test.ts ./lib/api/sandbox/access_tokens.test.ts`
- `npm -w front run tsgo`
- `npm -w front-api run tsgo`
- `npm -w front-spa run tsgo`
- `npm -w extension run tsgo`

## Risk

Low. This moves internal read call sites to `ConversationResource`; the underlying ownership data remains `sandbox_owners`.

The new executor only parallelizes per-workspace owner queries at concurrency 4. Each query still filters by `workspaceId` and the same sandbox id set as before.

## Deploy Plan

- [x] #28040 has merged into `main`.
- [ ] Merge this PR after CI and review are green.
- [ ] Deploy normally as app code only.
- [ ] No schema migration, data migration, or backfill is required for this PR.
