### PR TITLE
Add pod sandbox owner adapter

### DIFF
--- a/front/lib/resources/pod_sandbox_adapter.ts
+++ b/front/lib/resources/pod_sandbox_adapter.ts
@@ -1,0 +1,191 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  type EnsureSandboxResult,
+  type SandboxCreateBlob,
+  type SandboxDeleteOwner,
+  type SandboxLifecycleOwner,
+  SandboxResource,
+} from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { Result } from "@app/types/shared/result";
+import assert from "assert";
+import type { Transaction } from "sequelize";
+
+// Pods are project spaces, but SpaceResource cannot import SandboxResource
+// without creating an import cycle. Keep this as a thin owner adapter rather
+// than a model-backed Resource.
+export class PodSandboxAdapter {
+  private static assertPod(space: SpaceResource) {
+    assert(space.isProject(), "Only pod spaces can own sandboxes.");
+  }
+
+  private static async fetchSandboxByPod(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<SandboxResource | null> {
+    this.assertPod(pod);
+
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const link = await SandboxOwnerModel.findOne({
+      where: {
+        spaceId: pod.id,
+        workspaceId: workspaceModelId,
+      },
+    });
+
+    if (!link) {
+      return null;
+    }
+
+    return SandboxResource.fetchByModelIdForWorkspace(auth, link.sandboxId);
+  }
+
+  private static async createSandboxRecordForPod(
+    auth: Authenticator,
+    pod: SpaceResource,
+    blob: SandboxCreateBlob
+  ): Promise<SandboxResource> {
+    this.assertPod(pod);
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+
+    return withTransaction(async (transaction) => {
+      const sandbox = await SandboxResource.makeNew(auth, blob, {
+        transaction,
+      });
+
+      await SandboxOwnerModel.create(
+        {
+          workspaceId: workspaceModelId,
+          spaceId: pod.id,
+          sandboxId: sandbox.id,
+        },
+        { transaction }
+      );
+
+      return sandbox;
+    });
+  }
+
+  private static toSandboxLifecycleOwner(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): SandboxLifecycleOwner {
+    this.assertPod(pod);
+
+    return {
+      lockKey: pod.sId,
+      fetchSandbox: () => this.fetchSandboxByPod(auth, pod),
+    };
+  }
+
+  private static toSandboxDeleteOwner(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): SandboxDeleteOwner {
+    this.assertPod(pod);
+
+    return {
+      lockKey: pod.sId,
+      fetchSandbox: () => this.fetchSandboxByPod(auth, pod),
+      deleteSandbox: async (
+        sandbox: SandboxResource,
+        transaction: Transaction
+      ) => {
+        await SandboxOwnerModel.destroy({
+          where: {
+            spaceId: pod.id,
+            sandboxId: sandbox.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+          transaction,
+        });
+      },
+    };
+  }
+
+  static async fetchSandbox(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<SandboxResource | null> {
+    return this.fetchSandboxByPod(auth, pod);
+  }
+
+  static async ensureSandboxActive(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<Result<EnsureSandboxResult, Error>> {
+    this.assertPod(pod);
+
+    return SandboxResource.ensureActive(auth, {
+      lockKey: pod.sId,
+      envVars: { SPACE_ID: pod.sId },
+      logLabel: "pod",
+      fetchSandbox: () => this.fetchSandboxByPod(auth, pod),
+      createSandbox: (blob) => this.createSandboxRecordForPod(auth, pod, blob),
+    });
+  }
+
+  static async pauseSandboxForApproval(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<Result<void, Error>> {
+    this.assertPod(pod);
+
+    return SandboxResource.pauseForApproval(auth, {
+      lockKey: pod.sId,
+      fetchSandbox: () => this.fetchSandboxByPod(auth, pod),
+    });
+  }
+
+  static async deleteSandbox(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.deleteByOwner(
+      auth,
+      this.toSandboxDeleteOwner(auth, pod)
+    );
+  }
+
+  static async dangerouslySleepSandboxIfRunning(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslySleepIfRunning(
+      auth,
+      this.toSandboxLifecycleOwner(auth, pod)
+    );
+  }
+
+  static async dangerouslySleepSandboxIfPendingApproval(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslySleepIfPendingApproval(
+      auth,
+      this.toSandboxLifecycleOwner(auth, pod)
+    );
+  }
+
+  static async dangerouslyDestroySandboxIfSleeping(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslyDestroyIfSleeping(
+      auth,
+      this.toSandboxLifecycleOwner(auth, pod)
+    );
+  }
+
+  static async dangerouslyDestroySandboxIfKillRequested(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslyDestroyIfKillRequested(
+      auth,
+      this.toSandboxLifecycleOwner(auth, pod)
+    );
+  }
+}

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -714,7 +714,7 @@ describe("SandboxResource.ensureActive", () => {
           imageId: { imageName: "test-image", tag: "0.0.1" },
           envVars: {
             DST_API_TOKEN: "image-token",
-            POD_ID: "image-pod-id",
+            SPACE_ID: "image-space-id",
             WORKSPACE_ID: "image-workspace-id",
           },
           network: { egress: "restricted" },
@@ -831,7 +831,7 @@ describe("SandboxResource.ensureActive", () => {
       "DD_HOST"
     );
     expect(mockProviderCreate.mock.calls[0]?.[0].envVars).not.toHaveProperty(
-      "POD_ID"
+      "SPACE_ID"
     );
     expect(mockProviderExec).not.toHaveBeenCalled();
   });

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -77,7 +77,7 @@ export type SandboxDeleteOwner = SandboxLifecycleOwner & {
 // only enforces the env contract and does not interpret owner types.
 const SANDBOX_OWNER_ENV_VAR_CONTRACT_NAMES = new Set([
   "CONVERSATION_ID",
-  "POD_ID",
+  "SPACE_ID",
 ]);
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging

--- a/front/lib/resources/space_resource.sandbox.test.ts
+++ b/front/lib/resources/space_resource.sandbox.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { mockExecuteWithLock, mockGetSandboxImage, mockGetSandboxProvider } =
+  vi.hoisted(() => ({
+    mockExecuteWithLock: vi.fn(),
+    mockGetSandboxImage: vi.fn(),
+    mockGetSandboxProvider: vi.fn(),
+  }));
+
+vi.mock("@app/lib/api/sandbox", () => ({
+  getSandboxProvider: mockGetSandboxProvider,
+}));
+
+vi.mock("@app/lib/api/sandbox/image", () => ({
+  getSandboxImage: mockGetSandboxImage,
+}));
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: mockExecuteWithLock,
+}));
+
+import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
+import {
+  SandboxModel,
+  SandboxOwnerModel,
+} from "@app/lib/resources/storage/models/sandbox";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Ok } from "@app/types/shared/result";
+
+describe("PodSandboxAdapter", () => {
+  it("creates a sandbox and pod ownership row", async () => {
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockGetSandboxImage.mockReturnValue(
+      new Ok({
+        toCreateConfig: () => ({
+          imageId: { imageName: "test-image", tag: "0.0.1" },
+          envVars: {},
+          network: { egress: "restricted" },
+          resources: { cpu: 1, memoryMB: 512 },
+        }),
+      })
+    );
+    mockGetSandboxProvider.mockReturnValue({
+      create: vi.fn().mockResolvedValue(new Ok({ providerId: "provider-id" })),
+    });
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+
+    const result = await PodSandboxAdapter.ensureSandboxActive(
+      authenticator,
+      pod
+    );
+
+    expect(result.isOk()).toBe(true);
+    const sandbox = result.isOk() ? result.value.sandbox : null;
+    expect(sandbox).not.toBeNull();
+    await expect(
+      SandboxOwnerModel.count({
+        where: {
+          sandboxId: sandbox?.id,
+          spaceId: pod.id,
+          workspaceId: workspace.id,
+        },
+      })
+    ).resolves.toBe(1);
+  });
+
+  it("deleteSandbox deletes the owner link and sandbox row", async () => {
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockGetSandboxImage.mockReturnValue(
+      new Ok({
+        toCreateConfig: () => ({
+          imageId: { imageName: "test-image", tag: "0.0.1" },
+          envVars: {},
+          network: { egress: "restricted" },
+          resources: { cpu: 1, memoryMB: 512 },
+        }),
+      })
+    );
+    mockGetSandboxProvider.mockReturnValue({
+      create: vi.fn().mockResolvedValue(new Ok({ providerId: "provider-id" })),
+      destroy: vi.fn().mockResolvedValue(new Ok(undefined)),
+    });
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const createResult = await PodSandboxAdapter.ensureSandboxActive(
+      authenticator,
+      pod
+    );
+    if (createResult.isErr()) {
+      throw createResult.error;
+    }
+
+    const deleteResult = await PodSandboxAdapter.deleteSandbox(
+      authenticator,
+      pod
+    );
+
+    expect(deleteResult.isOk()).toBe(true);
+    const where = {
+      sandboxId: createResult.value.sandbox.id,
+      spaceId: pod.id,
+      workspaceId: workspace.id,
+    };
+    await expect(SandboxOwnerModel.count({ where })).resolves.toBe(0);
+    await expect(
+      SandboxModel.count({
+        where: {
+          id: createResult.value.sandbox.id,
+          workspaceId: workspace.id,
+        },
+      })
+    ).resolves.toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

No UI changes.

#28094 has merged into `main`. This PR adds the pod sandbox owner adapter for project spaces.

Pods are represented by `SpaceResource` rows with `kind: "project"`. The sandbox glue is kept in `PodSandboxAdapter` instead of directly on `SpaceResource` because `SpaceResource -> SandboxResource` creates an import cycle through the existing auth/data-source/resource-with-space graph. This module is a thin owner adapter, not a model-backed Resource.

What changes here:
- Adds pod fetch, ensure active, pause, delete, sleep, and destroy methods through `PodSandboxAdapter`.
- Creates a `sandbox_owners` row with `spaceId` in the same transaction as sandbox row creation.
- Injects `SPACE_ID` through the owner env contract.
- Uses the auth-scoped `SandboxResource.fetchByModelIdForWorkspace(auth, sandboxModelId)` helper for normal pod sandbox fetches.
- Does not write any legacy conversation ownership field on the sandbox row.

Current open stack:
- #28047: add pod sandbox owner adapter.
- #28048: wire pod sandbox owners into the reaper.

## Tests

Latest local verification after rebasing on `origin/main`:

- `npm exec -- biome check front/lib/resources/pod_sandbox_adapter.ts front/lib/resources/space_resource.sandbox.test.ts front/lib/resources/space_resource.ts front/lib/resources/sandbox_resource.ts`
- `cd front && source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_ENV=test npm test -- ./lib/resources/space_resource.sandbox.test.ts`
- `npm -w front run tsgo`
- `npm -w front-api run tsgo`
- `npm -w front-spa run tsgo`
- `npm -w extension run tsgo`

## Risk

Medium-low. This adds new pod entry points without changing existing conversation call sites. App rollback is safe because the earlier schema PR creates the generic ownership table before this code can be exercised.

Normal pod fetches are auth-scoped; the adapter exists only to avoid the current `SpaceResource` import cycle with `SandboxResource`.

## Deploy Plan

- [x] #28094 has merged into `main`.
- [ ] Merge and deploy this PR after CI and review are green.
- [ ] Deploy normally as app code only.
- [ ] No schema migration, data migration, or backfill is required for this PR.
