### PR TITLE
[Builder] Restore Sidekick default in agent builder

### DIFF
--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -186,9 +186,8 @@ export function AgentBuilderRightPanel({
   const { isPreviewPanelOpen, setIsPreviewPanelOpen } =
     usePreviewPanelContext();
 
-  const [selectedTab, setSelectedTab] = useState<AgentBuilderRightPanelTabType>(
-    isSidekickDisabled ? "preview" : "sidekick"
-  );
+  const [selectedTab, setSelectedTab] =
+    useState<AgentBuilderRightPanelTabType>("sidekick");
   const activeTab =
     isSidekickDisabled && selectedTab === "sidekick" ? "preview" : selectedTab;
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9275

Fixes regression in https://github.com/dust-tt/dust/pull/27820. Admin editors briefly have Sidekick disabled while editor membership loads. The right panel initialized its stored selected tab from that transient disabled state, so it stayed on Preview after the user was confirmed as an editor.

This keeps Sidekick as the stored default tab and only renders Preview as the active fallback while Sidekick is disabled.

## Risks

Blast radius: agent builder right panel tab selection while Sidekick is temporarily disabled.
Risk: low

## Deploy Plan
- pmrr
- deploy front