### PR TITLE
Drop conversation sandbox ownership table

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -121,7 +121,6 @@ import {
   RunUsageModel,
 } from "@app/lib/resources/storage/models/runs";
 import {
-  ConversationSandboxModel,
   SandboxModel,
   SandboxOwnerModel,
 } from "@app/lib/resources/storage/models/sandbox";
@@ -258,7 +257,6 @@ export function loadAllModels() {
     AcademyQuizAttemptModel,
     AcademyChapterVisitModel,
     SandboxModel,
-    ConversationSandboxModel,
     SandboxOwnerModel,
     ConversationBranchModel,
     ConversationForkModel,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -6838,12 +6838,10 @@ const KNOWN_CONVERSATION_RELATED_MODELS = [
   "conversation_mcp_server_view",
   "conversation_participant",
   "conversation_selected_spaces",
-  "conversation_sandbox",
   "conversation_skills",
   "data_source",
   "message",
   "project_todo_conversation",
-  "sandbox",
   "sandbox_owner",
   // skill_suggestion.notificationConversationId is ON DELETE SET NULL, so no
   // explicit cleanup is needed in destroyConversation — the DB clears it.

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -53,7 +53,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import {
-  ConversationSandboxModel,
   SandboxModel,
   SandboxOwnerModel,
 } from "@app/lib/resources/storage/models/sandbox";
@@ -238,7 +237,7 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
     expect(reloaded?.status).toBe("deleted");
   });
 
-  it("does not fall back to the legacy conversationId column when ownership is missing", async () => {
+  it("does not operate on a sandbox when ownership is missing", async () => {
     const sandbox = await SandboxFactory.create(
       authenticator,
       conversationResource.toJSON(),
@@ -252,7 +251,6 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
       workspaceId: authenticator.getNonNullableWorkspace().id,
     };
     await SandboxOwnerModel.destroy({ where });
-    await ConversationSandboxModel.destroy({ where });
 
     const result = await SandboxResource.dangerouslyDestroyIfSleeping(
       authenticator,
@@ -392,7 +390,7 @@ describe("SandboxResource.dangerouslyGetKillRequestedSandboxes", () => {
   });
 
   it("returns rows with killRequestedAt set and status != deleted", async () => {
-    await SandboxFactory.create(authenticator, conversation, {
+    const sandbox = await SandboxFactory.create(authenticator, conversation, {
       status: "running",
       killRequestedAt: new Date(),
     });
@@ -402,7 +400,7 @@ describe("SandboxResource.dangerouslyGetKillRequestedSandboxes", () => {
     });
 
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.conversationId).toBe(conversation.id);
+    expect(rows[0]?.id).toBe(sandbox.id);
   });
 
   it("skips deleted rows even when killRequestedAt is set", async () => {
@@ -587,15 +585,9 @@ describe("SandboxResource.fetchByConversation", () => {
     });
   }
 
-  it("reads from conversation_sandboxes even when the legacy conversationId column disagrees", async () => {
+  it("reads from sandbox_owners", async () => {
     const conversation = await makeConversation();
-    const otherConversation = await makeConversation();
     const sandbox = await SandboxFactory.create(authenticator, conversation);
-
-    await SandboxModel.update(
-      { conversationId: otherConversation.id },
-      { where: { id: sandbox.id } }
-    );
 
     const fetched = await SandboxResource.fetchByConversation(
       authenticator,
@@ -605,7 +597,7 @@ describe("SandboxResource.fetchByConversation", () => {
     expect(fetched?.id).toBe(sandbox.id);
   });
 
-  it("writes both ownership tables", async () => {
+  it("writes sandbox_owners", async () => {
     const conversation = await makeConversation();
     const sandbox = await SandboxFactory.create(authenticator, conversation);
     const where = {
@@ -613,27 +605,7 @@ describe("SandboxResource.fetchByConversation", () => {
       workspaceId: authenticator.getNonNullableWorkspace().id,
     };
 
-    await expect(ConversationSandboxModel.count({ where })).resolves.toBe(1);
     await expect(SandboxOwnerModel.count({ where })).resolves.toBe(1);
-  });
-
-  it("falls back to conversation_sandboxes during the migration window", async () => {
-    const conversation = await makeConversation();
-    const sandbox = await SandboxFactory.create(authenticator, conversation);
-
-    await SandboxOwnerModel.destroy({
-      where: {
-        sandboxId: sandbox.id,
-        workspaceId: authenticator.getNonNullableWorkspace().id,
-      },
-    });
-
-    const fetched = await SandboxResource.fetchByConversation(
-      authenticator,
-      conversation
-    );
-
-    expect(fetched?.id).toBe(sandbox.id);
   });
 
   it("returns null when no ownership row exists", async () => {
@@ -645,10 +617,6 @@ describe("SandboxResource.fetchByConversation", () => {
     };
 
     await SandboxOwnerModel.destroy({ where });
-
-    await ConversationSandboxModel.destroy({
-      where,
-    });
 
     const fetched = await SandboxResource.fetchByConversation(
       authenticator,
@@ -843,7 +811,7 @@ describe("SandboxResource.ensureActive", () => {
     expect(persisted?.baseImage).toBe("test-image");
     expect(persisted?.version).toBe("0.0.1");
 
-    const link = await ConversationSandboxModel.findOne({
+    const link = await SandboxOwnerModel.findOne({
       where: {
         conversationId: conversation.id,
         workspaceId: authenticator.getNonNullableWorkspace().id,

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -22,7 +22,6 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import {
-  ConversationSandboxModel,
   SandboxModel,
   SandboxOwnerModel,
 } from "@app/lib/resources/storage/models/sandbox";
@@ -59,8 +58,6 @@ export interface SandboxResource extends ReadonlyAttributesType<SandboxModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SandboxResource extends BaseResource<SandboxModel> {
   static model: ModelStaticWorkspaceAware<SandboxModel> = SandboxModel;
-  private static conversationSandboxModel: ModelStaticWorkspaceAware<ConversationSandboxModel> =
-    ConversationSandboxModel;
   private static sandboxOwnerModel: ModelStaticWorkspaceAware<SandboxOwnerModel> =
     SandboxOwnerModel;
 
@@ -136,15 +133,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           workspaceId,
           lastActivityAt: now,
           statusChangedAt: now,
-        },
-        { transaction: t }
-      );
-
-      await ConversationSandboxModel.create(
-        {
-          workspaceId,
-          conversationId: blob.conversationId,
-          sandboxId: sandbox.id,
         },
         { transaction: t }
       );
@@ -229,19 +217,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       },
     });
 
-    const link =
-      owner ??
-      (await this.conversationSandboxModel.findOne({
-        where: {
-          workspaceId: conversation.workspaceId,
-          conversationId: conversation.id,
-        },
-      }));
-
-    if (link) {
+    if (owner) {
       const sandbox = await this.model.findOne({
         where: {
-          id: link.sandboxId,
+          id: owner.sandboxId,
           workspaceId: conversation.workspaceId,
         },
       });
@@ -266,19 +245,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       },
     });
 
-    const link =
-      owner ??
-      (await this.conversationSandboxModel.findOne({
-        where: {
-          conversationId: conversation.id,
-          workspaceId,
-        },
-      }));
-
-    if (link) {
+    if (owner) {
       const sandboxes = await this.baseFetch(auth, {
         where: {
-          id: link.sandboxId,
+          id: owner.sandboxId,
         },
       });
 
@@ -331,22 +301,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         attributes: ["sandboxId", "conversationId"],
       });
 
-      const conversationRows = await this.conversationSandboxModel.findAll({
-        where: {
-          workspaceId: workspaceModelId,
-          sandboxId: {
-            [Op.in]: sandboxModelIds,
-          },
-        },
-        attributes: ["sandboxId", "conversationId"],
-      });
-
-      for (const row of conversationRows) {
-        conversationModelIdsBySandboxModelId.set(
-          row.sandboxId,
-          row.conversationId
-        );
-      }
       for (const row of ownerRows) {
         if (row.conversationId !== null) {
           conversationModelIdsBySandboxModelId.set(
@@ -409,14 +363,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         transaction: t,
       });
 
-      await ConversationSandboxModel.destroy({
-        where: {
-          sandboxId: this.id,
-          workspaceId,
-        },
-        transaction: t,
-      });
-
       return SandboxModel.destroy({
         where: {
           id: this.id,
@@ -467,14 +413,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         await SandboxOwnerModel.destroy({
           where: {
             sandboxId: sandbox.id,
-            workspaceId: auth.getNonNullableWorkspace().id,
-          },
-          transaction,
-        });
-
-        await ConversationSandboxModel.destroy({
-          where: {
-            conversationId: conversation.id,
             workspaceId: auth.getNonNullableWorkspace().id,
           },
           transaction,
@@ -1198,7 +1136,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     return {
       id: this.sId,
       workspaceId: this.workspaceId,
-      conversationId: this.conversationId,
       providerId: this.providerId,
       status: this.status,
       lastActivityAt: this.lastActivityAt.toISOString(),

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -125,11 +125,12 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   ) {
     const now = new Date();
     const workspaceId = auth.getNonNullableWorkspace().id;
+    const { conversationId, ...sandboxBlob } = blob;
 
     const createSandbox = async (t: Transaction) => {
       const sandbox = await this.model.create(
         {
-          ...blob,
+          ...sandboxBlob,
           workspaceId,
           lastActivityAt: now,
           statusChangedAt: now,
@@ -140,7 +141,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       await SandboxOwnerModel.create(
         {
           workspaceId,
-          conversationId: blob.conversationId,
+          conversationId,
           sandboxId: sandbox.id,
         },
         { transaction: t }

--- a/front/lib/resources/storage/models/sandbox.ts
+++ b/front/lib/resources/storage/models/sandbox.ts
@@ -15,9 +15,6 @@ export class SandboxModel extends WorkspaceAwareModel<SandboxModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  // TODO(2026-06-17 SANDBOX): Drop this legacy owner column once
-  // sandbox_owners fully replaces it.
-  declare conversationId: ForeignKey<ConversationModel["id"]> | null;
   declare providerId: string;
   declare status: SandboxStatus;
   declare statusChangedAt: CreationOptional<Date>;
@@ -25,9 +22,6 @@ export class SandboxModel extends WorkspaceAwareModel<SandboxModel> {
   declare baseImage: CreationOptional<string | null>;
   declare version: CreationOptional<string | null>;
   declare killRequestedAt: CreationOptional<Date | null>;
-
-  // Associations.
-  declare conversation: NonAttribute<ConversationModel>;
 }
 
 SandboxModel.init(
@@ -41,14 +35,6 @@ SandboxModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-    conversationId: {
-      type: DataTypes.BIGINT,
-      allowNull: true,
-      references: {
-        model: ConversationModel,
-        key: "id",
-      },
     },
     providerId: {
       type: DataTypes.STRING,
@@ -86,16 +72,6 @@ SandboxModel.init(
     sequelize: frontSequelize,
     indexes: [
       {
-        unique: true,
-        fields: ["workspaceId", "conversationId"],
-        name: "sandboxes_workspace_conversation_idx",
-      },
-      {
-        fields: ["conversationId"],
-        name: "sandboxes_conversation_id_idx",
-        concurrently: true,
-      },
-      {
         fields: ["status", "lastActivityAt"],
         name: "sandboxes_status_last_activity_idx",
       },
@@ -111,89 +87,6 @@ SandboxModel.init(
     ],
   }
 );
-
-ConversationModel.hasMany(SandboxModel, {
-  foreignKey: "conversationId",
-  onDelete: "RESTRICT",
-});
-
-SandboxModel.belongsTo(ConversationModel, {
-  foreignKey: "conversationId",
-});
-
-export class ConversationSandboxModel extends WorkspaceAwareModel<ConversationSandboxModel> {
-  declare createdAt: CreationOptional<Date>;
-  declare updatedAt: CreationOptional<Date>;
-
-  declare conversationId: ForeignKey<ConversationModel["id"]>;
-  declare sandboxId: ForeignKey<SandboxModel["id"]>;
-
-  declare conversation: NonAttribute<ConversationModel>;
-  declare sandbox: NonAttribute<SandboxModel>;
-}
-
-ConversationSandboxModel.init(
-  {
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    conversationId: {
-      type: DataTypes.BIGINT,
-      allowNull: false,
-    },
-    sandboxId: {
-      type: DataTypes.BIGINT,
-      allowNull: false,
-    },
-  },
-  {
-    modelName: "conversation_sandbox",
-    sequelize: frontSequelize,
-    indexes: [
-      {
-        unique: true,
-        fields: ["workspaceId", "conversationId"],
-        name: "conversation_sandboxes_workspace_conversation_idx",
-        concurrently: true,
-      },
-      {
-        unique: true,
-        fields: ["workspaceId", "sandboxId"],
-        name: "conversation_sandboxes_workspace_sandbox_idx",
-        concurrently: true,
-      },
-    ],
-  }
-);
-
-ConversationSandboxModel.belongsTo(ConversationModel, {
-  foreignKey: { name: "conversationId", allowNull: false },
-  onDelete: "RESTRICT",
-  as: "conversation",
-});
-
-ConversationModel.hasMany(ConversationSandboxModel, {
-  foreignKey: { name: "conversationId", allowNull: false },
-  as: "sandboxLinks",
-});
-
-ConversationSandboxModel.belongsTo(SandboxModel, {
-  foreignKey: { name: "sandboxId", allowNull: false },
-  onDelete: "RESTRICT",
-  as: "sandbox",
-});
-
-SandboxModel.hasOne(ConversationSandboxModel, {
-  foreignKey: { name: "sandboxId", allowNull: false },
-  as: "conversationLink",
-});
 
 export class SandboxOwnerModel extends WorkspaceAwareModel<SandboxOwnerModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/migrations/post-deploy/20260627110000_drop_conversation_sandboxes.sql
+++ b/front/migrations/post-deploy/20260627110000_drop_conversation_sandboxes.sql
@@ -1,0 +1,10 @@
+-- Drop the legacy conversation-specific sandbox ownership table.
+SET lock_timeout = '5s';
+
+DROP TABLE "public"."conversation_sandboxes";
+
+DROP INDEX CONCURRENTLY IF EXISTS "sandboxes_workspace_conversation_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "sandboxes_conversation_id_idx";
+
+ALTER TABLE "public"."sandboxes"
+  DROP COLUMN "conversationId";


### PR DESCRIPTION
## Description

Stacked on #28077. Drops the legacy conversation sandbox ownership storage after runtime reads and writes have moved to `sandbox_owners`.

This removes the `ConversationSandboxModel`, dev/test DB registration, the legacy `sandboxes.conversationId` field from `SandboxModel`, and the remaining tests that asserted legacy table behavior. The post-deploy migration drops `conversation_sandboxes`, the legacy sandbox conversation indexes, and the `sandboxes.conversationId` column.

Stack:
- PR 1: create `sandbox_owners`, dual write/read, and add the data migration script, #28036.
- PR 2: cut runtime usage over to `sandbox_owners`, #28077.
- PR 3: cleanup the legacy `conversation_sandboxes` table and `sandboxes.conversationId` column.
- Follow-ups: rebase the conversation boundary, space sandbox resource, and reaper PRs on top.

## Tests

- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && npx biome check --write --error-on-warnings front/lib/resources/storage/models/sandbox.ts front/lib/resources/sandbox_resource.ts front/lib/resources/sandbox_resource.test.ts front/lib/resources/conversation_resource.test.ts front/migrations/post-deploy/20260627110000_drop_conversation_sandboxes.sql`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_ENV=test npm test -- ./lib/resources/sandbox_resource.test.ts`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_ENV=test npm test -- ./lib/resources/conversation_resource.test.ts -t "conversation model relationship detection"`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_ENV=test npm test -- ./lib/resources/space_resource.test.ts -t "model relationship detection"`
- `source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit`
- Applied `front/migrations/post-deploy/20260627110000_drop_conversation_sandboxes.sql` against the Hive test DB after recreating the legacy table, indexes, and column; verified `sandboxes.conversationId` no longer exists.

## Risk

Medium. This should only merge after #28077 is deployed. Rollback after the post-deploy migration would require a forward migration to recreate the legacy table and column, so the previous PR must be stable first.

## Deploy Plan

- [ ] Merge after #28077 is deployed.
- [ ] Deploy front without the legacy model or `sandboxes.conversationId` field.
- [ ] Apply `front/migrations/post-deploy/20260627110000_drop_conversation_sandboxes.sql` in both regions.
!
