### PR TITLE
Add a tool-search prompt hint in the Anthropic client when the search tool is present

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.test.ts
+++ b/front/lib/api/llm/clients/anthropic/index.test.ts
@@ -1,0 +1,49 @@
+import { buildSystemBlocks } from "@app/lib/api/llm/clients/anthropic/index";
+import type { StructuredSystemPrompt } from "@app/lib/api/llm/types/options";
+import { TOOL_SEARCH_INSTRUCTION } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
+import { describe, expect, it } from "vitest";
+
+const prompt: StructuredSystemPrompt = {
+  instructions: [{ role: "instruction", content: "You are a helpful agent." }],
+  sharedContext: [{ role: "context", content: "Shared directives." }],
+  ephemeralContext: [{ role: "context", content: "Per-call data." }],
+};
+
+function systemText(blocks: { text: string }[]): string {
+  return blocks.map((b) => b.text).join("\n\n");
+}
+
+describe("buildSystemBlocks", () => {
+  it("omits the tool search instruction by default", () => {
+    const blocks = buildSystemBlocks(prompt, {});
+
+    expect(systemText(blocks)).not.toContain(TOOL_SEARCH_INSTRUCTION);
+  });
+
+  it("appends the tool search instruction to the shared tier when requested", () => {
+    const blocks = buildSystemBlocks(prompt, {
+      includeToolSearchInstruction: true,
+    });
+
+    // The instruction lands in the shared tier, not the instructions tier (see
+    // the placement rationale in buildSystemBlocks).
+    const sharedBlock = blocks.find((b) =>
+      b.text.includes("Shared directives.")
+    );
+    expect(sharedBlock?.text).toContain(TOOL_SEARCH_INSTRUCTION);
+
+    const instructionsBlock = blocks.find((b) =>
+      b.text.includes("You are a helpful agent.")
+    );
+    expect(instructionsBlock?.text).not.toContain(TOOL_SEARCH_INSTRUCTION);
+  });
+
+  it("emits a shared block carrying the instruction even with no shared context", () => {
+    const blocks = buildSystemBlocks(
+      { ...prompt, sharedContext: [] },
+      { includeToolSearchInstruction: true }
+    );
+
+    expect(systemText(blocks)).toContain(TOOL_SEARCH_INSTRUCTION);
+  });
+});

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -41,6 +41,10 @@ import type {
 } from "@app/lib/api/llm/types/options";
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
+import {
+  includesToolSearchTool,
+  TOOL_SEARCH_INSTRUCTION,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import { getMinimumReasoningEffort } from "@app/types/assistant/models/types";
@@ -95,12 +99,32 @@ type AnthropicStreamPayload = BetaMessageStreamParams & {
  *
  * /!\ Do not add breakpoints here without auditing total usage across the request.
  */
-function buildSystemBlocks(
+export function buildSystemBlocks(
   { instructions, sharedContext, ephemeralContext }: StructuredSystemPrompt,
-  { hasConditionalJITTools }: { hasConditionalJITTools?: boolean }
+  {
+    hasConditionalJITTools,
+    includeToolSearchInstruction,
+  }: {
+    hasConditionalJITTools?: boolean;
+    includeToolSearchInstruction?: boolean;
+  }
 ) {
   const instructionsText = instructions.map((s) => s.content).join("\n");
-  const sharedText = sharedContext.map((s) => s.content).join("\n");
+  // The tool search instruction is a constant string that renders on every turn
+  // tool search is on, so it could live in the long-lived 1h instructions tier.
+  // It stays in the shared 5min tier for now because conditional JIT tools
+  // (attachment-driven: files, query, search) are auto-internal and hot, not
+  // deferred, so they still force the instructions tier to downgrade.
+  //
+  // TODO(tool-search): once the hot tool set is reduced to a minimal curated set
+  // so those conditional additions are deferred too, move this instruction to the
+  // instructions tier to get the 1h TTL.
+  const sharedText = [
+    sharedContext.map((s) => s.content).join("\n"),
+    ...(includeToolSearchInstruction ? [TOOL_SEARCH_INSTRUCTION] : []),
+  ]
+    .filter(Boolean)
+    .join("\n");
   const ephemeralText = ephemeralContext.map((s) => s.content).join("\n");
 
   const system: Anthropic.Beta.Messages.BetaTextBlockParam[] = [];
@@ -219,8 +243,14 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
             this.modelConfig.useNativeLightReasoning
           );
 
+    // Build the tools once so the system prompt can be derived from what is
+    // actually sent: the tool search instruction is added only when the search
+    // tool is present in this request.
+    const tools = toToolsParam(specifications, forceToolCall);
+
     const system = buildSystemBlocks(normalizePrompt(prompt), {
       hasConditionalJITTools,
+      includeToolSearchInstruction: includesToolSearchTool(tools),
     });
 
     return {
@@ -229,7 +259,7 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       system,
       messages,
       temperature: this.temperature ?? undefined,
-      tools: toToolsParam(specifications, forceToolCall),
+      tools,
       max_tokens: this.modelConfig.generationTokensCount,
       tool_choice: toToolChoiceParam(specifications, forceToolCall),
     };

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.test.ts
@@ -1,9 +1,13 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import {
+  includesToolSearchTool,
+  TOOL_SEARCH_TOOL,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
 import { describe, expect, it } from "vitest";
 
 import { toTool, toToolsParam } from "./conversation_to_anthropic";
 
-const TOOL_SEARCH_TYPE = "tool_search_tool_bm25_20251119";
+const TOOL_SEARCH_TYPE = TOOL_SEARCH_TOOL.type;
 
 const hotSpec: AgentActionSpecification = {
   name: "hot",
@@ -80,6 +84,29 @@ describe("toToolsParam", () => {
     // ...but the force-called tool was un-deferred.
     const forced = tools.find((t) => t.name === "cold");
     expect(forced && "defer_loading" in forced && forced.defer_loading).toBe(
+      false
+    );
+  });
+});
+
+// The system-prompt hint is gated on whether the search tool actually ends up in
+// the request, derived from the converted tools array. These tests pin that the
+// predicate agrees with toToolsParam, including the force-call edge case.
+describe("includesToolSearchTool", () => {
+  it("is false when nothing is deferred", () => {
+    expect(includesToolSearchTool(toToolsParam([hotSpec], undefined))).toBe(
+      false
+    );
+  });
+
+  it("is true when a deferred tool prepends the search tool", () => {
+    expect(
+      includesToolSearchTool(toToolsParam([hotSpec, coldSpec], undefined))
+    ).toBe(true);
+  });
+
+  it("is false when the only deferred tool is force-called", () => {
+    expect(includesToolSearchTool(toToolsParam([coldSpec], "cold"))).toBe(
       false
     );
   });

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -10,6 +10,7 @@ import type {
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { extractEncryptedContentFromMetadata } from "@app/lib/api/llm/utils";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
+import { TOOL_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   AgentFunctionCallContentType,
@@ -276,14 +277,6 @@ export function toTool(tool: AgentActionSpecification): Tool {
     ...(tool.deferLoading ? { defer_loading: true } : {}),
   };
 }
-
-// Tool search lets the model discover deferred (cold) tools on demand without
-// loading their schemas into the cached prefix. bm25 uses natural-language
-// queries, which match well across diverse MCP tool names and descriptions.
-const TOOL_SEARCH_TOOL = {
-  type: "tool_search_tool_bm25_20251119",
-  name: "tool_search_tool_bm25",
-} as const;
 
 // Builds the Anthropic `tools` array from the agent's tool specifications.
 // Cold specs carry `deferLoading`, which toTool maps to `defer_loading`. When

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
@@ -7,6 +7,10 @@ import type {
 import type { Client } from "@app/lib/model_constructors/client";
 import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import {
+  includesToolSearchTool,
+  TOOL_SEARCH_INSTRUCTION,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
+import {
   assistantReasoningMessageToThinkingBlocks,
   assistantTextMessageToTextBlock,
   assistantToolCallRequestToToolUseBlock,
@@ -82,13 +86,21 @@ export function WithAnthropicAIInputConverter<
           : {}),
       };
 
+      // Build the tools first so the prompt reflects what is actually sent: the
+      // tool search instruction is appended only when the search tool is in the
+      // request, as a trailing block outside the cached system prefix.
+      const anthropicTools = toolSpecsToAnthropicAITools(tools, { forceTool });
+      const system = this.systemMessagesToSystemParam(conversation.system);
+
       return {
         model: this.modelIdToApiModelId(this.constructor.modelId),
         max_tokens: this.constructor.maxOutputTokens,
         messages: await this.conversationToMessages(conversation),
-        system: this.systemMessagesToSystemParam(conversation.system),
+        system: includesToolSearchTool(anthropicTools)
+          ? [...system, { type: "text", text: TOOL_SEARCH_INSTRUCTION }]
+          : system,
         thinking: thinkingConfig.thinking,
-        tools: toolSpecsToAnthropicAITools(tools, { forceTool }),
+        tools: anthropicTools,
         tool_choice: forceToolNameToToolChoice(tools, forceTool),
         temperature,
         ...(Object.keys(outputConfig).length > 0

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.test.ts
@@ -1,0 +1,56 @@
+import {
+  includesToolSearchTool,
+  TOOL_SEARCH_INSTRUCTION,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
+import { toolSpecsToAnthropicAITools } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
+import type { ToolSpecification } from "@app/lib/model_constructors/types/input/configuration";
+import { describe, expect, it } from "vitest";
+
+const hot: ToolSpecification = {
+  name: "hot",
+  description: "A hot tool.",
+  inputSchema: { type: "object", properties: {} },
+};
+
+const cold: ToolSpecification = {
+  name: "cold",
+  description: "A cold tool.",
+  inputSchema: { type: "object", properties: {} },
+  deferLoading: true,
+};
+
+// The new client appends the tool search instruction iff the search tool is in
+// the request. The predicate reads the converted tools, so it stays in lockstep
+// with toolSpecsToAnthropicAITools, including the force-call edge case.
+describe("includesToolSearchTool", () => {
+  it("is false when nothing is deferred", () => {
+    expect(
+      includesToolSearchTool(
+        toolSpecsToAnthropicAITools([hot], { forceTool: undefined })
+      )
+    ).toBe(false);
+  });
+
+  it("is true when a deferred tool prepends the search tool", () => {
+    expect(
+      includesToolSearchTool(
+        toolSpecsToAnthropicAITools([hot, cold], { forceTool: undefined })
+      )
+    ).toBe(true);
+  });
+
+  it("is false when the only deferred tool is force-called", () => {
+    expect(
+      includesToolSearchTool(
+        toolSpecsToAnthropicAITools([cold], { forceTool: "cold" })
+      )
+    ).toBe(false);
+  });
+});
+
+describe("TOOL_SEARCH_INSTRUCTION", () => {
+  it("is a non-empty hint that does not name the underlying search tool", () => {
+    expect(TOOL_SEARCH_INSTRUCTION.length).toBeGreaterThan(0);
+    expect(TOOL_SEARCH_INSTRUCTION).not.toContain("bm25");
+  });
+});

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.ts
@@ -1,0 +1,33 @@
+// Shared by the legacy LLM client (lib/api/llm/clients/anthropic) and the
+// model_constructors client. Both prepend the tool search tool when at least one
+// tool is deferred, and both surface the same system-prompt hint so the model
+// searches for deferred tools instead of guessing.
+
+// The tool search tool both clients prepend to the tools array whenever at least
+// one tool is deferred, so the model can discover those tools on demand.
+export const TOOL_SEARCH_TOOL = {
+  type: "tool_search_tool_bm25_20251119",
+  name: "tool_search_tool_bm25",
+} as const;
+
+// The predicate below reads the converted tools array instead of re-deriving from
+// the specs, so it stays in lockstep with the prepend decision, including the
+// force-call edge case where the only deferred tool is un-deferred and no search
+// tool is prepended.
+const TOOL_SEARCH_TOOL_TYPE = TOOL_SEARCH_TOOL.type;
+
+// Added to the system prompt only when the search tool is in the request. Phrased
+// without naming the bm25 tool so it stays accurate across search implementations.
+export const TOOL_SEARCH_INSTRUCTION =
+  "You can search for and load far more tools than are visible to you now, " +
+  "including ones that fetch live or account-specific data and act in external " +
+  "systems. When a request needs current state, the user's own systems, or an " +
+  "action your visible tools cannot take, search for a tool before making " +
+  "something up, answering from stale memory, or telling the user it is not " +
+  "possible.";
+
+export function includesToolSearchTool(
+  tools: ReadonlyArray<{ type?: string | null }>
+): boolean {
+  return tools.some((tool) => tool.type === TOOL_SEARCH_TOOL_TYPE);
+}

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
@@ -16,6 +16,7 @@ import type {
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import type { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import { TOOL_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
 import type {
   OutputFormat,
   ToolSpecification,
@@ -337,13 +338,6 @@ export function toolSpecToAnthropicAITool(tool: ToolSpecification): Tool {
     ...(tool.deferLoading ? { defer_loading: true } : {}),
   };
 }
-
-// Search tool that lets the model discover deferred tools on demand. Prepended
-// to the tools array whenever at least one tool is deferred.
-const TOOL_SEARCH_TOOL = {
-  type: "tool_search_tool_bm25_20251119",
-  name: "tool_search_tool_bm25",
-} as const;
 
 export function toolSpecsToAnthropicAITools(
   tools: ToolSpecification[],


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Behind the `anthropic_tool_search` flag, cold MCP tools are deferred and the model is supposed to discover them through Anthropic's tool search tool. In practice it often skips the search and guesses or answers from memory, so this PR adds a system-prompt hint telling it to search for tools before answering.

The hint is injected in the Anthropic client layer and gated on whether a tool search tool actually ends up in the request, derived from the converted tools array rather than re-derived from a feature flag upstream. This is the only place that already knows for certain whether the search tool is being sent, including the case where a forced tool gets un-deferred and no search tool is added. As a result the hint is present if and only if the search tool is present in the same request, so it never reaches providers that expose all tools at once and have no search tool, and it cannot drift out of sync with the deferral decision.

The hint sits in the shared cache tier for now. With tool search on there is effectively always a deferred tool, so it could live in the longer-lived instructions tier, but conditional attachment-driven tools are hot and still force that tier to downgrade. A TODO marks moving it up once the hot tool set is reduced to a minimal curated set.

Applied to both the live client and the new model_constructors client for parity.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
