### PR TITLE
[front] feat: register Claude Haiku 4.5 direct-Anthropic global stream endpoint

### DIFF
--- a/front/lib/llms/stream/endpoints/anthropic_global_claude_haiku_four_dot_five.ts
+++ b/front/lib/llms/stream/endpoints/anthropic_global_claude_haiku_four_dot_five.ts
@@ -1,0 +1,11 @@
+import { WithDustClaudeHaikuFourDotFive } from "@app/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AnthropicGlobalClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five";
+
+export class DustAnthropicGlobalClaudeHaikuFourDotFiveStream extends WithDustClaudeHaikuFourDotFive(
+  AnthropicGlobalClaudeHaikuFourDotFiveStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustAnthropicGlobalClaudeHaikuFourDotFiveStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -4,6 +4,7 @@ import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/ll
 import { DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
 import { DustAgentPlatformEuropeGeminiThreeDotOneProStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_1_pro";
 import { DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
+import { DustAnthropicGlobalClaudeHaikuFourDotFiveStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_haiku_four_dot_five";
 import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { DustAnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
 import { DustAnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
@@ -39,6 +40,8 @@ import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
 export const DUST_STREAM_ENDPOINTS = {
   [DustAnthropicGlobalClaudeSonnetFourDotSixStream.id]:
     DustAnthropicGlobalClaudeSonnetFourDotSixStream,
+  [DustAnthropicGlobalClaudeHaikuFourDotFiveStream.id]:
+    DustAnthropicGlobalClaudeHaikuFourDotFiveStream,
   [DustAnthropicGlobalClaudeOpusFourDotEightStream.id]:
     DustAnthropicGlobalClaudeOpusFourDotEightStream,
   [DustAnthropicGlobalClaudeOpusFourDotSevenStream.id]:

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -4,6 +4,7 @@ import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_
 import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
 import { AgentPlatformEuropeGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_pro";
 import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
+import { AnthropicGlobalClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five";
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { AnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
 import { AnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
@@ -32,6 +33,8 @@ import { TogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/model_co
 export const STREAM_ENDPOINTS = {
   [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:
     AnthropicGlobalClaudeSonnetFourDotSixStream,
+  [AnthropicGlobalClaudeHaikuFourDotFiveStream.id]:
+    AnthropicGlobalClaudeHaikuFourDotFiveStream,
   [AnthropicGlobalClaudeOpusFourDotEightStream.id]:
     AnthropicGlobalClaudeOpusFourDotEightStream,
   [AnthropicGlobalClaudeOpusFourDotSevenStream.id]:


### PR DESCRIPTION
## Description

The `AnthropicGlobalClaudeHaikuFourDotFiveStream` endpoint class already existed in `model_constructors` (with correct Haiku 4.5 pricing — $1/$5 per MTok, cache-write 1.25×, cache-read 0.1×), but it was never added to `STREAM_ENDPOINTS`, leaving it dead code. Only the EU/Vertex Haiku endpoint was reachable through the new router, so the direct-Anthropic global endpoint for `claude-haiku-4-5` could never be selected.

This PR registers the global endpoint:
- Adds it to the core stream registry (`model_constructors/stream/index.ts`), which extends the `StreamEndpointId` union.
- Adds the global Dust wrapper (`llms/stream/endpoints/anthropic_global_claude_haiku_four_dot_five.ts`) with an unrestricted `endpointFilter`, matching the other Anthropic global endpoints (the EU/Vertex variant keeps its feature-flag / credit-priced gate).
- Registers that wrapper in `DUST_STREAM_ENDPOINTS`. Since this registry is a fully-required `Record<StreamEndpointId, …>`, the wrapper is enforced by the typechecker.

## Tests

- `tsgo --noEmit` clean for all touched files and both registries; the exhaustive `Record<StreamEndpointId, …>` type guarantees registry consistency at compile time.
- Biome formatting clean.
- Did not run the live LLM integration test (gated on `RUN_LLM_TEST`, burns real API tokens) — the endpoint statics were already verified and the registry exhaustiveness is enforced by the type system.

## Risk

Low. Additive only — registers an existing, already-implemented endpoint. No existing endpoints or behavior change. The new global endpoint is unrestricted (like the other Anthropic globals), so it becomes selectable for `claude-haiku-4-5` traffic through the new router; behind `use_new_llm_router`, which falls back to legacy when no endpoint is selected. Safe to roll back by reverting.

## Deploy Plan

Standard deploy. No migration or coordination required.