### PR TITLE
[front] API key credit cap (9/10): backfill poke plugin

### DIFF
--- a/front/lib/api/keys/spend_limit.ts
+++ b/front/lib/api/keys/spend_limit.ts
@@ -1,4 +1,7 @@
-import { reconcileApiKey } from "@app/lib/api/metronome/reconcile_credit_state";
+import {
+  reconcileApiKey,
+  reconcileWorkspaceApiKeyCreditStates,
+} from "@app/lib/api/metronome/reconcile_credit_state";
 import type { Authenticator } from "@app/lib/auth";
 import {
   clearMetronomeApiKeyCapAlert,
@@ -20,6 +23,10 @@ import type { LightWorkspaceType } from "@app/types/user";
 
 export const MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS = 1;
 export const MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
+
+// 1 AWU credit = $0.01 = 10,000 microUSD. Used to convert the legacy per-key
+// USD cap to the new credit cap during backfill.
+const MICRO_USD_PER_AWU_CREDIT = 10_000;
 
 export type ApiKeySpendLimitErrorType =
   | "key_not_found"
@@ -250,4 +257,53 @@ export async function syncApiKeyCapAlertsForWorkspace(
     },
     { concurrency: 5 }
   );
+}
+
+/**
+ * One-shot backfill for a workspace adopting credit-priced per-key caps:
+ * convert any legacy USD cap to the new credit cap, (re)create the Metronome
+ * alerts, then reconcile each key's credit state. Idempotent.
+ */
+export async function backfillApiKeyCreditCapsForWorkspace(
+  workspace: LightWorkspaceType,
+  {
+    metronomeContractId,
+    planCode,
+  }: { metronomeContractId: string | null; planCode: string }
+): Promise<{ converted: number }> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return { converted: 0 };
+  }
+
+  const keys = await KeyResource.listNonSystemKeysByWorkspace(workspace);
+  let converted = 0;
+  // One UPDATE per legacy key being migrated. Bounded by the workspace's key
+  // count (small) and only runs on this one-shot admin backfill, not a hot path.
+  for (const key of keys) {
+    if (
+      key.isActive &&
+      key.monthlyCapAwuCredits === null &&
+      key.monthlyCapMicroUsd !== null
+    ) {
+      // Clamp to >= 1 so a tiny legacy cap doesn't become a 0-credit
+      // (always-capped) limit.
+      const credits = Math.max(
+        MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS,
+        Math.round(key.monthlyCapMicroUsd / MICRO_USD_PER_AWU_CREDIT)
+      );
+      await key.updateMonthlyCapAwuCredits(credits);
+      converted += 1;
+    }
+  }
+
+  await syncApiKeyCapAlertsForWorkspace(workspace);
+  await reconcileWorkspaceApiKeyCreditStates({
+    workspace,
+    metronomeCustomerId,
+    metronomeContractId,
+    planCode,
+  });
+
+  return { converted };
 }

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -40,6 +40,7 @@ export * from "./run_reinforcement_workflow";
 export * from "./send_onboarding_conversation";
 export * from "./set_web_providers";
 export * from "./soft_delete_conversation";
+export * from "./sync_api_key_cap_alerts";
 export * from "./sync_default_pool_cap_alerts";
 export * from "./sync_metronome_seats";
 export * from "./sync_missing_transcripts_date_range";

--- a/front/lib/api/poke/plugins/workspaces/sync_api_key_cap_alerts.ts
+++ b/front/lib/api/poke/plugins/workspaces/sync_api_key_cap_alerts.ts
@@ -1,0 +1,49 @@
+import { backfillApiKeyCreditCapsForWorkspace } from "@app/lib/api/keys/spend_limit";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { isCreditPricedPlan } from "@app/types/plan";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const syncApiKeyCapAlertsPlugin = createPlugin({
+  manifest: {
+    id: "sync-api-key-cap-alerts",
+    name: "Sync API Key Credit Cap Alerts",
+    description:
+      "Backfill per-API-key credit caps: convert any legacy USD cap to credits, " +
+      "(re)create the Metronome per-key cap alerts, and reconcile each key's " +
+      "credit state. Use when a workspace adopts credit pricing or to repair " +
+      "missing alerts.",
+    resourceTypes: ["workspaces"],
+    args: {},
+    requiredRoles: ["billing"],
+  },
+
+  isApplicableTo: (auth) => {
+    const plan = auth.plan();
+    return plan !== null && isCreditPricedPlan(plan);
+  },
+
+  execute: async (auth, _resource, _args) => {
+    const workspace = auth.getNonNullableWorkspace();
+    const plan = auth.plan();
+    if (!plan) {
+      return new Err(new Error("Workspace has no plan."));
+    }
+    const metronomeContractId =
+      auth.subscription()?.metronomeContractId ?? null;
+
+    const { converted } = await backfillApiKeyCreditCapsForWorkspace(
+      workspace,
+      {
+        metronomeContractId,
+        planCode: plan.code,
+      }
+    );
+
+    return new Ok({
+      display: "text",
+      value:
+        `API key credit cap alerts synced. ` +
+        `Converted ${converted} legacy USD cap(s) to credits.`,
+    });
+  },
+});


### PR DESCRIPTION
Part of the **per-API-key credit spend limit** stack. Builds on #28063.

### This PR — backfill
- **`backfillApiKeyCreditCapsForWorkspace`** — for a credit-priced workspace: converts any legacy USD per-key cap to a credit cap (microUSD / 10,000, clamped to ≥ 1), (re)creates the Metronome per-key cap alerts, and reconciles each key's credit state from live usage. Idempotent.
- **"Sync API Key Credit Cap Alerts"** poke plugin (billing role, credit-priced workspaces) wrapping it — run on credit-pricing adoption or to repair missing alerts.

This closes the migration gap: workspaces already on credit pricing with keys that had a legacy cap get their alerts/state created without waiting for a manual edit.

### Next in stack
Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)