### PR TITLE
[front] free plan switch: rely on webhook for subscription update

### DIFF
--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -8,7 +8,6 @@ import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
-import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import { BUSINESS_USD_PACKAGE_ALIAS } from "@app/lib/metronome/types";
 import { PlanModel } from "@app/lib/models/plan";
 import {
@@ -17,7 +16,6 @@ import {
 } from "@app/lib/plans/billing_currency";
 import { CREDIT_PRICED_FREE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
-import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -118,23 +116,6 @@ export async function activateCreditPricedFreePlan(
       `Failed to provision Metronome contract: ${contractResult.error.message}`
     );
   }
-  const { metronomeContractId } = contractResult.value;
-
-  const subscriptionResult =
-    await SubscriptionResource.createSubscriptionFromCheckout({
-      workspaceModelId: owner.id,
-      plan,
-      metronomeContractId,
-      now,
-    });
-  if (subscriptionResult.isErr()) {
-    throw new Error(
-      `Failed to create subscription: ${subscriptionResult.error.message}`
-    );
-  }
-
-  await invalidateContractCache(owner.sId);
-  await restoreWorkspaceAfterSubscription(auth);
 }
 
 export async function restoreWorkspaceAfterSubscription(auth: Authenticator) {

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -2,7 +2,6 @@ import { sendProactiveTrialCancelledEmail } from "@app/lib/api/email";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
-import { DustError } from "@app/lib/error";
 import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
   ensureMetronomeCustomerForWorkspace,
@@ -185,61 +184,6 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       subscription.get(),
       plan
     );
-  }
-
-  static async createSubscriptionFromCheckout({
-    workspaceModelId,
-    plan,
-    metronomeContractId,
-    now,
-  }: {
-    workspaceModelId: ModelId;
-    plan: PlanModel;
-    metronomeContractId: string;
-    now: Date;
-  }): Promise<Result<void, DustError>> {
-    return withTransaction(async (t) => {
-      const activeSubscription =
-        await SubscriptionResource.fetchActiveByWorkspaceModelId(
-          workspaceModelId,
-          t
-        );
-
-      if (activeSubscription?.planId === plan.id) {
-        return new Err(
-          new DustError(
-            "subscription_already_exists",
-            `Active subscription already exists for plan ${plan.code}.`
-          )
-        );
-      }
-
-      if (activeSubscription?.isBilled) {
-        return new Err(
-          new DustError(
-            "subscription_already_exists",
-            "Active paid subscription already exists."
-          )
-        );
-      }
-
-      await activeSubscription?.markAsEnded("ended", t);
-      await SubscriptionResource.makeNew(
-        {
-          sId: generateRandomModelSId(),
-          workspaceId: workspaceModelId,
-          planId: plan.id,
-          status: "active",
-          trialing: false,
-          startDate: now,
-          metronomeContractId,
-        },
-        renderPlanFromModel({ plan }),
-        t
-      );
-
-      return new Ok(undefined);
-    });
   }
 
   private static readonly subscriptionCacheKeyResolver = (


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9261

Function activateCreditPricedFreePlan called during free plan creation was updating the subscription using createSubscriptionFromCheckout.
BUT the subscription is also updated by Metronome contract.start webhook that could create a race condition where createSubscriptionFromCheckout failed as the subscription was already updated ([see logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod%20%22Error%3A%20Failed%20to%20create%20subscription%3A%20Active%20paid%20subscription%20already%20exists.%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1781861830902&to_ts=1782466630902&live=true))
=> remove call to createSubscriptionFromCheckout and rely only on the webhook for subscription update

## Tests

Tested locally

## Risk

Medium, impacts the free plan subscription flow

## Deploy Plan

Deploy front