### PR TITLE
dsbx function: run with $DUST_FUNCTIONS_DIR as the working directory

### DIFF
--- a/cli/dust-sandbox/functions-runner/fixtures/cwd.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/cwd.ts
@@ -1,0 +1,13 @@
+// A test/debug function that reports where the function process is running:
+// the current working directory, the folder the bundle was loaded from, and the
+// effective uid/gid (handy for verifying the privilege drop in the sandbox).
+export default {
+  async fetch(_req: Request): Promise<Response> {
+    return Response.json({
+      cwd: process.cwd(),
+      dir: import.meta.dir,
+      uid: process.getuid?.() ?? null,
+      gid: process.getgid?.() ?? null,
+    });
+  },
+};

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -123,6 +123,9 @@ fn resolve_drop_target() -> Result<Option<DropTarget>> {
 /// child can read both even when the originals are root-only.
 pub(crate) async fn run_bun(subcommand: &str, name: &str, inherit_stdin: bool) -> Result<()> {
     let path = resolve_existing(name)?;
+    // The function runs with $DUST_FUNCTIONS_DIR as its working directory (the
+    // parent of the resolved <name>.ts), not wherever dsbx was invoked from.
+    let functions_dir = path.parent().map(Path::to_path_buf);
     let runner = ensure_runner()?;
     let drop = resolve_drop_target()?;
 
@@ -154,6 +157,11 @@ pub(crate) async fn run_bun(subcommand: &str, name: &str, inherit_stdin: bool) -
         })
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
+    if let Some(dir) = &functions_dir {
+        // chdir happens before the pre_exec privilege drop, i.e. while still
+        // root, so it works even when the dir is root-only.
+        cmd.current_dir(dir);
+    }
 
     if let Some(t) = drop {
         // Drop privileges in the forked child before exec, in order, while still


### PR DESCRIPTION
## Description

`dsbx function run`/`get` execute the function via a `bun` child that, until now, inherited `dsbx`'s working directory (wherever the sandbox resource launched it). This sets the child's working directory to **`$DUST_FUNCTIONS_DIR`** (the parent of the resolved `<name>.ts`), so relative paths in a function resolve predictably against the function folder rather than an arbitrary cwd.

Implemented with `Command::current_dir(...)`. The `chdir` runs **before** the `pre_exec` privilege drop — i.e. while still root — so it succeeds even when the function dir is root-only (the dropped agent uid never needs to traverse to it itself).

Applies to both `run` and `get` (shared `run_bun` helper). Also adds a small `cwd.ts` debug fixture that reports `cwd` / `import.meta.dir` / `uid` / `gid`, handy for confirming both this and the privilege drop in a sandbox.

Note: in the privilege-drop (sandbox) path the bundle is staged into a temp dir, so a handler's `import.meta.dir` is that temp dir while its `cwd` is `$DUST_FUNCTIONS_DIR`. The harness only ever *reads* the function folder; relative *writes* from handler code would target it (subject to the dropped uid's permissions — a root-only folder blocks them).

## Tests

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` (240) all pass.
- Manually verified: invoking `dsbx` from `cli/dust-sandbox`, the `cwd` fixture reports `cwd` = the functions dir, not the invocation dir.
- biome clean for the new fixture.

## Risk

Low. Single, self-contained behavior change to where the function process starts; no change to the request/response contract or exit codes. Builds on the already-merged `dsbx function` feature.

## Deploy Plan

None — developer/sandbox tooling in `dsbx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)