### PR TITLE
Add slug and description to sandbox functions

### DIFF
--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -48,6 +48,8 @@ async function setupSandboxFunction({
   const sandboxFunction = await SandboxFunctionResource.makeNew(adminAuth, {
     space,
     file,
+    slug: "run-function",
+    description: "Run the function.",
     inputSchema,
     outputSchema,
   });

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.test.ts
@@ -24,11 +24,11 @@ const outputSchema: JSONSchema = {
 async function makeFunction(
   auth: Authenticator,
   space: SpaceResource,
-  fileName: string
+  { slug, description }: { slug: string; description: string }
 ): Promise<SandboxFunctionResource> {
   const file = await FileFactory.create(auth, null, {
     contentType: sandboxFunctionContentType,
-    fileName,
+    fileName: `${slug}.ts`,
     fileSize: 100,
     status: "created",
     useCase: "project_context",
@@ -38,6 +38,8 @@ async function makeFunction(
   return SandboxFunctionResource.makeNew(auth, {
     space,
     file,
+    slug,
+    description,
     inputSchema,
     outputSchema,
   });
@@ -50,20 +52,25 @@ describe("formatSandboxFunctionsList", () => {
     );
   });
 
-  it("renders name, sId and schemas for a function", async () => {
+  it("renders slug, description and schemas", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
     const space = await SpaceFactory.project(workspace);
-    const fn = await makeFunction(authenticator, space, "greet.ts");
+    const fn = await makeFunction(authenticator, space, {
+      slug: "greet",
+      description: "Greet a user by name.",
+    });
 
     const out = formatSandboxFunctionsList([fn]);
 
     expect(out).toContain("Sandbox functions:");
-    expect(out).toContain(`- greet.ts (${fn.sId})`);
-    expect(fn.sId).toMatch(/^sfn_/);
+    expect(out).toContain("- greet: Greet a user by name.");
     expect(out).toContain(`input: ${JSON.stringify(fn.inputSchema)}`);
     expect(out).toContain(`output: ${JSON.stringify(fn.outputSchema)}`);
+    // Neither the bundle filename nor the internal sId is surfaced.
+    expect(out).not.toContain("greet.ts");
+    expect(out).not.toContain(fn.sId);
   });
 
   it("lists every function", async () => {
@@ -71,13 +78,19 @@ describe("formatSandboxFunctionsList", () => {
       role: "admin",
     });
     const space = await SpaceFactory.project(workspace);
-    await makeFunction(authenticator, space, "greet.ts");
-    await makeFunction(authenticator, space, "farewell.ts");
+    await makeFunction(authenticator, space, {
+      slug: "greet",
+      description: "Greet a user.",
+    });
+    await makeFunction(authenticator, space, {
+      slug: "translate-text",
+      description: "Translate text.",
+    });
 
     const fns = await SandboxFunctionResource.listBySpace(authenticator, space);
     const out = formatSandboxFunctionsList(fns);
 
-    expect(out).toContain("greet.ts");
-    expect(out).toContain("farewell.ts");
+    expect(out).toContain("greet");
+    expect(out).toContain("translate-text");
   });
 });

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
@@ -15,7 +15,7 @@ export function formatSandboxFunctionsList(
 
   const lines = sandboxFunctions.map((fn) =>
     [
-      `- ${fn.file.fileName} (${fn.sId})`,
+      `- ${fn.slug}: ${fn.description}`,
       `  input: ${JSON.stringify(fn.inputSchema)}`,
       `  output: ${JSON.stringify(fn.outputSchema)}`,
     ].join("\n")

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -47,6 +47,8 @@ describe("SandboxFunctionResource", () => {
       {
         space,
         file,
+        slug: "add-comment",
+        description: "Add a comment.",
         inputSchema,
         outputSchema,
       }
@@ -55,6 +57,8 @@ describe("SandboxFunctionResource", () => {
     expect(sandboxFunction.sId).toMatch(/^sfn_/);
     expect(sandboxFunction.spaceId).toBe(space.id);
     expect(sandboxFunction.fileId).toBe(file.id);
+    expect(sandboxFunction.slug).toBe("add-comment");
+    expect(sandboxFunction.description).toBe("Add a comment.");
     expect(sandboxFunction.inputSchema).toEqual(inputSchema);
     expect(sandboxFunction.outputSchema).toEqual(outputSchema);
     expect(sandboxFunction.file.id).toBe(file.id);
@@ -64,6 +68,8 @@ describe("SandboxFunctionResource", () => {
       sandboxFunction.sId
     );
     expect(fetched?.id).toBe(sandboxFunction.id);
+    expect(fetched?.slug).toBe("add-comment");
+    expect(fetched?.description).toBe("Add a comment.");
     expect(fetched?.space.id).toBe(space.id);
     expect(fetched?.file.id).toBe(file.id);
 
@@ -103,6 +109,8 @@ describe("SandboxFunctionResource", () => {
       {
         space: accessibleSpace,
         file: accessibleFile,
+        slug: "fetch-accessible",
+        description: "Fetch accessible data.",
         inputSchema,
         outputSchema,
       }
@@ -112,6 +120,8 @@ describe("SandboxFunctionResource", () => {
       {
         space: restrictedSpace,
         file: restrictedFile,
+        slug: "fetch-restricted",
+        description: "Fetch restricted data.",
         inputSchema,
         outputSchema,
       }
@@ -193,10 +203,74 @@ describe("SandboxFunctionResource", () => {
       SandboxFunctionResource.makeNew(authenticator, {
         space: regularSpace,
         file,
+        slug: "add-comment",
+        description: "Add a comment.",
         inputSchema,
         outputSchema,
       })
     ).rejects.toThrow("Sandbox functions can only belong to pods.");
+  });
+
+  it("rejects a malformed slug", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const file = await FileFactory.create(authenticator, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: "comments.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+
+    await expect(
+      SandboxFunctionResource.makeNew(authenticator, {
+        space,
+        file,
+        slug: "Not A Slug",
+        description: "Add a comment.",
+        inputSchema,
+        outputSchema,
+      })
+    ).rejects.toThrow("The slug must be lowercase");
+  });
+
+  it("rejects a duplicate slug in the same pod", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const makeFile = (fileName: string) =>
+      FileFactory.create(authenticator, null, {
+        contentType: sandboxFunctionContentType,
+        fileName,
+        fileSize: 100,
+        status: "created",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: space.sId },
+      });
+
+    await SandboxFunctionResource.makeNew(authenticator, {
+      space,
+      file: await makeFile("first.ts"),
+      slug: "greet",
+      description: "First greet.",
+      inputSchema,
+      outputSchema,
+    });
+
+    await expect(
+      SandboxFunctionResource.makeNew(authenticator, {
+        space,
+        file: await makeFile("second.ts"),
+        slug: "greet",
+        description: "Second greet.",
+        inputSchema,
+        outputSchema,
+      })
+    ).rejects.toThrow();
   });
 
   it("rejects a file outside project context", async () => {
@@ -216,6 +290,8 @@ describe("SandboxFunctionResource", () => {
       SandboxFunctionResource.makeNew(authenticator, {
         space,
         file,
+        slug: "add-comment",
+        description: "Add a comment.",
         inputSchema,
         outputSchema,
       })
@@ -240,17 +316,23 @@ describe("SandboxFunctionResource", () => {
       SandboxFunctionResource.makeNew(authenticator, {
         space,
         file,
+        slug: "add-comment",
+        description: "Add a comment.",
         inputSchema: { type: "number", multipleOf: 0 },
         outputSchema,
       })
     ).rejects.toThrow("Invalid JSON schema");
   });
 
-  it("declares a unique file index", () => {
+  it("declares unique file and slug indexes", () => {
     expect(SandboxFunctionModel.options.indexes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           fields: ["fileId"],
+          unique: true,
+        }),
+        expect.objectContaining({
+          fields: ["workspaceId", "spaceId", "slug"],
           unique: true,
         }),
       ])
@@ -275,6 +357,8 @@ describe("SandboxFunctionResource", () => {
       {
         space,
         file,
+        slug: "add-comment",
+        description: "Add a comment.",
         inputSchema,
         outputSchema,
       }
@@ -312,6 +396,8 @@ describe("SandboxFunctionResource", () => {
     const sandboxFunction = await SandboxFunctionResource.makeNew(adminAuth, {
       space,
       file,
+      slug: "add-comment",
+      description: "Add a comment.",
       inputSchema,
       outputSchema,
     });

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -2,7 +2,10 @@ import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
+import {
+  isValidSandboxFunctionSlug,
+  SandboxFunctionModel,
+} from "@app/lib/resources/storage/models/sandbox_function";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import {
@@ -63,17 +66,25 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     {
       space,
       file,
+      slug,
+      description,
       inputSchema,
       outputSchema,
     }: {
       space: SpaceResource;
       file: FileResource;
+      slug: string;
+      description: string;
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionResource> {
     assert(space.isProject(), "Sandbox functions can only belong to pods.");
+    assert(
+      isValidSandboxFunctionSlug(slug),
+      "The slug must be lowercase alphanumeric with single hyphen separators."
+    );
     assert(
       space.workspaceId === auth.getNonNullableWorkspace().id,
       "The space must belong to the authenticated workspace."
@@ -100,6 +111,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         workspaceId: auth.getNonNullableWorkspace().id,
         spaceId: space.id,
         fileId: file.id,
+        slug,
+        description,
         inputSchema,
         outputSchema,
       },

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -18,12 +18,29 @@ function validateSandboxFunctionJsonSchema(value: unknown): void {
   }
 }
 
+// Lowercase alphanumeric with single hyphen separators (e.g. `greet`, `send-slack-message`).
+export const SANDBOX_FUNCTION_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export function isValidSandboxFunctionSlug(value: unknown): value is string {
+  return typeof value === "string" && SANDBOX_FUNCTION_SLUG_REGEX.test(value);
+}
+
+function validateSandboxFunctionSlug(value: unknown): void {
+  if (!isValidSandboxFunctionSlug(value)) {
+    throw new Error(
+      "Slug must be lowercase alphanumeric with single hyphen separators."
+    );
+  }
+}
+
 export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare spaceId: ForeignKey<SpaceModel["id"]>;
   declare fileId: ForeignKey<FileModel["id"]>;
+  declare slug: string;
+  declare description: string;
   declare inputSchema: JSONSchema;
   declare outputSchema: JSONSchema;
 
@@ -51,6 +68,17 @@ SandboxFunctionModel.init(
       type: DataTypes.BIGINT,
       allowNull: false,
     },
+    slug: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      validate: {
+        isValidSlug: validateSandboxFunctionSlug,
+      },
+    },
+    description: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
     inputSchema: {
       type: DataTypes.JSONB,
       allowNull: false,
@@ -72,6 +100,11 @@ SandboxFunctionModel.init(
     indexes: [
       {
         fields: ["workspaceId", "spaceId", "fileId"],
+        unique: true,
+        concurrently: true,
+      },
+      {
+        fields: ["workspaceId", "spaceId", "slug"],
         unique: true,
         concurrently: true,
       },

--- a/front/migrations/pre-deploy/20260629113000_add_sandbox_function_slug_and_description.sql
+++ b/front/migrations/pre-deploy/20260629113000_add_sandbox_function_slug_and_description.sql
@@ -1,0 +1,20 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions" ADD COLUMN "slug" character varying(255) NOT NULL;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions" ADD COLUMN "description" character varying(255) NOT NULL;
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY sandbox_functions_workspace_id_space_id_slug ON public.sandbox_functions USING btree ("workspaceId", "spaceId", "slug");


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Sandbox functions had no identity of their own (outside of the opaque sId). There was no human-readable description, which gave a model little to choose on.

This gives each sandbox function a model-provided slug and a required description. The slug is a lowercase, hyphenated identifier, unique within a pod, and serves as the stable handle the model reasons about. It's the canonical way to reference a function. The description is a short summary that helps the model pick the right function. The list output now reads as slug and description only, dropping both the bundle filename and the internal identifier, neither of which the model needs.

A pre-deploy migration adds the two columns and a per-pod uniqueness constraint on the slug. Both columns are required, which is safe because the feature is still behind a flag with no creation path live yet, so the table is empty.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Apply migration
- [ ] Deploy front
