### PR TITLE
[front] API key credit cap (7/10): API contract (create + update)

### DIFF
--- a/front-api/routes/w/[wId]/keys/[id]/index.ts
+++ b/front-api/routes/w/[wId]/keys/[id]/index.ts
@@ -3,9 +3,16 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import {
+  MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS,
+  MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS,
+  setApiKeySpendLimit,
+} from "@app/lib/api/keys/spend_limit";
 import { invalidateKeyCapCache } from "@app/lib/api/programmatic_usage/key_cap";
 import { KeyResource } from "@app/lib/resources/key_resource";
+import type { ApiKeySpendLimit } from "@app/types/api/keys/spend_limit";
 import type { KeyType } from "@app/types/key";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -22,8 +29,12 @@ const KeyIdParamSchema = z.object({
   id: z.string(),
 });
 
+// Both fields are optional for backward compatibility: legacy plans send
+// `monthly_cap_micro_usd`; credit-priced plans send `monthly_cap_awu_credits`
+// (null = unlimited).
 const PatchKeyBodySchema = z.object({
-  monthly_cap_micro_usd: z.number().nullable(),
+  monthly_cap_micro_usd: z.number().nullable().optional(),
+  monthly_cap_awu_credits: z.number().nullable().optional(),
 });
 
 // Mounted at /api/w/:wId/keys/:id.
@@ -44,7 +55,8 @@ app.patch(
     const owner = auth.getNonNullableWorkspace();
 
     const { id } = ctx.req.valid("param");
-    const { monthly_cap_micro_usd } = ctx.req.valid("json");
+    const { monthly_cap_micro_usd, monthly_cap_awu_credits } =
+      ctx.req.valid("json");
 
     const key = await KeyResource.fetchByWorkspaceAndId({
       workspace: owner,
@@ -57,6 +69,110 @@ app.patch(
         api_error: {
           type: "key_not_found",
           message: "Could not find the key.",
+        },
+      });
+    }
+
+    // Credit-priced per-key spend limit (AWU credits).
+    if (monthly_cap_awu_credits !== undefined) {
+      if (
+        monthly_cap_awu_credits !== null &&
+        (monthly_cap_awu_credits < MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS ||
+          monthly_cap_awu_credits > MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS)
+      ) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              `monthly_cap_awu_credits must be between ` +
+              `${MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS} and ` +
+              `${MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS}, or null for unlimited.`,
+          },
+        });
+      }
+
+      const previousCapAwuCredits = key.monthlyCapAwuCredits;
+      const limit: ApiKeySpendLimit =
+        monthly_cap_awu_credits === null
+          ? { kind: "unlimited" }
+          : { kind: "limited", awuCredits: monthly_cap_awu_credits };
+
+      const result = await setApiKeySpendLimit(auth, {
+        keyModelId: key.id,
+        limit,
+      });
+      if (result.isErr()) {
+        switch (result.error.type) {
+          case "key_not_found":
+            return apiError(ctx, {
+              status_code: 404,
+              api_error: {
+                type: "key_not_found",
+                message: result.error.message,
+              },
+            });
+          case "system_key":
+          case "workspace_not_credit_priced":
+          case "workspace_not_metronome_billed":
+            return apiError(ctx, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: result.error.message,
+              },
+            });
+          case "metronome_error":
+            return apiError(ctx, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: result.error.message,
+              },
+            });
+          default:
+            assertNever(result.error.type);
+        }
+      }
+
+      void emitAuditLogEvent({
+        auth,
+        action: "api_key.updated",
+        targets: [
+          buildAuditLogTarget("workspace", owner),
+          buildAuditLogTarget("api_key", {
+            sId: String(key.id),
+            name: key.name,
+          }),
+        ],
+        context: getAuditLogContext(auth),
+        metadata: {
+          previous_spending_cap_awu_credits: String(
+            previousCapAwuCredits ?? "none"
+          ),
+          new_spending_cap_awu_credits: String(
+            monthly_cap_awu_credits ?? "none"
+          ),
+        },
+      });
+
+      // Re-read so the response reflects the persisted cap (setApiKeySpendLimit
+      // updates its own resource instance).
+      const updated = await KeyResource.fetchByWorkspaceAndId({
+        workspace: owner,
+        id,
+      });
+      return ctx.json({ key: (updated ?? key).toJSON() });
+    }
+
+    // Legacy USD monthly cap.
+    if (monthly_cap_micro_usd === undefined) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Provide monthly_cap_micro_usd or monthly_cap_awu_credits to update.",
         },
       });
     }

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -3,6 +3,11 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import {
+  MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS,
+  MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS,
+  setApiKeySpendLimit,
+} from "@app/lib/api/keys/spend_limit";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
@@ -11,6 +16,7 @@ import type {
   GetKeysResponseBody,
   PostKeysResponseBody,
 } from "@app/types/api/keys";
+import { isCreditPricedPlan } from "@app/types/plan";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -26,6 +32,9 @@ const CreateKeyPostBodySchema = z.object({
   group_id: z.string().optional(),
   group_ids: z.array(z.string()).optional(),
   monthly_cap_micro_usd: z.number().nullish(),
+  // Per-key credit cap in AWU credits (credit-priced plans only). null/omitted
+  // = unlimited.
+  monthly_cap_awu_credits: z.number().nullish(),
   role: z.enum(["user", "builder", "admin"]).optional(),
 });
 
@@ -57,8 +66,14 @@ app.post(
     const user = auth.getNonNullableUser();
     const owner = auth.getNonNullableWorkspace();
 
-    const { name, group_id, group_ids, monthly_cap_micro_usd, role } =
-      ctx.req.valid("json");
+    const {
+      name,
+      group_id,
+      group_ids,
+      monthly_cap_micro_usd,
+      monthly_cap_awu_credits,
+      role,
+    } = ctx.req.valid("json");
     const trimmedName = name.trim();
     const keyRole = role ?? "builder";
 
@@ -84,6 +99,41 @@ app.post(
           message: "monthly_cap_micro_usd must be greater than or equal to 0",
         },
       });
+    }
+
+    // Per-key credit cap: only valid on credit-priced plans and within range.
+    // Validated up front so we never create a key whose requested cap can't be
+    // applied.
+    if (
+      monthly_cap_awu_credits !== null &&
+      monthly_cap_awu_credits !== undefined
+    ) {
+      const plan = auth.subscription()?.plan;
+      if (!plan || !isCreditPricedPlan(plan)) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Per-key credit spend limits are only available on credit-priced plans.",
+          },
+        });
+      }
+      if (
+        monthly_cap_awu_credits < MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS ||
+        monthly_cap_awu_credits > MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS
+      ) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              `monthly_cap_awu_credits must be between ` +
+              `${MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS} and ` +
+              `${MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS}.`,
+          },
+        });
+      }
     }
 
     const existingKey = await KeyResource.fetchByName(auth, {
@@ -189,9 +239,45 @@ app.post(
       },
     });
 
+    // Apply the per-key credit cap (persists the cap, creates the Metronome
+    // alert, reconciles state). Validated above, so only a Metronome failure
+    // can error here.
+    if (
+      monthly_cap_awu_credits !== null &&
+      monthly_cap_awu_credits !== undefined
+    ) {
+      const limitResult = await setApiKeySpendLimit(auth, {
+        keyModelId: key.id,
+        limit: { kind: "limited", awuCredits: monthly_cap_awu_credits },
+      });
+      if (limitResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: owner.sId,
+            keyName: trimmedName,
+            err: limitResult.error,
+          },
+          "[Keys] Failed to apply credit cap on newly created key"
+        );
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Key created but failed to set credit cap: ${limitResult.error.message}`,
+          },
+        });
+      }
+    }
+
+    const created =
+      (await KeyResource.fetchByWorkspaceAndId({
+        workspace: owner,
+        id: key.id,
+      })) ?? key;
+
     return ctx.json(
       {
-        key: key.toJSON(),
+        key: created.toJSON(),
       },
       201
     );

--- a/front/admin/audit_log_schemas/api_key.updated.json
+++ b/front/admin/audit_log_schemas/api_key.updated.json
@@ -11,6 +11,8 @@
   "metadata": {
     "previous_spending_cap": "string",
     "new_spending_cap": "string",
+    "previous_spending_cap_awu_credits": "string",
+    "new_spending_cap_awu_credits": "string",
     "actor_type": "string"
   }
 }


### PR DESCRIPTION
Part of the **per-API-key credit spend limit** stack. Builds on #28059.

### This PR — API contract
Both the create (`POST /api/w/:wId/keys`) and update (`PATCH /api/w/:wId/keys/:id`) routes now accept **`monthly_cap_awu_credits`** (AWU credits; `null` = unlimited) alongside the legacy `monthly_cap_micro_usd`. Both fields are optional → backward compatible ([BACK12]).

When the credit field is present, the route delegates to `setApiKeySpendLimit` (credit-priced gate + Metronome alert sync + reconcile) and maps the domain `Result` error to HTTP. The legacy USD path is untouched for non-credit plans. On create, the cap is validated up front (credit-priced + range) so a key is never created with an unappliable cap.

Adds `previous_spending_cap_awu_credits` / `new_spending_cap_awu_credits` to the `api_key.updated` audit schema.

Routes are `@ignoreswagger` (internal), so no Swagger schema changes.

### ⚠️ Post-merge action ([AUDIT10])
Re-register the audit schema before deploy:
`npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`

### Next in stack
UI + SWR → backfill plugin → tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)