### PR TITLE
[front] BillingPeriodSwitch: small UI fix

### DIFF
--- a/front/components/pages/onboarding/SubscriptionPlans.tsx
+++ b/front/components/pages/onboarding/SubscriptionPlans.tsx
@@ -131,11 +131,25 @@ interface BillingPeriodSwitchProps {
   size?: React.ComponentProps<typeof ButtonsSwitchList>["size"];
 }
 
+const CHIP_SIZE_FOR_SWITCH: Record<
+  "xs" | "sm" | "md",
+  React.ComponentProps<typeof Chip>["size"]
+> = {
+  xs: "mini",
+  sm: "xs",
+  md: "sm",
+};
+
 export function BillingPeriodSwitch({
   defaultValue = "monthly",
   onValueChange,
   size,
 }: BillingPeriodSwitchProps) {
+  const chipSize =
+    size && size in CHIP_SIZE_FOR_SWITCH
+      ? CHIP_SIZE_FOR_SWITCH[size as keyof typeof CHIP_SIZE_FOR_SWITCH]
+      : "xs";
+
   return (
     <ButtonsSwitchList
       defaultValue={defaultValue}
@@ -149,7 +163,7 @@ export function BillingPeriodSwitch({
         value="yearly"
         label="Yearly"
         className="flex-row-reverse"
-        icon={<Chip size="xs" color="blue" label="Save 20%" />}
+        icon={<Chip size={chipSize} color="blue" label="Save 20%" />}
       />
     </ButtonsSwitchList>
   );

--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -659,7 +659,6 @@ export function SubscriptionPage() {
                       <Page.H variant="h5">Choose a plan</Page.H>
                       <BillingPeriodSwitch
                         defaultValue={billingPeriod}
-                        size="xs"
                         onValueChange={setBillingPeriod}
                       />
                     </div>
@@ -682,7 +681,6 @@ export function SubscriptionPage() {
                       {!isWorkspaceWhitelistedBusinessPlan && (
                         <BillingPeriodSwitch
                           defaultValue={billingPeriod}
-                          size="xs"
                           onValueChange={setBillingPeriod}
                         />
                       )}

--- a/front/components/paywall/TrialPricingCard.tsx
+++ b/front/components/paywall/TrialPricingCard.tsx
@@ -50,7 +50,6 @@ export function TrialPricingCard({
         {/* Billing toggle */}
         <BillingPeriodSwitch
           defaultValue={billingPeriod}
-          size="xs"
           onValueChange={onBillingPeriodChange}
         />
       </div>


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9251

* Adapt chip size in BillingPeriodSwitch, based on component size
* Use default size of BillingPeriodSwitch in the pages to get best rendering result

## Tests

Tested locally

## Risk

Low, UI only

## Deploy Plan

Deploy front