### PR TITLE
[front] enh: always enable `ask_user_question`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -112,4 +112,10 @@ describe("isHotMCPServerName", () => {
     expect(isHotMCPServerName("not_a_real_server")).toBe(false);
     expect(isHotMCPServerName("")).toBe(false);
   });
+
+  it("keeps ask_user_question hidden from the builder", () => {
+    expect(INTERNAL_MCP_SERVERS.ask_user_question.availability).toBe(
+      "auto_hidden_builder"
+    );
+  });
 });

--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -112,10 +112,4 @@ describe("isHotMCPServerName", () => {
     expect(isHotMCPServerName("not_a_real_server")).toBe(false);
     expect(isHotMCPServerName("")).toBe(false);
   });
-
-  it("keeps ask_user_question hidden from the builder", () => {
-    expect(INTERNAL_MCP_SERVERS.ask_user_question.availability).toBe(
-      "auto_hidden_builder"
-    );
-  });
 });

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1070,7 +1070,7 @@ export const INTERNAL_MCP_SERVERS = {
   },
   ask_user_question: {
     id: 1028,
-    availability: "auto",
+    availability: "auto_hidden_builder",
     allowMultipleInstances: false,
     isPreview: false,
     isRestricted: undefined,

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -439,10 +439,7 @@ export function _getDeepDiveGlobalAgent(
     featureFlags: WhitelistableFeature[];
   }
 ): AgentConfigurationType | null {
-  const {
-    run_agent: runAgentMCPServerView,
-    ask_user_question: askUserQuestionMCPServerView,
-  } = mcpServerViews;
+  const { run_agent: runAgentMCPServerView } = mcpServerViews;
   const pictureUrl = DUST_AVATAR_URL;
   const modelConfig = getModelConfig(auth, { featureFlags, excludeProviders });
 
@@ -568,27 +565,6 @@ export function _getDeepDiveGlobalAgent(
       dataSources: null,
       tables: null,
       childAgentId: GLOBAL_AGENTS_SID.DUST_PLANNING,
-      additionalConfiguration: {},
-      timeFrame: null,
-      dustAppConfiguration: null,
-      jsonSchema: null,
-      secretName: null,
-      dustProject: null,
-    });
-  }
-
-  if (askUserQuestionMCPServerView) {
-    actions.push({
-      id: -1,
-      sId: GLOBAL_AGENTS_SID.DEEP_DIVE + "-ask-user-question",
-      type: "mcp_server_configuration",
-      name: "ask_user_question",
-      description: "Ask the user a question with multiple-choice options.",
-      mcpServerViewId: askUserQuestionMCPServerView.sId,
-      internalMCPServerId: askUserQuestionMCPServerView.internalMCPServerId,
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
       additionalConfiguration: {},
       timeFrame: null,
       dustAppConfiguration: null,

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -281,10 +281,7 @@ function _getDustLikeGlobalAgent(
     omittedThinking?: boolean;
   }
 ): (AgentConfigurationType & { omittedThinking?: boolean }) | null {
-  const {
-    agent_memory: agentMemoryMCPServerView,
-    ask_user_question: askUserQuestionMCPServerView,
-  } = mcpServerViews;
+  const { agent_memory: agentMemoryMCPServerView } = mcpServerViews;
 
   const description = `Dust is your general purpose agent. It has access to all of your company data and tools available in the Company space. Dust can help you:
 - Find and analyze data across your company knowledge
@@ -430,27 +427,6 @@ function _getDustLikeGlobalAgent(
       description: "The agent memory tool",
       mcpServerViewId: agentMemoryMCPServerView.sId,
       internalMCPServerId: agentMemoryMCPServerView.internalMCPServerId,
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
-      additionalConfiguration: {},
-      timeFrame: null,
-      dustAppConfiguration: null,
-      jsonSchema: null,
-      secretName: null,
-      dustProject: null,
-    });
-  }
-
-  if (askUserQuestionMCPServerView) {
-    actions.push({
-      id: -1,
-      sId: agentId + "-ask-user-question",
-      type: "mcp_server_configuration",
-      name: "ask_user_question" satisfies InternalMCPServerNameType,
-      description: "Ask the user a question with multiple-choice options.",
-      mcpServerViewId: askUserQuestionMCPServerView.sId,
-      internalMCPServerId: askUserQuestionMCPServerView.internalMCPServerId,
       dataSources: null,
       tables: null,
       childAgentId: null,

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -319,15 +319,8 @@ export function _getSidekickGlobalAgent(
       })
     : null;
 
-  const askUserQuestionAction = sidekickContext?.mcpServerViews?.askUserQuestion
-    ? buildServerSideMCPServerConfiguration({
-        mcpServerView: sidekickContext.mcpServerViews.askUserQuestion,
-      })
-    : null;
-
   const actions = [
     ...(contextAction ? [contextAction] : []),
-    ...(askUserQuestionAction ? [askUserQuestionAction] : []),
     ...(companyDataAction ? [companyDataAction] : []),
   ];
 

--- a/front/lib/api/assistant/global_agents/sidekick_context.ts
+++ b/front/lib/api/assistant/global_agents/sidekick_context.ts
@@ -27,7 +27,6 @@ interface SidekickUserMetadata {
 export interface SidekickContext {
   mcpServerViews: {
     context: MCPServerViewResource;
-    askUserQuestion: MCPServerViewResource | null;
   } | null;
 }
 
@@ -267,13 +266,7 @@ export async function buildSidekickContext(
       auth,
       AGENT_SIDEKICK_CONTEXT_TOOL_NAME
     );
-  const askUserQuestion =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-      auth,
-      "ask_user_question"
-    );
-
   return {
-    mcpServerViews: context ? { context, askUserQuestion } : null,
+    mcpServerViews: context ? { context } : null,
   };
 }

--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -29,7 +29,6 @@ export const MCP_SERVERS_FOR_GLOBAL_AGENTS = [
   "toolsets",
   "data_warehouses",
   "agent_memory",
-  "ask_user_question",
 ] as const satisfies AutoInternalMCPServerNameType[];
 
 export type MCPServerViewsForGlobalAgentsMap = Record<

--- a/front/lib/api/assistant/jit/ask_user_question.ts
+++ b/front/lib/api/assistant/jit/ask_user_question.ts
@@ -1,0 +1,51 @@
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import logger from "@app/logger/logger";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+
+/**
+ * Get the ask_user_question MCP server for interactive clarifying questions.
+ */
+export function getAskUserQuestionServer(
+  agentConfiguration: LightAgentConfigurationType,
+  conversation: ConversationWithoutContentType,
+  autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
+): ServerSideMCPServerConfigurationType | null {
+  const askUserQuestionView =
+    autoInternalViews.get("ask_user_question") ?? null;
+
+  if (!askUserQuestionView) {
+    logger.warn(
+      {
+        agentConfigurationId: agentConfiguration.sId,
+        conversationId: conversation.sId,
+      },
+      "MCP server view not found for ask_user_question. Ensure auto tools are created."
+    );
+    return null;
+  }
+
+  return {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_server_configuration",
+    name: askUserQuestionView.name ?? "ask_user_question",
+    description:
+      askUserQuestionView.description ??
+      "Ask the user a question with multiple-choice options.",
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    secretName: null,
+    dustProject: null,
+    additionalConfiguration: {},
+    mcpServerViewId: askUserQuestionView.sId,
+    dustAppConfiguration: null,
+    internalMCPServerId: askUserQuestionView.mcpServerId,
+  };
+}

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -72,6 +72,22 @@ describe("getJITServers", () => {
       expect(commonUtilitiesServer?.mcpServerViewId).toBeDefined();
     });
 
+    it("should always return the ask_user_question MCP server", async () => {
+      const { servers: jitServers } = await getJITServers(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+        attachments: [],
+      });
+
+      const askUserQuestionServer = jitServers.find(
+        (server) => server.name === "ask_user_question"
+      );
+
+      expect(askUserQuestionServer).toBeDefined();
+      expect(askUserQuestionServer?.type).toBe("mcp_server_configuration");
+      expect(askUserQuestionServer?.mcpServerViewId).toBeDefined();
+    });
+
     it("should include conversation_files server when attachments exist", async () => {
       const user = auth.getNonNullableUser();
       const file = await FileFactory.csv(auth, user, {

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -1,6 +1,7 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import { getAskUserQuestionServer } from "@app/lib/api/assistant/jit/ask_user_question";
 import { getCommonUtilitiesServer } from "@app/lib/api/assistant/jit/common_utilities";
 import {
   getConversationFilesServer,
@@ -20,6 +21,7 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 import { removeNulls } from "@app/types/shared/utils/general";
 
 const ALWAYS_PREFETCHED_MCP_SERVERS: AutoInternalMCPServerNameType[] = [
+  "ask_user_question",
   "common_utilities",
   "files",
   "schedules_management",
@@ -68,6 +70,13 @@ async function getUnconditionalJITServers(
     autoInternalViews
   );
   servers.push(filesServer);
+
+  const askUserQuestionServer = getAskUserQuestionServer(
+    agentConfiguration,
+    conversation,
+    autoInternalViews
+  );
+  servers.push(askUserQuestionServer);
 
   return removeNulls(servers);
 }


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9284.

This PR adds `ask_user_question` unconditionally to all agents.

Marks the internal MCP server as `auto_hidden_builder` to hide it from agent builder.

## Tests

- Added tests, tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
