### PR TITLE
Add viz callFunction plumbing

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -15,7 +15,9 @@ import type {
   VisualizationRPCRequest,
 } from "@app/types/assistant/visualization";
 import { isVisualizationRPCRequest } from "@app/types/assistant/visualization";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import {
   AlertCircle,
   Button,
@@ -98,7 +100,7 @@ function useVisualizationDataHandler({
   createSandboxFunctionInvocation: (
     functionId: string,
     input?: unknown
-  ) => Promise<SandboxFunctionInvocationType>;
+  ) => Promise<Result<SandboxFunctionInvocationType, Error>>;
   getFileBlob: (fileId: string) => Promise<Blob | null>;
   onEditText?: EditTextFn;
   setCodeDrawerOpened: (v: SetStateAction<boolean>) => void;
@@ -163,26 +165,26 @@ function useVisualizationDataHandler({
 
       switch (data.command) {
         case "callFunction": {
-          // TODO(spolu): manage lifecycle of the function invocation.
-          try {
-            await createSandboxFunctionInvocation(
-              data.params.functionId,
-              data.params.input
-            );
-          } catch (error) {
+          const invocationRes = await createSandboxFunctionInvocation(
+            data.params.functionId,
+            data.params.input
+          );
+
+          if (invocationRes.isErr()) {
             sendResponseToIframe(
               data,
               {
                 result: null,
-                error:
-                  error instanceof Error
-                    ? error.message
-                    : "Failed to create sandbox function invocation.",
+                error: "Failed to call function: " + invocationRes.error.message,
               },
               event.source
             );
             break;
           }
+
+          // TODO(spolu): manage lifecycle of the function invocation, pulling events related to
+          // handle tools validations and returning the result to the iframe. For now, we just
+          // return a dummy result.
 
           sendResponseToIframe(
             data,
@@ -399,9 +401,11 @@ export const VisualizationActionIframe = forwardRef<
     async (
       functionId: string,
       input?: unknown
-    ): Promise<SandboxFunctionInvocationType> => {
+    ): Promise<Result<SandboxFunctionInvocationType, Error>> => {
       if (isPublic) {
-        throw new Error("Sandbox functions are not supported in shared frames.");
+        throw new Error(
+          "Sandbox functions are not supported in shared frames."
+        );
       }
 
       const body: PostSandboxFunctionInvocationRequestBody = {
@@ -429,13 +433,9 @@ export const VisualizationActionIframe = forwardRef<
         const result: PostSandboxFunctionInvocationResponseBody =
           await response.json();
 
-        return result.invocation;
+        return new Ok(result.invocation);
       } catch (error) {
-        throw new Error(
-          error instanceof Error
-            ? error.message
-            : "Failed to create sandbox function invocation."
-        );
+        return new Err(normalizeError(error));
       }
     },
     [frameFileId, isPublic, workspaceId]

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -175,7 +175,8 @@ function useVisualizationDataHandler({
               data,
               {
                 result: null,
-                error: "Failed to call function: " + invocationRes.error.message,
+                error:
+                  "Failed to call function: " + invocationRes.error.message,
               },
               event.source
             );

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -1,7 +1,13 @@
 import { useVisualizationRetry } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
+import { getErrorFromResponse } from "@app/lib/swr/swr";
 import datadogLogger from "@app/logger/datadogLogger";
+import type {
+  PostSandboxFunctionInvocationRequestBody,
+  PostSandboxFunctionInvocationResponseBody,
+  SandboxFunctionInvocationType,
+} from "@app/types/api/sandbox/functions";
 import type {
   CommandResultMap,
   EditTextFn,
@@ -80,6 +86,7 @@ const getExtensionFromBlob = (blob: Blob): string => {
 
 // Custom hook to encapsulate the logic for handling visualization messages.
 function useVisualizationDataHandler({
+  createSandboxFunctionInvocation,
   getFileBlob,
   onEditText,
   setCodeDrawerOpened,
@@ -88,6 +95,10 @@ function useVisualizationDataHandler({
   visualization,
   vizIframeRef,
 }: {
+  createSandboxFunctionInvocation: (
+    functionId: string,
+    input?: unknown
+  ) => Promise<SandboxFunctionInvocationType>;
   getFileBlob: (fileId: string) => Promise<Blob | null>;
   onEditText?: EditTextFn;
   setCodeDrawerOpened: (v: SetStateAction<boolean>) => void;
@@ -151,6 +162,36 @@ function useVisualizationDataHandler({
       }
 
       switch (data.command) {
+        case "callFunction": {
+          // TODO(spolu): manage lifecycle of the function invocation.
+          try {
+            await createSandboxFunctionInvocation(
+              data.params.functionId,
+              data.params.input
+            );
+          } catch (error) {
+            sendResponseToIframe(
+              data,
+              {
+                result: null,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "Failed to create sandbox function invocation.",
+              },
+              event.source
+            );
+            break;
+          }
+
+          sendResponseToIframe(
+            data,
+            { result: { hello: "world" } },
+            event.source
+          );
+          break;
+        }
+
         case "getFile":
           const fileBlob = await getFileBlob(data.params.fileId);
 
@@ -214,6 +255,7 @@ function useVisualizationDataHandler({
     return () => window.removeEventListener("message", listener);
   }, [
     code,
+    createSandboxFunctionInvocation,
     downloadFileFromBlob,
     getFileBlob,
     onEditText,
@@ -259,6 +301,7 @@ export function CodeDrawer({
 interface VisualizationActionIframeProps {
   agentConfigurationId: string | null;
   conversationId: string | null;
+  frameFileId?: string;
   isEditable?: boolean;
   isInDrawer?: boolean;
   isPublic?: boolean;
@@ -300,6 +343,7 @@ export const VisualizationActionIframe = forwardRef<
   const {
     agentConfigurationId,
     conversationId,
+    frameFileId,
     isEditable = false,
     isInDrawer = false,
     isPublic = false,
@@ -351,7 +395,54 @@ export const VisualizationActionIframe = forwardRef<
     [workspaceId, conversationId, spaceId]
   );
 
+  const createSandboxFunctionInvocation = useCallback(
+    async (
+      functionId: string,
+      input?: unknown
+    ): Promise<SandboxFunctionInvocationType> => {
+      if (isPublic) {
+        throw new Error("Sandbox functions are not supported in shared frames.");
+      }
+
+      const body: PostSandboxFunctionInvocationRequestBody = {
+        input,
+        context: frameFileId ? { frameFileId } : undefined,
+      };
+
+      try {
+        const response = await clientFetch(
+          `/api/w/${workspaceId}/sandbox-functions/${functionId}/invocations`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          throw new Error(error.message);
+        }
+
+        const result: PostSandboxFunctionInvocationResponseBody =
+          await response.json();
+
+        return result.invocation;
+      } catch (error) {
+        throw new Error(
+          error instanceof Error
+            ? error.message
+            : "Failed to create sandbox function invocation."
+        );
+      }
+    },
+    [frameFileId, isPublic, workspaceId]
+  );
+
   useVisualizationDataHandler({
+    createSandboxFunctionInvocation,
     getFileBlob,
     onEditText,
     setCodeDrawerOpened,

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -436,6 +436,7 @@ export function FrameRenderer({
                 identifier: `viz-${fileId}`,
               }}
               key={`viz-${fileId}`}
+              frameFileId={fileId}
               conversationId={conversation?.sId ?? null}
               isEditable={true}
               spaceId={frameSpaceId ?? undefined}

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -55,6 +55,7 @@ function PodPinnedBannerFrame({
         identifier: `viz-banner-${fileId}`,
       }}
       conversationId={null}
+      frameFileId={fileId}
       spaceId={podId}
       isInDrawer={true}
       ref={iframeRef}

--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -112,6 +112,7 @@ export function PodFrameSheet({
                 }}
                 key={`viz-${fileId}`}
                 conversationId={null}
+                frameFileId={fileId}
                 spaceId={fileMetadata?.useCaseMetadata.spaceId}
                 isInDrawer={true}
                 ref={iframeRef}

--- a/front/types/assistant/visualization.ts
+++ b/front/types/assistant/visualization.ts
@@ -130,7 +130,7 @@ export type VisualizationRPCRequestMap = {
 
 // Command results.
 export interface CommandResultMap {
-  callFunction: { result: Record<string, unknown> | null; error?: string };
+  callFunction: { result: unknown; error?: string };
   getCodeToExecute: { code: string };
   getFile: { fileBlob: Blob | null };
   downloadFileRequest: { blob: Blob; filename?: string };

--- a/front/types/assistant/visualization.ts
+++ b/front/types/assistant/visualization.ts
@@ -16,6 +16,13 @@ const GetFileParamsSchema = z.object({
 
 type GetFileParams = z.infer<typeof GetFileParamsSchema>;
 
+const CallFunctionParamsSchema = z.object({
+  functionId: z.string(),
+  input: z.unknown().optional(),
+});
+
+type CallFunctionParams = z.infer<typeof CallFunctionParamsSchema>;
+
 const SetContentHeightParamsSchema = z.object({
   height: z.number(),
 });
@@ -43,6 +50,11 @@ type SetErrorMessageParams = z.infer<typeof SetErrorMessageParamsSchema>;
 const GetFileRequestSchema = VisualizationRPCRequestBaseSchema.extend({
   command: z.literal("getFile"),
   params: GetFileParamsSchema,
+});
+
+const CallFunctionRequestSchema = VisualizationRPCRequestBaseSchema.extend({
+  command: z.literal("callFunction"),
+  params: CallFunctionParamsSchema,
 });
 
 const GetCodeToExecuteRequestSchema = VisualizationRPCRequestBaseSchema.extend({
@@ -88,6 +100,7 @@ const EditTextRequestSchema = VisualizationRPCRequestBaseSchema.extend({
 });
 
 const VisualizationRPCRequestSchema = z.union([
+  CallFunctionRequestSchema,
   GetFileRequestSchema,
   GetCodeToExecuteRequestSchema,
   SetContentHeightRequestSchema,
@@ -105,6 +118,7 @@ export type VisualizationRPCCommand = VisualizationRPCRequest["command"];
 
 // Define a mapped type for backward compatibility.
 export type VisualizationRPCRequestMap = {
+  callFunction: CallFunctionParams;
   getFile: GetFileParams;
   getCodeToExecute: null;
   setContentHeight: SetContentHeightParams;
@@ -116,6 +130,7 @@ export type VisualizationRPCRequestMap = {
 
 // Command results.
 export interface CommandResultMap {
+  callFunction: { result: Record<string, unknown> | null; error?: string };
   getCodeToExecute: { code: string };
   getFile: { fileBlob: Blob | null };
   downloadFileRequest: { blob: Blob; filename?: string };

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -436,6 +436,8 @@ export function VisualizationWrapper({
           "@dust/slideshow/v1": dustSlideshowV1,
           "@dust/slideshow/v2": dustSlideshowV2,
           "@dust/react-hooks": {
+            callFunction: (functionId: string, input?: unknown) =>
+              api.data.callFunction(functionId, input),
             captureScreenshot: handleScreenshotDownload,
             triggerUserFileDownload: memoizedDownloadFile,
             useFile: (fileId: string) => useFile(fileId, api.data),

--- a/viz/app/lib/data-apis/cache-data-api.ts
+++ b/viz/app/lib/data-apis/cache-data-api.ts
@@ -41,6 +41,16 @@ export class CacheDataAPI implements VisualizationDataAPI {
     }
   }
 
+  async callFunction(functionId: string) {
+    console.error(
+      `Sandbox function ${functionId} is not supported in cached frames.`
+    );
+    return {
+      result: null,
+      error: "Sandbox functions are not supported in cached frames.",
+    };
+  }
+
   async fetchFile(fileId: string): Promise<File | null> {
     return this.fileCache.get(fileId) || null;
   }

--- a/viz/app/lib/data-apis/cache-data-api.ts
+++ b/viz/app/lib/data-apis/cache-data-api.ts
@@ -43,11 +43,11 @@ export class CacheDataAPI implements VisualizationDataAPI {
 
   async callFunction(functionId: string) {
     console.error(
-      `Sandbox function ${functionId} is not supported in cached frames.`
+      `Sandbox function ${functionId} is not supported in public frames.`
     );
     return {
       result: null,
-      error: "Sandbox functions are not supported in cached frames.",
+      error: "Sandbox functions are not supported in public frames.",
     };
   }
 

--- a/viz/app/lib/data-apis/rpc-data-api.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.ts
@@ -24,6 +24,26 @@ export class RPCDataAPI implements VisualizationDataAPI {
     this.sendMessage = sendMessage;
   }
 
+  async callFunction(functionId: string, input?: unknown) {
+    try {
+      const result = await this.sendMessage("callFunction", {
+        functionId,
+        input,
+      });
+
+      return result;
+    } catch (error) {
+      console.error(`Failed to call sandbox function ${functionId}:`, error);
+      return {
+        result: null,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to call sandbox function.",
+      };
+    }
+  }
+
   async fetchFile(fileId: string): Promise<File | null> {
     try {
       console.log(">> RPCDataAPI: Fetching file via RPC", fileId);

--- a/viz/app/lib/visualization-api.ts
+++ b/viz/app/lib/visualization-api.ts
@@ -1,3 +1,4 @@
+import type { CommandResultMap } from "@viz/app/types";
 import type {
   SupportedEventType,
   SupportedMessage,
@@ -8,6 +9,14 @@ import type {
  * Implementation varies by wrapper (cache, RPC, etc.).
  */
 export interface VisualizationDataAPI {
+  /**
+   * Call a sandbox function.
+   */
+  callFunction(
+    functionId: string,
+    input?: unknown
+  ): Promise<CommandResultMap["callFunction"]>;
+
   /**
    * Fetch a file by ID.
    */

--- a/viz/app/types.ts
+++ b/viz/app/types.ts
@@ -6,6 +6,11 @@ interface GetFileParams {
   fileId: string;
 }
 
+interface CallFunctionParams {
+  functionId: string;
+  input?: unknown;
+}
+
 interface SetContentHeightParams {
   height: number;
 }
@@ -29,6 +34,7 @@ interface EditTextParams {
 
 // Define a mapped type to extend the base with specific parameters.
 export type VisualizationRPCRequestMap = {
+  callFunction: CallFunctionParams;
   getFile: GetFileParams;
   getCodeToExecute: null;
   setContentHeight: SetContentHeightParams;
@@ -44,6 +50,7 @@ export type VisualizationRPCCommand = keyof VisualizationRPCRequestMap;
 // Command results.
 
 export interface CommandResultMap {
+  callFunction: { result: Record<string, unknown> | null; error?: string };
   getCodeToExecute: { code: string };
   getFile: { fileBlob: Blob | null };
   downloadFileRequest: { blob: Blob; filename?: string };

--- a/viz/app/types.ts
+++ b/viz/app/types.ts
@@ -50,7 +50,7 @@ export type VisualizationRPCCommand = keyof VisualizationRPCRequestMap;
 // Command results.
 
 export interface CommandResultMap {
-  callFunction: { result: Record<string, unknown> | null; error?: string };
+  callFunction: { result: unknown; error?: string };
   getCodeToExecute: { code: string };
   getFile: { fileBlob: Blob | null };
   downloadFileRequest: { blob: Blob; filename?: string };


### PR DESCRIPTION
## Description

Adds RPC plumbing for calling sandbox functions from visualizations.

This wires a new `callFunction` command through the viz iframe RPC layer, exposes `callFunction(functionId, input?)` from `@dust/react-hooks`, creates a sandbox function invocation from the authenticated parent app, and returns a temporary stubbed result envelope to viz code. The invocation object is created and kept as the basis for future lifecycle/event handling, but the current command response intentionally remains `{ result: { hello: "world" } }`.

Public/shared cached frames return an unsupported error for this API.

## Tests

Tested locally. Below shows going from viz to the invocation endpoint and back.

<img width="312" height="409" alt="Screenshot 2026-06-28 at 22 09 10" src="https://github.com/user-attachments/assets/83834d1e-7278-445c-b261-50d049e26036" />

## Risk

Low. Rollback straightforward

## Deploy Plan

- deploy `front`