### PR TITLE
Add conversation sandbox adapter

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -16,6 +16,7 @@ import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { REINFORCED_SKILLS_METADATA_KEYS } from "@app/lib/reinforcement/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import {
@@ -23,11 +24,8 @@ import {
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
 import { RunResource } from "@app/lib/resources/run_resource";
-import {
-  type EnsureSandboxResult,
-  type SandboxCreateBlob,
-  type SandboxDeleteOwner,
-  type SandboxLifecycleOwner,
+import type {
+  EnsureSandboxResult,
   SandboxResource,
 } from "@app/lib/resources/sandbox_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -364,105 +362,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return conversations.map((c) => this.fromModel(c, null));
   }
 
-  private static async fetchSandboxByConversation(
-    auth: Authenticator,
-    conversation: ConversationSandboxOwner
-  ): Promise<SandboxResource | null> {
-    const workspaceModelId = auth.getNonNullableWorkspace().id;
-    const link = await SandboxOwnerModel.findOne({
-      where: {
-        conversationId: conversation.id,
-        workspaceId: workspaceModelId,
-      },
-    });
-
-    if (!link) {
-      return null;
-    }
-
-    return SandboxResource.fetchByModelIdForWorkspace(auth, link.sandboxId);
-  }
-
-  private static async dangerouslyFetchSandboxByConversation(
-    conversation: Pick<ConversationResource, "id" | "workspaceId">
-  ): Promise<SandboxResource | null> {
-    const link = await SandboxOwnerModel.findOne({
-      where: {
-        workspaceId: conversation.workspaceId,
-        conversationId: conversation.id,
-      },
-    });
-
-    if (!link) {
-      return null;
-    }
-
-    return SandboxResource.dangerouslyFetchByModelIdForWorkspace({
-      sandboxModelId: link.sandboxId,
-      workspaceModelId: conversation.workspaceId,
-    });
-  }
-
-  private static async createSandboxRecordForConversation(
-    auth: Authenticator,
-    conversation: ConversationSandboxOwner,
-    blob: SandboxCreateBlob
-  ): Promise<SandboxResource> {
-    const workspaceModelId = auth.getNonNullableWorkspace().id;
-
-    return withTransaction(async (transaction) => {
-      const sandbox = await SandboxResource.makeNew(auth, blob, {
-        transaction,
-      });
-
-      await SandboxOwnerModel.create(
-        {
-          workspaceId: workspaceModelId,
-          conversationId: conversation.id,
-          sandboxId: sandbox.id,
-        },
-        { transaction }
-      );
-
-      return sandbox;
-    });
-  }
-
-  private static toSandboxLifecycleOwner(
-    conversation: ConversationResource
-  ): SandboxLifecycleOwner {
-    return {
-      lockKey: conversation.sId,
-      fetchSandbox: () =>
-        this.dangerouslyFetchSandboxByConversation(conversation),
-    };
-  }
-
-  private static toSandboxDeleteOwner(
-    auth: Authenticator,
-    conversation: ConversationResource
-  ): SandboxDeleteOwner {
-    return {
-      lockKey: conversation.sId,
-      fetchSandbox: () => this.fetchSandboxByConversation(auth, conversation),
-      deleteSandbox: async (sandbox, transaction) => {
-        await SandboxOwnerModel.destroy({
-          where: {
-            conversationId: conversation.id,
-            sandboxId: sandbox.id,
-            workspaceId: auth.getNonNullableWorkspace().id,
-          },
-          transaction,
-        });
-      },
-    };
-  }
-
   static async fetchSandbox(
     auth: Authenticator,
     conversation: ConversationSandboxOwner
   ): Promise<SandboxResource | null> {
-    return this.fetchSandboxByConversation(auth, conversation);
+    return ConversationSandboxAdapter.fetchSandbox(auth, conversation);
   }
 
   async fetchSandbox(auth: Authenticator): Promise<SandboxResource | null> {
@@ -473,14 +377,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     auth: Authenticator,
     conversation: ConversationSandboxOwner
   ): Promise<Result<EnsureSandboxResult, Error>> {
-    return SandboxResource.ensureActive(auth, {
-      lockKey: conversation.sId,
-      envVars: { CONVERSATION_ID: conversation.sId },
-      logLabel: "conversation",
-      fetchSandbox: () => this.fetchSandbox(auth, conversation),
-      createSandbox: (blob) =>
-        this.createSandboxRecordForConversation(auth, conversation, blob),
-    });
+    return ConversationSandboxAdapter.ensureSandboxActive(auth, conversation);
   }
 
   async ensureSandboxActive(
@@ -493,10 +390,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     auth: Authenticator,
     conversation: ConversationSandboxOwner
   ): Promise<Result<void, Error>> {
-    return SandboxResource.pauseForApproval(auth, {
-      lockKey: conversation.sId,
-      fetchSandbox: () => this.fetchSandboxByConversation(auth, conversation),
-    });
+    return ConversationSandboxAdapter.pauseSandboxForApproval(
+      auth,
+      conversation
+    );
   }
 
   async pauseSandboxForApproval(
@@ -506,45 +403,42 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   }
 
   async deleteSandbox(auth: Authenticator): Promise<Result<void, Error>> {
-    return SandboxResource.deleteByOwner(
-      auth,
-      ConversationResource.toSandboxDeleteOwner(auth, this)
-    );
+    return ConversationSandboxAdapter.deleteSandbox(auth, this);
   }
 
   async dangerouslySleepSandboxIfRunning(
     auth: Authenticator
   ): Promise<Result<void, Error>> {
-    return SandboxResource.dangerouslySleepIfRunning(
+    return ConversationSandboxAdapter.dangerouslySleepSandboxIfRunning(
       auth,
-      ConversationResource.toSandboxLifecycleOwner(this)
+      this
     );
   }
 
   async dangerouslySleepSandboxIfPendingApproval(
     auth: Authenticator
   ): Promise<Result<void, Error>> {
-    return SandboxResource.dangerouslySleepIfPendingApproval(
+    return ConversationSandboxAdapter.dangerouslySleepSandboxIfPendingApproval(
       auth,
-      ConversationResource.toSandboxLifecycleOwner(this)
+      this
     );
   }
 
   async dangerouslyDestroySandboxIfSleeping(
     auth: Authenticator
   ): Promise<Result<void, Error>> {
-    return SandboxResource.dangerouslyDestroyIfSleeping(
+    return ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping(
       auth,
-      ConversationResource.toSandboxLifecycleOwner(this)
+      this
     );
   }
 
   async dangerouslyDestroySandboxIfKillRequested(
     auth: Authenticator
   ): Promise<Result<void, Error>> {
-    return SandboxResource.dangerouslyDestroyIfKillRequested(
+    return ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested(
       auth,
-      ConversationResource.toSandboxLifecycleOwner(this)
+      this
     );
   }
 

--- a/front/lib/resources/conversation_sandbox_adapter.ts
+++ b/front/lib/resources/conversation_sandbox_adapter.ts
@@ -1,0 +1,203 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  type EnsureSandboxResult,
+  type SandboxCreateBlob,
+  type SandboxDeleteOwner,
+  type SandboxLifecycleOwner,
+  SandboxResource,
+} from "@app/lib/resources/sandbox_resource";
+import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import type { Transaction } from "sequelize";
+
+type ConversationSandboxOwner = Pick<
+  ConversationWithoutContentType,
+  "id" | "sId"
+>;
+
+type ConversationSandboxLifecycleOwner = ConversationSandboxOwner & {
+  workspaceId: ModelId;
+};
+
+export class ConversationSandboxAdapter {
+  private static async fetchSandboxByConversation(
+    auth: Authenticator,
+    conversation: ConversationSandboxOwner
+  ): Promise<SandboxResource | null> {
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const link = await SandboxOwnerModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: workspaceModelId,
+      },
+    });
+
+    if (!link) {
+      return null;
+    }
+
+    return SandboxResource.fetchByModelIdForWorkspace(auth, link.sandboxId);
+  }
+
+  private static async dangerouslyFetchSandboxByConversation(
+    conversation: ConversationSandboxLifecycleOwner
+  ): Promise<SandboxResource | null> {
+    const link = await SandboxOwnerModel.findOne({
+      where: {
+        workspaceId: conversation.workspaceId,
+        conversationId: conversation.id,
+      },
+    });
+
+    if (!link) {
+      return null;
+    }
+
+    return SandboxResource.dangerouslyFetchByModelIdForWorkspace({
+      sandboxModelId: link.sandboxId,
+      workspaceModelId: conversation.workspaceId,
+    });
+  }
+
+  private static async createSandboxRecordForConversation(
+    auth: Authenticator,
+    conversation: ConversationSandboxOwner,
+    blob: SandboxCreateBlob
+  ): Promise<SandboxResource> {
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+
+    return withTransaction(async (transaction) => {
+      const sandbox = await SandboxResource.makeNew(auth, blob, {
+        transaction,
+      });
+
+      await SandboxOwnerModel.create(
+        {
+          workspaceId: workspaceModelId,
+          conversationId: conversation.id,
+          sandboxId: sandbox.id,
+        },
+        { transaction }
+      );
+
+      return sandbox;
+    });
+  }
+
+  private static toSandboxLifecycleOwner(
+    conversation: ConversationSandboxLifecycleOwner
+  ): SandboxLifecycleOwner {
+    return {
+      lockKey: conversation.sId,
+      fetchSandbox: () =>
+        this.dangerouslyFetchSandboxByConversation(conversation),
+    };
+  }
+
+  private static toSandboxDeleteOwner(
+    auth: Authenticator,
+    conversation: ConversationSandboxOwner
+  ): SandboxDeleteOwner {
+    return {
+      lockKey: conversation.sId,
+      fetchSandbox: () => this.fetchSandboxByConversation(auth, conversation),
+      deleteSandbox: async (
+        sandbox: SandboxResource,
+        transaction: Transaction
+      ) => {
+        await SandboxOwnerModel.destroy({
+          where: {
+            conversationId: conversation.id,
+            sandboxId: sandbox.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+          transaction,
+        });
+      },
+    };
+  }
+
+  static async fetchSandbox(
+    auth: Authenticator,
+    conversation: ConversationSandboxOwner
+  ): Promise<SandboxResource | null> {
+    return this.fetchSandboxByConversation(auth, conversation);
+  }
+
+  static async ensureSandboxActive(
+    auth: Authenticator,
+    conversation: ConversationSandboxOwner
+  ): Promise<Result<EnsureSandboxResult, Error>> {
+    return SandboxResource.ensureActive(auth, {
+      lockKey: conversation.sId,
+      envVars: { CONVERSATION_ID: conversation.sId },
+      logLabel: "conversation",
+      fetchSandbox: () => this.fetchSandbox(auth, conversation),
+      createSandbox: (blob) =>
+        this.createSandboxRecordForConversation(auth, conversation, blob),
+    });
+  }
+
+  static async pauseSandboxForApproval(
+    auth: Authenticator,
+    conversation: ConversationSandboxOwner
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.pauseForApproval(auth, {
+      lockKey: conversation.sId,
+      fetchSandbox: () => this.fetchSandboxByConversation(auth, conversation),
+    });
+  }
+
+  static async deleteSandbox(
+    auth: Authenticator,
+    conversation: ConversationSandboxOwner
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.deleteByOwner(
+      auth,
+      this.toSandboxDeleteOwner(auth, conversation)
+    );
+  }
+
+  static async dangerouslySleepSandboxIfRunning(
+    auth: Authenticator,
+    conversation: ConversationSandboxLifecycleOwner
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslySleepIfRunning(
+      auth,
+      this.toSandboxLifecycleOwner(conversation)
+    );
+  }
+
+  static async dangerouslySleepSandboxIfPendingApproval(
+    auth: Authenticator,
+    conversation: ConversationSandboxLifecycleOwner
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslySleepIfPendingApproval(
+      auth,
+      this.toSandboxLifecycleOwner(conversation)
+    );
+  }
+
+  static async dangerouslyDestroySandboxIfSleeping(
+    auth: Authenticator,
+    conversation: ConversationSandboxLifecycleOwner
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslyDestroyIfSleeping(
+      auth,
+      this.toSandboxLifecycleOwner(conversation)
+    );
+  }
+
+  static async dangerouslyDestroySandboxIfKillRequested(
+    auth: Authenticator,
+    conversation: ConversationSandboxLifecycleOwner
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslyDestroyIfKillRequested(
+      auth,
+      this.toSandboxLifecycleOwner(conversation)
+    );
+  }
+}


### PR DESCRIPTION
## Description

No UI changes.

Adds `ConversationSandboxAdapter` as the owner of conversation sandbox behavior. The adapter now contains the concrete fetch/create/delete/lifecycle implementation instead of passing through to `ConversationResource`.

What changes here:
- Adds the adapter boundary for conversation sandbox fetch, ensure active, pause, delete, and lifecycle methods.
- Moves the sandbox owner row lookup, sandbox row creation, owner row creation, delete cleanup, and lifecycle owner mapping into the adapter.
- Leaves temporary `ConversationResource` delegate methods in place so existing call sites keep working until #28093.
- Leaves the cross-workspace conversation owner-map lookup on `ConversationResource`; #28094 moves that final piece.

Current open stack after #28041:
- #28092: add `ConversationSandboxAdapter` with the concrete conversation sandbox implementation and temporary `ConversationResource` delegates.
- #28093: move external conversation sandbox callers to the adapter and remove the temporary delegates.
- #28094: move the remaining conversation owner-map lookup into the adapter.
- #28047: add pod sandbox owner adapter.
- #28048: wire pod sandbox owners into the reaper.

## Tests

Latest local verification on the rewritten stack:

- `npm exec -- biome check front/lib/resources/conversation_sandbox_adapter.ts front/lib/resources/conversation_resource.ts front/lib/resources/pod_sandbox_adapter.ts front/lib/resources/space_resource.sandbox.test.ts front/lib/resources/space_resource.ts front/lib/resources/sandbox_resource.ts front/lib/resources/sandbox_resource.test.ts front/temporal/sandbox_reaper/activities.ts front/temporal/sandbox_reaper/activities.test.ts front/temporal/sandbox_reaper/kill_requester/activities.test.ts front/lib/api/sandbox/access_tokens.test.ts front/tests/utils/SandboxFactory.ts front/lib/api/assistant/conversation/destroy.ts front/lib/api/sandbox/lifecycle.ts front/lib/api/sandbox/sandbox_child_block.ts 'front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts'`
- `cd front && source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_ENV=test npm test -- ./lib/resources/sandbox_resource.test.ts ./lib/resources/space_resource.sandbox.test.ts ./temporal/sandbox_reaper/activities.test.ts ./temporal/sandbox_reaper/kill_requester/activities.test.ts ./lib/api/sandbox/access_tokens.test.ts ./lib/api/sandbox/lifecycle.test.ts`
- `npm -w front run tsgo`
- `npm -w front-api run tsgo`
- `npm -w front-spa run tsgo`
- `npm -w extension run tsgo`

## Risk

Medium-low. The implementation moves behind the adapter, but existing call sites still flow through the same `ConversationResource` method surface until the next PR.

## Deploy Plan

- [x] #28041 has merged into `main`.
- [ ] Merge this PR after CI and review are green.
- [ ] Deploy normally as app code only.
- [ ] No schema migration, data migration, or backfill is required for this PR.