### PR TITLE
Cut sandbox reads over to sandbox owners

### DIFF
--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -53,7 +53,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import {
-  ConversationSandboxModel,
   SandboxModel,
   SandboxOwnerModel,
 } from "@app/lib/resources/storage/models/sandbox";
@@ -238,7 +237,7 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
     expect(reloaded?.status).toBe("deleted");
   });
 
-  it("does not fall back to the legacy conversationId column when ownership is missing", async () => {
+  it("does not operate on a sandbox when ownership is missing", async () => {
     const sandbox = await SandboxFactory.create(
       authenticator,
       conversationResource.toJSON(),
@@ -252,7 +251,6 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
       workspaceId: authenticator.getNonNullableWorkspace().id,
     };
     await SandboxOwnerModel.destroy({ where });
-    await ConversationSandboxModel.destroy({ where });
 
     const result = await SandboxResource.dangerouslyDestroyIfSleeping(
       authenticator,
@@ -392,7 +390,7 @@ describe("SandboxResource.dangerouslyGetKillRequestedSandboxes", () => {
   });
 
   it("returns rows with killRequestedAt set and status != deleted", async () => {
-    await SandboxFactory.create(authenticator, conversation, {
+    const sandbox = await SandboxFactory.create(authenticator, conversation, {
       status: "running",
       killRequestedAt: new Date(),
     });
@@ -402,7 +400,7 @@ describe("SandboxResource.dangerouslyGetKillRequestedSandboxes", () => {
     });
 
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.conversationId).toBe(conversation.id);
+    expect(rows[0]?.id).toBe(sandbox.id);
   });
 
   it("skips deleted rows even when killRequestedAt is set", async () => {
@@ -587,15 +585,9 @@ describe("SandboxResource.fetchByConversation", () => {
     });
   }
 
-  it("reads from conversation_sandboxes even when the legacy conversationId column disagrees", async () => {
+  it("reads from sandbox_owners", async () => {
     const conversation = await makeConversation();
-    const otherConversation = await makeConversation();
     const sandbox = await SandboxFactory.create(authenticator, conversation);
-
-    await SandboxModel.update(
-      { conversationId: otherConversation.id },
-      { where: { id: sandbox.id } }
-    );
 
     const fetched = await SandboxResource.fetchByConversation(
       authenticator,
@@ -605,7 +597,7 @@ describe("SandboxResource.fetchByConversation", () => {
     expect(fetched?.id).toBe(sandbox.id);
   });
 
-  it("writes both ownership tables", async () => {
+  it("writes sandbox_owners", async () => {
     const conversation = await makeConversation();
     const sandbox = await SandboxFactory.create(authenticator, conversation);
     const where = {
@@ -613,27 +605,7 @@ describe("SandboxResource.fetchByConversation", () => {
       workspaceId: authenticator.getNonNullableWorkspace().id,
     };
 
-    await expect(ConversationSandboxModel.count({ where })).resolves.toBe(1);
     await expect(SandboxOwnerModel.count({ where })).resolves.toBe(1);
-  });
-
-  it("falls back to conversation_sandboxes during the migration window", async () => {
-    const conversation = await makeConversation();
-    const sandbox = await SandboxFactory.create(authenticator, conversation);
-
-    await SandboxOwnerModel.destroy({
-      where: {
-        sandboxId: sandbox.id,
-        workspaceId: authenticator.getNonNullableWorkspace().id,
-      },
-    });
-
-    const fetched = await SandboxResource.fetchByConversation(
-      authenticator,
-      conversation
-    );
-
-    expect(fetched?.id).toBe(sandbox.id);
   });
 
   it("returns null when no ownership row exists", async () => {
@@ -645,10 +617,6 @@ describe("SandboxResource.fetchByConversation", () => {
     };
 
     await SandboxOwnerModel.destroy({ where });
-
-    await ConversationSandboxModel.destroy({
-      where,
-    });
 
     const fetched = await SandboxResource.fetchByConversation(
       authenticator,
@@ -843,7 +811,7 @@ describe("SandboxResource.ensureActive", () => {
     expect(persisted?.baseImage).toBe("test-image");
     expect(persisted?.version).toBe("0.0.1");
 
-    const link = await ConversationSandboxModel.findOne({
+    const link = await SandboxOwnerModel.findOne({
       where: {
         conversationId: conversation.id,
         workspaceId: authenticator.getNonNullableWorkspace().id,

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -22,7 +22,6 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import {
-  ConversationSandboxModel,
   SandboxModel,
   SandboxOwnerModel,
 } from "@app/lib/resources/storage/models/sandbox";
@@ -59,8 +58,6 @@ export interface SandboxResource extends ReadonlyAttributesType<SandboxModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SandboxResource extends BaseResource<SandboxModel> {
   static model: ModelStaticWorkspaceAware<SandboxModel> = SandboxModel;
-  private static conversationSandboxModel: ModelStaticWorkspaceAware<ConversationSandboxModel> =
-    ConversationSandboxModel;
   private static sandboxOwnerModel: ModelStaticWorkspaceAware<SandboxOwnerModel> =
     SandboxOwnerModel;
 
@@ -136,15 +133,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           workspaceId,
           lastActivityAt: now,
           statusChangedAt: now,
-        },
-        { transaction: t }
-      );
-
-      await ConversationSandboxModel.create(
-        {
-          workspaceId,
-          conversationId: blob.conversationId,
-          sandboxId: sandbox.id,
         },
         { transaction: t }
       );
@@ -229,19 +217,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       },
     });
 
-    const link =
-      owner ??
-      (await this.conversationSandboxModel.findOne({
-        where: {
-          workspaceId: conversation.workspaceId,
-          conversationId: conversation.id,
-        },
-      }));
-
-    if (link) {
+    if (owner) {
       const sandbox = await this.model.findOne({
         where: {
-          id: link.sandboxId,
+          id: owner.sandboxId,
           workspaceId: conversation.workspaceId,
         },
       });
@@ -266,19 +245,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       },
     });
 
-    const link =
-      owner ??
-      (await this.conversationSandboxModel.findOne({
-        where: {
-          conversationId: conversation.id,
-          workspaceId,
-        },
-      }));
-
-    if (link) {
+    if (owner) {
       const sandboxes = await this.baseFetch(auth, {
         where: {
-          id: link.sandboxId,
+          id: owner.sandboxId,
         },
       });
 
@@ -331,22 +301,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         attributes: ["sandboxId", "conversationId"],
       });
 
-      const conversationRows = await this.conversationSandboxModel.findAll({
-        where: {
-          workspaceId: workspaceModelId,
-          sandboxId: {
-            [Op.in]: sandboxModelIds,
-          },
-        },
-        attributes: ["sandboxId", "conversationId"],
-      });
-
-      for (const row of conversationRows) {
-        conversationModelIdsBySandboxModelId.set(
-          row.sandboxId,
-          row.conversationId
-        );
-      }
       for (const row of ownerRows) {
         if (row.conversationId !== null) {
           conversationModelIdsBySandboxModelId.set(
@@ -409,14 +363,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         transaction: t,
       });
 
-      await ConversationSandboxModel.destroy({
-        where: {
-          sandboxId: this.id,
-          workspaceId,
-        },
-        transaction: t,
-      });
-
       return SandboxModel.destroy({
         where: {
           id: this.id,
@@ -467,14 +413,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         await SandboxOwnerModel.destroy({
           where: {
             sandboxId: sandbox.id,
-            workspaceId: auth.getNonNullableWorkspace().id,
-          },
-          transaction,
-        });
-
-        await ConversationSandboxModel.destroy({
-          where: {
-            conversationId: conversation.id,
             workspaceId: auth.getNonNullableWorkspace().id,
           },
           transaction,
@@ -1198,7 +1136,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     return {
       id: this.sId,
       workspaceId: this.workspaceId,
-      conversationId: this.conversationId,
       providerId: this.providerId,
       status: this.status,
       lastActivityAt: this.lastActivityAt.toISOString(),


### PR DESCRIPTION
## Description

Stacked on #28036. Removes runtime reads and writes from `conversation_sandboxes` after `sandbox_owners` has been created and backfilled.

Conversation sandbox create, fetch, delete, and reaper owner mapping now use `sandbox_owners` only. This PR also stops reading the legacy `sandboxes.conversationId` field from `SandboxResource` serialization and tests. The legacy `sandboxes.conversationId` column remains in the model until the cleanup PR so rollback remains possible during the cutover window.

Stack:
- PR 1: create `sandbox_owners`, dual write/read, and add the data migration script, #28036.
- PR 2: cut runtime usage over to `sandbox_owners`.
- PR 3: cleanup the legacy `conversation_sandboxes` table and `sandboxes.conversationId` column, #28078.
- Follow-ups: rebase the conversation boundary, space sandbox resource, and reaper PRs on top.

## Tests

- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && npx biome check --write --error-on-warnings front/lib/resources/sandbox_resource.ts front/lib/resources/sandbox_resource.test.ts`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_ENV=test npm test -- ./lib/resources/sandbox_resource.test.ts`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit`

## Risk

Medium-low. This should only merge after the PR1 deploy and backfill have completed. Rollback is safe while the legacy table and column still exist, but app rollback would temporarily return to the old ownership path.

## Deploy Plan

- [x] Merge after #28036 is deployed.
- [x] Confirm `front/migrations/20260627_backfill_sandbox_owners.ts --execute` completed with `missing=0` and `extra=0` in both regions.
- [ ] Deploy front with `sandbox_owners` as the only runtime ownership table.
