### PR TITLE
[front] API key credit cap (5/10): webhook routing

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -7,6 +7,8 @@ import {
   maybeNotifyAdminsBalanceThresholdReached,
 } from "@app/lib/api/credits/balance_threshold_alert";
 import {
+  dispatchApiKeyCapReached,
+  dispatchApiKeyCapResolved,
   dispatchCreditsAdded,
   dispatchLowBalance,
   dispatchPaygCapReached,
@@ -68,6 +70,7 @@ import {
   USAGE_TYPE_GROUP_KEY,
   USAGE_TYPE_PROGRAMMATIC,
 } from "@app/lib/metronome/constants";
+import { API_KEY_NAME_GROUP_KEY } from "@app/lib/metronome/per_api_key_usage";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import type { ProgrammaticCreditEvent } from "@app/lib/metronome/programmatic_credit_state_machine";
 import { carryOverContractBalancesOnRenewal } from "@app/lib/metronome/renewal_carry_over";
@@ -774,6 +777,13 @@ export async function processMetronomeWebhook({
       const isPerUser = userIdGroup !== undefined;
       const userId = userIdGroup?.value;
 
+      // Per-API-key cap: scoped via an `api_key_name` group value (no user_id,
+      // no usage_type). Presence of the key, not its value, decides routing.
+      const apiKeyNameGroup = event.properties.group_values?.find(
+        (g) => g.key === API_KEY_NAME_GROUP_KEY
+      );
+      const apiKeyName = apiKeyNameGroup?.value;
+
       if (isPerUser) {
         if (!userId) {
           logger.warn(
@@ -789,6 +799,29 @@ export async function processMetronomeWebhook({
         });
         if (handleResult.isErr()) {
           return handleResult;
+        }
+      } else if (apiKeyNameGroup !== undefined) {
+        if (!apiKeyName) {
+          logger.warn(
+            { eventId: event.id, workspaceId: workspace.sId },
+            "[Metronome Webhook] spend_threshold_reached: per-API-key alert with no api_key_name value, skipping"
+          );
+          break;
+        }
+        const dispatchResult = await dispatchApiKeyCapReached({
+          workspace,
+          keyName: apiKeyName,
+        });
+        if (dispatchResult.isErr()) {
+          logger.error(
+            {
+              eventId: event.id,
+              workspaceId: workspace.sId,
+              keyName: apiKeyName,
+              err: dispatchResult.error,
+            },
+            "[Metronome Webhook] spend_threshold_reached: dispatchApiKeyCapReached failed"
+          );
         }
       } else if (isProgrammaticMonthlyCap(event)) {
         // Programmatic monthly cap alerts. Three alerts exist per workspace
@@ -862,6 +895,11 @@ export async function processMetronomeWebhook({
       const isPerUser = userIdGroup !== undefined;
       const userId = userIdGroup?.value;
 
+      const apiKeyNameGroup = event.properties.group_values?.find(
+        (g) => g.key === API_KEY_NAME_GROUP_KEY
+      );
+      const apiKeyName = apiKeyNameGroup?.value;
+
       if (isPerUser) {
         if (!userId) {
           logger.warn(
@@ -877,6 +915,31 @@ export async function processMetronomeWebhook({
         });
         if (handleResult.isErr()) {
           return handleResult;
+        }
+      } else if (apiKeyNameGroup !== undefined) {
+        if (!apiKeyName) {
+          logger.warn(
+            { eventId: event.id, workspaceId: workspace.sId },
+            "[Metronome Webhook] spend_threshold_resolved: per-API-key alert with no api_key_name value, skipping"
+          );
+          break;
+        }
+        // Billing-cycle renewal resets current_spend to 0, firing this for
+        // every previously-capped key — transition it back to on_pool.
+        const dispatchResult = await dispatchApiKeyCapResolved({
+          workspace,
+          keyName: apiKeyName,
+        });
+        if (dispatchResult.isErr()) {
+          logger.error(
+            {
+              eventId: event.id,
+              workspaceId: workspace.sId,
+              keyName: apiKeyName,
+              err: dispatchResult.error,
+            },
+            "[Metronome Webhook] spend_threshold_resolved: dispatchApiKeyCapResolved failed"
+          );
         }
       } else if (isProgrammaticMonthlyCap(event)) {
         await dispatchProgrammaticCapReset({ workspace });

--- a/front/lib/metronome/alerts/api_key_caps.ts
+++ b/front/lib/metronome/alerts/api_key_caps.ts
@@ -3,14 +3,10 @@ import {
   upsertMetronomeAlert,
 } from "@app/lib/metronome/alerts";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import { API_KEY_NAME_GROUP_KEY } from "@app/lib/metronome/per_api_key_usage";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-
-// Metronome billable-metric group key carried on every usage event. Spend
-// alerts can filter on it directly (it is a metric group key on the AWU
-// products), so per-key caps need no product/presentation-group-key change.
-const API_KEY_NAME_GROUP_KEY = "api_key_name";
 
 // The key name is the stable, workspace-unique join key between a key, this
 // alert, and the webhook that transitions `keys.creditState` (the name is

--- a/front/lib/metronome/per_api_key_usage.ts
+++ b/front/lib/metronome/per_api_key_usage.ts
@@ -13,7 +13,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-const API_KEY_NAME_GROUP_KEY = "api_key_name";
+export const API_KEY_NAME_GROUP_KEY = "api_key_name";
 
 function flattenUsageResults<T>(
   results: Array<Result<T[], Error>>


### PR DESCRIPTION
Part of the **per-API-key credit spend limit** stack. Builds on #28057.

### This PR — webhook routing
`processMetronomeWebhook` now routes `alerts.spend_threshold_reached` / `alerts.spend_threshold_resolved` events that carry an `api_key_name` group value to the per-API-key dispatchers:

- **reached** → `dispatchApiKeyCapReached` (key → `capped`)
- **resolved** → `dispatchApiKeyCapResolved` (billing-cycle renewal resets `current_spend` → `on_pool`)

The new branch sits between the per-user (`user_id`) and programmatic (`usage_type`) branches — the three are mutually exclusive by group key, so a per-API-key alert no longer falls through to the workspace PAYG handler.

### Next in stack
Enforcement gate → API/UI/Swagger/audit → backfill plugin → tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)