### PR TITLE
[front] chore: improve run_agent tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -30,6 +30,7 @@ import {
 import { RUN_AGENT_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import { getOrCreateConversation } from "@app/lib/api/actions/servers/run_agent/conversation";
 import {
+  getRunAgentToolDescription,
   RUN_AGENT_CONFIGURABLE_PROPERTIES,
   RUN_AGENT_PLACEHOLDER_TOOL_NAME,
   RUN_AGENT_TOOL_SCHEMA,
@@ -914,8 +915,17 @@ async function createServer(
     sId: childAgentId!, // We are sure childAgentId is *not* undefined here, as we check for childAgentBlob above
   });
   const toolDescription = isHandoffConfiguration
-    ? `Handoff completely to ${childAgentBlob.name} (${childAgentBlob.description}). Inform the user that you are handing off to ${mentionChild} before calling the tool since this agent will respond in the conversation.`
-    : `Run ${childAgentBlob.name} in the background and pass results back to the main agent. You will have access to the results of the agent in the conversation.`;
+    ? getRunAgentToolDescription({
+        executionMode: "handoff",
+        childAgentName: childAgentBlob.name,
+        childAgentDescription: childAgentBlob.description,
+        childAgentMention: mentionChild,
+      })
+    : getRunAgentToolDescription({
+        executionMode: "run-agent",
+        childAgentName: childAgentBlob.name,
+        childAgentDescription: childAgentBlob.description,
+      });
 
   const schema = {
     ...RUN_AGENT_TOOL_SCHEMA,

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -36,13 +36,13 @@ export function getRunAgentToolDescription(
     case "run-agent":
       return (
         `Delegate to ${args.childAgentName} (${args.childAgentDescription}) as a child agent/sub-agent in the background. ` +
-        "Use this specialist agent for research, analysis, drafting, or follow-up work that should run in its own conversation, then use its results in the main conversation."
+        "Use this configured child agent when the request should run in its own conversation, then use its results in the main conversation."
       );
 
     case "handoff":
       return (
         `Handoff completely to ${args.childAgentName} (${args.childAgentDescription}). ` +
-        `Inform the user that you are handing off to ${args.childAgentMention} before calling the tool since this specialist agent will respond directly in the conversation.`
+        `Inform the user that you are handing off to ${args.childAgentMention} before calling the tool since this child agent will respond directly in the conversation.`
       );
 
     default:

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -141,8 +141,7 @@ export const RUN_AGENT_SERVER = {
   serverInfo: {
     name: "run_agent",
     version: "1.0.0",
-    description:
-      "Delegate work to a configured child agent/sub-agent or hand off the conversation to a specialist agent.",
+    description: "Run a child agent (agent as tool).",
     authorization: null,
     icon: "ActionRobotIcon",
     documentationUrl: null,
@@ -153,8 +152,7 @@ export const RUN_AGENT_SERVER = {
   tools: [
     {
       name: RUN_AGENT_PLACEHOLDER_TOOL_NAME,
-      description:
-        "Delegate work to a configured child agent/sub-agent, either by running it in the background and using its results or by handing off the conversation.",
+      description: "Run a child agent (agent as tool).",
       inputSchema: zodToJsonSchema(
         z.object({
           ...RUN_AGENT_TOOL_SCHEMA,

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -6,6 +6,7 @@ import {
   FILES_SERVER_NAME,
 } from "@app/lib/api/actions/servers/files/metadata";
 import { getResourcePrefix } from "@app/lib/resources/string_ids";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
@@ -14,6 +15,40 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 // This is a placeholder tool name used in the metadata for UI detection.
 // The actual tool name is dynamic: `run_<agent_name>`.
 export const RUN_AGENT_PLACEHOLDER_TOOL_NAME = "run_agent" as const;
+
+type RunAgentToolDescriptionArgs =
+  | {
+      executionMode: "run-agent";
+      childAgentName: string;
+      childAgentDescription: string;
+    }
+  | {
+      executionMode: "handoff";
+      childAgentName: string;
+      childAgentDescription: string;
+      childAgentMention: string;
+    };
+
+export function getRunAgentToolDescription(
+  args: RunAgentToolDescriptionArgs
+): string {
+  switch (args.executionMode) {
+    case "run-agent":
+      return (
+        `Delegate to ${args.childAgentName} (${args.childAgentDescription}) as a child agent/sub-agent in the background. ` +
+        "Use this specialist agent for research, analysis, drafting, or follow-up work that should run in its own conversation, then use its results in the main conversation."
+      );
+
+    case "handoff":
+      return (
+        `Handoff completely to ${args.childAgentName} (${args.childAgentDescription}). ` +
+        `Inform the user that you are handing off to ${args.childAgentMention} before calling the tool since this specialist agent will respond directly in the conversation.`
+      );
+
+    default:
+      return assertNever(args);
+  }
+}
 
 export const RUN_AGENT_CONFIGURABLE_PROPERTIES = {
   executionMode: z
@@ -58,14 +93,13 @@ export const RUN_AGENT_TOOL_SCHEMA = {
   description: z
     .string()
     .describe(
-      "The reason this agent is being called and what it achieves, in a few words. Use infinitive verbs (e.g. " +
+      "A short phrase explaining why you are delegating to this child agent/sub-agent and what it should achieve. Use infinitive verbs (e.g. " +
         '"Review Q1 performance", "Assess support backlog").'
     ),
   query: z
     .string()
     .describe(
-      "The query sent to the agent. This is the question or instruction that will be " +
-        "processed by the agent, which will respond with its own capabilities and knowledge."
+      "The question or instruction to send to the child agent/sub-agent. The agent will process it using its own capabilities and knowledge."
     ),
   toolsetsToAdd: z
     .array(
@@ -74,7 +108,7 @@ export const RUN_AGENT_TOOL_SCHEMA = {
         .regex(new RegExp(`^${getResourcePrefix("mcp_server_view")}_\\w+$`))
     )
     .describe(
-      "The toolsets ids to add to the agent in addition to the ones already set in the agent configuration."
+      "The toolset IDs to give to the child agent in addition to the ones already set in the agent configuration."
     )
     .optional()
     .nullable(),
@@ -107,7 +141,8 @@ export const RUN_AGENT_SERVER = {
   serverInfo: {
     name: "run_agent",
     version: "1.0.0",
-    description: "Run a child agent (agent as tool).",
+    description:
+      "Delegate work to a configured child agent/sub-agent or hand off the conversation to a specialist agent.",
     authorization: null,
     icon: "ActionRobotIcon",
     documentationUrl: null,
@@ -118,7 +153,8 @@ export const RUN_AGENT_SERVER = {
   tools: [
     {
       name: RUN_AGENT_PLACEHOLDER_TOOL_NAME,
-      description: "Run a child agent (agent as tool).",
+      description:
+        "Delegate work to a configured child agent/sub-agent, either by running it in the background and using its results or by handing off the conversation.",
       inputSchema: zodToJsonSchema(
         z.object({
           ...RUN_AGENT_TOOL_SCHEMA,

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -732,6 +732,20 @@ export const QUERIES: LabeledQuery[] = [
     expected: "snowflake.query",
   },
 
+  // --- run_agent (sample dynamic child agents) ---
+  {
+    query: "delegate competitive pricing research to another agent",
+    expected: "run_agent.run_Research Analyst",
+  },
+  {
+    query: "ask an agent to investigate a customer refund ticket",
+    expected: "run_agent.run_Support Triage",
+  },
+  {
+    query: "have a specialist review this pull request for regressions",
+    expected: "run_agent.run_Code Reviewer",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -735,15 +735,15 @@ export const QUERIES: LabeledQuery[] = [
   // --- run_agent (sample dynamic child agents) ---
   {
     query: "delegate competitive pricing research to another agent",
-    expected: "run_agent.run_Research Analyst",
+    expected: "run_agent.run_ResearchAnalyst",
   },
   {
     query: "ask an agent to investigate a customer refund ticket",
-    expected: "run_agent.run_Support Triage",
+    expected: "run_agent.run_SupportTriage",
   },
   {
     query: "have a specialist review this pull request for regressions",
-    expected: "run_agent.run_Code Reviewer",
+    expected: "run_agent.run_CodeReviewer",
   },
 
   // --- cross-server (no platform named) ---

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -22,6 +22,12 @@ import { INTERACTIVE_CONTENT_SERVER } from "@app/lib/api/actions/servers/interac
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
+import {
+  getRunAgentToolDescription,
+  RUN_AGENT_CONFIGURABLE_PROPERTIES,
+  RUN_AGENT_SERVER,
+  RUN_AGENT_TOOL_SCHEMA,
+} from "@app/lib/api/actions/servers/run_agent/metadata";
 import { SALESFORCE_SERVER } from "@app/lib/api/actions/servers/salesforce/metadata";
 import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadata";
 import { SLACK_PERSONAL_SERVER } from "@app/lib/api/actions/servers/slack_personal/metadata";
@@ -31,6 +37,52 @@ import { buildIndex, rank } from "@app/scripts/mcp_bm25/bm25";
 import type { ServerEntry } from "@app/scripts/mcp_bm25/corpus";
 import { buildDocs } from "@app/scripts/mcp_bm25/corpus";
 import { QUERIES } from "@app/scripts/mcp_bm25/queries";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+const RUN_AGENT_SAMPLE_TOOL_SCHEMA = zodToJsonSchema(
+  z.object({
+    ...RUN_AGENT_TOOL_SCHEMA,
+    ...RUN_AGENT_CONFIGURABLE_PROPERTIES,
+  })
+) as JSONSchema;
+
+// run_agent tools are dynamic: one tool per configured child agent. The static
+// server metadata only contains the builder placeholder, so the harness adds a
+// few representative child-agent tools to sanity-check retrieval.
+const RUN_AGENT_SAMPLE_TOOLS: ServerEntry["tools"] = [
+  {
+    name: "run_Research Analyst",
+    description: getRunAgentToolDescription({
+      executionMode: "run-agent",
+      childAgentName: "Research Analyst",
+      childAgentDescription:
+        "Competitive market and customer research specialist for pricing, positioning, and source gathering.",
+    }),
+    inputSchema: RUN_AGENT_SAMPLE_TOOL_SCHEMA,
+  },
+  {
+    name: "run_Support Triage",
+    description: getRunAgentToolDescription({
+      executionMode: "run-agent",
+      childAgentName: "Support Triage",
+      childAgentDescription:
+        "Customer support specialist that investigates tickets, refunds, escalations, and account issues.",
+    }),
+    inputSchema: RUN_AGENT_SAMPLE_TOOL_SCHEMA,
+  },
+  {
+    name: "run_Code Reviewer",
+    description: getRunAgentToolDescription({
+      executionMode: "run-agent",
+      childAgentName: "Code Reviewer",
+      childAgentDescription:
+        "Engineering reviewer for pull requests, regressions, implementation risks, and test coverage.",
+    }),
+    inputSchema: RUN_AGENT_SAMPLE_TOOL_SCHEMA,
+  },
+];
 
 const SERVERS: ServerEntry[] = [
   { name: "agent_memory", tools: AGENT_MEMORY_SERVER.tools },
@@ -49,6 +101,10 @@ const SERVERS: ServerEntry[] = [
   { name: "salesforce", tools: SALESFORCE_SERVER.tools },
   { name: "interactive_content", tools: INTERACTIVE_CONTENT_SERVER.tools },
   { name: "snowflake", tools: SNOWFLAKE_SERVER.tools },
+  {
+    name: "run_agent",
+    tools: [...RUN_AGENT_SERVER.tools, ...RUN_AGENT_SAMPLE_TOOLS],
+  },
 ];
 
 function out(line: string): void {

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -25,7 +25,6 @@ import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_t
 import {
   getRunAgentToolDescription,
   RUN_AGENT_CONFIGURABLE_PROPERTIES,
-  RUN_AGENT_SERVER,
   RUN_AGENT_TOOL_SCHEMA,
 } from "@app/lib/api/actions/servers/run_agent/metadata";
 import { SALESFORCE_SERVER } from "@app/lib/api/actions/servers/salesforce/metadata";
@@ -49,8 +48,8 @@ const RUN_AGENT_SAMPLE_TOOL_SCHEMA = zodToJsonSchema(
 ) as JSONSchema;
 
 // run_agent tools are dynamic: one tool per configured child agent. The static
-// server metadata only contains the builder placeholder, so the harness adds a
-// few representative child-agent tools to sanity-check retrieval.
+// server metadata only contains the builder placeholder, which is never exposed
+// to an agent, so the harness adds representative child-agent tools instead.
 const RUN_AGENT_SAMPLE_TOOLS: ServerEntry["tools"] = [
   {
     name: "run_ResearchAnalyst",
@@ -103,7 +102,7 @@ const SERVERS: ServerEntry[] = [
   { name: "snowflake", tools: SNOWFLAKE_SERVER.tools },
   {
     name: "run_agent",
-    tools: [...RUN_AGENT_SERVER.tools, ...RUN_AGENT_SAMPLE_TOOLS],
+    tools: RUN_AGENT_SAMPLE_TOOLS,
   },
 ];
 

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -53,30 +53,30 @@ const RUN_AGENT_SAMPLE_TOOL_SCHEMA = zodToJsonSchema(
 // few representative child-agent tools to sanity-check retrieval.
 const RUN_AGENT_SAMPLE_TOOLS: ServerEntry["tools"] = [
   {
-    name: "run_Research Analyst",
+    name: "run_ResearchAnalyst",
     description: getRunAgentToolDescription({
       executionMode: "run-agent",
-      childAgentName: "Research Analyst",
+      childAgentName: "ResearchAnalyst",
       childAgentDescription:
         "Competitive market and customer research specialist for pricing, positioning, and source gathering.",
     }),
     inputSchema: RUN_AGENT_SAMPLE_TOOL_SCHEMA,
   },
   {
-    name: "run_Support Triage",
+    name: "run_SupportTriage",
     description: getRunAgentToolDescription({
       executionMode: "run-agent",
-      childAgentName: "Support Triage",
+      childAgentName: "SupportTriage",
       childAgentDescription:
         "Customer support specialist that investigates tickets, refunds, escalations, and account issues.",
     }),
     inputSchema: RUN_AGENT_SAMPLE_TOOL_SCHEMA,
   },
   {
-    name: "run_Code Reviewer",
+    name: "run_CodeReviewer",
     description: getRunAgentToolDescription({
       executionMode: "run-agent",
-      childAgentName: "Code Reviewer",
+      childAgentName: "CodeReviewer",
       childAgentDescription:
         "Engineering reviewer for pull requests, regressions, implementation risks, and test coverage.",
     }),


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9167.

This PR improves BM25 tool-search recall for the `run_agent` MCP server. Dynamic run-agent tools now include delegation/sub-agent/specialist wording and the configured child agent description, so tool search can match the work being delegated instead of relying mostly on the child agent name.

It also adds representative dynamic `run_agent` samples to the BM25 harness to keep this behavior easy to check as the shared corpus evolves.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.