### PR TITLE
Add: resource to handle models tiers

### DIFF
--- a/front/lib/api/models_picker/tiers.ts
+++ b/front/lib/api/models_picker/tiers.ts
@@ -14,6 +14,18 @@ export const MODEL_TIERS = [
 ] as const;
 export type ModelTier = (typeof MODEL_TIERS)[number];
 
+export const DEFAULT_MODEL_TIER: ModelTier = "frontier";
+
+export function isModelTier(value: string): value is ModelTier {
+  return (MODEL_TIERS as readonly string[]).includes(value);
+}
+
+export function resolveWorkspaceDefaultModelTier(
+  defaultModelsTier: ModelTier | null
+): ModelTier {
+  return defaultModelsTier ?? DEFAULT_MODEL_TIER;
+}
+
 /**
  * Blended cost thresholds in USD per million tokens (average of input + output).
  * Derived from the pricing initiative model picker spec:

--- a/front/lib/resources/model_tier_resource.test.ts
+++ b/front/lib/resources/model_tier_resource.test.ts
@@ -1,0 +1,233 @@
+import { DEFAULT_MODEL_TIER } from "@app/lib/api/models_picker/tiers";
+import { Authenticator } from "@app/lib/auth";
+import { ModelTierResource } from "@app/lib/resources/model_tier_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("ModelTierResource", () => {
+  let adminAuth: Authenticator;
+  let userAuth: Authenticator;
+  let adminWorkspace: LightWorkspaceType;
+
+  beforeEach(async () => {
+    const adminSetup = await createResourceTest({ role: "admin" });
+    adminAuth = adminSetup.authenticator;
+    adminWorkspace = adminSetup.workspace;
+
+    const nonAdminUser = await UserFactory.basic();
+    await MembershipFactory.associate(adminWorkspace, nonAdminUser, {
+      role: "user",
+    });
+    userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      nonAdminUser.sId,
+      adminWorkspace.sId
+    );
+  });
+
+  describe("workspace tier", () => {
+    it("returns null when no workspace default is configured", async () => {
+      expect(await ModelTierResource.getWorkspaceTier(adminAuth)).toBeNull();
+    });
+
+    it("sets and gets the workspace default tier as admin", async () => {
+      const result = await ModelTierResource.setWorkspaceTier(adminAuth, {
+        tier: "balanced",
+      });
+      expect(result.isOk()).toBe(true);
+
+      expect(await ModelTierResource.getWorkspaceTier(adminAuth)).toBe(
+        "balanced"
+      );
+    });
+
+    it("rejects set and clear for non-admins", async () => {
+      const setResult = await ModelTierResource.setWorkspaceTier(userAuth, {
+        tier: "balanced",
+      });
+      expect(setResult.isErr()).toBe(true);
+      if (setResult.isErr()) {
+        expect(setResult.error.message).toMatch(/Only admins/);
+      }
+
+      await ModelTierResource.setWorkspaceTier(adminAuth, { tier: "powerful" });
+
+      const clearResult = await ModelTierResource.clearWorkspaceTier(userAuth);
+      expect(clearResult.isErr()).toBe(true);
+      if (clearResult.isErr()) {
+        expect(clearResult.error.message).toMatch(/Only admins/);
+      }
+      expect(await ModelTierResource.getWorkspaceTier(adminAuth)).toBe(
+        "powerful"
+      );
+    });
+
+    it("clears the workspace default tier as admin", async () => {
+      await ModelTierResource.setWorkspaceTier(adminAuth, {
+        tier: "powerful",
+      });
+
+      const clearResult = await ModelTierResource.clearWorkspaceTier(adminAuth);
+      expect(clearResult.isOk()).toBe(true);
+      if (clearResult.isOk()) {
+        expect(clearResult.value).toBe(true);
+      }
+
+      expect(await ModelTierResource.getWorkspaceTier(adminAuth)).toBeNull();
+    });
+
+    it("returns false when clearing an already-default workspace tier", async () => {
+      const clearResult = await ModelTierResource.clearWorkspaceTier(adminAuth);
+      expect(clearResult.isOk()).toBe(true);
+      if (clearResult.isOk()) {
+        expect(clearResult.value).toBe(false);
+      }
+    });
+  });
+
+  describe("user tier override", () => {
+    it("returns null when the user has no override", async () => {
+      const user = await UserFactory.basic();
+
+      expect(
+        await ModelTierResource.getUserTier(adminAuth, { userId: user.id })
+      ).toBeNull();
+    });
+
+    it("sets, updates, and clears a user tier override as admin", async () => {
+      const user = await UserFactory.basic();
+
+      expect(
+        (
+          await ModelTierResource.setUserTier(adminAuth, {
+            userId: user.id,
+            tier: "fast",
+          })
+        ).isOk()
+      ).toBe(true);
+      expect(
+        await ModelTierResource.getUserTier(adminAuth, { userId: user.id })
+      ).toBe("fast");
+
+      expect(
+        (
+          await ModelTierResource.setUserTier(adminAuth, {
+            userId: user.id,
+            tier: "frontier",
+          })
+        ).isOk()
+      ).toBe(true);
+      expect(
+        await ModelTierResource.getUserTier(adminAuth, { userId: user.id })
+      ).toBe("frontier");
+
+      const clearResult = await ModelTierResource.clearUserTier(adminAuth, {
+        userId: user.id,
+      });
+      expect(clearResult.isOk()).toBe(true);
+      if (clearResult.isOk()) {
+        expect(clearResult.value).toBe(true);
+      }
+      expect(
+        await ModelTierResource.getUserTier(adminAuth, { userId: user.id })
+      ).toBeNull();
+    });
+
+    it("rejects set and clear for non-admins", async () => {
+      const user = await UserFactory.basic();
+
+      const setResult = await ModelTierResource.setUserTier(userAuth, {
+        userId: user.id,
+        tier: "fast",
+      });
+      expect(setResult.isErr()).toBe(true);
+
+      await ModelTierResource.setUserTier(adminAuth, {
+        userId: user.id,
+        tier: "fast",
+      });
+
+      const clearResult = await ModelTierResource.clearUserTier(userAuth, {
+        userId: user.id,
+      });
+      expect(clearResult.isErr()).toBe(true);
+      expect(
+        await ModelTierResource.getUserTier(adminAuth, { userId: user.id })
+      ).toBe("fast");
+    });
+  });
+
+  describe("group tier override", () => {
+    it("sets and clears a group tier override as admin", async () => {
+      const group = await GroupFactory.regular(adminWorkspace, "Engineering");
+
+      expect(
+        (
+          await ModelTierResource.setGroupTier(adminAuth, {
+            groupId: group.id,
+            tier: "powerful",
+          })
+        ).isOk()
+      ).toBe(true);
+      expect(
+        await ModelTierResource.getGroupTier(adminAuth, { groupId: group.id })
+      ).toBe("powerful");
+
+      const clearResult = await ModelTierResource.clearGroupTier(adminAuth, {
+        groupId: group.id,
+      });
+      expect(clearResult.isOk()).toBe(true);
+      if (clearResult.isOk()) {
+        expect(clearResult.value).toBe(true);
+      }
+      expect(
+        await ModelTierResource.getGroupTier(adminAuth, { groupId: group.id })
+      ).toBeNull();
+    });
+
+    it("rejects set and clear for non-admins", async () => {
+      const group = await GroupFactory.regular(adminWorkspace, "Design");
+
+      const setResult = await ModelTierResource.setGroupTier(userAuth, {
+        groupId: group.id,
+        tier: "powerful",
+      });
+      expect(setResult.isErr()).toBe(true);
+
+      await ModelTierResource.setGroupTier(adminAuth, {
+        groupId: group.id,
+        tier: "powerful",
+      });
+
+      const clearResult = await ModelTierResource.clearGroupTier(userAuth, {
+        groupId: group.id,
+      });
+      expect(clearResult.isErr()).toBe(true);
+      expect(
+        await ModelTierResource.getGroupTier(adminAuth, { groupId: group.id })
+      ).toBe("powerful");
+    });
+  });
+
+  it("does not conflate workspace default with user overrides", async () => {
+    const user = await UserFactory.basic();
+
+    await ModelTierResource.setWorkspaceTier(adminAuth, {
+      tier: DEFAULT_MODEL_TIER,
+    });
+    await ModelTierResource.setUserTier(adminAuth, {
+      userId: user.id,
+      tier: "fast",
+    });
+
+    expect(await ModelTierResource.getWorkspaceTier(adminAuth)).toBe(
+      DEFAULT_MODEL_TIER
+    );
+    expect(
+      await ModelTierResource.getUserTier(adminAuth, { userId: user.id })
+    ).toBe("fast");
+  });
+});

--- a/front/lib/resources/model_tier_resource.ts
+++ b/front/lib/resources/model_tier_resource.ts
@@ -1,0 +1,270 @@
+import { isModelTier, type ModelTier } from "@app/lib/api/models_picker/tiers";
+import type { Authenticator } from "@app/lib/auth";
+import { GroupModelTierModel } from "@app/lib/resources/storage/models/group_model_tier";
+import { UserModelTierModel } from "@app/lib/resources/storage/models/user_model_tier";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { Transaction } from "sequelize";
+
+const ADMIN_ONLY_ERROR = "Only admins can manage model tiers.";
+
+/**
+ * Facade over workspace, user, and group model tier configuration.
+ *
+ * - Workspace: stored on `workspaces.defaultModelsTier` (null = platform default).
+ * - User / group: sparse override rows in `user_model_tiers` / `group_model_tiers`.
+ */
+export class ModelTierResource {
+  static async getWorkspaceTier(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<ModelTier | null> {
+    const workspace = auth.getNonNullableWorkspace();
+    const workspaceResource = await WorkspaceResource.fetchById(
+      workspace.sId,
+      transaction
+    );
+    return workspaceResource?.defaultModelsTier ?? null;
+  }
+
+  static async setWorkspaceTier(
+    auth: Authenticator,
+    {
+      tier,
+      transaction,
+    }: {
+      tier: ModelTier;
+      transaction?: Transaction;
+    }
+  ): Promise<Result<void, Error>> {
+    if (!auth.isAdmin()) {
+      return new Err(new Error(ADMIN_ONLY_ERROR));
+    }
+
+    if (!isModelTier(tier)) {
+      return new Err(new Error(`Invalid model tier: ${tier}`));
+    }
+
+    try {
+      const workspace = auth.getNonNullableWorkspace();
+      const workspaceResource = await WorkspaceResource.fetchById(
+        workspace.sId,
+        transaction
+      );
+      if (!workspaceResource) {
+        return new Err(new Error(`Workspace not found: ${workspace.sId}`));
+      }
+
+      await workspaceResource.updateWorkspaceSettings(
+        { defaultModelsTier: tier },
+        transaction
+      );
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  static async clearWorkspaceTier(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<boolean, Error>> {
+    if (!auth.isAdmin()) {
+      return new Err(new Error(ADMIN_ONLY_ERROR));
+    }
+
+    try {
+      const workspace = auth.getNonNullableWorkspace();
+      const workspaceResource = await WorkspaceResource.fetchById(
+        workspace.sId,
+        transaction
+      );
+      if (!workspaceResource) {
+        return new Err(new Error(`Workspace not found: ${workspace.sId}`));
+      }
+
+      if (workspaceResource.defaultModelsTier === null) {
+        return new Ok(false);
+      }
+
+      await workspaceResource.updateWorkspaceSettings(
+        { defaultModelsTier: null },
+        transaction
+      );
+      return new Ok(true);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  static async getUserTier(
+    auth: Authenticator,
+    {
+      userId,
+      transaction,
+    }: {
+      userId: ModelId;
+      transaction?: Transaction;
+    }
+  ): Promise<ModelTier | null> {
+    const workspace = auth.getNonNullableWorkspace();
+    const row = await UserModelTierModel.findOne({
+      where: { workspaceId: workspace.id, userId },
+      transaction,
+    });
+    return row?.tier ?? null;
+  }
+
+  static async setUserTier(
+    auth: Authenticator,
+    {
+      userId,
+      tier,
+      transaction,
+    }: {
+      userId: ModelId;
+      tier: ModelTier;
+      transaction?: Transaction;
+    }
+  ): Promise<Result<void, Error>> {
+    if (!auth.isAdmin()) {
+      return new Err(new Error(ADMIN_ONLY_ERROR));
+    }
+
+    if (!isModelTier(tier)) {
+      return new Err(new Error(`Invalid model tier: ${tier}`));
+    }
+
+    try {
+      const workspace = auth.getNonNullableWorkspace();
+      const existing = await UserModelTierModel.findOne({
+        where: { workspaceId: workspace.id, userId },
+        transaction,
+      });
+      if (existing) {
+        await existing.update({ tier }, { transaction });
+      } else {
+        await UserModelTierModel.create(
+          { workspaceId: workspace.id, userId, tier },
+          { transaction }
+        );
+      }
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  static async clearUserTier(
+    auth: Authenticator,
+    {
+      userId,
+      transaction,
+    }: {
+      userId: ModelId;
+      transaction?: Transaction;
+    }
+  ): Promise<Result<boolean, Error>> {
+    if (!auth.isAdmin()) {
+      return new Err(new Error(ADMIN_ONLY_ERROR));
+    }
+
+    try {
+      const workspace = auth.getNonNullableWorkspace();
+      const deletedCount = await UserModelTierModel.destroy({
+        where: { workspaceId: workspace.id, userId },
+        transaction,
+      });
+      return new Ok(deletedCount > 0);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  static async getGroupTier(
+    auth: Authenticator,
+    {
+      groupId,
+      transaction,
+    }: {
+      groupId: ModelId;
+      transaction?: Transaction;
+    }
+  ): Promise<ModelTier | null> {
+    const workspace = auth.getNonNullableWorkspace();
+    const row = await GroupModelTierModel.findOne({
+      where: { workspaceId: workspace.id, groupId },
+      transaction,
+    });
+    return row?.tier ?? null;
+  }
+
+  static async setGroupTier(
+    auth: Authenticator,
+    {
+      groupId,
+      tier,
+      transaction,
+    }: {
+      groupId: ModelId;
+      tier: ModelTier;
+      transaction?: Transaction;
+    }
+  ): Promise<Result<void, Error>> {
+    if (!auth.isAdmin()) {
+      return new Err(new Error(ADMIN_ONLY_ERROR));
+    }
+
+    if (!isModelTier(tier)) {
+      return new Err(new Error(`Invalid model tier: ${tier}`));
+    }
+
+    try {
+      const workspace = auth.getNonNullableWorkspace();
+      const existing = await GroupModelTierModel.findOne({
+        where: { workspaceId: workspace.id, groupId },
+        transaction,
+      });
+      if (existing) {
+        await existing.update({ tier }, { transaction });
+      } else {
+        await GroupModelTierModel.create(
+          { workspaceId: workspace.id, groupId, tier },
+          { transaction }
+        );
+      }
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  static async clearGroupTier(
+    auth: Authenticator,
+    {
+      groupId,
+      transaction,
+    }: {
+      groupId: ModelId;
+      transaction?: Transaction;
+    }
+  ): Promise<Result<boolean, Error>> {
+    if (!auth.isAdmin()) {
+      return new Err(new Error(ADMIN_ONLY_ERROR));
+    }
+
+    try {
+      const workspace = auth.getNonNullableWorkspace();
+      const deletedCount = await GroupModelTierModel.destroy({
+        where: { workspaceId: workspace.id, groupId },
+        transaction,
+      });
+      return new Ok(deletedCount > 0);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+}

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -551,9 +551,10 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
         | "metadata"
         | "sharingPolicy"
       >
-    >
+    >,
+    transaction?: Transaction
   ) {
-    return this.update(updateableAttributes);
+    return this.update(updateableAttributes, transaction);
   }
 
   async updateDomainAutoJoinEnabled({


### PR DESCRIPTION
## Description

Introduces `ModelTierResource`, a static facade for reading and writing model tier configuration at three scopes: workspace, user, and group. Workspace tier is stored on `workspaces.defaultModelsTier` (null falls back to `DEFAULT_MODEL_TIER = "frontier"`). User and group tiers are stored as sparse override rows in `user_model_tiers` / `group_model_tiers`.

Also adds `isModelTier` type guard and `resolveWorkspaceDefaultModelTier` helper to `tiers.ts`, and threads an optional `transaction` parameter through `WorkspaceResource.updateWorkspaceSettings`.

## Tests

Added Vitest unit tests in `model_tier_resource.test.ts` covering set/get/clear for workspace, user, and group tiers, and an isolation test that verifies workspace defaults and user overrides don't bleed into each other.

## Risk

Low. Pure additive change — no existing call sites modified beyond making `updateWorkspaceSettings`'s `transaction` parameter optional. `ModelTierResource` is not wired to any route yet.

Dependency: `GroupModelTierModel` and `UserModelTierModel` (imported but not in this diff) must exist as Sequelize models with their backing DB tables before this code runs. Confirm the companion migration is in place.

## Deploy Plan

Deploy front. Ensure `user_model_tiers` and `group_model_tiers` tables are created (migration) before or alongside deployment.
