### PR TITLE
Add generic module bundler engine with Frame wrapper

### DIFF
--- a/front/lib/api/bundler/bundle_module.test.ts
+++ b/front/lib/api/bundler/bundle_module.test.ts
@@ -1,0 +1,356 @@
+// @vitest-environment node
+// esbuild relies on `new TextEncoder().encode("") instanceof Uint8Array`, which is false under
+// jsdom (cross-realm Uint8Array). Run this file in the node environment. Production runs the
+// bundler in the front Node server, so this only affects tests.
+
+import type {
+  BundleEsbuildOptions,
+  SourceReader,
+} from "@app/lib/api/bundler/bundle_module";
+import { bundleModule } from "@app/lib/api/bundler/bundle_module";
+import { describe, expect, it } from "vitest";
+
+// Default output options for the generic suite. Individual tests override (e.g. node platform for
+// the Function case) to prove the engine is not tied to one consumer's settings.
+const ESM_BROWSER: BundleEsbuildOptions = {
+  format: "esm",
+  platform: "browser",
+  jsx: "preserve",
+  minify: false,
+};
+
+function inMemoryReader(files: Record<string, string>): SourceReader {
+  return {
+    list: async () => Object.keys(files),
+    read: async (rel) => (rel in files ? files[rel] : null),
+  };
+}
+
+// A reader whose reads resolve asynchronously with per-file, deliberately out-of-order delays.
+// This exercises the engine's async resolution across several nesting levels: deeper files are
+// made to resolve FIRST, so the build cannot rely on read ordering matching import order. It also
+// records which files were read, so tests can assert the dependency graph was fully walked.
+function asyncLatencyReader(files: Record<string, string>): {
+  reader: SourceReader;
+  reads: string[];
+} {
+  const reads: string[] = [];
+  // Shorter paths (the entry) wait longer, so reads complete in roughly reverse-dependency order.
+  const delayMsFor = (rel: string) => Math.max(1, 30 - rel.length);
+  const reader: SourceReader = {
+    list: async () => {
+      await new Promise((r) => setTimeout(r, 1));
+      return Object.keys(files);
+    },
+    read: async (rel) => {
+      await new Promise((r) => setTimeout(r, delayMsFor(rel)));
+      reads.push(rel);
+      return rel in files ? files[rel] : null;
+    },
+  };
+  return { reader, reads };
+}
+
+// A module whose entry pulls a nested sibling and a cross-dir util, an external lib, and a data
+// ref. Mirrors a realistic multi-file source tree authored against the engine.
+const MULTI_FILE_MODULE: Record<string, string> = {
+  "dashboard.tsx": `
+import React from "react";
+import { Chart } from "./components/Chart";
+import { useFile } from "@dust/react-hooks";
+
+export default function Dashboard() {
+  const [count] = React.useState(0);
+  const data = useFile("fil_abcdefghij");
+  return (
+    <div className="p-4">
+      <h1>Sales {count}</h1>
+      <Chart />
+    </div>
+  );
+}
+`,
+  "components/Chart.tsx": `
+import { LineChart, Line } from "recharts";
+import { palette } from "../theme";
+
+interface ChartProps { title?: string; }
+
+export function Chart({ title }: ChartProps) {
+  return (
+    <LineChart width={300} height={150} data={[{ x: 1, y: 2 }]}>
+      <Line dataKey="y" stroke={palette.primary} />
+    </LineChart>
+  );
+}
+`,
+  "theme.ts": `export const palette = { primary: "#3366ff" };\n`,
+};
+
+async function build(
+  files: Record<string, string>,
+  entry = "dashboard.tsx",
+  {
+    esbuild = ESM_BROWSER,
+    transform,
+  }: {
+    esbuild?: BundleEsbuildOptions;
+    transform?: (relPath: string, content: string) => string;
+  } = {}
+) {
+  return bundleModule({
+    entryRelPath: entry,
+    reader: inMemoryReader(files),
+    esbuild,
+    transform,
+  });
+}
+
+describe("bundleModule", () => {
+  it("inlines relative imports and keeps non-relative specifiers external", async () => {
+    const result = await build(MULTI_FILE_MODULE);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    const { code } = result.value;
+
+    // Externals preserved as imports for the runtime import scope to resolve.
+    expect(code).toMatch(/from\s+["']react["']/);
+    expect(code).toMatch(/from\s+["']recharts["']/);
+    expect(code).toMatch(/from\s+["']@dust\/react-hooks["']/);
+
+    // Relative siblings inlined (no relative import statements remain).
+    expect(code).not.toMatch(/["']\.\/components\/Chart["']/);
+    expect(code).not.toMatch(/["']\.\.\/theme["']/);
+    // Cross-dir util content made it into the bundle.
+    expect(code).toContain("#3366ff");
+  });
+
+  it("preserves data refs and JSX, and strips TS types", async () => {
+    const result = await build(MULTI_FILE_MODULE);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    const { code } = result.value;
+
+    expect(code).toContain("fil_abcdefghij");
+    expect(code).toContain("<LineChart");
+    expect(code).not.toContain("interface ChartProps");
+  });
+
+  it("builds a single self-contained file with no relative imports", async () => {
+    const single = {
+      "main.tsx": `export default function M() { return <p>hi</p>; }`,
+    };
+    const result = await build(single, "main.tsx");
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.code).toContain("<p");
+  });
+
+  it("returns entry_not_found when the entry is missing", async () => {
+    const result = await build(MULTI_FILE_MODULE, "missing.tsx");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("entry_not_found");
+    }
+  });
+
+  it("rejects relative imports that escape the module root", async () => {
+    const files = {
+      "dashboard.tsx": `import { secret } from "../../outside/secret";\nexport default () => <div>{secret}</div>;\n`,
+    };
+    const result = await build(files);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("build_failed");
+      expect(result.error.message).toContain("outside module root");
+    }
+  });
+
+  it("fails the build when a relative import cannot be resolved", async () => {
+    const files = {
+      "dashboard.tsx": `import { X } from "./nope";\nexport default () => <div>{X}</div>;\n`,
+    };
+    const result = await build(files);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("build_failed");
+    }
+  });
+
+  it("surfaces read_failed when a listed file cannot be read", async () => {
+    // `ghost.tsx` is listed but reads as null (e.g. deleted between list and read).
+    const reader: SourceReader = {
+      list: async () => ["dashboard.tsx", "ghost.tsx"],
+      read: async (rel) =>
+        rel === "dashboard.tsx"
+          ? `import { G } from "./ghost";\nexport default () => <div>{G}</div>;\n`
+          : null,
+    };
+    const result = await bundleModule({
+      entryRelPath: "dashboard.tsx",
+      reader,
+      esbuild: ESM_BROWSER,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("read_failed");
+    }
+  });
+
+  it("reports a syntax error as build_failed", async () => {
+    const files = {
+      "dashboard.tsx": `export default function Broken() { return <div> ; }`,
+    };
+    const result = await build(files);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("build_failed");
+    }
+  });
+
+  it("resolves a deep relative import chain across several levels", async () => {
+    // entry -> a -> b -> c -> leaf, each in a different directory.
+    const files = {
+      "entry.tsx": `import { a } from "./l1/a";\nexport default () => <div>{a()}</div>;\n`,
+      "l1/a.ts": `import { b } from "../l2/b";\nexport const a = () => "a" + b();\n`,
+      "l2/b.ts": `import { c } from "./deep/c";\nexport const b = () => "b" + c();\n`,
+      "l2/deep/c.ts": `import { leaf } from "../../l3/leaf";\nexport const c = () => "c" + leaf();\n`,
+      "l3/leaf.ts": `export const leaf = () => "LEAF_MARKER";\n`,
+    };
+    const result = await build(files, "entry.tsx");
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    // Every level's content reached the bundle, and no relative import statements remain.
+    expect(result.value.code).toContain("LEAF_MARKER");
+    expect(result.value.code).not.toMatch(/from\s+["']\.\.?\//);
+  });
+
+  it("loads files asynchronously and out of order across several levels", async () => {
+    const files = {
+      "entry.tsx": `import { a } from "./l1/a";\nexport default () => <div>{a()}</div>;\n`,
+      "l1/a.ts": `import { b } from "../l2/b";\nexport const a = () => "a" + b();\n`,
+      "l2/b.ts": `export const b = () => "DEEP_ASYNC_MARKER";\n`,
+    };
+    const { reader, reads } = asyncLatencyReader(files);
+    const result = await bundleModule({
+      entryRelPath: "entry.tsx",
+      reader,
+      esbuild: ESM_BROWSER,
+    });
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    // The async, out-of-order reads still produced a correct, fully-inlined bundle...
+    expect(result.value.code).toContain("DEEP_ASYNC_MARKER");
+    // ...and every file in the graph was actually read (no level skipped).
+    expect(new Set(reads)).toEqual(
+      new Set(["entry.tsx", "l1/a.ts", "l2/b.ts"])
+    );
+  });
+
+  it("resolves directory imports via an index file", async () => {
+    const files = {
+      "dashboard.tsx": `import { Widget } from "./components";\nexport default () => <Widget />;\n`,
+      "components/index.tsx": `export const Widget = () => <span>WIDGET_INDEX</span>;\n`,
+    };
+    const result = await build(files);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.code).toContain("WIDGET_INDEX");
+    }
+  });
+
+  it("inlines an imported JSON module", async () => {
+    const files = {
+      "dashboard.tsx": `import config from "./config.json";\nexport default () => <div>{config.label}</div>;\n`,
+      "config.json": `{ "label": "JSON_LABEL" }`,
+    };
+    const result = await build(files);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.code).toContain("JSON_LABEL");
+    }
+  });
+
+  it("inlines a shared module imported via two paths (diamond) without duplication", async () => {
+    const files = {
+      "dashboard.tsx": `import { a } from "./a";\nimport { b } from "./b";\nexport default () => <div>{a() + b()}</div>;\n`,
+      "a.ts": `import { shared } from "./shared";\nexport const a = () => shared() + "A";\n`,
+      "b.ts": `import { shared } from "./shared";\nexport const b = () => shared() + "B";\n`,
+      "shared.ts": `export const shared = () => "SHARED_ONCE";\n`,
+    };
+    const result = await build(files);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    // The shared util is bundled exactly once even though two modules import it.
+    const occurrences = result.value.code.split("SHARED_ONCE").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("applies the per-file transform hook to every inlined source", async () => {
+    // The transform is the engine's only consumer-specific seam (Frames use it for JSX tagging).
+    // Prove it runs on every file in the graph, with the root-relative path.
+    const files = {
+      "entry.ts": `import { helper } from "./util/helper";\nexport const run = () => helper();\n`,
+      "util/helper.ts": `export const helper = () => "BASE";\n`,
+    };
+    const seen: string[] = [];
+    const result = await build(files, "entry.ts", {
+      esbuild: {
+        format: "esm",
+        platform: "node",
+        jsx: "transform",
+        minify: false,
+      },
+      transform: (relPath, content) => {
+        seen.push(relPath);
+        // Inject a discoverable marker keyed by file so we can assert per-file application. Use a
+        // legal comment (`/*! ... */`) so esbuild preserves it through bundling.
+        return `/*! T:${relPath} */\n${content}`;
+      },
+    });
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(new Set(seen)).toEqual(new Set(["entry.ts", "util/helper.ts"]));
+    expect(result.value.code).toContain("T:entry.ts");
+    expect(result.value.code).toContain("T:util/helper.ts");
+  });
+
+  it("bundles a non-JSX TypeScript entry for node (generic primitive, e.g. a Function)", async () => {
+    // The engine is not frame-specific: a plain TS entry built for node, with relative imports and
+    // an external dependency, bundles the same way. This is what the future Function build will use.
+    const files = {
+      "index.ts": `import { label } from "./meta";\nimport { z } from "zod";\nexport const handler = () => label + z.string().parse("x");\n`,
+      "meta.ts": `export const label: string = "FUNCTION_MARKER";\n`,
+    };
+    const result = await build(files, "index.ts", {
+      esbuild: {
+        format: "esm",
+        platform: "node",
+        jsx: "transform",
+        minify: false,
+      },
+    });
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    // Relative util inlined, external kept for the runtime to resolve, types stripped.
+    expect(result.value.code).toContain("FUNCTION_MARKER");
+    expect(result.value.code).toMatch(/from\s+["']zod["']/);
+    expect(result.value.code).not.toContain(": string");
+  });
+});

--- a/front/lib/api/bundler/bundle_module.test.ts
+++ b/front/lib/api/bundler/bundle_module.test.ts
@@ -8,6 +8,7 @@ import type {
   SourceReader,
 } from "@app/lib/api/bundler/bundle_module";
 import { bundleModule } from "@app/lib/api/bundler/bundle_module";
+import { setTimeoutAync } from "@app/lib/utils/async_utils";
 import { describe, expect, it } from "vitest";
 
 // Default output options for the generic suite. Individual tests override (e.g. node platform for
@@ -39,11 +40,11 @@ function asyncLatencyReader(files: Record<string, string>): {
   const delayMsFor = (rel: string) => Math.max(1, 30 - rel.length);
   const reader: SourceReader = {
     list: async () => {
-      await new Promise((r) => setTimeout(r, 1));
+      await setTimeoutAync(1);
       return Object.keys(files);
     },
     read: async (rel) => {
-      await new Promise((r) => setTimeout(r, delayMsFor(rel)));
+      await setTimeoutAync(delayMsFor(rel));
       reads.push(rel);
       return rel in files ? files[rel] : null;
     },

--- a/front/lib/api/bundler/bundle_module.ts
+++ b/front/lib/api/bundler/bundle_module.ts
@@ -56,7 +56,10 @@ export interface BundleModuleParams {
   transform?: (relPath: string, content: string) => string;
 }
 
-// Extensions probed when a relative import omits one (e.g. `./Chart` -> `./Chart.tsx`).
+// Extensions probed, in order, when a relative import omits one (e.g. `./Chart` -> `./Chart.tsx`).
+// Resolution is first-match-wins by this order, never an ambiguity error, so the order is the
+// tie-breaker when sibling files share a base name (`./Chart` resolves to Chart.tsx over Chart.ts).
+// The leading "" matches a specifier that already carries its extension.
 const RESOLVE_EXTENSIONS = ["", ".tsx", ".ts", ".jsx", ".js", ".json"] as const;
 const BUNDLE_NAMESPACE = "bundle";
 
@@ -154,19 +157,24 @@ export async function bundleModule({
       return { error: "escape" };
     }
 
-    for (const ext of RESOLVE_EXTENSIONS) {
-      if (index.has(`${joined}${ext}`)) {
-        return { rel: `${joined}${ext}` };
-      }
-    }
+    const probe = (base: string, allowBare: boolean): string | null => {
+      for (const ext of RESOLVE_EXTENSIONS) {
+        if (!ext && !allowBare) {
+          continue;
+        }
 
-    for (const ext of RESOLVE_EXTENSIONS) {
-      if (ext && index.has(`${joined}/index${ext}`)) {
-        return { rel: `${joined}/index${ext}` };
+        if (index.has(`${base}${ext}`)) {
+          return `${base}${ext}`;
+        }
       }
-    }
 
-    return { error: "missing" };
+      return null;
+    };
+
+    // A direct file (with or without extension) wins over a directory index.
+    const resolved = probe(joined, true) ?? probe(`${joined}/index`, false);
+
+    return resolved ? { rel: resolved } : { error: "missing" };
   };
 
   // Captures a read failure inside onLoad so we can surface it as a typed error rather than

--- a/front/lib/api/bundler/bundle_module.ts
+++ b/front/lib/api/bundler/bundle_module.ts
@@ -1,0 +1,246 @@
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { Loader, Plugin } from "esbuild";
+import path from "path";
+
+/**
+ * Reads a module's source tree, abstracted from storage so the engine works over any backend
+ * (an in-memory tree, a Frame mount, a future Function store). Paths are root-relative
+ * (e.g. `index.ts`, `components/Chart.tsx`).
+ */
+export interface SourceReader {
+  // Root-relative paths of every file under the module root.
+  list(): Promise<string[]>;
+  // Read a root-relative file, or null when it does not exist.
+  read(relPath: string): Promise<string | null>;
+}
+
+export type BundleErrorCode =
+  | "entry_not_found"
+  | "read_failed"
+  | "build_failed";
+
+export class BundleError extends Error {
+  constructor(
+    readonly code: BundleErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "BundleError";
+  }
+}
+
+/**
+ * esbuild output knobs that vary per consumer. Frames build for the browser with JSX preserved and
+ * no minification (so data refs stay discoverable). A Function builds for node. Consumers set
+ * these explicitly so the engine carries no frame-specific defaults.
+ */
+export interface BundleEsbuildOptions {
+  format: "esm" | "cjs";
+  platform: "browser" | "node" | "neutral";
+  jsx: "preserve" | "transform" | "automatic";
+  minify: boolean;
+}
+
+export interface BundleModuleParams {
+  // Root-relative path of the entry file (e.g. `index.ts`, `dashboard.tsx`).
+  entryRelPath: string;
+  reader: SourceReader;
+  esbuild: BundleEsbuildOptions;
+  /**
+   * Per-file transform applied before a file is handed to esbuild, the engine's only
+   * consumer-specific seam. Frames use it to stamp JSX source-location tags. Receives the
+   * root-relative path and raw contents, returns the (possibly rewritten) contents.
+   */
+  transform?: (relPath: string, content: string) => string;
+}
+
+// Extensions probed when a relative import omits one (e.g. `./Chart` -> `./Chart.tsx`).
+const RESOLVE_EXTENSIONS = ["", ".tsx", ".ts", ".jsx", ".js", ".json"] as const;
+const BUNDLE_NAMESPACE = "bundle";
+
+function isRelativeSpecifier(spec: string): boolean {
+  return spec.startsWith("./") || spec.startsWith("../");
+}
+
+function loaderForPath(relPath: string): Loader {
+  if (relPath.endsWith(".ts")) {
+    return "ts";
+  }
+  if (relPath.endsWith(".js")) {
+    return "js";
+  }
+  if (relPath.endsWith(".jsx")) {
+    return "jsx";
+  }
+  if (relPath.endsWith(".json")) {
+    return "json";
+  }
+  return "tsx";
+}
+
+function isEsbuildFailure(
+  err: unknown
+): err is { errors: { text?: string }[] } {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "errors" in err &&
+    Array.isArray(err.errors)
+  );
+}
+
+function formatEsbuildError(err: unknown): string {
+  if (isEsbuildFailure(err)) {
+    const messages = err.errors
+      .map((e) => e.text ?? "")
+      .filter((t) => t.length > 0);
+    if (messages.length > 0) {
+      return messages.join("; ");
+    }
+  }
+  return normalizeError(err).message;
+}
+
+/**
+ * Bundle a multi-file module into a single self-contained file. Storage- and consumer-agnostic
+ * build engine shared by Frames and (later) Functions: it walks a relative-import graph and inlines
+ * it.
+ *
+ * - Relative imports (`./`, `../`) resolve against the module root, with extension probing
+ *   (`./Chart` -> `./Chart.tsx`) and directory index resolution (`./components` ->
+ *   `./components/index.tsx`). A module reached via several paths (diamond) is inlined once.
+ * - Non-relative specifiers (react, zod, scoped data refs, ...) stay external for the runtime
+ *   import scope to resolve.
+ * - Imports escaping the module root (`../` past the top) are rejected.
+ * - Reads go through the async {@link SourceReader}, at any nesting depth.
+ *
+ * Per-consumer behavior (JSX tagging, browser vs node, minify) comes from `transform` and
+ * `esbuild`, not hardcoded here.
+ */
+export async function bundleModule({
+  entryRelPath,
+  reader,
+  esbuild: esbuildOptions,
+  transform,
+}: BundleModuleParams): Promise<Result<{ code: string }, BundleError>> {
+  const index = new Set(await reader.list());
+  if (!index.has(entryRelPath)) {
+    return new Err(
+      new BundleError(
+        "entry_not_found",
+        `Entry file not found in module root: ${entryRelPath}`
+      )
+    );
+  }
+
+  // Resolve a relative specifier against the importer, probing known extensions and an index
+  // file. Returns the resolved root-relative path or an error marker.
+  const resolveRelative = (
+    importerRel: string,
+    spec: string
+  ): { rel: string } | { error: "escape" | "missing" } => {
+    const joined = path.posix.normalize(
+      path.posix.join(path.posix.dirname(importerRel), spec)
+    );
+    if (joined.startsWith("..") || path.posix.isAbsolute(joined)) {
+      return { error: "escape" };
+    }
+    for (const ext of RESOLVE_EXTENSIONS) {
+      if (index.has(`${joined}${ext}`)) {
+        return { rel: `${joined}${ext}` };
+      }
+    }
+    for (const ext of RESOLVE_EXTENSIONS) {
+      if (ext && index.has(`${joined}/index${ext}`)) {
+        return { rel: `${joined}/index${ext}` };
+      }
+    }
+    return { error: "missing" };
+  };
+
+  // Captures a read failure inside onLoad so we can surface it as a typed error rather than
+  // the generic esbuild build failure.
+  let readError: BundleError | null = null;
+
+  const plugin: Plugin = {
+    name: "module-source-reader",
+    setup(build) {
+      build.onResolve({ filter: /.*/ }, (args) => {
+        if (args.kind === "entry-point") {
+          return { path: entryRelPath, namespace: BUNDLE_NAMESPACE };
+        }
+        if (isRelativeSpecifier(args.path)) {
+          const resolved = resolveRelative(args.importer, args.path);
+          if ("error" in resolved) {
+            const message =
+              resolved.error === "escape"
+                ? `Refusing import outside module root: "${args.path}" from "${args.importer}"`
+                : `Cannot resolve "${args.path}" from "${args.importer}"`;
+            return { errors: [{ text: message }] };
+          }
+          return { path: resolved.rel, namespace: BUNDLE_NAMESPACE };
+        }
+        // Non-relative specifiers stay external (resolved by the runtime import scope).
+        return { path: args.path, external: true };
+      });
+
+      build.onLoad(
+        { filter: /.*/, namespace: BUNDLE_NAMESPACE },
+        async (args) => {
+          const content = await reader.read(args.path);
+          if (content === null) {
+            readError = new BundleError(
+              "read_failed",
+              `Failed to read module source: ${args.path}`
+            );
+            return { errors: [{ text: readError.message }] };
+          }
+          return {
+            contents: transform ? transform(args.path, content) : content,
+            loader: loaderForPath(args.path),
+            resolveDir: "/",
+          };
+        }
+      );
+    },
+  };
+
+  try {
+    // Lazy import: esbuild is a heavy node-only module that breaks under jsdom. Loading it here
+    // keeps it out of this engine's consumers' import graph, so they stay importable in any test
+    // environment and esbuild is pulled in only when a build runs.
+    const { default: esbuild } = await import("esbuild");
+    const result = await esbuild.build({
+      entryPoints: [entryRelPath],
+      bundle: true,
+      write: false,
+      format: esbuildOptions.format,
+      jsx: esbuildOptions.jsx,
+      platform: esbuildOptions.platform,
+      minify: esbuildOptions.minify,
+      sourcemap: false,
+      logLevel: "silent",
+      plugins: [plugin],
+    });
+
+    if (readError) {
+      return new Err(readError);
+    }
+
+    const output = result.outputFiles[0];
+    if (!output) {
+      return new Err(
+        new BundleError("build_failed", "esbuild produced no output")
+      );
+    }
+
+    return new Ok({ code: output.text });
+  } catch (err) {
+    if (readError) {
+      return new Err(readError);
+    }
+    return new Err(new BundleError("build_failed", formatEsbuildError(err)));
+  }
+}

--- a/front/lib/api/bundler/bundle_module.ts
+++ b/front/lib/api/bundler/bundle_module.ts
@@ -6,7 +6,7 @@ import path from "path";
 
 /**
  * Reads a module's source tree, abstracted from storage so the engine works over any backend
- * (an in-memory tree, a Frame mount, a future Function store). Paths are root-relative
+ * (an in-memory tree, DustFileSystem). Paths are root-relative
  * (e.g. `index.ts`, `components/Chart.tsx`).
  */
 export interface SourceReader {
@@ -17,9 +17,9 @@ export interface SourceReader {
 }
 
 export type BundleErrorCode =
+  | "build_failed"
   | "entry_not_found"
-  | "read_failed"
-  | "build_failed";
+  | "read_failed";
 
 export class BundleError extends Error {
   constructor(
@@ -68,15 +68,19 @@ function loaderForPath(relPath: string): Loader {
   if (relPath.endsWith(".ts")) {
     return "ts";
   }
+
   if (relPath.endsWith(".js")) {
     return "js";
   }
+
   if (relPath.endsWith(".jsx")) {
     return "jsx";
   }
+
   if (relPath.endsWith(".json")) {
     return "json";
   }
+
   return "tsx";
 }
 
@@ -100,12 +104,13 @@ function formatEsbuildError(err: unknown): string {
       return messages.join("; ");
     }
   }
+
   return normalizeError(err).message;
 }
 
 /**
  * Bundle a multi-file module into a single self-contained file. Storage- and consumer-agnostic
- * build engine shared by Frames and (later) Functions: it walks a relative-import graph and inlines
+ * build engine shared by Frames and Functions: it walks a relative-import graph and inlines
  * it.
  *
  * - Relative imports (`./`, `../`) resolve against the module root, with extension probing
@@ -144,19 +149,23 @@ export async function bundleModule({
     const joined = path.posix.normalize(
       path.posix.join(path.posix.dirname(importerRel), spec)
     );
+    // TODO(FRAMES BUNDLE): Consider relaxing this to allow imports from pods/ in the conversation.
     if (joined.startsWith("..") || path.posix.isAbsolute(joined)) {
       return { error: "escape" };
     }
+
     for (const ext of RESOLVE_EXTENSIONS) {
       if (index.has(`${joined}${ext}`)) {
         return { rel: `${joined}${ext}` };
       }
     }
+
     for (const ext of RESOLVE_EXTENSIONS) {
       if (ext && index.has(`${joined}/index${ext}`)) {
         return { rel: `${joined}/index${ext}` };
       }
     }
+
     return { error: "missing" };
   };
 
@@ -171,6 +180,7 @@ export async function bundleModule({
         if (args.kind === "entry-point") {
           return { path: entryRelPath, namespace: BUNDLE_NAMESPACE };
         }
+
         if (isRelativeSpecifier(args.path)) {
           const resolved = resolveRelative(args.importer, args.path);
           if ("error" in resolved) {
@@ -178,10 +188,13 @@ export async function bundleModule({
               resolved.error === "escape"
                 ? `Refusing import outside module root: "${args.path}" from "${args.importer}"`
                 : `Cannot resolve "${args.path}" from "${args.importer}"`;
+
             return { errors: [{ text: message }] };
           }
+
           return { path: resolved.rel, namespace: BUNDLE_NAMESPACE };
         }
+
         // Non-relative specifiers stay external (resolved by the runtime import scope).
         return { path: args.path, external: true };
       });
@@ -195,8 +208,10 @@ export async function bundleModule({
               "read_failed",
               `Failed to read module source: ${args.path}`
             );
+
             return { errors: [{ text: readError.message }] };
           }
+
           return {
             contents: transform ? transform(args.path, content) : content,
             loader: loaderForPath(args.path),
@@ -241,6 +256,7 @@ export async function bundleModule({
     if (readError) {
       return new Err(readError);
     }
+
     return new Err(new BundleError("build_failed", formatEsbuildError(err)));
   }
 }

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -251,6 +251,7 @@ export async function getStreamLLM(
       { modelId: llmParameters.modelId },
       `Sending request to ${llmParameters.modelId} with new router`
     );
+
     return streamEndpointLLM;
   }
 

--- a/front/lib/api/viz/build_frame_bundle.test.ts
+++ b/front/lib/api/viz/build_frame_bundle.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+// esbuild relies on `new TextEncoder().encode("") instanceof Uint8Array`, which is false under
+// jsdom (cross-realm Uint8Array). Run this file in the node environment. Production runs the
+// bundler in the front Node server, so this only affects tests.
+//
+// Generic bundling (resolution, externals, async/multi-level loading, diamond dedup, JSON, error
+// cases, non-JSX entries) is covered by the engine suite in `lib/api/bundler/bundle_module.test.ts`.
+// This file covers only what the frame wrapper adds: JSX source-location tagging and viz options.
+
+import type { FrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
+import { buildFrameBundle } from "@app/lib/api/viz/build_frame_bundle";
+import { describe, expect, it } from "vitest";
+
+function inMemoryReader(files: Record<string, string>): FrameSourceReader {
+  return {
+    list: async () => Object.keys(files),
+    read: async (rel) => (rel in files ? files[rel] : null),
+  };
+}
+
+// A multi-file frame so we can assert tags carry each element's true origin file.
+const MULTI_FILE_FRAME: Record<string, string> = {
+  "dashboard.tsx": `
+import { Chart } from "./components/Chart";
+
+export default function Dashboard() {
+  return (
+    <div className="p-4">
+      <h1>Sales</h1>
+      <Chart />
+    </div>
+  );
+}
+`,
+  "components/Chart.tsx": `
+import { LineChart, Line } from "recharts";
+
+export function Chart() {
+  return (
+    <LineChart width={300} height={150} data={[{ x: 1, y: 2 }]}>
+      <Line dataKey="y" />
+    </LineChart>
+  );
+}
+`,
+};
+
+async function build(files: Record<string, string>, entry = "dashboard.tsx") {
+  return buildFrameBundle({
+    entryRelPath: entry,
+    reader: inMemoryReader(files),
+  });
+}
+
+describe("buildFrameBundle", () => {
+  it("stamps source-location tags carrying each element's origin file", async () => {
+    const result = await build(MULTI_FILE_FRAME);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    const { code } = result.value;
+
+    expect(code).toMatch(/data-source="dashboard\.tsx:\d+:\d+"/);
+    expect(code).toMatch(/data-source="components\/Chart\.tsx:\d+:\d+"/);
+  });
+
+  it("preserves JSX and keeps non-relative specifiers external (viz options)", async () => {
+    const result = await build(MULTI_FILE_FRAME);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    const { code } = result.value;
+
+    // JSX is preserved (react-runner transpiles at render), not compiled to createElement.
+    expect(code).toContain("<LineChart");
+    // The charting lib stays external for the viz import scope.
+    expect(code).toMatch(/from\s+["']recharts["']/);
+    // The relative sibling was inlined (no relative import remains).
+    expect(code).not.toMatch(/["']\.\/components\/Chart["']/);
+  });
+
+  it("tags a single self-contained frame", async () => {
+    const single = {
+      "main.tsx": `export default function M() { return <p>hi</p>; }`,
+    };
+    const result = await build(single, "main.tsx");
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.code).toContain("data-source=");
+    }
+  });
+});

--- a/front/lib/api/viz/build_frame_bundle.ts
+++ b/front/lib/api/viz/build_frame_bundle.ts
@@ -1,5 +1,6 @@
 import type {
   BundleError,
+  BundleEsbuildOptions,
   SourceReader,
 } from "@app/lib/api/bundler/bundle_module";
 import { bundleModule } from "@app/lib/api/bundler/bundle_module";
@@ -14,18 +15,18 @@ export type FrameSourceReader = SourceReader;
 // Frames render in an iframe via `react-runner`, which transpiles JSX, so JSX is preserved. Output
 // targets the browser and is not minified so data refs (`fil_...`) stay discoverable by
 // `extract_file_refs`.
-const FRAME_ESBUILD_OPTIONS = {
+const FRAME_ESBUILD_OPTIONS: BundleEsbuildOptions = {
   format: "esm",
   jsx: "preserve",
   platform: "browser",
   minify: false,
-} as const;
+};
 
 /**
  * Bundle a multi-file frame into a single self-contained module. Thin wrapper over
  * {@link bundleModule} supplying the viz esbuild options and the JSX source-location transform, so
  * live edits on the rendered bundle route back to the correct source file. All graph-walking lives
- * in the generic engine, shared with future consumers (e.g. Functions).
+ * in the generic engine.
  */
 export async function buildFrameBundle({
   entryRelPath,
@@ -63,8 +64,10 @@ export function createMountFrameSourceReader(
           { err: listResult.error, root },
           "buildFrameBundle: failed to list frame root"
         );
+
         return [];
       }
+
       return listResult.value
         .filter((entry) => !entry.isDirectory && entry.path.startsWith(prefix))
         .map((entry) => entry.path.slice(prefix.length));
@@ -76,8 +79,10 @@ export function createMountFrameSourceReader(
           { err: bufferResult.error, root, relPath },
           "buildFrameBundle: failed to read frame source"
         );
+
         return null;
       }
+
       return bufferResult.value ? bufferResult.value.toString("utf8") : null;
     },
   };

--- a/front/lib/api/viz/build_frame_bundle.ts
+++ b/front/lib/api/viz/build_frame_bundle.ts
@@ -1,0 +1,84 @@
+import type {
+  BundleError,
+  SourceReader,
+} from "@app/lib/api/bundler/bundle_module";
+import { bundleModule } from "@app/lib/api/bundler/bundle_module";
+import type { DustFileSystem } from "@app/lib/api/file_system";
+import { injectSourceLocationTags } from "@app/lib/api/viz/source_location_tags";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+
+// A frame's source tree reader, the generic engine reader under a frame-named alias.
+export type FrameSourceReader = SourceReader;
+
+// Frames render in an iframe via `react-runner`, which transpiles JSX, so JSX is preserved. Output
+// targets the browser and is not minified so data refs (`fil_...`) stay discoverable by
+// `extract_file_refs`.
+const FRAME_ESBUILD_OPTIONS = {
+  format: "esm",
+  jsx: "preserve",
+  platform: "browser",
+  minify: false,
+} as const;
+
+/**
+ * Bundle a multi-file frame into a single self-contained module. Thin wrapper over
+ * {@link bundleModule} supplying the viz esbuild options and the JSX source-location transform, so
+ * live edits on the rendered bundle route back to the correct source file. All graph-walking lives
+ * in the generic engine, shared with future consumers (e.g. Functions).
+ */
+export async function buildFrameBundle({
+  entryRelPath,
+  reader,
+}: {
+  entryRelPath: string;
+  reader: FrameSourceReader;
+}): Promise<Result<{ code: string }, BundleError>> {
+  return bundleModule({
+    entryRelPath,
+    reader,
+    esbuild: FRAME_ESBUILD_OPTIONS,
+    // Stamp each source file with `data-source` tags before inlining so the rendered bundle keeps
+    // the origin of every JSX element for live edits.
+    transform: injectSourceLocationTags,
+  });
+}
+
+/**
+ * Adapter exposing a frame's mount subtree (rooted at `rootScopedPath`, e.g.
+ * `conversation-<cId>/dashboards/sales`) as a {@link FrameSourceReader}.
+ */
+export function createMountFrameSourceReader(
+  dustFs: DustFileSystem,
+  rootScopedPath: string
+): FrameSourceReader {
+  const root = rootScopedPath.replace(/\/+$/, "");
+  const prefix = `${root}/`;
+
+  return {
+    async list(): Promise<string[]> {
+      const listResult = await dustFs.list(root);
+      if (listResult.isErr()) {
+        logger.warn(
+          { err: listResult.error, root },
+          "buildFrameBundle: failed to list frame root"
+        );
+        return [];
+      }
+      return listResult.value
+        .filter((entry) => !entry.isDirectory && entry.path.startsWith(prefix))
+        .map((entry) => entry.path.slice(prefix.length));
+    },
+    async read(relPath: string): Promise<string | null> {
+      const bufferResult = await dustFs.readBuffer(`${root}/${relPath}`);
+      if (bufferResult.isErr()) {
+        logger.warn(
+          { err: bufferResult.error, root, relPath },
+          "buildFrameBundle: failed to read frame source"
+        );
+        return null;
+      }
+      return bufferResult.value ? bufferResult.value.toString("utf8") : null;
+    },
+  };
+}

--- a/front/lib/api/viz/source_location_tags.test.ts
+++ b/front/lib/api/viz/source_location_tags.test.ts
@@ -1,0 +1,74 @@
+import {
+  injectSourceLocationTags,
+  SOURCE_LOCATION_ATTRIBUTE,
+} from "@app/lib/api/viz/source_location_tags";
+import { describe, expect, it } from "vitest";
+
+describe("injectSourceLocationTags", () => {
+  it("tags an opening element with its 1-based file:line:col", () => {
+    const out = injectSourceLocationTags("a.tsx", `<div>Hi</div>`);
+    // `div` tagName starts at column 2 (after `<`) on line 1.
+    expect(out).toBe(`<div ${SOURCE_LOCATION_ATTRIBUTE}="a.tsx:1:2">Hi</div>`);
+  });
+
+  it("tags nested elements each with their own location", () => {
+    const out = injectSourceLocationTags("a.tsx", `<div><span>Hi</span></div>`);
+    expect(out).toContain(`<div ${SOURCE_LOCATION_ATTRIBUTE}="a.tsx:1:2">`);
+    expect(out).toContain(`<span ${SOURCE_LOCATION_ATTRIBUTE}="a.tsx:1:7">`);
+  });
+
+  it("tags self-closing elements", () => {
+    const out = injectSourceLocationTags("a.tsx", `<img src="x" />`);
+    expect(out).toBe(
+      `<img ${SOURCE_LOCATION_ATTRIBUTE}="a.tsx:1:2" src="x" />`
+    );
+  });
+
+  it("computes line numbers across multiple lines", () => {
+    const code = [
+      "function C() {",
+      "  return (",
+      "    <h1>Title</h1>",
+      "  );",
+      "}",
+    ].join("\n");
+    const out = injectSourceLocationTags("comp.tsx", code);
+    // `h1` is on line 3, indented 4 spaces, so the tagName starts at column 6.
+    expect(out).toContain(`<h1 ${SOURCE_LOCATION_ATTRIBUTE}="comp.tsx:3:6">`);
+  });
+
+  it("preserves existing attributes and text content", () => {
+    const out = injectSourceLocationTags(
+      "a.tsx",
+      `<button className="btn" onClick={go}>Click</button>`
+    );
+    expect(out).toContain(`${SOURCE_LOCATION_ATTRIBUTE}="a.tsx:1:2"`);
+    expect(out).toContain(`className="btn"`);
+    expect(out).toContain(`onClick={go}`);
+    expect(out).toContain(`>Click</button>`);
+  });
+
+  it("does not tag fragments and leaves other elements intact", () => {
+    const out = injectSourceLocationTags("a.tsx", `<><p>x</p></>`);
+    // Fragments have no tag name, so only the <p> is tagged. `<>` is 2 chars, so the
+    // `p` tag name starts at column 4.
+    expect(out).toBe(`<><p ${SOURCE_LOCATION_ATTRIBUTE}="a.tsx:1:4">x</p></>`);
+  });
+
+  it("uses the provided file name (the mount-relative path) in the tag", () => {
+    const out = injectSourceLocationTags(
+      "components/Chart.tsx",
+      `<div>c</div>`
+    );
+    expect(out).toContain(`"components/Chart.tsx:1:2"`);
+  });
+
+  it("returns the input unchanged when there is no JSX", () => {
+    const code = `export const palette = { primary: "#3366ff" };`;
+    expect(injectSourceLocationTags("theme.ts", code)).toBe(code);
+  });
+
+  it("does not throw on malformed input", () => {
+    expect(() => injectSourceLocationTags("a.tsx", `<div><span`)).not.toThrow();
+  });
+});

--- a/front/lib/api/viz/source_location_tags.ts
+++ b/front/lib/api/viz/source_location_tags.ts
@@ -1,0 +1,63 @@
+import logger from "@app/logger/logger";
+import ts from "typescript";
+
+// DOM attribute carrying a JSX element's source origin as `<file>:<line>:<col>` (1-based).
+// It is injected before bundling so it survives esbuild inlining and reaches the rendered
+// DOM, letting inline ("live") edits route a clicked element back to its source file and
+// location. The viz selection runtime reads this attribute.
+export const SOURCE_LOCATION_ATTRIBUTE = "data-source";
+
+/**
+ * Inject a `data-source="<file>:<line>:<col>"` attribute on every JSX element of `code`.
+ *
+ * Implemented as a string splice over positions from the TypeScript AST (the same technique
+ * as `transformEditableText`) rather than reprinting the AST: this keeps the original source
+ * bytes intact (no reformatting) and stays tolerant of partial code. On any parse failure it
+ * returns the input unchanged so a tagging issue never breaks a build.
+ *
+ * `fileName` should be the path used to address the source later (the mount-relative path),
+ * since that is what the live-edit write-back resolves.
+ */
+export function injectSourceLocationTags(
+  fileName: string,
+  code: string
+): string {
+  const inserts: { pos: number; text: string }[] = [];
+
+  try {
+    const sourceFile = ts.createSourceFile(
+      fileName,
+      code,
+      ts.ScriptTarget.Latest,
+      /* setParentNodes */ true,
+      ts.ScriptKind.TSX
+    );
+
+    const visit = (node: ts.Node): void => {
+      if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+        const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+          node.tagName.getStart(sourceFile)
+        );
+        const value = `${fileName}:${line + 1}:${character + 1}`;
+        inserts.push({
+          pos: node.tagName.getEnd(),
+          text: ` ${SOURCE_LOCATION_ATTRIBUTE}="${value}"`,
+        });
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  } catch (err) {
+    logger.error({ err, fileName }, "Failed to inject source-location tags");
+    return code;
+  }
+
+  // Splice right-to-left so earlier byte offsets stay valid after each insertion.
+  inserts.sort((a, b) => b.pos - a.pos);
+
+  let out = code;
+  for (const ins of inserts) {
+    out = out.slice(0, ins.pos) + ins.text + out.slice(ins.pos);
+  }
+  return out;
+}

--- a/front/lib/api/viz/source_location_tags.ts
+++ b/front/lib/api/viz/source_location_tags.ts
@@ -38,14 +38,17 @@ export function injectSourceLocationTags(
         const { line, character } = sourceFile.getLineAndCharacterOfPosition(
           node.tagName.getStart(sourceFile)
         );
+
         const value = `${fileName}:${line + 1}:${character + 1}`;
         inserts.push({
           pos: node.tagName.getEnd(),
           text: ` ${SOURCE_LOCATION_ATTRIBUTE}="${value}"`,
         });
       }
+
       ts.forEachChild(node, visit);
     };
+
     visit(sourceFile);
   } catch (err) {
     logger.error({ err, fileName }, "Failed to inject source-location tags");
@@ -59,5 +62,6 @@ export function injectSourceLocationTags(
   for (const ins of inserts) {
     out = out.slice(0, ins.pos) + ins.text + out.slice(ins.pos);
   }
+
   return out;
 }

--- a/front/lib/utils/async_utils.ts
+++ b/front/lib/utils/async_utils.ts
@@ -120,3 +120,7 @@ export async function withPeriodicHeartbeat<T>(
     clearInterval(interval);
   }
 }
+
+export async function setTimeoutAync(delayMs: number = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces a storage- and consumer-agnostic bundler that takes a multi-file source tree and produces a single self-contained module. It resolves and inlines relative imports (with extension and directory-index probing), keeps non-relative specifiers external for the runtime to resolve, rejects imports that escape the module root, and reads sources through an async interface so it can run over any backend at any nesting depth.

The engine is deliberately decoupled from frames. The two things that genuinely differ per consumer are explicit inputs: the esbuild output options (a frame builds for the browser with JSX preserved and no minification, a sandbox Function will build for node) and an optional per-file transform, which is the only consumer-specific seam. This is what lets us reuse the exact same bundling logic for the upcoming sandbox Functions without forking it.

Frames are layered on top as a thin wrapper that supplies the viz esbuild options and a JSX source-location transform, so a published frame keeps the origin of every element for live editing.

This PR is the inert foundation: nothing in production imports the engine yet. The publish pipeline and render path that consume it land in the next PR.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
