### PR TITLE
Add scripts to seed provisioned groups.

### DIFF
--- a/front/scripts/reset_directory_created_groups.ts
+++ b/front/scripts/reset_directory_created_groups.ts
@@ -2,17 +2,24 @@ import { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { makeScript } from "@app/scripts/helpers";
+import { isFakeWorkOSOrganizationId } from "@app/scripts/workspace_helpers";
 
 makeScript(
   {
     workspaceId: {
       alias: "w",
       type: "string",
-      description: "Workspace sID",
+      describe: "Workspace sID",
       demandOption: true,
     },
+    addFakeWorkOSOrganizationId: {
+      type: "boolean",
+      describe:
+        "Also clear the fake workOSOrganizationId if it was set by the seed script",
+      default: false,
+    },
   },
-  async ({ execute, workspaceId }, logger) => {
+  async ({ execute, workspaceId, addFakeWorkOSOrganizationId }, logger) => {
     const workspace = await WorkspaceResource.fetchById(workspaceId);
     if (!workspace) {
       logger.error({ workspaceId }, "Workspace not found");
@@ -64,6 +71,44 @@ makeScript(
           { groupId: group.sId, name: group.name, kind: group.kind },
           "Dry run -- not deleting group "
         );
+      }
+    }
+
+    if (addFakeWorkOSOrganizationId) {
+      if (
+        isFakeWorkOSOrganizationId(
+          workspace.workOSOrganizationId,
+          workspace.sId
+        )
+      ) {
+        logger.info(
+          { workOSOrganizationId: workspace.workOSOrganizationId },
+          execute
+            ? "Clearing fake WorkOS organization ID"
+            : "Would clear fake WorkOS organization ID"
+        );
+
+        if (execute) {
+          const updateRes = await WorkspaceResource.updateWorkOSOrganizationId(
+            workspace.id,
+            null
+          );
+          if (updateRes.isErr()) {
+            logger.error(
+              { error: updateRes.error },
+              "Failed to clear fake WorkOS organization ID"
+            );
+          } else {
+            logger.info({}, "Cleared fake WorkOS organization ID");
+          }
+        }
+      } else if (workspace.workOSOrganizationId) {
+        logger.warn(
+          { workOSOrganizationId: workspace.workOSOrganizationId },
+          "Workspace WorkOS organization ID is not a fake one, not clearing"
+        );
+      } else {
+        logger.info({}, "No WorkOS organization ID to clear");
       }
     }
   }

--- a/front/scripts/seed_directory_provisioned_groups.ts
+++ b/front/scripts/seed_directory_provisioned_groups.ts
@@ -1,0 +1,253 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import {
+  getFakeWorkOSOrganizationId,
+  isFakeWorkOSOrganizationId,
+} from "@app/scripts/workspace_helpers";
+
+/**
+ * Seed fake SCIM/directory provisioned groups for local development and testing.
+ *
+ * Usage:
+ *   npx tsx ./scripts/seed_directory_provisioned_groups.ts \
+ *     --workspace-id <workspace-sId> \
+ *     --count 3 \
+ *     --add-fake-work-os-organization-id \
+ *     --execute
+ *
+ * To clean up:
+ *   npx tsx ./scripts/reset_directory_created_groups.ts \
+ *     --workspace-id <workspace-sId> \
+ *     --add-fake-work-os-organization-id \
+ *     --execute
+ */
+
+function generateFakeWorkOSGroupId(index: number): string {
+  const timestamp = Date.now();
+  const randomId = Math.random().toString(36).substring(2, 9);
+  return `directory_group_${timestamp}_${index}_${randomId}`;
+}
+
+function pickRandomUsers(users: UserResource[]): UserResource[] {
+  if (users.length === 0) {
+    return [];
+  }
+
+  const selected = users.filter(() => Math.random() < 0.5);
+  if (selected.length === 0) {
+    return [users[Math.floor(Math.random() * users.length)]];
+  }
+
+  return selected;
+}
+
+makeScript(
+  {
+    workspaceId: {
+      alias: "w",
+      type: "string",
+      describe: "Workspace sID",
+      demandOption: true,
+    },
+    count: {
+      type: "number",
+      describe: "Number of fake provisioned groups to create",
+      default: 3,
+    },
+    groupNames: {
+      type: "array",
+      describe:
+        "Group names to create (space-separated). Overrides --count when provided.",
+    },
+    addFakeWorkOSOrganizationId: {
+      type: "boolean",
+      describe:
+        "Set a fake workOSOrganizationId on the workspace if it does not have one",
+      default: false,
+    },
+  },
+  async (
+    { execute, workspaceId, count, groupNames, addFakeWorkOSOrganizationId },
+    logger
+  ) => {
+    const workspace = await WorkspaceResource.fetchById(workspaceId);
+    if (!workspace) {
+      logger.error({ workspaceId }, "Workspace not found");
+      return;
+    }
+
+    logger.info({ workspaceId, workspace: workspace.name }, "Found workspace");
+
+    if (addFakeWorkOSOrganizationId) {
+      const fakeWorkOSOrganizationId = getFakeWorkOSOrganizationId(
+        workspace.sId
+      );
+
+      if (workspace.workOSOrganizationId) {
+        if (
+          isFakeWorkOSOrganizationId(
+            workspace.workOSOrganizationId,
+            workspace.sId
+          )
+        ) {
+          logger.info(
+            { workOSOrganizationId: workspace.workOSOrganizationId },
+            "Workspace already has fake WorkOS organization ID"
+          );
+        } else {
+          logger.warn(
+            {
+              workOSOrganizationId: workspace.workOSOrganizationId,
+            },
+            "Workspace already has a WorkOS organization ID, not overwriting"
+          );
+        }
+      } else if (execute) {
+        const updateRes = await WorkspaceResource.updateWorkOSOrganizationId(
+          workspace.id,
+          fakeWorkOSOrganizationId
+        );
+        if (updateRes.isErr()) {
+          logger.error(
+            { error: updateRes.error },
+            "Failed to set fake WorkOS organization ID"
+          );
+          return;
+        }
+        logger.info(
+          { workOSOrganizationId: fakeWorkOSOrganizationId },
+          "Set fake WorkOS organization ID on workspace"
+        );
+      } else {
+        logger.info(
+          { workOSOrganizationId: fakeWorkOSOrganizationId },
+          "Would set fake WorkOS organization ID on workspace"
+        );
+      }
+    }
+
+    const namesToCreate =
+      groupNames && groupNames.length > 0
+        ? groupNames
+        : Array.from(
+            { length: count },
+            (_, i) => `Fake Provisioned Group ${i + 1}`
+          );
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const { memberships } = await MembershipResource.getActiveMemberships({
+      workspace: renderLightWorkspaceType({ workspace }),
+    });
+    const workspaceUsers = await UserResource.fetchByModelIds(
+      memberships.map((membership) => membership.userId)
+    );
+
+    if (workspaceUsers.length === 0) {
+      logger.warn(
+        { workspaceId },
+        "No active workspace users found to assign to groups"
+      );
+    } else {
+      logger.info(
+        {
+          workspaceId,
+          userCount: workspaceUsers.length,
+          userEmails: workspaceUsers.map((user) => user.email),
+        },
+        "Found workspace users for random group assignment"
+      );
+    }
+
+    const groupsToCreate = namesToCreate.map((groupName) => ({
+      groupName,
+      users: pickRandomUsers(workspaceUsers),
+    }));
+
+    const createdGroups: {
+      groupId: string;
+      groupName: string;
+      memberEmails: string[];
+    }[] = [];
+
+    for (const [index, { groupName, users }] of groupsToCreate.entries()) {
+      const workOSGroupId = generateFakeWorkOSGroupId(index);
+      const memberEmails = users.map((user) => user.email);
+
+      logger.info(
+        { groupName, workOSGroupId, memberEmails },
+        execute
+          ? "Creating fake provisioned group"
+          : "Would create fake provisioned group"
+      );
+
+      if (execute) {
+        const group = await GroupResource.makeNew({
+          name: groupName,
+          workOSGroupId,
+          updatedAt: new Date(),
+          kind: "provisioned",
+          workspaceId: workspace.id,
+        });
+
+        if (users.length > 0) {
+          const addMembersResult = await group.dangerouslyAddMembers(auth, {
+            users: users.map((user) => user.toJSON()),
+            allowProvisionedGroups: true,
+          });
+          if (addMembersResult.isErr()) {
+            logger.error(
+              {
+                groupId: group.sId,
+                groupName: group.name,
+                error: addMembersResult.error,
+              },
+              "Failed to add members to fake provisioned group"
+            );
+          }
+        }
+
+        createdGroups.push({
+          groupId: group.sId,
+          groupName: group.name,
+          memberEmails,
+        });
+        logger.info(
+          {
+            groupId: group.sId,
+            groupName: group.name,
+            workOSGroupId,
+            memberEmails,
+          },
+          "Created fake provisioned group"
+        );
+      }
+    }
+
+    logger.info(
+      {
+        workspaceId,
+        groupCount: namesToCreate.length,
+        createdGroups,
+      },
+      execute
+        ? "Finished seeding fake provisioned groups"
+        : "Dry run -- no groups were created"
+    );
+
+    const resetCommand = [
+      "npx tsx ./scripts/reset_directory_created_groups.ts",
+      `--workspace-id ${workspaceId}`,
+      ...(addFakeWorkOSOrganizationId
+        ? ["--add-fake-work-os-organization-id"]
+        : []),
+      "--execute",
+    ].join(" ");
+
+    logger.info({}, `To clean up, run:\n  ${resetCommand}`);
+  }
+);

--- a/front/scripts/workspace_helpers.ts
+++ b/front/scripts/workspace_helpers.ts
@@ -3,6 +3,19 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { LightWorkspaceType } from "@app/types/user";
 
+const FAKE_WORKOS_ORG_ID_PREFIX = "org_fake_local_dev_";
+
+export function getFakeWorkOSOrganizationId(workspaceSId: string): string {
+  return `${FAKE_WORKOS_ORG_ID_PREFIX}${workspaceSId}`;
+}
+
+export function isFakeWorkOSOrganizationId(
+  workOSOrganizationId: string | null,
+  workspaceSId: string
+): boolean {
+  return workOSOrganizationId === getFakeWorkOSOrganizationId(workspaceSId);
+}
+
 /**
  * Run a worker function on workspaces.
  *


### PR DESCRIPTION
## Description

Adds `seed_directory_provisioned_groups.ts` to create fake SCIM/directory-provisioned `GroupResource` entries for local dev and testing. The script generates groups with fake `workOSGroupId` values, assigns random active workspace members via `dangerouslyAddMembers`, and optionally sets a fake `workOSOrganizationId` (prefixed `org_fake_local_dev_`) on the workspace via `WorkspaceResource.updateWorkOSOrganizationId`.

Extends `reset_directory_created_groups.ts` with an `--add-fake-work-os-organization-id` flag to also clear that fake org ID on cleanup. Extracts `getFakeWorkOSOrganizationId` and `isFakeWorkOSOrganizationId` helpers into `workspace_helpers.ts` to keep the fake-ID logic consistent across both scripts.

## Tests

Tested locally — ran seed script in dry-run then with `--execute`, verified groups appeared in DB, ran reset script to clean up.

## Risk

No production risk — scripts are local/dev tooling only. The `org_fake_local_dev_` prefix on fake org IDs makes them easily identifiable; `isFakeWorkOSOrganizationId` guards against accidentally clearing real WorkOS org IDs.

## Deploy Plan

No deploy needed — scripts-only change.
