### PR TITLE
Instrument Anthropic BM25 tool search queries

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -3,6 +3,8 @@ import { AnthropicError, APIError } from "@anthropic-ai/sdk";
 import type {
   BetaMessage,
   BetaRawMessageStreamEvent,
+  BetaToolSearchToolResultError,
+  BetaToolSearchToolSearchResultBlock,
 } from "@anthropic-ai/sdk/resources/beta.mjs";
 import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches.mjs";
 import type {
@@ -27,6 +29,7 @@ import type {
 import { EventError } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import {
   assertNever,
@@ -251,12 +254,26 @@ function* handleContentBlockStart(
       // "Redacted thinking" provides no actionable information, as everything is encrypted
       return;
     case "server_tool_use":
+      // Server-side tool use (the only one we enable is Anthropic's tool search
+      // tool). The search query streams in as input_json_delta chunks, so we
+      // track a tool_search state to accumulate them and log the query at stop.
+      stateContainer.state = {
+        currentBlockIndex: event.index,
+        accumulator: "",
+        accumulatorType: "tool_search",
+        toolName: event.content_block.name,
+      };
+      return;
+    case "tool_search_tool_result":
+      // The discovered tool references arrive inline in this block (no deltas),
+      // so log them here. State stays null; the matching stop is a no-op.
+      logToolSearchResult(event.content_block.content, metadata);
+      return;
     case "web_search_tool_result":
     case "web_fetch_tool_result":
     case "code_execution_tool_result":
     case "bash_code_execution_tool_result":
     case "text_editor_code_execution_tool_result":
-    case "tool_search_tool_result":
     case "mcp_tool_use":
     case "mcp_tool_result":
     case "container_upload":
@@ -383,8 +400,83 @@ function* handleContentBlockStop(
       });
       break;
     }
+    case "tool_search":
+      logToolSearchQuery({
+        metadata,
+        rawInput: stateContainer.state.accumulator,
+        toolName: stateContainer.state.toolName,
+      });
+      break;
   }
   stateContainer.state = null;
+}
+
+// Logs the natural-language query the model issued against a server-side tool
+// search tool (e.g. tool_search_tool_bm25), plus a StatsD counter so we can
+// monitor search volume per model. The query arrives as accumulated
+// input_json_delta JSON: `{"query":"..."}`.
+function logToolSearchQuery({
+  metadata,
+  rawInput,
+  toolName,
+}: {
+  metadata: LLMClientMetadata;
+  rawInput: string;
+  toolName: string;
+}): void {
+  let query: string | undefined;
+  const parsed = safeParseJSON(rawInput);
+  if (
+    parsed.isOk() &&
+    parsed.value !== null &&
+    isRecord(parsed.value) &&
+    typeof parsed.value.query === "string"
+  ) {
+    query = parsed.value.query;
+  }
+
+  logger.info(
+    {
+      toolName,
+      query,
+      // Keep the raw payload only when parsing failed, to debug malformed input.
+      rawInput: query === undefined ? rawInput : undefined,
+      ...metadata,
+    },
+    "Anthropic tool search query"
+  );
+
+  getStatsDClient().increment("llm_tool_search.requests", 1, [
+    `client_id:${metadata.clientId}`,
+    `inference_provider:${metadata.inferenceProvider}`,
+    `model_id:${metadata.modelId}`,
+    `tool_name:${toolName}`,
+  ]);
+}
+
+// Logs the tools surfaced by a server-side tool search, or the error code when
+// the search failed (e.g. too_many_requests, unavailable).
+function logToolSearchResult(
+  content: BetaToolSearchToolResultError | BetaToolSearchToolSearchResultBlock,
+  metadata: LLMClientMetadata
+): void {
+  if (content.type === "tool_search_tool_result_error") {
+    logger.warn(
+      {
+        errorCode: content.error_code,
+        errorMessage: content.error_message,
+        ...metadata,
+      },
+      "Anthropic tool search returned an error"
+    );
+    return;
+  }
+
+  const toolReferences = content.tool_references.map((ref) => ref.tool_name);
+  logger.info(
+    { toolReferences, resultCount: toolReferences.length, ...metadata },
+    "Anthropic tool search results"
+  );
 }
 
 function* handleMessageDelta(

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -3,8 +3,6 @@ import { AnthropicError, APIError } from "@anthropic-ai/sdk";
 import type {
   BetaMessage,
   BetaRawMessageStreamEvent,
-  BetaToolSearchToolResultError,
-  BetaToolSearchToolSearchResultBlock,
 } from "@anthropic-ai/sdk/resources/beta.mjs";
 import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches.mjs";
 import type {
@@ -29,7 +27,10 @@ import type {
 import { EventError } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import {
+  logToolSearchQuery,
+  logToolSearchResult,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/tool_search_logging";
 import logger from "@app/logger/logger";
 import {
   assertNever,
@@ -253,6 +254,7 @@ function* handleContentBlockStart(
     case "redacted_thinking":
       // "Redacted thinking" provides no actionable information, as everything is encrypted
       return;
+
     case "server_tool_use":
       // Server-side tool use (the only one we enable is Anthropic's tool search
       // tool). The search query streams in as input_json_delta chunks, so we
@@ -264,11 +266,16 @@ function* handleContentBlockStart(
         toolName: event.content_block.name,
       };
       return;
+
     case "tool_search_tool_result":
       // The discovered tool references arrive inline in this block (no deltas),
-      // so log them here. State stays null; the matching stop is a no-op.
-      logToolSearchResult(event.content_block.content, metadata);
+      // so log them here. State stays null and the matching stop is a no-op.
+      logToolSearchResult({
+        content: event.content_block.content,
+        logFields: metadata,
+      });
       return;
+
     case "web_search_tool_result":
     case "web_fetch_tool_result":
     case "code_execution_tool_result":
@@ -400,83 +407,26 @@ function* handleContentBlockStop(
       });
       break;
     }
+
     case "tool_search":
       logToolSearchQuery({
-        metadata,
         rawInput: stateContainer.state.accumulator,
         toolName: stateContainer.state.toolName,
+        tags: toolSearchTags(metadata),
+        logFields: metadata,
       });
       break;
   }
   stateContainer.state = null;
 }
 
-// Logs the natural-language query the model issued against a server-side tool
-// search tool (e.g. tool_search_tool_bm25), plus a StatsD counter so we can
-// monitor search volume per model. The query arrives as accumulated
-// input_json_delta JSON: `{"query":"..."}`.
-function logToolSearchQuery({
-  metadata,
-  rawInput,
-  toolName,
-}: {
-  metadata: LLMClientMetadata;
-  rawInput: string;
-  toolName: string;
-}): void {
-  let query: string | undefined;
-  const parsed = safeParseJSON(rawInput);
-  if (
-    parsed.isOk() &&
-    parsed.value !== null &&
-    isRecord(parsed.value) &&
-    typeof parsed.value.query === "string"
-  ) {
-    query = parsed.value.query;
-  }
-
-  logger.info(
-    {
-      toolName,
-      query,
-      // Keep the raw payload only when parsing failed, to debug malformed input.
-      rawInput: query === undefined ? rawInput : undefined,
-      ...metadata,
-    },
-    "Anthropic tool search query"
-  );
-
-  getStatsDClient().increment("llm_tool_search.requests", 1, [
+// StatsD tags for the tool search counter, derived from this client's metadata.
+function toolSearchTags(metadata: LLMClientMetadata): string[] {
+  return [
     `client_id:${metadata.clientId}`,
     `inference_provider:${metadata.inferenceProvider}`,
     `model_id:${metadata.modelId}`,
-    `tool_name:${toolName}`,
-  ]);
-}
-
-// Logs the tools surfaced by a server-side tool search, or the error code when
-// the search failed (e.g. too_many_requests, unavailable).
-function logToolSearchResult(
-  content: BetaToolSearchToolResultError | BetaToolSearchToolSearchResultBlock,
-  metadata: LLMClientMetadata
-): void {
-  if (content.type === "tool_search_tool_result_error") {
-    logger.warn(
-      {
-        errorCode: content.error_code,
-        errorMessage: content.error_message,
-        ...metadata,
-      },
-      "Anthropic tool search returned an error"
-    );
-    return;
-  }
-
-  const toolReferences = content.tool_references.map((ref) => ref.tool_name);
-  logger.info(
-    { toolReferences, resultCount: toolReferences.length, ...metadata },
-    "Anthropic tool search results"
-  );
+  ];
 }
 
 function* handleMessageDelta(

--- a/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
@@ -165,6 +165,69 @@ describe("streamLLMEvents", () => {
       emptyToolCallLLMEvents.map((e) => ({ ...e, metadata }))
     );
   });
+
+  // The model's BM25 tool search streams the query as input_json_delta chunks on
+  // a server_tool_use block, followed by a tool_search_tool_result block. The
+  // query block must be tracked so its deltas don't trip the null-state
+  // assertion, and the search must not surface as a client-visible tool_call.
+  it("should consume server-side tool search without emitting a tool call", async () => {
+    const toolSearchEvents: BetaRawMessageStreamEvent[] = [
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "server_tool_use",
+          id: "srvtoolu_01ABC",
+          name: "tool_search_tool_bm25",
+          input: {},
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"query":"send a ' },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: 'slack message"}' },
+      },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "content_block_start",
+        index: 1,
+        content_block: {
+          type: "tool_search_tool_result",
+          tool_use_id: "srvtoolu_01ABC",
+          content: {
+            type: "tool_search_tool_search_result",
+            tool_references: [
+              { type: "tool_reference", tool_name: "slack__post_message" },
+            ],
+          },
+        },
+      },
+      { type: "content_block_stop", index: 1 },
+    ];
+
+    const result = [];
+    for await (const event of streamLLMEvents(
+      createAsyncGenerator(toolSearchEvents),
+      metadata
+    )) {
+      result.push(event);
+    }
+
+    // The search itself yields no tool_call; only the heartbeat deltas, then the
+    // usual end-of-turn events.
+    expect(result.map((e) => e.type)).toEqual([
+      "tool_call_delta",
+      "tool_call_delta",
+      "token_usage",
+      "success",
+    ]);
+    expect(result.some((e) => e.type === "tool_call")).toBe(false);
+  });
 });
 
 describe("batchResultToLLMEvents", () => {

--- a/front/lib/api/llm/clients/anthropic/utils/types.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/types.ts
@@ -20,4 +20,17 @@ export type ToolUseState = BaseState & {
   };
 };
 
-export type StreamState = TextState | ReasoningState | ToolUseState | null;
+// Server-side tool search (e.g. tool_search_tool_bm25). Anthropic streams the
+// search query as input_json_delta chunks on a `server_tool_use` block, which
+// accumulate here just like a regular tool call's arguments.
+export type ToolSearchState = BaseState & {
+  accumulatorType: "tool_search";
+  toolName: string;
+};
+
+export type StreamState =
+  | TextState
+  | ReasoningState
+  | ToolUseState
+  | ToolSearchState
+  | null;

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/tool_search_logging.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/tool_search_logging.ts
@@ -46,11 +46,11 @@ export function logToolSearchQuery({
 
   logger.info(
     {
+      ...logFields,
       toolName,
       query,
       // Keep the raw payload only when parsing failed, to debug malformed input.
       rawInput: query === undefined ? rawInput : undefined,
-      ...logFields,
     },
     "Anthropic tool search query"
   );

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/tool_search_logging.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/tool_search_logging.ts
@@ -1,0 +1,90 @@
+import type {
+  ToolSearchToolResultError,
+  ToolSearchToolSearchResultBlock,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import { getStatsDClient } from "@app/lib/utils/statsd";
+import logger from "@app/logger/logger";
+import { isRecord, isString } from "@app/types/shared/utils/general";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+
+// The result block content. The legacy (beta) and model_constructors (non-beta)
+// SDK types are structurally identical, so the beta caller can pass its own
+// value where this non-beta type is expected.
+type ToolSearchResultContent =
+  | ToolSearchToolResultError
+  | ToolSearchToolSearchResultBlock;
+
+// Shared instrumentation for Anthropic's server-side tool search, used by both
+// the legacy (lib/api/llm) and model_constructors client stacks. Callers map
+// their own metadata into `tags` (StatsD) and `logFields` (structured logs).
+// The parsing, log shape, and metric name live here so they stay in sync.
+
+// Logs the natural-language query the model issued against a tool search tool
+// (e.g. tool_search_tool_bm25) and increments a per-search StatsD counter. The
+// query arrives as accumulated input_json_delta JSON: `{"query":"..."}`.
+export function logToolSearchQuery({
+  rawInput,
+  toolName,
+  tags,
+  logFields,
+}: {
+  rawInput: string;
+  toolName: string;
+  tags: string[];
+  logFields: Record<string, unknown>;
+}): void {
+  let query: string | undefined;
+  const parsed = safeParseJSON(rawInput);
+  if (
+    parsed.isOk() &&
+    parsed.value !== null &&
+    isRecord(parsed.value) &&
+    isString(parsed.value.query)
+  ) {
+    query = parsed.value.query;
+  }
+
+  logger.info(
+    {
+      toolName,
+      query,
+      // Keep the raw payload only when parsing failed, to debug malformed input.
+      rawInput: query === undefined ? rawInput : undefined,
+      ...logFields,
+    },
+    "Anthropic tool search query"
+  );
+
+  getStatsDClient().increment("llm_tool_search.requests", 1, [
+    `tool_name:${toolName}`,
+    ...tags,
+  ]);
+}
+
+// Logs the tools surfaced by a tool search, or the error code when the search
+// failed (e.g. too_many_requests, unavailable).
+export function logToolSearchResult({
+  content,
+  logFields,
+}: {
+  content: ToolSearchResultContent;
+  logFields: Record<string, unknown>;
+}): void {
+  if (content.type === "tool_search_tool_result_error") {
+    logger.warn(
+      {
+        errorCode: content.error_code,
+        errorMessage: content.error_message,
+        ...logFields,
+      },
+      "Anthropic tool search returned an error"
+    );
+    return;
+  }
+
+  const toolReferences = content.tool_references.map((ref) => ref.tool_name);
+  logger.info(
+    { toolReferences, resultCount: toolReferences.length, ...logFields },
+    "Anthropic tool search results"
+  );
+}

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
@@ -611,6 +611,57 @@ describe("contentBlockStartToEvents", () => {
     expect(events).toEqual([]);
     expect(state).toBe(prior);
   });
+
+  it("opens a server tool search block as a tool_search cursor", () => {
+    const event = {
+      type: "content_block_start",
+      index: 5,
+      content_block: {
+        type: "server_tool_use",
+        id: "srvtoolu_1",
+        name: "tool_search_tool_bm25",
+        input: {},
+      },
+    } as RawContentBlockStartEvent;
+    const [events, state] = contentBlockStartToEvents(
+      event,
+      null,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([]);
+    expect(state).toEqual({
+      index: 5,
+      accumulator: "",
+      type: "tool_search",
+      toolName: "tool_search_tool_bm25",
+    });
+  });
+
+  it("consumes a tool search result block without opening a cursor", () => {
+    const event = {
+      type: "content_block_start",
+      index: 6,
+      content_block: {
+        type: "tool_search_tool_result",
+        tool_use_id: "srvtoolu_1",
+        content: {
+          type: "tool_search_tool_search_result",
+          tool_references: [
+            { type: "tool_reference", tool_name: "slack__post_message" },
+          ],
+        },
+      },
+    } as RawContentBlockStartEvent;
+    const [events, state] = contentBlockStartToEvents(
+      event,
+      null,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([]);
+    expect(state).toBeNull();
+  });
 });
 
 describe("contentBlockDeltaToEvents", () => {
@@ -900,6 +951,18 @@ describe("contentBlockStopToEvents", () => {
         metadata,
       },
     ]);
+  });
+
+  it("closes a tool_search block without emitting a tool_call", () => {
+    const state = {
+      index: 0,
+      accumulator: '{"query":"send a slack message"}',
+      type: "tool_search" as const,
+      toolName: "tool_search_tool_bm25",
+    };
+    expect(
+      contentBlockStopToEvents(stopEvent, state, metadata, realConverters)
+    ).toEqual([[], null]);
   });
 });
 

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -16,6 +16,10 @@ import type {
   RawMessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import { parseToolArguments } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
+import {
+  logToolSearchQuery,
+  logToolSearchResult,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/tool_search_logging";
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type {
   ErrorEvent,
@@ -108,6 +112,15 @@ export type BlockState =
       accumulator: string;
       type: "tool_use";
       toolId: string;
+      toolName: string;
+    }
+  // Server-side tool search (e.g. tool_search_tool_bm25). The query streams in
+  // as input_json_delta chunks on a server_tool_use block, accumulating here
+  // like a regular tool call's arguments.
+  | {
+      index: number;
+      accumulator: string;
+      type: "tool_search";
       toolName: string;
     };
 
@@ -507,17 +520,38 @@ export function contentBlockStartToEvents(
           toolName: block.name,
         },
       ];
-    // Block types we don't surface: redacted thinking, server tools, and their
-    // result / container blocks. Listed explicitly so the default stays
+
+    case "server_tool_use":
+      // The only server tool we enable is tool search. Track its state so the
+      // query deltas accumulate, then log the query at content_block_stop.
+      return [
+        [],
+        {
+          index: event.index,
+          accumulator: "",
+          type: "tool_search",
+          toolName: block.name,
+        },
+      ];
+
+    case "tool_search_tool_result":
+      // The discovered tool references arrive inline here (no deltas), so log
+      // them now. State stays null and the matching stop is a no-op.
+      logToolSearchResult({
+        content: block.content,
+        logFields: toolSearchLogFields(metadata),
+      });
+      return [[], null];
+
+    // Block types we don't surface: redacted thinking, other server tools, and
+    // their result / container blocks. Listed explicitly so the default stays
     // exhaustive.
     case "redacted_thinking":
-    case "server_tool_use":
     case "web_search_tool_result":
     case "web_fetch_tool_result":
     case "code_execution_tool_result":
     case "bash_code_execution_tool_result":
     case "text_editor_code_execution_tool_result":
-    case "tool_search_tool_result":
     case "container_upload":
       return [[], state];
     default:
@@ -643,9 +677,33 @@ export function contentBlockStopToEvents(
         null,
       ];
     }
+
+    case "tool_search":
+      logToolSearchQuery({
+        rawInput: block.accumulator,
+        toolName: block.toolName,
+        tags: [
+          `provider_id:${metadata.providerId}`,
+          `api:${metadata.api}`,
+          `model_id:${metadata.modelId}`,
+        ],
+        logFields: toolSearchLogFields(metadata),
+      });
+      return [[], null];
+
     default:
       assertNever(block);
   }
+}
+
+// Maps endpoint metadata into the structured log fields shared by both tool
+// search log lines.
+function toolSearchLogFields(metadata: EndpointMetadata) {
+  return {
+    providerId: metadata.providerId,
+    api: metadata.api,
+    modelId: metadata.modelId,
+  };
 }
 
 // Returns the events to emit alongside the latest usage snapshot, so the caller


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We recently introduced Anthropic's tool search tool behind a FF, deferring cold MCP tools so the model discovers them on demand via BM25. We had no visibility into what the model actually searches for, so we couldn't tell whether deferred tools are discoverable or how to tune their names and descriptions for recall.

This adds logging of the natural-language query the model issues on each BM25 search, the tools it discovers in return, and search errors, plus a StatsD counter of search volume broken down by model and provider. Search-result blocks are now consumed properly instead of being treated as something to surface to the client.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
