### PR TITLE
[front] API key credit cap (8/10): UI for per-key credit cap

### DIFF
--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -1,6 +1,7 @@
 import { APIKeyCreationSheet } from "@app/components/workspace/api-keys/APIKeyCreationSheet";
 import { APIKeysList } from "@app/components/workspace/api-keys/APIKeysList";
 import { EditKeyCapDialog } from "@app/components/workspace/api-keys/EditKeyCapDialog";
+import { EditKeyCreditCapDialog } from "@app/components/workspace/api-keys/EditKeyCreditCapDialog";
 import { NewAPIKeyDialog } from "@app/components/workspace/api-keys/NewAPIKeyDialog";
 import type { KeyRole } from "@app/components/workspace/api-keys/utils";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -27,6 +28,7 @@ export function APIKeys({ owner }: APIKeysProps) {
   const { mutate } = useSWRConfig();
   const { subscription } = useAuth();
   const showLegacyUsdMonthlyCap = !isCreditPricedPlan(subscription.plan);
+  const showCreditMonthlyCap = isCreditPricedPlan(subscription.plan);
   const [isNewApiKeyCreatedOpen, setIsNewApiKeyCreatedOpen] = useState(false);
   const [editCapKey, setEditCapKey] = useState<KeyType | null>(null);
 
@@ -48,11 +50,13 @@ export function APIKeys({ owner }: APIKeysProps) {
         name,
         groups: selectedGroups,
         monthlyCapMicroUsd,
+        monthlyCapAwuCredits,
         role,
       }: {
         name: string;
         groups: GroupType[];
         monthlyCapMicroUsd: number | null;
+        monthlyCapAwuCredits: number | null;
         role: KeyRole;
       }) => {
         const response = await clientFetch(`/api/w/${owner.sId}/keys`, {
@@ -64,6 +68,7 @@ export function APIKeys({ owner }: APIKeysProps) {
             name,
             group_ids: selectedGroups.map((g) => g.sId),
             monthly_cap_micro_usd: monthlyCapMicroUsd,
+            monthly_cap_awu_credits: monthlyCapAwuCredits,
             role,
           }),
         });
@@ -131,6 +136,40 @@ export function APIKeys({ owner }: APIKeysProps) {
       }
     });
 
+  const { submit: handleUpdateCreditCap, isSubmitting: isUpdatingCreditCap } =
+    useSubmitFunction(async (monthlyCapAwuCredits: number | null) => {
+      if (!editCapKey) {
+        return;
+      }
+      const response = await clientFetch(
+        `/api/w/${owner.sId}/keys/${editCapKey.id}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            monthly_cap_awu_credits: monthlyCapAwuCredits,
+          }),
+        }
+      );
+      await mutate(`/api/w/${owner.sId}/keys`);
+      if (response.ok) {
+        sendNotification({
+          title: "Credit cap updated",
+          type: "success",
+        });
+        setEditCapKey(null);
+      } else {
+        const errorResponse = await response.json();
+        sendNotification({
+          title: "Error updating credit cap",
+          description: get(errorResponse, "error.message", "Unknown error"),
+          type: "error",
+        });
+      }
+    });
+
   // Show a loading spinner while API keys or groups are being fetched.
   if (isValidating || isGroupsLoading) {
     return <Spinner />;
@@ -175,6 +214,7 @@ export function APIKeys({ owner }: APIKeysProps) {
         onRevoke={handleRevoke}
         onEditCap={setEditCapKey}
         showLegacyUsdMonthlyCap={showLegacyUsdMonthlyCap}
+        showCreditMonthlyCap={showCreditMonthlyCap}
       />
       {showLegacyUsdMonthlyCap && editCapKey && (
         <EditKeyCapDialog
@@ -183,6 +223,15 @@ export function APIKeys({ owner }: APIKeysProps) {
           onClose={() => setEditCapKey(null)}
           onSave={handleUpdateCap}
           isSaving={isUpdatingCap}
+        />
+      )}
+      {showCreditMonthlyCap && editCapKey && (
+        <EditKeyCreditCapDialog
+          keyData={editCapKey}
+          isOpen={!!editCapKey}
+          onClose={() => setEditCapKey(null)}
+          onSave={handleUpdateCreditCap}
+          isSaving={isUpdatingCreditCap}
         />
       )}
     </>

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -19,6 +19,7 @@ type APIKeysListProps = {
   onRevoke: (key: KeyType) => Promise<void>;
   onEditCap: (key: KeyType) => void;
   showLegacyUsdMonthlyCap: boolean;
+  showCreditMonthlyCap: boolean;
 };
 
 const getKeySpaces = (
@@ -56,6 +57,7 @@ export const APIKeysList = ({
   onRevoke,
   onEditCap,
   showLegacyUsdMonthlyCap,
+  showCreditMonthlyCap,
 }: APIKeysListProps) => {
   return (
     <div className="space-y-4 divide-y divide-gray-200 dark:divide-gray-200-night">
@@ -66,10 +68,10 @@ export const APIKeysList = ({
               <div className="flex items-center">
                 <div className="flex flex-col">
                   <div className="flex flex-row">
-                    <div className="my-auto mr-2 mt-0.5 flex flex-shrink-0">
+                    <div className="mr-2 mt-0.5 flex w-16 flex-shrink-0 flex-col items-start gap-0.5">
                       <p
                         className={cn(
-                          "mb-0.5 inline-flex rounded-full px-2 text-xs font-semibold leading-5",
+                          "inline-flex rounded-full px-2 text-xs font-semibold leading-5",
                           key.status === "active"
                             ? "bg-green-100 text-green-800"
                             : "bg-gray-100 text-gray-800"
@@ -77,6 +79,11 @@ export const APIKeysList = ({
                       >
                         {key.status === "active" ? "active" : "revoked"}
                       </p>
+                      {showCreditMonthlyCap && key.creditState === "capped" && (
+                        <p className="inline-flex rounded-full bg-red-100 px-2 text-xs font-semibold leading-5 text-red-800">
+                          capped
+                        </p>
+                      )}
                     </div>
                     <div className="dd-privacy-mask">
                       <p
@@ -129,6 +136,21 @@ export const APIKeysList = ({
                           </strong>
                         </p>
                       )}
+                      {showCreditMonthlyCap && (
+                        <p
+                          className={cn(
+                            "truncate font-mono text-sm",
+                            "text-muted-foreground dark:text-muted-foreground-night"
+                          )}
+                        >
+                          Monthly credit cap:{" "}
+                          <strong>
+                            {key.monthlyCapAwuCredits !== null
+                              ? `${key.monthlyCapAwuCredits} credits`
+                              : "Unlimited"}
+                          </strong>
+                        </p>
+                      )}
                       <pre className="text-sm">{key.secret}</pre>
                       <p
                         className={cn(
@@ -166,7 +188,7 @@ export const APIKeysList = ({
               </div>
               {key.status === "active" ? (
                 <div className="flex gap-2">
-                  {showLegacyUsdMonthlyCap && (
+                  {(showLegacyUsdMonthlyCap || showCreditMonthlyCap) && (
                     <Button
                       variant="outline"
                       disabled={isRevoking || isGenerating}

--- a/front/components/workspace/api-keys/EditKeyCreditCapDialog.tsx
+++ b/front/components/workspace/api-keys/EditKeyCreditCapDialog.tsx
@@ -1,0 +1,112 @@
+import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
+import {
+  creditsToString,
+  monthlyCapCreditsSchema,
+  parseCreditsString,
+} from "@app/components/workspace/api-keys/utils";
+import type { KeyType } from "@app/types/key";
+import {
+  Input,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { z } from "zod";
+
+const formSchema = z.object({
+  capValueCredits: monthlyCapCreditsSchema,
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface EditKeyCreditCapDialogProps {
+  keyData: KeyType;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (monthlyCapAwuCredits: number | null) => Promise<void>;
+  isSaving: boolean;
+}
+
+export function EditKeyCreditCapDialog({
+  keyData,
+  isOpen,
+  onClose,
+  onSave,
+  isSaving,
+}: EditKeyCreditCapDialogProps) {
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    mode: "onChange",
+    defaultValues: {
+      capValueCredits: creditsToString(keyData.monthlyCapAwuCredits),
+    },
+  });
+
+  const { handleSubmit, reset, formState } = form;
+
+  useEffect(() => {
+    reset({
+      capValueCredits: creditsToString(keyData.monthlyCapAwuCredits),
+    });
+  }, [keyData, reset]);
+
+  const onSubmit = async (data: FormValues) => {
+    await onSave(parseCreditsString(data.capValueCredits));
+  };
+
+  return (
+    <Sheet
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Edit credit cap - {keyData.name}</SheetTitle>
+        </SheetHeader>
+        <SheetContainer>
+          <FormProvider {...form}>
+            <BaseFormFieldSection
+              title="Monthly credit cap"
+              fieldName="capValueCredits"
+            >
+              {({ registerRef, registerProps, onChange, errorMessage }) => (
+                <Input
+                  ref={registerRef}
+                  {...registerProps}
+                  onChange={onChange}
+                  placeholder="Leave empty for unlimited"
+                  isError={!!errorMessage}
+                  message={errorMessage}
+                  messageStatus="error"
+                />
+              )}
+            </BaseFormFieldSection>
+          </FormProvider>
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Save",
+            variant: "primary",
+            onClick: handleSubmit(onSubmit),
+            disabled: isSaving || !formState.isValid,
+          }}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
+++ b/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
@@ -4,7 +4,9 @@ import {
   isKeyRole,
   KEY_ROLES,
   type KeyRole,
+  monthlyCapCreditsSchema,
   monthlyCapDollarsSchema,
+  parseCreditsString,
   prettifyGroupName,
 } from "@app/components/workspace/api-keys/utils";
 import type { GroupType } from "@app/types/groups";
@@ -40,6 +42,7 @@ import { z } from "zod";
 const formSchema = z.object({
   name: z.string().min(1, "API key name is required"),
   monthlyCapDollars: monthlyCapDollarsSchema,
+  monthlyCapCredits: monthlyCapCreditsSchema,
   selectedGroupIds: z.array(z.number()),
   role: z.enum(KEY_ROLES),
 });
@@ -54,6 +57,7 @@ interface NewAPIKeyDialogProps {
     name: string;
     groups: GroupType[];
     monthlyCapMicroUsd: number | null;
+    monthlyCapAwuCredits: number | null;
     role: KeyRole;
   }) => Promise<void>;
   showLegacyUsdMonthlyCap: boolean;
@@ -75,6 +79,7 @@ export const NewAPIKeyDialog = ({
     defaultValues: {
       name: "",
       monthlyCapDollars: "",
+      monthlyCapCredits: "",
       selectedGroupIds: [],
       role: "builder",
     },
@@ -137,6 +142,7 @@ export const NewAPIKeyDialog = ({
       name: data.name,
       groups: selectedGroups,
       monthlyCapMicroUsd: dollarsToMicroUsd(dollars),
+      monthlyCapAwuCredits: parseCreditsString(data.monthlyCapCredits),
       role: data.role,
     });
     handleClose();
@@ -287,10 +293,27 @@ export const NewAPIKeyDialog = ({
                 </RadioGroup>
               </div>
 
-              {showLegacyUsdMonthlyCap && (
+              {showLegacyUsdMonthlyCap ? (
                 <BaseFormFieldSection
                   title="Monthly cap (USD)"
                   fieldName="monthlyCapDollars"
+                >
+                  {({ registerRef, registerProps, onChange, errorMessage }) => (
+                    <Input
+                      ref={registerRef}
+                      {...registerProps}
+                      onChange={onChange}
+                      placeholder="Leave empty for unlimited"
+                      isError={!!errorMessage}
+                      message={errorMessage}
+                      messageStatus="error"
+                    />
+                  )}
+                </BaseFormFieldSection>
+              ) : (
+                <BaseFormFieldSection
+                  title="Monthly credit cap"
+                  fieldName="monthlyCapCredits"
                 >
                   {({ registerRef, registerProps, onChange, errorMessage }) => (
                     <Input

--- a/front/components/workspace/api-keys/utils.ts
+++ b/front/components/workspace/api-keys/utils.ts
@@ -49,6 +49,32 @@ export function dollarsToMicroUsd(dollars: number | null): number | null {
   return Math.round(dollars * 1_000_000);
 }
 
+/**
+ * Schema for the per-key credit cap input (credit-priced plans), as a string
+ * from the input. Empty → unlimited. Otherwise a whole number of AWU credits
+ * (min 1) — no decimals or scientific notation.
+ */
+export const monthlyCapCreditsSchema = z.string().refine(
+  (value) => {
+    if (value === "") {
+      return true;
+    }
+    if (!/^\d+$/.test(value)) {
+      return false;
+    }
+    return parseInt(value, 10) >= 1;
+  },
+  { message: "Credit cap must be a whole number of credits (min 1)" }
+);
+
+export function creditsToString(credits: number | null): string {
+  return credits === null ? "" : credits.toString();
+}
+
+export function parseCreditsString(value: string): number | null {
+  return value === "" ? null : parseInt(value, 10);
+}
+
 export const prettifyGroupName = (group: GroupType) => {
   if (group.kind === "global") {
     return GLOBAL_SPACE_NAME;


### PR DESCRIPTION
Part of the **per-API-key credit spend limit** stack. Builds on #28061.

### This PR — UI
Surfaces the per-key credit cap on credit-priced plans (gated on `isCreditPricedPlan`, the inverse of the legacy USD-cap gate so the two never show together):

- **APIKeysList** — shows the monthly credit cap and a **capped** badge derived from `key.creditState`; the *Edit cap* button now appears on credit plans too.
- **NewAPIKeyDialog** — a credit-denominated cap input on credit plans, passed through create as `monthly_cap_awu_credits`.
- **EditKeyCreditCapDialog** — new credits-denominated edit sheet (mirrors the USD one).
- **APIKeysPage** — create/update handlers send `monthly_cap_awu_credits`.
- **utils** — credit-cap zod schema + parse/format helpers.

Follows the file's existing inline `clientFetch` pattern for consistency.

### Next in stack
Backfill plugin → tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)