### PR TITLE
Introduce SandboxFunctionResource

### DIFF
--- a/front/lib/api/files/upsert.test.ts
+++ b/front/lib/api/files/upsert.test.ts
@@ -642,7 +642,7 @@ describe("isFileTypeUpsertableForUseCase", () => {
     expect(
       isFileTypeUpsertableForUseCase({
         contentType: sandboxFunctionContentType,
-        useCase: "conversation",
+        useCase: "project_context",
       })
     ).toBe(false);
   });

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -1,0 +1,154 @@
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { describe, expect, it } from "vitest";
+
+const inputSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    message: { type: "string" },
+  },
+  required: ["message"],
+};
+
+const outputSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    commentId: { type: "string" },
+  },
+  required: ["commentId"],
+};
+
+describe("SandboxFunctionResource", () => {
+  it("creates and fetches a sandbox function for a Pod", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const file = await FileFactory.create(authenticator, null, {
+      contentType: "text/plain",
+      fileName: "comments.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+
+    const sandboxFunction = await SandboxFunctionResource.makeNew(
+      authenticator,
+      {
+        pod,
+        file,
+        inputSchema,
+        outputSchema,
+      }
+    );
+
+    expect(sandboxFunction.sId).toMatch(/^sfn_/);
+    expect(sandboxFunction.podId).toBe(pod.id);
+    expect(sandboxFunction.fileId).toBe(file.id);
+    expect(sandboxFunction.inputSchema).toEqual(inputSchema);
+    expect(sandboxFunction.outputSchema).toEqual(outputSchema);
+
+    const fetched = await SandboxFunctionResource.fetchById(
+      authenticator,
+      sandboxFunction.sId
+    );
+    expect(fetched?.id).toBe(sandboxFunction.id);
+
+    const listed = await SandboxFunctionResource.listByPod(authenticator, pod);
+    expect(listed.map(({ id }) => id)).toEqual([sandboxFunction.id]);
+  });
+
+  it("rejects a non-Pod space", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const regularSpace = await SpaceFactory.regular(workspace);
+    const file = await FileFactory.create(authenticator, null, {
+      contentType: "text/plain",
+      fileName: "comments.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: regularSpace.sId },
+    });
+
+    await expect(
+      SandboxFunctionResource.makeNew(authenticator, {
+        pod: regularSpace,
+        file,
+        inputSchema,
+        outputSchema,
+      })
+    ).rejects.toThrow("Sandbox functions can only belong to Pod spaces.");
+  });
+
+  it("rejects an invalid JSON Schema", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const file = await FileFactory.create(authenticator, null, {
+      contentType: "text/plain",
+      fileName: "comments.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+
+    await expect(
+      SandboxFunctionResource.makeNew(authenticator, {
+        pod,
+        file,
+        inputSchema: { type: "number", multipleOf: 0 },
+        outputSchema,
+      })
+    ).rejects.toThrow("Invalid JSON schema");
+  });
+
+  it("declares a unique file index", () => {
+    expect(SandboxFunctionModel.options.indexes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fields: ["fileId"],
+          unique: true,
+        }),
+      ])
+    );
+  });
+
+  it("deletes all sandbox functions for a Pod", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const file = await FileFactory.create(authenticator, null, {
+      contentType: "text/plain",
+      fileName: "comments.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    const sandboxFunction = await SandboxFunctionResource.makeNew(
+      authenticator,
+      {
+        pod,
+        file,
+        inputSchema,
+        outputSchema,
+      }
+    );
+
+    await SandboxFunctionResource.deleteAllForPod(authenticator, pod);
+
+    await expect(
+      SandboxFunctionResource.fetchById(authenticator, sandboxFunction.sId)
+    ).resolves.toBeNull();
+  });
+});

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -287,4 +287,46 @@ describe("SandboxFunctionResource", () => {
       FileResource.fetchById(authenticator, file.sId)
     ).resolves.toBeNull();
   });
+
+  it("refuses to delete when the user cannot access the Pod", async () => {
+    const { authenticator: adminAuth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const file = await FileFactory.create(adminAuth, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: "comments.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    const sandboxFunction = await SandboxFunctionResource.makeNew(adminAuth, {
+      pod,
+      file,
+      inputSchema,
+      outputSchema,
+    });
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    expect(userAuth).not.toBeNull();
+    if (!userAuth) {
+      return;
+    }
+
+    const deleteResult = await sandboxFunction.delete(userAuth);
+
+    expect(deleteResult.isErr()).toBe(true);
+    expect(deleteResult.isErr() ? deleteResult.error.message : null).toBe(
+      "Sandbox function Pod is not accessible."
+    );
+    await expect(
+      SandboxFunctionResource.fetchById(adminAuth, sandboxFunction.sId)
+    ).resolves.toMatchObject({ id: sandboxFunction.id });
+  });
 });

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -113,10 +113,12 @@ describe("SandboxFunctionResource", () => {
 
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
-    const addMemberResult =
-      await accessiblePod.groups[0].dangerouslyAddMember(adminAuth, {
+    const addMemberResult = await accessiblePod.groups[0].dangerouslyAddMember(
+      adminAuth,
+      {
         user: user.toJSON(),
-      });
+      }
+    );
     expect(addMemberResult.isOk()).toBe(true);
 
     const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -129,10 +131,7 @@ describe("SandboxFunctionResource", () => {
     }
 
     await expect(
-      SandboxFunctionResource.fetchById(
-        userAuth,
-        accessibleSandboxFunction.sId
-      )
+      SandboxFunctionResource.fetchById(userAuth, accessibleSandboxFunction.sId)
     ).resolves.toMatchObject({
       id: accessibleSandboxFunction.id,
       pod: expect.objectContaining({ id: accessiblePod.id }),
@@ -148,9 +147,7 @@ describe("SandboxFunctionResource", () => {
     expect(accessibleList.map(({ id }) => id)).toEqual([
       accessibleSandboxFunction.id,
     ]);
-    expect(accessibleList.map(({ pod }) => pod.id)).toEqual([
-      accessiblePod.id,
-    ]);
+    expect(accessibleList.map(({ pod }) => pod.id)).toEqual([accessiblePod.id]);
 
     await expect(
       SandboxFunctionResource.listByPod(userAuth, restrictedPod)

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -1,3 +1,4 @@
+import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -29,12 +30,11 @@ describe("SandboxFunctionResource", () => {
     });
     const pod = await SpaceFactory.project(workspace);
     const file = await FileFactory.create(authenticator, null, {
-      contentType: "text/plain",
+      contentType: "text/typescript",
       fileName: "comments.ts",
       fileSize: 100,
       status: "created",
-      useCase: "project_context",
-      useCaseMetadata: { spaceId: pod.sId },
+      useCase: "sandbox_function",
     });
 
     const sandboxFunction = await SandboxFunctionResource.makeNew(
@@ -69,12 +69,11 @@ describe("SandboxFunctionResource", () => {
     });
     const regularSpace = await SpaceFactory.regular(workspace);
     const file = await FileFactory.create(authenticator, null, {
-      contentType: "text/plain",
+      contentType: "text/typescript",
       fileName: "comments.ts",
       fileSize: 100,
       status: "created",
-      useCase: "project_context",
-      useCaseMetadata: { spaceId: regularSpace.sId },
+      useCase: "sandbox_function",
     });
 
     await expect(
@@ -93,12 +92,11 @@ describe("SandboxFunctionResource", () => {
     });
     const pod = await SpaceFactory.project(workspace);
     const file = await FileFactory.create(authenticator, null, {
-      contentType: "text/plain",
+      contentType: "text/typescript",
       fileName: "comments.ts",
       fileSize: 100,
       status: "created",
-      useCase: "project_context",
-      useCaseMetadata: { spaceId: pod.sId },
+      useCase: "sandbox_function",
     });
 
     await expect(
@@ -128,12 +126,11 @@ describe("SandboxFunctionResource", () => {
     });
     const pod = await SpaceFactory.project(workspace);
     const file = await FileFactory.create(authenticator, null, {
-      contentType: "text/plain",
+      contentType: "text/typescript",
       fileName: "comments.ts",
       fileSize: 100,
       status: "created",
-      useCase: "project_context",
-      useCaseMetadata: { spaceId: pod.sId },
+      useCase: "sandbox_function",
     });
     const sandboxFunction = await SandboxFunctionResource.makeNew(
       authenticator,
@@ -149,6 +146,9 @@ describe("SandboxFunctionResource", () => {
 
     await expect(
       SandboxFunctionResource.fetchById(authenticator, sandboxFunction.sId)
+    ).resolves.toBeNull();
+    await expect(
+      FileResource.fetchById(authenticator, file.sId)
     ).resolves.toBeNull();
   });
 });

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -1,9 +1,12 @@
+import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { sandboxFunctionContentType } from "@app/types/files";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { describe, expect, it } from "vitest";
@@ -60,9 +63,108 @@ describe("SandboxFunctionResource", () => {
       sandboxFunction.sId
     );
     expect(fetched?.id).toBe(sandboxFunction.id);
+    expect(fetched?.pod.id).toBe(pod.id);
 
     const listed = await SandboxFunctionResource.listByPod(authenticator, pod);
     expect(listed.map(({ id }) => id)).toEqual([sandboxFunction.id]);
+    expect(listed.map(({ pod }) => pod.id)).toEqual([pod.id]);
+  });
+
+  it("only fetches sandbox functions from accessible Pods", async () => {
+    const { authenticator: adminAuth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const accessiblePod = await SpaceFactory.project(workspace);
+    const restrictedPod = await SpaceFactory.project(workspace);
+    const accessibleFile = await FileFactory.create(adminAuth, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: "accessible.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: accessiblePod.sId },
+    });
+    const restrictedFile = await FileFactory.create(adminAuth, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: "restricted.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: restrictedPod.sId },
+    });
+    const accessibleSandboxFunction = await SandboxFunctionResource.makeNew(
+      adminAuth,
+      {
+        pod: accessiblePod,
+        file: accessibleFile,
+        inputSchema,
+        outputSchema,
+      }
+    );
+    const restrictedSandboxFunction = await SandboxFunctionResource.makeNew(
+      adminAuth,
+      {
+        pod: restrictedPod,
+        file: restrictedFile,
+        inputSchema,
+        outputSchema,
+      }
+    );
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const addMemberResult =
+      await accessiblePod.groups[0].dangerouslyAddMember(adminAuth, {
+        user: user.toJSON(),
+      });
+    expect(addMemberResult.isOk()).toBe(true);
+
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    expect(userAuth).not.toBeNull();
+    if (!userAuth) {
+      return;
+    }
+
+    await expect(
+      SandboxFunctionResource.fetchById(
+        userAuth,
+        accessibleSandboxFunction.sId
+      )
+    ).resolves.toMatchObject({
+      id: accessibleSandboxFunction.id,
+      pod: expect.objectContaining({ id: accessiblePod.id }),
+    });
+    await expect(
+      SandboxFunctionResource.fetchById(userAuth, restrictedSandboxFunction.sId)
+    ).resolves.toBeNull();
+
+    const accessibleList = await SandboxFunctionResource.listByPod(
+      userAuth,
+      accessiblePod
+    );
+    expect(accessibleList.map(({ id }) => id)).toEqual([
+      accessibleSandboxFunction.id,
+    ]);
+    expect(accessibleList.map(({ pod }) => pod.id)).toEqual([
+      accessiblePod.id,
+    ]);
+
+    await expect(
+      SandboxFunctionResource.listByPod(userAuth, restrictedPod)
+    ).resolves.toEqual([]);
+
+    await expect(
+      SandboxFunctionResource.fetchById(
+        adminAuth,
+        restrictedSandboxFunction.sId
+      )
+    ).resolves.toMatchObject({
+      id: restrictedSandboxFunction.id,
+      pod: expect.objectContaining({ id: restrictedPod.id }),
+    });
   });
 
   it("rejects a non-Pod space", async () => {

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -4,6 +4,7 @@ import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { sandboxFunctionContentType } from "@app/types/files";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { describe, expect, it } from "vitest";
 
@@ -30,11 +31,12 @@ describe("SandboxFunctionResource", () => {
     });
     const pod = await SpaceFactory.project(workspace);
     const file = await FileFactory.create(authenticator, null, {
-      contentType: "text/typescript",
+      contentType: sandboxFunctionContentType,
       fileName: "comments.ts",
       fileSize: 100,
       status: "created",
-      useCase: "sandbox_function",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
     });
 
     const sandboxFunction = await SandboxFunctionResource.makeNew(
@@ -69,11 +71,12 @@ describe("SandboxFunctionResource", () => {
     });
     const regularSpace = await SpaceFactory.regular(workspace);
     const file = await FileFactory.create(authenticator, null, {
-      contentType: "text/typescript",
+      contentType: sandboxFunctionContentType,
       fileName: "comments.ts",
       fileSize: 100,
       status: "created",
-      useCase: "sandbox_function",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: regularSpace.sId },
     });
 
     await expect(
@@ -86,17 +89,41 @@ describe("SandboxFunctionResource", () => {
     ).rejects.toThrow("Sandbox functions can only belong to Pod spaces.");
   });
 
+  it("rejects a file outside project context", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const file = await FileFactory.create(authenticator, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: "comments.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "conversation",
+    });
+
+    await expect(
+      SandboxFunctionResource.makeNew(authenticator, {
+        pod,
+        file,
+        inputSchema,
+        outputSchema,
+      })
+    ).rejects.toThrow("The file must use the project_context use case.");
+  });
+
   it("rejects an invalid JSON Schema", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
     const pod = await SpaceFactory.project(workspace);
     const file = await FileFactory.create(authenticator, null, {
-      contentType: "text/typescript",
+      contentType: sandboxFunctionContentType,
       fileName: "comments.ts",
       fileSize: 100,
       status: "created",
-      useCase: "sandbox_function",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
     });
 
     await expect(
@@ -126,11 +153,12 @@ describe("SandboxFunctionResource", () => {
     });
     const pod = await SpaceFactory.project(workspace);
     const file = await FileFactory.create(authenticator, null, {
-      contentType: "text/typescript",
+      contentType: sandboxFunctionContentType,
       fileName: "comments.ts",
       fileSize: 100,
       status: "created",
-      useCase: "sandbox_function",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
     });
     const sandboxFunction = await SandboxFunctionResource.makeNew(
       authenticator,

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -170,7 +170,13 @@ describe("SandboxFunctionResource", () => {
       }
     );
 
-    await SandboxFunctionResource.deleteAllForPod(authenticator, pod);
+    const deleteResult = await SandboxFunctionResource.deleteAllForPod(
+      authenticator,
+      pod
+    );
+
+    expect(deleteResult.isOk()).toBe(true);
+    expect(deleteResult.isOk() ? deleteResult.value : undefined).toBe(1);
 
     await expect(
       SandboxFunctionResource.fetchById(authenticator, sandboxFunction.sId)

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -1,7 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -27,12 +27,15 @@ export interface SandboxFunctionResource
 export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> {
   static model: ModelStaticWorkspaceAware<SandboxFunctionModel> =
     SandboxFunctionModel;
+  pod: SpaceResource;
 
   constructor(
     model: ModelStaticWorkspaceAware<SandboxFunctionModel>,
-    blob: Attributes<SandboxFunctionModel>
+    blob: Attributes<SandboxFunctionModel>,
+    pod: SpaceResource
   ) {
     super(model, blob);
+    this.pod = pod;
   }
 
   get sId(): string {
@@ -100,7 +103,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       { transaction }
     );
 
-    return new this(this.model, sandboxFunction.get());
+    return new this(this.model, sandboxFunction.get(), pod);
   }
 
   private static async baseFetch(
@@ -116,9 +119,28 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       ...rest,
     });
 
-    return sandboxFunctions.map(
-      (sandboxFunction) => new this(this.model, sandboxFunction.get())
+    const pods = await SpaceResource.fetchByModelIds(
+      auth,
+      Array.from(
+        new Set(
+          sandboxFunctions.map((sandboxFunction) => sandboxFunction.get().podId)
+        )
+      )
     );
+    const accessiblePodsById = new Map(
+      pods
+        .filter((pod) => pod.isProject() && pod.canReadOrAdministrate(auth))
+        .map((pod) => [pod.id, pod])
+    );
+
+    return sandboxFunctions.flatMap((sandboxFunction) => {
+      const pod = accessiblePodsById.get(sandboxFunction.get().podId);
+      if (!pod) {
+        return [];
+      }
+
+      return [new this(this.model, sandboxFunction.get(), pod)];
+    });
   }
 
   static async fetchById(

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -13,7 +13,7 @@ import {
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { sandboxFunctionContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
-import { Err, type Result } from "@app/types/shared/result";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -155,7 +155,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   static async deleteAllForPod(
     auth: Authenticator,
     pod: SpaceResource
-  ): Promise<number> {
+  ): Promise<Result<number, Error>> {
     assert(pod.isProject(), "Sandbox functions can only belong to Pod spaces.");
 
     const sandboxFunctions = await this.listByPod(auth, pod);
@@ -164,11 +164,11 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       // which deletes a whole bunch of records).
       const result = await sandboxFunction.delete(auth);
       if (result.isErr()) {
-        throw result.error;
+        return new Err(result.error);
       }
     }
 
-    return sandboxFunctions.length;
+    return new Ok(sandboxFunctions.length);
   }
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -12,7 +12,8 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { ModelId } from "@app/types/shared/model_id";
-import { Ok, type Result } from "@app/types/shared/result";
+import { Err, type Result } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { Attributes, Transaction } from "sequelize";
@@ -65,21 +66,23 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionResource> {
-    const workspaceModelId = auth.getNonNullableWorkspace().id;
-
     assert(pod.isProject(), "Sandbox functions can only belong to Pod spaces.");
     assert(
-      pod.workspaceId === workspaceModelId,
+      pod.workspaceId === auth.getNonNullableWorkspace().id,
       "The Pod must belong to the authenticated workspace."
     );
     assert(
-      file.workspaceId === workspaceModelId,
+      file.workspaceId === auth.getNonNullableWorkspace().id,
       "The file must belong to the authenticated workspace."
+    );
+    assert(
+      file.useCase === "sandbox_function",
+      "The file must use the sandbox_function use case."
     );
 
     const sandboxFunction = await this.model.create(
       {
-        workspaceId: workspaceModelId,
+        workspaceId: auth.getNonNullableWorkspace().id,
         podId: pod.id,
         fileId: file.id,
         inputSchema,
@@ -142,32 +145,38 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
   static async deleteAllForPod(
     auth: Authenticator,
-    pod: SpaceResource,
-    transaction?: Transaction
+    pod: SpaceResource
   ): Promise<number> {
     assert(pod.isProject(), "Sandbox functions can only belong to Pod spaces.");
 
-    return this.model.destroy({
-      where: {
-        podId: pod.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-      transaction,
-    });
+    const sandboxFunctions = await this.listByPod(auth, pod);
+    for (const sandboxFunction of sandboxFunctions) {
+      const result = await sandboxFunction.delete(auth);
+      if (result.isErr()) {
+        throw result.error;
+      }
+    }
+
+    return sandboxFunctions.length;
   }
 
-  async delete(
-    auth: Authenticator,
-    { transaction }: { transaction?: Transaction }
-  ): Promise<Result<undefined, Error>> {
-    await this.model.destroy({
-      where: {
-        id: this.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-      transaction,
-    });
+  async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
+    try {
+      const file = await FileResource.fetchByModelIdWithAuth(auth, this.fileId);
+      if (!file) {
+        return new Err(new Error("Sandbox function file not found."));
+      }
 
-    return new Ok(undefined);
+      await this.model.destroy({
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      });
+
+      return file.delete(auth);
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
   }
 }

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -1,0 +1,173 @@
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import {
+  getResourceIdFromSId,
+  isResourceSId,
+  makeSId,
+} from "@app/lib/resources/string_ids";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Ok, type Result } from "@app/types/shared/result";
+import assert from "assert";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type { Attributes, Transaction } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface SandboxFunctionResource
+  extends ReadonlyAttributesType<SandboxFunctionModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> {
+  static model: ModelStaticWorkspaceAware<SandboxFunctionModel> =
+    SandboxFunctionModel;
+
+  constructor(
+    model: ModelStaticWorkspaceAware<SandboxFunctionModel>,
+    blob: Attributes<SandboxFunctionModel>
+  ) {
+    super(model, blob);
+  }
+
+  get sId(): string {
+    return SandboxFunctionResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("sandbox_function", { id, workspaceId });
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    {
+      pod,
+      file,
+      inputSchema,
+      outputSchema,
+    }: {
+      pod: SpaceResource;
+      file: FileResource;
+      inputSchema: JSONSchema;
+      outputSchema: JSONSchema;
+    },
+    transaction?: Transaction
+  ): Promise<SandboxFunctionResource> {
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+
+    assert(pod.isProject(), "Sandbox functions can only belong to Pod spaces.");
+    assert(
+      pod.workspaceId === workspaceModelId,
+      "The Pod must belong to the authenticated workspace."
+    );
+    assert(
+      file.workspaceId === workspaceModelId,
+      "The file must belong to the authenticated workspace."
+    );
+
+    const sandboxFunction = await this.model.create(
+      {
+        workspaceId: workspaceModelId,
+        podId: pod.id,
+        fileId: file.id,
+        inputSchema,
+        outputSchema,
+      },
+      { transaction }
+    );
+
+    return new this(this.model, sandboxFunction.get());
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    options?: ResourceFindOptions<SandboxFunctionModel>
+  ): Promise<SandboxFunctionResource[]> {
+    const { where, ...rest } = options ?? {};
+    const sandboxFunctions = await this.model.findAll({
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      ...rest,
+    });
+
+    return sandboxFunctions.map(
+      (sandboxFunction) => new this(this.model, sandboxFunction.get())
+    );
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    sandboxFunctionId: string
+  ): Promise<SandboxFunctionResource | null> {
+    if (!isResourceSId("sandbox_function", sandboxFunctionId)) {
+      return null;
+    }
+
+    const sandboxFunctionModelId = getResourceIdFromSId(sandboxFunctionId);
+    if (sandboxFunctionModelId === null) {
+      return null;
+    }
+
+    const [sandboxFunction] = await this.baseFetch(auth, {
+      where: { id: sandboxFunctionModelId },
+    });
+
+    return sandboxFunction ?? null;
+  }
+
+  static async listByPod(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<SandboxFunctionResource[]> {
+    if (!pod.isProject()) {
+      return [];
+    }
+
+    return this.baseFetch(auth, { where: { podId: pod.id } });
+  }
+
+  static async deleteAllForPod(
+    auth: Authenticator,
+    pod: SpaceResource,
+    transaction?: Transaction
+  ): Promise<number> {
+    assert(pod.isProject(), "Sandbox functions can only belong to Pod spaces.");
+
+    return this.model.destroy({
+      where: {
+        podId: pod.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction }
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+}

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -195,6 +195,10 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
     try {
+      if (!this.pod.canReadOrAdministrate(auth)) {
+        return new Err(new Error("Sandbox function Pod is not accessible."));
+      }
+
       const file = await FileResource.fetchByModelIdWithAuth(auth, this.fileId);
       if (!file) {
         return new Err(new Error("Sandbox function file not found."));

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -11,6 +11,7 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { sandboxFunctionContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -76,8 +77,16 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       "The file must belong to the authenticated workspace."
     );
     assert(
-      file.useCase === "sandbox_function",
-      "The file must use the sandbox_function use case."
+      file.contentType === sandboxFunctionContentType,
+      `The file must use the ${sandboxFunctionContentType} content type.`
+    );
+    assert(
+      file.useCase === "project_context",
+      "The file must use the project_context use case."
+    );
+    assert(
+      file.useCaseMetadata?.spaceId === pod.sId,
+      "The file must belong to the same Pod as the sandbox function."
     );
 
     const sandboxFunction = await this.model.create(
@@ -151,6 +160,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
     const sandboxFunctions = await this.listByPod(auth, pod);
     for (const sandboxFunction of sandboxFunctions) {
+      // TODO(spolu): potentially optimize as this may be quite slow (each delete calls file delete
+      // which deletes a whole bunch of records).
       const result = await sandboxFunction.delete(auth);
       if (result.isErr()) {
         throw result.error;

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -73,6 +73,9 @@ export const RESOURCES_PREFIX = {
   // Project metadata.
   project_metadata: "pmd",
 
+  // Sandbox functions.
+  sandbox_function: "sfn",
+
   // Academy quiz attempts.
   academy_quiz_attempt: "aqz",
   academy_chapter_visit: "acv",

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -163,7 +163,11 @@ export async function scrubSpaceActivity({
   if (space.isProject()) {
     // Delete sandbox functions first because their file foreign keys can otherwise prevent Pod
     // files from being deleted.
-    await SandboxFunctionResource.deleteAllForPod(auth, space);
+    const deleteSandboxFunctionsResult =
+      await SandboxFunctionResource.deleteAllForPod(auth, space);
+    if (deleteSandboxFunctionsResult.isErr()) {
+      throw deleteSandboxFunctionsResult.error;
+    }
   }
 
   // Delete all the data sources of the spaces.

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -161,8 +161,6 @@ export async function scrubSpaceActivity({
   assert(space.isDeletable(), "Space cannot be deleted.");
 
   if (space.isProject()) {
-    // Delete sandbox functions first because their file foreign keys can otherwise prevent Pod
-    // files from being deleted.
     const deleteSandboxFunctionsResult =
       await SandboxFunctionResource.deleteAllForPod(auth, space);
     if (deleteSandboxFunctionsResult.isErr()) {

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -50,6 +50,7 @@ import { ProjectTaskStateResource } from "@app/lib/resources/project_task_state_
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -158,6 +159,12 @@ export async function scrubSpaceActivity({
   }
 
   assert(space.isDeletable(), "Space cannot be deleted.");
+
+  if (space.isProject()) {
+    // Delete sandbox functions first because their file foreign keys can otherwise prevent Pod
+    // files from being deleted.
+    await SandboxFunctionResource.deleteAllForPod(auth, space);
+  }
 
   // Delete all the data sources of the spaces.
   const dataSources = await DataSourceResource.listBySpace(auth, space, {


### PR DESCRIPTION
## Description

Follow-up from: https://github.com/dust-tt/dust/pull/28024

Introduce basic scaffolding for the `SandboxFunctionResource`.

Deletion by pods is not super optimized but at least fully implemented. Optimization is likely slightly involved given the number of models hidden behind FileResource. Right now, sequential delete which will be peaceful on the DB but potentially a bit slow for the user. The deleteByPod should only happen on pod deletion which is rare enough.
 
## Tests

Some tests, but mostly N/A

## Risk

None

## Deploy Plan

N/A