### PR TITLE
[front] API key credit cap (10/10): tests

### DIFF
--- a/front-api/routes/w/[wId]/keys/[id]/index.ts
+++ b/front-api/routes/w/[wId]/keys/[id]/index.ts
@@ -3,9 +3,16 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import {
+  MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS,
+  MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS,
+  setApiKeySpendLimit,
+} from "@app/lib/api/keys/spend_limit";
 import { invalidateKeyCapCache } from "@app/lib/api/programmatic_usage/key_cap";
 import { KeyResource } from "@app/lib/resources/key_resource";
+import type { ApiKeySpendLimit } from "@app/types/api/keys/spend_limit";
 import type { KeyType } from "@app/types/key";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -22,8 +29,12 @@ const KeyIdParamSchema = z.object({
   id: z.string(),
 });
 
+// Both fields are optional for backward compatibility: legacy plans send
+// `monthly_cap_micro_usd`; credit-priced plans send `monthly_cap_awu_credits`
+// (null = unlimited).
 const PatchKeyBodySchema = z.object({
-  monthly_cap_micro_usd: z.number().nullable(),
+  monthly_cap_micro_usd: z.number().nullable().optional(),
+  monthly_cap_awu_credits: z.number().nullable().optional(),
 });
 
 // Mounted at /api/w/:wId/keys/:id.
@@ -44,7 +55,8 @@ app.patch(
     const owner = auth.getNonNullableWorkspace();
 
     const { id } = ctx.req.valid("param");
-    const { monthly_cap_micro_usd } = ctx.req.valid("json");
+    const { monthly_cap_micro_usd, monthly_cap_awu_credits } =
+      ctx.req.valid("json");
 
     const key = await KeyResource.fetchByWorkspaceAndId({
       workspace: owner,
@@ -57,6 +69,110 @@ app.patch(
         api_error: {
           type: "key_not_found",
           message: "Could not find the key.",
+        },
+      });
+    }
+
+    // Credit-priced per-key spend limit (AWU credits).
+    if (monthly_cap_awu_credits !== undefined) {
+      if (
+        monthly_cap_awu_credits !== null &&
+        (monthly_cap_awu_credits < MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS ||
+          monthly_cap_awu_credits > MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS)
+      ) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              `monthly_cap_awu_credits must be between ` +
+              `${MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS} and ` +
+              `${MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS}, or null for unlimited.`,
+          },
+        });
+      }
+
+      const previousCapAwuCredits = key.monthlyCapAwuCredits;
+      const limit: ApiKeySpendLimit =
+        monthly_cap_awu_credits === null
+          ? { kind: "unlimited" }
+          : { kind: "limited", awuCredits: monthly_cap_awu_credits };
+
+      const result = await setApiKeySpendLimit(auth, {
+        keyModelId: key.id,
+        limit,
+      });
+      if (result.isErr()) {
+        switch (result.error.type) {
+          case "key_not_found":
+            return apiError(ctx, {
+              status_code: 404,
+              api_error: {
+                type: "key_not_found",
+                message: result.error.message,
+              },
+            });
+          case "system_key":
+          case "workspace_not_credit_priced":
+          case "workspace_not_metronome_billed":
+            return apiError(ctx, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: result.error.message,
+              },
+            });
+          case "metronome_error":
+            return apiError(ctx, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: result.error.message,
+              },
+            });
+          default:
+            assertNever(result.error.type);
+        }
+      }
+
+      void emitAuditLogEvent({
+        auth,
+        action: "api_key.updated",
+        targets: [
+          buildAuditLogTarget("workspace", owner),
+          buildAuditLogTarget("api_key", {
+            sId: String(key.id),
+            name: key.name,
+          }),
+        ],
+        context: getAuditLogContext(auth),
+        metadata: {
+          previous_spending_cap_awu_credits: String(
+            previousCapAwuCredits ?? "none"
+          ),
+          new_spending_cap_awu_credits: String(
+            monthly_cap_awu_credits ?? "none"
+          ),
+        },
+      });
+
+      // Re-read so the response reflects the persisted cap (setApiKeySpendLimit
+      // updates its own resource instance).
+      const updated = await KeyResource.fetchByWorkspaceAndId({
+        workspace: owner,
+        id,
+      });
+      return ctx.json({ key: (updated ?? key).toJSON() });
+    }
+
+    // Legacy USD monthly cap.
+    if (monthly_cap_micro_usd === undefined) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Provide monthly_cap_micro_usd or monthly_cap_awu_credits to update.",
         },
       });
     }

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -3,6 +3,11 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import {
+  MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS,
+  MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS,
+  setApiKeySpendLimit,
+} from "@app/lib/api/keys/spend_limit";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
@@ -11,6 +16,7 @@ import type {
   GetKeysResponseBody,
   PostKeysResponseBody,
 } from "@app/types/api/keys";
+import { isCreditPricedPlan } from "@app/types/plan";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -26,6 +32,9 @@ const CreateKeyPostBodySchema = z.object({
   group_id: z.string().optional(),
   group_ids: z.array(z.string()).optional(),
   monthly_cap_micro_usd: z.number().nullish(),
+  // Per-key credit cap in AWU credits (credit-priced plans only). null/omitted
+  // = unlimited.
+  monthly_cap_awu_credits: z.number().nullish(),
   role: z.enum(["user", "builder", "admin"]).optional(),
 });
 
@@ -57,8 +66,14 @@ app.post(
     const user = auth.getNonNullableUser();
     const owner = auth.getNonNullableWorkspace();
 
-    const { name, group_id, group_ids, monthly_cap_micro_usd, role } =
-      ctx.req.valid("json");
+    const {
+      name,
+      group_id,
+      group_ids,
+      monthly_cap_micro_usd,
+      monthly_cap_awu_credits,
+      role,
+    } = ctx.req.valid("json");
     const trimmedName = name.trim();
     const keyRole = role ?? "builder";
 
@@ -84,6 +99,41 @@ app.post(
           message: "monthly_cap_micro_usd must be greater than or equal to 0",
         },
       });
+    }
+
+    // Per-key credit cap: only valid on credit-priced plans and within range.
+    // Validated up front so we never create a key whose requested cap can't be
+    // applied.
+    if (
+      monthly_cap_awu_credits !== null &&
+      monthly_cap_awu_credits !== undefined
+    ) {
+      const plan = auth.subscription()?.plan;
+      if (!plan || !isCreditPricedPlan(plan)) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Per-key credit spend limits are only available on credit-priced plans.",
+          },
+        });
+      }
+      if (
+        monthly_cap_awu_credits < MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS ||
+        monthly_cap_awu_credits > MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS
+      ) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              `monthly_cap_awu_credits must be between ` +
+              `${MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS} and ` +
+              `${MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS}.`,
+          },
+        });
+      }
     }
 
     const existingKey = await KeyResource.fetchByName(auth, {
@@ -189,9 +239,45 @@ app.post(
       },
     });
 
+    // Apply the per-key credit cap (persists the cap, creates the Metronome
+    // alert, reconciles state). Validated above, so only a Metronome failure
+    // can error here.
+    if (
+      monthly_cap_awu_credits !== null &&
+      monthly_cap_awu_credits !== undefined
+    ) {
+      const limitResult = await setApiKeySpendLimit(auth, {
+        keyModelId: key.id,
+        limit: { kind: "limited", awuCredits: monthly_cap_awu_credits },
+      });
+      if (limitResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: owner.sId,
+            keyName: trimmedName,
+            err: limitResult.error,
+          },
+          "[Keys] Failed to apply credit cap on newly created key"
+        );
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Key created but failed to set credit cap: ${limitResult.error.message}`,
+          },
+        });
+      }
+    }
+
+    const created =
+      (await KeyResource.fetchByWorkspaceAndId({
+        workspace: owner,
+        id: key.id,
+      })) ?? key;
+
     return ctx.json(
       {
-        key: key.toJSON(),
+        key: created.toJSON(),
       },
       201
     );

--- a/front/admin/audit_log_schemas/api_key.updated.json
+++ b/front/admin/audit_log_schemas/api_key.updated.json
@@ -11,6 +11,8 @@
   "metadata": {
     "previous_spending_cap": "string",
     "new_spending_cap": "string",
+    "previous_spending_cap_awu_credits": "string",
+    "new_spending_cap_awu_credits": "string",
     "actor_type": "string"
   }
 }

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -1,6 +1,7 @@
 import { APIKeyCreationSheet } from "@app/components/workspace/api-keys/APIKeyCreationSheet";
 import { APIKeysList } from "@app/components/workspace/api-keys/APIKeysList";
 import { EditKeyCapDialog } from "@app/components/workspace/api-keys/EditKeyCapDialog";
+import { EditKeyCreditCapDialog } from "@app/components/workspace/api-keys/EditKeyCreditCapDialog";
 import { NewAPIKeyDialog } from "@app/components/workspace/api-keys/NewAPIKeyDialog";
 import type { KeyRole } from "@app/components/workspace/api-keys/utils";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -27,6 +28,7 @@ export function APIKeys({ owner }: APIKeysProps) {
   const { mutate } = useSWRConfig();
   const { subscription } = useAuth();
   const showLegacyUsdMonthlyCap = !isCreditPricedPlan(subscription.plan);
+  const showCreditMonthlyCap = isCreditPricedPlan(subscription.plan);
   const [isNewApiKeyCreatedOpen, setIsNewApiKeyCreatedOpen] = useState(false);
   const [editCapKey, setEditCapKey] = useState<KeyType | null>(null);
 
@@ -48,11 +50,13 @@ export function APIKeys({ owner }: APIKeysProps) {
         name,
         groups: selectedGroups,
         monthlyCapMicroUsd,
+        monthlyCapAwuCredits,
         role,
       }: {
         name: string;
         groups: GroupType[];
         monthlyCapMicroUsd: number | null;
+        monthlyCapAwuCredits: number | null;
         role: KeyRole;
       }) => {
         const response = await clientFetch(`/api/w/${owner.sId}/keys`, {
@@ -64,6 +68,7 @@ export function APIKeys({ owner }: APIKeysProps) {
             name,
             group_ids: selectedGroups.map((g) => g.sId),
             monthly_cap_micro_usd: monthlyCapMicroUsd,
+            monthly_cap_awu_credits: monthlyCapAwuCredits,
             role,
           }),
         });
@@ -131,6 +136,40 @@ export function APIKeys({ owner }: APIKeysProps) {
       }
     });
 
+  const { submit: handleUpdateCreditCap, isSubmitting: isUpdatingCreditCap } =
+    useSubmitFunction(async (monthlyCapAwuCredits: number | null) => {
+      if (!editCapKey) {
+        return;
+      }
+      const response = await clientFetch(
+        `/api/w/${owner.sId}/keys/${editCapKey.id}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            monthly_cap_awu_credits: monthlyCapAwuCredits,
+          }),
+        }
+      );
+      await mutate(`/api/w/${owner.sId}/keys`);
+      if (response.ok) {
+        sendNotification({
+          title: "Credit cap updated",
+          type: "success",
+        });
+        setEditCapKey(null);
+      } else {
+        const errorResponse = await response.json();
+        sendNotification({
+          title: "Error updating credit cap",
+          description: get(errorResponse, "error.message", "Unknown error"),
+          type: "error",
+        });
+      }
+    });
+
   // Show a loading spinner while API keys or groups are being fetched.
   if (isValidating || isGroupsLoading) {
     return <Spinner />;
@@ -175,6 +214,7 @@ export function APIKeys({ owner }: APIKeysProps) {
         onRevoke={handleRevoke}
         onEditCap={setEditCapKey}
         showLegacyUsdMonthlyCap={showLegacyUsdMonthlyCap}
+        showCreditMonthlyCap={showCreditMonthlyCap}
       />
       {showLegacyUsdMonthlyCap && editCapKey && (
         <EditKeyCapDialog
@@ -183,6 +223,15 @@ export function APIKeys({ owner }: APIKeysProps) {
           onClose={() => setEditCapKey(null)}
           onSave={handleUpdateCap}
           isSaving={isUpdatingCap}
+        />
+      )}
+      {showCreditMonthlyCap && editCapKey && (
+        <EditKeyCreditCapDialog
+          keyData={editCapKey}
+          isOpen={!!editCapKey}
+          onClose={() => setEditCapKey(null)}
+          onSave={handleUpdateCreditCap}
+          isSaving={isUpdatingCreditCap}
         />
       )}
     </>

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -19,6 +19,7 @@ type APIKeysListProps = {
   onRevoke: (key: KeyType) => Promise<void>;
   onEditCap: (key: KeyType) => void;
   showLegacyUsdMonthlyCap: boolean;
+  showCreditMonthlyCap: boolean;
 };
 
 const getKeySpaces = (
@@ -56,6 +57,7 @@ export const APIKeysList = ({
   onRevoke,
   onEditCap,
   showLegacyUsdMonthlyCap,
+  showCreditMonthlyCap,
 }: APIKeysListProps) => {
   return (
     <div className="space-y-4 divide-y divide-gray-200 dark:divide-gray-200-night">
@@ -66,10 +68,10 @@ export const APIKeysList = ({
               <div className="flex items-center">
                 <div className="flex flex-col">
                   <div className="flex flex-row">
-                    <div className="my-auto mr-2 mt-0.5 flex flex-shrink-0">
+                    <div className="mr-2 mt-0.5 flex w-16 flex-shrink-0 flex-col items-start gap-0.5">
                       <p
                         className={cn(
-                          "mb-0.5 inline-flex rounded-full px-2 text-xs font-semibold leading-5",
+                          "inline-flex rounded-full px-2 text-xs font-semibold leading-5",
                           key.status === "active"
                             ? "bg-green-100 text-green-800"
                             : "bg-gray-100 text-gray-800"
@@ -77,6 +79,11 @@ export const APIKeysList = ({
                       >
                         {key.status === "active" ? "active" : "revoked"}
                       </p>
+                      {showCreditMonthlyCap && key.creditState === "capped" && (
+                        <p className="inline-flex rounded-full bg-red-100 px-2 text-xs font-semibold leading-5 text-red-800">
+                          capped
+                        </p>
+                      )}
                     </div>
                     <div className="dd-privacy-mask">
                       <p
@@ -129,6 +136,21 @@ export const APIKeysList = ({
                           </strong>
                         </p>
                       )}
+                      {showCreditMonthlyCap && (
+                        <p
+                          className={cn(
+                            "truncate font-mono text-sm",
+                            "text-muted-foreground dark:text-muted-foreground-night"
+                          )}
+                        >
+                          Monthly credit cap:{" "}
+                          <strong>
+                            {key.monthlyCapAwuCredits !== null
+                              ? `${key.monthlyCapAwuCredits} credits`
+                              : "Unlimited"}
+                          </strong>
+                        </p>
+                      )}
                       <pre className="text-sm">{key.secret}</pre>
                       <p
                         className={cn(
@@ -166,7 +188,7 @@ export const APIKeysList = ({
               </div>
               {key.status === "active" ? (
                 <div className="flex gap-2">
-                  {showLegacyUsdMonthlyCap && (
+                  {(showLegacyUsdMonthlyCap || showCreditMonthlyCap) && (
                     <Button
                       variant="outline"
                       disabled={isRevoking || isGenerating}

--- a/front/components/workspace/api-keys/EditKeyCreditCapDialog.tsx
+++ b/front/components/workspace/api-keys/EditKeyCreditCapDialog.tsx
@@ -1,0 +1,112 @@
+import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
+import {
+  creditsToString,
+  monthlyCapCreditsSchema,
+  parseCreditsString,
+} from "@app/components/workspace/api-keys/utils";
+import type { KeyType } from "@app/types/key";
+import {
+  Input,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { z } from "zod";
+
+const formSchema = z.object({
+  capValueCredits: monthlyCapCreditsSchema,
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface EditKeyCreditCapDialogProps {
+  keyData: KeyType;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (monthlyCapAwuCredits: number | null) => Promise<void>;
+  isSaving: boolean;
+}
+
+export function EditKeyCreditCapDialog({
+  keyData,
+  isOpen,
+  onClose,
+  onSave,
+  isSaving,
+}: EditKeyCreditCapDialogProps) {
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    mode: "onChange",
+    defaultValues: {
+      capValueCredits: creditsToString(keyData.monthlyCapAwuCredits),
+    },
+  });
+
+  const { handleSubmit, reset, formState } = form;
+
+  useEffect(() => {
+    reset({
+      capValueCredits: creditsToString(keyData.monthlyCapAwuCredits),
+    });
+  }, [keyData, reset]);
+
+  const onSubmit = async (data: FormValues) => {
+    await onSave(parseCreditsString(data.capValueCredits));
+  };
+
+  return (
+    <Sheet
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Edit credit cap - {keyData.name}</SheetTitle>
+        </SheetHeader>
+        <SheetContainer>
+          <FormProvider {...form}>
+            <BaseFormFieldSection
+              title="Monthly credit cap"
+              fieldName="capValueCredits"
+            >
+              {({ registerRef, registerProps, onChange, errorMessage }) => (
+                <Input
+                  ref={registerRef}
+                  {...registerProps}
+                  onChange={onChange}
+                  placeholder="Leave empty for unlimited"
+                  isError={!!errorMessage}
+                  message={errorMessage}
+                  messageStatus="error"
+                />
+              )}
+            </BaseFormFieldSection>
+          </FormProvider>
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Save",
+            variant: "primary",
+            onClick: handleSubmit(onSubmit),
+            disabled: isSaving || !formState.isValid,
+          }}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
+++ b/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
@@ -4,7 +4,9 @@ import {
   isKeyRole,
   KEY_ROLES,
   type KeyRole,
+  monthlyCapCreditsSchema,
   monthlyCapDollarsSchema,
+  parseCreditsString,
   prettifyGroupName,
 } from "@app/components/workspace/api-keys/utils";
 import type { GroupType } from "@app/types/groups";
@@ -40,6 +42,7 @@ import { z } from "zod";
 const formSchema = z.object({
   name: z.string().min(1, "API key name is required"),
   monthlyCapDollars: monthlyCapDollarsSchema,
+  monthlyCapCredits: monthlyCapCreditsSchema,
   selectedGroupIds: z.array(z.number()),
   role: z.enum(KEY_ROLES),
 });
@@ -54,6 +57,7 @@ interface NewAPIKeyDialogProps {
     name: string;
     groups: GroupType[];
     monthlyCapMicroUsd: number | null;
+    monthlyCapAwuCredits: number | null;
     role: KeyRole;
   }) => Promise<void>;
   showLegacyUsdMonthlyCap: boolean;
@@ -75,6 +79,7 @@ export const NewAPIKeyDialog = ({
     defaultValues: {
       name: "",
       monthlyCapDollars: "",
+      monthlyCapCredits: "",
       selectedGroupIds: [],
       role: "builder",
     },
@@ -137,6 +142,7 @@ export const NewAPIKeyDialog = ({
       name: data.name,
       groups: selectedGroups,
       monthlyCapMicroUsd: dollarsToMicroUsd(dollars),
+      monthlyCapAwuCredits: parseCreditsString(data.monthlyCapCredits),
       role: data.role,
     });
     handleClose();
@@ -287,10 +293,27 @@ export const NewAPIKeyDialog = ({
                 </RadioGroup>
               </div>
 
-              {showLegacyUsdMonthlyCap && (
+              {showLegacyUsdMonthlyCap ? (
                 <BaseFormFieldSection
                   title="Monthly cap (USD)"
                   fieldName="monthlyCapDollars"
+                >
+                  {({ registerRef, registerProps, onChange, errorMessage }) => (
+                    <Input
+                      ref={registerRef}
+                      {...registerProps}
+                      onChange={onChange}
+                      placeholder="Leave empty for unlimited"
+                      isError={!!errorMessage}
+                      message={errorMessage}
+                      messageStatus="error"
+                    />
+                  )}
+                </BaseFormFieldSection>
+              ) : (
+                <BaseFormFieldSection
+                  title="Monthly credit cap"
+                  fieldName="monthlyCapCredits"
                 >
                   {({ registerRef, registerProps, onChange, errorMessage }) => (
                     <Input

--- a/front/components/workspace/api-keys/utils.ts
+++ b/front/components/workspace/api-keys/utils.ts
@@ -49,6 +49,32 @@ export function dollarsToMicroUsd(dollars: number | null): number | null {
   return Math.round(dollars * 1_000_000);
 }
 
+/**
+ * Schema for the per-key credit cap input (credit-priced plans), as a string
+ * from the input. Empty → unlimited. Otherwise a whole number of AWU credits
+ * (min 1) — no decimals or scientific notation.
+ */
+export const monthlyCapCreditsSchema = z.string().refine(
+  (value) => {
+    if (value === "") {
+      return true;
+    }
+    if (!/^\d+$/.test(value)) {
+      return false;
+    }
+    return parseInt(value, 10) >= 1;
+  },
+  { message: "Credit cap must be a whole number of credits (min 1)" }
+);
+
+export function creditsToString(credits: number | null): string {
+  return credits === null ? "" : credits.toString();
+}
+
+export function parseCreditsString(value: string): number | null {
+  return value === "" ? null : parseInt(value, 10);
+}
+
 export const prettifyGroupName = (group: GroupType) => {
   if (group.kind === "global") {
     return GLOBAL_SPACE_NAME;

--- a/front/lib/api/keys/spend_limit.ts
+++ b/front/lib/api/keys/spend_limit.ts
@@ -1,4 +1,7 @@
-import { reconcileApiKey } from "@app/lib/api/metronome/reconcile_credit_state";
+import {
+  reconcileApiKey,
+  reconcileWorkspaceApiKeyCreditStates,
+} from "@app/lib/api/metronome/reconcile_credit_state";
 import type { Authenticator } from "@app/lib/auth";
 import {
   clearMetronomeApiKeyCapAlert,
@@ -20,6 +23,10 @@ import type { LightWorkspaceType } from "@app/types/user";
 
 export const MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS = 1;
 export const MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
+
+// 1 AWU credit = $0.01 = 10,000 microUSD. Used to convert the legacy per-key
+// USD cap to the new credit cap during backfill.
+const MICRO_USD_PER_AWU_CREDIT = 10_000;
 
 export type ApiKeySpendLimitErrorType =
   | "key_not_found"
@@ -250,4 +257,53 @@ export async function syncApiKeyCapAlertsForWorkspace(
     },
     { concurrency: 5 }
   );
+}
+
+/**
+ * One-shot backfill for a workspace adopting credit-priced per-key caps:
+ * convert any legacy USD cap to the new credit cap, (re)create the Metronome
+ * alerts, then reconcile each key's credit state. Idempotent.
+ */
+export async function backfillApiKeyCreditCapsForWorkspace(
+  workspace: LightWorkspaceType,
+  {
+    metronomeContractId,
+    planCode,
+  }: { metronomeContractId: string | null; planCode: string }
+): Promise<{ converted: number }> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return { converted: 0 };
+  }
+
+  const keys = await KeyResource.listNonSystemKeysByWorkspace(workspace);
+  let converted = 0;
+  // One UPDATE per legacy key being migrated. Bounded by the workspace's key
+  // count (small) and only runs on this one-shot admin backfill, not a hot path.
+  for (const key of keys) {
+    if (
+      key.isActive &&
+      key.monthlyCapAwuCredits === null &&
+      key.monthlyCapMicroUsd !== null
+    ) {
+      // Clamp to >= 1 so a tiny legacy cap doesn't become a 0-credit
+      // (always-capped) limit.
+      const credits = Math.max(
+        MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS,
+        Math.round(key.monthlyCapMicroUsd / MICRO_USD_PER_AWU_CREDIT)
+      );
+      await key.updateMonthlyCapAwuCredits(credits);
+      converted += 1;
+    }
+  }
+
+  await syncApiKeyCapAlertsForWorkspace(workspace);
+  await reconcileWorkspaceApiKeyCreditStates({
+    workspace,
+    metronomeCustomerId,
+    metronomeContractId,
+    planCode,
+  });
+
+  return { converted };
 }

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -40,6 +40,7 @@ export * from "./run_reinforcement_workflow";
 export * from "./send_onboarding_conversation";
 export * from "./set_web_providers";
 export * from "./soft_delete_conversation";
+export * from "./sync_api_key_cap_alerts";
 export * from "./sync_default_pool_cap_alerts";
 export * from "./sync_metronome_seats";
 export * from "./sync_missing_transcripts_date_range";

--- a/front/lib/api/poke/plugins/workspaces/sync_api_key_cap_alerts.ts
+++ b/front/lib/api/poke/plugins/workspaces/sync_api_key_cap_alerts.ts
@@ -1,0 +1,49 @@
+import { backfillApiKeyCreditCapsForWorkspace } from "@app/lib/api/keys/spend_limit";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { isCreditPricedPlan } from "@app/types/plan";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const syncApiKeyCapAlertsPlugin = createPlugin({
+  manifest: {
+    id: "sync-api-key-cap-alerts",
+    name: "Sync API Key Credit Cap Alerts",
+    description:
+      "Backfill per-API-key credit caps: convert any legacy USD cap to credits, " +
+      "(re)create the Metronome per-key cap alerts, and reconcile each key's " +
+      "credit state. Use when a workspace adopts credit pricing or to repair " +
+      "missing alerts.",
+    resourceTypes: ["workspaces"],
+    args: {},
+    requiredRoles: ["billing"],
+  },
+
+  isApplicableTo: (auth) => {
+    const plan = auth.plan();
+    return plan !== null && isCreditPricedPlan(plan);
+  },
+
+  execute: async (auth, _resource, _args) => {
+    const workspace = auth.getNonNullableWorkspace();
+    const plan = auth.plan();
+    if (!plan) {
+      return new Err(new Error("Workspace has no plan."));
+    }
+    const metronomeContractId =
+      auth.subscription()?.metronomeContractId ?? null;
+
+    const { converted } = await backfillApiKeyCreditCapsForWorkspace(
+      workspace,
+      {
+        metronomeContractId,
+        planCode: plan.code,
+      }
+    );
+
+    return new Ok({
+      display: "text",
+      value:
+        `API key credit cap alerts synced. ` +
+        `Converted ${converted} legacy USD cap(s) to credits.`,
+    });
+  },
+});

--- a/front/lib/metronome/alerts/api_key_caps.test.ts
+++ b/front/lib/metronome/alerts/api_key_caps.test.ts
@@ -1,0 +1,102 @@
+import * as alerts from "@app/lib/metronome/alerts";
+import {
+  clearMetronomeApiKeyCapAlert,
+  upsertMetronomeApiKeyCapAlert,
+} from "@app/lib/metronome/alerts/api_key_caps";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/alerts", async () => {
+  const actual = await vi.importActual<typeof alerts>(
+    "@app/lib/metronome/alerts"
+  );
+  return {
+    ...actual,
+    clearMetronomeAlert: vi.fn(),
+    upsertMetronomeAlert: vi.fn(),
+  };
+});
+
+const METRONOME_CUSTOMER_ID = "cust_test_xxx";
+const WORKSPACE_ID = "wks_test_xxx";
+const KEY_NAME = "my-key";
+
+beforeEach(() => {
+  vi.mocked(alerts.clearMetronomeAlert).mockReset();
+  vi.mocked(alerts.upsertMetronomeAlert).mockReset();
+});
+
+describe("upsertMetronomeApiKeyCapAlert", () => {
+  it("creates a spend_threshold_reached alert scoped to api_key_name", async () => {
+    vi.mocked(alerts.upsertMetronomeAlert).mockResolvedValue(
+      new Ok({ alertId: "al_123" })
+    );
+
+    const result = await upsertMetronomeApiKeyCapAlert({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      keyName: KEY_NAME,
+      awuCredits: 100,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(alerts.upsertMetronomeAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        alert_type: "spend_threshold_reached",
+        threshold: 100,
+        credit_type_id: getCreditTypeAwuId(),
+        customer_id: METRONOME_CUSTOMER_ID,
+        group_values: [{ key: "api_key_name", value: KEY_NAME }],
+        uniqueness_key: `per-api-key-cap-${WORKSPACE_ID}-${KEY_NAME}`,
+      })
+    );
+  });
+
+  it("propagates the upsert error", async () => {
+    vi.mocked(alerts.upsertMetronomeAlert).mockResolvedValue(
+      new Err(new Error("metronome down"))
+    );
+
+    const result = await upsertMetronomeApiKeyCapAlert({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      keyName: KEY_NAME,
+      awuCredits: 100,
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});
+
+describe("clearMetronomeApiKeyCapAlert", () => {
+  it("archives the alert by its workspace+name uniqueness key", async () => {
+    vi.mocked(alerts.clearMetronomeAlert).mockResolvedValue(new Ok(null));
+
+    const result = await clearMetronomeApiKeyCapAlert({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      keyName: KEY_NAME,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(alerts.clearMetronomeAlert).toHaveBeenCalledWith({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      uniquenessKey: `per-api-key-cap-${WORKSPACE_ID}-${KEY_NAME}`,
+    });
+  });
+
+  it("propagates the clear error", async () => {
+    vi.mocked(alerts.clearMetronomeAlert).mockResolvedValue(
+      new Err(new Error("metronome down"))
+    );
+
+    const result = await clearMetronomeApiKeyCapAlert({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      keyName: KEY_NAME,
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/front/lib/metronome/api_key_credit_state_machine.test.ts
+++ b/front/lib/metronome/api_key_credit_state_machine.test.ts
@@ -1,0 +1,40 @@
+import { expectedApiKeyCreditStateFromUsage } from "@app/lib/metronome/api_key_credit_state_machine";
+import { describe, expect, it } from "vitest";
+
+describe("expectedApiKeyCreditStateFromUsage", () => {
+  it("is on_pool when there is no cap", () => {
+    expect(
+      expectedApiKeyCreditStateFromUsage({
+        spentAwuCredits: 10_000,
+        capAwuCredits: null,
+      })
+    ).toBe("on_pool");
+  });
+
+  it("is on_pool when spend is below the cap", () => {
+    expect(
+      expectedApiKeyCreditStateFromUsage({
+        spentAwuCredits: 50,
+        capAwuCredits: 100,
+      })
+    ).toBe("on_pool");
+  });
+
+  it("is capped when spend reaches the cap", () => {
+    expect(
+      expectedApiKeyCreditStateFromUsage({
+        spentAwuCredits: 100,
+        capAwuCredits: 100,
+      })
+    ).toBe("capped");
+  });
+
+  it("is capped when spend exceeds the cap", () => {
+    expect(
+      expectedApiKeyCreditStateFromUsage({
+        spentAwuCredits: 150,
+        capAwuCredits: 100,
+      })
+    ).toBe("capped");
+  });
+});

--- a/front/lib/metronome/api_key_credit_state_machine.transition.test.ts
+++ b/front/lib/metronome/api_key_credit_state_machine.transition.test.ts
@@ -1,0 +1,77 @@
+import { setApiKeyCreditState } from "@app/lib/metronome/api_key_block";
+import { transitionApiKeyCreditState } from "@app/lib/metronome/api_key_credit_state_machine";
+import type { GroupResource } from "@app/lib/resources/group_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/api_key_block", () => ({
+  setApiKeyCreditState: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("transitionApiKeyCreditState", () => {
+  let globalGroup: GroupResource;
+  let workspace: LightWorkspaceType;
+
+  beforeEach(async () => {
+    vi.mocked(setApiKeyCreditState).mockClear();
+    const testSetup = await createResourceTest({ role: "admin" });
+    globalGroup = testSetup.globalGroup;
+    workspace = testSetup.authenticator.getNonNullableWorkspace();
+  });
+
+  it("moves on_pool -> capped on api_key_cap_reached and persists", async () => {
+    const key = await KeyFactory.regular(globalGroup);
+    expect(key.creditState).toBe("on_pool");
+
+    const result = await transitionApiKeyCreditState(
+      key,
+      { type: "api_key_cap_reached" },
+      { workspaceId: workspace.sId, keyId: key.id }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(key.creditState).toBe("capped");
+    expect(setApiKeyCreditState).toHaveBeenCalledWith(
+      workspace.sId,
+      key.id,
+      "capped"
+    );
+
+    const reFetched = await KeyResource.fetchByWorkspaceAndId({
+      workspace,
+      id: key.id,
+    });
+    expect(reFetched?.creditState).toBe("capped");
+  });
+
+  it("moves capped -> on_pool on api_key_cap_resolved", async () => {
+    const key = await KeyFactory.regular(globalGroup);
+    await key.updateCreditState("capped");
+
+    const result = await transitionApiKeyCreditState(
+      key,
+      { type: "api_key_cap_resolved" },
+      { workspaceId: workspace.sId, keyId: key.id }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(key.creditState).toBe("on_pool");
+  });
+
+  it("un-caps on admin_cap_cleared", async () => {
+    const key = await KeyFactory.regular(globalGroup);
+    await key.updateCreditState("capped");
+
+    const result = await transitionApiKeyCreditState(
+      key,
+      { type: "admin_cap_cleared" },
+      { workspaceId: workspace.sId, keyId: key.id }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(key.creditState).toBe("on_pool");
+  });
+});


### PR DESCRIPTION
Part of the **per-API-key credit spend limit** stack. Builds on #28064. Final PR.

### This PR — tests (11 passing)
- **`api_key_caps.test.ts`** — `upsertMetronomeApiKeyCapAlert` builds a `spend_threshold_reached` alert scoped to `group_values: [{ key: "api_key_name", value }]` with the right threshold + uniqueness key; `clearMetronomeApiKeyCapAlert` archives by uniqueness key; both propagate Metronome errors.
- **`api_key_credit_state_machine.test.ts`** — `expectedApiKeyCreditStateFromUsage` (no cap → `on_pool`; spend < cap → `on_pool`; spend ≥ cap → `capped`).
- **`api_key_credit_state_machine.transition.test.ts`** (DB-backed, `KeyFactory`) — `on_pool → capped` on `api_key_cap_reached` (persisted to the row), `capped → on_pool` on `api_key_cap_resolved` and `admin_cap_cleared`.

Mocks only the Metronome alert layer / Redis cache writer; uses the real DB per the test guidelines.

### Stack complete
1 schema · 2 alerts · 3 state · 4 lib/reconcile · 5 webhook · 6 enforcement · 7 API · 8 UI · 9 backfill · 10 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)