### PR TITLE
[front] chore: improve include data tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -12,11 +12,15 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
+const RETRIEVE_RECENT_DOCUMENTS_DESCRIPTION =
+  "Load and include full document content, documents, or docs from selected data sources or the company knowledge base as conversation context. " +
+  "Retrieves the most recent documents in reverse chronological order up to the retrieval limit, " +
+  "so the latest pre-configured information is included when the agent needs broad full-context data or all available recent content.";
+
 // Base tool without tags support
 export const INCLUDE_DATA_BASE_TOOLS_METADATA = createToolsRecord({
   retrieve_recent_documents: {
-    description:
-      "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
+    description: RETRIEVE_RECENT_DOCUMENTS_DESCRIPTION,
     schema: IncludeInputSchema.shape,
     stake: "never_ask",
     displayLabels: {
@@ -34,8 +38,7 @@ const includeWithTagsSchema = {
 
 export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
   retrieve_recent_documents: {
-    description:
-      "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
+    description: RETRIEVE_RECENT_DOCUMENTS_DESCRIPTION,
     schema: includeWithTagsSchema,
     stake: "never_ask",
     displayLabels: {

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -491,6 +491,16 @@ export const QUERIES: LabeledQuery[] = [
     expected: "confluence.get_current_user",
   },
 
+  // --- include_data ---
+  {
+    query: "include all recent documents as context",
+    expected: "include_data.retrieve_recent_documents",
+  },
+  {
+    query: "load the latest documents from my selected data sources",
+    expected: "include_data.retrieve_recent_documents",
+  },
+
   // --- hubspot ---
   {
     query: "find a hubspot contact by email address",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -18,6 +18,7 @@ import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
 import { GOOGLE_SHEETS_SERVER } from "@app/lib/api/actions/servers/google_sheets/metadata";
 import { HUBSPOT_SERVER } from "@app/lib/api/actions/servers/hubspot/metadata";
+import { INCLUDE_DATA_SERVER } from "@app/lib/api/actions/servers/include_data/metadata";
 import { INTERACTIVE_CONTENT_SERVER } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
@@ -97,6 +98,7 @@ const SERVERS: ServerEntry[] = [
   { name: "microsoft_teams", tools: MICROSOFT_TEAMS_SERVER.tools },
   { name: "confluence", tools: CONFLUENCE_SERVER.tools },
   { name: "hubspot", tools: HUBSPOT_SERVER.tools },
+  { name: "include_data", tools: INCLUDE_DATA_SERVER.tools },
   { name: "salesforce", tools: SALESFORCE_SERVER.tools },
   { name: "interactive_content", tools: INTERACTIVE_CONTENT_SERVER.tools },
   { name: "snowflake", tools: SNOWFLAKE_SERVER.tools },


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9167.

Tweaks the `include_data` tool descriptions so BM25 tool search matches include/load/full-context/recent-docs intents against include data instead of nearby search or extraction tools.
Adds `include_data` to the MCP BM25 harness with representative queries for those intents.

## Tests

- Added include-data BM25 harness samples.
- Tested locally.

## Risk

- Low. Metadata-only change.

## Deploy Plan

- Deploy front.
