### PR TITLE
feat(front): add models_picker feature flag

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -360,6 +360,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Publish a Frame's edited source tree into a built bundle so model and live edits become the rendered, shareable Frame.",
     stage: "dust_only",
   },
+  input_bar_model_picker: {
+    description:
+      "Model picker in the conversation input bar: pick a model tier (Fast, Balanced, Powerful, Frontier) or a specific model.",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -360,7 +360,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Publish a Frame's edited source tree into a built bundle so model and live edits become the rendered, shareable Frame.",
     stage: "dust_only",
   },
-  input_bar_model_picker: {
+  models_picker: {
     description:
       "Model picker in the conversation input bar: pick a model tier (Fast, Balanced, Powerful, Frontier) or a specific model.",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -734,6 +734,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "hootl_subscriptions"
   | "http_client_tool"
   | "index_private_slack_channel"
+  | "input_bar_model_picker"
   | "labs_mcp_actions_dashboard"
   | "labs_transcripts"
   | "legacy_dust_apps"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -734,7 +734,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "hootl_subscriptions"
   | "http_client_tool"
   | "index_private_slack_channel"
-  | "input_bar_model_picker"
+  | "models_picker"
   | "labs_mcp_actions_dashboard"
   | "labs_transcripts"
   | "legacy_dust_apps"


### PR DESCRIPTION
Registers the `models_picker ` feature flag (`dust_only` stage).

This is the base of the stack — the model picker UI that consumes the flag is in #28049, stacked on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)