### PR TITLE
Move conversation sandbox owner map to adapter

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -23,11 +23,9 @@ import {
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
 import { RunResource } from "@app/lib/resources/run_resource";
-import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
-import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -94,8 +92,6 @@ export type FetchConversationOptions = {
 };
 
 type SpaceConversationsFilter = "all" | "group" | "with_me";
-
-const SANDBOX_OWNER_LOOKUP_CONCURRENCY = 4;
 
 interface UserParticipation {
   actionRequired: boolean;
@@ -351,57 +347,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
 
     return conversations.map((c) => this.fromModel(c, null));
-  }
-
-  static async dangerouslyFetchConversationModelIdsBySandboxes(
-    sandboxes: Pick<SandboxResource, "id" | "workspaceId">[]
-  ): Promise<Map<ModelId, ModelId>> {
-    if (sandboxes.length === 0) {
-      return new Map();
-    }
-
-    const sandboxModelIdsByWorkspaceModelId = new Map<ModelId, ModelId[]>();
-    for (const sandbox of sandboxes) {
-      const sandboxModelIds =
-        sandboxModelIdsByWorkspaceModelId.get(sandbox.workspaceId) ?? [];
-      sandboxModelIds.push(sandbox.id);
-      sandboxModelIdsByWorkspaceModelId.set(
-        sandbox.workspaceId,
-        sandboxModelIds
-      );
-    }
-
-    const rows = (
-      await concurrentExecutor(
-        [...sandboxModelIdsByWorkspaceModelId.entries()],
-        async ([workspaceModelId, sandboxModelIds]) =>
-          SandboxOwnerModel.findAll({
-            where: {
-              workspaceId: workspaceModelId,
-              conversationId: {
-                [Op.ne]: null,
-              },
-              sandboxId: {
-                [Op.in]: sandboxModelIds,
-              },
-            },
-            attributes: ["sandboxId", "conversationId"],
-          }),
-        { concurrency: SANDBOX_OWNER_LOOKUP_CONCURRENCY }
-      )
-    ).flat();
-
-    const conversationModelIdsBySandboxModelId = new Map<ModelId, ModelId>();
-    for (const row of rows) {
-      if (row.conversationId !== null) {
-        conversationModelIdsBySandboxModelId.set(
-          row.sandboxId,
-          row.conversationId
-        );
-      }
-    }
-
-    return conversationModelIdsBySandboxModelId;
   }
 
   get forkingData(): ConversationForkingDataType | undefined {

--- a/front/lib/resources/conversation_sandbox_adapter.ts
+++ b/front/lib/resources/conversation_sandbox_adapter.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import {
   type EnsureSandboxResult,
   type SandboxCreateBlob,
@@ -7,20 +8,24 @@ import {
   SandboxResource,
 } from "@app/lib/resources/sandbox_resource";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
-import type { Transaction } from "sequelize";
+import { Op, type Transaction } from "sequelize";
 
 type ConversationSandboxOwner = Pick<
   ConversationWithoutContentType,
   "id" | "sId"
 >;
 
-type ConversationSandboxLifecycleOwner = ConversationSandboxOwner & {
-  workspaceId: ModelId;
-};
+type ConversationSandboxLifecycleOwner = Pick<
+  ConversationResource,
+  "id" | "sId" | "workspaceId"
+>;
+
+const SANDBOX_OWNER_LOOKUP_CONCURRENCY = 4;
 
 export class ConversationSandboxAdapter {
   private static async fetchSandboxByConversation(
@@ -199,5 +204,56 @@ export class ConversationSandboxAdapter {
       auth,
       this.toSandboxLifecycleOwner(conversation)
     );
+  }
+
+  static async dangerouslyFetchConversationModelIdsBySandboxes(
+    sandboxes: Pick<SandboxResource, "id" | "workspaceId">[]
+  ): Promise<Map<ModelId, ModelId>> {
+    if (sandboxes.length === 0) {
+      return new Map();
+    }
+
+    const sandboxModelIdsByWorkspaceModelId = new Map<ModelId, ModelId[]>();
+    for (const sandbox of sandboxes) {
+      const sandboxModelIds =
+        sandboxModelIdsByWorkspaceModelId.get(sandbox.workspaceId) ?? [];
+      sandboxModelIds.push(sandbox.id);
+      sandboxModelIdsByWorkspaceModelId.set(
+        sandbox.workspaceId,
+        sandboxModelIds
+      );
+    }
+
+    const rows = (
+      await concurrentExecutor(
+        [...sandboxModelIdsByWorkspaceModelId.entries()],
+        async ([workspaceModelId, sandboxModelIds]) =>
+          SandboxOwnerModel.findAll({
+            where: {
+              workspaceId: workspaceModelId,
+              conversationId: {
+                [Op.ne]: null,
+              },
+              sandboxId: {
+                [Op.in]: sandboxModelIds,
+              },
+            },
+            attributes: ["sandboxId", "conversationId"],
+          }),
+        { concurrency: SANDBOX_OWNER_LOOKUP_CONCURRENCY }
+      )
+    ).flat();
+
+    const conversationModelIdsBySandboxModelId = new Map<ModelId, ModelId>();
+    for (const row of rows) {
+      if (row.conversationId !== null) {
+        conversationModelIdsBySandboxModelId.set(
+          row.sandboxId,
+          row.conversationId
+        );
+      }
+    }
+
+    return conversationModelIdsBySandboxModelId;
   }
 }

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -665,7 +665,7 @@ describe("ConversationSandboxAdapter.fetchSandbox", () => {
     const sandbox = await SandboxFactory.create(authenticator, conversation);
 
     const conversationModelIdsBySandboxModelId =
-      await ConversationResource.dangerouslyFetchConversationModelIdsBySandboxes(
+      await ConversationSandboxAdapter.dangerouslyFetchConversationModelIdsBySandboxes(
         [sandbox]
       );
 
@@ -679,7 +679,7 @@ describe("ConversationSandboxAdapter.fetchSandbox", () => {
     const sandbox = await SandboxFactory.create(authenticator, conversation);
 
     const conversationModelIdsBySandboxModelId =
-      await ConversationResource.dangerouslyFetchConversationModelIdsBySandboxes(
+      await ConversationSandboxAdapter.dangerouslyFetchConversationModelIdsBySandboxes(
         [
           {
             id: sandbox.id,

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -61,7 +61,7 @@ async function fetchConversationMap(
   sandboxes: SandboxResource[]
 ): Promise<ConversationMaps> {
   const conversationModelIdsBySandboxModelId =
-    await ConversationResource.dangerouslyFetchConversationModelIdsBySandboxes(
+    await ConversationSandboxAdapter.dangerouslyFetchConversationModelIdsBySandboxes(
       sandboxes
     );
   const conversationModelIds = [


### PR DESCRIPTION
## Description

No UI changes.

#28093 has merged into `main`. This PR moves the remaining conversation sandbox owner-map lookup from `ConversationResource` into `ConversationSandboxAdapter`.

What changes here:
- Moves `dangerouslyFetchConversationModelIdsBySandboxes` into the adapter with the direct `sandbox_owners.conversationId` query.
- Moves the reaper owner-map call site to the adapter.
- Updates the owner-map tests to assert through the adapter.
- Keeps the low-concurrency per-workspace `concurrentExecutor` lookup.
- Removes the final sandbox ownership dependency from `ConversationResource`.

Current open stack:
- #28094: move the remaining conversation owner-map lookup into the adapter.
- #28047: add pod sandbox owner adapter.
- #28048: wire pod sandbox owners into the reaper.

## Tests

Latest local verification after rebasing on `origin/main`:

- `npm exec -- biome check front/lib/resources/conversation_resource.ts front/lib/resources/conversation_sandbox_adapter.ts front/lib/resources/sandbox_resource.test.ts front/temporal/sandbox_reaper/activities.ts`
- `cd front && source "$HOME/.dust-hive/envs/s1-conv-sandbox/env.sh" && NODE_ENV=test npm test -- ./lib/resources/sandbox_resource.test.ts`
- `npm -w front run tsgo`
- `npm -w front-api run tsgo`
- `npm -w front-spa run tsgo`
- `npm -w extension run tsgo`

## Risk

Low. This moves an internal lookup and its reaper call site to the adapter without changing query semantics.

## Deploy Plan

- [x] #28093 has merged into `main`.
- [ ] Merge and deploy this PR after CI and review are green.
- [ ] Deploy normally as app code only.
- [ ] No schema migration, data migration, or backfill is required for this PR.
