### PR TITLE
Add sandbox_functions MCP server with list tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -577,6 +577,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "bash": "never_ask",
     "describe_toolset": "never_ask",
   },
+  "sandbox_functions": {
+    "list": "never_ask",
+  },
   "schedules_management": {
     "create_schedule": "high",
     "disable_schedule": "high",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -68,6 +68,7 @@ import {
   SANDBOX_MCP_REQUEST_TIMEOUT_MS,
   SANDBOX_SERVER,
 } from "@app/lib/api/actions/servers/sandbox/metadata";
+import { SANDBOX_FUNCTIONS_SERVER } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { SCHEDULES_MANAGEMENT_SERVER } from "@app/lib/api/actions/servers/schedules_management/metadata";
 import { SEARCH_SERVER } from "@app/lib/api/actions/servers/search/metadata";
 import { SKILL_AUTHORING_SERVER } from "@app/lib/api/actions/servers/skill_authoring/metadata";
@@ -220,6 +221,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "pod_tasks",
   "poke",
   "sandbox",
+  "sandbox_functions",
   "ask_user_question",
   "wakeups",
   "plan_mode",
@@ -1045,6 +1047,19 @@ export const INTERNAL_MCP_SERVERS = {
     // Derived from the max command timeout plus a buffer so the in-container
     // timeout returns captured output before this MCP deadline aborts the call.
     timeoutMs: SANDBOX_MCP_REQUEST_TIMEOUT_MS,
+  },
+  sandbox_functions: {
+    id: 1037,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isPreview: true,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("sandbox_functions");
+    },
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: SANDBOX_FUNCTIONS_SERVER,
   },
   user_mentions: {
     id: 1026,

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -32,7 +32,8 @@
     { "name": "plan_mode", "id": 1032 },
     { "name": "files", "id": 1033 },
     { "name": "skill_authoring", "id": 1034 },
-    { "name": "workspace_analytics", "id": 1035 }
+    { "name": "workspace_analytics", "id": 1035 },
+    { "name": "sandbox_functions", "id": 1037 }
   ],
   "manual": [
     { "name": "github", "id": 1 },

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -60,6 +60,7 @@ import { default as dustAppServer } from "@app/lib/api/actions/servers/run_dust_
 import { default as salesforceServer } from "@app/lib/api/actions/servers/salesforce";
 import { default as salesloftServer } from "@app/lib/api/actions/servers/salesloft";
 import { default as sandboxServer } from "@app/lib/api/actions/servers/sandbox";
+import { default as sandboxFunctionsServer } from "@app/lib/api/actions/servers/sandbox_functions";
 import { default as schedulesManagementServer } from "@app/lib/api/actions/servers/schedules_management";
 import { default as searchServer } from "@app/lib/api/actions/servers/search";
 import { default as skillAuthoringServer } from "@app/lib/api/actions/servers/skill_authoring";
@@ -269,6 +270,8 @@ export async function getInternalMCPServer(
       return statuspageServer(auth, agentLoopContext);
     case "sandbox":
       return sandboxServer(auth, agentLoopContext);
+    case "sandbox_functions":
+      return sandboxFunctionsServer(auth, agentLoopContext);
     case "wakeups":
       return wakeupsServer(auth, agentLoopContext);
     case "plan_mode":

--- a/front/lib/api/actions/servers/sandbox_functions/index.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/index.ts
@@ -1,0 +1,24 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/sandbox_functions/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer(SANDBOX_FUNCTIONS_SERVER_NAME);
+
+  for (const tool of TOOLS) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: SANDBOX_FUNCTIONS_SERVER_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -1,0 +1,47 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const SANDBOX_FUNCTIONS_SERVER_NAME = "sandbox_functions" as const;
+
+export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
+  list: {
+    description:
+      "List the sandbox functions published in the current pod, with their " +
+      "name and input/output schemas.",
+    schema: {},
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing sandbox functions...",
+      done: "Listed sandbox functions",
+    },
+  },
+  // TODO(SANDBOX_FUNCTION) Add publish tool once we have pod's sandboxes.
+});
+
+export const SANDBOX_FUNCTIONS_SERVER = {
+  serverInfo: {
+    name: SANDBOX_FUNCTIONS_SERVER_NAME,
+    version: "1.0.0",
+    description:
+      "Sandbox functions: schema-typed callables bundled and run on the pod's " +
+      "sandbox.",
+    icon: "CommandLineIcon",
+    authorization: null,
+    documentationUrl: null,
+  },
+  tools: Object.values(SANDBOX_FUNCTIONS_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(SANDBOX_FUNCTIONS_TOOLS_METADATA).map((t) => [
+      t.name,
+      t.stake,
+    ])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/sandbox_functions/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/index.ts
@@ -1,0 +1,9 @@
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { SANDBOX_FUNCTIONS_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
+import { listHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/list";
+
+const HANDLERS = {
+  list: listHandler,
+};
+
+export const TOOLS = buildTools(SANDBOX_FUNCTIONS_TOOLS_METADATA, HANDLERS);

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.test.ts
@@ -1,0 +1,83 @@
+import { formatSandboxFunctionsList } from "@app/lib/api/actions/servers/sandbox_functions/tools/list";
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { sandboxFunctionContentType } from "@app/types/files";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { describe, expect, it } from "vitest";
+
+const inputSchema: JSONSchema = {
+  type: "object",
+  properties: { name: { type: "string" } },
+  required: ["name"],
+};
+
+const outputSchema: JSONSchema = {
+  type: "object",
+  properties: { greeting: { type: "string" } },
+  required: ["greeting"],
+};
+
+async function makeFunction(
+  auth: Authenticator,
+  space: SpaceResource,
+  fileName: string
+): Promise<SandboxFunctionResource> {
+  const file = await FileFactory.create(auth, null, {
+    contentType: sandboxFunctionContentType,
+    fileName,
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: space.sId },
+  });
+
+  return SandboxFunctionResource.makeNew(auth, {
+    space,
+    file,
+    inputSchema,
+    outputSchema,
+  });
+}
+
+describe("formatSandboxFunctionsList", () => {
+  it("returns an explicit empty message when there are none", () => {
+    expect(formatSandboxFunctionsList([])).toBe(
+      "No sandbox functions published in this pod."
+    );
+  });
+
+  it("renders name, sId and schemas for a function", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const fn = await makeFunction(authenticator, space, "greet.ts");
+
+    const out = formatSandboxFunctionsList([fn]);
+
+    expect(out).toContain("Sandbox functions:");
+    expect(out).toContain(`- greet.ts (${fn.sId})`);
+    expect(fn.sId).toMatch(/^sfn_/);
+    expect(out).toContain(`input: ${JSON.stringify(fn.inputSchema)}`);
+    expect(out).toContain(`output: ${JSON.stringify(fn.outputSchema)}`);
+  });
+
+  it("lists every function", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    await makeFunction(authenticator, space, "greet.ts");
+    await makeFunction(authenticator, space, "farewell.ts");
+
+    const fns = await SandboxFunctionResource.listBySpace(authenticator, space);
+    const out = formatSandboxFunctionsList(fns);
+
+    expect(out).toContain("greet.ts");
+    expect(out).toContain("farewell.ts");
+  });
+});

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
@@ -1,0 +1,44 @@
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getPod } from "@app/lib/api/actions/servers/pod_manager/helpers";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { Err, Ok } from "@app/types/shared/result";
+
+export function formatSandboxFunctionsList(
+  sandboxFunctions: SandboxFunctionResource[]
+): string {
+  if (sandboxFunctions.length === 0) {
+    return "No sandbox functions published in this pod.";
+  }
+
+  const lines = sandboxFunctions.map((fn) =>
+    [
+      `- ${fn.file.fileName} (${fn.sId})`,
+      `  input: ${JSON.stringify(fn.inputSchema)}`,
+      `  output: ${JSON.stringify(fn.outputSchema)}`,
+    ].join("\n")
+  );
+
+  return `Sandbox functions:\n${lines.join("\n")}`;
+}
+
+export async function listHandler(
+  _params: Record<string, never>,
+  { auth, agentLoopContext }: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const podResult = await getPod(auth, { agentLoopContext });
+  if (podResult.isErr()) {
+    return new Err(podResult.error);
+  }
+
+  const sandboxFunctions = await SandboxFunctionResource.listBySpace(
+    auth,
+    podResult.value.pod
+  );
+
+  return new Ok([
+    { type: "text", text: formatSandboxFunctionsList(sandboxFunctions) },
+  ]);
+}

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -106,6 +106,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
   extract_data: "advanced",
   http_client: "advanced",
   sandbox: "advanced",
+  sandbox_functions: "advanced",
   file_generation: "advanced",
   image_generation: "advanced",
   sound_studio: "advanced",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Introduces an internal MCP server for sandbox functions, exposing a single read-only list tool (for now) that returns the schema-typed functions published in the current pod together with their input and output schemas.

The server is hidden by default and gated behind the `sandbox_functions` feature flag, so it only surfaces for workspaces that have opted in. It resolves the pod from the conversation context and reads functions scoped to that pod.

This is the first step toward the broader sandbox functions capability. Publishing, which bundles a function on the pod's own sandbox and persists the built artifact, is intentionally left out and will land in a follow-up so this PR stays small and focused on read access.

**🔮 What's next**
- Add a `description` and `name` field on the `SanboxFunctionModel`
- Consolidate around exposing a single invocation handle (I guess sId)
- Adopt the lean-list plus detailed-get pattern: keep list lightweight (name, description, a compact signature) and move full JSON schemas behind a dedicated detail tool, so discovery stays cheap as the number and size of functions grow.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
