### PR TITLE
Add models for model tier picker.

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -93,6 +93,7 @@ import {
   SharingGrantModel,
 } from "@app/lib/resources/storage/models/files";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupModelTierModel } from "@app/lib/resources/storage/models/group_model_tier";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
@@ -137,6 +138,7 @@ import {
   UserModel,
   UserToolApprovalModel,
 } from "@app/lib/resources/storage/models/user";
+import { UserModelTierModel } from "@app/lib/resources/storage/models/user_model_tier";
 import { UserProjectPreferencesModel } from "@app/lib/resources/storage/models/user_project_preferences";
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -269,6 +271,8 @@ export function loadAllModels() {
     TakeawaySourcesModel,
     TakeawaysVersionModel,
     UserProjectPreferencesModel,
+    UserModelTierModel,
+    GroupModelTierModel,
     WorkspaceSensitivityLabelConfigModel,
     WorkspaceSandboxEnvVarModel,
     WorkspaceSeatLimitModel,

--- a/front/lib/resources/storage/models/group_model_tier.ts
+++ b/front/lib/resources/storage/models/group_model_tier.ts
@@ -1,0 +1,76 @@
+import { MODEL_TIERS, type ModelTier } from "@app/lib/api/models_picker/tiers";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey } from "sequelize";
+
+/**
+ * Per-(workspace, group) model tier override.
+ *
+ * When absent, members of the group inherit the workspace default tier unless
+ * they have a user-level override.
+ */
+export class GroupModelTierModel extends WorkspaceAwareModel<GroupModelTierModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare groupId: ForeignKey<GroupModel["id"]>;
+  declare tier: ModelTier;
+}
+
+GroupModelTierModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    groupId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: GroupModel,
+        key: "id",
+      },
+    },
+    tier: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        isIn: [MODEL_TIERS],
+      },
+    },
+  },
+  {
+    modelName: "group_model_tiers",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "group_model_tiers_workspace_group_unique",
+        fields: ["workspaceId", "groupId"],
+        unique: true,
+        concurrently: true,
+      },
+      {
+        name: "group_model_tiers_group_id",
+        fields: ["groupId"],
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+GroupModel.hasMany(GroupModelTierModel, {
+  foreignKey: { name: "groupId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+GroupModelTierModel.belongsTo(GroupModel, {
+  foreignKey: { name: "groupId", allowNull: false },
+  targetKey: "id",
+});

--- a/front/lib/resources/storage/models/user_model_tier.ts
+++ b/front/lib/resources/storage/models/user_model_tier.ts
@@ -1,0 +1,76 @@
+import { MODEL_TIERS, type ModelTier } from "@app/lib/api/models_picker/tiers";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey } from "sequelize";
+
+/**
+ * Per-(workspace, user) model tier override.
+ *
+ * When absent, the user's effective tier falls back to their group tier (if any)
+ * and then the workspace default.
+ */
+export class UserModelTierModel extends WorkspaceAwareModel<UserModelTierModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare userId: ForeignKey<UserModel["id"]>;
+  declare tier: ModelTier;
+}
+
+UserModelTierModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    userId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: UserModel,
+        key: "id",
+      },
+    },
+    tier: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        isIn: [MODEL_TIERS],
+      },
+    },
+  },
+  {
+    modelName: "user_model_tiers",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "user_model_tiers_workspace_user_unique",
+        fields: ["workspaceId", "userId"],
+        unique: true,
+        concurrently: true,
+      },
+      {
+        name: "user_model_tiers_user_id",
+        fields: ["userId"],
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+UserModel.hasMany(UserModelTierModel, {
+  foreignKey: { name: "userId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+UserModelTierModel.belongsTo(UserModel, {
+  foreignKey: { name: "userId", allowNull: false },
+  targetKey: "id",
+});

--- a/front/lib/resources/storage/models/workspace.ts
+++ b/front/lib/resources/storage/models/workspace.ts
@@ -1,3 +1,4 @@
+import { MODEL_TIERS, type ModelTier } from "@app/lib/api/models_picker/tiers";
 import type { SubscriptionModel } from "@app/lib/models/plan";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
@@ -34,6 +35,7 @@ export class WorkspaceModel extends BaseModel<WorkspaceModel> {
   declare subscriptions: NonAttribute<SubscriptionModel[]>;
   declare whiteListedProviders: ModelProviderIdType[] | null;
   declare defaultEmbeddingProvider: EmbeddingProviderIdType | null;
+  declare defaultModelsTier: ModelTier | null;
   declare metadata: Record<string, string | number | boolean | object> | null;
   declare sharingPolicy: CreationOptional<WorkspaceSharingPolicy>;
   declare conversationsRetentionDays: number | null;
@@ -108,6 +110,14 @@ WorkspaceModel.init(
       allowNull: true,
       validate: {
         isIn: [modelProviders],
+      },
+    },
+    defaultModelsTier: {
+      type: DataTypes.STRING,
+      defaultValue: null,
+      allowNull: true,
+      validate: {
+        isIn: [MODEL_TIERS],
       },
     },
     metadata: {

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -1,3 +1,4 @@
+import type { ModelTier } from "@app/lib/api/models_picker/tiers";
 import {
   listWorkOSOrganizationsWithDomain,
   removeWorkOSOrganizationDomain,
@@ -74,6 +75,7 @@ type CachedWorkspaceData = {
   workOSOrganizationId: string | null;
   whiteListedProviders: ModelProviderIdType[] | null;
   defaultEmbeddingProvider: EmbeddingProviderIdType | null;
+  defaultModelsTier: ModelTier | null;
   metadata: Record<string, string | number | boolean | object> | null;
   sharingPolicy: WorkspaceSharingPolicy;
   conversationsRetentionDays: number | null;
@@ -211,6 +213,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       workOSOrganizationId: workspace.workOSOrganizationId,
       whiteListedProviders: whiteListedProviders,
       defaultEmbeddingProvider: workspace.defaultEmbeddingProvider,
+      defaultModelsTier: workspace.defaultModelsTier,
       metadata: workspace.metadata,
       sharingPolicy: workspace.sharingPolicy,
       conversationsRetentionDays: workspace.conversationsRetentionDays,
@@ -254,6 +257,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       workOSOrganizationId: data.workOSOrganizationId,
       whiteListedProviders: data.whiteListedProviders,
       defaultEmbeddingProvider: data.defaultEmbeddingProvider,
+      defaultModelsTier: data.defaultModelsTier,
       metadata: data.metadata,
       sharingPolicy: data.sharingPolicy,
       conversationsRetentionDays: data.conversationsRetentionDays,
@@ -542,6 +546,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
         | "regionalModelsOnly"
         | "whiteListedProviders"
         | "defaultEmbeddingProvider"
+        | "defaultModelsTier"
         | "workOSOrganizationId"
         | "metadata"
         | "sharingPolicy"

--- a/front/migrations/pre-deploy/20260626174515_add_model_tier_tables_and_workspace_default.sql
+++ b/front/migrations/pre-deploy/20260626174515_add_model_tier_tables_and_workspace_default.sql
@@ -1,0 +1,39 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+
+CREATE TABLE "public"."group_model_tiers"
+(
+  "createdAt"   TIMESTAMP WITH TIME ZONE NOT NULL,
+  "updatedAt"   TIMESTAMP WITH TIME ZONE NOT NULL,
+  "tier"        VARCHAR(255)             NOT NULL,
+  "workspaceId" BIGINT                   NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "id"          BIGSERIAL,
+  "groupId"     BIGINT                   NOT NULL REFERENCES "groups" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "group_model_tiers_workspace_group_unique"
+  ON "group_model_tiers" ("workspaceId", "groupId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "group_model_tiers_group_id"
+  ON "group_model_tiers" ("groupId");
+
+CREATE TABLE "public"."user_model_tiers"
+(
+  "createdAt"   TIMESTAMP WITH TIME ZONE NOT NULL,
+  "updatedAt"   TIMESTAMP WITH TIME ZONE NOT NULL,
+  "tier"        VARCHAR(255)             NOT NULL,
+  "workspaceId" BIGINT                   NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "id"          BIGSERIAL,
+  "userId"      BIGINT                   NOT NULL REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "user_model_tiers_workspace_user_unique"
+  ON "user_model_tiers" ("workspaceId", "userId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "user_model_tiers_user_id"
+  ON "user_model_tiers" ("userId");
+
+ALTER TABLE "public"."workspaces"
+  ADD COLUMN IF NOT EXISTS "defaultModelsTier" VARCHAR(255) DEFAULT NULL;


### PR DESCRIPTION
## Description

Lays the data-model foundation for the model tier picker. Adds two new `WorkspaceAwareModel` tables — `group_model_tiers` (`GroupModelTierModel`) and `user_model_tiers` (`UserModelTierModel`) — that store per-(workspace, group) and per-(workspace, user) `ModelTier` overrides. Adds `defaultModelsTier: ModelTier | null` to `WorkspaceModel` and `WorkspaceResource` as the workspace-level fallback. The effective tier resolution order will be: user-level → group-level → workspace default.

## Tests

No business logic in this PR — pure schema and model registration. Tested that migrations apply cleanly locally.

## Risk

Low. The SQL migration is additive only (new tables + nullable column with `DEFAULT NULL`). No existing queries or code paths are affected. `onDelete: RESTRICT` on both FKs prevents orphaned tiers. Tables are empty until write logic is wired in a follow-up PR.

## Deploy Plan

1. Run pre-deploy SQL migration `20260626174515_add_model_tier_tables_and_workspace_default.sql` against the front DB.
2. Deploy front.
