### PR TITLE
Use conversation sandbox adapter at call sites

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
@@ -1,5 +1,6 @@
 import type { GetConversationSandboxResponseBody } from "@app/lib/api/assistant/conversation/sandbox";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -32,7 +33,10 @@ app.get(
       });
     }
 
-    const sandbox = await ConversationResource.fetchSandbox(auth, conversation);
+    const sandbox = await ConversationSandboxAdapter.fetchSandbox(
+      auth,
+      conversation
+    );
 
     return ctx.json({
       sandboxStatus: sandbox?.status ?? null,

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -20,6 +20,7 @@ import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import {
@@ -311,7 +312,7 @@ export async function destroyConversation(
     where: { workspaceId: owner.id, sourceId: conversation.sId },
   });
 
-  await conversation.deleteSandbox(auth);
+  await ConversationSandboxAdapter.deleteSandbox(auth, conversation);
 
   // TODO(2026-03-09 SANDBOX): Implement proper file deletion.
   // FileResource records associated with this conversation (via

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -8,6 +8,7 @@ const {
   mockLoggerError,
   mockLoggerInfo,
   mockLoggerWarn,
+  mockLoggerChild,
   mockForConversation,
   mockSetupSandboxMount,
   mockRefreshSandboxMount,
@@ -23,6 +24,7 @@ const {
     mockLoggerError: vi.fn(),
     mockLoggerInfo: vi.fn(),
     mockLoggerWarn: vi.fn(),
+    mockLoggerChild: vi.fn(),
     mockForConversation: vi.fn(),
     mockSetupSandboxMount,
     mockRefreshSandboxMount,
@@ -50,19 +52,22 @@ vi.mock("@app/lib/api/sandbox/telemetry", () => ({
   startTelemetry: mockStartTelemetry,
 }));
 
-vi.mock("@app/lib/resources/conversation_resource", () => ({
-  ConversationResource: {
+vi.mock("@app/lib/resources/conversation_sandbox_adapter", () => ({
+  ConversationSandboxAdapter: {
     ensureSandboxActive: mockEnsureSandboxActive,
   },
 }));
 
-vi.mock("@app/logger/logger", () => ({
-  default: {
+vi.mock("@app/logger/logger", () => {
+  const logger = {
     error: mockLoggerError,
     info: mockLoggerInfo,
     warn: mockLoggerWarn,
-  },
-}));
+    child: mockLoggerChild,
+  };
+  mockLoggerChild.mockReturnValue(logger);
+  return { default: logger };
+});
 
 import { ensureSandboxReady } from "./lifecycle";
 

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -10,7 +10,7 @@ import {
 } from "@app/lib/api/sandbox/instrumentation";
 import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
@@ -22,7 +22,7 @@ export interface EnsureSandboxReadyResult {
 }
 
 // /!\ All sandbox-touching tools must use this helper rather than calling
-// ConversationResource.ensureSandboxActive directly, otherwise the GCS FUSE mount and
+// ConversationSandboxAdapter.ensureSandboxActive directly, otherwise the GCS FUSE mount and
 // egress forwarder bring-up will be skipped.
 export async function ensureSandboxReady(
   auth: Authenticator,
@@ -38,7 +38,7 @@ export async function ensureSandboxReady(
     return await traceSandboxStartupPhase("total", async () => {
       const ensureResult = await traceSandboxStartupPhase(
         "provider_ensure",
-        () => ConversationResource.ensureSandboxActive(auth, conversation)
+        () => ConversationSandboxAdapter.ensureSandboxActive(auth, conversation)
       );
       if (ensureResult.isErr()) {
         status = "error";

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -5,7 +5,7 @@ import {
 } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type {
@@ -58,7 +58,7 @@ export async function pauseSandboxBashForBlockedChild(
   // reconnects via execId. DB-first is the self-converging shape.
   await parentAction.updateStatus("blocked_child_action_input_required");
 
-  const pauseResult = await ConversationResource.pauseSandboxForApproval(
+  const pauseResult = await ConversationSandboxAdapter.pauseSandboxForApproval(
     auth,
     conversation
   );

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -16,7 +16,6 @@ import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { REINFORCED_SKILLS_METADATA_KEYS } from "@app/lib/reinforcement/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
-import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import {
@@ -24,10 +23,7 @@ import {
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
 import { RunResource } from "@app/lib/resources/run_resource";
-import type {
-  EnsureSandboxResult,
-  SandboxResource,
-} from "@app/lib/resources/sandbox_resource";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
@@ -88,11 +84,6 @@ import type {
   WhereOptions,
 } from "sequelize";
 import { col, fn, literal, Op, QueryTypes, Sequelize, where } from "sequelize";
-
-type ConversationSandboxOwner = Pick<
-  ConversationWithoutContentType,
-  "id" | "sId"
->;
 
 export type FetchConversationOptions = {
   includeDeleted?: boolean;
@@ -360,86 +351,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
 
     return conversations.map((c) => this.fromModel(c, null));
-  }
-
-  static async fetchSandbox(
-    auth: Authenticator,
-    conversation: ConversationSandboxOwner
-  ): Promise<SandboxResource | null> {
-    return ConversationSandboxAdapter.fetchSandbox(auth, conversation);
-  }
-
-  async fetchSandbox(auth: Authenticator): Promise<SandboxResource | null> {
-    return ConversationResource.fetchSandbox(auth, this);
-  }
-
-  static async ensureSandboxActive(
-    auth: Authenticator,
-    conversation: ConversationSandboxOwner
-  ): Promise<Result<EnsureSandboxResult, Error>> {
-    return ConversationSandboxAdapter.ensureSandboxActive(auth, conversation);
-  }
-
-  async ensureSandboxActive(
-    auth: Authenticator
-  ): Promise<Result<EnsureSandboxResult, Error>> {
-    return ConversationResource.ensureSandboxActive(auth, this);
-  }
-
-  static async pauseSandboxForApproval(
-    auth: Authenticator,
-    conversation: ConversationSandboxOwner
-  ): Promise<Result<void, Error>> {
-    return ConversationSandboxAdapter.pauseSandboxForApproval(
-      auth,
-      conversation
-    );
-  }
-
-  async pauseSandboxForApproval(
-    auth: Authenticator
-  ): Promise<Result<void, Error>> {
-    return ConversationResource.pauseSandboxForApproval(auth, this);
-  }
-
-  async deleteSandbox(auth: Authenticator): Promise<Result<void, Error>> {
-    return ConversationSandboxAdapter.deleteSandbox(auth, this);
-  }
-
-  async dangerouslySleepSandboxIfRunning(
-    auth: Authenticator
-  ): Promise<Result<void, Error>> {
-    return ConversationSandboxAdapter.dangerouslySleepSandboxIfRunning(
-      auth,
-      this
-    );
-  }
-
-  async dangerouslySleepSandboxIfPendingApproval(
-    auth: Authenticator
-  ): Promise<Result<void, Error>> {
-    return ConversationSandboxAdapter.dangerouslySleepSandboxIfPendingApproval(
-      auth,
-      this
-    );
-  }
-
-  async dangerouslyDestroySandboxIfSleeping(
-    auth: Authenticator
-  ): Promise<Result<void, Error>> {
-    return ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping(
-      auth,
-      this
-    );
-  }
-
-  async dangerouslyDestroySandboxIfKillRequested(
-    auth: Authenticator
-  ): Promise<Result<void, Error>> {
-    return ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested(
-      auth,
-      this
-    );
   }
 
   static async dangerouslyFetchConversationModelIdsBySandboxes(

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -51,6 +51,7 @@ vi.mock("@app/lib/lock", () => ({
 
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import {
   SandboxModel,
@@ -140,7 +141,7 @@ describe("SandboxResource.updateStatus", () => {
 
     expect(mockDistribution).not.toHaveBeenCalled();
 
-    const reloaded = await ConversationResource.fetchSandbox(
+    const reloaded = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       conversation
     );
@@ -161,7 +162,7 @@ describe("SandboxResource.updateStatus", () => {
     await sandbox.updateStatus("sleeping", { ctx });
     const afterTransition = Date.now();
 
-    const reloaded = await ConversationResource.fetchSandbox(
+    const reloaded = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       conversation
     );
@@ -175,7 +176,7 @@ describe("SandboxResource.updateStatus", () => {
   });
 });
 
-describe("ConversationResource.dangerouslyDestroySandboxIfSleeping", () => {
+describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping", () => {
   let authenticator: Authenticator;
   let conversationResource: ConversationResource;
 
@@ -220,8 +221,9 @@ describe("ConversationResource.dangerouslyDestroySandboxIfSleeping", () => {
     );
 
     const result =
-      await conversationResource.dangerouslyDestroySandboxIfSleeping(
-        authenticator
+      await ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping(
+        authenticator,
+        conversationResource
       );
 
     expect(result.isOk()).toBe(true);
@@ -230,7 +232,7 @@ describe("ConversationResource.dangerouslyDestroySandboxIfSleeping", () => {
     });
     expect(mockDeleteSandboxPolicy).toHaveBeenCalledWith(sandbox.providerId);
 
-    const reloaded = await ConversationResource.fetchSandbox(
+    const reloaded = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       conversationResource.toJSON()
     );
@@ -253,8 +255,9 @@ describe("ConversationResource.dangerouslyDestroySandboxIfSleeping", () => {
     await SandboxOwnerModel.destroy({ where });
 
     const result =
-      await conversationResource.dangerouslyDestroySandboxIfSleeping(
-        authenticator
+      await ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping(
+        authenticator,
+        conversationResource
       );
 
     expect(result.isOk()).toBe(true);
@@ -276,7 +279,10 @@ describe("ConversationResource.dangerouslyDestroySandboxIfSleeping", () => {
     );
     const workspaceModelId = authenticator.getNonNullableWorkspace().id;
 
-    const result = await conversationResource.deleteSandbox(authenticator);
+    const result = await ConversationSandboxAdapter.deleteSandbox(
+      authenticator,
+      conversationResource
+    );
 
     expect(result.isOk()).toBe(true);
     const [linkCount, sandboxCount] = await Promise.all([
@@ -295,7 +301,7 @@ describe("ConversationResource.dangerouslyDestroySandboxIfSleeping", () => {
   });
 });
 
-describe("ConversationResource.dangerouslyDestroySandboxIfKillRequested", () => {
+describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested", () => {
   let authenticator: Authenticator;
   let conversationResource: ConversationResource;
 
@@ -345,8 +351,9 @@ describe("ConversationResource.dangerouslyDestroySandboxIfKillRequested", () => 
     );
 
     const result =
-      await conversationResource.dangerouslyDestroySandboxIfKillRequested(
-        authenticator
+      await ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested(
+        authenticator,
+        conversationResource
       );
 
     expect(result.isOk()).toBe(true);
@@ -354,7 +361,7 @@ describe("ConversationResource.dangerouslyDestroySandboxIfKillRequested", () => 
       workspaceId: authenticator.getNonNullableWorkspace().sId,
     });
 
-    const reloaded = await ConversationResource.fetchSandbox(
+    const reloaded = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       conversationResource.toJSON()
     );
@@ -367,14 +374,15 @@ describe("ConversationResource.dangerouslyDestroySandboxIfKillRequested", () => 
     });
 
     const result =
-      await conversationResource.dangerouslyDestroySandboxIfKillRequested(
-        authenticator
+      await ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested(
+        authenticator,
+        conversationResource
       );
 
     expect(result.isOk()).toBe(true);
     expect(mockProviderDestroy).not.toHaveBeenCalled();
 
-    const reloaded = await ConversationResource.fetchSandbox(
+    const reloaded = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       conversationResource.toJSON()
     );
@@ -388,8 +396,9 @@ describe("ConversationResource.dangerouslyDestroySandboxIfKillRequested", () => 
     });
 
     const result =
-      await conversationResource.dangerouslyDestroySandboxIfKillRequested(
-        authenticator
+      await ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested(
+        authenticator,
+        conversationResource
       );
 
     expect(result.isOk()).toBe(true);
@@ -498,7 +507,7 @@ describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
     });
 
     expect(affected).toBe(2);
-    const stillUnmarked = await ConversationResource.fetchSandbox(
+    const stillUnmarked = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       other
     );
@@ -535,7 +544,7 @@ describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
     });
 
     expect(affected).toBe(2);
-    const matched = await ConversationResource.fetchSandbox(
+    const matched = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       cMatch
     );
@@ -565,7 +574,7 @@ describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
     });
 
     expect(affected).toBe(1);
-    const alreadyMarked = await ConversationResource.fetchSandbox(
+    const alreadyMarked = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       cAlreadyMarked
     );
@@ -589,7 +598,7 @@ describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
   });
 });
 
-describe("ConversationResource.fetchSandbox", () => {
+describe("ConversationSandboxAdapter.fetchSandbox", () => {
   let authenticator: Authenticator;
   let agentConfigId: string;
 
@@ -614,7 +623,7 @@ describe("ConversationResource.fetchSandbox", () => {
     const conversation = await makeConversation();
     const sandbox = await SandboxFactory.create(authenticator, conversation);
 
-    const fetched = await ConversationResource.fetchSandbox(
+    const fetched = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       conversation
     );
@@ -643,7 +652,7 @@ describe("ConversationResource.fetchSandbox", () => {
 
     await SandboxOwnerModel.destroy({ where });
 
-    const fetched = await ConversationResource.fetchSandbox(
+    const fetched = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       conversation
     );
@@ -786,7 +795,7 @@ describe("SandboxResource.ensureActive", () => {
       },
     ]);
 
-    const result = await ConversationResource.ensureSandboxActive(
+    const result = await ConversationSandboxAdapter.ensureSandboxActive(
       authenticator,
       conversation
     );
@@ -828,14 +837,14 @@ describe("SandboxResource.ensureActive", () => {
   });
 
   it("records baseImage and version from the registered image on fresh create", async () => {
-    const result = await ConversationResource.ensureSandboxActive(
+    const result = await ConversationSandboxAdapter.ensureSandboxActive(
       authenticator,
       conversation
     );
 
     expect(result.isOk()).toBe(true);
 
-    const persisted = await ConversationResource.fetchSandbox(
+    const persisted = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       conversation
     );
@@ -858,14 +867,14 @@ describe("SandboxResource.ensureActive", () => {
       version: "0.0.0-old",
     });
 
-    const result = await ConversationResource.ensureSandboxActive(
+    const result = await ConversationSandboxAdapter.ensureSandboxActive(
       authenticator,
       conversation
     );
 
     expect(result.isOk()).toBe(true);
 
-    const persisted = await ConversationResource.fetchSandbox(
+    const persisted = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       conversation
     );
@@ -883,7 +892,7 @@ describe("SandboxResource.ensureActive", () => {
       killRequestedAt: new Date(),
     });
 
-    const result = await ConversationResource.ensureSandboxActive(
+    const result = await ConversationSandboxAdapter.ensureSandboxActive(
       authenticator,
       conversation
     );
@@ -894,7 +903,7 @@ describe("SandboxResource.ensureActive", () => {
     });
     expect(mockProviderCreate).toHaveBeenCalled();
 
-    const persisted = await ConversationResource.fetchSandbox(
+    const persisted = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
       conversation
     );

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -166,7 +167,10 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
     await processSandboxes(
       killRequestedSandboxes,
       (auth, conversation) =>
-        conversation.dangerouslyDestroySandboxIfKillRequested(auth),
+        ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested(
+          auth,
+          conversation
+        ),
       "Reaper: failed to destroy kill-requested sandbox — continuing."
     );
   }
@@ -187,7 +191,10 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
     await processSandboxes(
       runningSandboxes,
       (auth, conversation) =>
-        conversation.dangerouslySleepSandboxIfRunning(auth),
+        ConversationSandboxAdapter.dangerouslySleepSandboxIfRunning(
+          auth,
+          conversation
+        ),
       "Reaper: failed to sleep sandbox — continuing."
     );
   }
@@ -208,7 +215,10 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
     await processSandboxes(
       pendingSandboxes,
       (auth, conversation) =>
-        conversation.dangerouslySleepSandboxIfPendingApproval(auth),
+        ConversationSandboxAdapter.dangerouslySleepSandboxIfPendingApproval(
+          auth,
+          conversation
+        ),
       "Reaper: failed to transition pending_approval sandbox — continuing."
     );
   }
@@ -229,7 +239,10 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
     await processSandboxes(
       sleepingSandboxes,
       (auth, conversation) =>
-        conversation.dangerouslyDestroySandboxIfSleeping(auth),
+        ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping(
+          auth,
+          conversation
+        ),
       "Reaper: failed to destroy sandbox — continuing."
     );
   }

--- a/front/temporal/sandbox_reaper/kill_requester/activities.test.ts
+++ b/front/temporal/sandbox_reaper/kill_requester/activities.test.ts
@@ -1,4 +1,4 @@
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { requestSandboxKillsActivity } from "@app/temporal/sandbox_reaper/kill_requester/activities";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -52,7 +52,10 @@ describe("requestSandboxKillsActivity", () => {
     });
 
     expect(hasMore).toBe(false);
-    const marked = await ConversationResource.fetchSandbox(authenticator, c1);
+    const marked = await ConversationSandboxAdapter.fetchSandbox(
+      authenticator,
+      c1
+    );
     expect(marked?.killRequestedAt).not.toBeNull();
   });
 });

--- a/front/tests/utils/SandboxFactory.ts
+++ b/front/tests/utils/SandboxFactory.ts
@@ -1,5 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import {
@@ -47,7 +47,10 @@ export class SandboxFactory {
       );
     }
 
-    const result = await ConversationResource.fetchSandbox(auth, conversation);
+    const result = await ConversationSandboxAdapter.fetchSandbox(
+      auth,
+      conversation
+    );
     if (!result) {
       throw new Error("Sandbox not found after creation");
     }


### PR DESCRIPTION
## Description

No UI changes.

#28092 has merged into `main`. This PR moves external conversation sandbox callers to `ConversationSandboxAdapter` and removes the temporary sandbox delegate methods from `ConversationResource`.

What changes here:
- Updates API, lifecycle, child-block, destroy, factory, reaper lifecycle, and tests to call the adapter directly for conversation sandbox operations.
- Removes the temporary `ConversationResource` sandbox fetch, ensure active, pause, delete, and lifecycle delegate methods added in #28092.
- Keeps the cross-workspace owner-map lookup on `ConversationResource`; #28094 moves that final lookup into the adapter with its concrete implementation.

Current open stack:
- #28093: move external conversation sandbox callers to the adapter and remove the temporary delegates.
- #28094: move the remaining conversation owner-map lookup into the adapter.
- #28047: add pod sandbox owner adapter.
- #28048: wire pod sandbox owners into the reaper.

## Tests

Latest local verification after rebasing on `origin/main`:

- `npm exec -- biome check front/lib/resources/conversation_resource.ts front/lib/resources/sandbox_resource.test.ts front/temporal/sandbox_reaper/activities.ts front/temporal/sandbox_reaper/kill_requester/activities.test.ts front/tests/utils/SandboxFactory.ts front/lib/api/assistant/conversation/destroy.ts front/lib/api/sandbox/lifecycle.ts front/lib/api/sandbox/lifecycle.test.ts front/lib/api/sandbox/sandbox_child_block.ts 'front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts'`
- `cd front && source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_ENV=test npm test -- ./lib/resources/sandbox_resource.test.ts ./temporal/sandbox_reaper/kill_requester/activities.test.ts ./lib/api/sandbox/lifecycle.test.ts`
- `npm -w front run tsgo`
- `npm -w front-api run tsgo`
- `npm -w front-spa run tsgo`
- `npm -w extension run tsgo`

## Risk

Medium-low. This changes call sites to use the adapter directly but does not change the underlying conversation sandbox implementation introduced in #28092.

## Deploy Plan

- [x] #28092 has merged into `main`.
- [ ] Merge and deploy this PR after CI and review are green.
- [ ] Deploy normally as app code only.
- [ ] No schema migration, data migration, or backfill is required for this PR.
