### PR TITLE
Add pod sandbox readiness lifecycle

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -97,7 +97,7 @@ vi.mock("@app/lib/api/sandbox/instrumentation", () => ({
 }));
 
 vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
-  ensureSandboxReady: mockEnsureSandboxReady,
+  ensureConversationSandboxReady: mockEnsureSandboxReady,
 }));
 
 vi.mock("@app/lib/resources/workspace_sandbox_env_var_resource", () => ({

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -40,7 +40,7 @@ import {
   wrapCommandWithCapture,
 } from "@app/lib/api/sandbox/image/profile";
 import { recordToolDuration } from "@app/lib/api/sandbox/instrumentation";
-import { ensureSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { ensureConversationSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import type { ExecResult } from "@app/lib/api/sandbox/provider";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -320,7 +320,7 @@ export async function runSandboxBashTool(
     : null;
   const isResumeMode = resumeExecId !== null;
 
-  const ensureResult = await ensureSandboxReady(auth, conversation);
+  const ensureResult = await ensureConversationSandboxReady(auth, conversation);
   if (ensureResult.isErr()) {
     return new Err(new MCPError(ensureResult.error.message));
   }
@@ -500,7 +500,7 @@ export async function addEgressDomainTool(
     return new Err(new MCPError("No conversation context available."));
   }
 
-  const ensureResult = await ensureSandboxReady(auth, conversation);
+  const ensureResult = await ensureConversationSandboxReady(auth, conversation);
   if (ensureResult.isErr()) {
     return new Err(new MCPError(ensureResult.error.message));
   }

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -199,6 +199,9 @@ describe("DustFileSystem.forPod", () => {
     expect(mounts[0].kind).toBe("pod");
     expect(mounts[0].id).toBe(projectSpace.sId);
     expect(mounts[0].scopedPrefix).toBe(`pod-${projectSpace.sId}`);
+    expect(mounts[0].sandboxMountPoint).toBe(`/files/pod-${projectSpace.sId}`);
+    expect(mounts[0].legacyPrefix).toBeNull();
+    expect(mounts[0].legacySandboxMountPoint).toBeNull();
     expect(mounts[0].permissions.canRead).toBe(true);
   });
 });

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -104,15 +104,16 @@ function createConversationMount(
 
 function createPodMount(
   auth: Authenticator,
-  space: SpaceResource
+  space: SpaceResource,
+  { includeLegacy }: { includeLegacy: boolean }
 ): FileSystemMount {
   return {
     kind: "pod",
     id: space.sId,
     scopedPrefix: `${SCOPED_PREFIX_POD}${space.sId}`,
     sandboxMountPoint: `/files/${SCOPED_PREFIX_POD}${space.sId}`,
-    legacyPrefix: LEGACY_PREFIX_PROJECT,
-    legacySandboxMountPoint: `/files/pod`,
+    legacyPrefix: includeLegacy ? LEGACY_PREFIX_PROJECT : null,
+    legacySandboxMountPoint: includeLegacy ? `/files/pod` : null,
     permissions: {
       canRead: space.canRead(auth),
       canWrite: space.canWrite(auth),
@@ -223,7 +224,7 @@ export class DustFileSystem {
       for (const spaceId of uniqueSpaceIds) {
         const space = spaceById.get(spaceId);
         if (space) {
-          mounts.push(createPodMount(auth, space));
+          mounts.push(createPodMount(auth, space, { includeLegacy: true }));
         }
       }
     }
@@ -267,7 +268,7 @@ export class DustFileSystem {
     }
 
     const owner = auth.getNonNullableWorkspace();
-    const mount = createPodMount(auth, space);
+    const mount = createPodMount(auth, space, { includeLegacy: false });
 
     const backend = new GCSFileSystemBackend(
       owner.sId,
@@ -353,7 +354,7 @@ export class DustFileSystem {
           );
         }
 
-        mounts.push(createPodMount(auth, space));
+        mounts.push(createPodMount(auth, space, { includeLegacy: false }));
       }
     }
 

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -129,6 +129,10 @@ describe("sandbox egress helpers", () => {
   const auth = {
     getNonNullableWorkspace: () => ({ sId: "workspace-id" }),
   } as never;
+  const runtimeOwner = {
+    kind: "conversation" as const,
+    conversationId: "conversation-id",
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -145,11 +149,14 @@ describe("sandbox egress helpers", () => {
   });
 
   function setup(sandbox: unknown) {
-    return setupEgressForwarder(auth, sandbox as never);
+    return setupEgressForwarder(auth, sandbox as never, { runtimeOwner });
   }
 
   function ensure(sandbox: unknown, opts: { wokeFromSleep: boolean }) {
-    return ensureSandboxEgressOnExec(auth, sandbox as never, opts);
+    return ensureSandboxEgressOnExec(auth, sandbox as never, {
+      ...opts,
+      runtimeOwner,
+    });
   }
 
   it("mints a proxy JWT bound to the provider sandbox id", () => {
@@ -213,7 +220,11 @@ describe("sandbox egress helpers", () => {
     );
     expect(tokenCall).toContain("/etc/dust/egress-token");
     expect(mockWriteEgressSecretsFile).toHaveBeenCalledWith(auth, sandbox);
-    expect(mockWriteSandboxEnvManifestFile).toHaveBeenCalledWith(auth, sandbox);
+    expect(mockWriteSandboxEnvManifestFile).toHaveBeenCalledWith(
+      auth,
+      sandbox,
+      runtimeOwner
+    );
     const spawnCall = getRootCommandCall(sandbox.execRoot, 1);
     expect(spawnCall).toContain("--proxy-addr 203.0.113.10:4443");
     expect(spawnCall).toContain("--proxy-tls-name eu.sandbox-egress.dust.tt");
@@ -500,7 +511,11 @@ describe("sandbox egress helpers", () => {
 
     expect(result).toEqual(new Ok(undefined));
     expect(mockWriteEgressSecretsFile).toHaveBeenCalledWith(auth, sandbox);
-    expect(mockWriteSandboxEnvManifestFile).toHaveBeenCalledWith(auth, sandbox);
+    expect(mockWriteSandboxEnvManifestFile).toHaveBeenCalledWith(
+      auth,
+      sandbox,
+      runtimeOwner
+    );
     expect(getRootCommandCall(sandbox.execRoot, 1)).toContain("dsbx forward");
     expect(getRootCommandCall(sandbox.execRoot, 2)).toContain(
       "/opt/bin/dsbx forward"

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -9,6 +9,7 @@ import {
 import { writeSandboxEnvManifestFile } from "@app/lib/api/sandbox/env_manifest";
 import { SANDBOX_AGENT_PROXIED_UID } from "@app/lib/api/sandbox/image/types";
 import { traceSandboxStartupPhase } from "@app/lib/api/sandbox/instrumentation";
+import type { SandboxRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import {
   type RootCommand,
   renderRootCommand,
@@ -312,12 +313,13 @@ export async function checkEgressForwarderHealth(
 // the network policy chosen in getSandboxImage().
 export async function prepareSandboxEgressBeforeMount(
   auth: Authenticator,
-  sandbox: SandboxResource
+  sandbox: SandboxResource,
+  { runtimeOwner }: { runtimeOwner: SandboxRuntimeOwner }
 ): Promise<Result<void, Error>> {
   if (config.getSandboxDevUnrestrictedEgress()) {
     return teardownInSandboxEgressRedirect(auth, sandbox);
   }
-  return setupEgressForwarder(auth, sandbox);
+  return setupEgressForwarder(auth, sandbox, { runtimeOwner });
 }
 
 // Egress check that runs after GCS mounts on every exec: in prod, verifies
@@ -327,7 +329,10 @@ export async function prepareSandboxEgressBeforeMount(
 export async function ensureSandboxEgressOnExec(
   auth: Authenticator,
   sandbox: SandboxResource,
-  { wokeFromSleep }: { wokeFromSleep: boolean }
+  {
+    runtimeOwner,
+    wokeFromSleep,
+  }: { runtimeOwner: SandboxRuntimeOwner; wokeFromSleep: boolean }
 ): Promise<Result<void, Error>> {
   if (config.getSandboxDevUnrestrictedEgress()) {
     if (wokeFromSleep) {
@@ -345,7 +350,10 @@ export async function ensureSandboxEgressOnExec(
       },
       "Sandbox woke from sleep, re-running full egress setup"
     );
-    return setupEgressForwarder(auth, sandbox, { restartExisting: true });
+    return setupEgressForwarder(auth, sandbox, {
+      restartExisting: true,
+      runtimeOwner,
+    });
   }
 
   const healthResult = await checkEgressForwarderHealth(auth, sandbox);
@@ -364,7 +372,10 @@ export async function ensureSandboxEgressOnExec(
       { ...baseLogContext, event: "egress.health_fail" },
       "Sandbox egress forwarder port not listening, restarting"
     );
-    return setupEgressForwarder(auth, sandbox, { restartExisting: true });
+    return setupEgressForwarder(auth, sandbox, {
+      restartExisting: true,
+      runtimeOwner,
+    });
   }
 
   if (!resolverOk || !nftablesOk) {
@@ -472,7 +483,10 @@ async function writeEgressTokenFile(
 export async function setupEgressForwarder(
   auth: Authenticator,
   sandbox: SandboxResource,
-  { restartExisting = false }: { restartExisting?: boolean } = {}
+  {
+    restartExisting = false,
+    runtimeOwner,
+  }: { restartExisting?: boolean; runtimeOwner: SandboxRuntimeOwner }
 ): Promise<Result<void, Error>> {
   const logContext = {
     event: "egress.setup",
@@ -526,7 +540,7 @@ export async function setupEgressForwarder(
 
   const manifestWriteResult = await traceSandboxStartupPhase(
     "egress.write_manifest",
-    () => writeSandboxEnvManifestFile(auth, sandbox)
+    () => writeSandboxEnvManifestFile(auth, sandbox, runtimeOwner)
   );
   if (manifestWriteResult.isErr()) {
     return manifestWriteResult;

--- a/front/lib/api/sandbox/env_manifest.test.ts
+++ b/front/lib/api/sandbox/env_manifest.test.ts
@@ -14,6 +14,12 @@ import {
 } from "./env_manifest";
 
 describe("sandbox environment manifest", () => {
+  const conversationOwner = {
+    kind: "conversation" as const,
+    conversationId: "conversation-id",
+  };
+  const podOwner = { kind: "pod" as const, spaceId: "space-id" };
+
   it("builds a deterministic manifest without any value field", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
 
@@ -63,7 +69,10 @@ describe("sandbox environment manifest", () => {
       throw apiSecretResult.error;
     }
 
-    const manifestResult = await buildSandboxEnvManifest(authenticator);
+    const manifestResult = await buildSandboxEnvManifest(
+      authenticator,
+      conversationOwner
+    );
 
     expect(manifestResult.isOk()).toBe(true);
     if (manifestResult.isErr()) {
@@ -109,6 +118,31 @@ describe("sandbox environment manifest", () => {
     expect(json).not.toContain("slack-secret");
   });
 
+  it("uses SPACE_ID instead of CONVERSATION_ID for pod sandbox manifests", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const manifestResult = await buildSandboxEnvManifest(
+      authenticator,
+      podOwner
+    );
+
+    expect(manifestResult.isOk()).toBe(true);
+    if (manifestResult.isErr()) {
+      throw manifestResult.error;
+    }
+
+    expect(manifestResult.value.system).toEqual([
+      {
+        name: "SPACE_ID",
+        description: "current pod space sId",
+      },
+      {
+        name: "WORKSPACE_ID",
+        description: "current workspace sId",
+      },
+    ]);
+  });
+
   it("rejects an HTTPS secret missing a placeholder nonce", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
 
@@ -140,7 +174,10 @@ describe("sandbox environment manifest", () => {
       "listForWorkspace"
     ).mockResolvedValueOnce([secretResult.value]);
 
-    const manifestResult = await buildSandboxEnvManifest(authenticator);
+    const manifestResult = await buildSandboxEnvManifest(
+      authenticator,
+      conversationOwner
+    );
 
     expect(manifestResult.isErr()).toBe(true);
     if (manifestResult.isErr()) {
@@ -174,7 +211,8 @@ describe("sandbox environment manifest", () => {
 
     const result = await writeSandboxEnvManifestFile(
       authenticator,
-      sandbox as never
+      sandbox as never,
+      conversationOwner
     );
 
     expect(result).toEqual(new Ok(undefined));

--- a/front/lib/api/sandbox/env_manifest.ts
+++ b/front/lib/api/sandbox/env_manifest.ts
@@ -1,6 +1,10 @@
 import { randomBytes } from "node:crypto";
 
 import { renderEgressSecretPlaceholder } from "@app/lib/api/sandbox/env_vars";
+import {
+  getSandboxOwnerEnvManifestEntries,
+  type SandboxRuntimeOwner,
+} from "@app/lib/api/sandbox/owner";
 import { rootCommand } from "@app/lib/api/sandbox/root_command";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -31,7 +35,8 @@ function sortByName<T extends { name: string }>(entries: T[]): T[] {
 }
 
 export async function buildSandboxEnvManifest(
-  auth: Authenticator
+  auth: Authenticator,
+  owner: SandboxRuntimeOwner
 ): Promise<Result<SandboxEnvManifest, Error>> {
   const allVars = await WorkspaceSandboxEnvVarResource.listForWorkspace(auth);
 
@@ -65,10 +70,7 @@ export async function buildSandboxEnvManifest(
   return new Ok({
     version: 1,
     system: sortByName([
-      {
-        name: "CONVERSATION_ID",
-        description: "current conversation sId",
-      },
+      ...getSandboxOwnerEnvManifestEntries(owner),
       {
         name: "WORKSPACE_ID",
         description: "current workspace sId",
@@ -85,9 +87,10 @@ export async function buildSandboxEnvManifest(
 
 export async function writeSandboxEnvManifestFile(
   auth: Authenticator,
-  sandbox: SandboxResource
+  sandbox: SandboxResource,
+  owner: SandboxRuntimeOwner
 ): Promise<Result<void, Error>> {
-  const manifestResult = await buildSandboxEnvManifest(auth);
+  const manifestResult = await buildSandboxEnvManifest(auth, owner);
   if (manifestResult.isErr()) {
     return manifestResult;
   }

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.37",
+      tag: "0.8.38",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.37";
+const DUST_BASE_IMAGE_VERSION = "0.8.38";
 const DSBX_CLI_VERSION = "0.1.26";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that

--- a/front/lib/api/sandbox/image/telemetry/enrich.lua
+++ b/front/lib/api/sandbox/image/telemetry/enrich.lua
@@ -47,6 +47,7 @@ function enrich_message(tag, timestamp, record)
 
     record["sandbox_id"] = os.getenv("E2B_SANDBOX_ID")
     record["conversation_id"] = os.getenv("CONVERSATION_ID")
+    record["space_id"] = os.getenv("SPACE_ID")
     record["workspace_id"] = os.getenv("WORKSPACE_ID")
 
     record["uid"] = record["_UID"]

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -27,7 +27,7 @@ function buildTags(ctx: MetricContext): string[] {
 // Naming: coarse phases are snake_case (`provider_ensure`, `gcs_mount`);
 // sub-steps are `<area>.step` (`gcs.gcsfuse_mount`) so they group by prefix.
 export type SandboxStartupPhase =
-  // Coarse phases (one per ensureSandboxReady step).
+  // Coarse phases (one per sandbox readiness step).
   | "total"
   | "provider_ensure"
   | "egress_prep"
@@ -76,13 +76,13 @@ export function traceSandboxStartupPhase<T>(
 }
 
 // The single net-new aggregate metric: the headline "0 -> first command" wall
-// time for one ensureSandboxReady, split cold (fresh create path) vs warm
+// time for one sandbox readiness run, split cold (fresh create path) vs warm
 // (wake/reuse). This is NOT covered by sandbox.tools.duration, whose timer
 // starts only once setup is already done and times the user command alone.
 //
 // Intentionally NOT tagged by workspace_id: the cold/warm split per region is
 // what matters for latency, and workspace_id would multiply cardinality on a
-// per-ensureSandboxReady distribution. Per-workspace drill-down stays available
+// per-readiness-run distribution. Per-workspace drill-down stays available
 // via APM traces.
 export function recordSandboxStartupTotal(
   durationMs: number,

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockEnsureSandboxActive,
+  mockEnsurePodSandboxActive,
   mockEnsureSandboxEgressOnExec,
   mockGetSandboxImage,
   mockLoggerError,
@@ -10,6 +11,7 @@ const {
   mockLoggerWarn,
   mockLoggerChild,
   mockForConversation,
+  mockForPod,
   mockSetupSandboxMount,
   mockRefreshSandboxMount,
   mockPrepareSandboxEgressBeforeMount,
@@ -19,6 +21,7 @@ const {
   const mockRefreshSandboxMount = vi.fn();
   return {
     mockEnsureSandboxActive: vi.fn(),
+    mockEnsurePodSandboxActive: vi.fn(),
     mockEnsureSandboxEgressOnExec: vi.fn(),
     mockGetSandboxImage: vi.fn(),
     mockLoggerError: vi.fn(),
@@ -26,6 +29,7 @@ const {
     mockLoggerWarn: vi.fn(),
     mockLoggerChild: vi.fn(),
     mockForConversation: vi.fn(),
+    mockForPod: vi.fn(),
     mockSetupSandboxMount,
     mockRefreshSandboxMount,
     mockPrepareSandboxEgressBeforeMount: vi.fn(),
@@ -41,6 +45,7 @@ vi.mock("@app/lib/api/sandbox/egress", () => ({
 vi.mock("@app/lib/api/file_system/dust_file_system", () => ({
   DustFileSystem: {
     forConversation: mockForConversation,
+    forPod: mockForPod,
   },
 }));
 
@@ -58,6 +63,12 @@ vi.mock("@app/lib/resources/conversation_sandbox_adapter", () => ({
   },
 }));
 
+vi.mock("@app/lib/resources/pod_sandbox_adapter", () => ({
+  PodSandboxAdapter: {
+    ensureSandboxActive: mockEnsurePodSandboxActive,
+  },
+}));
+
 vi.mock("@app/logger/logger", () => {
   const logger = {
     error: mockLoggerError,
@@ -69,7 +80,10 @@ vi.mock("@app/logger/logger", () => {
   return { default: logger };
 });
 
-import { ensureSandboxReady } from "./lifecycle";
+import {
+  ensureConversationSandboxReady,
+  ensurePodSandboxReady,
+} from "./lifecycle";
 
 function createDeferred<T>() {
   let resolvePromise: ((value: T | PromiseLike<T>) => void) | undefined;
@@ -84,9 +98,18 @@ function createDeferred<T>() {
   return { promise, resolve: resolvePromise };
 }
 
-describe("ensureSandboxReady", () => {
+describe("ensureConversationSandboxReady", () => {
   const auth = { getNonNullableWorkspace: () => ({ sId: "workspace-id" }) };
   const conversation = { sId: "conversation-id" };
+  const conversationOwner = {
+    kind: "conversation",
+    conversationId: conversation.sId,
+  };
+  const pod = { sId: "space-id" };
+  const podOwner = {
+    kind: "pod",
+    spaceId: pod.sId,
+  };
   const image = { name: "dust-base" };
   const sandbox = { providerId: "provider-id", sId: "sandbox-id" };
   const mockFs = {
@@ -100,11 +123,15 @@ describe("ensureSandboxReady", () => {
     mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: false, sandbox, wokeFromSleep: false })
     );
+    mockEnsurePodSandboxActive.mockResolvedValue(
+      new Ok({ freshlyCreated: false, sandbox, wokeFromSleep: false })
+    );
     mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Ok(undefined));
     mockEnsureSandboxEgressOnExec.mockResolvedValue(new Ok(undefined));
     mockGetSandboxImage.mockReturnValue(new Ok(image));
     mockStartTelemetry.mockResolvedValue(new Ok(undefined));
     mockForConversation.mockResolvedValue(new Ok(mockFs));
+    mockForPod.mockResolvedValue(new Ok(mockFs));
     mockSetupSandboxMount.mockResolvedValue(new Ok(undefined));
     mockRefreshSandboxMount.mockResolvedValue(new Ok(undefined));
   });
@@ -114,7 +141,7 @@ describe("ensureSandboxReady", () => {
       new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
     );
 
-    const result = await ensureSandboxReady(
+    const result = await ensureConversationSandboxReady(
       auth as never,
       conversation as never
     );
@@ -123,12 +150,19 @@ describe("ensureSandboxReady", () => {
     expect(mockPrepareSandboxEgressBeforeMount).toHaveBeenCalledTimes(1);
     expect(mockPrepareSandboxEgressBeforeMount).toHaveBeenCalledWith(
       auth,
-      sandbox
+      sandbox,
+      { runtimeOwner: conversationOwner }
+    );
+    expect(mockStartTelemetry).toHaveBeenCalledWith(
+      auth,
+      sandbox,
+      conversationOwner
     );
     expect(mockForConversation).toHaveBeenCalledWith(auth, conversation);
     expect(mockSetupSandboxMount).toHaveBeenCalledWith(sandbox, image);
     expect(mockRefreshSandboxMount).not.toHaveBeenCalled();
     expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
+      runtimeOwner: conversationOwner,
       wokeFromSleep: false,
     });
 
@@ -148,7 +182,7 @@ describe("ensureSandboxReady", () => {
       return prepResult.promise;
     });
 
-    const resultPromise = ensureSandboxReady(
+    const resultPromise = ensureConversationSandboxReady(
       auth as never,
       conversation as never
     );
@@ -173,7 +207,7 @@ describe("ensureSandboxReady", () => {
       new Ok({ freshlyCreated: false, sandbox, wokeFromSleep: true })
     );
 
-    const result = await ensureSandboxReady(
+    const result = await ensureConversationSandboxReady(
       auth as never,
       conversation as never
     );
@@ -184,12 +218,13 @@ describe("ensureSandboxReady", () => {
     expect(mockForConversation).toHaveBeenCalledWith(auth, conversation);
     expect(mockRefreshSandboxMount).toHaveBeenCalledWith(sandbox, image);
     expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
+      runtimeOwner: conversationOwner,
       wokeFromSleep: true,
     });
   });
 
   it("refreshes the GCS token for already-running sandboxes", async () => {
-    const result = await ensureSandboxReady(
+    const result = await ensureConversationSandboxReady(
       auth as never,
       conversation as never
     );
@@ -204,11 +239,36 @@ describe("ensureSandboxReady", () => {
     );
   });
 
+  it("uses pod owner plumbing and pod filesystem mounts for pod sandboxes", async () => {
+    mockEnsurePodSandboxActive.mockResolvedValue(
+      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+    );
+
+    const result = await ensurePodSandboxReady(auth as never, pod as never);
+
+    expect(result.isOk()).toBe(true);
+    expect(mockEnsurePodSandboxActive).toHaveBeenCalledWith(auth, pod);
+    expect(mockEnsureSandboxActive).not.toHaveBeenCalled();
+    expect(mockForPod).toHaveBeenCalledWith(auth, pod);
+    expect(mockForConversation).not.toHaveBeenCalled();
+    expect(mockPrepareSandboxEgressBeforeMount).toHaveBeenCalledWith(
+      auth,
+      sandbox,
+      { runtimeOwner: podOwner }
+    );
+    expect(mockStartTelemetry).toHaveBeenCalledWith(auth, sandbox, podOwner);
+    expect(mockSetupSandboxMount).toHaveBeenCalledWith(sandbox, image);
+    expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
+      runtimeOwner: podOwner,
+      wokeFromSleep: false,
+    });
+  });
+
   it("short-circuits when the sandbox image lookup fails", async () => {
     const imageError = new Error("image unavailable");
     mockGetSandboxImage.mockReturnValue(new Err(imageError));
 
-    const result = await ensureSandboxReady(
+    const result = await ensureConversationSandboxReady(
       auth as never,
       conversation as never
     );
@@ -229,7 +289,7 @@ describe("ensureSandboxReady", () => {
       new Err(new Error("ensure failed"))
     );
 
-    const result = await ensureSandboxReady(
+    const result = await ensureConversationSandboxReady(
       auth as never,
       conversation as never
     );
@@ -246,7 +306,7 @@ describe("ensureSandboxReady", () => {
     );
     mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Err(setupError));
 
-    const result = await ensureSandboxReady(
+    const result = await ensureConversationSandboxReady(
       auth as never,
       conversation as never
     );
@@ -267,7 +327,7 @@ describe("ensureSandboxReady", () => {
     mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Err(setupError));
     mockSetupSandboxMount.mockResolvedValue(new Err(new Error("mount failed")));
 
-    const result = await ensureSandboxReady(
+    const result = await ensureConversationSandboxReady(
       auth as never,
       conversation as never
     );
@@ -286,7 +346,7 @@ describe("ensureSandboxReady", () => {
     );
     mockSetupSandboxMount.mockResolvedValue(new Err(new Error("mount failed")));
 
-    const result = await ensureSandboxReady(
+    const result = await ensureConversationSandboxReady(
       auth as never,
       conversation as never
     );
@@ -303,7 +363,7 @@ describe("ensureSandboxReady", () => {
       new Err(new Error("space not found"))
     );
 
-    const result = await ensureSandboxReady(
+    const result = await ensureConversationSandboxReady(
       auth as never,
       conversation as never
     );
@@ -318,7 +378,7 @@ describe("ensureSandboxReady", () => {
       new Err(new Error("refresh failed"))
     );
 
-    const result = await ensureSandboxReady(
+    const result = await ensureConversationSandboxReady(
       auth as never,
       conversation as never
     );
@@ -332,7 +392,7 @@ describe("ensureSandboxReady", () => {
       new Err(new Error("ensure-egress failed"))
     );
 
-    const result = await ensureSandboxReady(
+    const result = await ensureConversationSandboxReady(
       auth as never,
       conversation as never
     );

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -8,10 +8,16 @@ import {
   recordSandboxStartupTotal,
   traceSandboxStartupPhase,
 } from "@app/lib/api/sandbox/instrumentation";
+import type { SandboxRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
-import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
+import type {
+  EnsureSandboxResult,
+  SandboxResource,
+} from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Ok, type Result } from "@app/types/shared/result";
@@ -21,12 +27,18 @@ export interface EnsureSandboxReadyResult {
   freshlyCreated: boolean;
 }
 
-// /!\ All sandbox-touching tools must use this helper rather than calling
-// ConversationSandboxAdapter.ensureSandboxActive directly, otherwise the GCS FUSE mount and
-// egress forwarder bring-up will be skipped.
-export async function ensureSandboxReady(
+type SandboxReadyConfig = {
+  ensureActive: () => Promise<Result<EnsureSandboxResult, Error>>;
+  getFileSystem: () => Promise<Result<DustFileSystem, Error>>;
+  runtimeOwner: SandboxRuntimeOwner;
+};
+
+// /!\ All sandbox-touching tools must use the owner-specific ready helper rather than calling
+// the owner adapter directly, otherwise the GCS FUSE mount and egress forwarder bring-up will be
+// skipped.
+async function ensureOwnerSandboxReady(
   auth: Authenticator,
-  conversation: ConversationType
+  { ensureActive, getFileSystem, runtimeOwner }: SandboxReadyConfig
 ): Promise<Result<EnsureSandboxReadyResult, Error>> {
   const startMs = performance.now();
   // cold is unknown until ensureActive returns; if it errors first (rare) we
@@ -38,7 +50,7 @@ export async function ensureSandboxReady(
     return await traceSandboxStartupPhase("total", async () => {
       const ensureResult = await traceSandboxStartupPhase(
         "provider_ensure",
-        () => ConversationSandboxAdapter.ensureSandboxActive(auth, conversation)
+        ensureActive
       );
       if (ensureResult.isErr()) {
         status = "error";
@@ -60,7 +72,7 @@ export async function ensureSandboxReady(
       }
       const image = imageResult.value;
 
-      void startTelemetry(auth, sandbox, conversation).catch((err) =>
+      void startTelemetry(auth, sandbox, runtimeOwner).catch((err) =>
         logger.error({ err }, "Telemetry start failed (fire-and-forget)")
       );
 
@@ -79,13 +91,10 @@ export async function ensureSandboxReady(
         // errors still taking precedence.
         const [prepResult, mountResult] = await Promise.all([
           traceSandboxStartupPhase("egress_prep", () =>
-            prepareSandboxEgressBeforeMount(auth, sandbox)
+            prepareSandboxEgressBeforeMount(auth, sandbox, { runtimeOwner })
           ),
           traceSandboxStartupPhase("gcs_mount", async () => {
-            const fsResult = await DustFileSystem.forConversation(
-              auth,
-              conversation
-            );
+            const fsResult = await getFileSystem();
             if (fsResult.isErr()) {
               return fsResult;
             }
@@ -104,10 +113,7 @@ export async function ensureSandboxReady(
         const refreshResult = await traceSandboxStartupPhase(
           "gcs_refresh",
           async () => {
-            const fsResult = await DustFileSystem.forConversation(
-              auth,
-              conversation
-            );
+            const fsResult = await getFileSystem();
             if (fsResult.isErr()) {
               return fsResult;
             }
@@ -122,7 +128,11 @@ export async function ensureSandboxReady(
 
       const ensureEgressResult = await traceSandboxStartupPhase(
         "egress_on_exec",
-        () => ensureSandboxEgressOnExec(auth, sandbox, { wokeFromSleep })
+        () =>
+          ensureSandboxEgressOnExec(auth, sandbox, {
+            runtimeOwner,
+            wokeFromSleep,
+          })
       );
       if (ensureEgressResult.isErr()) {
         status = "error";
@@ -134,4 +144,33 @@ export async function ensureSandboxReady(
   } finally {
     recordSandboxStartupTotal(performance.now() - startMs, { cold }, status);
   }
+}
+
+export async function ensureConversationSandboxReady(
+  auth: Authenticator,
+  conversation: ConversationType
+): Promise<Result<EnsureSandboxReadyResult, Error>> {
+  return ensureOwnerSandboxReady(auth, {
+    ensureActive: () =>
+      ConversationSandboxAdapter.ensureSandboxActive(auth, conversation),
+    getFileSystem: () => DustFileSystem.forConversation(auth, conversation),
+    runtimeOwner: {
+      kind: "conversation",
+      conversationId: conversation.sId,
+    },
+  });
+}
+
+export async function ensurePodSandboxReady(
+  auth: Authenticator,
+  pod: SpaceResource
+): Promise<Result<EnsureSandboxReadyResult, Error>> {
+  return ensureOwnerSandboxReady(auth, {
+    ensureActive: () => PodSandboxAdapter.ensureSandboxActive(auth, pod),
+    getFileSystem: () => DustFileSystem.forPod(auth, pod),
+    runtimeOwner: {
+      kind: "pod",
+      spaceId: pod.sId,
+    },
+  });
 }

--- a/front/lib/api/sandbox/owner.ts
+++ b/front/lib/api/sandbox/owner.ts
@@ -1,0 +1,60 @@
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export type SandboxRuntimeOwner =
+  | { kind: "conversation"; conversationId: string }
+  | { kind: "pod"; spaceId: string };
+
+export function getSandboxOwnerEnvVars(
+  owner: SandboxRuntimeOwner
+): Record<string, string> {
+  switch (owner.kind) {
+    case "conversation":
+      return { CONVERSATION_ID: owner.conversationId };
+
+    case "pod":
+      return { SPACE_ID: owner.spaceId };
+
+    default:
+      assertNever(owner);
+  }
+}
+
+export function getSandboxOwnerLogContext(
+  owner: SandboxRuntimeOwner
+): Record<string, string> {
+  switch (owner.kind) {
+    case "conversation":
+      return { conversationId: owner.conversationId };
+
+    case "pod":
+      return { spaceId: owner.spaceId };
+
+    default:
+      assertNever(owner);
+  }
+}
+
+export function getSandboxOwnerEnvManifestEntries(
+  owner: SandboxRuntimeOwner
+): { name: string; description: string }[] {
+  switch (owner.kind) {
+    case "conversation":
+      return [
+        {
+          name: "CONVERSATION_ID",
+          description: "current conversation sId",
+        },
+      ];
+
+    case "pod":
+      return [
+        {
+          name: "SPACE_ID",
+          description: "current pod space sId",
+        },
+      ];
+
+    default:
+      assertNever(owner);
+  }
+}

--- a/front/lib/api/sandbox/telemetry/index.ts
+++ b/front/lib/api/sandbox/telemetry/index.ts
@@ -1,10 +1,14 @@
 import config from "@app/lib/api/config";
 import { traceSandboxStartupPhase } from "@app/lib/api/sandbox/instrumentation";
+import {
+  getSandboxOwnerEnvVars,
+  getSandboxOwnerLogContext,
+  type SandboxRuntimeOwner,
+} from "@app/lib/api/sandbox/owner";
 import { rootCommand } from "@app/lib/api/sandbox/root_command";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
-import type { ConversationType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 
@@ -20,14 +24,18 @@ import { Ok } from "@app/types/shared/result";
 export async function startTelemetry(
   auth: Authenticator,
   sandbox: SandboxResource,
-  conversation: ConversationType
+  owner: SandboxRuntimeOwner
 ): Promise<Result<void, Error>> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
+  const ownerEnvVars = getSandboxOwnerEnvVars(owner);
+  const ownerSystemdEnv = Object.keys(ownerEnvVars)
+    .map((name) => `${name}="$${name}"`)
+    .join(" ");
 
   const childLogger = logger.child({
     sandboxId: sandbox.sId,
     workspaceId,
-    conversationId: conversation.sId,
+    ...getSandboxOwnerLogContext(owner),
   });
 
   // /!\ DD_API_KEY must never appear literally in the command string;
@@ -36,7 +44,7 @@ export async function startTelemetry(
     sandbox.execRoot(
       auth,
       rootCommand.unsafeShell(
-        `/usr/bin/systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" CONVERSATION_ID="$CONVERSATION_ID" WORKSPACE_ID="$WORKSPACE_ID" && /usr/bin/systemctl start fluent-bit`,
+        `/usr/bin/systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" ${ownerSystemdEnv} WORKSPACE_ID="$WORKSPACE_ID" && /usr/bin/systemctl start fluent-bit`,
         "systemctl environment command expands sandbox env vars without embedding secrets in the TypeScript command string"
       ),
       {
@@ -44,7 +52,7 @@ export async function startTelemetry(
           DD_HOST: "http-intake.logs.datadoghq.eu",
           DD_API_KEY: config.getDatadogApiKey() ?? "",
           E2B_SANDBOX_ID: sandbox.providerId,
-          CONVERSATION_ID: conversation.sId,
+          ...ownerEnvVars,
           WORKSPACE_ID: workspaceId,
         },
       }


### PR DESCRIPTION
## Description

Follow up of [#28048](https://github.com/dust-tt/dust/pull/28048). This adds the pod sandbox readiness path without wiring product call sites yet.

- Adds `ensurePodSandboxReady`, backed by `PodSandboxAdapter` and `DustFileSystem.forPod`.
- Threads sandbox owner context into telemetry, Fluent Bit enrichment, and the egress env manifest so pods expose `SPACE_ID`, not `CONVERSATION_ID`.
- Keeps conversation-created pod mounts backward compatible, while pod-only filesystem setup does not request the legacy `/files/pod` sandbox alias.
- Updates existing conversation sandbox tool callers to use `ensureConversationSandboxReady` explicitly.

Next PR: wire pod sandbox callers to this lifecycle helper.

## Tests

- `NODE_ENV=test npm test -- lib/api/sandbox/lifecycle.test.ts lib/api/sandbox/egress.test.ts lib/api/sandbox/env_manifest.test.ts lib/api/file_system/dust_file_system.test.ts lib/api/actions/servers/sandbox/tools/index.test.ts lib/api/sandbox/image/registry.test.ts`
- `NODE_OPTIONS="--max-old-space-size=8192" npx tsgo --noEmit`

## Risk

Low. There are no pod sandbox call sites yet; existing conversation callers still use the same readiness path through `ensureConversationSandboxReady`. Worst case, pod-only readiness is unused until the next PR. Safe to rollback.

## Deploy Plan

- [ ] Standard deploy.
- [ ] After deploy, open `/poke/kill` (Kill Switches) and request a kill of older `dust-base` sandbox image versions so live sandboxes pick up `0.8.38`.