### PR TITLE
feat(front): add model picker to conversation input bar

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -31,6 +31,7 @@ import {
 } from "@app/types/assistant/assistant";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { isEqualNode } from "@app/types/data_source_view";
@@ -43,6 +44,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -55,7 +57,8 @@ interface InputBarProps {
     input: string,
     mentions: RichMention[],
     contentFragments: ContentFragmentsType,
-    selectedMCPServerViewIds?: string[]
+    selectedMCPServerViewIds?: string[],
+    modelSelection?: ModelSelectionType
   ) => Promise<Result<undefined, DustError>>;
   draftKey: string;
   conversation?: ConversationWithoutContentType;
@@ -115,6 +118,17 @@ export const InputBar = React.memo(function InputBar({
   const [attachedNodes, setAttachedNodes] = useState<
     DataSourceViewContentNode[]
   >([]);
+
+  // Latest model-picker selection, kept in a ref so the picker's change events
+  // don't re-render the whole input bar; read at submit time. `undefined` means
+  // no override (run the agent's configured model).
+  const modelSelectionRef = useRef<ModelSelectionType | undefined>(undefined);
+  const handleModelSelectionChange = useCallback(
+    (modelSelection: ModelSelectionType | undefined) => {
+      modelSelectionRef.current = modelSelection;
+    },
+    []
+  );
 
   const {
     getAndClearSelectedAgent,
@@ -350,7 +364,8 @@ export const InputBar = React.memo(function InputBar({
           },
           // Only send the selectedMCPServerViewIds if we are creating a new conversation.
           // Once the conversation is created, the selectedMCPServerViewIds will be updated in the conversationTools hook.
-          selectedMCPServerViews.map((sv) => sv.sId)
+          selectedMCPServerViews.map((sv) => sv.sId),
+          modelSelectionRef.current
         );
 
         if (r.isOk()) {
@@ -366,17 +381,25 @@ export const InputBar = React.memo(function InputBar({
       setIsLocalSubmitting(true);
 
       try {
-        const submitPromise = onSubmit(markdown, mentions, {
-          uploaded: fileUploaderService.getFileBlobs().map((cf) => {
-            return {
-              title: cf.filename,
-              fileId: cf.fileId,
-              contentType: cf.contentType,
-              url: cf.sourceUrl,
-            };
-          }),
-          contentNodes: attachedNodes,
-        });
+        const submitPromise = onSubmit(
+          markdown,
+          mentions,
+          {
+            uploaded: fileUploaderService.getFileBlobs().map((cf) => {
+              return {
+                title: cf.filename,
+                fileId: cf.fileId,
+                contentType: cf.contentType,
+                url: cf.sourceUrl,
+              };
+            }),
+            contentNodes: attachedNodes,
+          },
+          // Existing conversation: MCP server views are synced via the
+          // conversationTools hook, so only the model selection is passed here.
+          undefined,
+          modelSelectionRef.current
+        );
 
         // Execute these operations in parallel with the submission.
         resetEditorText();
@@ -515,6 +538,7 @@ export const InputBar = React.memo(function InputBar({
             onNodeUnselect={handleNodesAttachmentRemove}
             selectedMCPServerViews={selectedMCPServerViews}
             onMCPServerViewSelect={handleMCPServerViewSelect}
+            onModelSelectionChange={handleModelSelectionChange}
             onMCPServerViewDeselect={handleMCPServerViewDeselect}
             onResetMCPServerViews={handleResetMCPServerViews}
             isAgentBuilder={isAgentBuilder}

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -2,6 +2,7 @@ import { AgentPicker } from "@app/components/assistant/AgentPicker";
 import { CapabilitiesPicker } from "@app/components/assistant/CapabilitiesPicker";
 import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
 import type { InputBarAction } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
+import { InputBarModelPicker } from "@app/components/assistant/conversation/input_bar/InputBarModelPicker";
 import type useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -15,6 +16,7 @@ import type {
   RichMention,
 } from "@app/types/assistant/mentions";
 import { toRichAgentMentionType } from "@app/types/assistant/mentions";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { getSupportedFileExtensions } from "@app/types/files";
@@ -54,6 +56,9 @@ interface InputBarButtonsProps {
   isInputDisabled: boolean;
   onAgentRemove: () => void;
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
+  onModelSelectionChange?: (
+    modelSelection: ModelSelectionType | undefined
+  ) => void;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
   onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
@@ -84,6 +89,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   isInputDisabled,
   onAgentRemove,
   onMCPServerViewSelect,
+  onModelSelectionChange,
   onNodeSelect,
   onNodeUnselect,
   onSkillSelect,
@@ -235,9 +241,26 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       </>
     );
 
+  const selectedAgentModel =
+    (selectedAgent &&
+      allAgents.find((a) => a.sId === selectedAgent.id)?.model) ??
+    null;
+
+  const modelPickerButton = actions.includes("model-picker") && (
+    <InputBarModelPicker
+      agentModel={selectedAgentModel}
+      owner={owner}
+      buttonSize={buttonSize}
+      side={conversation ? "top" : "bottom"}
+      disabled={isInputDisabled}
+      onSelectionChange={onModelSelectionChange}
+    />
+  );
+
   return (
     <>
       {agentButton}
+      {modelPickerButton}
       {!hideCapabilities && toolsButton}
       {attachmentButton}
     </>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -347,41 +347,6 @@ const InputBarContainer = ({
   const [showKnowledgePicker, setShowKnowledgePicker] = useState(false);
   const [isToolbarOpen, setIsToolbarOpen] = useState(false);
   const plusButtonRef = useRef<HTMLDivElement>(null);
-  // On mobile the bottom button row scrolls horizontally under the pinned
-  // voice/send cluster. We fade its right edge only while there is more content
-  // to scroll to, so the fade reads as "there's more" rather than clipping the
-  // last button when everything already fits.
-  const [hasButtonRowOverflow, setHasButtonRowOverflow] = useState(false);
-  // Track whether the mobile button row can still scroll right, to toggle the
-  // right-edge fade. We use a callback ref (rather than useEffect) so setup runs
-  // exactly when the row mounts/unmounts — the row is conditionally rendered
-  // while recording, and observing the row and its content catches both viewport
-  // resizes and changes to the set of buttons.
-  const buttonRowCleanupRef = useRef<(() => void) | null>(null);
-  const buttonRowRef = useCallback((el: HTMLDivElement | null) => {
-    buttonRowCleanupRef.current?.();
-    buttonRowCleanupRef.current = null;
-    if (!el) {
-      setHasButtonRowOverflow(false);
-      return;
-    }
-    const update = () => {
-      setHasButtonRowOverflow(
-        el.scrollLeft + el.clientWidth < el.scrollWidth - 1
-      );
-    };
-    update();
-    const observer = new ResizeObserver(update);
-    observer.observe(el);
-    if (el.firstElementChild) {
-      observer.observe(el.firstElementChild);
-    }
-    el.addEventListener("scroll", update, { passive: true });
-    buttonRowCleanupRef.current = () => {
-      observer.disconnect();
-      el.removeEventListener("scroll", update);
-    };
-  }, []);
   const clientType = useClientType();
   const shouldEnableSlashSuggestion = actions.includes("capabilities");
 
@@ -1679,24 +1644,13 @@ const InputBarContainer = ({
                 className={cn(
                   "flex w-full items-center px-2",
                   // The voice/send cluster is absolutely positioned at the
-                  // bottom-right. On mobile the button row would otherwise slide
-                  // underneath it, so reserve that space and let the row scroll.
+                  // bottom-right. On mobile, reserve that space so the button
+                  // row doesn't slide underneath it.
                   isMobile && "pr-24"
                 )}
               >
                 {!isRecording && (
-                  <div
-                    ref={buttonRowRef}
-                    className={cn(
-                      "flex items-center",
-                      isMobile && "min-w-0 overflow-x-auto scrollbar-hide",
-                      // Fade the right edge (only while there's more to scroll to)
-                      // so it's clear the row continues under the send cluster.
-                      isMobile &&
-                        hasButtonRowOverflow &&
-                        "[-webkit-mask-image:linear-gradient(to_right,black_calc(100%-56px),transparent)] mask-[linear-gradient(to_right,black_calc(100%-56px),transparent)]"
-                    )}
-                  >
+                  <div className="flex items-center">
                     <InputBarButtons
                       actions={actions}
                       allAgents={allAgents}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -65,6 +65,7 @@ import {
   isRichUserMention,
   toRichAgentMentionType,
 } from "@app/types/assistant/mentions";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import {
@@ -137,6 +138,7 @@ export const INPUT_BAR_ACTIONS = [
   "attachment",
   "agents-list",
   "agents-list-with-actions",
+  "model-picker",
   "turn-into-agent",
   "voice",
   "fullscreen",
@@ -217,6 +219,9 @@ export interface InputBarContainerProps {
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
   onMCPServerViewDeselect: (serverView: MCPServerViewType) => void;
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
+  onModelSelectionChange?: (
+    modelSelection: ModelSelectionType | undefined
+  ) => void;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
   onResetMCPServerViews: () => void;
@@ -266,6 +271,7 @@ const InputBarContainer = ({
   onNodeUnselect,
   attachedNodes,
   onMCPServerViewSelect,
+  onModelSelectionChange,
   onMCPServerViewDeselect,
   selectedMCPServerViews,
   onResetMCPServerViews,
@@ -341,6 +347,41 @@ const InputBarContainer = ({
   const [showKnowledgePicker, setShowKnowledgePicker] = useState(false);
   const [isToolbarOpen, setIsToolbarOpen] = useState(false);
   const plusButtonRef = useRef<HTMLDivElement>(null);
+  // On mobile the bottom button row scrolls horizontally under the pinned
+  // voice/send cluster. We fade its right edge only while there is more content
+  // to scroll to, so the fade reads as "there's more" rather than clipping the
+  // last button when everything already fits.
+  const [hasButtonRowOverflow, setHasButtonRowOverflow] = useState(false);
+  // Track whether the mobile button row can still scroll right, to toggle the
+  // right-edge fade. We use a callback ref (rather than useEffect) so setup runs
+  // exactly when the row mounts/unmounts — the row is conditionally rendered
+  // while recording, and observing the row and its content catches both viewport
+  // resizes and changes to the set of buttons.
+  const buttonRowCleanupRef = useRef<(() => void) | null>(null);
+  const buttonRowRef = useCallback((el: HTMLDivElement | null) => {
+    buttonRowCleanupRef.current?.();
+    buttonRowCleanupRef.current = null;
+    if (!el) {
+      setHasButtonRowOverflow(false);
+      return;
+    }
+    const update = () => {
+      setHasButtonRowOverflow(
+        el.scrollLeft + el.clientWidth < el.scrollWidth - 1
+      );
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    if (el.firstElementChild) {
+      observer.observe(el.firstElementChild);
+    }
+    el.addEventListener("scroll", update, { passive: true });
+    buttonRowCleanupRef.current = () => {
+      observer.disconnect();
+      el.removeEventListener("scroll", update);
+    };
+  }, []);
   const clientType = useClientType();
   const shouldEnableSlashSuggestion = actions.includes("capabilities");
 
@@ -1554,6 +1595,32 @@ const InputBarContainer = ({
         }}
       >
         <div className="flex w-0 flex-grow flex-col">
+          {!isRecording && editor && (
+            <div
+              className={cn("relative flex px-0 pt-1", !isMobile && "hidden")}
+            >
+              <Button
+                variant="ghost-secondary"
+                icon={Type01}
+                size={buttonSize}
+                onClick={() => setIsToolbarOpen(!isToolbarOpen)}
+              />
+              <Toolbar
+                variant="overlay"
+                className={cn(
+                  isToolbarOpen
+                    ? "pointer-events-auto w-full"
+                    : "pointer-events-none hidden"
+                )}
+                onClose={(e: React.MouseEvent<HTMLButtonElement>) => {
+                  e.stopPropagation();
+                  setIsToolbarOpen(false);
+                }}
+              >
+                <ToolBarContent editor={editor} />
+              </Toolbar>
+            </div>
+          )}
           <div className="relative">
             <EditorContent
               editor={editor}
@@ -1608,38 +1675,28 @@ const InputBarContainer = ({
               ))}
             </div>
             <div className="relative flex min-h-8 w-full items-center justify-between">
-              {!isRecording && editor && (
-                <Toolbar
-                  variant="overlay"
-                  className={cn(
-                    isToolbarOpen
-                      ? "pointer-events-auto w-full"
-                      : "pointer-events-none hidden w-[120px]",
-                    !isMobile && "hidden"
-                  )}
-                  onClose={(e: React.MouseEvent<HTMLButtonElement>) => {
-                    e.stopPropagation();
-                    setIsToolbarOpen(false);
-                  }}
-                >
-                  <ToolBarContent editor={editor} />
-                </Toolbar>
-              )}
               <div
                 className={cn(
                   "flex w-full items-center px-2",
-                  isToolbarOpen && "opacity-0"
+                  // The voice/send cluster is absolutely positioned at the
+                  // bottom-right. On mobile the button row would otherwise slide
+                  // underneath it, so reserve that space and let the row scroll.
+                  isMobile && "pr-24"
                 )}
               >
                 {!isRecording && (
-                  <div className="flex items-center">
-                    <Button
-                      variant="ghost-secondary"
-                      icon={Type01}
-                      size={buttonSize}
-                      className={cn("flex", !isMobile && "hidden")}
-                      onClick={() => setIsToolbarOpen(!isToolbarOpen)}
-                    />
+                  <div
+                    ref={buttonRowRef}
+                    className={cn(
+                      "flex items-center",
+                      isMobile && "min-w-0 overflow-x-auto scrollbar-hide",
+                      // Fade the right edge (only while there's more to scroll to)
+                      // so it's clear the row continues under the send cluster.
+                      isMobile &&
+                        hasButtonRowOverflow &&
+                        "[-webkit-mask-image:linear-gradient(to_right,black_calc(100%-56px),transparent)] mask-[linear-gradient(to_right,black_calc(100%-56px),transparent)]"
+                    )}
+                  >
                     <InputBarButtons
                       actions={actions}
                       allAgents={allAgents}
@@ -1657,6 +1714,7 @@ const InputBarContainer = ({
                       isInputDisabled={disableInput}
                       onAgentRemove={() => setSelectedSingleAgent(null)}
                       onMCPServerViewSelect={onMCPServerViewSelect}
+                      onModelSelectionChange={onModelSelectionChange}
                       onNodeSelect={onNodeSelect}
                       onNodeUnselect={onNodeUnselect}
                       onSkillSelect={handleSkillSelect}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1640,15 +1640,7 @@ const InputBarContainer = ({
               ))}
             </div>
             <div className="relative flex min-h-8 w-full items-center justify-between">
-              <div
-                className={cn(
-                  "flex w-full items-center px-2",
-                  // The voice/send cluster is absolutely positioned at the
-                  // bottom-right. On mobile, reserve that space so the button
-                  // row doesn't slide underneath it.
-                  isMobile && "pr-24"
-                )}
-              >
+              <div className={cn("flex w-full items-center px-2")}>
                 {!isRecording && (
                   <div className="flex items-center">
                     <InputBarButtons

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -1,5 +1,6 @@
 import { ModelPickerContent } from "@app/components/assistant/conversation/input_bar/ModelPickerContent";
 import type {
+  ModelPickerListState,
   ModelWithReasoningEffort,
   ProviderGroup,
   Selection,
@@ -197,6 +198,29 @@ export function InputBarModelPicker({
   const showAuto = !isSearching;
   const showList = expanded || isSearching || selection.kind === "model";
 
+  const hasResults = isSearching
+    ? filteredAll.length > 0
+    : suggestedModelsWithEfforts.length > 0 || moreByProvider.length > 0;
+
+  // Collapse the correlated list booleans + data arrays into a single state so
+  // the picker content receives one flat, exhaustively-typed prop.
+  let listState: ModelPickerListState = {
+    kind: "browse",
+    suggested: suggestedModelsWithEfforts,
+    moreByProvider,
+  };
+  if (!showList) {
+    listState = { kind: "hidden" };
+  } else if (isModelsLoading) {
+    listState = { kind: "loading" };
+  } else if (!hasResults) {
+    listState = { kind: "empty" };
+  } else if (isSearching) {
+    listState = { kind: "search", models: filteredAll };
+  }
+
+  const auto = showAuto ? { isOn: isAutoOn } : null;
+
   const label = isMobile
     ? "Model"
     : `Model: ${getModelWithReasoningEffortLabel(selection)}`;
@@ -214,10 +238,6 @@ export function InputBarModelPicker({
       setExpanded(false);
     }
   };
-
-  const hasResults = isSearching
-    ? filteredAll.length > 0
-    : suggestedModelsWithEfforts.length > 0 || moreByProvider.length > 0;
 
   if (!hasModelsPicker) {
     return null;
@@ -249,18 +269,9 @@ export function InputBarModelPicker({
         side={side}
         search={search}
         onSearchChange={setSearch}
-        isModelsLoading={isModelsLoading}
-        isSearching={isSearching}
-        hasResults={hasResults}
-        filteredAll={filteredAll}
-        suggestedModelsWithEfforts={suggestedModelsWithEfforts}
-        moreByProvider={moreByProvider}
+        listState={listState}
+        auto={auto}
         selectedKey={selectedKey}
-        isMobile={isMobile}
-        isDark={isDark}
-        showAuto={showAuto}
-        isAutoOn={isAutoOn}
-        showList={showList}
         onToggleAuto={toggleAuto}
         onSelectModel={(modelWithEffort: ModelWithReasoningEffort) =>
           commitSelection({

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -1,11 +1,23 @@
+import { ModelPickerContent } from "@app/components/assistant/conversation/input_bar/ModelPickerContent";
+import type {
+  ModelLine,
+  ProviderGroup,
+  Selection,
+  SuggestedLine,
+} from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import {
+  getLineKey,
+  getLineLabel,
+  getSelectableReasoningEfforts,
+  SUGGESTED_PINS,
+  toModelSelection,
+} from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useModels } from "@app/lib/swr/models";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
-import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
-import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
 import { getProviderDisplayName } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
@@ -14,148 +26,10 @@ import type {
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
-import {
-  Button,
-  ChevronDown,
-  ChevronRight,
-  Chip,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSearchbar,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
-  DropdownTooltipTrigger,
-  Icon,
-  SliderToggle,
-  Spinner,
-} from "@dust-tt/sparkle";
-import capitalize from "lodash/capitalize";
-import type { ReactElement, ReactNode } from "react";
-import { Fragment, useMemo, useRef, useState } from "react";
+import { Button, DropdownMenu, DropdownMenuTrigger } from "@dust-tt/sparkle";
+import { useMemo, useRef, useState } from "react";
 
-const SUGGESTED_PINS: {
-  providerId: ModelProviderIdType;
-  modelId: string;
-  effort: ReasoningEffort;
-  recommendation: string;
-}[] = [
-  {
-    providerId: "anthropic",
-    modelId: CLAUDE_SONNET_4_6_MODEL_ID,
-    effort: "light",
-    recommendation:
-      "Quick answers. Recommended for easy retrieval, light analysis or general questions.",
-  },
-  {
-    providerId: "anthropic",
-    modelId: CLAUDE_SONNET_4_6_MODEL_ID,
-    effort: "medium",
-    recommendation:
-      "Everyday tasks. Recommended for multi-step tasks, Frames, analysis.",
-  },
-  {
-    providerId: "openai",
-    modelId: GPT_5_5_MODEL_ID,
-    effort: "high",
-    recommendation:
-      "Hard problems. Recommended for high quality retrieval, complex analysis and Frames",
-  },
-];
-
-const AUTO_TOOLTIP =
-  "Dust selects and switches model for cost efficient performance and reliability. When an agent is created using a specific model, we use this model.";
-
-// Per reasoning-effort blurbs shown in each model's hover tooltip: what the
-// effort does, and what it is recommended for.
-const REASONING_EFFORT_INFO: Record<ReasoningEffort, { reasoning: string }> = {
-  none: {
-    reasoning: "No additional reasoning, for the fastest responses",
-  },
-  light: {
-    reasoning: "Light reasoning effort, faster responses.",
-  },
-  medium: {
-    reasoning: "Medium reasoning effort, balancing speed and quality.",
-  },
-  high: {
-    reasoning: "High reasoning effort, longer wait times but higher quality.",
-  },
-};
-
-interface ModelLine {
-  model: ModelConfigurationType;
-  effort: ReasoningEffort;
-}
-
-interface SuggestedLine extends ModelLine {
-  recommendation: string;
-}
-
-interface ProviderGroup {
-  providerId: ModelProviderIdType;
-  models: { model: ModelConfigurationType; efforts: ReasoningEffort[] }[];
-}
-
-type Selection =
-  | { kind: "auto" }
-  | { kind: "model"; model: ModelConfigurationType; effort: ReasoningEffort };
-
-function getSelectableReasoningEfforts(
-  model: ModelConfigurationType
-): ReasoningEffort[] {
-  const efforts = getAvailableReasoningEfforts(model.supportedReasoningEfforts);
-  const withReasoning = efforts.filter((effort) => effort !== "none");
-  return withReasoning.length > 0 ? withReasoning : efforts;
-}
-
-function getLineKey(
-  providerId: string,
-  modelId: string,
-  effort: ReasoningEffort
-): string {
-  return `${providerId}/${modelId}/${effort}`;
-}
-
-function getLineLabel(selection: Selection): string {
-  if (selection.kind === "auto") {
-    return "Auto";
-  }
-  const { model, effort } = selection;
-
-  if (effort === "none") {
-    return model.displayName;
-  }
-
-  return `${model.displayName} ${capitalize(effort)}`;
-}
-
-// Converts the picker's local selection into the API model selection
-function toModelSelection(
-  selection: Selection
-): ModelSelectionType | undefined {
-  switch (selection.kind) {
-    case "auto":
-      return undefined;
-    case "model":
-      return {
-        providerId: selection.model.providerId,
-        modelId: selection.model.modelId,
-        reasoningEffort: selection.effort,
-      };
-    default:
-      assertNeverAndIgnore(selection);
-      return undefined;
-  }
-}
 // TODO: test for EU
 interface InputBarModelPickerProps {
   agentModel: AgentModelConfigurationType | null;
@@ -286,22 +160,20 @@ export function InputBarModelPicker({
 
   const isSearching = search.trim() !== "";
 
-  const filterLines = <T extends ModelLine>(lines: T[]): T[] => {
+  // While searching we show a single flat list over every model/effort.
+  const filteredAll = useMemo<ModelLine[]>(() => {
     const q = search.trim().toLowerCase();
     if (!q) {
-      return lines;
+      return allLines;
     }
-    return lines.filter(
+    return allLines.filter(
       (l) =>
         getLineLabel({ model: l.model, effort: l.effort, kind: "model" })
           .toLowerCase()
           .includes(q) ||
         getProviderDisplayName(l.model.providerId).toLowerCase().includes(q)
     );
-  };
-
-  // While searching we show a single flat list over every model/effort.
-  const filteredAll = filterLines(allLines);
+  }, [allLines, search]);
 
   const selectedKey =
     selection.kind === "model"
@@ -318,9 +190,9 @@ export function InputBarModelPicker({
   const showAuto = !isSearching;
   const showList = expanded || isSearching || selection.kind === "model";
 
-  let label = isMobile ? "Model" : `Model: ${getLineLabel(selection)}`;
+  const label = isMobile ? "Model" : `Model: ${getLineLabel(selection)}`;
 
-  let buttonIcon =
+  const buttonIcon =
     isMobile && selection.kind === "model"
       ? getModelProviderLogo(selection.model.providerId, isDark)
       : undefined;
@@ -334,91 +206,13 @@ export function InputBarModelPicker({
     }
   };
 
-  if (!hasModelsPicker) {
-    return null;
-  }
-
-  // Wraps a dropdown row in its hover tooltip on desktop. On mobile there is no
-  // hover, so we skip the tooltip entirely and render the row as-is. The `key` is
-  // applied to whichever element ends up outermost so it is valid inside `.map`.
-  const withTooltip = (
-    key: string,
-    description: string,
-    media: ReactNode,
-    child: ReactElement
-  ): ReactElement => {
-    if (isMobile) {
-      return <Fragment key={key}>{child}</Fragment>;
-    }
-    return (
-      <DropdownTooltipTrigger key={key} description={description} media={media}>
-        {child}
-      </DropdownTooltipTrigger>
-    );
-  };
-
-  const renderModelLine = (line: ModelLine, recommendation?: string) => {
-    const key = getLineKey(
-      line.model.providerId,
-      line.model.modelId,
-      line.effort
-    );
-    const info = REASONING_EFFORT_INFO[line.effort];
-    return withTooltip(
-      key,
-      recommendation ?? "",
-      <div className="flex flex-col gap-3 text-sm">
-        <div>
-          <div className="font-medium text-foreground dark:text-foreground-night">
-            {line.model.displayName}
-          </div>
-          <div className="text-muted-foreground dark:text-muted-foreground-night">
-            {line.model.shortDescription}
-          </div>
-        </div>
-        <div className="text-muted-foreground dark:text-muted-foreground-night">
-          {info.reasoning}
-        </div>
-      </div>,
-      <DropdownMenuRadioItem
-        value={key}
-        onClick={() =>
-          commitSelection({
-            kind: "model",
-            model: line.model,
-            effort: line.effort,
-          })
-        }
-      >
-        <span className="flex grow items-center gap-2">
-          <span className="line-clamp-1">{line.model.displayName}</span>
-          {line.effort !== "none" && (
-            <Chip size="mini" label={capitalize(line.effort)} />
-          )}
-        </span>
-      </DropdownMenuRadioItem>
-    );
-  };
-
-  // The per-model sections (one label + its effort lines) shown for a provider.
-  // Rendered inside a submenu on desktop and inline under the provider name on
-  // mobile.
-  const renderProviderModels = (provider: ProviderGroup) =>
-    provider.models.map((entry, index) => (
-      <Fragment key={entry.model.modelId}>
-        {index > 0 && <DropdownMenuSeparator />}
-        <DropdownMenuLabel label={entry.model.displayName} />
-        <DropdownMenuRadioGroup value={selectedKey}>
-          {entry.efforts.map((effort) =>
-            renderModelLine({ model: entry.model, effort })
-          )}
-        </DropdownMenuRadioGroup>
-      </Fragment>
-    ));
-
   const hasResults = isSearching
     ? filteredAll.length > 0
     : suggestedLines.length > 0 || moreByProvider.length > 0;
+
+  if (!hasModelsPicker) {
+    return null;
+  }
 
   return (
     <DropdownMenu
@@ -442,117 +236,37 @@ export function InputBarModelPicker({
           isSelect
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-72" align="start" side={side}>
-        <div className="sticky top-0 z-10 bg-overlay-background pb-1">
-          <DropdownMenuSearchbar
-            autoFocus={!isMobile}
-            name="search-models"
-            placeholder="Search models"
-            value={search}
-            onChange={setSearch}
-          />
-        </div>
-
-        {showAuto &&
-          withTooltip(
-            "auto",
-            AUTO_TOOLTIP,
-            undefined,
-            <DropdownMenuItem
-              label="Auto"
-              endComponent={<SliderToggle size="xs" selected={isAutoOn} />}
-              onClick={toggleAuto}
-              onSelect={(e) => e.preventDefault()}
-            />
-          )}
-
-        {showList &&
-          (isModelsLoading ? (
-            <div className="flex h-20 items-center justify-center">
-              <Spinner size="sm" />
-            </div>
-          ) : !hasResults ? (
-            <div className="flex items-center justify-center py-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
-              No models found
-            </div>
-          ) : isSearching ? (
-            <>
-              <DropdownMenuSeparator />
-              <DropdownMenuRadioGroup value={selectedKey}>
-                {filteredAll.map((line) => renderModelLine(line))}
-              </DropdownMenuRadioGroup>
-            </>
-          ) : (
-            <>
-              {suggestedLines.length > 0 && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuLabel label="Suggested" />
-                  <DropdownMenuRadioGroup value={selectedKey}>
-                    {suggestedLines.map((line) =>
-                      renderModelLine(line, line.recommendation)
-                    )}
-                  </DropdownMenuRadioGroup>
-                </>
-              )}
-              {moreByProvider.length > 0 && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuLabel label="More models" />
-                  {moreByProvider.map((provider) =>
-                    isMobile ? (
-                      // On mobile the provider expands inline below its name
-                      // instead of opening a nested submenu (which is awkward to
-                      // reach on touch).
-                      <Fragment key={provider.providerId}>
-                        <DropdownMenuItem
-                          label={getProviderDisplayName(provider.providerId)}
-                          icon={getModelProviderLogo(
-                            provider.providerId,
-                            isDark
-                          )}
-                          endComponent={
-                            <Icon
-                              visual={
-                                expandedProvider === provider.providerId
-                                  ? ChevronDown
-                                  : ChevronRight
-                              }
-                              size="xs"
-                            />
-                          }
-                          onClick={() =>
-                            setExpandedProvider((current) =>
-                              current === provider.providerId
-                                ? null
-                                : provider.providerId
-                            )
-                          }
-                          onSelect={(e) => e.preventDefault()}
-                        />
-                        {expandedProvider === provider.providerId &&
-                          renderProviderModels(provider)}
-                      </Fragment>
-                    ) : (
-                      <DropdownMenuSub key={provider.providerId}>
-                        <DropdownMenuSubTrigger
-                          label={getProviderDisplayName(provider.providerId)}
-                          icon={getModelProviderLogo(
-                            provider.providerId,
-                            isDark
-                          )}
-                        />
-                        <DropdownMenuSubContent>
-                          {renderProviderModels(provider)}
-                        </DropdownMenuSubContent>
-                      </DropdownMenuSub>
-                    )
-                  )}
-                </>
-              )}
-            </>
-          ))}
-      </DropdownMenuContent>
+      <ModelPickerContent
+        side={side}
+        search={search}
+        onSearchChange={setSearch}
+        isModelsLoading={isModelsLoading}
+        isSearching={isSearching}
+        hasResults={hasResults}
+        filteredAll={filteredAll}
+        suggestedLines={suggestedLines}
+        moreByProvider={moreByProvider}
+        selectedKey={selectedKey}
+        isMobile={isMobile}
+        isDark={isDark}
+        showAuto={showAuto}
+        isAutoOn={isAutoOn}
+        showList={showList}
+        onToggleAuto={toggleAuto}
+        onSelectLine={(line: ModelLine) =>
+          commitSelection({
+            kind: "model",
+            model: line.model,
+            effort: line.effort,
+          })
+        }
+        expandedProvider={expandedProvider}
+        onToggleProvider={(providerId) =>
+          setExpandedProvider((current) =>
+            current === providerId ? null : providerId
+          )
+        }
+      />
     </DropdownMenu>
   );
 }

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -4,10 +4,7 @@ import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useModels } from "@app/lib/swr/models";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
-import {
-  CLAUDE_OPUS_4_8_MODEL_ID,
-  CLAUDE_SONNET_4_6_MODEL_ID,
-} from "@app/types/assistant/models/anthropic";
+import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
 import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
 import { getProviderDisplayName } from "@app/types/assistant/models/providers";
 import type {
@@ -41,106 +38,77 @@ import {
   SliderToggle,
   Spinner,
 } from "@dust-tt/sparkle";
+import capitalize from "lodash/capitalize";
 import type { ReactElement, ReactNode } from "react";
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useMemo, useRef, useState } from "react";
 
-// Models pinned at the top of the list under "Suggested", in display order. Each
-// pin is a concrete model + reasoning-effort pair (there can be several pins for
-// the same model). A pin is only shown if the workspace actually has the model
-// and it supports the given reasoning effort.
 const SUGGESTED_PINS: {
   providerId: ModelProviderIdType;
   modelId: string;
   effort: ReasoningEffort;
-  // Overrides the default per-effort recommendation for this pin. When omitted,
-  // the effort's recommendation from REASONING_EFFORT_INFO is used.
-  recommendation?: string;
+  recommendation: string;
 }[] = [
   {
     providerId: "anthropic",
     modelId: CLAUDE_SONNET_4_6_MODEL_ID,
     effort: "light",
+    recommendation:
+      "Quick answers. Recommended for easy retrieval, light analysis or general questions.",
   },
   {
     providerId: "anthropic",
     modelId: CLAUDE_SONNET_4_6_MODEL_ID,
     effort: "medium",
+    recommendation:
+      "Everyday tasks. Recommended for multi-step tasks, Frames, analysis.",
   },
   {
     providerId: "openai",
     modelId: GPT_5_5_MODEL_ID,
-    effort: "medium",
-    recommendation:
-      "Recommended for quality retrieval, complex analysis and Frames",
-  },
-  {
-    providerId: "anthropic",
-    modelId: CLAUDE_OPUS_4_8_MODEL_ID,
     effort: "high",
+    recommendation:
+      "Hard problems. Recommended for high quality retrieval, complex analysis and Frames",
   },
 ];
 
-// Tooltip shown on the "Auto" row.
 const AUTO_TOOLTIP =
   "Dust selects and switches model for cost efficient performance and reliability. When an agent is created using a specific model, we use this model.";
 
 // Per reasoning-effort blurbs shown in each model's hover tooltip: what the
 // effort does, and what it is recommended for.
-const REASONING_EFFORT_INFO: Record<
-  ReasoningEffort,
-  { reasoning: string; recommendation: string }
-> = {
+const REASONING_EFFORT_INFO: Record<ReasoningEffort, { reasoning: string }> = {
   none: {
     reasoning: "No additional reasoning, for the fastest responses",
-    recommendation: "Recommended for simple, high-volume tasks",
   },
   light: {
-    reasoning: "Light reasoning effort, resulting in less tokens produced",
-    recommendation:
-      "Recommended for easy retrieval, light analysis or general questions",
+    reasoning: "Light reasoning effort, faster responses.",
   },
   medium: {
-    reasoning: "Medium reasoning effort, balancing speed and quality",
-    recommendation: "Recommended for everyday work and multi-step tasks",
+    reasoning: "Medium reasoning effort, balancing speed and quality.",
   },
   high: {
-    reasoning: "High reasoning effort, producing more tokens",
-    recommendation:
-      "Recommended for complex, multi-step reasoning and hard problems",
+    reasoning: "High reasoning effort, longer wait times but higher quality.",
   },
 };
 
-// A concrete model + reasoning-effort pair rendered as a single line.
 interface ModelLine {
   model: ModelConfigurationType;
   effort: ReasoningEffort;
 }
 
-// A suggested line additionally carries the recommendation blurb shown in its
-// tooltip. Only suggested lines show a recommendation; "More models" lines do
-// not.
 interface SuggestedLine extends ModelLine {
   recommendation: string;
 }
 
-// The "More models" list grouped by provider, then by model, so it can be
-// rendered as a submenu per provider with one section per model.
 interface ProviderGroup {
   providerId: ModelProviderIdType;
   models: { model: ModelConfigurationType; efforts: ReasoningEffort[] }[];
 }
 
-// Either "Auto" (follow the agent's configured model, i.e. no override) or a
-// concrete model + reasoning-effort pick.
 type Selection =
   | { kind: "auto" }
   | { kind: "model"; model: ModelConfigurationType; effort: ReasoningEffort };
 
-// The reasoning efforts a user can actually pick for a model. "none" means "no
-// reasoning"; when a model also supports real reasoning efforts we drop the bare
-// "none" option so the user has to pick an explicit effort rather than "just the
-// model" (e.g. no plain "GPT-5.4 Mini" when Light/Medium/High exist). "none" is
-// only offered when it is the model's sole supported effort.
 function getSelectableReasoningEfforts(
   model: ModelConfigurationType
 ): ReasoningEffort[] {
@@ -149,9 +117,6 @@ function getSelectableReasoningEfforts(
   return withReasoning.length > 0 ? withReasoning : efforts;
 }
 
-// A model + effort combo identity. `modelId` is not unique across providers, and
-// the same model appears once per reasoning effort, so key on all three. Used for
-// radio values and de-duplicating pinned combos out of the "More models" list.
 function getLineKey(
   providerId: string,
   modelId: string,
@@ -160,13 +125,6 @@ function getLineKey(
   return `${providerId}/${modelId}/${effort}`;
 }
 
-// e.g. "Light", "Medium", "High". "none" has no meaningful label.
-function capitalizeEffort(effort: ReasoningEffort): string {
-  return effort.charAt(0).toUpperCase() + effort.slice(1);
-}
-
-// e.g. "Claude Sonnet 4.6 High". Models with no reasoning effort ("none") show
-// just their display name.
 function getLineLabel(selection: Selection): string {
   if (selection.kind === "auto") {
     return "Auto";
@@ -177,12 +135,10 @@ function getLineLabel(selection: Selection): string {
     return model.displayName;
   }
 
-  return `${model.displayName} ${capitalizeEffort(effort)}`;
+  return `${model.displayName} ${capitalize(effort)}`;
 }
 
-// Converts the picker's local selection into the API model selection sent on
-// message send. "Auto" means no override (run the agent's configured model),
-// i.e. undefined.
+// Converts the picker's local selection into the API model selection
 function toModelSelection(
   selection: Selection
 ): ModelSelectionType | undefined {
@@ -200,7 +156,7 @@ function toModelSelection(
       return undefined;
   }
 }
-
+// TODO: test for EU
 interface InputBarModelPickerProps {
   agentModel: AgentModelConfigurationType | null;
   owner: LightWorkspaceType;
@@ -210,9 +166,6 @@ interface InputBarModelPickerProps {
   // conversation screen where there is room below.
   side?: "top" | "bottom";
   disabled?: boolean;
-  // Notified with the API model selection whenever the picker changes (including
-  // resets), so the parent can attach it to the next message send. `undefined`
-  // means no override (run the agent's configured model).
   onSelectionChange?: (modelSelection: ModelSelectionType | undefined) => void;
 }
 
@@ -231,39 +184,43 @@ export function InputBarModelPicker({
 
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState("");
-  // The list of models is hidden while "Auto" is on; toggling Auto off (or
-  // searching) reveals it without yet committing a model pick.
+
+  // The list of models is hidden while "Auto" is on.
   const [expanded, setExpanded] = useState(false);
   const [selection, setSelection] = useState<Selection>({ kind: "auto" });
+
   // On mobile there are no nested submenus: the "More models" providers expand
   // inline below their name. This tracks the single provider currently expanded.
   const [expandedProvider, setExpandedProvider] =
     useState<ModelProviderIdType | null>(null);
+
+  // Commit a selection and notify the parent so it can attach (or, for "auto",
+  // clear) the per-message model override on the next send. Called from the
+  // user-driven handlers below and from the agent-change reset. `onSelectionChange`
+  // only stashes the value in a parent ref, so calling it here — including during
+  // the render-time reset — triggers no parent re-render.
+  const commitSelection = (next: Selection) => {
+    setSelection(next);
+    onSelectionChange?.(toModelSelection(next));
+  };
 
   // Reset to Auto when the agent changes: a per-message override should not leak
   // across agents.
   const agentModelKey = agentModel
     ? `${agentModel.providerId}/${agentModel.modelId}`
     : null;
-  const [prevAgentModelKey, setPrevAgentModelKey] = useState(agentModelKey);
-  if (agentModelKey !== prevAgentModelKey) {
-    setPrevAgentModelKey(agentModelKey);
-    setSelection({ kind: "auto" });
+  const prevAgentModelKeyRef = useRef(agentModelKey);
+  if (agentModelKey !== prevAgentModelKeyRef.current) {
+    prevAgentModelKeyRef.current = agentModelKey;
+    commitSelection({ kind: "auto" });
     setExpanded(false);
   }
-
-  // Keep the parent in sync with the current selection (including the reset
-  // above) so it can attach the override to the next message send.
-  useEffect(() => {
-    onSelectionChange?.(toModelSelection(selection));
-  }, [selection, onSelectionChange]);
 
   const { models, isModelsLoading } = useModels({
     owner,
     disabled: !hasModelsPicker,
   });
 
-  // Every model expanded into one line per available reasoning effort.
   const allLines = useMemo<ModelLine[]>(
     () =>
       models.flatMap((model) =>
@@ -295,19 +252,13 @@ export function InputBarModelPicker({
           {
             model,
             effort: pin.effort,
-            recommendation:
-              pin.recommendation ??
-              REASONING_EFFORT_INFO[pin.effort].recommendation,
+            recommendation: pin.recommendation,
           },
         ];
       }),
     [models]
   );
 
-  // "More models" lists every model/effort grouped by provider then model,
-  // preserving encounter order, so it can be rendered as one submenu per provider
-  // with one section per model. Models pinned in "Suggested" are intentionally
-  // still shown here too.
   const moreByProvider = useMemo<ProviderGroup[]>(() => {
     const providers = new Map<
       ModelProviderIdType,
@@ -374,13 +325,11 @@ export function InputBarModelPicker({
       ? getModelProviderLogo(selection.model.providerId, isDark)
       : undefined;
 
-  // Clicking anywhere on the Auto row toggles it: off reveals the model list
-  // (without committing a pick yet), on resets back to the agent's model.
   const toggleAuto = () => {
     if (isAutoOn) {
       setExpanded(true);
     } else {
-      setSelection({ kind: "auto" });
+      commitSelection({ kind: "auto" });
       setExpanded(false);
     }
   };
@@ -408,9 +357,6 @@ export function InputBarModelPicker({
     );
   };
 
-  // A model line rendered with the model name and the reasoning effort shown as a
-  // badge to the right. No provider logo. Reused across the "Suggested" section,
-  // flat search results, and the provider submenus.
   const renderModelLine = (line: ModelLine, recommendation?: string) => {
     const key = getLineKey(
       line.model.providerId,
@@ -437,7 +383,7 @@ export function InputBarModelPicker({
       <DropdownMenuRadioItem
         value={key}
         onClick={() =>
-          setSelection({
+          commitSelection({
             kind: "model",
             model: line.model,
             effort: line.effort,
@@ -447,7 +393,7 @@ export function InputBarModelPicker({
         <span className="flex grow items-center gap-2">
           <span className="line-clamp-1">{line.model.displayName}</span>
           {line.effort !== "none" && (
-            <Chip size="mini" label={capitalizeEffort(line.effort)} />
+            <Chip size="mini" label={capitalize(line.effort)} />
           )}
         </span>
       </DropdownMenuRadioItem>

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -21,6 +21,8 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
+  ChevronDown,
+  ChevronRight,
   Chip,
   DropdownMenu,
   DropdownMenuContent,
@@ -35,9 +37,11 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   DropdownTooltipTrigger,
+  Icon,
   SliderToggle,
   Spinner,
 } from "@dust-tt/sparkle";
+import type { ReactElement, ReactNode } from "react";
 import { Fragment, useEffect, useMemo, useState } from "react";
 
 // Models pinned at the top of the list under "Suggested", in display order. Each
@@ -231,6 +235,10 @@ export function InputBarModelPicker({
   // searching) reveals it without yet committing a model pick.
   const [expanded, setExpanded] = useState(false);
   const [selection, setSelection] = useState<Selection>({ kind: "auto" });
+  // On mobile there are no nested submenus: the "More models" providers expand
+  // inline below their name. This tracks the single provider currently expanded.
+  const [expandedProvider, setExpandedProvider] =
+    useState<ModelProviderIdType | null>(null);
 
   // Reset to Auto when the agent changes: a per-message override should not leak
   // across agents.
@@ -381,6 +389,25 @@ export function InputBarModelPicker({
     return null;
   }
 
+  // Wraps a dropdown row in its hover tooltip on desktop. On mobile there is no
+  // hover, so we skip the tooltip entirely and render the row as-is. The `key` is
+  // applied to whichever element ends up outermost so it is valid inside `.map`.
+  const withTooltip = (
+    key: string,
+    description: string,
+    media: ReactNode,
+    child: ReactElement
+  ): ReactElement => {
+    if (isMobile) {
+      return <Fragment key={key}>{child}</Fragment>;
+    }
+    return (
+      <DropdownTooltipTrigger key={key} description={description} media={media}>
+        {child}
+      </DropdownTooltipTrigger>
+    );
+  };
+
   // A model line rendered with the model name and the reasoning effort shown as a
   // badge to the right. No provider logo. Reused across the "Suggested" section,
   // flat search results, and the provider submenus.
@@ -391,46 +418,57 @@ export function InputBarModelPicker({
       line.effort
     );
     const info = REASONING_EFFORT_INFO[line.effort];
-    return (
-      <DropdownTooltipTrigger
-        key={key}
-        description={recommendation ?? ""}
-        media={
-          <div className="flex flex-col gap-3 text-sm">
-            <div>
-              <div className="font-medium text-foreground dark:text-foreground-night">
-                {line.model.displayName}
-              </div>
-              <div className="text-muted-foreground dark:text-muted-foreground-night">
-                {line.model.shortDescription}
-              </div>
-            </div>
-            <div className="text-muted-foreground dark:text-muted-foreground-night">
-              {info.reasoning}
-            </div>
+    return withTooltip(
+      key,
+      recommendation ?? "",
+      <div className="flex flex-col gap-3 text-sm">
+        <div>
+          <div className="font-medium text-foreground dark:text-foreground-night">
+            {line.model.displayName}
           </div>
+          <div className="text-muted-foreground dark:text-muted-foreground-night">
+            {line.model.shortDescription}
+          </div>
+        </div>
+        <div className="text-muted-foreground dark:text-muted-foreground-night">
+          {info.reasoning}
+        </div>
+      </div>,
+      <DropdownMenuRadioItem
+        value={key}
+        onClick={() =>
+          setSelection({
+            kind: "model",
+            model: line.model,
+            effort: line.effort,
+          })
         }
       >
-        <DropdownMenuRadioItem
-          value={key}
-          onClick={() =>
-            setSelection({
-              kind: "model",
-              model: line.model,
-              effort: line.effort,
-            })
-          }
-        >
-          <span className="flex grow items-center gap-2">
-            <span className="line-clamp-1">{line.model.displayName}</span>
-            {line.effort !== "none" && (
-              <Chip size="mini" label={capitalizeEffort(line.effort)} />
-            )}
-          </span>
-        </DropdownMenuRadioItem>
-      </DropdownTooltipTrigger>
+        <span className="flex grow items-center gap-2">
+          <span className="line-clamp-1">{line.model.displayName}</span>
+          {line.effort !== "none" && (
+            <Chip size="mini" label={capitalizeEffort(line.effort)} />
+          )}
+        </span>
+      </DropdownMenuRadioItem>
     );
   };
+
+  // The per-model sections (one label + its effort lines) shown for a provider.
+  // Rendered inside a submenu on desktop and inline under the provider name on
+  // mobile.
+  const renderProviderModels = (provider: ProviderGroup) =>
+    provider.models.map((entry, index) => (
+      <Fragment key={entry.model.modelId}>
+        {index > 0 && <DropdownMenuSeparator />}
+        <DropdownMenuLabel label={entry.model.displayName} />
+        <DropdownMenuRadioGroup value={selectedKey}>
+          {entry.efforts.map((effort) =>
+            renderModelLine({ model: entry.model, effort })
+          )}
+        </DropdownMenuRadioGroup>
+      </Fragment>
+    ));
 
   const hasResults = isSearching
     ? filteredAll.length > 0
@@ -444,6 +482,7 @@ export function InputBarModelPicker({
         if (open) {
           setSearch("");
           setExpanded(false);
+          setExpandedProvider(null);
         }
       }}
     >
@@ -468,16 +507,18 @@ export function InputBarModelPicker({
           />
         </div>
 
-        {showAuto && (
-          <DropdownTooltipTrigger description={AUTO_TOOLTIP}>
+        {showAuto &&
+          withTooltip(
+            "auto",
+            AUTO_TOOLTIP,
+            undefined,
             <DropdownMenuItem
               label="Auto"
               endComponent={<SliderToggle size="xs" selected={isAutoOn} />}
               onClick={toggleAuto}
               onSelect={(e) => e.preventDefault()}
             />
-          </DropdownTooltipTrigger>
-        )}
+          )}
 
         {showList &&
           (isModelsLoading ? (
@@ -512,29 +553,55 @@ export function InputBarModelPicker({
                 <>
                   <DropdownMenuSeparator />
                   <DropdownMenuLabel label="More models" />
-                  {moreByProvider.map((provider) => (
-                    <DropdownMenuSub key={provider.providerId}>
-                      <DropdownMenuSubTrigger
-                        label={getProviderDisplayName(provider.providerId)}
-                        icon={getModelProviderLogo(provider.providerId, isDark)}
-                      />
-                      <DropdownMenuSubContent>
-                        {provider.models.map((entry, index) => (
-                          <Fragment key={entry.model.modelId}>
-                            {index > 0 && <DropdownMenuSeparator />}
-                            <DropdownMenuLabel
-                              label={entry.model.displayName}
+                  {moreByProvider.map((provider) =>
+                    isMobile ? (
+                      // On mobile the provider expands inline below its name
+                      // instead of opening a nested submenu (which is awkward to
+                      // reach on touch).
+                      <Fragment key={provider.providerId}>
+                        <DropdownMenuItem
+                          label={getProviderDisplayName(provider.providerId)}
+                          icon={getModelProviderLogo(
+                            provider.providerId,
+                            isDark
+                          )}
+                          endComponent={
+                            <Icon
+                              visual={
+                                expandedProvider === provider.providerId
+                                  ? ChevronDown
+                                  : ChevronRight
+                              }
+                              size="xs"
                             />
-                            <DropdownMenuRadioGroup value={selectedKey}>
-                              {entry.efforts.map((effort) =>
-                                renderModelLine({ model: entry.model, effort })
-                              )}
-                            </DropdownMenuRadioGroup>
-                          </Fragment>
-                        ))}
-                      </DropdownMenuSubContent>
-                    </DropdownMenuSub>
-                  ))}
+                          }
+                          onClick={() =>
+                            setExpandedProvider((current) =>
+                              current === provider.providerId
+                                ? null
+                                : provider.providerId
+                            )
+                          }
+                          onSelect={(e) => e.preventDefault()}
+                        />
+                        {expandedProvider === provider.providerId &&
+                          renderProviderModels(provider)}
+                      </Fragment>
+                    ) : (
+                      <DropdownMenuSub key={provider.providerId}>
+                        <DropdownMenuSubTrigger
+                          label={getProviderDisplayName(provider.providerId)}
+                          icon={getModelProviderLogo(
+                            provider.providerId,
+                            isDark
+                          )}
+                        />
+                        <DropdownMenuSubContent>
+                          {renderProviderModels(provider)}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuSub>
+                    )
+                  )}
                 </>
               )}
             </>

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -1,13 +1,13 @@
 import { ModelPickerContent } from "@app/components/assistant/conversation/input_bar/ModelPickerContent";
 import type {
-  ModelLine,
+  ModelWithReasoningEffort,
   ProviderGroup,
   Selection,
-  SuggestedLine,
+  SuggestedModelWithReasoningEffort,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import {
-  getLineKey,
-  getLineLabel,
+  getModelWithReasoningEffortKey,
+  getModelWithReasoningEffortLabel,
   getSelectableReasoningEfforts,
   SUGGESTED_PINS,
   toModelSelection,
@@ -94,7 +94,7 @@ export function InputBarModelPicker({
     disabled: !hasModelsPicker,
   });
 
-  const allLines = useMemo<ModelLine[]>(
+  const allModelsWithEfforts = useMemo<ModelWithReasoningEffort[]>(
     () =>
       models.flatMap((model) =>
         getSelectableReasoningEfforts(model).map((effort) => ({
@@ -107,7 +107,9 @@ export function InputBarModelPicker({
 
   // Resolve the pinned combos against the workspace's actual models (skipping any
   // the workspace doesn't have or that don't support the pinned effort).
-  const suggestedLines = useMemo<SuggestedLine[]>(
+  const suggestedModelsWithEfforts = useMemo<
+    SuggestedModelWithReasoningEffort[]
+  >(
     () =>
       SUGGESTED_PINS.flatMap((pin) => {
         const model = models.find(
@@ -137,46 +139,52 @@ export function InputBarModelPicker({
       ModelProviderIdType,
       Map<string, { model: ModelConfigurationType; efforts: ReasoningEffort[] }>
     >();
-    for (const line of allLines) {
-      const providerId = line.model.providerId;
+    for (const modelWithEffort of allModelsWithEfforts) {
+      const providerId = modelWithEffort.model.providerId;
       let modelsMap = providers.get(providerId);
       if (!modelsMap) {
         modelsMap = new Map();
         providers.set(providerId, modelsMap);
       }
-      let entry = modelsMap.get(line.model.modelId);
+      let entry = modelsMap.get(modelWithEffort.model.modelId);
       if (!entry) {
-        entry = { model: line.model, efforts: [] };
-        modelsMap.set(line.model.modelId, entry);
+        entry = { model: modelWithEffort.model, efforts: [] };
+        modelsMap.set(modelWithEffort.model.modelId, entry);
       }
-      entry.efforts.push(line.effort);
+      entry.efforts.push(modelWithEffort.effort);
     }
     return Array.from(providers.entries()).map(([providerId, modelsMap]) => ({
       providerId,
       models: Array.from(modelsMap.values()),
     }));
-  }, [allLines]);
+  }, [allModelsWithEfforts]);
 
   const isSearching = search.trim() !== "";
 
   // While searching we show a single flat list over every model/effort.
-  const filteredAll = useMemo<ModelLine[]>(() => {
+  const filteredAll = useMemo<ModelWithReasoningEffort[]>(() => {
     const q = search.trim().toLowerCase();
     if (!q) {
-      return allLines;
+      return allModelsWithEfforts;
     }
-    return allLines.filter(
-      (l) =>
-        getLineLabel({ model: l.model, effort: l.effort, kind: "model" })
+    return allModelsWithEfforts.filter(
+      (modelWithEffort) =>
+        getModelWithReasoningEffortLabel({
+          model: modelWithEffort.model,
+          effort: modelWithEffort.effort,
+          kind: "model",
+        })
           .toLowerCase()
           .includes(q) ||
-        getProviderDisplayName(l.model.providerId).toLowerCase().includes(q)
+        getProviderDisplayName(modelWithEffort.model.providerId)
+          .toLowerCase()
+          .includes(q)
     );
-  }, [allLines, search]);
+  }, [allModelsWithEfforts, search]);
 
   const selectedKey =
     selection.kind === "model"
-      ? getLineKey(
+      ? getModelWithReasoningEffortKey(
           selection.model.providerId,
           selection.model.modelId,
           selection.effort
@@ -189,7 +197,9 @@ export function InputBarModelPicker({
   const showAuto = !isSearching;
   const showList = expanded || isSearching || selection.kind === "model";
 
-  const label = isMobile ? "Model" : `Model: ${getLineLabel(selection)}`;
+  const label = isMobile
+    ? "Model"
+    : `Model: ${getModelWithReasoningEffortLabel(selection)}`;
 
   const buttonIcon =
     isMobile && selection.kind === "model"
@@ -207,7 +217,7 @@ export function InputBarModelPicker({
 
   const hasResults = isSearching
     ? filteredAll.length > 0
-    : suggestedLines.length > 0 || moreByProvider.length > 0;
+    : suggestedModelsWithEfforts.length > 0 || moreByProvider.length > 0;
 
   if (!hasModelsPicker) {
     return null;
@@ -243,7 +253,7 @@ export function InputBarModelPicker({
         isSearching={isSearching}
         hasResults={hasResults}
         filteredAll={filteredAll}
-        suggestedLines={suggestedLines}
+        suggestedModelsWithEfforts={suggestedModelsWithEfforts}
         moreByProvider={moreByProvider}
         selectedKey={selectedKey}
         isMobile={isMobile}
@@ -252,11 +262,11 @@ export function InputBarModelPicker({
         isAutoOn={isAutoOn}
         showList={showList}
         onToggleAuto={toggleAuto}
-        onSelectLine={(line: ModelLine) =>
+        onSelectModel={(modelWithEffort: ModelWithReasoningEffort) =>
           commitSelection({
             kind: "model",
-            model: line.model,
-            effort: line.effort,
+            model: modelWithEffort.model,
+            effort: modelWithEffort.effort,
           })
         }
         expandedProvider={expandedProvider}

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -1,0 +1,545 @@
+import { getModelProviderLogo } from "@app/components/providers/types";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useModels } from "@app/lib/swr/models";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
+import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
+import {
+  CLAUDE_OPUS_4_8_MODEL_ID,
+  CLAUDE_SONNET_4_6_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
+import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
+import { getProviderDisplayName } from "@app/types/assistant/models/providers";
+import type {
+  ModelConfigurationType,
+  ModelProviderIdType,
+  ModelSelectionType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
+import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Chip,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+  DropdownTooltipTrigger,
+  SliderToggle,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { Fragment, useEffect, useMemo, useState } from "react";
+
+// Models pinned at the top of the list under "Suggested", in display order. Each
+// pin is a concrete model + reasoning-effort pair (there can be several pins for
+// the same model). A pin is only shown if the workspace actually has the model
+// and it supports the given reasoning effort.
+const SUGGESTED_PINS: {
+  providerId: ModelProviderIdType;
+  modelId: string;
+  effort: ReasoningEffort;
+  // Overrides the default per-effort recommendation for this pin. When omitted,
+  // the effort's recommendation from REASONING_EFFORT_INFO is used.
+  recommendation?: string;
+}[] = [
+  {
+    providerId: "anthropic",
+    modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+    effort: "light",
+  },
+  {
+    providerId: "anthropic",
+    modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+    effort: "medium",
+  },
+  {
+    providerId: "openai",
+    modelId: GPT_5_5_MODEL_ID,
+    effort: "medium",
+    recommendation:
+      "Recommended for quality retrieval, complex analysis and Frames",
+  },
+  {
+    providerId: "anthropic",
+    modelId: CLAUDE_OPUS_4_8_MODEL_ID,
+    effort: "high",
+  },
+];
+
+// Tooltip shown on the "Auto" row.
+const AUTO_TOOLTIP =
+  "Dust selects and switches model for cost efficient performance and reliability. When an agent is created using a specific model, we use this model.";
+
+// Per reasoning-effort blurbs shown in each model's hover tooltip: what the
+// effort does, and what it is recommended for.
+const REASONING_EFFORT_INFO: Record<
+  ReasoningEffort,
+  { reasoning: string; recommendation: string }
+> = {
+  none: {
+    reasoning: "No additional reasoning, for the fastest responses",
+    recommendation: "Recommended for simple, high-volume tasks",
+  },
+  light: {
+    reasoning: "Light reasoning effort, resulting in less tokens produced",
+    recommendation:
+      "Recommended for easy retrieval, light analysis or general questions",
+  },
+  medium: {
+    reasoning: "Medium reasoning effort, balancing speed and quality",
+    recommendation: "Recommended for everyday work and multi-step tasks",
+  },
+  high: {
+    reasoning: "High reasoning effort, producing more tokens",
+    recommendation:
+      "Recommended for complex, multi-step reasoning and hard problems",
+  },
+};
+
+// A concrete model + reasoning-effort pair rendered as a single line.
+interface ModelLine {
+  model: ModelConfigurationType;
+  effort: ReasoningEffort;
+}
+
+// A suggested line additionally carries the recommendation blurb shown in its
+// tooltip. Only suggested lines show a recommendation; "More models" lines do
+// not.
+interface SuggestedLine extends ModelLine {
+  recommendation: string;
+}
+
+// The "More models" list grouped by provider, then by model, so it can be
+// rendered as a submenu per provider with one section per model.
+interface ProviderGroup {
+  providerId: ModelProviderIdType;
+  models: { model: ModelConfigurationType; efforts: ReasoningEffort[] }[];
+}
+
+// Either "Auto" (follow the agent's configured model, i.e. no override) or a
+// concrete model + reasoning-effort pick.
+type Selection =
+  | { kind: "auto" }
+  | { kind: "model"; model: ModelConfigurationType; effort: ReasoningEffort };
+
+// The reasoning efforts a user can actually pick for a model. "none" means "no
+// reasoning"; when a model also supports real reasoning efforts we drop the bare
+// "none" option so the user has to pick an explicit effort rather than "just the
+// model" (e.g. no plain "GPT-5.4 Mini" when Light/Medium/High exist). "none" is
+// only offered when it is the model's sole supported effort.
+function getSelectableReasoningEfforts(
+  model: ModelConfigurationType
+): ReasoningEffort[] {
+  const efforts = getAvailableReasoningEfforts(model.supportedReasoningEfforts);
+  const withReasoning = efforts.filter((effort) => effort !== "none");
+  return withReasoning.length > 0 ? withReasoning : efforts;
+}
+
+// A model + effort combo identity. `modelId` is not unique across providers, and
+// the same model appears once per reasoning effort, so key on all three. Used for
+// radio values and de-duplicating pinned combos out of the "More models" list.
+function getLineKey(
+  providerId: string,
+  modelId: string,
+  effort: ReasoningEffort
+): string {
+  return `${providerId}/${modelId}/${effort}`;
+}
+
+// e.g. "Light", "Medium", "High". "none" has no meaningful label.
+function capitalizeEffort(effort: ReasoningEffort): string {
+  return effort.charAt(0).toUpperCase() + effort.slice(1);
+}
+
+// e.g. "Claude Sonnet 4.6 High". Models with no reasoning effort ("none") show
+// just their display name.
+function getLineLabel(selection: Selection): string {
+  if (selection.kind === "auto") {
+    return "Auto";
+  }
+  const { model, effort } = selection;
+
+  if (effort === "none") {
+    return model.displayName;
+  }
+
+  return `${model.displayName} ${capitalizeEffort(effort)}`;
+}
+
+// Converts the picker's local selection into the API model selection sent on
+// message send. "Auto" means no override (run the agent's configured model),
+// i.e. undefined.
+function toModelSelection(
+  selection: Selection
+): ModelSelectionType | undefined {
+  switch (selection.kind) {
+    case "auto":
+      return undefined;
+    case "model":
+      return {
+        providerId: selection.model.providerId,
+        modelId: selection.model.modelId,
+        reasoningEffort: selection.effort,
+      };
+    default:
+      assertNeverAndIgnore(selection);
+      return undefined;
+  }
+}
+
+interface InputBarModelPickerProps {
+  agentModel: AgentModelConfigurationType | null;
+  owner: LightWorkspaceType;
+  buttonSize: "xs" | "sm";
+  // Which side the dropdown opens toward. Mirrors the agent picker: "top" in an
+  // active conversation (input bar pinned to the bottom), "bottom" on the new
+  // conversation screen where there is room below.
+  side?: "top" | "bottom";
+  disabled?: boolean;
+  // Notified with the API model selection whenever the picker changes (including
+  // resets), so the parent can attach it to the next message send. `undefined`
+  // means no override (run the agent's configured model).
+  onSelectionChange?: (modelSelection: ModelSelectionType | undefined) => void;
+}
+
+export function InputBarModelPicker({
+  agentModel,
+  owner,
+  buttonSize,
+  side = "top",
+  disabled,
+  onSelectionChange,
+}: InputBarModelPickerProps) {
+  const { hasFeature } = useFeatureFlags();
+  const hasModelsPicker = hasFeature("models_picker");
+  const { isDark } = useTheme();
+  const isMobile = useIsMobile();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  // The list of models is hidden while "Auto" is on; toggling Auto off (or
+  // searching) reveals it without yet committing a model pick.
+  const [expanded, setExpanded] = useState(false);
+  const [selection, setSelection] = useState<Selection>({ kind: "auto" });
+
+  // Reset to Auto when the agent changes: a per-message override should not leak
+  // across agents.
+  const agentModelKey = agentModel
+    ? `${agentModel.providerId}/${agentModel.modelId}`
+    : null;
+  const [prevAgentModelKey, setPrevAgentModelKey] = useState(agentModelKey);
+  if (agentModelKey !== prevAgentModelKey) {
+    setPrevAgentModelKey(agentModelKey);
+    setSelection({ kind: "auto" });
+    setExpanded(false);
+  }
+
+  // Keep the parent in sync with the current selection (including the reset
+  // above) so it can attach the override to the next message send.
+  useEffect(() => {
+    onSelectionChange?.(toModelSelection(selection));
+  }, [selection, onSelectionChange]);
+
+  const { models, isModelsLoading } = useModels({
+    owner,
+    disabled: !hasModelsPicker,
+  });
+
+  // Every model expanded into one line per available reasoning effort.
+  const allLines = useMemo<ModelLine[]>(
+    () =>
+      models.flatMap((model) =>
+        getSelectableReasoningEfforts(model).map((effort) => ({
+          model,
+          effort,
+        }))
+      ),
+    [models]
+  );
+
+  // Resolve the pinned combos against the workspace's actual models (skipping any
+  // the workspace doesn't have or that don't support the pinned effort).
+  const suggestedLines = useMemo<SuggestedLine[]>(
+    () =>
+      SUGGESTED_PINS.flatMap((pin) => {
+        const model = models.find(
+          (m) => m.providerId === pin.providerId && m.modelId === pin.modelId
+        );
+        if (
+          !model ||
+          !getAvailableReasoningEfforts(
+            model.supportedReasoningEfforts
+          ).includes(pin.effort)
+        ) {
+          return [];
+        }
+        return [
+          {
+            model,
+            effort: pin.effort,
+            recommendation:
+              pin.recommendation ??
+              REASONING_EFFORT_INFO[pin.effort].recommendation,
+          },
+        ];
+      }),
+    [models]
+  );
+
+  // "More models" lists every model/effort grouped by provider then model,
+  // preserving encounter order, so it can be rendered as one submenu per provider
+  // with one section per model. Models pinned in "Suggested" are intentionally
+  // still shown here too.
+  const moreByProvider = useMemo<ProviderGroup[]>(() => {
+    const providers = new Map<
+      ModelProviderIdType,
+      Map<string, { model: ModelConfigurationType; efforts: ReasoningEffort[] }>
+    >();
+    for (const line of allLines) {
+      const providerId = line.model.providerId;
+      let modelsMap = providers.get(providerId);
+      if (!modelsMap) {
+        modelsMap = new Map();
+        providers.set(providerId, modelsMap);
+      }
+      let entry = modelsMap.get(line.model.modelId);
+      if (!entry) {
+        entry = { model: line.model, efforts: [] };
+        modelsMap.set(line.model.modelId, entry);
+      }
+      entry.efforts.push(line.effort);
+    }
+    return Array.from(providers.entries()).map(([providerId, modelsMap]) => ({
+      providerId,
+      models: Array.from(modelsMap.values()),
+    }));
+  }, [allLines]);
+
+  const isSearching = search.trim() !== "";
+
+  const filterLines = <T extends ModelLine>(lines: T[]): T[] => {
+    const q = search.trim().toLowerCase();
+    if (!q) {
+      return lines;
+    }
+    return lines.filter(
+      (l) =>
+        getLineLabel({ model: l.model, effort: l.effort, kind: "model" })
+          .toLowerCase()
+          .includes(q) ||
+        getProviderDisplayName(l.model.providerId).toLowerCase().includes(q)
+    );
+  };
+
+  // While searching we show a single flat list over every model/effort.
+  const filteredAll = filterLines(allLines);
+
+  const selectedKey =
+    selection.kind === "model"
+      ? getLineKey(
+          selection.model.providerId,
+          selection.model.modelId,
+          selection.effort
+        )
+      : undefined;
+
+  // Auto is "on" while it is the committed selection and the list has not been
+  // manually expanded for browsing. It is hidden entirely while searching.
+  const isAutoOn = selection.kind === "auto" && !expanded;
+  const showAuto = !isSearching;
+  const showList = expanded || isSearching || selection.kind === "model";
+
+  let label = isMobile ? "Model" : `Model: ${getLineLabel(selection)}`;
+
+  let buttonIcon =
+    isMobile && selection.kind === "model"
+      ? getModelProviderLogo(selection.model.providerId, isDark)
+      : undefined;
+
+  // Clicking anywhere on the Auto row toggles it: off reveals the model list
+  // (without committing a pick yet), on resets back to the agent's model.
+  const toggleAuto = () => {
+    if (isAutoOn) {
+      setExpanded(true);
+    } else {
+      setSelection({ kind: "auto" });
+      setExpanded(false);
+    }
+  };
+
+  if (!hasModelsPicker) {
+    return null;
+  }
+
+  // A model line rendered with the model name and the reasoning effort shown as a
+  // badge to the right. No provider logo. Reused across the "Suggested" section,
+  // flat search results, and the provider submenus.
+  const renderModelLine = (line: ModelLine, recommendation?: string) => {
+    const key = getLineKey(
+      line.model.providerId,
+      line.model.modelId,
+      line.effort
+    );
+    const info = REASONING_EFFORT_INFO[line.effort];
+    return (
+      <DropdownTooltipTrigger
+        key={key}
+        description={recommendation ?? ""}
+        media={
+          <div className="flex flex-col gap-3 text-sm">
+            <div>
+              <div className="font-medium text-foreground dark:text-foreground-night">
+                {line.model.displayName}
+              </div>
+              <div className="text-muted-foreground dark:text-muted-foreground-night">
+                {line.model.shortDescription}
+              </div>
+            </div>
+            <div className="text-muted-foreground dark:text-muted-foreground-night">
+              {info.reasoning}
+            </div>
+          </div>
+        }
+      >
+        <DropdownMenuRadioItem
+          value={key}
+          onClick={() =>
+            setSelection({
+              kind: "model",
+              model: line.model,
+              effort: line.effort,
+            })
+          }
+        >
+          <span className="flex grow items-center gap-2">
+            <span className="line-clamp-1">{line.model.displayName}</span>
+            {line.effort !== "none" && (
+              <Chip size="mini" label={capitalizeEffort(line.effort)} />
+            )}
+          </span>
+        </DropdownMenuRadioItem>
+      </DropdownTooltipTrigger>
+    );
+  };
+
+  const hasResults = isSearching
+    ? filteredAll.length > 0
+    : suggestedLines.length > 0 || moreByProvider.length > 0;
+
+  return (
+    <DropdownMenu
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (open) {
+          setSearch("");
+          setExpanded(false);
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost-secondary"
+          size={buttonSize}
+          label={label}
+          icon={buttonIcon}
+          disabled={disabled}
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-72" align="start" side={side}>
+        <div className="sticky top-0 z-10 bg-overlay-background pb-1">
+          <DropdownMenuSearchbar
+            autoFocus={!isMobile}
+            name="search-models"
+            placeholder="Search models"
+            value={search}
+            onChange={setSearch}
+          />
+        </div>
+
+        {showAuto && (
+          <DropdownTooltipTrigger description={AUTO_TOOLTIP}>
+            <DropdownMenuItem
+              label="Auto"
+              endComponent={<SliderToggle size="xs" selected={isAutoOn} />}
+              onClick={toggleAuto}
+              onSelect={(e) => e.preventDefault()}
+            />
+          </DropdownTooltipTrigger>
+        )}
+
+        {showList &&
+          (isModelsLoading ? (
+            <div className="flex h-20 items-center justify-center">
+              <Spinner size="sm" />
+            </div>
+          ) : !hasResults ? (
+            <div className="flex items-center justify-center py-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+              No models found
+            </div>
+          ) : isSearching ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuRadioGroup value={selectedKey}>
+                {filteredAll.map((line) => renderModelLine(line))}
+              </DropdownMenuRadioGroup>
+            </>
+          ) : (
+            <>
+              {suggestedLines.length > 0 && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel label="Suggested" />
+                  <DropdownMenuRadioGroup value={selectedKey}>
+                    {suggestedLines.map((line) =>
+                      renderModelLine(line, line.recommendation)
+                    )}
+                  </DropdownMenuRadioGroup>
+                </>
+              )}
+              {moreByProvider.length > 0 && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel label="More models" />
+                  {moreByProvider.map((provider) => (
+                    <DropdownMenuSub key={provider.providerId}>
+                      <DropdownMenuSubTrigger
+                        label={getProviderDisplayName(provider.providerId)}
+                        icon={getModelProviderLogo(provider.providerId, isDark)}
+                      />
+                      <DropdownMenuSubContent>
+                        {provider.models.map((entry, index) => (
+                          <Fragment key={entry.model.modelId}>
+                            {index > 0 && <DropdownMenuSeparator />}
+                            <DropdownMenuLabel
+                              label={entry.model.displayName}
+                            />
+                            <DropdownMenuRadioGroup value={selectedKey}>
+                              {entry.efforts.map((effort) =>
+                                renderModelLine({ model: entry.model, effort })
+                              )}
+                            </DropdownMenuRadioGroup>
+                          </Fragment>
+                        ))}
+                      </DropdownMenuSubContent>
+                    </DropdownMenuSub>
+                  ))}
+                </>
+              )}
+            </>
+          ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -30,7 +30,6 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { Button, DropdownMenu, DropdownMenuTrigger } from "@dust-tt/sparkle";
 import { useMemo, useRef, useState } from "react";
 
-// TODO: test for EU
 interface InputBarModelPickerProps {
   agentModel: AgentModelConfigurationType | null;
   owner: LightWorkspaceType;

--- a/front/components/assistant/conversation/input_bar/ModelPickerContent.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerContent.tsx
@@ -1,0 +1,210 @@
+import { ModelPickerLineItem } from "@app/components/assistant/conversation/input_bar/ModelPickerLineItem";
+import { ModelPickerProviderSection } from "@app/components/assistant/conversation/input_bar/ModelPickerProviderSection";
+import { ModelPickerRowTooltip } from "@app/components/assistant/conversation/input_bar/ModelPickerRowTooltip";
+import type {
+  ModelLine,
+  ProviderGroup,
+  SuggestedLine,
+} from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import {
+  AUTO_TOOLTIP,
+  getLineKey,
+} from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import { getModelProviderLogo } from "@app/components/providers/types";
+import { getProviderDisplayName } from "@app/types/assistant/models/providers";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import {
+  ChevronDown,
+  ChevronRight,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  Icon,
+  SliderToggle,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { Fragment } from "react";
+
+interface ModelPickerContentProps {
+  side: "top" | "bottom";
+  search: string;
+  onSearchChange: (value: string) => void;
+  isModelsLoading: boolean;
+  isSearching: boolean;
+  hasResults: boolean;
+  filteredAll: ModelLine[];
+  suggestedLines: SuggestedLine[];
+  moreByProvider: ProviderGroup[];
+  selectedKey?: string;
+  isMobile: boolean;
+  isDark: boolean;
+  showAuto: boolean;
+  isAutoOn: boolean;
+  showList: boolean;
+  onToggleAuto: () => void;
+  onSelectLine: (line: ModelLine) => void;
+  // On mobile the "More models" providers expand inline; this tracks the single
+  // provider currently expanded.
+  expandedProvider: ModelProviderIdType | null;
+  onToggleProvider: (providerId: ModelProviderIdType) => void;
+}
+
+export function ModelPickerContent({
+  side,
+  search,
+  onSearchChange,
+  isModelsLoading,
+  isSearching,
+  hasResults,
+  filteredAll,
+  suggestedLines,
+  moreByProvider,
+  selectedKey,
+  isMobile,
+  isDark,
+  showAuto,
+  isAutoOn,
+  showList,
+  onToggleAuto,
+  onSelectLine,
+  expandedProvider,
+  onToggleProvider,
+}: ModelPickerContentProps) {
+  return (
+    <DropdownMenuContent className="w-72" align="start" side={side}>
+      <div className="sticky top-0 z-10 bg-overlay-background pb-1">
+        <DropdownMenuSearchbar
+          autoFocus={!isMobile}
+          name="search-models"
+          placeholder="Search models"
+          value={search}
+          onChange={onSearchChange}
+        />
+      </div>
+
+      {showAuto && (
+        <ModelPickerRowTooltip description={AUTO_TOOLTIP} isMobile={isMobile}>
+          <DropdownMenuItem
+            label="Auto"
+            endComponent={<SliderToggle size="xs" selected={isAutoOn} />}
+            onClick={onToggleAuto}
+            onSelect={(e) => e.preventDefault()}
+          />
+        </ModelPickerRowTooltip>
+      )}
+
+      {showList &&
+        (isModelsLoading ? (
+          <div className="flex h-20 items-center justify-center">
+            <Spinner size="sm" />
+          </div>
+        ) : !hasResults ? (
+          <div className="flex items-center justify-center py-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+            No models found
+          </div>
+        ) : isSearching ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuRadioGroup value={selectedKey}>
+              {filteredAll.map((line) => (
+                <ModelPickerLineItem
+                  key={getLineKey(
+                    line.model.providerId,
+                    line.model.modelId,
+                    line.effort
+                  )}
+                  line={line}
+                  isMobile={isMobile}
+                  onSelect={onSelectLine}
+                />
+              ))}
+            </DropdownMenuRadioGroup>
+          </>
+        ) : (
+          <>
+            {suggestedLines.length > 0 && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel label="Suggested" />
+                <DropdownMenuRadioGroup value={selectedKey}>
+                  {suggestedLines.map((line) => (
+                    <ModelPickerLineItem
+                      key={getLineKey(
+                        line.model.providerId,
+                        line.model.modelId,
+                        line.effort
+                      )}
+                      line={line}
+                      isMobile={isMobile}
+                      onSelect={onSelectLine}
+                      recommendation={line.recommendation}
+                    />
+                  ))}
+                </DropdownMenuRadioGroup>
+              </>
+            )}
+            {moreByProvider.length > 0 && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel label="More models" />
+                {moreByProvider.map((provider) =>
+                  isMobile ? (
+                    // On mobile the provider expands inline below its name
+                    // instead of opening a nested submenu (which is awkward to
+                    // reach on touch).
+                    <Fragment key={provider.providerId}>
+                      <DropdownMenuItem
+                        label={getProviderDisplayName(provider.providerId)}
+                        icon={getModelProviderLogo(provider.providerId, isDark)}
+                        endComponent={
+                          <Icon
+                            visual={
+                              expandedProvider === provider.providerId
+                                ? ChevronDown
+                                : ChevronRight
+                            }
+                            size="xs"
+                          />
+                        }
+                        onClick={() => onToggleProvider(provider.providerId)}
+                        onSelect={(e) => e.preventDefault()}
+                      />
+                      {expandedProvider === provider.providerId && (
+                        <ModelPickerProviderSection
+                          provider={provider}
+                          selectedKey={selectedKey}
+                          isMobile={isMobile}
+                          onSelect={onSelectLine}
+                        />
+                      )}
+                    </Fragment>
+                  ) : (
+                    <DropdownMenuSub key={provider.providerId}>
+                      <DropdownMenuSubTrigger
+                        label={getProviderDisplayName(provider.providerId)}
+                        icon={getModelProviderLogo(provider.providerId, isDark)}
+                      />
+                      <DropdownMenuSubContent>
+                        <ModelPickerProviderSection
+                          provider={provider}
+                          selectedKey={selectedKey}
+                          isMobile={isMobile}
+                          onSelect={onSelectLine}
+                        />
+                      </DropdownMenuSubContent>
+                    </DropdownMenuSub>
+                  )
+                )}
+              </>
+            )}
+          </>
+        ))}
+    </DropdownMenuContent>
+  );
+}

--- a/front/components/assistant/conversation/input_bar/ModelPickerContent.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerContent.tsx
@@ -1,52 +1,28 @@
-import { ModelPickerLineItem } from "@app/components/assistant/conversation/input_bar/ModelPickerLineItem";
-import { ModelPickerProviderSection } from "@app/components/assistant/conversation/input_bar/ModelPickerProviderSection";
+import { ModelPickerList } from "@app/components/assistant/conversation/input_bar/ModelPickerList";
 import { ModelPickerRowTooltip } from "@app/components/assistant/conversation/input_bar/ModelPickerRowTooltip";
 import type {
+  ModelPickerListState,
   ModelWithReasoningEffort,
-  ProviderGroup,
-  SuggestedModelWithReasoningEffort,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
-import {
-  AUTO_TOOLTIP,
-  getModelWithReasoningEffortKey,
-} from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
-import { getModelProviderLogo } from "@app/components/providers/types";
-import { getProviderDisplayName } from "@app/types/assistant/models/providers";
+import { AUTO_TOOLTIP } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import {
-  ChevronDown,
-  ChevronRight,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
   DropdownMenuSearchbar,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  Icon,
   SliderToggle,
-  Spinner,
 } from "@dust-tt/sparkle";
-import { Fragment } from "react";
 
 interface ModelPickerContentProps {
   side: "top" | "bottom";
   search: string;
   onSearchChange: (value: string) => void;
-  isModelsLoading: boolean;
-  isSearching: boolean;
-  hasResults: boolean;
-  filteredAll: ModelWithReasoningEffort[];
-  suggestedModelsWithEfforts: SuggestedModelWithReasoningEffort[];
-  moreByProvider: ProviderGroup[];
+  listState: ModelPickerListState;
+  // The Auto row: null hides it entirely (e.g. while searching), otherwise
+  // `isOn` drives the toggle state.
+  auto: { isOn: boolean } | null;
   selectedKey?: string;
-  isMobile: boolean;
-  isDark: boolean;
-  showAuto: boolean;
-  isAutoOn: boolean;
-  showList: boolean;
   onToggleAuto: () => void;
   onSelectModel: (modelWithEffort: ModelWithReasoningEffort) => void;
   // On mobile the "More models" providers expand inline; this tracks the single
@@ -59,23 +35,16 @@ export function ModelPickerContent({
   side,
   search,
   onSearchChange,
-  isModelsLoading,
-  isSearching,
-  hasResults,
-  filteredAll,
-  suggestedModelsWithEfforts,
-  moreByProvider,
+  listState,
+  auto,
   selectedKey,
-  isMobile,
-  isDark,
-  showAuto,
-  isAutoOn,
-  showList,
   onToggleAuto,
   onSelectModel,
   expandedProvider,
   onToggleProvider,
 }: ModelPickerContentProps) {
+  const isMobile = useIsMobile();
+
   return (
     <DropdownMenuContent className="w-72" align="start" side={side}>
       <div className="sticky top-0 z-10 bg-overlay-background pb-1">
@@ -88,123 +57,24 @@ export function ModelPickerContent({
         />
       </div>
 
-      {showAuto && (
+      {auto && (
         <ModelPickerRowTooltip description={AUTO_TOOLTIP} isMobile={isMobile}>
           <DropdownMenuItem
             label="Auto"
-            endComponent={<SliderToggle selected={isAutoOn} />}
+            endComponent={<SliderToggle selected={auto.isOn} />}
             onClick={onToggleAuto}
             onSelect={(e) => e.preventDefault()}
           />
         </ModelPickerRowTooltip>
       )}
 
-      {showList &&
-        (isModelsLoading ? (
-          <div className="flex h-20 items-center justify-center">
-            <Spinner size="sm" />
-          </div>
-        ) : !hasResults ? (
-          <div className="flex items-center justify-center py-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
-            No models found
-          </div>
-        ) : isSearching ? (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuRadioGroup value={selectedKey}>
-              {filteredAll.map((modelWithEffort) => (
-                <ModelPickerLineItem
-                  key={getModelWithReasoningEffortKey(
-                    modelWithEffort.model.providerId,
-                    modelWithEffort.model.modelId,
-                    modelWithEffort.effort
-                  )}
-                  modelWithEffort={modelWithEffort}
-                  isMobile={isMobile}
-                  onSelect={onSelectModel}
-                />
-              ))}
-            </DropdownMenuRadioGroup>
-          </>
-        ) : (
-          <>
-            {suggestedModelsWithEfforts.length > 0 && (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuLabel label="Suggested" />
-                <DropdownMenuRadioGroup value={selectedKey}>
-                  {suggestedModelsWithEfforts.map((modelWithEffort) => (
-                    <ModelPickerLineItem
-                      key={getModelWithReasoningEffortKey(
-                        modelWithEffort.model.providerId,
-                        modelWithEffort.model.modelId,
-                        modelWithEffort.effort
-                      )}
-                      modelWithEffort={modelWithEffort}
-                      isMobile={isMobile}
-                      onSelect={onSelectModel}
-                      recommendation={modelWithEffort.recommendation}
-                    />
-                  ))}
-                </DropdownMenuRadioGroup>
-              </>
-            )}
-            {moreByProvider.length > 0 && (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuLabel label="More models" />
-                {moreByProvider.map((provider) =>
-                  isMobile ? (
-                    // On mobile the provider expands inline below its name
-                    // instead of opening a nested submenu (which is awkward to
-                    // reach on touch).
-                    <Fragment key={provider.providerId}>
-                      <DropdownMenuItem
-                        label={getProviderDisplayName(provider.providerId)}
-                        icon={getModelProviderLogo(provider.providerId, isDark)}
-                        endComponent={
-                          <Icon
-                            visual={
-                              expandedProvider === provider.providerId
-                                ? ChevronDown
-                                : ChevronRight
-                            }
-                            size="xs"
-                          />
-                        }
-                        onClick={() => onToggleProvider(provider.providerId)}
-                        onSelect={(e) => e.preventDefault()}
-                      />
-                      {expandedProvider === provider.providerId && (
-                        <ModelPickerProviderSection
-                          provider={provider}
-                          selectedKey={selectedKey}
-                          isMobile={isMobile}
-                          onSelect={onSelectModel}
-                        />
-                      )}
-                    </Fragment>
-                  ) : (
-                    <DropdownMenuSub key={provider.providerId}>
-                      <DropdownMenuSubTrigger
-                        label={getProviderDisplayName(provider.providerId)}
-                        icon={getModelProviderLogo(provider.providerId, isDark)}
-                      />
-                      <DropdownMenuSubContent>
-                        <ModelPickerProviderSection
-                          provider={provider}
-                          selectedKey={selectedKey}
-                          isMobile={isMobile}
-                          onSelect={onSelectModel}
-                        />
-                      </DropdownMenuSubContent>
-                    </DropdownMenuSub>
-                  )
-                )}
-              </>
-            )}
-          </>
-        ))}
+      <ModelPickerList
+        listState={listState}
+        selectedKey={selectedKey}
+        onSelectModel={onSelectModel}
+        expandedProvider={expandedProvider}
+        onToggleProvider={onToggleProvider}
+      />
     </DropdownMenuContent>
   );
 }

--- a/front/components/assistant/conversation/input_bar/ModelPickerContent.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerContent.tsx
@@ -2,13 +2,13 @@ import { ModelPickerLineItem } from "@app/components/assistant/conversation/inpu
 import { ModelPickerProviderSection } from "@app/components/assistant/conversation/input_bar/ModelPickerProviderSection";
 import { ModelPickerRowTooltip } from "@app/components/assistant/conversation/input_bar/ModelPickerRowTooltip";
 import type {
-  ModelLine,
+  ModelWithReasoningEffort,
   ProviderGroup,
-  SuggestedLine,
+  SuggestedModelWithReasoningEffort,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import {
   AUTO_TOOLTIP,
-  getLineKey,
+  getModelWithReasoningEffortKey,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { getProviderDisplayName } from "@app/types/assistant/models/providers";
@@ -38,8 +38,8 @@ interface ModelPickerContentProps {
   isModelsLoading: boolean;
   isSearching: boolean;
   hasResults: boolean;
-  filteredAll: ModelLine[];
-  suggestedLines: SuggestedLine[];
+  filteredAll: ModelWithReasoningEffort[];
+  suggestedModelsWithEfforts: SuggestedModelWithReasoningEffort[];
   moreByProvider: ProviderGroup[];
   selectedKey?: string;
   isMobile: boolean;
@@ -48,7 +48,7 @@ interface ModelPickerContentProps {
   isAutoOn: boolean;
   showList: boolean;
   onToggleAuto: () => void;
-  onSelectLine: (line: ModelLine) => void;
+  onSelectModel: (modelWithEffort: ModelWithReasoningEffort) => void;
   // On mobile the "More models" providers expand inline; this tracks the single
   // provider currently expanded.
   expandedProvider: ModelProviderIdType | null;
@@ -63,7 +63,7 @@ export function ModelPickerContent({
   isSearching,
   hasResults,
   filteredAll,
-  suggestedLines,
+  suggestedModelsWithEfforts,
   moreByProvider,
   selectedKey,
   isMobile,
@@ -72,7 +72,7 @@ export function ModelPickerContent({
   isAutoOn,
   showList,
   onToggleAuto,
-  onSelectLine,
+  onSelectModel,
   expandedProvider,
   onToggleProvider,
 }: ModelPickerContentProps) {
@@ -92,7 +92,7 @@ export function ModelPickerContent({
         <ModelPickerRowTooltip description={AUTO_TOOLTIP} isMobile={isMobile}>
           <DropdownMenuItem
             label="Auto"
-            endComponent={<SliderToggle size="xs" selected={isAutoOn} />}
+            endComponent={<SliderToggle selected={isAutoOn} />}
             onClick={onToggleAuto}
             onSelect={(e) => e.preventDefault()}
           />
@@ -112,38 +112,38 @@ export function ModelPickerContent({
           <>
             <DropdownMenuSeparator />
             <DropdownMenuRadioGroup value={selectedKey}>
-              {filteredAll.map((line) => (
+              {filteredAll.map((modelWithEffort) => (
                 <ModelPickerLineItem
-                  key={getLineKey(
-                    line.model.providerId,
-                    line.model.modelId,
-                    line.effort
+                  key={getModelWithReasoningEffortKey(
+                    modelWithEffort.model.providerId,
+                    modelWithEffort.model.modelId,
+                    modelWithEffort.effort
                   )}
-                  line={line}
+                  modelWithEffort={modelWithEffort}
                   isMobile={isMobile}
-                  onSelect={onSelectLine}
+                  onSelect={onSelectModel}
                 />
               ))}
             </DropdownMenuRadioGroup>
           </>
         ) : (
           <>
-            {suggestedLines.length > 0 && (
+            {suggestedModelsWithEfforts.length > 0 && (
               <>
                 <DropdownMenuSeparator />
                 <DropdownMenuLabel label="Suggested" />
                 <DropdownMenuRadioGroup value={selectedKey}>
-                  {suggestedLines.map((line) => (
+                  {suggestedModelsWithEfforts.map((modelWithEffort) => (
                     <ModelPickerLineItem
-                      key={getLineKey(
-                        line.model.providerId,
-                        line.model.modelId,
-                        line.effort
+                      key={getModelWithReasoningEffortKey(
+                        modelWithEffort.model.providerId,
+                        modelWithEffort.model.modelId,
+                        modelWithEffort.effort
                       )}
-                      line={line}
+                      modelWithEffort={modelWithEffort}
                       isMobile={isMobile}
-                      onSelect={onSelectLine}
-                      recommendation={line.recommendation}
+                      onSelect={onSelectModel}
+                      recommendation={modelWithEffort.recommendation}
                     />
                   ))}
                 </DropdownMenuRadioGroup>
@@ -180,7 +180,7 @@ export function ModelPickerContent({
                           provider={provider}
                           selectedKey={selectedKey}
                           isMobile={isMobile}
-                          onSelect={onSelectLine}
+                          onSelect={onSelectModel}
                         />
                       )}
                     </Fragment>
@@ -195,7 +195,7 @@ export function ModelPickerContent({
                           provider={provider}
                           selectedKey={selectedKey}
                           isMobile={isMobile}
-                          onSelect={onSelectLine}
+                          onSelect={onSelectModel}
                         />
                       </DropdownMenuSubContent>
                     </DropdownMenuSub>

--- a/front/components/assistant/conversation/input_bar/ModelPickerLineItem.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerLineItem.tsx
@@ -1,0 +1,61 @@
+import { ModelPickerRowTooltip } from "@app/components/assistant/conversation/input_bar/ModelPickerRowTooltip";
+import type { ModelLine } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import {
+  getLineKey,
+  REASONING_EFFORT_INFO,
+} from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import { Chip, DropdownMenuRadioItem } from "@dust-tt/sparkle";
+import capitalize from "lodash/capitalize";
+
+interface ModelPickerLineItemProps {
+  line: ModelLine;
+  isMobile: boolean;
+  onSelect: (line: ModelLine) => void;
+  recommendation?: string;
+}
+
+// A single selectable model/effort row, wrapped in its hover tooltip.
+export function ModelPickerLineItem({
+  line,
+  isMobile,
+  onSelect,
+  recommendation,
+}: ModelPickerLineItemProps) {
+  const key = getLineKey(
+    line.model.providerId,
+    line.model.modelId,
+    line.effort
+  );
+  const info = REASONING_EFFORT_INFO[line.effort];
+
+  return (
+    <ModelPickerRowTooltip
+      description={recommendation ?? ""}
+      isMobile={isMobile}
+      media={
+        <div className="flex flex-col gap-3 text-sm">
+          <div>
+            <div className="font-medium text-foreground dark:text-foreground-night">
+              {line.model.displayName}
+            </div>
+            <div className="text-muted-foreground dark:text-muted-foreground-night">
+              {line.model.shortDescription}
+            </div>
+          </div>
+          <div className="text-muted-foreground dark:text-muted-foreground-night">
+            {info.reasoning}
+          </div>
+        </div>
+      }
+    >
+      <DropdownMenuRadioItem value={key} onClick={() => onSelect(line)}>
+        <span className="flex grow items-center gap-2">
+          <span className="line-clamp-1">{line.model.displayName}</span>
+          {line.effort !== "none" && (
+            <Chip size="mini" label={capitalize(line.effort)} />
+          )}
+        </span>
+      </DropdownMenuRadioItem>
+    </ModelPickerRowTooltip>
+  );
+}

--- a/front/components/assistant/conversation/input_bar/ModelPickerLineItem.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerLineItem.tsx
@@ -1,32 +1,32 @@
 import { ModelPickerRowTooltip } from "@app/components/assistant/conversation/input_bar/ModelPickerRowTooltip";
-import type { ModelLine } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import type { ModelWithReasoningEffort } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import {
-  getLineKey,
+  getModelWithReasoningEffortKey,
   REASONING_EFFORT_INFO,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { Chip, DropdownMenuRadioItem } from "@dust-tt/sparkle";
 import capitalize from "lodash/capitalize";
 
 interface ModelPickerLineItemProps {
-  line: ModelLine;
+  modelWithEffort: ModelWithReasoningEffort;
   isMobile: boolean;
-  onSelect: (line: ModelLine) => void;
+  onSelect: (modelWithEffort: ModelWithReasoningEffort) => void;
   recommendation?: string;
 }
 
 // A single selectable model/effort row, wrapped in its hover tooltip.
 export function ModelPickerLineItem({
-  line,
+  modelWithEffort,
   isMobile,
   onSelect,
   recommendation,
 }: ModelPickerLineItemProps) {
-  const key = getLineKey(
-    line.model.providerId,
-    line.model.modelId,
-    line.effort
+  const key = getModelWithReasoningEffortKey(
+    modelWithEffort.model.providerId,
+    modelWithEffort.model.modelId,
+    modelWithEffort.effort
   );
-  const info = REASONING_EFFORT_INFO[line.effort];
+  const info = REASONING_EFFORT_INFO[modelWithEffort.effort];
 
   return (
     <ModelPickerRowTooltip
@@ -36,10 +36,10 @@ export function ModelPickerLineItem({
         <div className="flex flex-col gap-3 text-sm">
           <div>
             <div className="font-medium text-foreground dark:text-foreground-night">
-              {line.model.displayName}
+              {modelWithEffort.model.displayName}
             </div>
             <div className="text-muted-foreground dark:text-muted-foreground-night">
-              {line.model.shortDescription}
+              {modelWithEffort.model.shortDescription}
             </div>
           </div>
           <div className="text-muted-foreground dark:text-muted-foreground-night">
@@ -48,11 +48,16 @@ export function ModelPickerLineItem({
         </div>
       }
     >
-      <DropdownMenuRadioItem value={key} onClick={() => onSelect(line)}>
+      <DropdownMenuRadioItem
+        value={key}
+        onClick={() => onSelect(modelWithEffort)}
+      >
         <span className="flex grow items-center gap-2">
-          <span className="line-clamp-1">{line.model.displayName}</span>
-          {line.effort !== "none" && (
-            <Chip size="mini" label={capitalize(line.effort)} />
+          <span className="line-clamp-1">
+            {modelWithEffort.model.displayName}
+          </span>
+          {modelWithEffort.effort !== "none" && (
+            <Chip size="mini" label={capitalize(modelWithEffort.effort)} />
           )}
         </span>
       </DropdownMenuRadioItem>

--- a/front/components/assistant/conversation/input_bar/ModelPickerList.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerList.tsx
@@ -1,0 +1,173 @@
+import { ModelPickerLineItem } from "@app/components/assistant/conversation/input_bar/ModelPickerLineItem";
+import { ModelPickerProviderSection } from "@app/components/assistant/conversation/input_bar/ModelPickerProviderSection";
+import type {
+  ModelPickerListState,
+  ModelWithReasoningEffort,
+} from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import { getModelWithReasoningEffortKey } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import { getModelProviderLogo } from "@app/components/providers/types";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
+import { getProviderDisplayName } from "@app/types/assistant/models/providers";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import {
+  ChevronDown,
+  ChevronRight,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  Icon,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { Fragment } from "react";
+
+interface ModelPickerListProps {
+  listState: ModelPickerListState;
+  selectedKey?: string;
+  onSelectModel: (modelWithEffort: ModelWithReasoningEffort) => void;
+  // On mobile the "More models" providers expand inline; this tracks the single
+  // provider currently expanded.
+  expandedProvider: ModelProviderIdType | null;
+  onToggleProvider: (providerId: ModelProviderIdType) => void;
+}
+
+export function ModelPickerList({
+  listState,
+  selectedKey,
+  onSelectModel,
+  expandedProvider,
+  onToggleProvider,
+}: ModelPickerListProps) {
+  const { isDark } = useTheme();
+  const isMobile = useIsMobile();
+
+  switch (listState.kind) {
+    case "hidden":
+      return null;
+
+    case "loading":
+      return (
+        <div className="flex h-20 items-center justify-center">
+          <Spinner size="sm" />
+        </div>
+      );
+
+    case "empty":
+      return (
+        <div className="flex items-center justify-center py-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+          No models found
+        </div>
+      );
+
+    case "search":
+      return (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuRadioGroup value={selectedKey}>
+            {listState.models.map((modelWithEffort) => (
+              <ModelPickerLineItem
+                key={getModelWithReasoningEffortKey(
+                  modelWithEffort.model.providerId,
+                  modelWithEffort.model.modelId,
+                  modelWithEffort.effort
+                )}
+                modelWithEffort={modelWithEffort}
+                isMobile={isMobile}
+                onSelect={onSelectModel}
+              />
+            ))}
+          </DropdownMenuRadioGroup>
+        </>
+      );
+
+    case "browse":
+      return (
+        <>
+          {listState.suggested.length > 0 && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel label="Suggested" />
+              <DropdownMenuRadioGroup value={selectedKey}>
+                {listState.suggested.map((modelWithEffort) => (
+                  <ModelPickerLineItem
+                    key={getModelWithReasoningEffortKey(
+                      modelWithEffort.model.providerId,
+                      modelWithEffort.model.modelId,
+                      modelWithEffort.effort
+                    )}
+                    modelWithEffort={modelWithEffort}
+                    isMobile={isMobile}
+                    onSelect={onSelectModel}
+                    recommendation={modelWithEffort.recommendation}
+                  />
+                ))}
+              </DropdownMenuRadioGroup>
+            </>
+          )}
+          {listState.moreByProvider.length > 0 && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel label="More models" />
+              {listState.moreByProvider.map((provider) =>
+                isMobile ? (
+                  // On mobile the provider expands inline below its name
+                  // instead of opening a nested submenu (which is awkward to
+                  // reach on touch).
+                  <Fragment key={provider.providerId}>
+                    <DropdownMenuItem
+                      label={getProviderDisplayName(provider.providerId)}
+                      icon={getModelProviderLogo(provider.providerId, isDark)}
+                      endComponent={
+                        <Icon
+                          visual={
+                            expandedProvider === provider.providerId
+                              ? ChevronDown
+                              : ChevronRight
+                          }
+                          size="xs"
+                        />
+                      }
+                      onClick={() => onToggleProvider(provider.providerId)}
+                      onSelect={(e) => e.preventDefault()}
+                    />
+                    {expandedProvider === provider.providerId && (
+                      <ModelPickerProviderSection
+                        provider={provider}
+                        selectedKey={selectedKey}
+                        isMobile={isMobile}
+                        onSelect={onSelectModel}
+                      />
+                    )}
+                  </Fragment>
+                ) : (
+                  <DropdownMenuSub key={provider.providerId}>
+                    <DropdownMenuSubTrigger
+                      label={getProviderDisplayName(provider.providerId)}
+                      icon={getModelProviderLogo(provider.providerId, isDark)}
+                    />
+                    <DropdownMenuSubContent>
+                      <ModelPickerProviderSection
+                        provider={provider}
+                        selectedKey={selectedKey}
+                        isMobile={isMobile}
+                        onSelect={onSelectModel}
+                      />
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                )
+              )}
+            </>
+          )}
+        </>
+      );
+
+    default:
+      assertNeverAndIgnore(listState);
+      return null;
+  }
+}

--- a/front/components/assistant/conversation/input_bar/ModelPickerProviderSection.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerProviderSection.tsx
@@ -1,0 +1,57 @@
+import { ModelPickerLineItem } from "@app/components/assistant/conversation/input_bar/ModelPickerLineItem";
+import type {
+  ModelLine,
+  ProviderGroup,
+} from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import { getLineKey } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import {
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuSeparator,
+} from "@dust-tt/sparkle";
+import { Fragment } from "react";
+
+interface ModelPickerProviderSectionProps {
+  provider: ProviderGroup;
+  selectedKey?: string;
+  isMobile: boolean;
+  onSelect: (line: ModelLine) => void;
+}
+
+// The per-model sections (one label + its effort lines) shown for a provider.
+// Rendered inside a submenu on desktop and inline under the provider name on
+// mobile.
+export function ModelPickerProviderSection({
+  provider,
+  selectedKey,
+  isMobile,
+  onSelect,
+}: ModelPickerProviderSectionProps) {
+  return (
+    <>
+      {provider.models.map((entry, index) => (
+        <Fragment key={entry.model.modelId}>
+          {index > 0 && <DropdownMenuSeparator />}
+          <DropdownMenuLabel label={entry.model.displayName} />
+          <DropdownMenuRadioGroup value={selectedKey}>
+            {entry.efforts.map((effort) => {
+              const line = { model: entry.model, effort };
+              return (
+                <ModelPickerLineItem
+                  key={getLineKey(
+                    entry.model.providerId,
+                    entry.model.modelId,
+                    effort
+                  )}
+                  line={line}
+                  isMobile={isMobile}
+                  onSelect={onSelect}
+                />
+              );
+            })}
+          </DropdownMenuRadioGroup>
+        </Fragment>
+      ))}
+    </>
+  );
+}

--- a/front/components/assistant/conversation/input_bar/ModelPickerProviderSection.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerProviderSection.tsx
@@ -1,9 +1,9 @@
 import { ModelPickerLineItem } from "@app/components/assistant/conversation/input_bar/ModelPickerLineItem";
 import type {
-  ModelLine,
+  ModelWithReasoningEffort,
   ProviderGroup,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
-import { getLineKey } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import { getModelWithReasoningEffortKey } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import {
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
@@ -15,7 +15,7 @@ interface ModelPickerProviderSectionProps {
   provider: ProviderGroup;
   selectedKey?: string;
   isMobile: boolean;
-  onSelect: (line: ModelLine) => void;
+  onSelect: (modelWithEffort: ModelWithReasoningEffort) => void;
 }
 
 // The per-model sections (one label + its effort lines) shown for a provider.
@@ -35,15 +35,15 @@ export function ModelPickerProviderSection({
           <DropdownMenuLabel label={entry.model.displayName} />
           <DropdownMenuRadioGroup value={selectedKey}>
             {entry.efforts.map((effort) => {
-              const line = { model: entry.model, effort };
+              const modelWithEffort = { model: entry.model, effort };
               return (
                 <ModelPickerLineItem
-                  key={getLineKey(
+                  key={getModelWithReasoningEffortKey(
                     entry.model.providerId,
                     entry.model.modelId,
                     effort
                   )}
-                  line={line}
+                  modelWithEffort={modelWithEffort}
                   isMobile={isMobile}
                   onSelect={onSelect}
                 />

--- a/front/components/assistant/conversation/input_bar/ModelPickerRowTooltip.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerRowTooltip.tsx
@@ -1,0 +1,30 @@
+import { DropdownTooltipTrigger } from "@dust-tt/sparkle";
+import type { ReactElement, ReactNode } from "react";
+
+interface ModelPickerRowTooltipProps {
+  description: string;
+  media?: ReactNode;
+  // On mobile there is no hover, so we skip the tooltip entirely and render the
+  // row as-is.
+  isMobile: boolean;
+  children: ReactElement;
+}
+
+// Wraps a dropdown row in its hover tooltip on desktop. When used inside a
+// `.map`, apply the React `key` to this component so it is valid regardless of
+// whether the tooltip is rendered.
+export function ModelPickerRowTooltip({
+  description,
+  media,
+  isMobile,
+  children,
+}: ModelPickerRowTooltipProps) {
+  if (isMobile) {
+    return children;
+  }
+  return (
+    <DropdownTooltipTrigger description={description} media={media}>
+      {children}
+    </DropdownTooltipTrigger>
+  );
+}

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -81,6 +81,21 @@ export type Selection =
   | { kind: "auto" }
   | { kind: "model"; model: ModelConfigurationType; effort: ReasoningEffort };
 
+// The list body is a small state machine: hidden while Auto is on, then a
+// loading / empty / search-results / browse view depending on the models
+// query and the search input. Modeling it as a single discriminated union
+// keeps the picker's props flat instead of a fistful of correlated booleans.
+export type ModelPickerListState =
+  | { kind: "hidden" }
+  | { kind: "loading" }
+  | { kind: "empty" }
+  | { kind: "search"; models: ModelWithReasoningEffort[] }
+  | {
+      kind: "browse";
+      suggested: SuggestedModelWithReasoningEffort[];
+      moreByProvider: ProviderGroup[];
+    };
+
 export function getSelectableReasoningEfforts(
   model: ModelConfigurationType
 ): ReasoningEffort[] {

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -62,12 +62,13 @@ export const REASONING_EFFORT_INFO: Record<
   },
 };
 
-export interface ModelLine {
+export interface ModelWithReasoningEffort {
   model: ModelConfigurationType;
   effort: ReasoningEffort;
 }
 
-export interface SuggestedLine extends ModelLine {
+export interface SuggestedModelWithReasoningEffort
+  extends ModelWithReasoningEffort {
   recommendation: string;
 }
 
@@ -88,7 +89,7 @@ export function getSelectableReasoningEfforts(
   return withReasoning.length > 0 ? withReasoning : efforts;
 }
 
-export function getLineKey(
+export function getModelWithReasoningEffortKey(
   providerId: string,
   modelId: string,
   effort: ReasoningEffort
@@ -96,7 +97,7 @@ export function getLineKey(
   return `${providerId}/${modelId}/${effort}`;
 }
 
-export function getLineLabel(selection: Selection): string {
+export function getModelWithReasoningEffortLabel(selection: Selection): string {
   if (selection.kind === "auto") {
     return "Auto";
   }

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -1,0 +1,129 @@
+import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
+import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
+import type {
+  ModelConfigurationType,
+  ModelProviderIdType,
+  ModelSelectionType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
+import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import capitalize from "lodash/capitalize";
+
+export const SUGGESTED_PINS: {
+  providerId: ModelProviderIdType;
+  modelId: string;
+  effort: ReasoningEffort;
+  recommendation: string;
+}[] = [
+  {
+    providerId: "anthropic",
+    modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+    effort: "light",
+    recommendation:
+      "Quick answers. Recommended for easy retrieval, light analysis or general questions.",
+  },
+  {
+    providerId: "anthropic",
+    modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+    effort: "medium",
+    recommendation:
+      "Everyday tasks. Recommended for multi-step tasks, Frames, analysis.",
+  },
+  {
+    providerId: "openai",
+    modelId: GPT_5_5_MODEL_ID,
+    effort: "high",
+    recommendation:
+      "Hard problems. Recommended for high quality retrieval, complex analysis and Frames",
+  },
+];
+
+export const AUTO_TOOLTIP =
+  "Dust selects and switches model for cost efficient performance and reliability. When an agent is created using a specific model, we use this model.";
+
+// Per reasoning-effort blurbs shown in each model's hover tooltip: what the
+// effort does, and what it is recommended for.
+export const REASONING_EFFORT_INFO: Record<
+  ReasoningEffort,
+  { reasoning: string }
+> = {
+  none: {
+    reasoning: "No additional reasoning, for the fastest responses",
+  },
+  light: {
+    reasoning: "Light reasoning effort, faster responses.",
+  },
+  medium: {
+    reasoning: "Medium reasoning effort, balancing speed and quality.",
+  },
+  high: {
+    reasoning: "High reasoning effort, longer wait times but higher quality.",
+  },
+};
+
+export interface ModelLine {
+  model: ModelConfigurationType;
+  effort: ReasoningEffort;
+}
+
+export interface SuggestedLine extends ModelLine {
+  recommendation: string;
+}
+
+export interface ProviderGroup {
+  providerId: ModelProviderIdType;
+  models: { model: ModelConfigurationType; efforts: ReasoningEffort[] }[];
+}
+
+export type Selection =
+  | { kind: "auto" }
+  | { kind: "model"; model: ModelConfigurationType; effort: ReasoningEffort };
+
+export function getSelectableReasoningEfforts(
+  model: ModelConfigurationType
+): ReasoningEffort[] {
+  const efforts = getAvailableReasoningEfforts(model.supportedReasoningEfforts);
+  const withReasoning = efforts.filter((effort) => effort !== "none");
+  return withReasoning.length > 0 ? withReasoning : efforts;
+}
+
+export function getLineKey(
+  providerId: string,
+  modelId: string,
+  effort: ReasoningEffort
+): string {
+  return `${providerId}/${modelId}/${effort}`;
+}
+
+export function getLineLabel(selection: Selection): string {
+  if (selection.kind === "auto") {
+    return "Auto";
+  }
+  const { model, effort } = selection;
+
+  if (effort === "none") {
+    return model.displayName;
+  }
+
+  return `${model.displayName} ${capitalize(effort)}`;
+}
+
+// Converts the picker's local selection into the API model selection
+export function toModelSelection(
+  selection: Selection
+): ModelSelectionType | undefined {
+  switch (selection.kind) {
+    case "auto":
+      return undefined;
+    case "model":
+      return {
+        providerId: selection.model.providerId,
+        modelId: selection.model.modelId,
+        reasoningEffort: selection.effort,
+      };
+    default:
+      assertNeverAndIgnore(selection);
+      return undefined;
+  }
+}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -318,7 +318,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   models_picker: {
     description:
-      "Model picker in the conversation input bar: pick a specific model.",
+      "Model picker in the conversation input bar: keep Auto (the agent's configured model) or pick a specific model and reasoning effort.",
     stage: "dust_only",
   },
   activation_skill: {


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/68ebb81c-6433-4f8c-ba7a-c4f446f89490


Adds the model-picker dropdown to the conversation input bar and mounts it next to the agent chip, gated behind the `models_picker` feature flag (`dust_only` stage).

- Introduces `InputBarModelPicker`: keep **Auto** (the agent's configured model) or pick a specific model, with an optional reasoning-effort override and a set of suggested pins.
- Mounts the picker in `InputBarButtons` (when the `model-picker` action is enabled) and feeds its selection up through `InputBar` / `InputBarContainer` into the send path plumbed in #28489, which the backend (#28346) applies as a per-message override.

The send-path plumbing (#28489) and the agent-chip rework (#28488) it depends on are split into their own PRs below in the stack; this PR is just the picker component and its wiring into the input bar.

Top of the model-picker stack (bottom → top): #28344 → #28346 → #28488 → #28489 → **#28049 (this)**.

## Tests

Manual: with `models_picker` enabled, open the picker, keep Auto and confirm the agent's configured model runs; pick a specific model (and a reasoning effort) and confirm the sent message runs on the override. With the flag off, the picker is not shown.

## Risk

Low. Frontend is gated by `models_picker`; the backend override only takes effect when a selection is sent, so with no selection behavior is unchanged. Rollback by disabling the flag.
