### PR TITLE
[front] API key credit cap (1/10): keys schema + credit state

### DIFF
--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -14,7 +14,7 @@ import {
   invalidateCacheAfterCommit,
   invalidateCacheWithRedis,
 } from "@app/lib/utils/cache";
-import type { KeyType } from "@app/types/key";
+import type { ApiKeyCreditState, KeyType } from "@app/types/key";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { redactString } from "@app/types/shared/utils/string_utils";
@@ -79,6 +79,8 @@ export class KeyResource extends BaseResource<KeyModel> {
       isSystem: key.isSystem,
       role: key.role,
       monthlyCapMicroUsd: key.monthlyCapMicroUsd,
+      monthlyCapAwuCredits: key.monthlyCapAwuCredits,
+      creditState: key.creditState,
       workspaceId: key.workspaceId,
       groupIds: key.groupIds,
       userId: key.userId,
@@ -330,6 +332,8 @@ export class KeyResource extends BaseResource<KeyModel> {
       groupIds: this.groupIds,
       role: this.role,
       monthlyCapMicroUsd: this.monthlyCapMicroUsd,
+      monthlyCapAwuCredits: this.monthlyCapAwuCredits,
+      creditState: this.creditState,
     };
   }
 
@@ -359,5 +363,19 @@ export class KeyResource extends BaseResource<KeyModel> {
     monthlyCapMicroUsd: number | null;
   }) {
     await this.update({ monthlyCapMicroUsd });
+  }
+
+  async updateMonthlyCapAwuCredits(
+    monthlyCapAwuCredits: number | null,
+    transaction?: Transaction
+  ) {
+    await this.update({ monthlyCapAwuCredits }, transaction);
+  }
+
+  async updateCreditState(
+    creditState: ApiKeyCreditState,
+    transaction?: Transaction
+  ) {
+    await this.update({ creditState }, transaction);
   }
 }

--- a/front/lib/resources/storage/models/keys.ts
+++ b/front/lib/resources/storage/models/keys.ts
@@ -2,6 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { ApiKeyCreditState } from "@app/types/key";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { RoleType } from "@app/types/user";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
@@ -22,6 +23,14 @@ export class KeyModel extends WorkspaceAwareModel<KeyModel> {
 
   declare name: string;
   declare monthlyCapMicroUsd: number | null;
+  // Admin-set cap on workspace-pool AWU consumption, in AWU credits. NULL means
+  // no cap (unlimited). On credit-priced plans this is the enforcement source:
+  // a Metronome `spend_threshold_reached` alert (group key `api_key_name`,
+  // threshold = this value) drives `creditState`. Key names are NOT unique, and
+  // Metronome aggregates spend by name — so the cap is effectively per-name:
+  // all active keys sharing a name share the limit and are blocked together.
+  declare monthlyCapAwuCredits: number | null;
+  declare creditState: CreationOptional<ApiKeyCreditState>;
   declare user: NonAttribute<UserModel>;
 }
 KeyModel.init(
@@ -65,6 +74,15 @@ KeyModel.init(
     monthlyCapMicroUsd: {
       type: DataTypes.BIGINT,
       allowNull: true,
+    },
+    monthlyCapAwuCredits: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    creditState: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "on_pool",
     },
     groupIds: {
       type: DataTypes.ARRAY(DataTypes.BIGINT),

--- a/front/migrations/pre-deploy/20260626181623_add_credit_cap_and_state_to_keys.sql
+++ b/front/migrations/pre-deploy/20260626181623_add_credit_cap_and_state_to_keys.sql
@@ -1,0 +1,13 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."keys" ADD COLUMN "monthlyCapAwuCredits" integer;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."keys" ADD COLUMN "creditState" character varying(255) NOT NULL DEFAULT 'on_pool'::character varying;

--- a/front/types/key.ts
+++ b/front/types/key.ts
@@ -1,6 +1,24 @@
 import type { ModelId } from "@app/types/shared/model_id";
 import type { RoleType } from "@app/types/user";
 
+// Per-API-key credit state, mirroring the per-user `memberships.creditState`
+// but with only two states for new-pricing (credit) plans:
+//   - "on_pool": the key can spend from the workspace pool.
+//   - "capped": the key hit its admin-configured per-key spend cap and is
+//     blocked until the cap resets (billing-period renewal) or is raised.
+export const API_KEY_CREDIT_STATES = ["on_pool", "capped"] as const;
+
+export type ApiKeyCreditState = (typeof API_KEY_CREDIT_STATES)[number];
+
+export function isApiKeyCreditState(
+  value: unknown
+): value is ApiKeyCreditState {
+  return (
+    typeof value === "string" &&
+    (API_KEY_CREDIT_STATES as readonly string[]).includes(value)
+  );
+}
+
 export type KeyType = {
   id: ModelId;
   createdAt: number;
@@ -12,4 +30,6 @@ export type KeyType = {
   groupIds: ModelId[];
   role: RoleType;
   monthlyCapMicroUsd: number | null;
+  monthlyCapAwuCredits: number | null;
+  creditState: ApiKeyCreditState;
 };


### PR DESCRIPTION
First PR in the stack adding **per-API-key credit spend limits** on new-pricing (credit) plans, mirroring the existing per-user spend-limit machinery (Metronome `spend_threshold_reached` alerts → credit-state transitions).

### This PR — data model only
- **`keys.monthlyCapAwuCredits`** (nullable int): admin-set cap in AWU credits (1 credit = $0.01 = 10,000 microUSD). `NULL` = unlimited.
- **`keys.creditState`** (`"on_pool" | "capped"`, default `"on_pool"`): per-key credit state; the enforcement source on credit-priced plans (added in a later PR).
- Plumbs both fields through `KeyModel`, `KeyResource` (secret cache, `toJSON`, update helpers), `KeyType`, and adds the `ApiKeyCreditState` type + guard.

### Key names are NOT unique — the cap is per-name
Production data has many active keys sharing a `(workspaceId, name)` pair, and Metronome aggregates spend by `api_key_name`. So the cap is effectively **per-name**: all active keys sharing a name share the limit and are blocked/unblocked together (handled in the webhook PR). No uniqueness is introduced or enforced.

### Deploy note
The migration is `pre-deploy` (two plain `ADD COLUMN`s, no index) — safe to apply before the code ships.

> Migration SQL was hand-written in the generator's format (this Conductor workspace has no live front DB to diff against). Please re-validate / `migration:apply` in a warm env.

### Next in stack
Metronome alert wiring → state machine → set-cap lib/reconcile → webhook routing → enforcement gate → API/UI/Swagger/audit → backfill → tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)