### PR TITLE
[sparkle, front] Restyle OptionCard + Counter to new design

### DIFF
--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -48,6 +48,7 @@ vi.mock("@dust-tt/sparkle", () => {
       .join(" ");
 
   const OptionCard = ({
+    type = "option",
     label,
     description,
     selected,
@@ -57,8 +58,18 @@ vi.mock("@dust-tt/sparkle", () => {
     disabled,
     onFocusCapture,
     onMouseEnter,
+    value,
+    onChange,
+    placeholder,
+    name,
+    id,
+    inputRef,
+    onFocus,
+    onBlur,
+    onKeyDown,
   }: {
-    label: string;
+    type?: "option" | "input";
+    label?: string;
     description?: string | null;
     selected?: boolean;
     disableHover?: boolean;
@@ -67,26 +78,51 @@ vi.mock("@dust-tt/sparkle", () => {
     disabled?: boolean;
     onFocusCapture?: React.FocusEventHandler<HTMLButtonElement>;
     onMouseEnter?: React.MouseEventHandler<HTMLButtonElement>;
-  }) => (
-    <button
-      type="button"
-      onClick={onClick}
-      onFocusCapture={onFocusCapture}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onClick?.();
-        }
-      }}
-      onMouseEnter={onMouseEnter}
-      disabled={disabled}
-      className={cn(!disableHover && "hover-enabled", className)}
-      data-selected={selected ? "true" : "false"}
-    >
-      <span>{label}</span>
-      {description ? <span>{description}</span> : null}
-    </button>
-  );
+    value?: string;
+    onChange?: (value: string) => void;
+    placeholder?: string;
+    name?: string;
+    id?: string;
+    inputRef?: React.Ref<HTMLInputElement>;
+    onFocus?: React.FocusEventHandler<HTMLInputElement>;
+    onBlur?: React.FocusEventHandler<HTMLInputElement>;
+    onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
+  }) =>
+    type === "input" ? (
+      <div className={className}>
+        <input
+          ref={inputRef}
+          id={id}
+          name={name}
+          placeholder={placeholder}
+          value={value}
+          disabled={disabled}
+          onChange={(e) => onChange?.(e.target.value)}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onKeyDown={onKeyDown}
+        />
+      </div>
+    ) : (
+      <button
+        type="button"
+        onClick={onClick}
+        onFocusCapture={onFocusCapture}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onClick?.();
+          }
+        }}
+        onMouseEnter={onMouseEnter}
+        disabled={disabled}
+        className={cn(!disableHover && "hover-enabled", className)}
+        data-selected={selected ? "true" : "false"}
+      >
+        <span>{label}</span>
+        {description ? <span>{description}</span> : null}
+      </button>
+    );
 
   const Card = ({
     children,

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -6,16 +6,7 @@ import type { UserQuestionAnswer } from "@app/lib/actions/types";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import {
-  ArrowUp,
-  Button,
-  Card,
-  Counter,
-  cn,
-  Input,
-  OptionCard,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { ArrowUp, Button, cn, OptionCard, Spinner } from "@dust-tt/sparkle";
 import type { KeyboardEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 
@@ -310,49 +301,26 @@ export function UserAnswerRequired({
               disabled={isAnswerSubmitting}
             />
           ))}
-          <Card
-            variant="tertiary"
-            className={cn(
-              "w-full items-center gap-2 transition-colors",
-              isCustomResponseActive
-                ? "bg-primary-100"
-                : [
-                    "bg-background",
-                    !isKeyboardNavigating && "hover:bg-primary-100",
-                  ]
-            )}
-          >
-            <Counter
-              value={question.options.length + 1}
-              size="sm"
-              variant="ghost"
-              className="shrink-0 bg-border-darker"
-            />
-            <Input
-              ref={customResponseInputRef}
-              id={`custom-response-${blockedAction.actionId}`}
-              containerClassName="flex-1"
-              className={cn(
-                "h-auto w-full rounded-none border-transparent bg-transparent",
-                "px-0 py-0 text-sm shadow-none",
-                "",
-                "focus-visible:border-transparent focus-visible:ring-0",
-                "",
-                isKeyboardNavigating && "cursor-none"
-              )}
-              placeholder="Type something else"
-              value={answerDraft.customResponse}
-              onFocus={() => {
-                setIsCustomResponseFocused(true);
-                answerDraft.selectCustomResponse();
-              }}
-              onBlur={() => setIsCustomResponseFocused(false)}
-              onChange={(e) => answerDraft.updateCustomResponse(e.target.value)}
-              onKeyDown={handleCustomResponseKeyDown}
-              name="custom-response"
-              disabled={isSubmitting}
-            />
-          </Card>
+          <OptionCard
+            type="input"
+            counterValue={question.options.length + 1}
+            selected={isCustomResponseActive}
+            disableHover={isKeyboardNavigating}
+            className={cn(isKeyboardNavigating && "cursor-none")}
+            inputRef={customResponseInputRef}
+            id={`custom-response-${blockedAction.actionId}`}
+            name="custom-response"
+            placeholder="Type something else"
+            value={answerDraft.customResponse}
+            disabled={isSubmitting}
+            onFocus={() => {
+              setIsCustomResponseFocused(true);
+              answerDraft.selectCustomResponse();
+            }}
+            onBlur={() => setIsCustomResponseFocused(false)}
+            onChange={(value) => answerDraft.updateCustomResponse(value)}
+            onKeyDown={handleCustomResponseKeyDown}
+          />
         </div>
       )}
       {errorMessage && (

--- a/sparkle/src/components/Counter.tsx
+++ b/sparkle/src/components/Counter.tsx
@@ -4,14 +4,19 @@ import * as React from "react";
 
 export const COUNTER_SIZES = ["xs", "sm", "md"] as const;
 
+const pillShadow =
+  "drop-shadow-[0px_1px_0.75px_rgba(0,0,0,0.08)] [text-shadow:0px_1px_1.5px_rgba(0,0,0,0.08)]";
+
 const counterVariants = cva(
   "inline-flex items-center justify-center rounded-full",
   {
     variants: {
+      // Fixed height == min-width keeps single digits circular; box-border
+      // absorbs the outline variant's 1px border so it stays a circle.
       size: {
-        xs: "h-4 min-w-[16px] px-0.5 text-xs",
-        sm: "h-5 min-w-[20px] px-1 heading-xs",
-        md: "h-6 min-w-[24px] px-1.5 heading-sm",
+        xs: "h-5 min-w-5 px-1 heading-xs",
+        sm: "h-6 min-w-6 px-1 heading-sm",
+        md: "h-7 min-w-7 px-1.5 heading-base",
       },
       variant: {
         primary: "",
@@ -19,6 +24,7 @@ const counterVariants = cva(
         "highlight-secondary": "",
         warning: "",
         "warning-secondary": "",
+        info: "",
         outline: "",
         ghost: "",
         "ghost-secondary": "",
@@ -32,27 +38,50 @@ const counterVariants = cva(
       {
         isInButton: false,
         variant: "primary",
-        className: "bg-primary text-primary-50",
+        className: cn(
+          "bg-gradient-to-b from-primary-700 to-primary-950 text-primary-50",
+          pillShadow
+        ),
       },
+      // Non-greyscale variants use the semantic colored tokens (aliases of the
+      // blue/rose/golden palette), shared with Chip and dark-mode aware.
       {
         isInButton: false,
         variant: ["highlight", "highlight-secondary"],
-        className: "bg-highlight text-white",
+        className: cn(
+          "bg-gradient-to-b from-highlight-400 to-highlight-500 text-white",
+          pillShadow
+        ),
       },
       {
         isInButton: false,
         variant: ["warning", "warning-secondary"],
-        className: "bg-warning text-white",
+        className: cn(
+          "bg-gradient-to-b from-warning-400 to-warning-500 text-white",
+          pillShadow
+        ),
+      },
+      {
+        isInButton: false,
+        variant: "info",
+        className: cn(
+          "bg-gradient-to-b from-info-400 to-info-500 text-white",
+          pillShadow
+        ),
       },
       {
         isInButton: false,
         variant: "outline",
-        className: "bg-primary-150 text-primary-900",
+        className: cn(
+          "bg-gradient-to-b from-background to-muted-background border border-border text-muted-foreground",
+          pillShadow
+        ),
       },
       {
         isInButton: false,
         variant: ["ghost", "ghost-secondary"],
-        className: "text-primary",
+        className:
+          "text-muted-foreground [text-shadow:0px_1px_1.5px_rgba(0,0,0,0.08)]",
       },
       {
         isInButton: true,
@@ -68,6 +97,11 @@ const counterVariants = cva(
         isInButton: true,
         variant: ["warning", "warning-secondary"],
         className: "bg-warning-400 text-white",
+      },
+      {
+        isInButton: true,
+        variant: "info",
+        className: "bg-info-400 text-white",
       },
       {
         isInButton: true,

--- a/sparkle/src/components/OptionCard.tsx
+++ b/sparkle/src/components/OptionCard.tsx
@@ -1,4 +1,4 @@
-import { Card, type CardVariantType } from "@sparkle/components/Card";
+import { Card } from "@sparkle/components/Card";
 import {
   checkboxIndicatorStyles,
   checkboxStyles,
@@ -14,34 +14,59 @@ import React from "react";
 
 export type OptionCardSelectionIndicator = "radio" | "checkbox";
 
-export interface OptionCardProps {
-  label: string;
-  description?: string | null;
+interface OptionCardSharedProps {
   counterValue?: number;
   selected?: boolean;
   disabled?: boolean;
   disableHover?: boolean;
   className?: string;
-  selectionIndicator?: OptionCardSelectionIndicator;
-  onClick?: () => void;
   onFocusCapture?: React.FocusEventHandler<HTMLDivElement>;
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
 }
 
-export function OptionCard({
-  label,
-  description,
-  counterValue,
-  selected = false,
-  disabled = false,
-  disableHover = false,
-  className,
-  onClick,
-  onFocusCapture,
-  onMouseEnter,
-  selectionIndicator,
-}: OptionCardProps) {
-  const variant: CardVariantType = selected ? "active" : "tertiary";
+interface OptionCardOptionProps extends OptionCardSharedProps {
+  type?: "option";
+  label: string;
+  description?: string | null;
+  selectionIndicator?: OptionCardSelectionIndicator;
+  onClick?: () => void;
+}
+
+interface OptionCardInputProps extends OptionCardSharedProps {
+  // Input state: a free-text "type something else" option. The field is
+  // rendered and styled by OptionCard (borderless, faint placeholder); the
+  // card keeps the same chrome and counter.
+  type: "input";
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  // Accessible name for the field (screen readers). Falls back to the
+  // placeholder so the input is never unlabeled.
+  ariaLabel?: string;
+  inputRef?: React.Ref<HTMLInputElement>;
+  name?: string;
+  id?: string;
+  onFocus?: React.FocusEventHandler<HTMLInputElement>;
+  onBlur?: React.FocusEventHandler<HTMLInputElement>;
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
+}
+
+export type OptionCardProps = OptionCardOptionProps | OptionCardInputProps;
+
+export function OptionCard(props: OptionCardProps) {
+  const {
+    counterValue,
+    selected = false,
+    disabled = false,
+    disableHover = false,
+    className,
+    onFocusCapture,
+    onMouseEnter,
+  } = props;
+
+  const isInput = props.type === "input";
+  const onClick = isInput ? undefined : props.onClick;
+  const selectionIndicator = isInput ? undefined : props.selectionIndicator;
   const isInteractive = onClick !== undefined && !disabled;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -53,11 +78,16 @@ export function OptionCard({
 
   return (
     <Card
-      variant={variant}
+      variant="tertiary"
+      size="sm"
       className={cn(
-        "w-full items-center gap-2 rounded-2xl text-left transition-colors",
-        !disabled && "cursor-pointer",
-        disabled && "pointer-events-none opacity-60",
+        "w-full items-center gap-2 text-left transition-colors",
+        isInteractive && "cursor-pointer",
+        // In input mode `disabled` targets the field, not the card chrome.
+        !isInput && disabled && "pointer-events-none opacity-60",
+        // Selected state is a flat "transparency-selected" overlay (6% of the
+        // foreground); the token is dark-mode aware on its own.
+        selected && "bg-foreground/[0.06] hover:bg-foreground/[0.06]",
         !selected && !disableHover && "hover:bg-muted-background/60",
         className
       )}
@@ -65,21 +95,54 @@ export function OptionCard({
       onKeyDown={isInteractive ? handleKeyDown : undefined}
       onFocusCapture={onFocusCapture}
       onMouseEnter={onMouseEnter}
-      tabIndex={disabled ? -1 : isInteractive ? 0 : undefined}
+      tabIndex={
+        isInput ? undefined : disabled ? -1 : isInteractive ? 0 : undefined
+      }
       aria-pressed={isInteractive ? selected : undefined}
     >
       {counterValue !== undefined && (
         <Counter
           value={counterValue}
-          size="sm"
-          variant="ghost"
-          className="shrink-0 bg-border-dark"
+          size="xs"
+          variant="outline"
+          className="shrink-0"
         />
       )}
       <div className="flex min-w-0 flex-1 flex-col">
-        <span className="text-sm font-medium text-foreground">{label}</span>
-        {description && (
-          <span className="text-xs text-muted-foreground">{description}</span>
+        {props.type === "input" ? (
+          <input
+            ref={props.inputRef}
+            type="text"
+            id={props.id}
+            name={props.name}
+            value={props.value}
+            placeholder={props.placeholder}
+            aria-label={props.ariaLabel ?? props.placeholder}
+            disabled={disabled}
+            onChange={(e) => props.onChange(e.target.value)}
+            onFocus={props.onFocus}
+            onBlur={props.onBlur}
+            onKeyDown={props.onKeyDown}
+            className={cn(
+              "w-full border-0 bg-transparent p-0 shadow-none outline-none",
+              // No blue focus ring on the field; focus is shown by the card's
+              // greyscale border (focus-within) instead.
+              "focus:ring-0 focus-visible:ring-0 focus-visible:outline-none",
+              "copy-sm text-foreground placeholder:text-faint",
+              "disabled:cursor-not-allowed"
+            )}
+          />
+        ) : (
+          <>
+            <span className="text-sm font-medium tracking-[-0.28px] text-foreground">
+              {props.label}
+            </span>
+            {props.description && (
+              <span className="text-xs text-muted-foreground">
+                {props.description}
+              </span>
+            )}
+          </>
         )}
       </div>
       {selectionIndicator === "radio" && (

--- a/sparkle/src/stories/Counter.stories.tsx
+++ b/sparkle/src/stories/Counter.stories.tsx
@@ -38,7 +38,7 @@ const meta = {
     },
     variant: {
       control: { type: "select" },
-      options: ["primary", "highlight", "warning", "outline", "ghost"],
+      options: ["primary", "highlight", "warning", "info", "outline", "ghost"],
     },
     isInButton: {
       control: "boolean",
@@ -72,6 +72,28 @@ export const Warning: Story = {
 export const Outline: Story = {
   args: { variant: "outline" },
   tags: ["ai-generated", "needs-work"],
+};
+
+export const Info: Story = {
+  args: { variant: "info" },
+  tags: ["ai-generated", "needs-work"],
+};
+
+// Every variant as a gradient pill, across the three sizes.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      {(
+        ["primary", "highlight", "warning", "info", "outline", "ghost"] as const
+      ).map((variant) => (
+        <div key={variant} className="flex items-center gap-2">
+          <Counter value={1} size="xs" variant={variant} />
+          <Counter value={42} size="sm" variant={variant} />
+          <Counter value={128} size="md" variant={variant} />
+        </div>
+      ))}
+    </div>
+  ),
 };
 
 // All three counter sizes side by side.

--- a/sparkle/src/stories/OptionCard.stories.tsx
+++ b/sparkle/src/stories/OptionCard.stories.tsx
@@ -18,11 +18,18 @@ const meta = {
 - Provide \`onClick\` to make the card interactive; without it the card is display-only.
 - Use \`counterValue\` to convey ordering or quantity, and \`selected\` to reflect the current choice (it sets \`aria-pressed\`).
 - Use \`selectionIndicator="radio"\` for single-select lists and \`selectionIndicator="checkbox"\` for multi-select lists, so the selection mode is visually unambiguous.
+- Set \`type="input"\` for a free-text "type something else" option; OptionCard renders the field itself (pass \`value\`/\`onChange\`) and keeps the same chrome and counter.
 - Stack multiple cards in a column; for one-tap suggested prompts that send immediately, use **QuickReplyBlock** instead.`,
       },
     },
   },
   tags: ["autodocs"],
+} satisfies Meta<typeof OptionCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
   args: {
     label: "Summarize today's emails",
     description:
@@ -31,38 +38,76 @@ const meta = {
     selected: false,
     disabled: false,
   },
-} satisfies Meta<typeof OptionCard>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Playground: Story = {};
-
-export const GenericQuestion: Story = {
-  render: () => (
-    <div className="flex w-full max-w-sm flex-col gap-2">
-      <OptionCard
-        label="Unread emails"
-        description="Only conversations you have not opened yet."
-        counterValue={1}
-        selected
-      />
-      <OptionCard
-        label="Slack mentions"
-        description="Messages where you were directly tagged."
-        counterValue={2}
-        selected
-      />
-      <OptionCard
-        label="Calendar conflicts"
-        description="Events that overlap with your focus blocks."
-        counterValue={3}
-      />
-    </div>
-  ),
 };
 
-export const DisabledOption: Story = {
+// type="option", default state.
+export const Default: Story = {
+  args: {
+    label: "Unread emails",
+    description: "Only conversations you have not opened yet.",
+    counterValue: 1,
+    selected: false,
+  },
+};
+
+// type="option", selected state.
+export const Selected: Story = {
+  args: {
+    label: "Unread emails",
+    description: "Only conversations you have not opened yet.",
+    counterValue: 1,
+    selected: true,
+  },
+};
+
+// type="input": a free-text "type something else" option.
+export const Input: StoryObj = {
+  render: () => {
+    const [custom, setCustom] = React.useState("");
+    return (
+      <div className="w-full max-w-sm">
+        <OptionCard
+          type="input"
+          counterValue={3}
+          placeholder="Type something else"
+          value={custom}
+          onChange={setCustom}
+        />
+      </div>
+    );
+  },
+};
+
+// The three states stacked the way they appear in a question.
+export const AllStates: StoryObj = {
+  render: () => {
+    const [custom, setCustom] = React.useState("");
+    return (
+      <div className="flex w-full max-w-sm flex-col gap-2">
+        <OptionCard
+          label="Unread emails"
+          description="Only conversations you have not opened yet."
+          counterValue={1}
+          selected
+        />
+        <OptionCard
+          label="Slack mentions"
+          description="Messages where you were directly tagged."
+          counterValue={2}
+        />
+        <OptionCard
+          type="input"
+          counterValue={3}
+          placeholder="Type something else"
+          value={custom}
+          onChange={setCustom}
+        />
+      </div>
+    );
+  },
+};
+
+export const DisabledOption: StoryObj = {
   render: () => (
     <div className="flex w-full max-w-sm flex-col gap-2">
       <OptionCard
@@ -80,7 +125,7 @@ export const DisabledOption: Story = {
   ),
 };
 
-export const SingleSelect: Story = {
+export const SingleSelect: StoryObj = {
   render: () => (
     <div className="flex w-full max-w-sm flex-col gap-2">
       <OptionCard
@@ -106,7 +151,7 @@ export const SingleSelect: Story = {
   ),
 };
 
-export const MultiSelect: Story = {
+export const MultiSelect: StoryObj = {
   render: () => (
     <div className="flex w-full max-w-sm flex-col gap-2">
       <OptionCard


### PR DESCRIPTION
## Description
- OptionCard: match new Figma design — p-3/rounded-xl chrome, flat transparency-selected overlay for the selected state, light outline counter, -0.28px title tracking. Add an "input" type (mirrors Figma's State=Input) for a free-text "type something else" option: borderless full-width field with faint placeholder, selected color on focus.
- Counter: new gradient-pill design with drop/text shadows across all variants, new size scale (xs/sm/md = 20/24/28px), and a new info variant. Mapped to semantic tokens (already in main) to preserve dark mode; stone migration deferred to a single later pass.
- UserAnswerRequired: replace the hand-rolled custom-response row with <OptionCard type="input"> so it shares the cards' chrome and counter.
- Stories: per-state OptionCard stories (Default/Selected/Input/ AllStates) and Counter AllVariants/Info.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Sparkle preview and spot check 
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
Deploy front
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
