### PR TITLE
[front] enh: improve query tables tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -62,7 +62,8 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
   [EXECUTE_DATABASE_QUERY_TOOL_NAME]: {
     description:
       "Run and execute SQL against selected agent-configured structured data tables to analyze, aggregate, filter, join, or export result rows. " +
-      "Use this only after the table structure for every involved table has been inspected.",
+      "Before using this tool, the agent should have already called get_database_schema for every involved table URI and should use that inspected table structure to write the SQL. " +
+      "The SQL query must respect the guidelines and schema returned by get_database_schema.",
     schema: {
       tables:
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE],

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -32,8 +32,8 @@ const tableUrisSchema = z
 export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
   [LIST_TABLES_TOOL_NAME]: {
     description:
-      "List all tables available to this agent. Returns lightweight table metadata and URIs. " +
-      "Call this first to discover tables, then pass selected URIs to get_database_schema.",
+      "List and discover the agent-configured structured data tables, datasets, and table URIs available to this agent. " +
+      "Returns lightweight table metadata and URIs. Call this first to find available agent tables, then pass selected URIs to get_database_schema.",
     schema: {
       tables:
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE],
@@ -47,9 +47,8 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
   },
   [GET_DATABASE_SCHEMA_TOOL_NAME]: {
     description:
-      "Retrieve the database schema for a subset of tables. You MUST call list_tables first to discover " +
-      "available tables, then call this tool with the URIs of the tables you need before attempting to query. " +
-      "This tool provides essential information about table columns, types, and relationships needed to write accurate SQL queries.",
+      "Inspect the schema and structure for selected agent-configured tables before SQL. Use this to answer which columns, fields, column names, sample rows, and relationships exist in tables selected from list_tables. " +
+      "You MUST call list_tables first, then call this tool with the URIs of the tables you need before running SQL.",
     schema: {
       tableUris: tableUrisSchema,
     },
@@ -62,9 +61,8 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
   },
   [EXECUTE_DATABASE_QUERY_TOOL_NAME]: {
     description:
-      "Execute a query on the database. You MUST call get_database_schema for the tables involved in your query " +
-      "at least once before attempting to execute a query. The query must respect the guidelines and schema " +
-      "provided by the get_database_schema tool.",
+      "Run and execute SQL against selected agent-configured structured data tables to analyze, aggregate, filter, join, or export result rows. " +
+      "Use this only after the table structure for every involved table has been inspected.",
     schema: {
       tables:
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE],
@@ -72,12 +70,12 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
         .string()
         .describe(
           "The reason this query is being run and what it achieves, in a few words. Use infinitive verbs (e.g. " +
-            '"Analyze revenue trends", "Identify top customers").'
+            '"Analyze trends", "Identify top customers").'
         ),
       query: z
         .string()
         .describe(
-          "The query to execute. Must respect the guidelines provided by the `get_database_schema` tool."
+          "The SQL query to execute. Must respect the guidelines provided by the schema inspection tool."
         ),
       fileName: z
         .string()

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -770,23 +770,11 @@ export const QUERIES: LabeledQuery[] = [
     expected: "query_tables_v2.list_tables",
   },
   {
-    query: "find the available datasets and table uris",
-    expected: "query_tables_v2.list_tables",
-  },
-  {
-    query: "what columns are in this agent table",
-    expected: "query_tables_v2.get_database_schema",
-  },
-  {
     query: "get the schema for an agent configured table before writing sql",
     expected: "query_tables_v2.get_database_schema",
   },
   {
     query: "run sql against this agent configured table",
-    expected: "query_tables_v2.execute_database_query",
-  },
-  {
-    query: "execute a database query and save the results",
     expected: "query_tables_v2.execute_database_query",
   },
 

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -764,6 +764,32 @@ export const QUERIES: LabeledQuery[] = [
     expected: "data_warehouses.query",
   },
 
+  // --- query_tables_v2 ---
+  {
+    query: "list agent configured table uris",
+    expected: "query_tables_v2.list_tables",
+  },
+  {
+    query: "find the available datasets and table uris",
+    expected: "query_tables_v2.list_tables",
+  },
+  {
+    query: "what columns are in this agent table",
+    expected: "query_tables_v2.get_database_schema",
+  },
+  {
+    query: "get the schema for an agent configured table before writing sql",
+    expected: "query_tables_v2.get_database_schema",
+  },
+  {
+    query: "run sql against this agent configured table",
+    expected: "query_tables_v2.execute_database_query",
+  },
+  {
+    query: "execute a database query and save the results",
+    expected: "query_tables_v2.execute_database_query",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -23,6 +23,7 @@ import { INTERACTIVE_CONTENT_SERVER } from "@app/lib/api/actions/servers/interac
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
+import { QUERY_TABLES_V2_SERVER } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
 import {
   getRunAgentToolDescription,
   RUN_AGENT_CONFIGURABLE_PROPERTIES,
@@ -106,6 +107,7 @@ const SERVERS: ServerEntry[] = [
     tools: RUN_AGENT_SAMPLE_TOOLS,
   },
   { name: "data_warehouses", tools: DATA_WAREHOUSES_SERVER.tools },
+  { name: "query_tables_v2", tools: QUERY_TABLES_V2_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9164

This PR sharpens the `query_tables_v2` tool descriptions so that tool search separates table discovery, schema inspection, and SQL execution intents well.

It also adds Query Tables in the BM25 harness and adds samples covering list/schema/execute retrieval.

## Tests

- Tested locally with the BM25 harness.

## Risk

- Low.

## Deploy Plan

- Deploy front.
