### PR TITLE
feat(usage): show member groups column on the usage page

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -96,6 +96,7 @@ function memberFromUpgradeRequest(
     name: request.requester.name,
     email: request.requester.email,
     image: request.requester.image,
+    groups: [],
     seatType: request.requester.seatType,
     memberUsageLimit: null,
     seatBalanceAwu: null,
@@ -154,6 +155,7 @@ export function UsagePage() {
   // invite, seat changes, spend limits, settings) is disabled.
   const isReadOnly = !isCreditPriced && hasFeature("usage_page_read_only");
   const canViewUsage = isCreditPriced || isReadOnly;
+  const pricingGroupsEnabled = hasFeature("pricing_groups");
   const [searchTerm, setSearchTerm] = useState("");
   const [seatTypeFilter, setSeatTypeFilter] = useState<
     MembershipSeatType | "none" | null
@@ -609,6 +611,7 @@ export function UsagePage() {
       totalRowCount={totalMembersUsage}
       sorting={sorting}
       setSorting={handleSetSorting}
+      showGroupsColumn={pricingGroupsEnabled}
     />
   );
 

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -439,14 +439,10 @@ const actionsColumn: ColumnDef<RowData, string> = {
 
 function buildColumns(showGroupsColumn: boolean): ColumnDef<RowData, string>[] {
   return [
-    showGroupsColumn
-      ? { ...nameColumn, meta: { className: "w-72" } }
-      : nameColumn,
+    nameColumn,
     ...(showGroupsColumn ? [groupsColumn] : []),
     seatTypeColumn,
-    showGroupsColumn
-      ? consumedAwuCreditsColumn
-      : { ...consumedAwuCreditsColumn, meta: { className: "w-64" } },
+    { ...consumedAwuCreditsColumn, meta: { className: "w-64" } },
     actionsColumn,
   ];
 }

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -38,6 +38,7 @@ type RowData = {
   name: string;
   email: string | null;
   image: string | null;
+  groups: string[];
   seatType: MembershipSeatType | null;
   memberUsageLimit: number | null;
   seatBalanceAwu: number | null;
@@ -331,7 +332,32 @@ export function AwuUsageBar({
   );
 }
 
-const nameColumn = buildMemberNameColumn<RowData>();
+const nameColumn: ColumnDef<RowData, string> = {
+  ...buildMemberNameColumn<RowData>(),
+  meta: {
+    className: "w-72",
+  },
+};
+
+const groupsColumn: ColumnDef<RowData, string> = {
+  id: "groups" as const,
+  header: "Groups",
+  enableSorting: false,
+  accessorFn: (row) => row.groups.join(", "),
+  cell: (info: Info) => {
+    const { groups } = info.row.original;
+    return (
+      <DataTable.CellContent>
+        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {groups.length > 0 ? groups.join(", ") : "--"}
+        </span>
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-48",
+  },
+};
 
 const seatTypeColumn: ColumnDef<RowData, string> = {
   id: "seatType" as const,
@@ -400,9 +426,6 @@ const consumedAwuCreditsColumn: ColumnDef<RowData, string> = {
       />
     </div>
   ),
-  meta: {
-    className: "w-64",
-  },
   enableSorting: true,
 };
 
@@ -419,8 +442,14 @@ const actionsColumn: ColumnDef<RowData, string> = {
   },
 };
 
-function buildColumns(): ColumnDef<RowData, string>[] {
-  return [nameColumn, seatTypeColumn, consumedAwuCreditsColumn, actionsColumn];
+function buildColumns(showGroupsColumn: boolean): ColumnDef<RowData, string>[] {
+  return [
+    nameColumn,
+    ...(showGroupsColumn ? [groupsColumn] : []),
+    seatTypeColumn,
+    consumedAwuCreditsColumn,
+    actionsColumn,
+  ];
 }
 
 interface MembersUsageTableProps {
@@ -439,6 +468,7 @@ interface MembersUsageTableProps {
   totalRowCount: number;
   sorting: SortingState;
   setSorting: (sorting: SortingState) => void;
+  showGroupsColumn?: boolean;
 }
 
 export function MembersUsageTable({
@@ -457,6 +487,7 @@ export function MembersUsageTable({
   totalRowCount,
   sorting,
   setSorting,
+  showGroupsColumn = false,
 }: MembersUsageTableProps) {
   const rows: RowData[] = useMemo(
     () =>
@@ -465,6 +496,7 @@ export function MembersUsageTable({
         name: m.name,
         email: m.email,
         image: m.image,
+        groups: m.groups,
         seatType: m.seatType,
         memberUsageLimit: m.memberUsageLimit,
         seatBalanceAwu: m.seatBalanceAwu,
@@ -542,7 +574,10 @@ export function MembersUsageTable({
     ]
   );
 
-  const columns = useMemo(() => buildColumns(), []);
+  const columns = useMemo(
+    () => buildColumns(showGroupsColumn),
+    [showGroupsColumn]
+  );
 
   if (isLoading) {
     return (

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -332,12 +332,7 @@ export function AwuUsageBar({
   );
 }
 
-const nameColumn: ColumnDef<RowData, string> = {
-  ...buildMemberNameColumn<RowData>(),
-  meta: {
-    className: "w-72",
-  },
-};
+const nameColumn = buildMemberNameColumn<RowData>();
 
 const groupsColumn: ColumnDef<RowData, string> = {
   id: "groups" as const,
@@ -444,10 +439,14 @@ const actionsColumn: ColumnDef<RowData, string> = {
 
 function buildColumns(showGroupsColumn: boolean): ColumnDef<RowData, string>[] {
   return [
-    nameColumn,
+    showGroupsColumn
+      ? { ...nameColumn, meta: { className: "w-72" } }
+      : nameColumn,
     ...(showGroupsColumn ? [groupsColumn] : []),
     seatTypeColumn,
-    consumedAwuCreditsColumn,
+    showGroupsColumn
+      ? consumedAwuCreditsColumn
+      : { ...consumedAwuCreditsColumn, meta: { className: "w-64" } },
     actionsColumn,
   ];
 }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -38,6 +38,7 @@ import {
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import { isUserAwuWarned } from "@app/lib/metronome/user_block";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
@@ -72,6 +73,7 @@ export type MemberUsageType = {
   name: string;
   email: string | null;
   image: string | null;
+  groups: string[];
   seatType: MembershipSeatType | null;
   // Per-user AWU allocation granted by the seat (in credits). Null when the
   // user has no seat or the seat carries no allocation.
@@ -861,6 +863,12 @@ export async function getMemberUsage({
     return { member: null };
   }
 
+  const groupNamesByUserModelId =
+    await GroupResource.listGroupNamesByUserModelIdInWorkspace({
+      workspace,
+      userModelIds: [userResource.id],
+    });
+
   const metronomeUserId =
     membership.seatType === "free" ? toFreeMetronomeUserId(userId) : userId;
   const totalConsumedCredits =
@@ -935,6 +943,7 @@ export async function getMemberUsage({
       name: userResource.fullName() || userResource.name,
       email: userResource.email ?? null,
       image: userResource.imageUrl ?? null,
+      groups: groupNamesByUserModelId.get(userResource.id) ?? [],
       seatType: membership.seatType ?? null,
       memberUsageLimit:
         effectiveAllocationAwu > 0 ? effectiveAllocationAwu : null,
@@ -1157,6 +1166,7 @@ export async function getMembersUsage({
     { freeBalanceByUserId, freeStartingByUserId },
     perUserSpendLimits,
     freeCreditAlertIdsByUserId,
+    groupNamesByUserModelId,
   ] = await Promise.all([
     fetchConsumedAwuCreditsByUserId({
       workspace,
@@ -1201,6 +1211,10 @@ export async function getMembersUsage({
           workspaceId: workspace.sId,
         })
       : Promise.resolve(null),
+    GroupResource.listGroupNamesByUserModelIdInWorkspace({
+      workspace,
+      userModelIds: users.map((u) => u.id),
+    }),
   ]);
   const freeCreditAlertIds =
     freeCreditAlertIdsByUserId?.isOk() === true
@@ -1331,6 +1345,7 @@ export async function getMembersUsage({
         name: u.fullName() || u.name,
         email: u.email ?? null,
         image: u.imageUrl ?? null,
+        groups: groupNamesByUserModelId.get(u.id) ?? [],
         seatType: membership.seatType ?? null,
         memberUsageLimit:
           effectiveAllocationAwu > 0 ? effectiveAllocationAwu : null,

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -158,6 +158,57 @@ describe("GroupResource", () => {
     });
   });
 
+  describe("listGroupNamesByUserModelIdInWorkspace", () => {
+    it("returns regular + provisioned group names per user, sorted, excluding global", async () => {
+      const user2 = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user2, { role: "user" });
+      const user3 = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user3, { role: "user" });
+
+      const sales = await GroupResource.makeNew({
+        name: "Sales",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await sales.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+      // Provisioned groups are synced from WorkOS; members are seeded directly.
+      await GroupResource.makeNew(
+        {
+          name: "Engineering",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-eng-group",
+        },
+        { memberIds: [user.id, user2.id] }
+      );
+
+      const result = await GroupResource.listGroupNamesByUserModelIdInWorkspace(
+        {
+          workspace,
+          userModelIds: [user.id, user2.id, user3.id],
+        }
+      );
+
+      // user is implicitly in the global group, which must be excluded.
+      expect(result.get(user.id)).toEqual(["Engineering", "Sales"]);
+      expect(result.get(user2.id)).toEqual(["Engineering"]);
+      expect(result.has(user3.id)).toBe(false);
+    });
+
+    it("returns an empty map when no user ids are given", async () => {
+      const result = await GroupResource.listGroupNamesByUserModelIdInWorkspace(
+        {
+          workspace,
+          userModelIds: [],
+        }
+      );
+
+      expect(result.size).toBe(0);
+    });
+  });
+
   describe("dangerouslyListUserGroupsForAuth caching", () => {
     it("returns groups for authenticated user", async () => {
       const regularGroup = await GroupResource.makeNew({

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1183,6 +1183,64 @@ export class GroupResource extends BaseResource<GroupModel> {
     return groups.map((group) => new this(GroupModel, group.get()));
   }
 
+  static async listGroupNamesByUserModelIdInWorkspace({
+    workspace,
+    userModelIds,
+    groupKinds = ["regular", "provisioned"],
+  }: {
+    workspace: LightWorkspaceType;
+    userModelIds: ModelId[];
+    groupKinds?: Exclude<GroupKind, "system">[];
+  }): Promise<Map<ModelId, string[]>> {
+    const result = new Map<ModelId, string[]>();
+    if (userModelIds.length === 0) {
+      return result;
+    }
+
+    const now = new Date();
+    const memberships = await GroupMembershipModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        userId: userModelIds,
+        status: "active",
+        startAt: { [Op.lte]: now },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+      },
+    });
+    if (memberships.length === 0) {
+      return result;
+    }
+
+    const groupModelIds = [...new Set(memberships.map((m) => m.groupId))];
+    const groups = await GroupModel.findAll({
+      where: {
+        id: groupModelIds,
+        workspaceId: workspace.id,
+        kind: groupKinds,
+      },
+    });
+    const nameByGroupId = new Map(groups.map((g) => [g.id, g.name]));
+
+    for (const m of memberships) {
+      const name = nameByGroupId.get(m.groupId);
+      if (!name) {
+        continue;
+      }
+      const existing = result.get(m.userId);
+      if (existing) {
+        existing.push(name);
+      } else {
+        result.set(m.userId, [name]);
+      }
+    }
+
+    for (const names of result.values()) {
+      names.sort((a, b) => a.localeCompare(b));
+    }
+
+    return result;
+  }
+
   static async getMemberCountsForGroups(
     auth: Authenticator,
     groups: GroupResource[]

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -167,6 +167,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Allow legacy-contract workspaces to view the Usage page in read-only mode (analytics and member spend visible; all actions disabled).",
     stage: "on_demand",
   },
+  pricing_groups: {
+    description:
+      "Surface org groups on the Usage page: groups column, groups filter, and bulk spend-limit editing across a selection of members.",
+    stage: "on_demand",
+  },
   xai_feature: {
     description: "Access to xAI models in the agent builder",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -771,6 +771,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "run_tools_from_prompt"
   | "usage_data_api"
   | "usage_page_read_only"
+  | "pricing_groups"
   | "workspace_analytics"
   | "xai_feature"
   | "conversations_slack_notifications"


### PR DESCRIPTION
## Description

Add a Groups column (regular + provisioned org groups) between Name and Seat in the members usage table, backed by a batched groups-by-user lookup on GroupResource to avoid the per-user N+1 the members page uses.

Constrain the name column width and let the credit-usage column absorb the remaining space so Name/Groups/Seat read as one identity block.

Behind feature flag

<img width="1161" height="754" alt="Screenshot 2026-06-29 at 12 15 33" src="https://github.com/user-attachments/assets/ef5c75c9-c6e3-4d3e-8f4f-e4838375d842" />


## Tests
Unit + local


## Risk

None, feature flagged
## Deploy Plan

Front