### PR TITLE
Rename pod -> space for sandbox functions

### DIFF
--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -53,7 +53,7 @@ describe("SandboxFunctionResource", () => {
     );
 
     expect(sandboxFunction.sId).toMatch(/^sfn_/);
-    expect(sandboxFunction.podId).toBe(pod.id);
+    expect(sandboxFunction.spaceId).toBe(pod.id);
     expect(sandboxFunction.fileId).toBe(file.id);
     expect(sandboxFunction.inputSchema).toEqual(inputSchema);
     expect(sandboxFunction.outputSchema).toEqual(outputSchema);

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -28,24 +28,24 @@ const outputSchema: JSONSchema = {
 };
 
 describe("SandboxFunctionResource", () => {
-  it("creates and fetches a sandbox function for a Pod", async () => {
+  it("creates and fetches a sandbox function for a space", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
-    const pod = await SpaceFactory.project(workspace);
+    const space = await SpaceFactory.project(workspace);
     const file = await FileFactory.create(authenticator, null, {
       contentType: sandboxFunctionContentType,
       fileName: "comments.ts",
       fileSize: 100,
       status: "created",
       useCase: "project_context",
-      useCaseMetadata: { spaceId: pod.sId },
+      useCaseMetadata: { spaceId: space.sId },
     });
 
     const sandboxFunction = await SandboxFunctionResource.makeNew(
       authenticator,
       {
-        pod,
+        space,
         file,
         inputSchema,
         outputSchema,
@@ -53,7 +53,7 @@ describe("SandboxFunctionResource", () => {
     );
 
     expect(sandboxFunction.sId).toMatch(/^sfn_/);
-    expect(sandboxFunction.spaceId).toBe(pod.id);
+    expect(sandboxFunction.spaceId).toBe(space.id);
     expect(sandboxFunction.fileId).toBe(file.id);
     expect(sandboxFunction.inputSchema).toEqual(inputSchema);
     expect(sandboxFunction.outputSchema).toEqual(outputSchema);
@@ -63,26 +63,29 @@ describe("SandboxFunctionResource", () => {
       sandboxFunction.sId
     );
     expect(fetched?.id).toBe(sandboxFunction.id);
-    expect(fetched?.pod.id).toBe(pod.id);
+    expect(fetched?.space.id).toBe(space.id);
 
-    const listed = await SandboxFunctionResource.listByPod(authenticator, pod);
+    const listed = await SandboxFunctionResource.listBySpace(
+      authenticator,
+      space
+    );
     expect(listed.map(({ id }) => id)).toEqual([sandboxFunction.id]);
-    expect(listed.map(({ pod }) => pod.id)).toEqual([pod.id]);
+    expect(listed.map(({ space }) => space.id)).toEqual([space.id]);
   });
 
-  it("only fetches sandbox functions from accessible Pods", async () => {
+  it("only fetches sandbox functions from accessible spaces", async () => {
     const { authenticator: adminAuth, workspace } = await createResourceTest({
       role: "admin",
     });
-    const accessiblePod = await SpaceFactory.project(workspace);
-    const restrictedPod = await SpaceFactory.project(workspace);
+    const accessibleSpace = await SpaceFactory.project(workspace);
+    const restrictedSpace = await SpaceFactory.project(workspace);
     const accessibleFile = await FileFactory.create(adminAuth, null, {
       contentType: sandboxFunctionContentType,
       fileName: "accessible.ts",
       fileSize: 100,
       status: "created",
       useCase: "project_context",
-      useCaseMetadata: { spaceId: accessiblePod.sId },
+      useCaseMetadata: { spaceId: accessibleSpace.sId },
     });
     const restrictedFile = await FileFactory.create(adminAuth, null, {
       contentType: sandboxFunctionContentType,
@@ -90,12 +93,12 @@ describe("SandboxFunctionResource", () => {
       fileSize: 100,
       status: "created",
       useCase: "project_context",
-      useCaseMetadata: { spaceId: restrictedPod.sId },
+      useCaseMetadata: { spaceId: restrictedSpace.sId },
     });
     const accessibleSandboxFunction = await SandboxFunctionResource.makeNew(
       adminAuth,
       {
-        pod: accessiblePod,
+        space: accessibleSpace,
         file: accessibleFile,
         inputSchema,
         outputSchema,
@@ -104,7 +107,7 @@ describe("SandboxFunctionResource", () => {
     const restrictedSandboxFunction = await SandboxFunctionResource.makeNew(
       adminAuth,
       {
-        pod: restrictedPod,
+        space: restrictedSpace,
         file: restrictedFile,
         inputSchema,
         outputSchema,
@@ -113,12 +116,10 @@ describe("SandboxFunctionResource", () => {
 
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
-    const addMemberResult = await accessiblePod.groups[0].dangerouslyAddMember(
-      adminAuth,
-      {
+    const addMemberResult =
+      await accessibleSpace.groups[0].dangerouslyAddMember(adminAuth, {
         user: user.toJSON(),
-      }
-    );
+      });
     expect(addMemberResult.isOk()).toBe(true);
 
     const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -134,23 +135,25 @@ describe("SandboxFunctionResource", () => {
       SandboxFunctionResource.fetchById(userAuth, accessibleSandboxFunction.sId)
     ).resolves.toMatchObject({
       id: accessibleSandboxFunction.id,
-      pod: expect.objectContaining({ id: accessiblePod.id }),
+      space: expect.objectContaining({ id: accessibleSpace.id }),
     });
     await expect(
       SandboxFunctionResource.fetchById(userAuth, restrictedSandboxFunction.sId)
     ).resolves.toBeNull();
 
-    const accessibleList = await SandboxFunctionResource.listByPod(
+    const accessibleList = await SandboxFunctionResource.listBySpace(
       userAuth,
-      accessiblePod
+      accessibleSpace
     );
     expect(accessibleList.map(({ id }) => id)).toEqual([
       accessibleSandboxFunction.id,
     ]);
-    expect(accessibleList.map(({ pod }) => pod.id)).toEqual([accessiblePod.id]);
+    expect(accessibleList.map(({ space }) => space.id)).toEqual([
+      accessibleSpace.id,
+    ]);
 
     await expect(
-      SandboxFunctionResource.listByPod(userAuth, restrictedPod)
+      SandboxFunctionResource.listBySpace(userAuth, restrictedSpace)
     ).resolves.toEqual([]);
 
     await expect(
@@ -160,11 +163,11 @@ describe("SandboxFunctionResource", () => {
       )
     ).resolves.toMatchObject({
       id: restrictedSandboxFunction.id,
-      pod: expect.objectContaining({ id: restrictedPod.id }),
+      space: expect.objectContaining({ id: restrictedSpace.id }),
     });
   });
 
-  it("rejects a non-Pod space", async () => {
+  it("rejects a non-project space", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
@@ -180,19 +183,19 @@ describe("SandboxFunctionResource", () => {
 
     await expect(
       SandboxFunctionResource.makeNew(authenticator, {
-        pod: regularSpace,
+        space: regularSpace,
         file,
         inputSchema,
         outputSchema,
       })
-    ).rejects.toThrow("Sandbox functions can only belong to Pod spaces.");
+    ).rejects.toThrow("Sandbox functions can only belong to project spaces.");
   });
 
   it("rejects a file outside project context", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
-    const pod = await SpaceFactory.project(workspace);
+    const space = await SpaceFactory.project(workspace);
     const file = await FileFactory.create(authenticator, null, {
       contentType: sandboxFunctionContentType,
       fileName: "comments.ts",
@@ -203,7 +206,7 @@ describe("SandboxFunctionResource", () => {
 
     await expect(
       SandboxFunctionResource.makeNew(authenticator, {
-        pod,
+        space,
         file,
         inputSchema,
         outputSchema,
@@ -215,19 +218,19 @@ describe("SandboxFunctionResource", () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
-    const pod = await SpaceFactory.project(workspace);
+    const space = await SpaceFactory.project(workspace);
     const file = await FileFactory.create(authenticator, null, {
       contentType: sandboxFunctionContentType,
       fileName: "comments.ts",
       fileSize: 100,
       status: "created",
       useCase: "project_context",
-      useCaseMetadata: { spaceId: pod.sId },
+      useCaseMetadata: { spaceId: space.sId },
     });
 
     await expect(
       SandboxFunctionResource.makeNew(authenticator, {
-        pod,
+        space,
         file,
         inputSchema: { type: "number", multipleOf: 0 },
         outputSchema,
@@ -246,32 +249,32 @@ describe("SandboxFunctionResource", () => {
     );
   });
 
-  it("deletes all sandbox functions for a Pod", async () => {
+  it("deletes all sandbox functions for a space", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
-    const pod = await SpaceFactory.project(workspace);
+    const space = await SpaceFactory.project(workspace);
     const file = await FileFactory.create(authenticator, null, {
       contentType: sandboxFunctionContentType,
       fileName: "comments.ts",
       fileSize: 100,
       status: "created",
       useCase: "project_context",
-      useCaseMetadata: { spaceId: pod.sId },
+      useCaseMetadata: { spaceId: space.sId },
     });
     const sandboxFunction = await SandboxFunctionResource.makeNew(
       authenticator,
       {
-        pod,
+        space,
         file,
         inputSchema,
         outputSchema,
       }
     );
 
-    const deleteResult = await SandboxFunctionResource.deleteAllForPod(
+    const deleteResult = await SandboxFunctionResource.deleteAllForSpace(
       authenticator,
-      pod
+      space
     );
 
     expect(deleteResult.isOk()).toBe(true);
@@ -285,21 +288,21 @@ describe("SandboxFunctionResource", () => {
     ).resolves.toBeNull();
   });
 
-  it("refuses to delete when the user cannot access the Pod", async () => {
+  it("refuses to delete when the user cannot access the space", async () => {
     const { authenticator: adminAuth, workspace } = await createResourceTest({
       role: "admin",
     });
-    const pod = await SpaceFactory.project(workspace);
+    const space = await SpaceFactory.project(workspace);
     const file = await FileFactory.create(adminAuth, null, {
       contentType: sandboxFunctionContentType,
       fileName: "comments.ts",
       fileSize: 100,
       status: "created",
       useCase: "project_context",
-      useCaseMetadata: { spaceId: pod.sId },
+      useCaseMetadata: { spaceId: space.sId },
     });
     const sandboxFunction = await SandboxFunctionResource.makeNew(adminAuth, {
-      pod,
+      space,
       file,
       inputSchema,
       outputSchema,
@@ -320,7 +323,7 @@ describe("SandboxFunctionResource", () => {
 
     expect(deleteResult.isErr()).toBe(true);
     expect(deleteResult.isErr() ? deleteResult.error.message : null).toBe(
-      "Sandbox function Pod is not accessible."
+      "Sandbox function space is not accessible."
     );
     await expect(
       SandboxFunctionResource.fetchById(adminAuth, sandboxFunction.sId)

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -72,7 +72,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   ): Promise<SandboxFunctionResource> {
     assert(
       space.isProject(),
-      "Sandbox functions can only belong to project spaces."
+      "Sandbox functions can only belong to pods."
     );
     assert(
       space.workspaceId === auth.getNonNullableWorkspace().id,
@@ -187,7 +187,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   ): Promise<Result<number, Error>> {
     assert(
       space.isProject(),
-      "Sandbox functions can only belong to project spaces."
+      "Sandbox functions can only belong to pods."
     );
 
     const sandboxFunctions = await this.listBySpace(auth, space);

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -95,7 +95,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     const sandboxFunction = await this.model.create(
       {
         workspaceId: auth.getNonNullableWorkspace().id,
-        podId: pod.id,
+        spaceId: pod.id,
         fileId: file.id,
         inputSchema,
         outputSchema,
@@ -123,7 +123,9 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       auth,
       Array.from(
         new Set(
-          sandboxFunctions.map((sandboxFunction) => sandboxFunction.get().podId)
+          sandboxFunctions.map(
+            (sandboxFunction) => sandboxFunction.get().spaceId
+          )
         )
       )
     );
@@ -134,7 +136,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     );
 
     return sandboxFunctions.flatMap((sandboxFunction) => {
-      const pod = accessiblePodsById.get(sandboxFunction.get().podId);
+      const pod = accessiblePodsById.get(sandboxFunction.get().spaceId);
       if (!pod) {
         return [];
       }
@@ -171,7 +173,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       return [];
     }
 
-    return this.baseFetch(auth, { where: { podId: pod.id } });
+    return this.baseFetch(auth, { where: { spaceId: pod.id } });
   }
 
   static async deleteAllForPod(

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -70,10 +70,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionResource> {
-    assert(
-      space.isProject(),
-      "Sandbox functions can only belong to pods."
-    );
+    assert(space.isProject(), "Sandbox functions can only belong to pods.");
     assert(
       space.workspaceId === auth.getNonNullableWorkspace().id,
       "The space must belong to the authenticated workspace."
@@ -185,10 +182,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     auth: Authenticator,
     space: SpaceResource
   ): Promise<Result<number, Error>> {
-    assert(
-      space.isProject(),
-      "Sandbox functions can only belong to pods."
-    );
+    assert(space.isProject(), "Sandbox functions can only belong to pods.");
 
     const sandboxFunctions = await this.listBySpace(auth, space);
     for (const sandboxFunction of sandboxFunctions) {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -27,15 +27,15 @@ export interface SandboxFunctionResource
 export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> {
   static model: ModelStaticWorkspaceAware<SandboxFunctionModel> =
     SandboxFunctionModel;
-  pod: SpaceResource;
+  space: SpaceResource;
 
   constructor(
     model: ModelStaticWorkspaceAware<SandboxFunctionModel>,
     blob: Attributes<SandboxFunctionModel>,
-    pod: SpaceResource
+    space: SpaceResource
   ) {
     super(model, blob);
-    this.pod = pod;
+    this.space = space;
   }
 
   get sId(): string {
@@ -58,22 +58,25 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   static async makeNew(
     auth: Authenticator,
     {
-      pod,
+      space,
       file,
       inputSchema,
       outputSchema,
     }: {
-      pod: SpaceResource;
+      space: SpaceResource;
       file: FileResource;
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionResource> {
-    assert(pod.isProject(), "Sandbox functions can only belong to Pod spaces.");
     assert(
-      pod.workspaceId === auth.getNonNullableWorkspace().id,
-      "The Pod must belong to the authenticated workspace."
+      space.isProject(),
+      "Sandbox functions can only belong to project spaces."
+    );
+    assert(
+      space.workspaceId === auth.getNonNullableWorkspace().id,
+      "The space must belong to the authenticated workspace."
     );
     assert(
       file.workspaceId === auth.getNonNullableWorkspace().id,
@@ -88,14 +91,14 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       "The file must use the project_context use case."
     );
     assert(
-      file.useCaseMetadata?.spaceId === pod.sId,
-      "The file must belong to the same Pod as the sandbox function."
+      file.useCaseMetadata?.spaceId === space.sId,
+      "The file must belong to the same space as the sandbox function."
     );
 
     const sandboxFunction = await this.model.create(
       {
         workspaceId: auth.getNonNullableWorkspace().id,
-        spaceId: pod.id,
+        spaceId: space.id,
         fileId: file.id,
         inputSchema,
         outputSchema,
@@ -103,7 +106,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       { transaction }
     );
 
-    return new this(this.model, sandboxFunction.get(), pod);
+    return new this(this.model, sandboxFunction.get(), space);
   }
 
   private static async baseFetch(
@@ -119,7 +122,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       ...rest,
     });
 
-    const pods = await SpaceResource.fetchByModelIds(
+    const spaces = await SpaceResource.fetchByModelIds(
       auth,
       Array.from(
         new Set(
@@ -129,19 +132,21 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         )
       )
     );
-    const accessiblePodsById = new Map(
-      pods
-        .filter((pod) => pod.isProject() && pod.canReadOrAdministrate(auth))
-        .map((pod) => [pod.id, pod])
+    const accessibleSpacesById = new Map(
+      spaces
+        .filter(
+          (space) => space.isProject() && space.canReadOrAdministrate(auth)
+        )
+        .map((space) => [space.id, space])
     );
 
     return sandboxFunctions.flatMap((sandboxFunction) => {
-      const pod = accessiblePodsById.get(sandboxFunction.get().spaceId);
-      if (!pod) {
+      const space = accessibleSpacesById.get(sandboxFunction.get().spaceId);
+      if (!space) {
         return [];
       }
 
-      return [new this(this.model, sandboxFunction.get(), pod)];
+      return [new this(this.model, sandboxFunction.get(), space)];
     });
   }
 
@@ -165,24 +170,27 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     return sandboxFunction ?? null;
   }
 
-  static async listByPod(
+  static async listBySpace(
     auth: Authenticator,
-    pod: SpaceResource
+    space: SpaceResource
   ): Promise<SandboxFunctionResource[]> {
-    if (!pod.isProject()) {
+    if (!space.isProject()) {
       return [];
     }
 
-    return this.baseFetch(auth, { where: { spaceId: pod.id } });
+    return this.baseFetch(auth, { where: { spaceId: space.id } });
   }
 
-  static async deleteAllForPod(
+  static async deleteAllForSpace(
     auth: Authenticator,
-    pod: SpaceResource
+    space: SpaceResource
   ): Promise<Result<number, Error>> {
-    assert(pod.isProject(), "Sandbox functions can only belong to Pod spaces.");
+    assert(
+      space.isProject(),
+      "Sandbox functions can only belong to project spaces."
+    );
 
-    const sandboxFunctions = await this.listByPod(auth, pod);
+    const sandboxFunctions = await this.listBySpace(auth, space);
     for (const sandboxFunction of sandboxFunctions) {
       // TODO(spolu): potentially optimize as this may be quite slow (each delete calls file delete
       // which deletes a whole bunch of records).
@@ -197,8 +205,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
     try {
-      if (!this.pod.canReadOrAdministrate(auth)) {
-        return new Err(new Error("Sandbox function Pod is not accessible."));
+      if (!this.space.canReadOrAdministrate(auth)) {
+        return new Err(new Error("Sandbox function space is not accessible."));
       }
 
       const file = await FileResource.fetchByModelIdWithAuth(auth, this.fileId);

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -89,7 +89,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     );
     assert(
       file.useCaseMetadata?.spaceId === space.sId,
-      "The file must belong to the same space as the sandbox function."
+      "The file must belong to the same pod as the sandbox function."
     );
 
     const sandboxFunction = await this.model.create(

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -27,7 +27,7 @@ export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionMod
   declare inputSchema: JSONSchema;
   declare outputSchema: JSONSchema;
 
-  declare pod: NonAttribute<SpaceModel>;
+  declare space: NonAttribute<SpaceModel>;
   declare file: NonAttribute<FileModel>;
 }
 
@@ -91,7 +91,7 @@ SandboxFunctionModel.init(
 SandboxFunctionModel.belongsTo(SpaceModel, {
   foreignKey: { name: "spaceId", allowNull: false },
   onDelete: "RESTRICT",
-  as: "pod",
+  as: "space",
 });
 
 SpaceModel.hasMany(SandboxFunctionModel, {

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -22,7 +22,7 @@ export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionMod
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare podId: ForeignKey<SpaceModel["id"]>;
+  declare spaceId: ForeignKey<SpaceModel["id"]>;
   declare fileId: ForeignKey<FileModel["id"]>;
   declare inputSchema: JSONSchema;
   declare outputSchema: JSONSchema;
@@ -43,7 +43,7 @@ SandboxFunctionModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    podId: {
+    spaceId: {
       type: DataTypes.BIGINT,
       allowNull: false,
     },
@@ -71,12 +71,12 @@ SandboxFunctionModel.init(
     sequelize: frontSequelize,
     indexes: [
       {
-        fields: ["workspaceId", "podId", "fileId"],
+        fields: ["workspaceId", "spaceId", "fileId"],
         unique: true,
         concurrently: true,
       },
       {
-        fields: ["podId"],
+        fields: ["spaceId"],
         concurrently: true,
       },
       {
@@ -89,13 +89,13 @@ SandboxFunctionModel.init(
 );
 
 SandboxFunctionModel.belongsTo(SpaceModel, {
-  foreignKey: { name: "podId", allowNull: false },
+  foreignKey: { name: "spaceId", allowNull: false },
   onDelete: "RESTRICT",
   as: "pod",
 });
 
 SpaceModel.hasMany(SandboxFunctionModel, {
-  foreignKey: { name: "podId", allowNull: false },
+  foreignKey: { name: "spaceId", allowNull: false },
   as: "sandboxFunctions",
 });
 

--- a/front/migrations/pre-deploy/20260627121000_rename_sandbox_functions_pod_id_to_space_id.sql
+++ b/front/migrations/pre-deploy/20260627121000_rename_sandbox_functions_pod_id_to_space_id.sql
@@ -1,0 +1,27 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions" RENAME COLUMN "podId" TO "spaceId";
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER INDEX "public"."sandbox_functions_pod_id" RENAME TO "sandbox_functions_space_id";
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER INDEX "public"."sandbox_functions_workspace_id_pod_id_file_id" RENAME TO "sandbox_functions_workspace_id_space_id_file_id";
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions" RENAME CONSTRAINT "sandbox_functions_podId_fkey" TO "sandbox_functions_spaceId_fkey";

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -162,7 +162,7 @@ export async function scrubSpaceActivity({
 
   if (space.isProject()) {
     const deleteSandboxFunctionsResult =
-      await SandboxFunctionResource.deleteAllForPod(auth, space);
+      await SandboxFunctionResource.deleteAllForSpace(auth, space);
     if (deleteSandboxFunctionsResult.isErr()) {
       throw deleteSandboxFunctionsResult.error;
     }


### PR DESCRIPTION
## Description

Rename podId to spaceId in model and code. Better aligned and future proof.

## Tests

Covered by tests

## Risk

Low

## Deploy Plan

- run pre-deploy migration
- deploy `front`