### PR TITLE
SandboxFunctionResource: load file at baseFetch

### DIFF
--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -57,6 +57,7 @@ describe("SandboxFunctionResource", () => {
     expect(sandboxFunction.fileId).toBe(file.id);
     expect(sandboxFunction.inputSchema).toEqual(inputSchema);
     expect(sandboxFunction.outputSchema).toEqual(outputSchema);
+    expect(sandboxFunction.file.id).toBe(file.id);
 
     const fetched = await SandboxFunctionResource.fetchById(
       authenticator,
@@ -64,6 +65,7 @@ describe("SandboxFunctionResource", () => {
     );
     expect(fetched?.id).toBe(sandboxFunction.id);
     expect(fetched?.space.id).toBe(space.id);
+    expect(fetched?.file.id).toBe(file.id);
 
     const listed = await SandboxFunctionResource.listBySpace(
       authenticator,
@@ -71,6 +73,7 @@ describe("SandboxFunctionResource", () => {
     );
     expect(listed.map(({ id }) => id)).toEqual([sandboxFunction.id]);
     expect(listed.map(({ space }) => space.id)).toEqual([space.id]);
+    expect(listed.map(({ file }) => file.id)).toEqual([file.id]);
   });
 
   it("only fetches sandbox functions from accessible spaces", async () => {
@@ -136,6 +139,7 @@ describe("SandboxFunctionResource", () => {
     ).resolves.toMatchObject({
       id: accessibleSandboxFunction.id,
       space: expect.objectContaining({ id: accessibleSpace.id }),
+      file: expect.objectContaining({ id: accessibleFile.id }),
     });
     await expect(
       SandboxFunctionResource.fetchById(userAuth, restrictedSandboxFunction.sId)
@@ -151,6 +155,9 @@ describe("SandboxFunctionResource", () => {
     expect(accessibleList.map(({ space }) => space.id)).toEqual([
       accessibleSpace.id,
     ]);
+    expect(accessibleList.map(({ file }) => file.id)).toEqual([
+      accessibleFile.id,
+    ]);
 
     await expect(
       SandboxFunctionResource.listBySpace(userAuth, restrictedSpace)
@@ -164,6 +171,7 @@ describe("SandboxFunctionResource", () => {
     ).resolves.toMatchObject({
       id: restrictedSandboxFunction.id,
       space: expect.objectContaining({ id: restrictedSpace.id }),
+      file: expect.objectContaining({ id: restrictedFile.id }),
     });
   });
 
@@ -188,7 +196,7 @@ describe("SandboxFunctionResource", () => {
         inputSchema,
         outputSchema,
       })
-    ).rejects.toThrow("Sandbox functions can only belong to project spaces.");
+    ).rejects.toThrow("Sandbox functions can only belong to pods.");
   });
 
   it("rejects a file outside project context", async () => {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -28,14 +28,17 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   static model: ModelStaticWorkspaceAware<SandboxFunctionModel> =
     SandboxFunctionModel;
   space: SpaceResource;
+  file: FileResource;
 
   constructor(
     model: ModelStaticWorkspaceAware<SandboxFunctionModel>,
     blob: Attributes<SandboxFunctionModel>,
-    space: SpaceResource
+    space: SpaceResource,
+    file: FileResource
   ) {
     super(model, blob);
     this.space = space;
+    this.file = file;
   }
 
   get sId(): string {
@@ -103,7 +106,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       { transaction }
     );
 
-    return new this(this.model, sandboxFunction.get(), space);
+    return new this(this.model, sandboxFunction.get(), space, file);
   }
 
   private static async baseFetch(
@@ -137,13 +140,26 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         .map((space) => [space.id, space])
     );
 
+    const files = await FileResource.fetchByModelIdsWithAuth(
+      auth,
+      Array.from(
+        new Set(
+          sandboxFunctions.map(
+            (sandboxFunction) => sandboxFunction.get().fileId
+          )
+        )
+      )
+    );
+    const filesById = new Map(files.map((file) => [file.id, file]));
+
     return sandboxFunctions.flatMap((sandboxFunction) => {
       const space = accessibleSpacesById.get(sandboxFunction.get().spaceId);
-      if (!space) {
+      const file = filesById.get(sandboxFunction.get().fileId);
+      if (!space || !file) {
         return [];
       }
 
-      return [new this(this.model, sandboxFunction.get(), space)];
+      return [new this(this.model, sandboxFunction.get(), space, file)];
     });
   }
 
@@ -203,11 +219,6 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         return new Err(new Error("Sandbox function space is not accessible."));
       }
 
-      const file = await FileResource.fetchByModelIdWithAuth(auth, this.fileId);
-      if (!file) {
-        return new Err(new Error("Sandbox function file not found."));
-      }
-
       await this.model.destroy({
         where: {
           id: this.id,
@@ -215,7 +226,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         },
       });
 
-      return file.delete(auth);
+      return this.file.delete(auth);
     } catch (error) {
       return new Err(normalizeError(error));
     }


### PR DESCRIPTION
## Description

Load FileResource on SandboxFunctionResource at baseFetch to save asyncs in many future places (already saves a load at delete).

## Tests

Covered by tests

## Risk

None

## Deploy Plan

N/A