### PR TITLE
Wire pod sandbox owners into reaper

### DIFF
--- a/front/lib/resources/pod_sandbox_adapter.ts
+++ b/front/lib/resources/pod_sandbox_adapter.ts
@@ -8,10 +8,14 @@ import {
 } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import assert from "assert";
-import type { Transaction } from "sequelize";
+import { Op, type Transaction } from "sequelize";
+
+const SANDBOX_OWNER_LOOKUP_CONCURRENCY = 4;
 
 // Pods are project spaces, but SpaceResource cannot import SandboxResource
 // without creating an import cycle. Keep this as a thin owner adapter rather
@@ -187,5 +191,53 @@ export class PodSandboxAdapter {
       auth,
       this.toSandboxLifecycleOwner(auth, pod)
     );
+  }
+
+  static async dangerouslyFetchPodModelIdsBySandboxes(
+    sandboxes: Pick<SandboxResource, "id" | "workspaceId">[]
+  ): Promise<Map<ModelId, ModelId>> {
+    if (sandboxes.length === 0) {
+      return new Map();
+    }
+
+    const sandboxModelIdsByWorkspaceModelId = new Map<ModelId, ModelId[]>();
+    for (const sandbox of sandboxes) {
+      const sandboxModelIds =
+        sandboxModelIdsByWorkspaceModelId.get(sandbox.workspaceId) ?? [];
+      sandboxModelIds.push(sandbox.id);
+      sandboxModelIdsByWorkspaceModelId.set(
+        sandbox.workspaceId,
+        sandboxModelIds
+      );
+    }
+
+    const rows = (
+      await concurrentExecutor(
+        [...sandboxModelIdsByWorkspaceModelId.entries()],
+        async ([workspaceModelId, sandboxModelIds]) =>
+          SandboxOwnerModel.findAll({
+            where: {
+              workspaceId: workspaceModelId,
+              spaceId: {
+                [Op.ne]: null,
+              },
+              sandboxId: {
+                [Op.in]: sandboxModelIds,
+              },
+            },
+            attributes: ["sandboxId", "spaceId"],
+          }),
+        { concurrency: SANDBOX_OWNER_LOOKUP_CONCURRENCY }
+      )
+    ).flat();
+
+    const podModelIdsBySandboxModelId = new Map<ModelId, ModelId>();
+    for (const row of rows) {
+      if (row.spaceId !== null) {
+        podModelIdsBySandboxModelId.set(row.sandboxId, row.spaceId);
+      }
+    }
+
+    return podModelIdsBySandboxModelId;
   }
 }

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -505,6 +505,34 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return spaces ?? [];
   }
 
+  static async dangerouslyFetchByModelIds(
+    spaceModelIds: ModelId[]
+  ): Promise<SpaceResource[]> {
+    if (spaceModelIds.length === 0) {
+      return [];
+    }
+
+    // WORKSPACE_ISOLATION_BYPASS: The sandbox reaper operates across
+    // workspaces. The ids come from workspace-scoped sandbox ownership rows.
+    const spaces = await this.model.findAll({
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+      where: {
+        id: {
+          [Op.in]: spaceModelIds,
+        },
+      },
+      include: [
+        {
+          model: GroupResource.model,
+        },
+      ],
+      includeDeleted: true,
+    });
+
+    return spaces.map(this.fromModel);
+  }
+
   static async fetchByName(
     auth: Authenticator,
     name: string,

--- a/front/temporal/sandbox_reaper/activities.test.ts
+++ b/front/temporal/sandbox_reaper/activities.test.ts
@@ -1,0 +1,113 @@
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
+import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
+import { reapStaleSandboxesActivity } from "@app/temporal/sandbox_reaper/activities";
+import { SLEEP_THRESHOLD_MS } from "@app/temporal/sandbox_reaper/config";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { describe, expect, it, vi } from "vitest";
+
+const {
+  mockExecuteWithLock,
+  mockGetSandboxImage,
+  mockGetSandboxProvider,
+  mockHeartbeat,
+  mockProviderSleep,
+} = vi.hoisted(() => ({
+  mockExecuteWithLock: vi.fn(),
+  mockGetSandboxImage: vi.fn(),
+  mockGetSandboxProvider: vi.fn(),
+  mockHeartbeat: vi.fn(),
+  mockProviderSleep: vi.fn(),
+}));
+
+vi.mock("@temporalio/activity", () => ({
+  heartbeat: mockHeartbeat,
+}));
+
+vi.mock("@app/lib/api/sandbox", () => ({
+  getSandboxProvider: mockGetSandboxProvider,
+}));
+
+vi.mock("@app/lib/api/sandbox/image", () => ({
+  getSandboxImage: mockGetSandboxImage,
+}));
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: mockExecuteWithLock,
+}));
+
+describe("reapStaleSandboxesActivity", () => {
+  it("sleeps stale conversation and pod sandboxes", async () => {
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockGetSandboxImage.mockReturnValue(
+      new Ok({
+        toCreateConfig: () => ({
+          imageId: { imageName: "test-image", tag: "0.0.1" },
+          envVars: {},
+          network: { egress: "restricted" },
+          resources: { cpu: 1, memoryMB: 512 },
+        }),
+      })
+    );
+    mockGetSandboxProvider.mockReturnValue({
+      create: vi
+        .fn()
+        .mockResolvedValueOnce(new Ok({ providerId: "conversation-provider" }))
+        .mockResolvedValueOnce(new Ok({ providerId: "pod-provider" })),
+      sleep: mockProviderSleep.mockResolvedValue(new Ok(undefined)),
+    });
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const conversationSandboxResult =
+      await ConversationSandboxAdapter.ensureSandboxActive(
+        authenticator,
+        conversation
+      );
+    const podSandboxResult = await PodSandboxAdapter.ensureSandboxActive(
+      authenticator,
+      pod
+    );
+    if (conversationSandboxResult.isErr()) {
+      throw conversationSandboxResult.error;
+    }
+    if (podSandboxResult.isErr()) {
+      throw podSandboxResult.error;
+    }
+    const staleLastActivityAt = new Date(Date.now() - SLEEP_THRESHOLD_MS - 1);
+    await SandboxModel.update(
+      { lastActivityAt: staleLastActivityAt },
+      {
+        where: {
+          id: [
+            conversationSandboxResult.value.sandbox.id,
+            podSandboxResult.value.sandbox.id,
+          ],
+        },
+      }
+    );
+
+    const hasMore = await reapStaleSandboxesActivity();
+
+    expect(hasMore).toBe(false);
+    expect(mockProviderSleep).toHaveBeenCalledWith("conversation-provider", {
+      workspaceId: workspace.sId,
+    });
+    expect(mockProviderSleep).toHaveBeenCalledWith("pod-provider", {
+      workspaceId: workspace.sId,
+    });
+  });
+});

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -1,7 +1,9 @@
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -18,9 +20,31 @@ import {
 
 const REAPER_CONCURRENCY = 16;
 
-type ConversationMaps = {
-  conversationModelIdsBySandboxModelId: Map<ModelId, ModelId>;
-  conversationsBySandboxModelId: Map<ModelId, ConversationResource>;
+type ReaperSandboxLifecycleOwner = {
+  kind: "conversation" | "pod";
+  modelId: ModelId;
+  dangerouslyDestroySandboxIfKillRequested(
+    auth: Authenticator
+  ): Promise<Result<void, Error>>;
+  dangerouslyDestroySandboxIfSleeping(
+    auth: Authenticator
+  ): Promise<Result<void, Error>>;
+  dangerouslySleepSandboxIfPendingApproval(
+    auth: Authenticator
+  ): Promise<Result<void, Error>>;
+  dangerouslySleepSandboxIfRunning(
+    auth: Authenticator
+  ): Promise<Result<void, Error>>;
+};
+
+type SandboxOwnerRef = {
+  kind: ReaperSandboxLifecycleOwner["kind"];
+  modelId: ModelId;
+};
+
+type SandboxOwnerMaps = {
+  ownerRefsBySandboxModelId: Map<ModelId, SandboxOwnerRef>;
+  ownersBySandboxModelId: Map<ModelId, ReaperSandboxLifecycleOwner>;
 };
 
 /**
@@ -53,88 +77,153 @@ async function fetchAuthMap(
 }
 
 /**
- * Fetch the ConversationResource for each sandbox, keyed by conversation
- * sandbox ModelId. The reaper spans every workspace, so we issue a single
- * cross-workspace query instead of one scoped query per workspace.
+ * Fetch the owner adapter for each sandbox. The reaper spans every workspace,
+ * so it resolves owner ids through join tables first, then issues one
+ * cross-workspace query per owner kind.
  */
-async function fetchConversationMap(
+async function fetchSandboxOwnerMaps(
   sandboxes: SandboxResource[]
-): Promise<ConversationMaps> {
+): Promise<SandboxOwnerMaps> {
   const conversationModelIdsBySandboxModelId =
     await ConversationSandboxAdapter.dangerouslyFetchConversationModelIdsBySandboxes(
       sandboxes
     );
+  const podModelIdsBySandboxModelId =
+    await PodSandboxAdapter.dangerouslyFetchPodModelIdsBySandboxes(sandboxes);
+
   const conversationModelIds = [
     ...new Set(conversationModelIdsBySandboxModelId.values()),
   ];
+  const podModelIds = [...new Set(podModelIdsBySandboxModelId.values())];
+
   const conversations =
     await ConversationResource.dangerouslyFetchByModelIds(conversationModelIds);
+  const pods = await SpaceResource.dangerouslyFetchByModelIds(podModelIds);
+
   const conversationsById = new Map(conversations.map((c) => [c.id, c]));
+  const podsById = new Map(
+    pods.filter((p) => p.isProject()).map((p) => [p.id, p])
+  );
 
-  return {
-    conversationModelIdsBySandboxModelId,
-    conversationsBySandboxModelId: new Map(
-      sandboxes.flatMap((sandbox) => {
-        const conversationModelId = conversationModelIdsBySandboxModelId.get(
-          sandbox.id
-        );
-        if (!conversationModelId) {
-          return [];
-        }
+  const ownerRefsBySandboxModelId = new Map<ModelId, SandboxOwnerRef>();
+  const ownersBySandboxModelId = new Map<
+    ModelId,
+    ReaperSandboxLifecycleOwner
+  >();
 
-        const conversation = conversationsById.get(conversationModelId);
+  for (const sandbox of sandboxes) {
+    const conversationModelId = conversationModelIdsBySandboxModelId.get(
+      sandbox.id
+    );
+    if (conversationModelId) {
+      ownerRefsBySandboxModelId.set(sandbox.id, {
+        kind: "conversation",
+        modelId: conversationModelId,
+      });
 
-        return conversation ? [[sandbox.id, conversation] as const] : [];
-      })
-    ),
-  };
+      const conversation = conversationsById.get(conversationModelId);
+      if (conversation) {
+        ownersBySandboxModelId.set(sandbox.id, {
+          kind: "conversation",
+          modelId: conversation.id,
+          dangerouslyDestroySandboxIfKillRequested: (auth) =>
+            ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested(
+              auth,
+              conversation
+            ),
+          dangerouslyDestroySandboxIfSleeping: (auth) =>
+            ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping(
+              auth,
+              conversation
+            ),
+          dangerouslySleepSandboxIfPendingApproval: (auth) =>
+            ConversationSandboxAdapter.dangerouslySleepSandboxIfPendingApproval(
+              auth,
+              conversation
+            ),
+          dangerouslySleepSandboxIfRunning: (auth) =>
+            ConversationSandboxAdapter.dangerouslySleepSandboxIfRunning(
+              auth,
+              conversation
+            ),
+        });
+      }
+      continue;
+    }
+
+    const podModelId = podModelIdsBySandboxModelId.get(sandbox.id);
+    if (!podModelId) {
+      continue;
+    }
+
+    ownerRefsBySandboxModelId.set(sandbox.id, {
+      kind: "pod",
+      modelId: podModelId,
+    });
+
+    const pod = podsById.get(podModelId);
+    if (pod) {
+      ownersBySandboxModelId.set(sandbox.id, {
+        kind: "pod",
+        modelId: pod.id,
+        dangerouslyDestroySandboxIfKillRequested: (auth) =>
+          PodSandboxAdapter.dangerouslyDestroySandboxIfKillRequested(auth, pod),
+        dangerouslyDestroySandboxIfSleeping: (auth) =>
+          PodSandboxAdapter.dangerouslyDestroySandboxIfSleeping(auth, pod),
+        dangerouslySleepSandboxIfPendingApproval: (auth) =>
+          PodSandboxAdapter.dangerouslySleepSandboxIfPendingApproval(auth, pod),
+        dangerouslySleepSandboxIfRunning: (auth) =>
+          PodSandboxAdapter.dangerouslySleepSandboxIfRunning(auth, pod),
+      });
+    }
+  }
+
+  return { ownerRefsBySandboxModelId, ownersBySandboxModelId };
 }
 
 /**
  * Shared driver for every reaper phase: resolve the workspace auth and the
- * ConversationResource for each sandbox, then run `action` concurrently. The
- * lifecycle methods run from the conversation resource so callers do not need
- * to know the conversation-owned sandbox lookup details.
+ * owner adapter for each sandbox, then run `action` concurrently. The
+ * lifecycle methods run from the owner adapter so callers do not need to know
+ * the sandbox lookup details.
  */
 async function processSandboxes(
   sandboxes: SandboxResource[],
   action: (
     auth: Authenticator,
-    conversation: ConversationResource
+    owner: ReaperSandboxLifecycleOwner
   ) => Promise<Result<void, Error>>,
   errorMessage: string
 ): Promise<void> {
   const authMap = await fetchAuthMap(sandboxes);
-  const conversationMaps = await fetchConversationMap(sandboxes);
+  const ownerMaps = await fetchSandboxOwnerMaps(sandboxes);
 
   await concurrentExecutor(
     sandboxes,
     async (sandbox) => {
       const auth = authMap.get(sandbox.workspaceId);
-      const conversation = conversationMaps.conversationsBySandboxModelId.get(
-        sandbox.id
-      );
+      const owner = ownerMaps.ownersBySandboxModelId.get(sandbox.id);
 
-      if (!auth || !conversation) {
+      if (!auth || !owner) {
+        const ownerRef = ownerMaps.ownerRefsBySandboxModelId.get(sandbox.id);
         logger.warn(
           {
-            ownershipConversationModelId:
-              conversationMaps.conversationModelIdsBySandboxModelId.get(
-                sandbox.id
-              ) ?? null,
+            ownerKind: ownerRef?.kind ?? null,
+            ownerModelId: ownerRef?.modelId ?? null,
             sandboxModelId: sandbox.id,
             workspaceModelId: sandbox.workspaceId,
           },
-          "Reaper: workspace or conversation not found, skipping."
+          "Reaper: workspace or sandbox owner not found, skipping."
         );
         return;
       }
 
-      const result = await action(auth, conversation);
+      const result = await action(auth, owner);
       if (result.isErr()) {
         logger.error(
           {
-            conversationModelId: conversation.id,
+            ownerKind: owner.kind,
+            ownerModelId: owner.modelId,
             error: result.error.message,
           },
           errorMessage
@@ -166,11 +255,7 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
 
     await processSandboxes(
       killRequestedSandboxes,
-      (auth, conversation) =>
-        ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested(
-          auth,
-          conversation
-        ),
+      (auth, owner) => owner.dangerouslyDestroySandboxIfKillRequested(auth),
       "Reaper: failed to destroy kill-requested sandbox — continuing."
     );
   }
@@ -190,11 +275,7 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
 
     await processSandboxes(
       runningSandboxes,
-      (auth, conversation) =>
-        ConversationSandboxAdapter.dangerouslySleepSandboxIfRunning(
-          auth,
-          conversation
-        ),
+      (auth, owner) => owner.dangerouslySleepSandboxIfRunning(auth),
       "Reaper: failed to sleep sandbox — continuing."
     );
   }
@@ -214,11 +295,7 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
 
     await processSandboxes(
       pendingSandboxes,
-      (auth, conversation) =>
-        ConversationSandboxAdapter.dangerouslySleepSandboxIfPendingApproval(
-          auth,
-          conversation
-        ),
+      (auth, owner) => owner.dangerouslySleepSandboxIfPendingApproval(auth),
       "Reaper: failed to transition pending_approval sandbox — continuing."
     );
   }
@@ -238,11 +315,7 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
 
     await processSandboxes(
       sleepingSandboxes,
-      (auth, conversation) =>
-        ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping(
-          auth,
-          conversation
-        ),
+      (auth, owner) => owner.dangerouslyDestroySandboxIfSleeping(auth),
       "Reaper: failed to destroy sandbox — continuing."
     );
   }


### PR DESCRIPTION
## Description

No UI changes.

#28047 has merged into `main`. This PR updates the sandbox reaper to resolve either conversation-owned or pod-owned sandboxes before running lifecycle actions.

What changes here:
- Resolves conversation owners through `ConversationSandboxAdapter`.
- Resolves pod owners through `sandbox_owners.spaceId`, loads each pod as a project `SpaceResource`, and runs lifecycle operations through `PodSandboxAdapter`.
- Runs the same lifecycle phase against the resolved owner adapter for both owner kinds.
- Groups pod sandbox owner lookups by workspace and runs them through `concurrentExecutor` with a low concurrency cap, matching the conversation lookup pattern.

Current open stack:
- #28048: wire pod sandbox owners into the reaper.

## Tests

Latest local verification after rebasing on `origin/main`:

- `npm exec -- biome check front/lib/resources/space_resource.ts front/lib/resources/sandbox_resource.test.ts front/temporal/sandbox_reaper/activities.ts front/temporal/sandbox_reaper/activities.test.ts`
- `cd front && source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_ENV=test npm test -- ./temporal/sandbox_reaper/activities.test.ts`
- `npm -w front run tsgo`
- `npm -w front-api run tsgo`
- `npm -w front-spa run tsgo`
- `npm -w extension run tsgo`

## Risk

Medium. The reaper now resolves two owner kinds. Missing owners are still skipped with a warning, existing conversation-owned sandboxes continue through the conversation sandbox adapter, and rollback is safe because no schema changes are included in this PR.

The new executor only parallelizes per-workspace pod owner queries at concurrency 4. Each query still filters by `workspaceId` and the same sandbox id set as before.

## Deploy Plan

- [x] #28047 has merged into `main`.
- [ ] Merge and deploy this PR after CI and review are green.
- [ ] Deploy normally as app code only.
- [ ] No schema migration, data migration, or backfill is required for this PR.
