### PR TITLE
[front] chore: tweak Snowflake tool descriptions for tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -83,7 +83,7 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     },
   },
   [SNOWFLAKE_QUERY_TOOL_NAME]: {
-    description: `Execute a read-only SQL query against Snowflake. Only SELECT queries are allowed; write operations are not permitted. Before writing a query, use ${SNOWFLAKE_LIST_DATABASES_TOOL_NAME}, ${SNOWFLAKE_LIST_SCHEMAS_TOOL_NAME}, ${SNOWFLAKE_LIST_TABLES_TOOL_NAME}, and ${SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME} (or ${SNOWFLAKE_DESCRIBE_SEMANTIC_VIEW_TOOL_NAME} for semantic views) to explore the schema.`,
+    description: `Execute a read-only SQL SELECT query against Snowflake to analyze data, answer questions, calculate metrics such as revenue, or retrieve rows. Write operations are not permitted. Before writing a query, use ${SNOWFLAKE_LIST_DATABASES_TOOL_NAME}, ${SNOWFLAKE_LIST_SCHEMAS_TOOL_NAME}, ${SNOWFLAKE_LIST_TABLES_TOOL_NAME}, and ${SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME} (or ${SNOWFLAKE_DESCRIBE_SEMANTIC_VIEW_TOOL_NAME} for semantic views) to explore the schema when database, schema, table, view, or column names are unknown.`,
     schema: {
       sql: z
         .string()

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -684,6 +684,32 @@ export const QUERIES: LabeledQuery[] = [
     expected: "google_sheets.move_worksheet",
   },
 
+  // --- snowflake ---
+  {
+    query: "what snowflake databases can i access",
+    expected: "snowflake.list_databases",
+  },
+  {
+    query: "show schemas in the analytics snowflake database",
+    expected: "snowflake.list_schemas",
+  },
+  {
+    query: "find available tables and views in snowflake analytics public",
+    expected: "snowflake.list_tables",
+  },
+  {
+    query: "what columns and data types are in a snowflake orders table",
+    expected: "snowflake.describe_table",
+  },
+  {
+    query: "show measures and dimensions in a snowflake semantic view",
+    expected: "snowflake.describe_semantic_view",
+  },
+  {
+    query: "calculate monthly revenue from snowflake data",
+    expected: "snowflake.query",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -24,6 +24,7 @@ import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_t
 import { SALESFORCE_SERVER } from "@app/lib/api/actions/servers/salesforce/metadata";
 import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadata";
 import { SLACK_PERSONAL_SERVER } from "@app/lib/api/actions/servers/slack_personal/metadata";
+import { SNOWFLAKE_SERVER } from "@app/lib/api/actions/servers/snowflake/metadata";
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import { buildIndex, rank } from "@app/scripts/mcp_bm25/bm25";
 import type { ServerEntry } from "@app/scripts/mcp_bm25/corpus";
@@ -45,6 +46,7 @@ const SERVERS: ServerEntry[] = [
   { name: "hubspot", tools: HUBSPOT_SERVER.tools },
   { name: "salesforce", tools: SALESFORCE_SERVER.tools },
   { name: "interactive_content", tools: INTERACTIVE_CONTENT_SERVER.tools },
+  { name: "snowflake", tools: SNOWFLAKE_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9164.

This PR follows up on the BM25 MCP tool-search harness work by tweaking descriptions for the Snowflake tools to rank better on tool search queries where it should rank well.

This is metadata-only; tool behavior is unchanged.

## Tests

- Tested locally with the BM25 harness; all Snowflake samples rank first.

## Risk

- Low.

## Deploy Plan

- Deploy front.
