### PR TITLE
Fix Gemini fallback models that are no longer routable

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
@@ -7,7 +7,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
-import { GEMINI_2_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
+import { GEMINI_3_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -104,8 +104,10 @@ function getFastModelConfigForSummarization(
   if (providers.has("anthropic")) {
     return CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG;
   }
+
   if (providers.has("google_ai_studio")) {
-    return GEMINI_2_5_FLASH_MODEL_CONFIG;
+    return GEMINI_3_5_FLASH_MODEL_CONFIG;
   }
+
   return getSmallWhitelistedModel(auth);
 }

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -21,7 +21,7 @@ import type {
 import { ConversationError } from "@app/types/assistant/conversation";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
-import { GEMINI_2_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
+import { GEMINI_3_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 import { GPT_5_1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
@@ -247,7 +247,7 @@ function getFastModelConfig(
     return CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG;
   }
   if (providers.has("google_ai_studio")) {
-    return GEMINI_2_5_FLASH_MODEL_CONFIG;
+    return GEMINI_3_5_FLASH_MODEL_CONFIG;
   }
 
   return getSmallWhitelistedModel(auth);

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -59,7 +59,6 @@ import {
 import {
   GEMINI_3_1_PRO_MODEL_CONFIG,
   GEMINI_3_5_FLASH_MODEL_CONFIG,
-  GEMINI_3_FLASH_MODEL_CONFIG,
 } from "@app/types/assistant/models/google_ai_studio";
 import { MISTRAL_MEDIUM_3_5_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
 import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
@@ -959,7 +958,7 @@ export function _getDustQuickGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST_QUICK,
     name: "dust-quick",
-    preferredModelConfiguration: GEMINI_3_FLASH_MODEL_CONFIG,
+    preferredModelConfiguration: GEMINI_3_5_FLASH_MODEL_CONFIG,
     preferredReasoningEffort: "light",
   });
 }
@@ -971,7 +970,7 @@ export function _getDustQuickMediumGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM,
     name: "dust-quick-medium",
-    preferredModelConfiguration: GEMINI_3_FLASH_MODEL_CONFIG,
+    preferredModelConfiguration: GEMINI_3_5_FLASH_MODEL_CONFIG,
     preferredReasoningEffort: "medium",
   });
 }

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -7,9 +7,8 @@ import {
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import {
-  GEMINI_2_5_FLASH_MODEL_CONFIG,
   GEMINI_3_1_PRO_MODEL_CONFIG,
-  GEMINI_3_FLASH_MODEL_CONFIG,
+  GEMINI_3_5_FLASH_MODEL_CONFIG,
 } from "@app/types/assistant/models/google_ai_studio";
 import {
   MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
@@ -131,7 +130,7 @@ export function selectEnabledModel(
 
 const ORDERED_FAST_MODEL_CONFIGS: ModelConfigurationType[] = [
   MISTRAL_SMALL_MODEL_CONFIG,
-  GEMINI_2_5_FLASH_MODEL_CONFIG,
+  GEMINI_3_5_FLASH_MODEL_CONFIG,
 ];
 
 export function getFastestWhitelistedModel(
@@ -168,7 +167,7 @@ export function getLargeWhitelistedModel(
 const ORDERED_SMALL_MODEL_CONFIGS: ModelConfigurationType[] = [
   GPT_5_MINI_MODEL_CONFIG,
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
-  GEMINI_3_FLASH_MODEL_CONFIG,
+  GEMINI_3_5_FLASH_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
   GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG,
 ];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/9270.

The fast and small model selectors, conversation title generation, web page summarization, and the `dust-quick` global agents all fell back to Gemini 2.5 Flash (and 3 Flash in a couple of spots) for workspaces where only Google was whitelisted.

Since Google routing was narrowed to Vertex, those model ids no longer resolve to a client and any request that selected them failed at runtime with "Model not supported". This swaps every one of those fallbacks to Gemini 3.5 Flash, which is routable through both the legacy Vertex path and the new router, restoring builder suggestions, title generation, and summarization for Google-only workspaces. Note this only fixes the internal selectors.

@adrsimon @pmilliotte some thoughts:
There is still an underlying gap here: a model can still pass the enablement check while having no routable endpoint, so an agent explicitly configured on an unroutable Gemini will still fail. Worth a follow-up to align model availability with actual routability.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
