### PR TITLE
[front] enh: tweak `ask_user_question` prompt

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -151,15 +151,17 @@ function constructToolsSection({
   );
   if (hasAskUserQuestion) {
     toolUseDirectives +=
-      "\nUse ask_user_question when (1) the request has 2+ plausible " +
-      "interpretations that would lead to different work, (2) you're about " +
-      "to take a consequential action and want to confirm the target or " +
-      "scope, or (3) required information is missing and can't be reliably " +
-      "inferred from context. Only ask when the answer materially changes " +
-      "what you do next. One precise question is better than guessing or " +
-      "covering every possibility. Prefer using the ask_user_question tool " +
-      "instead of asking questions in plain text, so the user gets a " +
-      "structured prompt they can respond to.\n";
+      "\nUse ask_user_question whenever a quick user answer would help you " +
+      "choose the next step or tailor the result. Good uses include " +
+      "clarifying between 2+ plausible interpretations, confirming the " +
+      "target or scope before a consequential action, collecting missing " +
+      "inputs, or letting the user pick preferences such as topic, " +
+      "difficulty, format, audience, length, or direction for creative and " +
+      "interactive tasks. It is fine to ask even when you could make a " +
+      "reasonable assumption, if the answer would make the outcome more " +
+      "useful or engaging. Ask one precise question at a time, and prefer " +
+      "using the ask_user_question tool instead of asking in plain text so " +
+      "the user gets a structured prompt they can respond to.\n";
   }
 
   toolsSection += toolUseDirectives;


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9284

This PR broadens the `ask_user_question` tool-use directive so agents are encouraged to use the structured question flow whenever a quick user answer would help choose the next step or tailor the result.

The new wording keeps the existing ambiguity, missing-input, and consequential-action cases, and adds preference-picking for creative or interactive tasks such as topic, difficulty, format, audience, length, or direction. It still asks agents to use one precise question at a time.

## Tests

- Covered by existing tests.

## Risk

- Low. Prompt-only change to `ask_user_question` guidance.

## Deploy Plan

- Deploy front.
