### PR TITLE
Improve Google Sheets tool descriptions for tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/google_sheets/metadata.ts
+++ b/front/lib/api/actions/servers/google_sheets/metadata.ts
@@ -9,13 +9,13 @@ export const GOOGLE_SHEETS_TOOL_NAME = "google_sheets" as const;
 export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
   list_spreadsheets: {
     description:
-      "List Google Sheets spreadsheets accessible by the user from both personal drive and shared drives. Supports pagination and search.",
+      "Search for and list your Google Sheets spreadsheets by name, across your personal and shared drives, to find a spreadsheet when you do not know its ID.",
     schema: {
       nameFilter: z
         .string()
         .optional()
         .describe(
-          "The text to search for in file names. Uses Google Drive's 'contains' operator which is case-insensitive and performs prefix matching only. For example, searching 'hello' will match 'HelloWorld' but not 'WorldHello'."
+          "Text to search for in spreadsheet names (case-insensitive prefix match)."
         ),
       pageToken: z.string().optional().describe("Page token for pagination."),
       pageSize: z
@@ -45,7 +45,7 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
   },
   get_worksheet: {
     description:
-      "Get data from a specific worksheet in a Google Sheets spreadsheet.",
+      "Read the cell values from a range in a Google Sheets worksheet (tab), returning the data found in the given A1 range.",
     schema: {
       spreadsheetId: z.string().describe("The ID of the spreadsheet."),
       range: z
@@ -193,7 +193,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
   },
   format_cells: {
-    description: "Apply formatting to cells in a Google Sheets spreadsheet.",
+    description:
+      "Apply formatting to a range of cells in a Google Sheets worksheet, such as bold or italic text, font size, background color, and horizontal alignment.",
     schema: {
       spreadsheetId: z.string().describe("The ID of the spreadsheet."),
       sheetId: z.number().describe("The ID of the worksheet to format."),
@@ -236,7 +237,7 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
   },
   copy_sheet: {
     description:
-      "Copy a sheet from one Google Sheets spreadsheet to another spreadsheet.",
+      "Copy a worksheet (tab) from one Google Sheets spreadsheet into another.",
     schema: {
       sourceSpreadsheetId: z
         .string()

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -48,6 +48,9 @@ export const QUERIES: LabeledQuery[] = [
   {
     query: "create a new google spreadsheet",
     expected: "google_drive.create_spreadsheet",
+    // google_sheets exposes a duplicate create_spreadsheet; without naming the
+    // server the two are not lexically separable and trade the top slot.
+    maxRank: 2,
   },
   {
     query: "make a new google slides deck",
@@ -614,6 +617,71 @@ export const QUERIES: LabeledQuery[] = [
   {
     query: "download a png screenshot of my dashboard",
     expected: "interactive_content.export_interactive_content_file",
+  },
+
+  // --- google_sheets ---
+  {
+    query: "find my budget spreadsheet in google sheets",
+    expected: "google_sheets.list_spreadsheets",
+    // google_drive exposes its own keyword-dense spreadsheet tools
+    // (create_spreadsheet, update_spreadsheet) that match "spreadsheet"
+    // cross-server; not separable until those servers are consolidated.
+    maxRank: 3,
+  },
+  {
+    query: "list all my google sheets spreadsheets",
+    expected: "google_sheets.list_spreadsheets",
+    // "list" collides with google_drive's short list_drives /
+    // list_file_permissions docs; the cross-server overlap caps this at 3.
+    maxRank: 3,
+  },
+  {
+    query: "get the properties of a google sheets spreadsheet",
+    expected: "google_sheets.get_spreadsheet",
+  },
+  {
+    query: "read the values from a range in a google sheet",
+    expected: "google_sheets.get_worksheet",
+  },
+  {
+    query: "write values into cells in a google sheet",
+    expected: "google_sheets.update_cells",
+  },
+  {
+    query: "append a new row of data to a google sheet",
+    expected: "google_sheets.append_data",
+  },
+  {
+    query: "clear the values from a range in a google sheet",
+    expected: "google_sheets.clear_range",
+  },
+  {
+    query: "create a brand new google sheets spreadsheet",
+    expected: "google_sheets.create_spreadsheet",
+  },
+  {
+    query: "add a new tab to a google sheets spreadsheet",
+    expected: "google_sheets.add_worksheet",
+  },
+  {
+    query: "delete a tab from a google sheets spreadsheet",
+    expected: "google_sheets.delete_worksheet",
+  },
+  {
+    query: "make a range of cells bold in a google sheet",
+    expected: "google_sheets.format_cells",
+  },
+  {
+    query: "copy a tab from one google spreadsheet to another",
+    expected: "google_sheets.copy_sheet",
+  },
+  {
+    query: "rename a tab in a google sheet",
+    expected: "google_sheets.rename_worksheet",
+  },
+  {
+    query: "reorder a tab to a different position in a google sheet",
+    expected: "google_sheets.move_worksheet",
   },
 
   // --- cross-server (no platform named) ---

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -15,6 +15,7 @@ import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metad
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
+import { GOOGLE_SHEETS_SERVER } from "@app/lib/api/actions/servers/google_sheets/metadata";
 import { HUBSPOT_SERVER } from "@app/lib/api/actions/servers/hubspot/metadata";
 import { INTERACTIVE_CONTENT_SERVER } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
@@ -31,6 +32,7 @@ import { QUERIES } from "@app/scripts/mcp_bm25/queries";
 
 const SERVERS: ServerEntry[] = [
   { name: "google_drive", tools: GOOGLE_DRIVE_SERVER.tools },
+  { name: "google_sheets", tools: GOOGLE_SHEETS_SERVER.tools },
   { name: "microsoft_drive", tools: MICROSOFT_DRIVE_SERVER.tools },
   { name: "jira", tools: JIRA_SERVER.tools },
   { name: "zendesk", tools: ZENDESK_SERVER.tools },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
⚠️ Server soon to be deprecated. Seen with @smb2268 and @frankaloia.

This sharpens the Google Sheets tool descriptions so the right one surfaces when tool search ranks them by how well a user's phrasing matches each tool's name, description, and parameters, and it registers the server in the offline diagnostic so we can keep checking that. Reading a range of values now leads with reading values, formatting now names the things people actually ask for such as bold text and colors, and finding a spreadsheet by name now leads with searching and no longer carries an oversized parameter explanation that was pushing it down the ranking. One sibling that repeated the word spreadsheet was trimmed so it stops crowding out the listing tool. With these changes every Google Sheets phrasing we test retrieves the intended tool. A handful of intents around creating and listing spreadsheets remain genuinely ambiguous because the Drive integration exposes its own overlapping spreadsheet tools, and since the ranking sees only the tool and not which integration it belongs to, those cannot be separated by wording alone. Those are marked as tolerant in the diagnostic with a note, and the durable fix is to consolidate the overlapping spreadsheet tools rather than to keep tuning text.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
