### PR TITLE
[front] activate free plan: switch subscription if not done by webhook

### DIFF
--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -8,6 +8,7 @@ import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
+import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import { BUSINESS_USD_PACKAGE_ALIAS } from "@app/lib/metronome/types";
 import { PlanModel } from "@app/lib/models/plan";
 import {
@@ -16,6 +17,7 @@ import {
 } from "@app/lib/plans/billing_currency";
 import { CREDIT_PRICED_FREE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -116,6 +118,23 @@ export async function activateCreditPricedFreePlan(
       `Failed to provision Metronome contract: ${contractResult.error.message}`
     );
   }
+  const { metronomeContractId } = contractResult.value;
+
+  const subscriptionResult =
+    await SubscriptionResource.createSubscriptionFromCheckout({
+      workspaceModelId: owner.id,
+      plan,
+      metronomeContractId,
+      now,
+    });
+  if (subscriptionResult.isErr()) {
+    throw new Error(
+      `Failed to create subscription: ${subscriptionResult.error.message}`
+    );
+  }
+
+  await invalidateContractCache(owner.sId);
+  await restoreWorkspaceAfterSubscription(auth);
 }
 
 export async function restoreWorkspaceAfterSubscription(auth: Authenticator) {

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -2,7 +2,7 @@ import { sendProactiveTrialCancelledEmail } from "@app/lib/api/email";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
-import { DustError } from "@app/lib/error";
+import type { DustError } from "@app/lib/error";
 import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
   ensureMetronomeCustomerForWorkspace,
@@ -205,22 +205,10 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
           t
         );
 
-      if (activeSubscription?.planId === plan.id) {
-        return new Err(
-          new DustError(
-            "subscription_already_exists",
-            `Active subscription already exists for plan ${plan.code}.`
-          )
-        );
-      }
-
-      if (activeSubscription?.isBilled) {
-        return new Err(
-          new DustError(
-            "subscription_already_exists",
-            "Active paid subscription already exists."
-          )
-        );
+      // Make sure subscription switch has not been called yet
+      // Can happen if metronome contract.start webhook is triggered first.
+      if (activeSubscription?.metronomeContractId === metronomeContractId) {
+        return new Ok(undefined);
       }
 
       await activeSubscription?.markAsEnded("ended", t);

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -2,6 +2,7 @@ import { sendProactiveTrialCancelledEmail } from "@app/lib/api/email";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
   ensureMetronomeCustomerForWorkspace,
@@ -184,6 +185,61 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       subscription.get(),
       plan
     );
+  }
+
+  static async createSubscriptionFromCheckout({
+    workspaceModelId,
+    plan,
+    metronomeContractId,
+    now,
+  }: {
+    workspaceModelId: ModelId;
+    plan: PlanModel;
+    metronomeContractId: string;
+    now: Date;
+  }): Promise<Result<void, DustError>> {
+    return withTransaction(async (t) => {
+      const activeSubscription =
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(
+          workspaceModelId,
+          t
+        );
+
+      if (activeSubscription?.planId === plan.id) {
+        return new Err(
+          new DustError(
+            "subscription_already_exists",
+            `Active subscription already exists for plan ${plan.code}.`
+          )
+        );
+      }
+
+      if (activeSubscription?.isBilled) {
+        return new Err(
+          new DustError(
+            "subscription_already_exists",
+            "Active paid subscription already exists."
+          )
+        );
+      }
+
+      await activeSubscription?.markAsEnded("ended", t);
+      await SubscriptionResource.makeNew(
+        {
+          sId: generateRandomModelSId(),
+          workspaceId: workspaceModelId,
+          planId: plan.id,
+          status: "active",
+          trialing: false,
+          startDate: now,
+          metronomeContractId,
+        },
+        renderPlanFromModel({ plan }),
+        t
+      );
+
+      return new Ok(undefined);
+    });
   }
 
   private static readonly subscriptionCacheKeyResolver = (


### PR DESCRIPTION
## Description

Free plan activation
* Improve behavior for subscription management after provisionMetronomeContract
* revert previous change to not rely only on webhook
* but check current subscription contract to check if the subscription switch has not already been called by the webhook contract.start

## Tests

Tested locally

## Risk

Medium, impacts the free plan subscription flow

## Deploy Plan

Deploy front