### PR TITLE
feat(rum): start session replay recording on real errors

### DIFF
--- a/front-spa/src/lib/initDatadog.ts
+++ b/front-spa/src/lib/initDatadog.ts
@@ -62,6 +62,14 @@ export function initDatadogRUM() {
           return false;
         }
 
+        // Start replay recording for real errors so engineers have browser-level
+        // context when investigating bugs — eliminates the manual reproduction step.
+        // The ambient sessionReplaySampleRate (5%) captures a random baseline;
+        // this ensures every real error session is also recorded.
+        if (event.type === "error") {
+          window.DD_RUM.startSessionReplayRecording();
+        }
+
         // Mask click actions within privacy-masked elements
         if (
           event.type === "action" &&

--- a/front-spa/src/lib/initDatadog.ts
+++ b/front-spa/src/lib/initDatadog.ts
@@ -66,6 +66,9 @@ export function initDatadogRUM() {
         // context when investigating bugs — eliminates the manual reproduction step.
         // The ambient sessionReplaySampleRate (5%) captures a random baseline;
         // this ensures every real error session is also recorded.
+        //
+        // Non-optional access is intentional: this callback only fires after
+        // onReady → init(), so window.DD_RUM is guaranteed defined here.
         if (event.type === "error") {
           window.DD_RUM.startSessionReplayRecording();
         }

--- a/front/global.d.ts
+++ b/front/global.d.ts
@@ -65,6 +65,7 @@ declare global {
       onReady: (callback: () => void) => void;
       setUser: (user: { id: string; name?: string; email?: string }) => void;
       setGlobalContext: (context: { [key: string]: string }) => void;
+      startSessionReplayRecording: () => void;
     };
   }
   interface ImportMeta {


### PR DESCRIPTION
## Description

Session Replay is live on the SPA but `sessionReplaySampleRate` is set to 5, so 95% of error sessions have no recording. Every EngRunner card for a browser bug starts with a manual reproduction step.

This PR calls `startSessionReplayRecording()` inside `beforeSend` when a real error fires. Benign ResizeObserver noise is filtered out first by the existing guard, so it doesn't trigger recording. The 5% ambient sampling is untouched.

Once this ships, the `[Eng] Analyse EngRunner Issues` skill can query `@type:error @session.has_replay:true` against RUM and surface a `https://app.datadoghq.eu/rum/replay/sessions/` link directly in the EngRunner card body. Engineers get DOM snapshots, network requests, console errors, and the full click trail for the exact session where the bug occurred.

**Cost:** ~6,500 unique error sessions/day on weekdays (measured over the last 7 days). At Datadog's current rate of $2.50/1,000 sessions, net additional replays come to ~$360/month.

> [!NOTE]
> `startSessionReplayRecording()` was missing from the `Window.DD_RUM` type definition. This PR adds it to `global.d.ts`. The existing `as any` on `init(...)` is pre-existing and out of scope.

> [!NOTE]
> `marketing/` is intentionally excluded. Marketing errors come from anonymous sessions with no customer identity and don't generate EngRunner cards.

## Tests

## Risks

## Deploy