### PR TITLE
[sparkle, front] Refresh Checkbox, RadioGroup, SliderToggle, and Chip visuals

### DIFF
--- a/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
+++ b/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
@@ -199,7 +199,7 @@ export function PersonalConnectionRequiredDialog({
                       </div>
                       <div>
                         {isAlreadyConnected ? (
-                          <Chip color="green" label="Connected" />
+                          <Chip color="success" label="Connected" />
                         ) : (
                           <Button
                             icon={CloudArrowLeftRight}

--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesFooter.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesFooter.tsx
@@ -36,7 +36,7 @@ export function CapabilitiesFooter({
                 label={skill.name}
                 onRemove={() => onRemoveSelectedSkill(skill)}
                 size="xs"
-                color="green"
+                color="success"
               />
             ))}
             {localSelectedTools.map((tool, index) => (
@@ -46,7 +46,7 @@ export function CapabilitiesFooter({
                 label={getSelectedToolLabel(tool)}
                 onRemove={() => onRemoveSelectedTool(tool)}
                 size="xs"
-                color="green"
+                color="success"
               />
             ))}
           </div>

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsFooter.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsFooter.tsx
@@ -33,7 +33,7 @@ export function MCPServerViewsFooter({
                     : undefined
                 }
                 size="xs"
-                color="green"
+                color="success"
               />
             ))}
           </div>

--- a/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
@@ -406,7 +406,6 @@ function ListConfigurationInput({
                 <div className="flex items-center space-x-3">
                   <Checkbox
                     checked={currentValue.includes(option.value)}
-                    size="xs"
                     onCheckedChange={(checked) => {
                       const current = Array.isArray(field.value)
                         ? field.value

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -165,7 +165,6 @@ function SlackChannelsList({
                       handleChannelToggle(channel, checked === true)
                     }
                     onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                    size="xs"
                   />
                   <span className="text-sm font-medium text-primary-900">
                     {channel.slackChannelName}

--- a/front/components/agent_builder/settings/TagsSelector.tsx
+++ b/front/components/agent_builder/settings/TagsSelector.tsx
@@ -241,7 +241,7 @@ export const TagsSelector = ({
                   : () => onRemoveTag(tag.sId)
               }
               size="xs"
-              color="golden"
+              color="info"
               label={tag.name}
             />
           ))}

--- a/front/components/agent_builder/triggers/TriggerFilterRenderer.tsx
+++ b/front/components/agent_builder/triggers/TriggerFilterRenderer.tsx
@@ -15,19 +15,19 @@ interface TriggerFilterRendererProps {
 
 interface OperationChipOptions {
   name: string;
-  color: "green" | "golden" | "warning" | "primary";
+  color: "success" | "info" | "warning" | "primary";
 }
 
 function getOperationChipOptions(
   op: LogicalOp | Operation
 ): OperationChipOptions {
-  let color: "green" | "golden" | "warning" | "primary";
+  let color: "success" | "info" | "warning" | "primary";
   switch (op) {
     case "and":
-      color = "green";
+      color = "success";
       break;
     case "or":
-      color = "golden";
+      color = "info";
       break;
     case "not":
       color = "warning";

--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionSheet.tsx
@@ -62,7 +62,6 @@ function ScheduleEditionStatusToggle({
       <div className="flex flex-row items-center gap-2">
         <span className="w-16">{isEnabled ? "Enabled" : "Disabled"}</span>
         <SliderToggle
-          size="xs"
           disabled={!isEditor}
           selected={isEnabled}
           onClick={() => setStatus(isEnabled ? "disabled" : "enabled")}

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
@@ -79,7 +79,6 @@ function WebhookEditionStatusToggle({
       <div className="flex flex-row items-center gap-2">
         <span className="w-16">{isEnabled ? "Enabled" : "Disabled"}</span>
         <SliderToggle
-          size="xs"
           disabled={!isEditor}
           selected={isEnabled}
           onClick={() => setStatus(isEnabled ? "disabled" : "enabled")}
@@ -207,7 +206,6 @@ function WebhookEditionIncludePayload({
   return (
     <div className="flex items-center gap-2">
       <Checkbox
-        size="sm"
         checked={includePayload}
         onClick={() => setIncludePayload(!includePayload)}
         disabled={!isEditor}

--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -105,7 +105,7 @@ export const AgentEditBar = ({
                   <DropdownMenuTagItem
                     key={t.sId}
                     label={t.name}
-                    color="golden"
+                    color="info"
                     onClick={async () => {
                       setIsLoading(true);
                       const agentIds = selectedAgents.map((a) => a.sId);

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -118,7 +118,7 @@ function CapabilitiesPickerItemsList({
       {items.map((item) => {
         const endComponent =
           item.kind === "uninstalled_tool" ? (
-            <Chip size="xs" color="golden" label="Configure" />
+            <Chip size="xs" color="info" label="Configure" />
           ) : (
             <Button
               icon={DotsHorizontal}

--- a/front/components/assistant/TagsFilterMenu.tsx
+++ b/front/components/assistant/TagsFilterMenu.tsx
@@ -101,7 +101,7 @@ export const TagsFilterMenu = ({
                 <DropdownMenuTagItem
                   key={tag.sId}
                   label={tag.name}
-                  color="golden"
+                  color="info"
                   className="m-0.5"
                   onClick={() => {
                     setSelectedTags([...selectedTags, tag]);

--- a/front/components/assistant/TagsManager.tsx
+++ b/front/components/assistant/TagsManager.tsx
@@ -31,7 +31,7 @@ const columns = [
     accessorKey: "name",
     header: "Tag label",
     cell: (info: CellContext<any, string>) => (
-      <Chip label={info.row.original.name} color="golden" />
+      <Chip label={info.row.original.name} color="info" />
     ),
   },
   {

--- a/front/components/assistant/TagsSuggestDialog.tsx
+++ b/front/components/assistant/TagsSuggestDialog.tsx
@@ -136,7 +136,7 @@ export const TagsSuggestDialog = ({
                       <Chip
                         size="xs"
                         label={suggestion.name}
-                        color="golden"
+                        color="info"
                         className="mb-2"
                       />
                       <ContextItem.Description

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -174,7 +174,7 @@ function PrunedContextChip() {
         <Chip
           label="Context limit reached"
           size="xs"
-          color="white"
+          color="primary"
           icon={InfoCircle}
         />
       }

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -321,7 +321,6 @@ export function FeedbackSelector({
                           onCheckedChange={(value) => {
                             isConversationSharedField.field.onChange(!!value);
                           }}
-                          size="xs"
                           className="mt-1"
                         />
                         <div className="flex flex-col">

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -161,7 +161,7 @@ function SearchPodItem({
       }}
       suffix={
         isArchived ? (
-          <Chip size="mini" color="white" label="Archived" />
+          <Chip size="mini" color="primary" label="Archived" />
         ) : undefined
       }
     />

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -364,7 +364,7 @@ function AgentActionsPanelContent({
               <Chip
                 key={skill.sId}
                 size="xs"
-                color="blue"
+                color="highlight"
                 label={skill.name}
                 icon={getSkillIcon(skill.icon)}
               />

--- a/front/components/assistant/conversation/agent_browser/shared.tsx
+++ b/front/components/assistant/conversation/agent_browser/shared.tsx
@@ -296,7 +296,7 @@ export function SearchDropdownContent({
               <Chip
                 key={tag.sId}
                 label={tag.name}
-                color="golden"
+                color="info"
                 size="xs"
                 onClick={() => onTagClick(tag.sId)}
               />

--- a/front/components/assistant/conversation/attachment/FileCitationCard.tsx
+++ b/front/components/assistant/conversation/attachment/FileCitationCard.tsx
@@ -125,7 +125,7 @@ export function FileCitationCard(props: FileCitationCardProps) {
     const chipProps = {
       children: chipContent,
       className: "inline-flex max-w-48 align-middle",
-      color: "white" as const,
+      color: "primary" as const,
       isBusy: isLoading,
       onRemove,
       size: "xs" as const,

--- a/front/components/assistant/conversation/tool_validation/PodMembersUpdateValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodMembersUpdateValidationDetails.tsx
@@ -86,13 +86,13 @@ function MemberChangeRow({
         {action === "add" && role && (
           <Chip
             size="xs"
-            color={role === "editor" ? "blue" : "primary"}
+            color={role === "editor" ? "highlight" : "primary"}
             label={role === "editor" ? "Editor" : "Member"}
           />
         )}
         <Chip
           size="xs"
-          color={action === "add" ? "green" : "rose"}
+          color={action === "add" ? "success" : "warning"}
           label={action === "add" ? "Will add" : "Will remove"}
         />
       </div>

--- a/front/components/assistant/conversation/tool_validation/PodTasksCreateValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodTasksCreateValidationDetails.tsx
@@ -140,14 +140,14 @@ export function PodTasksCreateValidationDetails({
               className="flex items-start gap-3 px-3 py-3"
             >
               <div className="mt-0.5 shrink-0">
-                <Checkbox size="xs" checked={isDone} disabled />
+                <Checkbox checked={isDone} disabled />
               </div>
               <div className="flex min-w-0 flex-1 flex-col gap-1.5">
                 <div className="flex flex-wrap items-start gap-2">
                   <p className="min-w-0 flex-1 break-words text-sm leading-5 text-foreground">
                     {task.text}
                   </p>
-                  {isDone && <Chip size="xs" color="green" label="Done" />}
+                  {isDone && <Chip size="xs" color="success" label="Done" />}
                 </div>
                 <p className="text-xs text-muted-foreground">
                   Assignee: {assigneeLabel}

--- a/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
@@ -156,7 +156,7 @@ function AssigneeChangeRow({
           <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
             {beforeLabel}
           </span>
-          <Chip size="xs" color="rose" label="Unassign" />
+          <Chip size="xs" color="warning" label="Unassign" />
         </div>
       </div>
     );
@@ -232,14 +232,14 @@ function TaskUpdateRow({
   return (
     <div className="flex items-start gap-3 px-3 py-3">
       <div className="mt-0.5 shrink-0">
-        <Checkbox size="xs" checked={isDone} disabled />
+        <Checkbox checked={isDone} disabled />
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-2">
         <div className="flex flex-wrap items-start gap-2">
           <p className="min-w-0 flex-1 break-words text-sm leading-5 text-foreground">
             {displayText}
           </p>
-          {isDone && <Chip size="xs" color="green" label="Done" />}
+          {isDone && <Chip size="xs" color="success" label="Done" />}
         </div>
 
         {currentTask ? (

--- a/front/components/assistant/details/AgentDetailsSheet.tsx
+++ b/front/components/assistant/details/AgentDetailsSheet.tsx
@@ -90,7 +90,7 @@ export const SCOPE_INFO: Record<
   {
     shortLabel: string;
     label: string;
-    color: "green" | "golden" | "blue" | "primary";
+    color: "success" | "info" | "highlight" | "primary";
     icon?: typeof Users01 | undefined;
     text: string;
   }
@@ -110,7 +110,7 @@ export const SCOPE_INFO: Record<
   visible: {
     shortLabel: "Published",
     label: "Published",
-    color: "green",
+    color: "success",
     text: "Visible agents.",
   },
 } as const;

--- a/front/components/assistant/details/MemberDetails.tsx
+++ b/front/components/assistant/details/MemberDetails.tsx
@@ -35,7 +35,7 @@ const formatDate = (dateString: string | null) => {
 
 const getRoleBadgeColor = (
   role: RoleType
-): "golden" | "rose" | "green" | "primary" => {
+): "info" | "warning" | "success" | "primary" => {
   if (role === "none") {
     return "primary";
   }

--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -44,7 +44,7 @@ export function AgentInfoTab({
       {agentConfiguration.tags.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {agentConfiguration.tags.map((tag) => (
-            <Chip key={tag.sId} color="golden" label={tag.name} size="xs" />
+            <Chip key={tag.sId} color="info" label={tag.name} size="xs" />
           ))}
         </div>
       )}

--- a/front/components/assistant/manager/GlobalAgentAction.tsx
+++ b/front/components/assistant/manager/GlobalAgentAction.tsx
@@ -38,7 +38,6 @@ export function GlobalAgentAction({
     return (
       <>
         <SliderToggle
-          size="xs"
           onClick={(e) => {
             e.stopPropagation();
             void handleToggleAgentStatus(agent);

--- a/front/components/assistant/manager/TableTagSelector.tsx
+++ b/front/components/assistant/manager/TableTagSelector.tsx
@@ -89,7 +89,7 @@ export const TableTagSelector = ({
                   >
                     <DropdownMenuTagItem
                       label={t.name}
-                      color="golden"
+                      color="info"
                       icon={isChecked ? Check : undefined}
                       onClick={async () => {
                         setIsLoading(true);

--- a/front/components/data_source/BigQueryUseMetadataForDBMLView.tsx
+++ b/front/components/data_source/BigQueryUseMetadataForDBMLView.tsx
@@ -63,7 +63,6 @@ export function BigQueryUseMetadataForDBMLView({
         action={
           <div className="relative">
             <SliderToggle
-              size="xs"
               onClick={async () => {
                 await handleSetUseMetadataForDBML(!useMetadataForDBML);
               }}

--- a/front/components/data_source/ConnectorOptionsPdfEnabled.tsx
+++ b/front/components/data_source/ConnectorOptionsPdfEnabled.tsx
@@ -40,7 +40,6 @@ export const createConnectorOptionsPdfEnabled = (description: string) => {
           action={
             <div className="relative">
               <SliderToggle
-                size="xs"
                 onClick={async () => {
                   await handleSetPdfEnabled(!pdfEnabled);
                 }}

--- a/front/components/data_source/GithubCodeEnableView.tsx
+++ b/front/components/data_source/GithubCodeEnableView.tsx
@@ -63,7 +63,6 @@ export function GithubCodeEnableView({
         action={
           <div className="relative">
             <SliderToggle
-              size="xs"
               onClick={async () => {
                 await handleSetCodeSyncEnabled(!codeSyncEnabled);
               }}

--- a/front/components/data_source/IntercomConfigView.tsx
+++ b/front/components/data_source/IntercomConfigView.tsx
@@ -65,7 +65,6 @@ export function IntercomConfigView({
         action={
           <div className="relative">
             <SliderToggle
-              size="xs"
               onClick={async () => {
                 await handleSetNewConfig(!isSyncNotesEnabled);
               }}

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -139,7 +139,6 @@ export function ZendeskConfigView({
         action={
           <div className="relative">
             <SliderToggle
-              size="xs"
               onClick={async () => {
                 await handleSetNewConfig(
                   ZENDESK_CONFIG_KEYS.SYNC_UNRESOLVED_TICKETS,
@@ -169,7 +168,6 @@ export function ZendeskConfigView({
         action={
           <div className="relative">
             <SliderToggle
-              size="xs"
               onClick={async () => {
                 await handleSetNewConfig(
                   ZENDESK_CONFIG_KEYS.HIDE_CUSTOMER_DETAILS,

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -473,7 +473,6 @@ export function GongOptionComponent({
           action={
             <div className="relative">
               <SliderToggle
-                size="xs"
                 onClick={async () => {
                   await handleConfigUpdate(
                     GONG_TRACKERS_CONFIG_KEY,
@@ -504,7 +503,6 @@ export function GongOptionComponent({
           action={
             <div className="relative">
               <SliderToggle
-                size="xs"
                 onClick={async () => {
                   await handleConfigUpdate(
                     GONG_ACCOUNTS_CONFIG_KEY,

--- a/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
@@ -26,7 +26,7 @@ interface KnowledgeChipProps {
 }
 
 export function KnowledgeChip({
-  color = "white",
+  color = "primary",
   node,
   title,
   onRemove,
@@ -91,7 +91,7 @@ function InlineKnowledgeIcon({ node }: InlineKnowledgeIconProps) {
 }
 
 export function InlineKnowledgeChip({
-  color = "white",
+  color = "primary",
   node,
   title,
   onRemove,
@@ -134,7 +134,7 @@ export function KnowledgeErrorChip({
     <Chip
       label={title}
       icon={AlertCircle}
-      color="white"
+      color="primary"
       onRemove={onRemove}
       size="xs"
     />

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -101,7 +101,7 @@ export function KnowledgeDisplayComponent({
 
   if (isFetchingNode || (needsFetch && !isFullKnowledgeItem(item))) {
     return (
-      <Chip label={item.label} color="white" size="xs">
+      <Chip label={item.label} color="primary" size="xs">
         <Spinner size="xs" />
       </Chip>
     );

--- a/front/components/editor/extensions/skill_builder/ToolChip.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolChip.tsx
@@ -26,7 +26,7 @@ interface ToolChipProps {
 }
 
 export function ToolChip({
-  color = "white",
+  color = "primary",
   onClick,
   onRemove,
   title,
@@ -54,7 +54,7 @@ export function ToolErrorChip({ onRemove, title }: ToolErrorChipProps) {
     <Chip
       label={title}
       icon={AlertCircle}
-      color="white"
+      color="primary"
       onRemove={onRemove}
       size="xs"
     />

--- a/front/components/editor/input_bar/DataSourceLinkComponent.tsx
+++ b/front/components/editor/input_bar/DataSourceLinkComponent.tsx
@@ -8,7 +8,12 @@ export const DataSourceLinkComponent = ({ node }: { node: { attrs: any } }) => {
 
   return (
     <NodeViewWrapper className="inline-flex align-middle">
-      <AttachmentChip label={title} href={url} target="_blank" color="white" />
+      <AttachmentChip
+        label={title}
+        href={url}
+        target="_blank"
+        color="primary"
+      />
     </NodeViewWrapper>
   );
 };

--- a/front/components/editor/input_bar/SkillNodeComponent.tsx
+++ b/front/components/editor/input_bar/SkillNodeComponent.tsx
@@ -58,7 +58,7 @@ export function SkillNodeComponent({
       <Chip
         label={skillName}
         icon={getSkillIcon(skillIcon)}
-        color="white"
+        color="primary"
         onClick={handleClick}
         onRemove={onRemove}
         size="xs"

--- a/front/components/markdown/ContentNodeMentionBlock.tsx
+++ b/front/components/markdown/ContentNodeMentionBlock.tsx
@@ -11,7 +11,7 @@ export function ContentNodeMentionBlock({
   url: string;
 }) {
   return (
-    <AttachmentChip label={title} href={url} target="_blank" color="white" />
+    <AttachmentChip label={title} href={url} target="_blank" color="primary" />
   );
 }
 

--- a/front/components/markdown/SkillBlock.tsx
+++ b/front/components/markdown/SkillBlock.tsx
@@ -31,7 +31,7 @@ export function SkillBlock({
       icon={{ visual: getSkillIcon(skillIcon), size: "xs" }}
       href={href}
       target={href ? "_blank" : undefined}
-      color="white"
+      color="primary"
       size="xs"
     />
   );

--- a/front/components/markdown/TaskDirectiveBlock.tsx
+++ b/front/components/markdown/TaskDirectiveBlock.tsx
@@ -388,7 +388,7 @@ function TaskDirectiveChipInner({
             <AttachmentChip
               label={displayLabel}
               icon={{ visual: CheckCircle }}
-              color="green"
+              color="success"
               className="min-w-0 max-w-full transition-opacity group-hover:opacity-90"
             />
           </button>

--- a/front/components/members/Roles.ts
+++ b/front/components/members/Roles.ts
@@ -12,12 +12,12 @@ export function displayRole(role: RoleType): string {
 
 export const ROLES_DATA: Record<
   ActiveRoleType,
-  { description: string; color: "rose" | "golden" | "green" | "primary" }
+  { description: string; color: "warning" | "info" | "success" | "primary" }
 > = {
   admin: {
     description:
       "Can use and create agents, manage settings, members, spaces, connections, and tools.",
-    color: "rose",
+    color: "warning",
   },
   business_admin: {
     description: "Business administrator.",
@@ -26,10 +26,10 @@ export const ROLES_DATA: Record<
   builder: {
     description:
       "Can use, create agents and manage folders, websites and dust apps in the company space.",
-    color: "golden",
+    color: "info",
   },
   user: {
     description: "Can use and create agents in conversations.",
-    color: "green",
+    color: "success",
   },
 };

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -304,7 +304,7 @@ export function ManageAgentsPage() {
                       key={tag.sId}
                       label={tag.name}
                       size="xs"
-                      color="golden"
+                      color="info"
                       onRemove={() =>
                         setSelectedTags(selectedTags.filter((t) => t !== tag))
                       }

--- a/front/components/pages/onboarding/SubscriptionPlans.tsx
+++ b/front/components/pages/onboarding/SubscriptionPlans.tsx
@@ -153,7 +153,7 @@ export function BillingPeriodSwitch({
         value="yearly"
         label="Yearly"
         className="flex-row-reverse"
-        icon={<Chip size={chipSize} color="blue" label="Save 20%" />}
+        icon={<Chip size={chipSize} color="highlight" label="Save 20%" />}
       />
     </ButtonsSwitchList>
   );

--- a/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
+++ b/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
@@ -535,7 +535,7 @@ export function EnvironmentSection() {
                           <Chip
                             key={domain}
                             size="xs"
-                            color="white"
+                            color="primary"
                             label={domain}
                           />
                         ))}
@@ -608,7 +608,6 @@ export function EnvironmentSection() {
                       </span>
                     </div>
                     <SliderToggle
-                      size="sm"
                       selected={kindField.value === "https_secret"}
                       disabled={isUpsertingWorkspaceSandboxEnvVar}
                       onClick={() => {

--- a/front/components/pages/workspace/developers/sections/NetworkSection.tsx
+++ b/front/components/pages/workspace/developers/sections/NetworkSection.tsx
@@ -162,7 +162,6 @@ export function NetworkSection() {
             </div>
           </div>
           <SliderToggle
-            size="xs"
             selected={allowAgentEgressRequests}
             onClick={() => {
               void handleToggleAgentEgressRequests();

--- a/front/components/pages/workspace/model_providers/AllProvidersToggle.tsx
+++ b/front/components/pages/workspace/model_providers/AllProvidersToggle.tsx
@@ -23,7 +23,6 @@ export function AllProvidersToggle({
           Make all providers available
         </span>
         <SliderToggle
-          size="xs"
           selected={selected}
           disabled={selected}
           onClick={onSelectAll}

--- a/front/components/pages/workspace/model_providers/ProviderToggleContextItem.tsx
+++ b/front/components/pages/workspace/model_providers/ProviderToggleContextItem.tsx
@@ -31,7 +31,6 @@ export function ProviderToggleContextItem({
       visual={<Icon visual={LogoComponent} size="lg" />}
       action={
         <SliderToggle
-          size="xs"
           selected={providersSelection[providerId]}
           onClick={handleToggleChange}
           disabled={disabled}

--- a/front/components/pages/workspace/model_providers/RegionalModelsOnlyToggle.tsx
+++ b/front/components/pages/workspace/model_providers/RegionalModelsOnlyToggle.tsx
@@ -56,7 +56,6 @@ export function RegionalModelsOnlyToggle({
       hasSeparator={false}
       action={
         <SliderToggle
-          size="xs"
           selected={workspace.regionalModelsOnly}
           disabled={isUpdatingWorkspaceRegionalModelsOnly}
           onClick={() => {

--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -518,7 +518,7 @@ export function SubscriptionPage() {
   const isProcessing =
     isSubscribingPlan || isGoingToStripePortal || isUpgradingToBusiness;
 
-  const chipColor = !isUpgraded(plan) ? "green" : "blue";
+  const chipColor = !isUpgraded(plan) ? "success" : "highlight";
 
   const planLabel =
     trialDaysRemaining === null

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -203,7 +203,7 @@ export function PodConversationsTab({
                 {greeting}
               </h2>
               {podInfo.archivedAt && (
-                <Chip size="xs" color="rose" label="Archived" />
+                <Chip size="xs" color="warning" label="Archived" />
               )}
             </div>
             {podInfo.archivedAt ? (

--- a/front/components/pod/settings/PodMembersTable.tsx
+++ b/front/components/pod/settings/PodMembersTable.tsx
@@ -202,7 +202,7 @@ export function PodMembersTable({
           return (
             <DataTable.CellContent>
               {info.row.original.isEditor && (
-                <Chip color="green" size="xs" label="Editor" />
+                <Chip color="success" size="xs" label="Editor" />
               )}
             </DataTable.CellContent>
           );

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -698,7 +698,6 @@ export function PodSettingsTab({
                     trigger={
                       <div>
                         <SliderToggle
-                          size="xs"
                           selected={isOpen}
                           onClick={handleVisibilityToggle}
                           disabled
@@ -708,7 +707,6 @@ export function PodSettingsTab({
                   />
                 ) : (
                   <SliderToggle
-                    size="xs"
                     selected={isOpen}
                     onClick={handleVisibilityToggle}
                     disabled={isVisibilityToggleDisabled}

--- a/front/components/pod/settings/SuggestedTasksGenerationTile.tsx
+++ b/front/components/pod/settings/SuggestedTasksGenerationTile.tsx
@@ -24,6 +24,11 @@ const SUGGEST_TASKS_TOOLTIP_NON_EDITOR = `${SUGGEST_TASKS_TOOLTIP} Only Pod edit
 const LAST_SCAN_NEVER_TOOLTIP =
   "Dust has not run an automatic scan for task suggestions for this Pod yet.";
 
+// Static chip hoisted out of the component so it isn't recreated every render.
+const EXPERIMENTAL_CHIP = (
+  <Chip color="info" label="Experimental" size="mini" />
+);
+
 function lastScanTooltip(lastTodoAnalysisAt: number | null): string {
   if (lastTodoAnalysisAt == null) {
     return LAST_SCAN_NEVER_TOOLTIP;
@@ -138,9 +143,7 @@ export function SuggestedTasksGenerationTile({
         icon={Stars02}
         title="Suggest tasks"
         description="Automatic task suggestions from Pod activity"
-        trailingInTitle={
-          <Chip color="golden" label="Experimental" size="mini" />
-        }
+        trailingInTitle={EXPERIMENTAL_CHIP}
       />
       <div className="flex shrink-0 items-center gap-2">
         <Tooltip
@@ -160,7 +163,6 @@ export function SuggestedTasksGenerationTile({
           trigger={
             <div>
               <SliderToggle
-                size="xs"
                 selected={pod.todoGenerationEnabled}
                 disabled={sliderDisabled}
                 onClick={onToggleClick}

--- a/front/components/pod/tasks/EditableTaskItem.tsx
+++ b/front/components/pod/tasks/EditableTaskItem.tsx
@@ -93,7 +93,6 @@ export function EditableTaskItem({ task }: EditableTaskItemProps) {
     <div className="group/task flex items-start gap-3 rounded-md p-1 transition-colors duration-200 hover:bg-muted-background">
       <div className="mt-0.5 shrink-0">
         <Checkbox
-          size="xs"
           checked={isDone}
           disabled={!canEdit}
           isMutedAfterCheck

--- a/front/components/pod/tasks/SuggestedTaskItem.tsx
+++ b/front/components/pod/tasks/SuggestedTaskItem.tsx
@@ -47,7 +47,7 @@ export const SuggestedTaskItem = memo(function SuggestedTaskItem({
   return (
     <div className="group/suggestion-item flex items-start gap-3 py-1 pl-6">
       <div className="mt-1 shrink-0">
-        <Checkbox size="xs" checked={false} disabled />
+        <Checkbox checked={false} disabled />
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <div className="relative min-w-0 text-left">

--- a/front/components/poke/PokeFavorites.tsx
+++ b/front/components/poke/PokeFavorites.tsx
@@ -25,13 +25,13 @@ export function getFavoriteChipColor(
 ): ComponentProps<typeof Chip>["color"] {
   switch (type) {
     case "Workspace":
-      return "blue";
+      return "highlight";
     case "Data Source":
-      return "golden";
+      return "info";
     case "Data Source View":
-      return "rose";
+      return "warning";
     case "Agent":
-      return "green";
+      return "success";
     case "Frame":
       return "highlight";
     default:

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -39,13 +39,13 @@ function getPokeItemChipColor(
 ): ComponentProps<typeof Chip>["color"] {
   switch (item.type) {
     case "Workspace":
-      return "blue";
+      return "highlight";
     case "Data Source":
-      return "golden";
+      return "info";
     case "Data Source View":
-      return "rose";
+      return "warning";
     case "Connector":
-      return "green";
+      return "success";
     case "Frame":
       return "highlight";
     default:

--- a/front/components/poke/credits/AlertChip.tsx
+++ b/front/components/poke/credits/AlertChip.tsx
@@ -10,12 +10,12 @@ import { Chip, LinkExternal01 } from "@dust-tt/sparkle";
 // label. `in_alarm` (breached) reads red; `ok` (resolved) green; `evaluating`
 // (pending) amber; `null` (unknown) neutral.
 function alertStatusChip(status: MetronomeAlertStatus): {
-  color: "rose" | "success" | "warning" | "info";
+  color: "warning" | "success" | "warning" | "info";
   label: string;
 } {
   switch (status) {
     case "in_alarm":
-      return { color: "rose", label: "in alarm" };
+      return { color: "warning", label: "in alarm" };
     case "ok":
       return { color: "success", label: "ok" };
     case "evaluating":

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -52,14 +52,14 @@ const DEFAULT_PAGE_SIZE = 25;
 
 const USER_CREDIT_STATE_CHIP_COLOR: Record<
   UserCreditState,
-  "success" | "warning" | "rose" | "info"
+  "success" | "warning" | "warning" | "info"
 > = {
   user_seat: "info",
   user_seat_low_balance: "warning",
   normal: "success",
   on_pool: "success",
   on_pool_low_balance: "warning",
-  capped: "rose",
+  capped: "warning",
 };
 
 // Free seats hold a per-user credit with two balance alerts: "low" (≤20%) and

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -35,7 +35,7 @@ interface PokeUsageTabProps {
   defaultAlerts: DefaultMetronomeAlerts;
 }
 
-type CreditStateChipColor = "success" | "warning" | "rose" | "info";
+type CreditStateChipColor = "success" | "warning" | "warning" | "info";
 
 // Shared color mapping for the workspace pool and programmatic credit states.
 // Both unions share the active/low/critical/depleted members; `overage` is
@@ -53,7 +53,7 @@ function creditStateChipColor(
     case "overage":
       return "info";
     case "depleted":
-      return "rose";
+      return "warning";
     default:
       assertNeverAndIgnore(state);
       return "info";
@@ -143,7 +143,7 @@ function PokeCreditConfigCard({
           <span className="text-xs text-muted-foreground">PAYG</span>
           <Chip
             size="xs"
-            color={paygEnabled ? "success" : "rose"}
+            color={paygEnabled ? "success" : "warning"}
             label={paygEnabled ? "enabled" : "disabled"}
           />
         </div>

--- a/front/components/poke/credits/columns.tsx
+++ b/front/components/poke/credits/columns.tsx
@@ -139,7 +139,7 @@ function StatusCell({
       );
     }
     return (
-      <Chip color="green" size="xs">
+      <Chip color="success" size="xs">
         Matched
       </Chip>
     );

--- a/front/components/poke/groups/columns.tsx
+++ b/front/components/poke/groups/columns.tsx
@@ -7,14 +7,14 @@ import type { ColumnDef } from "@tanstack/react-table";
 export const getPokeGroupKindChipColor = (kind: GroupKind) => {
   switch (kind) {
     case "provisioned":
-      return "blue";
+      return "highlight";
     case "global":
-      return "green";
+      return "success";
     case "system":
       return "warning";
     case "agent_editors":
     case "skill_editors":
-      return "rose";
+      return "warning";
     default:
       return "primary";
   }

--- a/front/components/poke/llm_traces/InputTab.tsx
+++ b/front/components/poke/llm_traces/InputTab.tsx
@@ -110,9 +110,9 @@ interface ConversationViewProps {
 
 function ConversationView({ conversation }: ConversationViewProps) {
   const roleChipColors: Record<string, ComponentProps<typeof Chip>["color"]> = {
-    user: "blue",
-    assistant: "green",
-    function: "golden",
+    user: "highlight",
+    assistant: "success",
+    function: "info",
   };
 
   return (

--- a/front/components/poke/llm_traces/ToolCallsView.tsx
+++ b/front/components/poke/llm_traces/ToolCallsView.tsx
@@ -30,7 +30,7 @@ export function ToolCallCard({ toolCall }: ToolCallCardProps) {
   return (
     <div className="rounded border p-3">
       <Chip
-        color="green"
+        color="success"
         size="xs"
         label={`tool_call: ${toolCall.name}`}
         className="mb-2"

--- a/front/components/poke/mcp_server_views/tools_config.tsx
+++ b/front/components/poke/mcp_server_views/tools_config.tsx
@@ -37,10 +37,10 @@ const STAKE_LABELS: Record<MCPToolStakeLevelType, string> = {
 };
 
 const STAKE_COLORS = {
-  high: "rose",
-  medium: "golden",
-  low: "blue",
-  never_ask: "green",
+  high: "warning",
+  medium: "info",
+  low: "highlight",
+  never_ask: "success",
 } as const satisfies Record<MCPToolStakeLevelType, string>;
 
 interface ToolConfigRow {

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -54,7 +54,7 @@ type ChipColor = NonNullable<ComponentProps<typeof Chip>["color"]>;
 const USER_VISIBILITY: Record<string, { label: string; color: ChipColor }> = {
   visible: { label: "sent", color: "success" },
   pending: { label: "queued", color: "warning" },
-  deleted: { label: "deleted", color: "rose" },
+  deleted: { label: "deleted", color: "warning" },
 };
 
 const AGENT_STATUS: Record<
@@ -63,7 +63,7 @@ const AGENT_STATUS: Record<
 > = {
   created: { label: "generating", color: "warning" },
   succeeded: { label: "succeeded", color: "success" },
-  failed: { label: "failed", color: "rose" },
+  failed: { label: "failed", color: "warning" },
   cancelled: { label: "cancelled", color: "primary" },
   interrupted: { label: "cancelled", color: "primary" },
   gracefully_stopped: {
@@ -78,7 +78,7 @@ const COMPACTION_STATUS: Record<
 > = {
   created: { label: "generating", color: "warning" },
   succeeded: { label: "succeeded", color: "success" },
-  failed: { label: "failed", color: "rose" },
+  failed: { label: "failed", color: "warning" },
 };
 
 function getLangfuseTraceUrl(langfuseUiBaseUrl: string, runId: string) {
@@ -180,11 +180,11 @@ function getActionStatus(
     case "succeeded":
       return null;
     case "errored":
-      return { label: "error", color: "rose" };
+      return { label: "error", color: "warning" };
     case "denied":
       return { label: "denied", color: "primary" };
     case "running":
-      return { label: "running", color: "blue" };
+      return { label: "running", color: "highlight" };
     case "ready_allowed_explicitly":
     case "ready_allowed_implicitly":
       return { label: "ready", color: "primary" };
@@ -855,7 +855,7 @@ export function ConversationPage() {
                 <div className="flex flex-col space-y-2">
                   <div className="flex items-center space-x-2">
                     <Chip
-                      color="blue"
+                      color="highlight"
                       label={`Tokens used: ${renderResult.tokensUsed}`}
                       size="xs"
                     />
@@ -870,7 +870,7 @@ export function ConversationPage() {
                       size="xs"
                     />
                     <Chip
-                      color="green"
+                      color="success"
                       label={`Tools tokens: ${renderResult.toolsTokenCountApprox}`}
                       size="xs"
                     />

--- a/front/components/poke/pages/CouponsPage.tsx
+++ b/front/components/poke/pages/CouponsPage.tsx
@@ -36,7 +36,7 @@ function getStatusChipColor(status: CouponRedemptionStatus) {
     case "pending":
       return "primary";
     case "failed":
-      return "rose";
+      return "warning";
     case "revoked":
       return "warning";
     default:

--- a/front/components/poke/pages/FramePage.tsx
+++ b/front/components/poke/pages/FramePage.tsx
@@ -88,7 +88,7 @@ export function FramePage() {
         {/* Summary Chips */}
         <div className="flex flex-wrap gap-2">
           <Chip
-            color={file.status === "ready" ? "green" : "warning"}
+            color={file.status === "ready" ? "success" : "warning"}
             label={`Status: ${file.status}`}
             size="sm"
           />

--- a/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
+++ b/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
@@ -38,7 +38,7 @@ function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
         const { thumbDirection } = row.original;
         return (
           <Chip
-            color={thumbDirection === "up" ? "green" : "rose"}
+            color={thumbDirection === "up" ? "success" : "warning"}
             size="xs"
             label={thumbDirection === "up" ? "up" : "down"}
           />

--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -252,7 +252,6 @@ export function KillPage() {
                         disabled={updatingKillSwitch !== null}
                         onClick={() => void updateKillSwitch(type, !isEnabled)}
                         selected={isEnabled}
-                        size="xs"
                       />
                     )}
                   </div>

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -93,7 +93,7 @@ export function LLMTracePage() {
           <div className="flex flex-wrap gap-2">
             {trace.context.agentConfigurationId && (
               <Chip
-                color="rose"
+                color="warning"
                 label={`Agent: ${trace.context.agentConfigurationId}`}
                 size="sm"
                 href={`/poke/${owner.sId}/assistants/${trace.context.agentConfigurationId}`}
@@ -102,7 +102,7 @@ export function LLMTracePage() {
             )}
             {trace.context.conversationId && (
               <Chip
-                color="golden"
+                color="info"
                 label={`Conversation`}
                 size="sm"
                 href={`/poke/${owner.sId}/conversation/${trace.context.conversationId}`}
@@ -114,7 +114,7 @@ export function LLMTracePage() {
 
         <div className="flex flex-wrap gap-2">
           <Chip
-            color="blue"
+            color="highlight"
             label={`Model: ${trace.input?.modelId ?? trace.metadata.modelId}`}
             size="sm"
           />
@@ -133,7 +133,7 @@ export function LLMTracePage() {
           {trace.output?.finishReason && (
             <Chip
               color={
-                trace.output.finishReason === "error" ? "warning" : "green"
+                trace.output.finishReason === "error" ? "warning" : "success"
               }
               label={`Finish reason: ${trace.output.finishReason}`}
               size="sm"

--- a/front/components/poke/pages/ProductionChecksPage.tsx
+++ b/front/components/poke/pages/ProductionChecksPage.tsx
@@ -36,8 +36,8 @@ const STATUS_CHIP_CONFIG: Record<
   CheckSummaryStatus,
   { color: ComponentProps<typeof Chip>["color"]; label: string }
 > = {
-  ok: { color: "green", label: "OK" },
-  alert: { color: "rose", label: "Alert" },
+  ok: { color: "success", label: "OK" },
+  alert: { color: "warning", label: "Alert" },
   "no-data": { color: "info", label: "No Data" },
 };
 
@@ -45,10 +45,10 @@ const HISTORY_STATUS_CHIP_CONFIG: Record<
   CheckHistoryRun["status"],
   { color: ComponentProps<typeof Chip>["color"]; label: string }
 > = {
-  success: { color: "green", label: "Success" },
-  failure: { color: "rose", label: "Failed" },
+  success: { color: "success", label: "Success" },
+  failure: { color: "warning", label: "Failed" },
   skipped: { color: "info", label: "Skipped" },
-  running: { color: "blue", label: "Running" },
+  running: { color: "highlight", label: "Running" },
 };
 
 const STATUS_CARD_CLASSES: Record<CheckSummaryStatus, string> = {

--- a/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
+++ b/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
@@ -69,11 +69,11 @@ export function SkillSuggestionDetailsPage() {
 
   const stateColorMap: Record<
     SkillSuggestionState,
-    "info" | "primary" | "warning" | "rose"
+    "info" | "primary" | "warning" | "warning"
   > = {
     pending: "warning",
     approved: "primary",
-    rejected: "rose",
+    rejected: "warning",
     outdated: "info",
   };
 

--- a/front/components/poke/skill_suggestions/columns.tsx
+++ b/front/components/poke/skill_suggestions/columns.tsx
@@ -124,11 +124,11 @@ export function makeColumnsForSkillSuggestions(
         const state = row.original.state;
         const colorMap: Record<
           string,
-          "info" | "primary" | "warning" | "rose"
+          "info" | "primary" | "warning" | "warning"
         > = {
           pending: "warning",
           approved: "primary",
-          rejected: "rose",
+          rejected: "warning",
           outdated: "info",
         };
         return (

--- a/front/components/poke/skills/SkillOverviewTable.tsx
+++ b/front/components/poke/skills/SkillOverviewTable.tsx
@@ -49,7 +49,7 @@ export function SkillOverviewTable({
                 <Chip
                   key={s.sId}
                   size="sm"
-                  color={s.isRestricted ? "warning" : "blue"}
+                  color={s.isRestricted ? "warning" : "highlight"}
                 >
                   {s.name}
                 </Chip>

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -84,7 +84,7 @@ function getSubscriptionDisplayStatus(
 const STATUS_CONFIG: Record<
   SubscriptionStatus,
   {
-    chipColor: "info" | "blue" | "warning" | "success" | "rose";
+    chipColor: "info" | "highlight" | "warning" | "success" | "warning";
     chipLabel: string;
     cardClass: string;
   }
@@ -95,7 +95,7 @@ const STATUS_CONFIG: Record<
     cardClass: "border-info-200 bg-info-50",
   },
   trialing: {
-    chipColor: "blue",
+    chipColor: "highlight",
     chipLabel: "Trialing",
     cardClass: "border-highlight-200 bg-highlight-50",
   },
@@ -110,7 +110,7 @@ const STATUS_CONFIG: Record<
     cardClass: "border-success-200 bg-success-50",
   },
   inconsistent: {
-    chipColor: "rose",
+    chipColor: "warning",
     chipLabel: "Inconsistent",
     cardClass: "border-warning-200 bg-warning-50",
   },
@@ -416,7 +416,7 @@ export function ActiveSubscriptionTable({
             <div className="flex items-center justify-between gap-2 pb-4">
               <div className="flex items-center gap-2">
                 <h2 className="text-md font-bold">Pending Subscription</h2>
-                <Chip color="blue" label="Pending activation" size="xs" />
+                <Chip color="highlight" label="Pending activation" size="xs" />
               </div>
               <CancelPendingSubscriptionButton owner={owner} />
             </div>

--- a/front/components/poke/suggestions/columns.tsx
+++ b/front/components/poke/suggestions/columns.tsx
@@ -112,11 +112,11 @@ export function makeColumnsForSuggestions(
         const state = row.original.state;
         const colorMap: Record<
           string,
-          "info" | "primary" | "warning" | "rose"
+          "info" | "primary" | "warning" | "warning"
         > = {
           pending: "warning",
           approved: "primary",
-          rejected: "rose",
+          rejected: "warning",
           outdated: "info",
         };
         return (

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -117,7 +117,7 @@ function PokeRecentWebhookRequestsContent({
     <div className="space-y-2">
       <div className="flex flex-wrap items-center gap-2 pt-2">
         <Chip
-          color={statusFilter === undefined ? "primary" : "white"}
+          color={statusFilter === undefined ? "primary" : "primary"}
           size="xs"
           label="All"
           className="cursor-pointer select-none"
@@ -129,7 +129,7 @@ function PokeRecentWebhookRequestsContent({
         {WEBHOOK_REQUEST_TRIGGER_STATUSES.map((s) => (
           <Chip
             key={s}
-            color={statusFilter === s ? "primary" : "white"}
+            color={statusFilter === s ? "primary" : "primary"}
             size="xs"
             label={STATUS_FILTER_LABELS[s]}
             className="cursor-pointer select-none"

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -46,7 +46,7 @@ export function WorkspaceInfoTable({
   const getStatusChipColor = (status: WorkOSConnectionSyncStatus["status"]) => {
     switch (status) {
       case "configured":
-        return "green";
+        return "success";
       case "configuring":
         return "warning";
       case "not_configured":
@@ -59,15 +59,15 @@ export function WorkspaceInfoTable({
   const getConnectionStateChipColor = (state: string) => {
     switch (state) {
       case "active":
-        return "green";
+        return "success";
       case "inactive":
       case "deleting":
       case "invalid_credentials":
-        return "rose";
+        return "warning";
       case "validating":
         return "warning";
       case "draft":
-        return "blue";
+        return "highlight";
       default:
         return "info";
     }

--- a/front/components/skill_builder/SkillBuilderEnableSuggestionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderEnableSuggestionsSection.tsx
@@ -43,7 +43,6 @@ export function SkillBuilderEnableSuggestionsSection({
         <SliderToggle
           selected={enabled && !isDisabled}
           onClick={handleToggle}
-          size="xs"
         />
         <span className="text-sm text-foreground">Self-improve</span>
         <Tooltip

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -77,7 +77,7 @@ function renderReferenceSummaryItem({
           key={`${item.kind}:${item.id}`}
           label={item.title}
           icon={{ visual: File02 }}
-          color="white"
+          color="primary"
           size="xs"
           className="text-xs"
           onClick={() => onReferenceClick(item)}
@@ -89,7 +89,7 @@ function renderReferenceSummaryItem({
           key={`${item.kind}:${item.id}`}
           label={item.title}
           icon={getSkillIcon(item.icon)}
-          color="white"
+          color="primary"
           size="xs"
           onClick={() => onReferenceClick(item)}
         />
@@ -100,7 +100,7 @@ function renderReferenceSummaryItem({
           key={`${item.kind}:${item.id}`}
           title={item.title}
           toolIcon={item.icon}
-          color="white"
+          color="primary"
           onClick={() => onReferenceClick(item)}
         />
       );

--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -41,7 +41,7 @@ export function SkillBuilderIsDefaultSection() {
   return (
     <>
       <div className="flex items-center gap-2">
-        <SliderToggle selected={isDefault} onClick={handleToggle} size="xs" />
+        <SliderToggle selected={isDefault} onClick={handleToggle} />
         <span className="text-sm text-foreground">
           Allow agents to discover this skill
         </span>

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -100,7 +100,7 @@ export function SpaceLayout({ children }: SpaceLayoutProps) {
               !canReadInSpace && space.kind !== "system" && (
                 <div>
                   <Chip
-                    color="rose"
+                    color="warning"
                     label="You are not a member of this space."
                     size="sm"
                     icon={InfoCircle}

--- a/front/components/workspace/CreditsList.tsx
+++ b/front/components/workspace/CreditsList.tsx
@@ -33,10 +33,10 @@ const TYPE_LABELS: Record<CreditType, string> = {
 // Chip colors for credit types
 export const TYPE_COLORS: Record<
   CreditType,
-  "green" | "blue" | "primary" | "warning"
+  "success" | "highlight" | "primary" | "warning"
 > = {
-  free: "green",
-  committed: "blue",
+  free: "success",
+  committed: "highlight",
   payg: "primary",
   excess: "warning",
 };

--- a/front/components/workspace/EditAdvancedModelsModal.tsx
+++ b/front/components/workspace/EditAdvancedModelsModal.tsx
@@ -338,7 +338,6 @@ export function EditAdvancedModelsModal({
                         <Spinner size="xs" />
                       ) : (
                         <SliderToggle
-                          size="xs"
                           selected={isAllowed}
                           disabled={readOnly}
                           onClick={() =>

--- a/front/components/workspace/WorkspaceAccessPanel.tsx
+++ b/front/components/workspace/WorkspaceAccessPanel.tsx
@@ -196,13 +196,13 @@ function DomainVerificationTable({
         cell: ({ getValue, row }: CellContext<DomainRowData, string>) => {
           const status = getValue();
           const workspaceVerifiedDomain = row.original.workspaceVerifiedDomain;
-          let chipColor: "success" | "info" | "rose" = "info";
+          let chipColor: "success" | "info" | "warning" = "info";
           let label: string = "Pending";
           if (workspaceVerifiedDomain && status === "verified") {
             chipColor = "success";
             label = "Verified";
           } else if (status === "failed") {
-            chipColor = "rose";
+            chipColor = "warning";
             label = "Failed";
           }
 

--- a/front/components/workspace/billing/SubscriptionStatusChip.tsx
+++ b/front/components/workspace/billing/SubscriptionStatusChip.tsx
@@ -6,12 +6,12 @@ export type SubscriptionStatus = "free" | "active" | "cancelled" | "ended";
 
 const STATUS_CHIP: Record<
   SubscriptionStatus,
-  { label: string; color: "green" | "blue" | "golden" | "rose" }
+  { label: string; color: "success" | "highlight" | "info" | "warning" }
 > = {
-  free: { label: "Free", color: "green" },
-  active: { label: "Active", color: "blue" },
-  cancelled: { label: "Cancelled", color: "golden" },
-  ended: { label: "Ended", color: "rose" },
+  free: { label: "Free", color: "success" },
+  active: { label: "Active", color: "highlight" },
+  cancelled: { label: "Cancelled", color: "info" },
+  ended: { label: "Ended", color: "warning" },
 };
 
 export function SubscriptionStatusChip() {

--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -49,7 +49,7 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
         title={
           <div className="flex items-center gap-2">
             <span>Email agents</span>
-            <Chip size="xs" color="golden" label="Beta" />
+            <Chip size="xs" color="info" label="Beta" />
           </div>
         }
         subElement={

--- a/front/components/workspace/settings/SelfImprovingSkillsListSection.tsx
+++ b/front/components/workspace/settings/SelfImprovingSkillsListSection.tsx
@@ -140,7 +140,6 @@ function getColumns(
         return (
           <DataTable.CellContent>
             <SliderToggle
-              size="xs"
               selected={selected}
               disabled={isEnabledUpdating || isLocked}
               onClick={onToggleEnabled}
@@ -192,7 +191,6 @@ function getColumns(
         return (
           <DataTable.CellContent>
             <SliderToggle
-              size="xs"
               selected={selected}
               disabled={isLockUpdating}
               onClick={onToggleLock}

--- a/front/lib/poke/regions.ts
+++ b/front/lib/poke/regions.ts
@@ -12,12 +12,14 @@ export const getRegionDisplay = (region: RegionType): string => {
   }
 };
 
-export const getRegionChipColor = (region: RegionType): "blue" | "green" => {
+export const getRegionChipColor = (
+  region: RegionType
+): "highlight" | "success" => {
   switch (region) {
     case "europe-west1":
-      return "blue";
+      return "highlight";
     case "us-central1":
-      return "green";
+      return "success";
     default:
       assertNever(region);
   }

--- a/marketing/components/home/content/Industry/configs/b2bSaasConfig.tsx
+++ b/marketing/components/home/content/Industry/configs/b2bSaasConfig.tsx
@@ -23,7 +23,7 @@ export const b2bSaasConfig: IndustryPageConfig = {
   hero: {
     chip: {
       label: "B2B SaaS",
-      color: "rose",
+      color: "warning",
       icon: Building04,
     },
     title: (

--- a/marketing/components/home/content/Industry/configs/consultingConfig.tsx
+++ b/marketing/components/home/content/Industry/configs/consultingConfig.tsx
@@ -19,7 +19,7 @@ export const consultingConfig: IndustryPageConfig = {
   hero: {
     chip: {
       label: "Consulting Firms",
-      color: "blue",
+      color: "highlight",
       icon: BarChart01,
     },
     title: (

--- a/marketing/components/home/content/Industry/configs/energyConfig.tsx
+++ b/marketing/components/home/content/Industry/configs/energyConfig.tsx
@@ -18,7 +18,7 @@ export const energyConfig: IndustryPageConfig = {
   hero: {
     chip: {
       label: "Energy & Utilities",
-      color: "green",
+      color: "success",
       icon: Stars02,
     },
     title: (

--- a/marketing/components/home/content/Industry/configs/financialServicesConfig.tsx
+++ b/marketing/components/home/content/Industry/configs/financialServicesConfig.tsx
@@ -23,7 +23,7 @@ export const financialServicesConfig: IndustryPageConfig = {
   hero: {
     chip: {
       label: "Financial Services",
-      color: "golden",
+      color: "info",
       icon: Bank,
     },
     title: (

--- a/marketing/components/home/content/Industry/configs/industrialFirmsConfig.tsx
+++ b/marketing/components/home/content/Industry/configs/industrialFirmsConfig.tsx
@@ -17,7 +17,7 @@ export const industrialFirmsConfig: IndustryPageConfig = {
   hero: {
     chip: {
       label: "Industrial Manufacturing",
-      color: "blue",
+      color: "highlight",
       icon: BarChart01,
     },
     title: (

--- a/marketing/components/home/content/Industry/configs/insuranceConfig.tsx
+++ b/marketing/components/home/content/Industry/configs/insuranceConfig.tsx
@@ -23,7 +23,7 @@ export const insuranceConfig: IndustryPageConfig = {
   hero: {
     chip: {
       label: "Insurance",
-      color: "blue",
+      color: "highlight",
       icon: MedicalCross,
     },
     title: (

--- a/marketing/components/home/content/Industry/configs/investmentConfig.tsx
+++ b/marketing/components/home/content/Industry/configs/investmentConfig.tsx
@@ -17,7 +17,7 @@ export const investmentConfig: IndustryPageConfig = {
   hero: {
     chip: {
       label: "Investment Firms",
-      color: "blue",
+      color: "highlight",
       icon: BarChart01,
     },
     title: (

--- a/marketing/components/home/content/Industry/configs/marketplaceConfig.tsx
+++ b/marketing/components/home/content/Industry/configs/marketplaceConfig.tsx
@@ -23,7 +23,7 @@ export const marketplaceConfig: IndustryPageConfig = {
   hero: {
     chip: {
       label: "Marketplace",
-      color: "blue",
+      color: "highlight",
       icon: ShoppingBag01,
     },
     title: (

--- a/marketing/components/home/content/Industry/configs/mediaConfig.tsx
+++ b/marketing/components/home/content/Industry/configs/mediaConfig.tsx
@@ -17,7 +17,7 @@ export const mediaConfig: IndustryPageConfig = {
   hero: {
     chip: {
       label: "Media Companies",
-      color: "blue",
+      color: "highlight",
       icon: BookOpen01,
     },
     title: (

--- a/marketing/components/home/content/Industry/configs/retailEcommerceConfig.tsx
+++ b/marketing/components/home/content/Industry/configs/retailEcommerceConfig.tsx
@@ -23,7 +23,7 @@ export const retailEcommerceConfig: IndustryPageConfig = {
   hero: {
     chip: {
       label: "Retail & e-Commerce",
-      color: "green",
+      color: "success",
       icon: ActionStore,
     },
     title: (

--- a/marketing/components/home/content/Industry/configs/utils.tsx
+++ b/marketing/components/home/content/Industry/configs/utils.tsx
@@ -9,16 +9,7 @@ export interface SeoConfig {
 // Basic config types
 export interface ChipConfig {
   label: string;
-  color:
-    | "primary"
-    | "success"
-    | "warning"
-    | "info"
-    | "highlight"
-    | "green"
-    | "blue"
-    | "rose"
-    | "golden";
+  color: "primary" | "success" | "warning" | "info" | "highlight";
   icon: React.ComponentType;
 }
 

--- a/sparkle/src/components/ActionCard.tsx
+++ b/sparkle/src/components/ActionCard.tsx
@@ -24,9 +24,9 @@ const actionCardDiffVariants = cva("p-3", {
 
 const DIFF_CHIP_CONFIG: Record<
   ActionCardDiffStatus,
-  { color: "green" | "warning"; icon: React.ComponentType }
+  { color: "success" | "warning"; icon: React.ComponentType }
 > = {
-  added: { color: "green", icon: Plus },
+  added: { color: "success", icon: Plus },
   removed: { color: "warning", icon: Minus },
 };
 
@@ -141,7 +141,7 @@ export const ActionCard = React.forwardRef<HTMLDivElement, ActionCardProps>(
                 {isSelected && (
                   <Chip
                     size="xs"
-                    color="green"
+                    color="success"
                     label="ADDED"
                     className={cn(FADE_TRANSITION_CLASSES, "opacity-100")}
                   />

--- a/sparkle/src/components/Checkbox.tsx
+++ b/sparkle/src/components/Checkbox.tsx
@@ -3,49 +3,32 @@ import { Check, Minus } from "@sparkle/icons/v2-stroke";
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 import React from "react";
-import { Icon } from "./Icon";
 import { Label } from "./Label";
 import { Tooltip } from "./Tooltip";
 
-export const CHECKBOX_SIZES = ["xs", "sm"] as const;
-export type CheckboxSizeType = (typeof CHECKBOX_SIZES)[number];
-
 const checkboxStyles = cva(
   cn(
-    "shrink-0 peer border transition duration-200 ease-in-out",
+    "h-4 w-4 rounded-md relative shrink-0 peer border transition duration-200 ease-in-out motion-reduce:transition-none",
+    "active:scale-95",
     "border-border-dark bg-background",
     "text-foreground",
     "focus-visible:ring-ring ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2",
-    "hover:border-highlight hover:bg-highlight-50"
-  ),
+    "disabled:cursor-not-allowed disabled:opacity-50 disabled:border-border-dark disabled:bg-background"
+  )
+);
+
+// The checked state renders a dark rounded square that fills the box's inner
+// content area; the light "ring" is the box's own border showing through.
+const checkboxIndicatorStyles = cva(
+  "absolute inset-0 flex items-center justify-center rounded-[3px]",
   {
     variants: {
-      checked: {
-        true: "data-[state=checked]:bg-primary data-[state=checked]:text-primary-50 data-[state=checked]:border-primary",
-        partial:
-          "data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-50 data-[state=indeterminate]:border-primary",
-        false: "",
-      },
       isMutedAfterCheck: {
-        true: "",
-        false: "",
-      },
-      size: {
-        xs: "h-4 w-4 rounded",
-        sm: "h-5 w-5 rounded-md",
+        true: "bg-faint/50",
+        false: "bg-foreground",
       },
     },
-    compoundVariants: [
-      {
-        checked: true,
-        isMutedAfterCheck: true,
-        className:
-          "data-[state=checked]:bg-faint/50 data-[state=checked]:border-transparent",
-      },
-    ],
     defaultVariants: {
-      size: "sm",
-      checked: false,
       isMutedAfterCheck: false,
     },
   }
@@ -58,7 +41,7 @@ interface CheckboxProps
       React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>,
       "checked" | "defaultChecked"
     >,
-    VariantProps<typeof checkboxStyles> {
+    VariantProps<typeof checkboxIndicatorStyles> {
   checked?: CheckBoxStateType;
   tooltip?: string;
 }
@@ -66,41 +49,33 @@ interface CheckboxProps
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   CheckboxProps
->(
-  (
-    { className, size, checked, id, tooltip, isMutedAfterCheck, ...props },
-    ref
-  ) => {
-    const checkbox = (
-      <CheckboxPrimitive.Root
-        ref={ref}
-        id={id}
-        className={cn(
-          checkboxStyles({ checked, size, isMutedAfterCheck }),
-          className
-        )}
-        checked={checked === "partial" ? "indeterminate" : checked}
-        {...props}
+>(({ className, checked, id, tooltip, isMutedAfterCheck, ...props }, ref) => {
+  const checkbox = (
+    <CheckboxPrimitive.Root
+      ref={ref}
+      id={id}
+      className={cn(checkboxStyles(), className)}
+      checked={checked === "partial" ? "indeterminate" : checked}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        className={checkboxIndicatorStyles({ isMutedAfterCheck })}
       >
-        <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
-          <span className={cn(size === "xs" ? "-mt-px" : "")}>
-            <Icon
-              size="xs"
-              visual={checked === "partial" ? Minus : Check}
-              className="text-background"
-            />
-          </span>
-        </CheckboxPrimitive.Indicator>
-      </CheckboxPrimitive.Root>
-    );
+        {checked === "partial" ? (
+          <Minus className="h-3 w-3 text-background" />
+        ) : (
+          <Check className="h-3 w-3 text-background" />
+        )}
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
 
-    return tooltip ? (
-      <Tooltip label={tooltip} trigger={checkbox} tooltipTriggerAsChild />
-    ) : (
-      checkbox
-    );
-  }
-);
+  return tooltip ? (
+    <Tooltip label={tooltip} trigger={checkbox} tooltipTriggerAsChild />
+  ) : (
+    checkbox
+  );
+});
 
 Checkbox.displayName = CheckboxPrimitive.Root.displayName;
 
@@ -112,7 +87,6 @@ function CheckboxWithText({
   text,
   tooltip,
   id: idProp,
-  size,
   ...props
 }: CheckboxWithTextProps) {
   // Unique id per instance so checkbox and label stay associated (htmlFor/id); required for a11y and click-label-to-toggle.
@@ -121,13 +95,10 @@ function CheckboxWithText({
 
   const content = (
     <div className="items-top flex items-center space-x-2">
-      <Checkbox id={id} size={size} {...props} />
+      <Checkbox id={id} {...props} />
       <Label
         htmlFor={id}
-        className={cn(
-          "cursor-pointer leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
-          size === "xs" ? "text-xs" : "text-sm"
-        )}
+        className="cursor-pointer text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
       >
         {text}
       </Label>
@@ -146,7 +117,6 @@ function CheckBoxWithTextAndDescription({
   description,
   tooltip,
   id: idProp,
-  size,
   ...props
 }: CheckboxWithTextAndDescriptionProps) {
   // Unique id per instance so checkbox and label stay associated (htmlFor/id); required for a11y and click-label-to-toggle.
@@ -155,14 +125,11 @@ function CheckBoxWithTextAndDescription({
 
   const content = (
     <div className="items-top flex space-x-2">
-      <Checkbox id={id} size={size} {...props} />
+      <Checkbox id={id} {...props} />
       <div className="grid gap-1.5 leading-none">
         <Label
           htmlFor={id}
-          className={cn(
-            "cursor-pointer leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
-            size === "xs" ? "text-xs" : "text-sm"
-          )}
+          className="cursor-pointer text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
         >
           {text}
         </Label>

--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -19,11 +19,6 @@ export const CHIP_COLORS = [
   "warning",
   "info",
   "highlight",
-  "green",
-  "blue",
-  "rose",
-  "golden",
-  "white",
 ] as const;
 
 type ChipColorType = (typeof CHIP_COLORS)[number];
@@ -31,40 +26,23 @@ type ChipColorType = (typeof CHIP_COLORS)[number];
 const chipVariants = cva("inline-flex box-border items-center", {
   variants: {
     size: {
-      mini: "rounded-md min-h-5 text-xs font-medium px-1.5 py-1 gap-0.5",
-      xs: "rounded-lg min-h-7 heading-xs px-3 gap-1",
-      sm: "rounded-xl min-h-9 heading-sm px-4 gap-1.5",
+      mini: "rounded-lg min-h-5 text-xs font-medium px-1.5 gap-1",
+      xs: "rounded-[9px] min-h-6 heading-xs px-[9px] gap-1",
+      sm: "rounded-xl min-h-8 heading-sm px-3 gap-1.5",
     },
+    // Semantic scales (primary/highlight/info/warning) auto-flip in the `.dark`
+    // block, so they need no dark variants. `primary` resolves to stone (Figma
+    // Badge Grey) via the token layer. `success` is overridden to the emerald
+    // palette to match the Figma Badge Green, so it carries dark variants.
     color: {
-      primary: cn("bg-muted-background border-border", "text-primary-900"),
-      highlight: cn(
-        "bg-highlight-100 border-highlight-200",
-        "text-highlight-900"
+      primary: cn("bg-primary-50 text-primary-700"),
+      success: cn(
+        "bg-emerald-50 text-emerald-700",
+        "dark:bg-emerald-950 dark:text-emerald-300"
       ),
-      success: cn("bg-success-100 border-success-200", "text-success-900"),
-      info: cn("bg-info-100 border-info-200", "text-info-900"),
-      warning: cn("bg-warning-100 border-warning-200", "text-warning-900"),
-      // The raw palette scales (green/blue/rose/golden) are not redefined in
-      // the `.dark` block (unlike the semantic scales above), so they need
-      // explicit dark variants to flip. The dark shades mirror the inverted
-      // mapping the v3 `-night` shades used (e.g. green-100 -> green-900).
-      green: cn(
-        "bg-green-100 border-green-200 text-green-900",
-        "dark:bg-green-900 dark:border-green-800 dark:text-green-100"
-      ),
-      blue: cn(
-        "bg-blue-100 border-blue-200 text-blue-900",
-        "dark:bg-blue-900 dark:border-blue-800 dark:text-blue-100"
-      ),
-      rose: cn(
-        "bg-rose-100 border-rose-200 text-rose-900",
-        "dark:bg-rose-900 dark:border-rose-800 dark:text-rose-100"
-      ),
-      golden: cn(
-        "bg-golden-100 border-golden-200 text-golden-900",
-        "dark:bg-golden-900 dark:border-golden-800 dark:text-golden-100"
-      ),
-      white: cn("border bg-background border-border", "text-primary-900"),
+      warning: cn("bg-warning-50 text-warning-700"),
+      info: cn("bg-info-50 text-info-700"),
+      highlight: cn("bg-highlight-50 text-highlight-700"),
     },
   },
   defaultVariants: {
@@ -75,35 +53,19 @@ const chipVariants = cva("inline-flex box-border items-center", {
 
 const closeIconVariants: Record<ChipColorType, string> = {
   primary: cn(
-    "text-primary-700 hover:text-primary-500 active:text-primary-950"
+    "text-primary-700 hover:text-primary-900 active:text-primary-950"
   ),
   highlight: cn(
-    "text-highlight-900 hover:text-highlight-700 active:text-highlight-950"
+    "text-highlight-700 hover:text-highlight-900 active:text-highlight-950"
   ),
   success: cn(
-    "text-success-900 hover:text-success-700 active:text-success-950"
+    "text-emerald-700 hover:text-emerald-900 active:text-emerald-950",
+    "dark:text-emerald-300 dark:hover:text-emerald-100 dark:active:text-emerald-50"
   ),
   warning: cn(
-    "text-warning-900 hover:text-warning-700 active:text-warning-950"
+    "text-warning-700 hover:text-warning-900 active:text-warning-950"
   ),
-  info: cn("text-info-900 hover:text-info-700 active:text-info-950"),
-  green: cn(
-    "text-green-900 hover:text-green-700 active:text-green-950",
-    "dark:text-green-100 dark:hover:text-green-300 dark:active:text-green-50"
-  ),
-  blue: cn(
-    "text-blue-900 hover:text-blue-700 active:text-blue-950",
-    "dark:text-blue-100 dark:hover:text-blue-300 dark:active:text-blue-50"
-  ),
-  rose: cn(
-    "text-rose-900 hover:text-rose-700 active:text-rose-950",
-    "dark:text-rose-100 dark:hover:text-rose-300 dark:active:text-rose-50"
-  ),
-  golden: cn(
-    "text-golden-900 hover:text-golden-700 active:text-golden-950",
-    "dark:text-golden-100 dark:hover:text-golden-300 dark:active:text-golden-50"
-  ),
-  white: cn("text-primary-700 hover:text-primary-500 active:text-primary-950"),
+  info: cn("text-info-700 hover:text-info-900 active:text-info-950"),
 };
 
 interface ChipInternalButtonProps {
@@ -123,7 +85,7 @@ const ChipButton = React.forwardRef<HTMLButtonElement, ChipInternalButtonProps>(
       aria-label={ariaLabel}
       className={cn(
         "rounded-md p-0.5",
-        "transition-colors duration-200",
+        "transition-colors duration-200 motion-reduce:transition-none",
         "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
         className
       )}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -1328,7 +1328,6 @@ export function createSelectionColumn<TData>({
     header: ({ table }) =>
       !hideSelectAll ? (
         <Checkbox
-          size="xs"
           checked={
             table.getIsAllRowsSelected()
               ? true
@@ -1347,7 +1346,6 @@ export function createSelectionColumn<TData>({
     cell: ({ row }) => (
       <div className="flex h-full w-full items-center">
         <Checkbox
-          size="xs"
           checked={row.getIsSelected()}
           disabled={!row.getCanSelect()}
           onCheckedChange={(state) => {
@@ -1375,16 +1373,14 @@ export function createRadioSelectionColumn<TData>(): ColumnDef<TData> {
       <div className="flex h-full w-full items-center">
         <div
           className={cn(
-            radioStyles({ size: "xs" }),
+            radioStyles(),
             row.getIsSelected() && "bg-muted/50",
             !row.getCanSelect() && "cursor-not-allowed opacity-50"
           )}
           aria-checked={row.getIsSelected()}
           role="radio"
         >
-          {row.getIsSelected() && (
-            <div className={radioIndicatorStyles({ size: "xs" })} />
-          )}
+          {row.getIsSelected() && <div className={radioIndicatorStyles()} />}
         </div>
       </div>
     ),

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -712,9 +712,9 @@ const DropdownMenuRadioItem = React.forwardRef<
       )}
       {...props}
     >
-      <span className={cn("absolute left-2", radioStyles({ size: "xs" }))}>
+      <span className={cn("absolute left-2", radioStyles())}>
         <DropdownMenuPrimitive.ItemIndicator>
-          <div className={radioIndicatorStyles({ size: "xs" })} />
+          <div className={radioIndicatorStyles()} />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       <ItemWithLabelIconAndDescription

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -1,49 +1,24 @@
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { Icon } from "@sparkle/components/Icon";
 import { Label } from "@sparkle/components/Label";
-import { Tooltip } from "@sparkle/components/Tooltip";
 import { cn } from "@sparkle/lib/utils";
-import { cva, type VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
 import * as React from "react";
 
 export const radioStyles = cva(
   cn(
-    "aspect-square rounded-full border transition duration-200 ease-in-out",
+    "h-5 w-5 aspect-square rounded-full border transition duration-200 ease-in-out motion-reduce:transition-none active:scale-95",
     "border-border-dark",
     "bg-background",
     "text-foreground",
     "flex items-center justify-center",
     "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring",
-    "hover:border-highlight hover:bg-highlight-50",
-    "checked:ring-0",
-    "checked:bg-highlight-500"
-  ),
-  {
-    variants: {
-      size: {
-        xs: "h-4 w-4",
-        sm: "h-5 w-5",
-      },
-    },
-    defaultVariants: {
-      size: "xs",
-    },
-  }
+    "checked:ring-0"
+  )
 );
 
 export const radioIndicatorStyles = cva(
-  "bg-primary flex items-center justify-center rounded-full",
-  {
-    variants: {
-      size: {
-        xs: "h-2 w-2",
-        sm: "h-2.5 w-2.5",
-      },
-    },
-    defaultVariants: {
-      size: "xs",
-    },
-  }
+  "h-3 w-3 bg-primary flex items-center justify-center rounded-full"
 );
 
 const RadioGroup = React.forwardRef<
@@ -62,76 +37,59 @@ RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
 
 interface RadioGroupItemProps
   extends Omit<
-      React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>,
-      "children"
-    >,
-    VariantProps<typeof radioStyles> {
-  tooltipMessage?: string;
+    React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>,
+    "children"
+  > {
   label: string;
-  labelProps?: Omit<React.ComponentPropsWithoutRef<typeof Label>, "children">;
   icon?: React.ComponentType;
 }
 
 const RadioGroupItem = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Item>,
   RadioGroupItemProps
->(
-  (
-    { tooltipMessage, className, icon, size, label, labelProps, id, ...props },
-    ref
-  ) => {
-    const renderIcon = (visual: React.ComponentType, extraClass = "") => (
-      <Icon
-        visual={visual}
-        size="sm"
-        className={cn("text-foreground", extraClass)}
-      />
-    );
+>(({ className, icon, label, id, ...props }, ref) => {
+  const renderIcon = (visual: React.ComponentType, extraClass = "") => (
+    <Icon
+      visual={visual}
+      size="sm"
+      className={cn("text-foreground", extraClass)}
+    />
+  );
 
-    const item = (
-      <RadioGroupPrimitive.Item
-        ref={ref}
-        id={id}
-        className={cn(radioStyles({ size }), className)}
-        {...props}
-      >
-        <RadioGroupPrimitive.Indicator
-          className={radioIndicatorStyles({ size })}
-        />
-      </RadioGroupPrimitive.Item>
-    );
+  const item = (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      id={id}
+      className={cn(radioStyles(), className)}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className={radioIndicatorStyles()} />
+    </RadioGroupPrimitive.Item>
+  );
 
-    const wrappedItem = (
-      <div className="flex w-full items-center gap-2">
-        {tooltipMessage ? (
-          <Tooltip trigger={item} label={tooltipMessage} />
-        ) : (
-          item
+  const wrappedItem = (
+    <div className="flex w-full items-center gap-2">
+      {item}
+      {icon && renderIcon(icon)}
+      <Label
+        htmlFor={id}
+        className={cn(
+          "cursor-pointer",
+          props.disabled && "cursor-not-allowed opacity-70"
         )}
-        {icon && renderIcon(icon)}
-        <Label
-          htmlFor={id}
-          {...labelProps}
-          className={cn(
-            "cursor-pointer",
-            props.disabled && "cursor-not-allowed opacity-70",
-            labelProps?.className
-          )}
-        >
-          {label}
-        </Label>
-      </div>
-    );
+      >
+        {label}
+      </Label>
+    </div>
+  );
 
-    return <div className="group w-full">{wrappedItem}</div>;
-  }
-);
+  return <div className="group w-full">{wrappedItem}</div>;
+});
 
 type IconPosition = "start" | "center" | "end";
 
 interface RadioGroupCustomItemProps
-  extends React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>,
-    VariantProps<typeof radioStyles> {
+  extends React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item> {
   iconPosition?: IconPosition;
   customItem: React.ReactNode;
   children?: React.ReactNode;
@@ -142,27 +100,17 @@ const RadioGroupCustomItem = React.forwardRef<
   RadioGroupCustomItemProps
 >(
   (
-    {
-      className,
-      size,
-      customItem,
-      iconPosition = "center",
-      children,
-      id,
-      ...props
-    },
+    { className, customItem, iconPosition = "center", children, id, ...props },
     ref
   ) => {
     const item = (
       <RadioGroupPrimitive.Item
         ref={ref}
         id={id}
-        className={cn(radioStyles({ size }), className)}
+        className={cn(radioStyles(), className)}
         {...props}
       >
-        <RadioGroupPrimitive.Indicator
-          className={radioIndicatorStyles({ size })}
-        />
+        <RadioGroupPrimitive.Indicator className={radioIndicatorStyles()} />
       </RadioGroupPrimitive.Item>
     );
 

--- a/sparkle/src/components/SliderToggle.tsx
+++ b/sparkle/src/components/SliderToggle.tsx
@@ -3,32 +3,21 @@ import React, { type MouseEventHandler } from "react";
 
 type SliderToggleProps = {
   onClick?: MouseEventHandler<HTMLElement>;
-  size?: "xs" | "sm";
   className?: string;
   disabled?: boolean;
   selected?: boolean;
 };
 
-const baseClasses =
-  "shrink-0 rounded-full cursor-pointer transition-colors duration-300 ease-out flex items-center";
-
-const sizeClasses = {
-  xs: "h-7 w-10",
-  sm: "h-9 w-14",
-};
-
-const cusrsorSizeClasses = {
-  xs: "h-6 w-6",
-  sm: "h-8 w-8",
-};
-const cusrsorTranslateSizeClasses = {
-  xs: "translate-x-[14px]",
-  sm: "translate-x-[22px]",
-};
+const baseClasses = cn(
+  "shrink-0 h-5 w-8 rounded-full cursor-pointer flex items-center",
+  // Track color and knob slide share timing so they animate as one unit.
+  "transition-colors duration-200 ease-in-out motion-reduce:transition-none",
+  "shadow-[inset_0px_-3px_3px_0px_rgba(255,255,255,0.25),inset_0px_0.5px_2px_0px_rgba(0,0,0,0.14)]"
+);
 
 const stateClasses = {
-  idle: cn("bg-primary-200", "hover:bg-highlight-300"),
-  selected: cn("bg-highlight-400"),
+  idle: cn("bg-primary-150", "hover:bg-primary-200"),
+  selected: cn("bg-highlight-500", "hover:bg-highlight-600"),
   disabled: cn(
     "bg-primary-200",
     "hover:bg-primary-200",
@@ -41,10 +30,8 @@ export function SliderToggle({
   disabled = false,
   className = "",
   selected = false,
-  size = "xs",
 }: SliderToggleProps) {
   const combinedStateClasses = cn(
-    size ? sizeClasses[size] : "",
     selected ? stateClasses.selected : stateClasses.idle,
     disabled ? stateClasses.disabled : ""
   );
@@ -61,10 +48,10 @@ export function SliderToggle({
       <div
         id="cursor"
         className={cn(
-          "transform rounded-full bg-white drop-shadow transition-transform duration-300 ease-out",
+          "h-4 w-4 transform rounded-full bg-white drop-shadow",
+          "transition-transform duration-200 ease-in-out motion-reduce:transition-none",
           disabled && "opacity-50",
-          size && cusrsorSizeClasses[size],
-          selected ? cusrsorTranslateSizeClasses[size] : "translate-x-[2px]"
+          selected ? "translate-x-[14px]" : "translate-x-[2px]"
         )}
       />
     </div>

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -261,7 +261,7 @@ Tree.Item = React.forwardRef<
             />
           )}
           {type === "leaf" && <div className="w-[24px] flex-shrink-0"></div>}
-          {checkbox && <Checkbox {...checkbox} size="xs" />}
+          {checkbox && <Checkbox {...checkbox} />}
           <Icon visual={visual} size="sm" className={tailwindIconTextColor} />
           {isTruncated ? (
             <TooltipProvider>

--- a/sparkle/src/components/markdown/ActionCardBlock.tsx
+++ b/sparkle/src/components/markdown/ActionCardBlock.tsx
@@ -228,7 +228,6 @@ export function ActionCardBlock({
           {hasCheck && (
             <CheckboxWithText
               text={checkLabel ?? DEFAULT_CHECK_LABEL}
-              size={isCompact ? "xs" : "sm"}
               checked={isChecked}
               disabled={isDisabled}
               onCheckedChange={(value) => setIsChecked(value === true)}

--- a/sparkle/src/components/markdown/InputBlock.tsx
+++ b/sparkle/src/components/markdown/InputBlock.tsx
@@ -35,7 +35,6 @@ export const InputBlock = memo(
       <div className="inline-flex items-center">
         <Checkbox
           ref={inputRef as unknown as React.Ref<HTMLButtonElement>}
-          size="xs"
           checked={checked}
           className="translate-y-[3px]"
           onCheckedChange={handleCheckedChange}

--- a/sparkle/src/stories/Checkbox.stories.tsx
+++ b/sparkle/src/stories/Checkbox.stories.tsx
@@ -2,8 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { expect } from "storybook/test";
 
-import { CHECKBOX_SIZES } from "@sparkle/components/Checkbox";
-
 import {
   Checkbox,
   type CheckboxProps,
@@ -44,14 +42,6 @@ const meta = {
     },
   },
   argTypes: {
-    size: {
-      description: "The size of the checkbox",
-      options: CHECKBOX_SIZES,
-      control: { type: "select" },
-      table: {
-        defaultValue: { summary: "sm" },
-      },
-    },
     checked: {
       description: "The checked state of the checkbox",
       options: Object.keys(CHECKED_STATES),
@@ -96,7 +86,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    size: "sm",
     checked: false,
     disabled: false,
   },

--- a/sparkle/src/stories/Chip.stories.tsx
+++ b/sparkle/src/stories/Chip.stories.tsx
@@ -104,20 +104,20 @@ export const RemovableChip: Story = {
     <div className="space-x-2">
       <Chip
         size="mini"
-        color="golden"
+        color="info"
         label="Remove me"
         href="https://notion.so"
         onRemove={() => alert("Removed")}
       />
       <Chip
         size="xs"
-        color="golden"
+        color="info"
         label="Remove me"
         onRemove={() => alert("Removed")}
       />
       <Chip
         size="sm"
-        color="golden"
+        color="info"
         label="Remove me"
         onRemove={() => alert("Removed")}
       />
@@ -129,85 +129,23 @@ export const AllColors: Story = {
   render: () => (
     <div className="flex flex-col gap-4">
       <div className="flex flex-wrap gap-2">
-        <Chip size="xs" color="primary" label="Primary" />
-        <Chip size="xs" color="primary" label="Primary" />
         <Chip size="sm" color="primary" label="Primary" />
-      </div>
-      <div className="flex flex-wrap gap-2">
-        <Chip size="sm" color="primary" label="Primary" />
-        <Chip size="sm" color="highlight" label="Highlight" />
         <Chip size="sm" color="success" label="Success" />
         <Chip size="sm" color="warning" label="Warning" />
         <Chip size="sm" color="info" label="Info" />
-        <Chip size="sm" color="green" label="Green" />
-        <Chip size="sm" color="blue" label="Blue" />
-        <Chip size="sm" color="rose" label="Rose" />
-        <Chip size="sm" color="golden" label="Golden" />
+        <Chip size="sm" color="highlight" label="Highlight" />
       </div>
       <div className="flex flex-wrap gap-2">
-        <Chip
-          size="sm"
-          color="primary"
-          label="Primary"
-          onClick={() => alert("Clicked")}
-          onRemove={() => alert("Removed")}
-        />
-        <Chip
-          size="sm"
-          color="highlight"
-          label="Highlight"
-          onClick={() => alert("Clicked")}
-          onRemove={() => alert("Removed")}
-        />
-        <Chip
-          size="sm"
-          color="success"
-          label="Success"
-          onClick={() => alert("Clicked")}
-          onRemove={() => alert("Removed")}
-        />
-        <Chip
-          size="sm"
-          color="warning"
-          label="Warning"
-          onClick={() => alert("Clicked")}
-          onRemove={() => alert("Removed")}
-        />
-        <Chip
-          size="sm"
-          color="info"
-          label="Info"
-          onClick={() => alert("Clicked")}
-          onRemove={() => alert("Removed")}
-        />
-        <Chip
-          size="sm"
-          color="green"
-          label="Green"
-          onClick={() => alert("Clicked")}
-          onRemove={() => alert("Removed")}
-        />
-        <Chip
-          size="sm"
-          color="blue"
-          label="Blue"
-          onClick={() => alert("Clicked")}
-          onRemove={() => alert("Removed")}
-        />
-        <Chip
-          size="sm"
-          color="rose"
-          label="Rose"
-          onClick={() => alert("Clicked")}
-          onRemove={() => alert("Removed")}
-        />
-        <Chip
-          size="sm"
-          color="golden"
-          label="Golden"
-          onClick={() => alert("Clicked")}
-          onRemove={() => alert("Removed")}
-        />
+        {CHIP_COLORS.map((color) => (
+          <Chip
+            key={color}
+            size="sm"
+            color={color}
+            label={color}
+            onClick={() => alert("Clicked")}
+            onRemove={() => alert("Removed")}
+          />
+        ))}
       </div>
     </div>
   ),

--- a/sparkle/src/stories/ContextItem.stories.tsx
+++ b/sparkle/src/stories/ContextItem.stories.tsx
@@ -62,7 +62,7 @@ export const ListItemExample = () => (
         visual={<Icon visual={Folder} size="md" />}
       >
         <div className="py-2">
-          <Chip size="xs" label="Last Sync ~7 days ago" color="green" />
+          <Chip size="xs" label="Last Sync ~7 days ago" color="success" />
         </div>
         <ContextItem.Description description="Lats, pricing, history of contacts, contact message" />
       </ContextItem>
@@ -105,7 +105,7 @@ export const ListItemExample = () => (
       <ContextItem
         title="Github"
         subElement={<>By: Stan</>}
-        action={<SliderToggle size="xs" />}
+        action={<SliderToggle />}
         visual={<ContextItem.Visual visual={GithubLogo} />}
       >
         <>
@@ -117,12 +117,9 @@ export const ListItemExample = () => (
       </ContextItem>
       <ContextItem
         title="@Gpt4"
-        action={<SliderToggle size="xs" />}
+        action={<SliderToggle />}
         visual={
-          <Avatar
-            visual="https://dust.tt/static/systemavatar/gpt4_avatar_full.png"
-            size="sm"
-          />
+          <Avatar visual="https://dust.tt/static/systemavatar/gpt4_avatar_full.png" />
         }
       >
         <ContextItem.Description description="Lats, pricing, history of contacts, contact message" />

--- a/sparkle/src/stories/MultiPageDialog.stories.tsx
+++ b/sparkle/src/stories/MultiPageDialog.stories.tsx
@@ -972,7 +972,6 @@ export const ActionValidation: Story = {
                 <div className="mt-4">
                   <label className="copy-xs flex w-fit cursor-pointer flex-row items-center gap-2 py-2 pr-2 font-normal">
                     <Checkbox
-                      size="xs"
                       checked={neverAskAgain}
                       onCheckedChange={(check) => {
                         setNeverAskAgain(!!check);

--- a/sparkle/src/stories/RadioGroup.stories.tsx
+++ b/sparkle/src/stories/RadioGroup.stories.tsx
@@ -66,8 +66,6 @@ export const RadioGroupExample = () => {
           <RadioGroupItem
             value="option-four"
             id="option-four"
-            size="sm"
-            tooltipMessage="This is a nice tooltip message"
             label="Option Four"
           />
         </div>
@@ -75,7 +73,6 @@ export const RadioGroupExample = () => {
           <RadioGroupItem
             value="option-five"
             id="option-five"
-            size="sm"
             disabled
             label="Option Five"
           />
@@ -84,7 +81,6 @@ export const RadioGroupExample = () => {
           <RadioGroupItem
             value="option-six"
             id="option-six"
-            size="sm"
             label="Option Six"
           />
         </div>

--- a/sparkle/src/stories/SliderToggle.stories.tsx
+++ b/sparkle/src/stories/SliderToggle.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component: `A compact on/off switch for toggling a single setting that takes effect immediately. Reflects state via **selected**, can be **disabled**, and comes in **sm** and **xs** **size**s.
+        component: `A compact on/off switch for toggling a single setting that takes effect immediately. Reflects state via **selected** and can be **disabled**.
 
 **When to use**
 - For binary settings that apply instantly without a separate save action (e.g. enabling a feature in a settings row).
@@ -33,19 +33,11 @@ export const SliderToggleBasic: Story = {
 };
 
 export const SliderExample = () => (
-  <div className="flex flex-col gap-6">
-    <div className="flex items-center gap-2">
-      <Button variant="outline" size="sm" label="Settings" />
-      <SliderToggle size="sm" />
-      <SliderToggle size="sm" selected />
-      <SliderToggle size="sm" disabled />
-    </div>
-
-    <div className="flex items-center gap-2">
-      <Button variant="outline" size="xs" label="Settings" />
-      <SliderToggle size="xs" />
-      <SliderToggle size="xs" selected />
-      <SliderToggle size="xs" disabled />
-    </div>
+  <div className="flex items-center gap-2">
+    <Button variant="outline" size="sm" label="Settings" />
+    <SliderToggle />
+    <SliderToggle selected />
+    <SliderToggle disabled />
+    <SliderToggle selected disabled />
   </div>
 );

--- a/sparkle/src/stories/Tree.stories.tsx
+++ b/sparkle/src/stories/Tree.stories.tsx
@@ -793,7 +793,7 @@ export const SelectDataSourceExample = () => {
                     <span className="text-sm text-muted-foreground">
                       Managed by: Stanislas Polu
                     </span>
-                    <Chip size="sm" color="green" label="Syncing (235)" />
+                    <Chip size="sm" color="success" label="Syncing (235)" />
                     <Button
                       label="Manage"
                       icon={Settings01}
@@ -813,7 +813,7 @@ export const SelectDataSourceExample = () => {
                     <span className="text-sm text-muted-foreground">
                       Managed by: Stanislas Polu
                     </span>
-                    <Chip size="sm" color="green" label="Syncing (235)" />
+                    <Chip size="sm" color="success" label="Syncing (235)" />
                     <Button
                       label="Manage"
                       icon={Settings01}
@@ -832,7 +832,7 @@ export const SelectDataSourceExample = () => {
                     <span className="text-sm text-muted-foreground">
                       Managed by: Stanislas Polu
                     </span>
-                    <Chip size="sm" color="green" label="Syncing (235)" />
+                    <Chip size="sm" color="success" label="Syncing (235)" />
                     <Button
                       label="Manage"
                       icon={Settings01}
@@ -860,7 +860,7 @@ export const SelectDataSourceExample = () => {
                     <span className="text-sm text-muted-foreground">
                       Managed by: Stanislas Polu
                     </span>
-                    <Chip size="sm" color="green" label="Syncing (235)" />
+                    <Chip size="sm" color="success" label="Syncing (235)" />
                     <Button
                       label="Manage"
                       icon={Settings01}


### PR DESCRIPTION
## Description
Apply the new design-system visuals to four small components while keeping their existing dimensions, so the ~215 call sites pick up the new look with no layout shift or API changes.

- Chip: borderless, 50-level background + 700-level text across all color variants; close-icon recolored to match.
- RadioGroup: selected state is a dark dot on a white circle (no blue fill).
- Checkbox: checked state is an inset dark square inside the bordered box.
- SliderToggle: on=blue-500, off=lighter grey, plus inner-shadow track depth.

Sizes updated to reflect new designs - most variants now have one size and all uses are aligned

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Check storybook and app preview
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
deploy front
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
