### PR TITLE
[front] chore: add index to speedup agent message skill lookups

### DIFF
--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -189,9 +189,9 @@ AgentMessageSkillModel.init(
         concurrently: true,
       },
       {
-        fields: ["workspaceId", "customSkillId"],
+        fields: ["customSkillId"],
         where: { customSkillId: { [Op.ne]: null } },
-        name: "idx_agent_message_skills_workspace_custom_skill",
+        name: "idx_agent_message_skills_custom_skill",
         concurrently: true,
       },
     ],

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -188,6 +188,12 @@ AgentMessageSkillModel.init(
         name: "idx_agent_message_skills_agent_message_id",
         concurrently: true,
       },
+      {
+        fields: ["workspaceId", "customSkillId"],
+        where: { customSkillId: { [Op.ne]: null } },
+        name: "idx_agent_message_skills_workspace_custom_skill",
+        concurrently: true,
+      },
     ],
     validate: {
       eitherGlobalOrCustomSkill: eitherGlobalOrCustomSkillValidation,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -3416,7 +3416,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ],
       where: {
         workspaceId: workspace.id,
-        customSkillId: { [Op.in]: [...skillsById.keys()] },
+        customSkillId: {
+          [Op.ne]: null,
+          [Op.in]: [...skillsById.keys()],
+        },
       },
     });
 

--- a/front/migrations/pre-deploy/20260626173438_add_agent_message_skills_custom_skill_index.sql
+++ b/front/migrations/pre-deploy/20260626173438_add_agent_message_skills_custom_skill_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY idx_agent_message_skills_custom_skill ON public.agent_message_skills USING btree ("customSkillId") WHERE "customSkillId" IS NOT NULL;

--- a/front/migrations/pre-deploy/20260626173438_add_agent_message_skills_workspace_custom_skill_index.sql
+++ b/front/migrations/pre-deploy/20260626173438_add_agent_message_skills_workspace_custom_skill_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY idx_agent_message_skills_workspace_custom_skill ON public.agent_message_skills USING btree ("workspaceId", "customSkillId") WHERE "customSkillId" IS NOT NULL;

--- a/front/migrations/pre-deploy/20260626173438_add_agent_message_skills_workspace_custom_skill_index.sql
+++ b/front/migrations/pre-deploy/20260626173438_add_agent_message_skills_workspace_custom_skill_index.sql
@@ -1,1 +1,0 @@
-CREATE INDEX CONCURRENTLY idx_agent_message_skills_workspace_custom_skill ON public.agent_message_skills USING btree ("workspaceId", "customSkillId") WHERE "customSkillId" IS NOT NULL;


### PR DESCRIPTION
## Description

- Adds an index on `agent_message_skills` to speed up this query: https://github.com/dust-tt/dust/blob/main/front/lib/resources/skill/skill_resource.ts#L3410 (`listAgentMessageSkillsByCustomSkills`, used for skill reinforcement).
- Breakdown of affected queries, scan cost change and write overhead in https://app.pganalyze.com/databases/-642267661/checks/index_advisor/indexing_engine/36722381.
- A partial index here gives the same usefulness for the query, with a lower storage/cache/write overhead, plus we always query with a non null custom skill ID.

## Tests

- Migration tested locally.

## Risk

- Low.

## Deploy Plan

- Run migration.
- Deploy front.

