### PR TITLE
Improve Frame tool descriptions for tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -32,11 +32,11 @@ export const EXPORT_INTERACTIVE_CONTENT_FILE_TOOL_NAME =
 export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
   [CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
-      "Create a new Interactive Content file that users can execute or interact with. Use this for " +
-      "content that provides functionality beyond static viewing. Validation (Tailwind, TypeScript) " +
-      "is non-blocking: the file is saved even with warnings, which you should fix immediately using " +
-      "targeted edits. Supports two creation modes: template-based (fetch content from existing node) " +
-      "or inline (provide content directly).",
+      "Create a new Frame: interactive content such as a dashboard, data visualization, or slideshow " +
+      "presentation that users can run and interact with, beyond static viewing. Choose 'template' " +
+      "mode to base it on an existing knowledge node, or 'inline' mode to provide the content " +
+      "directly. Validation (Tailwind, TypeScript) is non-blocking: the file is saved even with " +
+      "warnings, which you should fix immediately.",
     schema: {
       file_name: z
         .string()
@@ -90,20 +90,14 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
   },
   [EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
-      "Modifies content within an Interactive Content file by substituting specified text segments. " +
-      "Each edit creates a new version of the Interactive Content file. " +
-      "Performs single substitution by default, or multiple substitutions when " +
-      "`expected_replacements` is defined. This function demands comprehensive contextual " +
-      "information surrounding the target modification to ensure accurate targeting. " +
-      `Use the ${RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME} tool to review the file's ` +
-      "existing content prior to executing any text substitution. Requirements: " +
-      "1. `old_string` MUST contain the precise literal content for substitution " +
-      "(preserving all spacing, formatting, line breaks). " +
-      "2. `new_string` MUST contain the exact replacement content maintaining proper syntax. " +
-      "3. Include minimum 3 lines of surrounding context BEFORE and AFTER the target " +
-      "content for unique identification. " +
-      "**Critical:** Multiple matches or inexact matches will cause failure. " +
-      "Validation (Tailwind, TypeScript) is non-blocking: warnings are returned but the edit succeeds.",
+      "Edit an existing Frame: change its code, for example to fix a chart, adjust colors, or " +
+      "update text and layout. Replaces a specified text segment with new text; each edit creates " +
+      "a new version. " +
+      `Use the ${RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME} tool first to read the current text ` +
+      "to replace. `old_string` must match the existing text exactly (including all spacing, " +
+      "formatting, and line breaks), with at least 3 lines of surrounding context before and after " +
+      "so the match is unique; `new_string` is the exact replacement. Inexact or multiple matches " +
+      "fail unless `expected_replacements` is set. Validation (Tailwind, TypeScript) is non-blocking.",
     schema: {
       description: z
         .string()
@@ -148,7 +142,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
   },
   [REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
-      "Resets an Interactive Content file to its previous version. " +
+      "Revert a Frame to its previous version. " +
       "Each revert goes back one version in the file's history. ",
     schema: {
       file_id: z
@@ -166,7 +160,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
   },
   [RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
-      "Rename an Interactive Content file. Use this to change the file name while keeping the content unchanged.",
+      "Rename a Frame. Use this to change the file name of a Frame while keeping its content unchanged.",
     schema: {
       file_id: z
         .string()
@@ -188,9 +182,9 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
   },
   [RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
-      "Retrieve the current content of an existing Interactive Content file by its file ID. " +
-      "Use this to read back the content of Interactive Content files you have previously created " +
-      `or updated. Use this tool before calling ${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME} to ` +
+      "Read back the current content of an existing Frame by its file ID. " +
+      "Use this to inspect a Frame you have previously created " +
+      `or edited. Use this tool before calling ${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME} to ` +
       "understand the current file state and identify the exact text to replace.",
     schema: {
       file_id: z
@@ -208,7 +202,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
   },
   [GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME]: {
     description:
-      "Get the share URL for an Interactive Content file. Returns the share URL if the file is " +
+      "Get the share URL (share link) for a Frame. Returns the share URL if the Frame is " +
       "currently shared.",
     schema: {
       file_id: z
@@ -226,7 +220,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
   },
   [EXPORT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
-      "Export an Interactive Content file as a PNG screenshot or PDF document. " +
+      "Export a Frame as a PNG screenshot or PDF document. " +
       "PNG returns a visual snapshot of the rendered frame. " +
       "PDF renders the frame with optional orientation (portrait/landscape for regular frames, " +
       "landscape by default for slideshows).",

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -570,6 +570,52 @@ export const QUERIES: LabeledQuery[] = [
     expected: "salesforce.read_attachment",
   },
 
+  // --- interactive_content (frames) ---
+  {
+    query: "create an interactive dashboard frame",
+    expected: "interactive_content.create_interactive_content_file",
+  },
+  {
+    query: "build a data visualization to display",
+    expected: "interactive_content.create_interactive_content_file",
+  },
+  {
+    query: "make a slideshow presentation",
+    expected: "interactive_content.create_interactive_content_file",
+  },
+  {
+    query: "edit the code of my frame",
+    expected: "interactive_content.edit_interactive_content_file",
+  },
+  {
+    query: "change the chart colors in my dashboard",
+    expected: "interactive_content.edit_interactive_content_file",
+  },
+  {
+    query: "read back the content of my frame",
+    expected: "interactive_content.retrieve_interactive_content_file",
+  },
+  {
+    query: "revert my frame to the previous version",
+    expected: "interactive_content.revert_interactive_content_file",
+  },
+  {
+    query: "rename my frame file",
+    expected: "interactive_content.rename_interactive_content_file",
+  },
+  {
+    query: "get the share link for my dashboard",
+    expected: "interactive_content.get_interactive_content_file_share_url",
+  },
+  {
+    query: "export my frame as a pdf",
+    expected: "interactive_content.export_interactive_content_file",
+  },
+  {
+    query: "download a png screenshot of my dashboard",
+    expected: "interactive_content.export_interactive_content_file",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -16,6 +16,7 @@ import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/m
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
 import { HUBSPOT_SERVER } from "@app/lib/api/actions/servers/hubspot/metadata";
+import { INTERACTIVE_CONTENT_SERVER } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
@@ -41,6 +42,7 @@ const SERVERS: ServerEntry[] = [
   { name: "confluence", tools: CONFLUENCE_SERVER.tools },
   { name: "hubspot", tools: HUBSPOT_SERVER.tools },
   { name: "salesforce", tools: SALESFORCE_SERVER.tools },
+  { name: "interactive_content", tools: INTERACTIVE_CONTENT_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This improves how the Frame server's tools are retrieved by Anthropic's tool search, which ranks tools lexically over each tool's name, description, and input schema. The most important problem was that users (and us) call these artifacts "Frame"everywhere in the product, yet every tool description called them "Interactive Content file", a phrase nobody types. Because the word Frame only lived in the display labels, which the index never sees, requests phrased around a frame had nothing distinctive to match and the whole server ranked low. Each description now leads with its action verb and the word Frame so intent maps to the right tool.

The second problem was internal competition. The create tool had a long, keyword-dense description that acted as a magnet, and it even mentioned editing, so edit, read, and rename requests were all being pulled toward create instead. The edit tool was the longest in the server and repeated the same generic words many times, which under length normalization buried it even though it held the only terms that actually distinguished it, like changing a chart or its colors. Tightening create so it stops advertising other actions, and trimming edit down to its meaningful vocabulary while keeping the exact-match editing mechanics intact, resolved the collisions.

With these changes every Frame intent now retrieves its correct tool as the top result, up from roughly two thirds before, with no relaxed ranking tolerance needed. The change also registers the Frame server and its labeled queries in the existing retrieval diagnostic so this coverage is exercised alongside the other reviewed servers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
