### PR TITLE
Fix interactive stdin in sandbox_exec.ts

### DIFF
--- a/front/scripts/sandbox_exec.ts
+++ b/front/scripts/sandbox_exec.ts
@@ -108,7 +108,6 @@ async function runInteractive(sandbox: Sandbox, command: string, user: string) {
   });
 
   stdin.setRawMode(true);
-  stdin.setEncoding("utf8");
 
   stdin.on("data", (data: Buffer) => {
     void sandbox.pty.sendInput(pty.pid, new Uint8Array(data));


### PR DESCRIPTION
## Problem

Running `sandbox_exec.ts` in interactive mode (no `-- command`) opens the PTY and logs `mode: interactive`, but typing has no effect — the shell is alive yet unresponsive.

## Cause

In `runInteractive`, `stdin.setEncoding("utf8")` makes the `data` event emit **strings**, but the handler treats `data` as a `Buffer` and calls `new Uint8Array(data)`. `new Uint8Array(<string>)` produces an empty array, so every keystroke was forwarded to the PTY as zero bytes.

```
new Uint8Array("abc") // → []
new Uint8Array(Buffer.from("abc")) // → [97, 98, 99]
```

The `-- ls` path was unaffected because a provided command is sent programmatically via `TextEncoder().encode(...)`, not through the stdin handler.

## Fix

Remove the `setEncoding("utf8")` call so `data` arrives as a `Buffer` (correct for raw mode), letting `new Uint8Array(data)` produce the right bytes.

## Testing

Manually verified that `npx tsx scripts/sandbox_exec.ts -s <id>` now accepts keyboard input in the interactive shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)