### PR TITLE
[front] tool credit cost: centralize cost computation logic

### DIFF
--- a/front/lib/api/assistant/credit_cost.test.ts
+++ b/front/lib/api/assistant/credit_cost.test.ts
@@ -6,7 +6,10 @@ import {
   toolAwuFromActions,
 } from "@app/lib/metronome/events";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
+import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { describe, expect, it } from "vitest";
+
+const TEST_CONTEXT_ORIGIN: UserMessageOrigin = "api";
 
 function usage(
   overrides: Partial<RunUsageType & { runKey: string | null }>
@@ -40,26 +43,32 @@ describe("awuFromMicroUsd", () => {
 
 describe("intelligenceAwuFromRunUsages", () => {
   it("groups by model and ceils per group before summing", () => {
-    const sameModel = intelligenceAwuFromRunUsages([
-      usage({ costMicroUsd: 5000, modelId: "gpt-4o", providerId: "openai" }),
-      usage({ costMicroUsd: 5000, modelId: "gpt-4o", providerId: "openai" }),
-    ]);
+    const sameModel = intelligenceAwuFromRunUsages(
+      [
+        usage({ costMicroUsd: 5000, modelId: "gpt-4o", providerId: "openai" }),
+        usage({ costMicroUsd: 5000, modelId: "gpt-4o", providerId: "openai" }),
+      ],
+      TEST_CONTEXT_ORIGIN
+    );
     expect(sameModel).toBe(2);
 
-    const twoModels = intelligenceAwuFromRunUsages([
-      usage({ costMicroUsd: 5000, modelId: "gpt-4o", providerId: "openai" }),
-      usage({
-        costMicroUsd: 5000,
-        modelId: "claude-opus-4-8",
-        providerId: "anthropic",
-      }),
-    ]);
+    const twoModels = intelligenceAwuFromRunUsages(
+      [
+        usage({ costMicroUsd: 5000, modelId: "gpt-4o", providerId: "openai" }),
+        usage({
+          costMicroUsd: 5000,
+          modelId: "claude-opus-4-8",
+          providerId: "anthropic",
+        }),
+      ],
+      TEST_CONTEXT_ORIGIN
+    );
     // ceil(5000/8500)=1 per model -> 2.
     expect(twoModels).toBe(2);
   });
 
   it("returns 0 for no usages", () => {
-    expect(intelligenceAwuFromRunUsages([])).toBe(0);
+    expect(intelligenceAwuFromRunUsages([], TEST_CONTEXT_ORIGIN)).toBe(0);
   });
 });
 
@@ -67,32 +76,41 @@ describe("intelligenceAwuFromRunUsagesGroupedByRunKey", () => {
   it("ceils per runKey (execution) so it matches additive Metronome events on interrupt/resume", () => {
     // Ceiling over the union (the old behavior) would undercount: ceil(10000/8500)=2
     // here it happens to match, so use an uneven split to prove the difference.
-    const credits = intelligenceAwuFromRunUsagesGroupedByRunKey([
-      usage({ costMicroUsd: 9000, runKey: "exec1" }), // ceil -> 2
-      usage({ costMicroUsd: 1000, runKey: "exec2" }), // ceil -> 1
-    ]);
+    const credits = intelligenceAwuFromRunUsagesGroupedByRunKey(
+      [
+        usage({ costMicroUsd: 9000, runKey: "exec1" }), // ceil -> 2
+        usage({ costMicroUsd: 1000, runKey: "exec2" }), // ceil -> 1
+      ],
+      TEST_CONTEXT_ORIGIN
+    );
     expect(credits).toBe(3);
   });
 
   it("still ceils per (provider, model) within a single execution", () => {
-    const credits = intelligenceAwuFromRunUsagesGroupedByRunKey([
-      usage({ costMicroUsd: 5000, modelId: "gpt-4o", runKey: "exec1" }),
-      usage({
-        costMicroUsd: 5000,
-        modelId: "claude-opus-4-8",
-        providerId: "anthropic",
-        runKey: "exec1",
-      }),
-    ]);
+    const credits = intelligenceAwuFromRunUsagesGroupedByRunKey(
+      [
+        usage({ costMicroUsd: 5000, modelId: "gpt-4o", runKey: "exec1" }),
+        usage({
+          costMicroUsd: 5000,
+          modelId: "claude-opus-4-8",
+          providerId: "anthropic",
+          runKey: "exec1",
+        }),
+      ],
+      TEST_CONTEXT_ORIGIN
+    );
     // Same execution, two models: ceil(5000)=1 per model -> 2.
     expect(credits).toBe(2);
   });
 
   it("folds untagged (null runKey) usages into a single legacy group", () => {
-    const credits = intelligenceAwuFromRunUsagesGroupedByRunKey([
-      usage({ costMicroUsd: 9000, runKey: null }),
-      usage({ costMicroUsd: 1000, runKey: null }),
-    ]);
+    const credits = intelligenceAwuFromRunUsagesGroupedByRunKey(
+      [
+        usage({ costMicroUsd: 9000, runKey: null }),
+        usage({ costMicroUsd: 1000, runKey: null }),
+      ],
+      TEST_CONTEXT_ORIGIN
+    );
     // Both summed before ceiling: ceil(10000/8500) = 2.
     expect(credits).toBe(2);
   });
@@ -101,24 +119,35 @@ describe("intelligenceAwuFromRunUsagesGroupedByRunKey", () => {
 describe("toolAwuFromActions", () => {
   it("charges 1 credit for basic and 3 for advanced tools", () => {
     expect(
-      toolAwuFromActions([
-        { internalMCPServerName: "web_search_&_browse" }, // basic = 1
-        { internalMCPServerName: "search" }, // advanced = 3
-      ])
+      toolAwuFromActions(
+        [
+          { internalMCPServerName: "web_search_&_browse" }, // basic = 1
+          { internalMCPServerName: "search" }, // advanced = 3
+        ],
+        TEST_CONTEXT_ORIGIN
+      )
     ).toBe(4);
   });
 
   it("treats unknown / external servers as advanced (3)", () => {
-    expect(toolAwuFromActions([{ internalMCPServerName: null }])).toBe(3);
+    expect(
+      toolAwuFromActions([{ internalMCPServerName: null }], TEST_CONTEXT_ORIGIN)
+    ).toBe(3);
   });
 
   it("does not charge for free tools (priced at 0 in the rate card)", () => {
     // agent_memory is in FREE_TOOL_SERVERS — billed free, so contributes 0.
     expect(
-      toolAwuFromActions([{ internalMCPServerName: "agent_memory" }])
+      toolAwuFromActions(
+        [{ internalMCPServerName: "agent_memory" }],
+        TEST_CONTEXT_ORIGIN
+      )
     ).toBe(0);
     expect(
-      toolAwuFromActions([{ internalMCPServerName: "agent_memory" }])
+      toolAwuFromActions(
+        [{ internalMCPServerName: "agent_memory" }],
+        TEST_CONTEXT_ORIGIN
+      )
     ).toBe(0);
   });
 });
@@ -128,6 +157,7 @@ describe("computeAgentMessageCredits", () => {
     const credits = computeAgentMessageCredits({
       runUsages: [usage({ costMicroUsd: 8500 })], // 1 intelligence credit
       actions: [{ internalMCPServerName: "search", status: "succeeded" }], // 3 tool credits
+      contextOrigin: TEST_CONTEXT_ORIGIN,
     });
     expect(credits).toBe(4);
   });
@@ -136,13 +166,18 @@ describe("computeAgentMessageCredits", () => {
     const credits = computeAgentMessageCredits({
       runUsages: [],
       actions: [{ internalMCPServerName: "search", status: "running" }],
+      contextOrigin: TEST_CONTEXT_ORIGIN,
     });
     expect(credits).toBeNull();
   });
 
   it("returns null when there is no billable usage", () => {
     expect(
-      computeAgentMessageCredits({ runUsages: [], actions: [] })
+      computeAgentMessageCredits({
+        runUsages: [],
+        actions: [],
+        contextOrigin: TEST_CONTEXT_ORIGIN,
+      })
     ).toBeNull();
   });
 
@@ -150,7 +185,7 @@ describe("computeAgentMessageCredits", () => {
     const credits = computeAgentMessageCredits({
       runUsages: [usage({ costMicroUsd: 8500 })], // would be 1 intelligence credit
       actions: [{ internalMCPServerName: "search", status: "succeeded" }], // would be 3 tool credits
-      isFreeUsage: true,
+      contextOrigin: "agent_sidekick",
     });
     expect(credits).toBe(0);
   });
@@ -160,7 +195,7 @@ describe("computeAgentMessageCredits", () => {
       computeAgentMessageCredits({
         runUsages: [],
         actions: [],
-        isFreeUsage: true,
+        contextOrigin: "agent_sidekick",
       })
     ).toBeNull();
   });

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -1,3 +1,4 @@
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
@@ -20,7 +21,7 @@ import logger from "@app/logger/logger";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 
 interface CreditActionMinimalInput {
-  internalMCPServerName: string | null;
+  internalMCPServerName: InternalMCPServerNameType | null;
   status: ToolExecutionStatus;
 }
 

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -6,7 +6,6 @@ import type { Authenticator } from "@app/lib/auth";
 import {
   computeRunKey,
   intelligenceAwuFromRunUsagesGroupedByRunKey,
-  isFreeOrigin,
   toolAwuFromActions,
 } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -18,7 +17,10 @@ import {
   rateLimiter,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
-import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
+import {
+  AGENT_MESSAGE_STATUSES_TO_TRACK,
+  type UserMessageOrigin,
+} from "@app/types/assistant/conversation";
 
 interface CreditActionMinimalInput {
   internalMCPServerName: InternalMCPServerNameType | null;
@@ -28,11 +30,11 @@ interface CreditActionMinimalInput {
 export function computeAgentMessageCredits({
   runUsages,
   actions,
-  isFreeUsage = false,
+  contextOrigin,
 }: {
   runUsages: (RunUsageType & { runKey: string | null })[];
   actions: CreditActionMinimalInput[];
-  isFreeUsage?: boolean;
+  contextOrigin: UserMessageOrigin | null;
 }): number | null {
   const finalActions = actions.filter((a) =>
     isToolExecutionStatusFinal(a.status)
@@ -42,16 +44,12 @@ export function computeAgentMessageCredits({
     return null;
   }
 
-  if (isFreeUsage) {
-    return 0;
-  }
-
   // Intelligence cost is ceiled per agent-loop execution (runKey) to match the
   // per-execution Metronome events. Tool cost has no ceiling (fixed 1/3 per
   // action), so it is grouping-invariant and stays message-level.
   return (
-    intelligenceAwuFromRunUsagesGroupedByRunKey(runUsages) +
-    toolAwuFromActions(finalActions)
+    intelligenceAwuFromRunUsagesGroupedByRunKey(runUsages, contextOrigin) +
+    toolAwuFromActions(finalActions, contextOrigin)
   );
 }
 
@@ -122,9 +120,7 @@ export async function computeAndStoreAgentMessageCredits(
       internalMCPServerName: action.metadata.internalMCPServerName,
       status: action.status,
     })),
-    isFreeUsage:
-      triggeringUserMessageOrigin !== null &&
-      isFreeOrigin(triggeringUserMessageOrigin),
+    contextOrigin: triggeringUserMessageOrigin,
   });
 
   await ConversationResource.updateAgentMessageCostCredits(auth, {

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -152,9 +152,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
   clari_copilot: "advanced",
 };
 
-export function getToolCategory(
-  internalMCPServerName: string | null
-): ToolCategory {
+function getToolCategory(internalMCPServerName: string | null): ToolCategory {
   if (
     !internalMCPServerName ||
     !isInternalMCPServerName(internalMCPServerName)
@@ -184,7 +182,11 @@ const FREE_TOOL_SERVERS: ReadonlySet<string> = new Set<string>([
   "agent_memory",
 ]);
 
-export function isFreeOrigin(origin: UserMessageOrigin): boolean {
+function isFreeOrigin(origin: UserMessageOrigin | null): boolean {
+  if (origin == null) {
+    return false;
+  }
+
   return FREE_ORIGINS.has(origin);
 }
 
@@ -200,7 +202,7 @@ export function getUsageType(
 
 // A tool invocation is always free (priced at 0 in the rate card) when its
 // internal MCP server is platform plumbing — see FREE_TOOL_SERVERS.
-export function isFreeToolServer(
+function isFreeToolServer(
   internalMCPServerName: InternalMCPServerNameType | null
 ): boolean {
   return (
@@ -259,8 +261,13 @@ export function awuFromMicroUsd(microUsd: number): number {
 // `intelligenceAwuFromRunUsagesGroupedByRunKey` (which ceils per execution),
 // not this directly over the union of all runs.
 export function intelligenceAwuFromRunUsages(
-  runUsages: RunUsageType[]
+  runUsages: RunUsageType[],
+  contextOrigin: UserMessageOrigin | null
 ): number {
+  if (isFreeOrigin(contextOrigin)) {
+    return 0;
+  }
+
   const costByModel = new Map<string, number>();
   for (const usage of runUsages) {
     // Need this grouping to rightfully apply the Math.ceil in awuFromMicroUsd
@@ -287,8 +294,13 @@ const LEGACY_RUN_KEY = "__legacy__";
 // instead would undercount (`ceil(a) + ceil(b) >= ceil(a + b)`), so we group by
 // runKey first, ceil each group via `intelligenceAwuFromRunUsages`, then sum.
 export function intelligenceAwuFromRunUsagesGroupedByRunKey(
-  runUsages: (RunUsageType & { runKey: string | null })[]
+  runUsages: (RunUsageType & { runKey: string | null })[],
+  contextOrigin: UserMessageOrigin | null
 ): number {
+  if (isFreeOrigin(contextOrigin)) {
+    return 0;
+  }
+
   const byRunKey = new Map<string, RunUsageType[]>();
   for (const usage of runUsages) {
     const key = usage.runKey ?? LEGACY_RUN_KEY;
@@ -299,7 +311,7 @@ export function intelligenceAwuFromRunUsagesGroupedByRunKey(
 
   let total = 0;
   for (const group of byRunKey.values()) {
-    total += intelligenceAwuFromRunUsages(group);
+    total += intelligenceAwuFromRunUsages(group, contextOrigin);
   }
   return total;
 }
@@ -311,17 +323,28 @@ export function intelligenceAwuFromRunUsagesGroupedByRunKey(
 // should pass only final-status actions (matching the usage_queue extraction)
 // so this equals the billed amount.
 export function toolAwuFromActions(
-  actions: { internalMCPServerName: InternalMCPServerNameType | null }[]
+  actions: { internalMCPServerName: InternalMCPServerNameType | null }[],
+  contextOrigin: UserMessageOrigin | null
 ): number {
   return actions.reduce((total, action) => {
-    if (isFreeToolServer(action.internalMCPServerName)) {
-      return total;
-    }
     return (
-      total +
-      TOOL_CATEGORY_AWU_WEIGHTS[getToolCategory(action.internalMCPServerName)]
+      total + toolAwuFromServerName(action.internalMCPServerName, contextOrigin)
     );
   }, 0);
+}
+
+export function toolAwuFromServerName(
+  internalMCPServerName: InternalMCPServerNameType | null,
+  contextOrigin: UserMessageOrigin | null
+): number {
+  if (isFreeOrigin(contextOrigin)) {
+    return 0;
+  }
+
+  if (isFreeToolServer(internalMCPServerName)) {
+    return 0;
+  }
+  return TOOL_CATEGORY_AWU_WEIGHTS[getToolCategory(internalMCPServerName)];
 }
 
 // ---------------------------------------------------------------------------

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -172,9 +172,8 @@ export function getToolCategory(
 
 // Origins whose entire conversation is free (platform-assistive, not
 // user-requested output).
-export const FREE_ORIGINS: ReadonlySet<string> = new Set<string>([
-  "agent_sidekick",
-]);
+export const FREE_ORIGINS: ReadonlySet<UserMessageOrigin> =
+  new Set<UserMessageOrigin>(["agent_sidekick"]);
 
 // Internal MCP servers whose tool invocations are always free regardless of
 // the message-level usage type (platform plumbing, not user output).
@@ -185,13 +184,13 @@ const FREE_TOOL_SERVERS: ReadonlySet<string> = new Set<string>([
   "agent_memory",
 ]);
 
-export function isFreeOrigin(origin: string): boolean {
+export function isFreeOrigin(origin: UserMessageOrigin): boolean {
   return FREE_ORIGINS.has(origin);
 }
 
 export function getUsageType(
   isProgrammaticUsage: boolean,
-  origin: string
+  origin: UserMessageOrigin
 ): UsageType {
   if (isFreeOrigin(origin)) {
     return USAGE_TYPE_FREE;
@@ -202,7 +201,7 @@ export function getUsageType(
 // A tool invocation is always free (priced at 0 in the rate card) when its
 // internal MCP server is platform plumbing — see FREE_TOOL_SERVERS.
 export function isFreeToolServer(
-  internalMCPServerName: string | null
+  internalMCPServerName: InternalMCPServerNameType | null
 ): boolean {
   return (
     internalMCPServerName !== null &&
@@ -212,7 +211,7 @@ export function isFreeToolServer(
 
 function getToolUsageType(
   baseUsageType: UsageType,
-  internalMCPServerName: string | null
+  internalMCPServerName: InternalMCPServerNameType | null
 ): UsageType {
   if (isFreeToolServer(internalMCPServerName)) {
     return USAGE_TYPE_FREE;
@@ -312,7 +311,7 @@ export function intelligenceAwuFromRunUsagesGroupedByRunKey(
 // should pass only final-status actions (matching the usage_queue extraction)
 // so this equals the billed amount.
 export function toolAwuFromActions(
-  actions: { internalMCPServerName: string | null }[]
+  actions: { internalMCPServerName: InternalMCPServerNameType | null }[]
 ): number {
   return actions.reduce((total, action) => {
     if (isFreeToolServer(action.internalMCPServerName)) {

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -71,7 +71,7 @@ export function isToolCategory(value: string): value is ToolCategory {
 // Exhaustive map — TypeScript will error if a new internal MCP server is added
 // without being categorized here.
 const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
-  // Set as basic but overriden as free
+  // Set as basic but overridden as free
   agent_memory: "basic",
   agent_router: "basic",
   common_utilities: "basic",

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -71,16 +71,18 @@ export function isToolCategory(value: string): value is ToolCategory {
 // Exhaustive map — TypeScript will error if a new internal MCP server is added
 // without being categorized here.
 const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
+  // Set as basic but overriden as free
+  agent_memory: "basic",
+  agent_router: "basic",
+  common_utilities: "basic",
+  toolsets: "basic",
+
   // Basic (1 AWU) — web search, orchestration, platform utilities.
   "web_search_&_browse": "basic",
   run_agent: "basic",
-  agent_router: "basic",
   agent_sidekick_agent_state: "basic",
   agent_sidekick_context: "basic",
-  agent_memory: "basic",
   run_dust_app: "basic",
-  common_utilities: "basic",
-  toolsets: "basic",
   user_mentions: "basic",
   missing_action_catcher: "basic",
   primitive_types_debugger: "basic",
@@ -176,10 +178,10 @@ export const FREE_ORIGINS: ReadonlySet<UserMessageOrigin> =
 // Internal MCP servers whose tool invocations are always free regardless of
 // the message-level usage type (platform plumbing, not user output).
 const FREE_TOOL_SERVERS: ReadonlySet<string> = new Set<string>([
+  "agent_memory",
   "agent_router",
   "common_utilities",
   "toolsets",
-  "agent_memory",
 ]);
 
 function isFreeOrigin(origin: UserMessageOrigin | null): boolean {

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -19,11 +19,8 @@ import { isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import {
-  getToolCategory,
   intelligenceAwuFromRunUsages,
-  isFreeOrigin,
-  isFreeToolServer,
-  TOOL_CATEGORY_AWU_WEIGHTS,
+  toolAwuFromServerName,
 } from "@app/lib/metronome/events";
 import type { AgentMessageFeedbackModel } from "@app/lib/models/agent/conversation";
 import {
@@ -179,8 +176,6 @@ export async function storeAgentAnalytics(
     agentAgentMessageRow.id,
   ]);
 
-  const isFreeUsage = contextOrigin !== null && isFreeOrigin(contextOrigin);
-
   // Seat type at index time, to stamp `is_free_seat`. Mirrors Metronome's
   // free-seat user-id split: free-seat usage is dropped from a user's consumed
   // credits once they upgrade to a paid seat. Defaults to non-free when the
@@ -205,11 +200,13 @@ export async function storeAgentAnalytics(
   );
 
   // Collect tool usage data (with per-tool credit cost).
-  const toolsUsed = await collectToolUsageFromMessage(auth, actions, {
-    isFreeUsage,
-  });
+  const toolsUsed = await collectToolUsageFromMessage(
+    auth,
+    actions,
+    contextOrigin
+  );
 
-  const llmAwu = isFreeUsage ? 0 : intelligenceAwuFromRunUsages(runUsages);
+  const llmAwu = intelligenceAwuFromRunUsages(runUsages, contextOrigin);
   const toolAwu = toolsUsed.reduce((sum, tool) => sum + tool.cost_awu, 0);
   const cost = {
     full_awu: llmAwu + toolAwu,
@@ -331,7 +328,7 @@ function aggregateTokenUsage(
 async function collectToolUsageFromMessage(
   auth: Authenticator,
   actionResources: AgentMCPActionResource[],
-  { isFreeUsage }: { isFreeUsage: boolean }
+  contextOrigin: UserMessageOrigin | null
 ): Promise<AgentMessageAnalyticsToolUsed[]> {
   const uniqueConfigIds = Array.from(
     new Set(actionResources.map((a) => a.mcpServerConfigurationId))
@@ -374,12 +371,9 @@ async function collectToolUsageFromMessage(
       mcpServerId ??
       "unknown";
 
-    const cost_awu =
-      !isFreeUsage &&
-      isToolExecutionStatusFinal(actionResource.status) &&
-      !isFreeToolServer(internalMCPServerName)
-        ? TOOL_CATEGORY_AWU_WEIGHTS[getToolCategory(internalMCPServerName)]
-        : 0;
+    const cost_awu = isToolExecutionStatusFinal(actionResource.status)
+      ? toolAwuFromServerName(internalMCPServerName, contextOrigin)
+      : 0;
 
     return {
       step_index: actionResource.stepContent.step,

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -575,7 +575,8 @@ export async function recordSelfImprovingSkillsUsageActivity({
     // conversion rounds up per (provider, model) group, applied here at
     // conversation granularity.
     const conversationPriceAwuCredits = intelligenceAwuFromRunUsages(
-      conversationRunUsages
+      conversationRunUsages,
+      "reinforcement"
     );
 
     totalPriceMicroUsd += conversationPriceMicroUsd;


### PR DESCRIPTION
## Description

In preparation of evolution of credit cost per tool => centralize all the logic for credit cost computation at the same place

Move the free-origin check (isFreeOrigin) and the per-tool AWU weight lookup (toolAwuFromServerName) down into the low-level functions in metronome/events.ts, so all callers (intelligenceAwuFromRunUsages, toolAwuFromActions, etc.) apply the same billing rules automatically.

This removes the need for callers to know about isFreeUsage or contextOrigin handling — they just pass the origin and the right thing happens.

computeAgentMessageCredits now takes a contextOrigin instead of a boolean isFreeUsage, aligning it with the Metronome event functions it delegates to.

## Tests

Tested locally

## Risk

Medium, code refactoring but still impacts the cost computation which is key for us

## Deploy Plan

Deploy front