### PR TITLE
[front] chore: tweak data warehouse tool descriptions for tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -18,8 +18,8 @@ const dataSourcesSchema =
 export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
   list: {
     description:
-      "List the direct contents of a warehouse, database, or schema. Can be used to see what is inside a " +
-      "specific location in the tables hierarchy, like 'ls' in Unix. If no nodeId is provided, lists " +
+      "Browse and list the direct contents inside a warehouse, database, or schema: child databases, schemas, nested schemas, and tables. " +
+      "Use this to explore or navigate the tables hierarchy, like 'ls' in Unix. If no nodeId is provided, shows " +
       "all available data warehouses at the root level. Hierarchy supports: warehouse → database → schema → " +
       "nested schemas → tables. Schemas can be arbitrarily nested within other schemas. Results are paginated " +
       "with a default limit and you can fetch additional pages using the nextPageCursor.",
@@ -55,10 +55,10 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
   },
   find: {
     description:
-      "Find tables, schemas and databases based on their name starting from a specific node in the tables hierarchy. " +
-      "Can be used to search for tables by name across warehouses, databases, and schemas. " +
-      "The query supports partial matching - for example, searching for 'sales' will find " +
-      "'sales_2024', 'monthly_sales_report', etc. This is like using 'find' in Unix for tables.",
+      "Find, search, or locate tables, schemas, and databases by name starting from a specific node in the warehouse hierarchy. " +
+      "Use this for table-name lookup when you know a full or partial table, schema, or database name. " +
+      "The query supports partial matching - for example, searching for 'customer' will find " +
+      "'customer_profiles', 'dim_customers', etc. This is like using 'find' in Unix for tables.",
     schema: {
       dataSources: dataSourcesSchema,
       query: z
@@ -66,8 +66,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
         .optional()
         .describe(
           "The table name to search for. This supports partial matching and does not require the " +
-            "exact name. For example, searching for 'revenue' will find 'revenue_2024', " +
-            "'monthly_revenue', 'revenue_by_region', etc. If omitted, lists all tables."
+            "exact name. For example, searching for 'invoice' will find 'invoices', " +
+            "'invoice_lines', 'archived_invoices', etc. If omitted, lists all tables."
         ),
       rootNodeId: z
         .string()
@@ -100,10 +100,10 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
   },
   describe_tables: {
     description:
-      "Get detailed schema information for one or more tables. Provides DBML schema definitions, " +
+      "Describe known warehouse tables by retrieving their schema details: columns, types, DBML definitions, " +
       "SQL dialect-specific query guidelines, and example rows. All tables must be from the same " +
       "warehouse - cross-warehouse schema requests are not supported. Use this to understand table " +
-      "structure before writing queries.",
+      "structure before writing SQL queries.",
     schema: {
       dataSources: dataSourcesSchema,
       tableIds: z
@@ -123,8 +123,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
   },
   query: {
     description:
-      "Execute SQL queries on tables from the same warehouse. You MUST call describe_tables at least once " +
-      "before attempting to query tables to understand their structure. The query must respect the SQL dialect " +
+      "Run, execute, or write SQL queries on selected data warehouse tables to calculate metrics, aggregate results, analyze revenue, or answer business questions. " +
+      "You MUST call describe_tables at least once before attempting to query tables to understand their structure. The query must respect the SQL dialect " +
       "and guidelines provided by describe_tables. All tables in a single query must be from the same warehouse.",
     schema: {
       dataSources: dataSourcesSchema,

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -746,6 +746,24 @@ export const QUERIES: LabeledQuery[] = [
     expected: "run_agent.run_CodeReviewer",
   },
 
+  // --- data_warehouses ---
+  {
+    query: "browse the schemas in our revenue warehouse",
+    expected: "data_warehouses.list",
+  },
+  {
+    query: "find customer tables in the data warehouse",
+    expected: "data_warehouses.find",
+  },
+  {
+    query: "describe the schema and columns for this warehouse table",
+    expected: "data_warehouses.describe_tables",
+  },
+  {
+    query: "calculate monthly revenue by querying warehouse tables",
+    expected: "data_warehouses.query",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -13,6 +13,7 @@
 
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
+import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_warehouses/metadata";
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
@@ -104,6 +105,7 @@ const SERVERS: ServerEntry[] = [
     name: "run_agent",
     tools: RUN_AGENT_SAMPLE_TOOLS,
   },
+  { name: "data_warehouses", tools: DATA_WAREHOUSES_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9164

This PR tweaks the data warehouse tool descriptions to optimize for tool-search recall.

It also adds the tools in the BM25 harness and adds samples covering list/schema/execute retrieval.

## Tests

- Tested locally; all new data warehouse BM25 samples ranked the expected tool first.

## Risk

- Low.

## Deploy Plan

- Deploy front.
