### PR TITLE
[front] API key credit cap (3/10): state machine, block cache, dispatchers

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -4,6 +4,8 @@ import { recalculatePerUserCapAlertForSeatChange } from "@app/lib/api/membership
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
+import type { ApiKeyCreditEvent } from "@app/lib/metronome/api_key_credit_state_machine";
+import { transitionApiKeyCreditState } from "@app/lib/metronome/api_key_credit_state_machine";
 import { fetchLiveUserCreditInputs } from "@app/lib/metronome/live_user_credit_inputs";
 import { getWorkspacePoolAwuBalance } from "@app/lib/metronome/pool_balance";
 import { transitionProgrammaticCreditState } from "@app/lib/metronome/programmatic_credit_state_machine";
@@ -18,6 +20,7 @@ import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_s
 import { transitionWorkspaceCreditState } from "@app/lib/metronome/workspace_credit_state_machine";
 import { notifyAdminsProgrammaticCapReached } from "@app/lib/notifications/workflows/programmatic-cap-reached";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -394,6 +397,76 @@ async function resolveLiveUserBalance({
     perUserCapAwuCredits: liveResult.value.effectiveCapAwuCredits,
     consumedAwuCredits: liveResult.value.consumedAwuCredits,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Per-API-key credit state dispatchers
+// ---------------------------------------------------------------------------
+
+// Key names are not unique and Metronome aggregates spend per name, so the cap
+// is per-name: a single `api_key_name` alert covers every active key sharing
+// that name. Transition them all so they are blocked/unblocked together.
+async function transitionActiveKeysByName(
+  workspace: WorkspaceResource,
+  keyName: string,
+  event: ApiKeyCreditEvent,
+  logLabel: string
+): Promise<Result<void, Error>> {
+  const keys = await KeyResource.listActiveByWorkspaceAndName(
+    renderLightWorkspaceType({ workspace }),
+    keyName
+  );
+  if (keys.length === 0) {
+    logger.warn(
+      { workspaceId: workspace.sId, keyName },
+      `[CreditStateDispatcher] ${logLabel}: no active key found, skipping`
+    );
+    return new Ok(undefined);
+  }
+
+  for (const key of keys) {
+    const result = await transitionApiKeyCreditState(key, event, {
+      workspaceId: workspace.sId,
+      keyModelId: key.id,
+    });
+    if (result.isErr()) {
+      logger.warn(
+        { workspaceId: workspace.sId, keyName, keyModelId: key.id, event },
+        `[CreditStateDispatcher] ${logLabel}: transition skipped for a key`
+      );
+    }
+  }
+  return new Ok(undefined);
+}
+
+export async function dispatchApiKeyCapReached({
+  workspace,
+  keyName,
+}: {
+  workspace: WorkspaceResource;
+  keyName: string;
+}): Promise<Result<void, Error>> {
+  return transitionActiveKeysByName(
+    workspace,
+    keyName,
+    { type: "api_key_cap_reached" },
+    "api_key_cap_reached"
+  );
+}
+
+export async function dispatchApiKeyCapResolved({
+  workspace,
+  keyName,
+}: {
+  workspace: WorkspaceResource;
+  keyName: string;
+}): Promise<Result<void, Error>> {
+  return transitionActiveKeysByName(
+    workspace,
+    keyName,
+    { type: "api_key_cap_resolved" },
+    "api_key_cap_resolved"
+  );
 }
 
 export async function dispatchPoolExhausted({

--- a/front/lib/metronome/api_key_block.ts
+++ b/front/lib/metronome/api_key_block.ts
@@ -1,0 +1,83 @@
+// Redis fast-path cache for per-API-key credit-state-driven access control.
+//
+// Mirrors `user_block.ts` but for API keys: the key
+// `metronome:api_key_credit_state:<ws>:<keyModelId>` holds the per-key credit state
+// (mirrors `keys.creditState`). "capped" means the key is blocked because it
+// hit its admin-configured per-key spend cap. The DB column remains the source
+// of truth; cache writes are gated on DB transaction commit via
+// `invalidateCacheAfterCommit`, and cache misses fall back to DB and
+// repopulate the key.
+import { runOnRedis } from "@app/lib/api/redis";
+import { KeyResource } from "@app/lib/resources/key_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import logger from "@app/logger/logger";
+import type { ApiKeyCreditState } from "@app/types/key";
+import { isApiKeyCreditState } from "@app/types/key";
+import type { ModelId } from "@app/types/shared/model_id";
+
+const REDIS_ORIGIN = "metronome_limit" as const;
+
+function buildApiKeyCreditStateKey(
+  workspaceId: string,
+  keyModelId: ModelId
+): string {
+  return `metronome:api_key_credit_state:${workspaceId}:${keyModelId}`;
+}
+
+export async function setApiKeyCreditState(
+  workspaceId: string,
+  keyModelId: ModelId,
+  state: ApiKeyCreditState
+): Promise<void> {
+  await runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
+    await client.set(buildApiKeyCreditStateKey(workspaceId, keyModelId), state);
+  });
+}
+
+export async function getApiKeyCreditState(
+  workspaceId: string,
+  keyModelId: ModelId
+): Promise<ApiKeyCreditState> {
+  const cached = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
+    client.get(buildApiKeyCreditStateKey(workspaceId, keyModelId))
+  );
+
+  if (cached && isApiKeyCreditState(cached)) {
+    return cached;
+  }
+
+  logger.info(
+    { workspaceId, keyModelId, apiKeyCreditStateCacheHit: false },
+    "[MetronomeApiKeyBlock] Cache miss during API key credit state check, falling back to DB"
+  );
+
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.warn(
+      { workspaceId, keyModelId },
+      "[MetronomeApiKeyBlock] Workspace not found during API key credit state cache read-through fallback"
+    );
+    return "on_pool";
+  }
+
+  const key = await KeyResource.fetchByWorkspaceAndId({
+    workspace: renderLightWorkspaceType({ workspace }),
+    id: keyModelId,
+  });
+
+  const state: ApiKeyCreditState =
+    key && isApiKeyCreditState(key.creditState) ? key.creditState : "on_pool";
+
+  await setApiKeyCreditState(workspaceId, keyModelId, state);
+  return state;
+}
+
+export async function isApiKeyCapped(
+  workspaceId: string,
+  keyModelId: ModelId
+): Promise<boolean> {
+  // getApiKeyCreditState has its own DB fallback and cache repopulation.
+  const state = await getApiKeyCreditState(workspaceId, keyModelId);
+  return state === "capped";
+}

--- a/front/lib/metronome/api_key_credit_state_machine.ts
+++ b/front/lib/metronome/api_key_credit_state_machine.ts
@@ -1,0 +1,144 @@
+import { setApiKeyCreditState } from "@app/lib/metronome/api_key_block";
+import type { KeyResource } from "@app/lib/resources/key_resource";
+import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
+import logger from "@app/logger/logger";
+import type { ApiKeyCreditState } from "@app/types/key";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { Transaction } from "sequelize";
+
+export type ApiKeyCreditContext = {
+  workspaceId: string;
+  keyModelId: number;
+};
+
+export type ApiKeyCreditEvent =
+  /** This key hit its admin-configured per-key spend cap. */
+  | { type: "api_key_cap_reached" }
+  /**
+   * This key's spend dropped back below the cap — fires at billing-cycle
+   * renewal (current_spend resets to 0) via
+   * `alerts.spend_threshold_resolved`.
+   */
+  | { type: "api_key_cap_resolved" }
+  /**
+   * Admin raised or removed the per-key cap: unblock the key immediately
+   * instead of waiting for the next billing-cycle resolve.
+   */
+  | { type: "admin_cap_cleared" };
+
+type ApiKeyCreditTransition = {
+  from: ApiKeyCreditState | ApiKeyCreditState[];
+  event: ApiKeyCreditEvent["type"];
+  to: ApiKeyCreditState;
+};
+
+const TRANSITIONS: ApiKeyCreditTransition[] = [
+  {
+    from: ["on_pool", "capped"],
+    event: "api_key_cap_reached",
+    to: "capped",
+  },
+  {
+    from: ["on_pool", "capped"],
+    event: "api_key_cap_resolved",
+    to: "on_pool",
+  },
+  {
+    from: ["on_pool", "capped"],
+    event: "admin_cap_cleared",
+    to: "on_pool",
+  },
+];
+
+function findTransition(
+  current: ApiKeyCreditState,
+  event: ApiKeyCreditEvent
+): ApiKeyCreditTransition | undefined {
+  return TRANSITIONS.find((t) => {
+    const fromMatch = Array.isArray(t.from)
+      ? t.from.includes(current)
+      : t.from === current;
+    return fromMatch && t.event === event.type;
+  });
+}
+
+export async function transitionApiKeyCreditState(
+  key: KeyResource,
+  event: ApiKeyCreditEvent,
+  ctx: ApiKeyCreditContext,
+  { transaction }: { transaction?: Transaction } = {}
+): Promise<Result<ApiKeyCreditState, Error>> {
+  const currentState = key.creditState;
+  const match = findTransition(currentState, event);
+
+  if (!match) {
+    logger.warn(
+      {
+        workspaceId: ctx.workspaceId,
+        keyModelId: ctx.keyModelId,
+        fromState: currentState,
+        eventType: event.type,
+      },
+      "[ApiKeyCreditStateMachine] No matching transition - skipping"
+    );
+    return new Err(
+      new Error(
+        `[ApiKeyCreditStateMachine] Illegal transition: ${currentState} + ${event.type}`
+      )
+    );
+  }
+
+  if (currentState !== match.to) {
+    await key.updateCreditState(match.to, transaction);
+  }
+  invalidateCacheAfterCommit(transaction, () =>
+    setApiKeyCreditState(ctx.workspaceId, ctx.keyModelId, match.to)
+  );
+  logger.info(
+    {
+      workspaceId: ctx.workspaceId,
+      keyModelId: ctx.keyModelId,
+      fromState: currentState,
+      toState: match.to,
+      eventType: event.type,
+      wasStateChanged: currentState !== match.to,
+    },
+    "[ApiKeyCreditStateMachine] Transition applied"
+  );
+
+  return new Ok(match.to);
+}
+
+/**
+ * Authoritatively set an API key's credit state to `targetState`, bypassing
+ * the event/transition graph. Used by reconciliation, which computes the
+ * expected state directly from live Metronome usage vs. the configured cap.
+ * Persists the new state and syncs the same cache the transitions do.
+ */
+export async function setApiKeyCreditStateReconciled(
+  key: KeyResource,
+  targetState: ApiKeyCreditState,
+  ctx: ApiKeyCreditContext,
+  { transaction }: { transaction?: Transaction } = {}
+): Promise<ApiKeyCreditState> {
+  const currentState = key.creditState;
+  if (currentState !== targetState) {
+    await key.updateCreditState(targetState, transaction);
+  }
+  invalidateCacheAfterCommit(transaction, () =>
+    setApiKeyCreditState(ctx.workspaceId, ctx.keyModelId, targetState)
+  );
+  if (currentState !== targetState) {
+    logger.info(
+      {
+        workspaceId: ctx.workspaceId,
+        keyModelId: ctx.keyModelId,
+        fromState: currentState,
+        toState: targetState,
+      },
+      "[ApiKeyCreditStateMachine] State reconciled"
+    );
+  }
+  return targetState;
+}

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -221,6 +221,24 @@ export class KeyResource extends BaseResource<KeyModel> {
     return new this(KeyResource.model, key.get());
   }
 
+  // All active keys with a given name. Names are not unique, and Metronome
+  // aggregates spend per name, so the per-key credit cap is effectively
+  // per-name: the cap webhook transitions every active key sharing the name.
+  static async listActiveByWorkspaceAndName(
+    workspace: LightWorkspaceType,
+    name: string
+  ) {
+    const keys = await this.model.findAll({
+      where: {
+        workspaceId: workspace.id,
+        name,
+        status: "active",
+      },
+    });
+
+    return keys.map((key) => new this(KeyResource.model, key.get()));
+  }
+
   static async listNonSystemKeysByWorkspace(workspace: LightWorkspaceType) {
     const keys = await this.model.findAll({
       where: {


### PR DESCRIPTION
Part of the **per-API-key credit spend limit** stack. Builds on #28051.

### This PR — credit-state plumbing (mirrors per-user)
- **`api_key_credit_state_machine.ts`** — 2-state machine (`on_pool` / `capped`). `transitionApiKeyCreditState` handles `api_key_cap_reached`, `api_key_cap_resolved` (billing-cycle renewal), and `admin_cap_cleared`. `setApiKeyCreditStateReconciled` is the authoritative setter for reconciliation. Both persist `keys.creditState` and sync the cache via `invalidateCacheAfterCommit`.
- **`api_key_block.ts`** — Redis fast-path cache `metronome:api_key_credit_state:<ws>:<keyId>` with `getApiKeyCreditState` (DB read-through fallback + repopulation), `setApiKeyCreditState`, and `isApiKeyCapped`. Mirrors `user_block.ts`.
- **`KeyResource.listActiveByWorkspaceAndName`** — all active keys with a given name (names aren't unique).
- **`credit_state_dispatcher.ts`** — `dispatchApiKeyCapReached` / `dispatchApiKeyCapResolved` transition **every active key sharing the name** (the cap is per-name — Metronome aggregates spend by `api_key_name`), so same-named keys are blocked/unblocked together.

The dispatchers are exported but not yet called — the webhook wiring lands in a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)