### PR TITLE
Add: methods to bucket models in tiers.

### DIFF
--- a/front/lib/api/models_picker/tiers.test.ts
+++ b/front/lib/api/models_picker/tiers.test.ts
@@ -1,0 +1,139 @@
+import { MODEL_PRICING } from "@app/lib/api/assistant/token_pricing";
+import {
+  getBlendedModelCostUsdPerMillionTokens,
+  getModelsAllowedForTier,
+  getModelTier,
+  getModelTierForBlendedCost,
+  groupModelsByTier,
+  MODEL_PICKER_STATIC_MODEL_IDS,
+  MODEL_TIER_BLENDED_COST_THRESHOLDS_USD,
+  MODEL_TIERS,
+} from "@app/lib/api/models_picker/tiers";
+import { describe, expect, it } from "vitest";
+
+describe("getModelTierForBlendedCost", () => {
+  it("maps blended costs to the four pricing tiers", () => {
+    expect(getModelTierForBlendedCost(0.1)).toBe("fast");
+    expect(
+      getModelTierForBlendedCost(
+        MODEL_TIER_BLENDED_COST_THRESHOLDS_USD.balanced - 0.01
+      )
+    ).toBe("fast");
+    expect(
+      getModelTierForBlendedCost(
+        MODEL_TIER_BLENDED_COST_THRESHOLDS_USD.balanced
+      )
+    ).toBe("balanced");
+    expect(
+      getModelTierForBlendedCost(
+        MODEL_TIER_BLENDED_COST_THRESHOLDS_USD.powerful - 0.01
+      )
+    ).toBe("balanced");
+    expect(
+      getModelTierForBlendedCost(
+        MODEL_TIER_BLENDED_COST_THRESHOLDS_USD.powerful
+      )
+    ).toBe("powerful");
+    expect(
+      getModelTierForBlendedCost(
+        MODEL_TIER_BLENDED_COST_THRESHOLDS_USD.frontier - 0.01
+      )
+    ).toBe("powerful");
+    expect(
+      getModelTierForBlendedCost(
+        MODEL_TIER_BLENDED_COST_THRESHOLDS_USD.frontier
+      )
+    ).toBe("frontier");
+  });
+});
+
+describe("getModelTier", () => {
+  it("classifies representative models from the pricing table", () => {
+    expect(getModelTier("accounts/fireworks/models/glm-5")).toBe("fast");
+    expect(getModelTier("gemini-2.5-flash-lite")).toBe("fast");
+    expect(getModelTier("gpt-5-nano")).toBe("fast");
+
+    expect(getModelTier("gpt-5-mini")).toBe("balanced");
+    expect(getModelTier("gemini-3-flash-preview")).toBe("balanced");
+
+    expect(getModelTier("gpt-5.4")).toBe("powerful");
+    expect(getModelTier("claude-sonnet-4-6")).toBe("powerful");
+
+    expect(getModelTier("gpt-5.5")).toBe("frontier");
+    expect(getModelTier("claude-4-opus-20250514")).toBe("frontier");
+  });
+});
+
+describe("groupModelsByTier", () => {
+  it("assigns every picker model to exactly one tier", () => {
+    const grouped = groupModelsByTier();
+    const assignedModels = MODEL_TIERS.flatMap((tier) => grouped[tier]);
+
+    expect(assignedModels).toHaveLength(MODEL_PICKER_STATIC_MODEL_IDS.length);
+    expect(new Set(assignedModels)).toEqual(
+      new Set(MODEL_PICKER_STATIC_MODEL_IDS)
+    );
+  });
+
+  it("keeps models in the tier returned by getModelTier", () => {
+    const grouped = groupModelsByTier();
+
+    for (const tier of MODEL_TIERS) {
+      for (const modelId of grouped[tier]) {
+        expect(getModelTier(modelId)).toBe(tier);
+      }
+    }
+  });
+});
+
+describe("getModelsAllowedForTier", () => {
+  it("returns cumulative allowlists up to the selected ceiling", () => {
+    const grouped = groupModelsByTier();
+
+    expect(getModelsAllowedForTier("fast")).toEqual(
+      expect.arrayContaining(grouped.fast)
+    );
+    expect(getModelsAllowedForTier("fast")).toHaveLength(grouped.fast.length);
+
+    expect(getModelsAllowedForTier("balanced")).toEqual(
+      expect.arrayContaining([...grouped.fast, ...grouped.balanced])
+    );
+    expect(getModelsAllowedForTier("balanced")).toHaveLength(
+      grouped.fast.length + grouped.balanced.length
+    );
+
+    expect(getModelsAllowedForTier("powerful")).toHaveLength(
+      grouped.fast.length + grouped.balanced.length + grouped.powerful.length
+    );
+
+    expect(getModelsAllowedForTier("frontier")).toEqual(
+      expect.arrayContaining(MODEL_PICKER_STATIC_MODEL_IDS)
+    );
+    expect(getModelsAllowedForTier("frontier")).toHaveLength(
+      MODEL_PICKER_STATIC_MODEL_IDS.length
+    );
+  });
+
+  it("never includes models above the selected tier", () => {
+    const tierRank = Object.fromEntries(
+      MODEL_TIERS.map((tier, index) => [tier, index])
+    ) as Record<(typeof MODEL_TIERS)[number], number>;
+
+    for (const maxTier of MODEL_TIERS) {
+      const allowed = getModelsAllowedForTier(maxTier);
+
+      for (const modelId of allowed) {
+        expect(tierRank[getModelTier(modelId)]).toBeLessThanOrEqual(
+          tierRank[maxTier]
+        );
+      }
+    }
+  });
+});
+
+describe("getBlendedModelCostUsdPerMillionTokens", () => {
+  it("averages input and output pricing", () => {
+    const pricing = MODEL_PRICING["gpt-5-nano"];
+    expect(getBlendedModelCostUsdPerMillionTokens(pricing)).toBe(0.225);
+  });
+});

--- a/front/lib/api/models_picker/tiers.ts
+++ b/front/lib/api/models_picker/tiers.ts
@@ -1,0 +1,106 @@
+import type { PricingEntry } from "@app/lib/api/assistant/token_pricing";
+import { MODEL_PRICING } from "@app/lib/api/assistant/token_pricing";
+import {
+  STATIC_MODEL_IDS,
+  type StaticModelIdType,
+} from "@app/types/assistant/models/models";
+import { NOOP_MODEL_ID } from "@app/types/assistant/models/noop";
+
+export const MODEL_TIERS = [
+  "fast",
+  "balanced",
+  "powerful",
+  "frontier",
+] as const;
+export type ModelTier = (typeof MODEL_TIERS)[number];
+
+/**
+ * Blended cost thresholds in USD per million tokens (average of input + output).
+ * Derived from the pricing initiative model picker spec:
+ * Fast < $0.5, Balanced < $3, Powerful < $15, Frontier >= $15.
+ */
+export const MODEL_TIER_BLENDED_COST_THRESHOLDS_USD = {
+  balanced: 0.5,
+  powerful: 3,
+  frontier: 15,
+} as const;
+
+const MODEL_TIER_RANK: Record<ModelTier, number> = {
+  fast: 0,
+  balanced: 1,
+  powerful: 2,
+  frontier: 3,
+};
+
+export const MODEL_PICKER_STATIC_MODEL_IDS = STATIC_MODEL_IDS.filter(
+  (modelId) => modelId !== NOOP_MODEL_ID
+);
+
+export function getBlendedModelCostUsdPerMillionTokens(
+  pricing: PricingEntry
+): number {
+  return (pricing.input + pricing.output) / 2;
+}
+
+export function getModelTierForBlendedCost(
+  blendedCostUsdPerMillionTokens: number
+): ModelTier {
+  if (
+    blendedCostUsdPerMillionTokens <
+    MODEL_TIER_BLENDED_COST_THRESHOLDS_USD.balanced
+  ) {
+    return "fast";
+  }
+  if (
+    blendedCostUsdPerMillionTokens <
+    MODEL_TIER_BLENDED_COST_THRESHOLDS_USD.powerful
+  ) {
+    return "balanced";
+  }
+  if (
+    blendedCostUsdPerMillionTokens <
+    MODEL_TIER_BLENDED_COST_THRESHOLDS_USD.frontier
+  ) {
+    return "powerful";
+  }
+  return "frontier";
+}
+
+export function getModelTier(modelId: StaticModelIdType): ModelTier {
+  const pricing = MODEL_PRICING[modelId];
+  if (!pricing) {
+    throw new Error(`Missing pricing for model ${modelId}`);
+  }
+
+  return getModelTierForBlendedCost(
+    getBlendedModelCostUsdPerMillionTokens(pricing)
+  );
+}
+
+export function groupModelsByTier(
+  modelIds: StaticModelIdType[] = MODEL_PICKER_STATIC_MODEL_IDS
+): Record<ModelTier, StaticModelIdType[]> {
+  const grouped: Record<ModelTier, StaticModelIdType[]> = {
+    fast: [],
+    balanced: [],
+    powerful: [],
+    frontier: [],
+  };
+
+  for (const modelId of modelIds) {
+    grouped[getModelTier(modelId)].push(modelId);
+  }
+
+  return grouped;
+}
+
+export function getModelsAllowedForTier(
+  maxTier: ModelTier,
+  modelIds: StaticModelIdType[] = MODEL_PICKER_STATIC_MODEL_IDS
+): StaticModelIdType[] {
+  const maxRank = MODEL_TIER_RANK[maxTier];
+
+  return modelIds.filter(
+    (modelId) => MODEL_TIER_RANK[getModelTier(modelId)] <= maxRank
+  );
+}


### PR DESCRIPTION
## Description

Adds `front/lib/api/models_picker/tiers.ts`, the foundational tier-classification module for the model picker pricing initiative. Models are bucketed into four tiers (`fast`, `balanced`, `powerful`, `frontier`) based on blended cost (average of input + output pricing per million tokens), with thresholds at $0.5, $3, and $15 USD.

Key exports:
- `getModelTier(modelId)` — classifies a model via `MODEL_PRICING` lookup + `getModelTierForBlendedCost`
- `groupModelsByTier()` — partitions all picker models (`STATIC_MODEL_IDS` minus `NOOP_MODEL_ID`) into tier buckets
- `getModelsAllowedForTier(maxTier)` — returns a cumulative allowlist of all models at or below a tier ceiling, enabling workspace-level model access control

## Tests

Added Vitest unit tests in `tiers.test.ts` covering all exports: boundary conditions for `getModelTierForBlendedCost`, representative model classification for `getModelTier`, exhaustive partition coverage for `groupModelsByTier`, and allowlist ceiling enforcement for `getModelsAllowedForTier`.

## Risk

Low. Pure utility module — no DB changes, no API routes, no existing code modified. The only risk is incorrect tier assignment if `MODEL_PRICING` entries are missing or stale; `getModelTier` throws on missing entries, and the tests guard against misclassification.

## Deploy Plan

Deploy front.
