### PR TITLE
Support sandbox function invocation tokens

### DIFF
--- a/front-api/middlewares/sandbox_auth.ts
+++ b/front-api/middlewares/sandbox_auth.ts
@@ -1,4 +1,7 @@
-import { verifySandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
+import {
+  isSandboxExecTokenPayload,
+  verifySandboxExecToken,
+} from "@app/lib/api/sandbox/access_tokens";
 import {
   Authenticator,
   getAuthTokenKind,
@@ -67,6 +70,15 @@ export const sandboxAuth = createMiddleware<SandboxCtx>(async (ctx, next) => {
       api_error: {
         type: "invalid_sandbox_token_error",
         message: "The sandbox token is invalid or expired.",
+      },
+    });
+  }
+  if (!isSandboxExecTokenPayload(claims)) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "This sandbox token cannot access sandbox actions.",
       },
     });
   }

--- a/front/lib/api/sandbox/access_tokens.test.ts
+++ b/front/lib/api/sandbox/access_tokens.test.ts
@@ -1,5 +1,8 @@
 import {
   generateSandboxExecToken,
+  generateSandboxFunctionInvocationToken,
+  isSandboxExecTokenPayload,
+  isSandboxFunctionInvocationTokenPayload,
   SANDBOX_TOKEN_PREFIX,
   verifySandboxExecToken,
 } from "@app/lib/api/sandbox/access_tokens";
@@ -83,7 +86,16 @@ async function setupTest() {
     displayLabels: null,
   };
 
-  return { auth, agentConfig, agentMessage, conversation, sandbox, mockAction };
+  return {
+    auth,
+    agentConfig,
+    agentMessage,
+    conversation,
+    mockAction,
+    sandbox,
+    user,
+    workspace,
+  };
 }
 
 describe("sandbox access tokens", () => {
@@ -111,12 +123,48 @@ describe("sandbox access tokens", () => {
     const payload = await verifySandboxExecToken(token);
 
     expect(payload).not.toBeNull();
+    if (!payload || !isSandboxExecTokenPayload(payload)) {
+      return;
+    }
     expect(payload!.wId).toBe(auth.getNonNullableWorkspace().sId);
     expect(payload!.cId).toBe(conversation.sId);
     expect(payload!.uId).toBe(auth.getNonNullableUser().sId);
     expect(payload!.aId).toBe(agentConfig.sId);
     expect(payload!.mId).toBe(agentMessage.sId);
     expect(payload!.sbId).toBe(sandbox.sId);
+  });
+
+  it("round-trip: generate function invocation token → verify → check claims", async () => {
+    const { auth, sandbox } = await setupTest();
+    const pod = await SpaceFactory.project(auth.getNonNullableWorkspace());
+
+    const token = await generateSandboxFunctionInvocationToken(auth, {
+      sandbox,
+      sandboxFunction: {
+        sId: "sfn_test",
+        space: { sId: pod.sId },
+      },
+      conversationId: "conv_test",
+      invocationId: "test-invocation-id",
+      execId: "test-exec-id",
+    });
+
+    expect(token.startsWith(SANDBOX_TOKEN_PREFIX)).toBe(true);
+
+    const payload = await verifySandboxExecToken(token);
+
+    expect(payload).not.toBeNull();
+    if (!payload || !isSandboxFunctionInvocationTokenPayload(payload)) {
+      return;
+    }
+    expect(payload.wId).toBe(auth.getNonNullableWorkspace().sId);
+    expect(payload.cId).toBe("conv_test");
+    expect(payload.uId).toBe(auth.getNonNullableUser().sId);
+    expect(payload.sbId).toBe(sandbox.sId);
+    expect(payload.execId).toBe("test-exec-id");
+    expect(payload.spaceId).toBe(pod.sId);
+    expect(payload.sandboxFunctionId).toBe("sfn_test");
+    expect(payload.invocationId).toBe("test-invocation-id");
   });
 
   it("tampered token is rejected", async () => {

--- a/front/lib/api/sandbox/access_tokens.ts
+++ b/front/lib/api/sandbox/access_tokens.ts
@@ -16,22 +16,91 @@ import { z } from "zod";
 
 export const SANDBOX_TOKEN_PREFIX = "sbt-";
 
-const SandboxExecTokenPayloadSchema = z.object({
-  wId: z.string(),
-  cId: z.string(),
-  // Optional: omitted when the conversation is driven by a non-human actor
-  // (e.g. a Slack bot user with no associated Dust user).
-  uId: z.string().optional(),
-  aId: z.string(),
-  mId: z.string(),
-  sbId: z.string(),
-  execId: z.string(),
-  actionId: z.string(),
-});
+function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}
 
-export type SandboxExecTokenPayload = z.infer<
-  typeof SandboxExecTokenPayloadSchema
->;
+const SandboxTokenPayloadSchema = z
+  .object({
+    wId: z.string(),
+    uId: z.string().optional(),
+    sbId: z.string(),
+    execId: z.string(),
+    cId: z.string().optional(),
+    aId: z.string().optional(),
+    mId: z.string().optional(),
+    actionId: z.string().optional(),
+    spaceId: z.string().optional(),
+    sandboxFunctionId: z.string().optional(),
+    invocationId: z.string().optional(),
+  })
+  .superRefine((payload, ctx) => {
+    const actionClaims = [payload.aId, payload.mId, payload.actionId];
+    const invocationClaims = [
+      payload.spaceId,
+      payload.sandboxFunctionId,
+      payload.invocationId,
+    ];
+    const hasAction =
+      payload.cId !== undefined && actionClaims.every(isDefined);
+    const hasInvocation = invocationClaims.every(isDefined);
+
+    if (actionClaims.some(isDefined) && !hasAction) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Incomplete sandbox action token claims.",
+      });
+    }
+    if (invocationClaims.some(isDefined) && !hasInvocation) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Incomplete sandbox function invocation token claims.",
+      });
+    }
+    if (!hasAction && !hasInvocation) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Sandbox token payload must include action or function invocation claims.",
+      });
+    }
+  });
+
+export type SandboxTokenPayload = z.infer<typeof SandboxTokenPayloadSchema>;
+
+export type SandboxExecTokenPayload = SandboxTokenPayload & {
+  cId: string;
+  aId: string;
+  mId: string;
+  actionId: string;
+};
+
+export type SandboxFunctionInvocationTokenPayload = SandboxTokenPayload & {
+  spaceId: string;
+  sandboxFunctionId: string;
+  invocationId: string;
+};
+
+export function isSandboxExecTokenPayload(
+  payload: SandboxTokenPayload
+): payload is SandboxExecTokenPayload {
+  return (
+    payload.cId !== undefined &&
+    payload.aId !== undefined &&
+    payload.mId !== undefined &&
+    payload.actionId !== undefined
+  );
+}
+
+export function isSandboxFunctionInvocationTokenPayload(
+  payload: SandboxTokenPayload
+): payload is SandboxFunctionInvocationTokenPayload {
+  return (
+    payload.spaceId !== undefined &&
+    payload.sandboxFunctionId !== undefined &&
+    payload.invocationId !== undefined
+  );
+}
 
 const EXEC_TOKEN_REDIS_TTL_SECONDS = 24 * 60 * 60; // 24 hours
 
@@ -50,7 +119,7 @@ export function generateExecId(): string {
 }
 
 async function registerExecToken(
-  token: Pick<SandboxExecTokenPayload, "sbId" | "execId">
+  token: Pick<SandboxTokenPayload, "sbId" | "execId">
 ): Promise<void> {
   await runOnRedis({ origin: REDIS_ORIGIN }, (client) =>
     client.set(sandboxTokenRedisKey(token.sbId, token.execId), "1", {
@@ -60,7 +129,7 @@ async function registerExecToken(
 }
 
 export async function revokeExecToken(
-  token: Pick<SandboxExecTokenPayload, "sbId" | "execId">
+  token: Pick<SandboxTokenPayload, "sbId" | "execId">
 ): Promise<void> {
   await runOnRedis({ origin: REDIS_ORIGIN }, (client) =>
     client.del(sandboxTokenRedisKey(token.sbId, token.execId))
@@ -68,7 +137,7 @@ export async function revokeExecToken(
 }
 
 async function isExecTokenValid(
-  token: Pick<SandboxExecTokenPayload, "sbId" | "execId">
+  token: Pick<SandboxTokenPayload, "sbId" | "execId">
 ): Promise<boolean> {
   return runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
     const result = await client.exists(
@@ -137,12 +206,53 @@ export async function generateSandboxExecToken(
   return `${SANDBOX_TOKEN_PREFIX}${token}`;
 }
 
+export async function generateSandboxFunctionInvocationToken(
+  auth: Authenticator,
+  {
+    conversationId,
+    sandbox,
+    sandboxFunction,
+    invocationId,
+    execId,
+    expiryMs = 2 * 60 * 1000, // Default to 2 minutes
+  }: {
+    conversationId?: string;
+    sandbox: SandboxResource;
+    sandboxFunction: { sId: string; space: { sId: string } };
+    invocationId: string;
+    execId: string;
+    expiryMs?: number;
+  }
+): Promise<string> {
+  const payload: SandboxFunctionInvocationTokenPayload = {
+    wId: auth.getNonNullableWorkspace().sId,
+    uId: auth.user()?.sId,
+    cId: conversationId,
+    sbId: sandbox.sId,
+    execId,
+    spaceId: sandboxFunction.space.sId,
+    sandboxFunctionId: sandboxFunction.sId,
+    invocationId,
+  };
+
+  await registerExecToken(payload);
+
+  const secret = config.getSandboxJwtSecret();
+
+  const token = jwt.sign(payload, secret, {
+    algorithm: "HS256",
+    expiresIn: expiryMs / 1000, // expiresIn is in seconds
+  });
+
+  return `${SANDBOX_TOKEN_PREFIX}${token}`;
+}
+
 /**
  * Verify a sandbox exec token and check Redis-backed revocation.
  */
 export async function verifySandboxExecToken(
   token: string
-): Promise<SandboxExecTokenPayload | null> {
+): Promise<SandboxTokenPayload | null> {
   if (!token.startsWith(SANDBOX_TOKEN_PREFIX)) {
     return null;
   }
@@ -161,7 +271,7 @@ export async function verifySandboxExecToken(
     return null;
   }
 
-  const parseResult = SandboxExecTokenPayloadSchema.safeParse(rawPayload);
+  const parseResult = SandboxTokenPayloadSchema.safeParse(rawPayload);
   if (!parseResult.success) {
     logger.error(
       { error: parseResult.error.flatten() },

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1,7 +1,14 @@
 import config from "@app/lib/api/config";
 import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
-import type { SandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
-import { SANDBOX_TOKEN_PREFIX } from "@app/lib/api/sandbox/access_tokens";
+import type {
+  SandboxFunctionInvocationTokenPayload,
+  SandboxTokenPayload,
+} from "@app/lib/api/sandbox/access_tokens";
+import {
+  isSandboxExecTokenPayload,
+  isSandboxFunctionInvocationTokenPayload,
+  SANDBOX_TOKEN_PREFIX,
+} from "@app/lib/api/sandbox/access_tokens";
 import type { WorkOSJwtPayload } from "@app/lib/api/workos";
 import { getUserFromWorkOSToken, verifyWorkOSToken } from "@app/lib/api/workos";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -19,7 +26,10 @@ import {
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
-import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
+import {
+  getResourceIdFromSId,
+  isResourceSId,
+} from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -485,7 +495,7 @@ export class Authenticator {
   }
 
   static async fromSandboxToken(
-    claims: SandboxExecTokenPayload,
+    claims: SandboxTokenPayload,
     wId: string
   ): Promise<Result<Authenticator, APIErrorWithContentfulStatusCode>> {
     if (claims.wId !== wId) {
@@ -572,13 +582,40 @@ export class Authenticator {
       subscription = activeSubscription;
     }
 
-    // Restrict groups to the conversation's spaces so the sandbox auth can only
-    // access resources visible to the conversation, not everything the user can.
-    const groupModelIds = await this.restrictGroupsToConversationSpaces(
-      baseGroupModelIds,
-      claims.cId,
-      workspace.id
-    );
+    // Restrict groups to the sandbox owner's spaces so sandbox auth can only
+    // access resources visible to the workload, not everything the user can.
+    const groupModelIdSets: ModelId[][] = [];
+    if (isSandboxExecTokenPayload(claims)) {
+      groupModelIdSets.push(
+        await this.restrictGroupsToConversationSpaces(
+          baseGroupModelIds,
+          claims.cId,
+          workspace.id
+        )
+      );
+    }
+    if (isSandboxFunctionInvocationTokenPayload(claims)) {
+      const groupModelIdsRes =
+        await this.restrictGroupsToSandboxFunctionInvocationSpaces(
+          baseGroupModelIds,
+          claims,
+          workspace.id
+        );
+      if (groupModelIdsRes.isErr()) {
+        return new Err(groupModelIdsRes.error);
+      }
+      groupModelIdSets.push(groupModelIdsRes.value);
+    }
+    if (groupModelIdSets.length === 0) {
+      return new Err({
+        status_code: 401,
+        api_error: {
+          type: "invalid_sandbox_token_error",
+          message: "Unsupported sandbox token payload.",
+        },
+      });
+    }
+    const groupModelIds = [...new Set(groupModelIdSets.flat())];
 
     const providersHealth = await this.fetchByokProvidersHealth(
       workspace,
@@ -598,6 +635,25 @@ export class Authenticator {
     );
   }
 
+  private static async fetchRequestedSpaceIdsForSandboxTokenAuth({
+    conversationId,
+    workspaceId,
+  }: {
+    conversationId: string;
+    workspaceId: ModelId;
+  }): Promise<ModelId[] | null> {
+    // Keep this direct lookup local to Authenticator for now. Sandbox-token
+    // auth is being constructed here, and importing ConversationResource would
+    // currently create an auth <-> conversation_resource runtime cycle because
+    // ConversationResource imports auth helpers such as hasFeatureFlag.
+    const conversation = await ConversationModel.findOne({
+      where: { sId: conversationId, workspaceId },
+      attributes: ["requestedSpaceIds"],
+    });
+
+    return conversation?.requestedSpaceIds ?? null;
+  }
+
   /**
    * Given a user's full group IDs, restricts them to only the groups associated
    * with the conversation's requested spaces. Falls back to the full set if the
@@ -608,18 +664,19 @@ export class Authenticator {
     conversationId: string,
     workspaceId: ModelId
   ): Promise<ModelId[]> {
-    const conversation = await ConversationModel.findOne({
-      where: { sId: conversationId, workspaceId: workspaceId },
-      attributes: ["requestedSpaceIds"],
-    });
+    const requestedSpaceIds =
+      await this.fetchRequestedSpaceIdsForSandboxTokenAuth({
+        workspaceId,
+        conversationId,
+      });
 
-    if (!conversation || conversation.requestedSpaceIds.length === 0) {
+    if (requestedSpaceIds === null || requestedSpaceIds.length === 0) {
       return userGroupIds;
     }
 
     const spaceGroups = await GroupSpaceModel.findAll({
       where: {
-        vaultId: conversation.requestedSpaceIds,
+        vaultId: requestedSpaceIds,
         workspaceId: workspaceId,
       },
       attributes: ["groupId"],
@@ -630,6 +687,70 @@ export class Authenticator {
     );
 
     return userGroupIds.filter((id) => allowedGroupIds.has(id));
+  }
+
+  private static async restrictGroupsToSandboxFunctionInvocationSpaces(
+    userGroupIds: ModelId[],
+    claims: SandboxFunctionInvocationTokenPayload,
+    workspaceId: ModelId
+  ): Promise<Result<ModelId[], APIErrorWithContentfulStatusCode>> {
+    if (!isResourceSId("space", claims.spaceId)) {
+      return new Err({
+        status_code: 401,
+        api_error: {
+          type: "invalid_sandbox_token_error",
+          message: "The sandbox token pod space is invalid.",
+        },
+      });
+    }
+
+    const podSpaceModelId = getResourceIdFromSId(claims.spaceId);
+    if (podSpaceModelId === null) {
+      return new Err({
+        status_code: 401,
+        api_error: {
+          type: "invalid_sandbox_token_error",
+          message: "The sandbox token pod space is invalid.",
+        },
+      });
+    }
+
+    const allowedSpaceIds = new Set<ModelId>([podSpaceModelId]);
+    if (claims.cId) {
+      const requestedSpaceIds =
+        await this.fetchRequestedSpaceIdsForSandboxTokenAuth({
+          workspaceId,
+          conversationId: claims.cId,
+        });
+
+      if (requestedSpaceIds === null) {
+        return new Err({
+          status_code: 401,
+          api_error: {
+            type: "invalid_sandbox_token_error",
+            message: "The sandbox token conversation is invalid.",
+          },
+        });
+      }
+
+      for (const spaceId of requestedSpaceIds) {
+        allowedSpaceIds.add(spaceId);
+      }
+    }
+
+    const spaceGroups = await GroupSpaceModel.findAll({
+      where: {
+        vaultId: [...allowedSpaceIds],
+        workspaceId,
+      },
+      attributes: ["groupId"],
+    });
+
+    const allowedGroupIds = new Set(
+      spaceGroups.map((sg) => Number(sg.groupId) as ModelId)
+    );
+
+    return new Ok(userGroupIds.filter((id) => allowedGroupIds.has(id)));
   }
 
   /**


### PR DESCRIPTION
## Description

Follow up of #28117 and prep for sandbox function invocation.

Adds the token/auth plumbing needed by pod sandbox function invocations:
- Sandbox tokens now support function invocation claims under the existing `sbt-` prefix, with a required invocation ID claim and optional conversation claim.
- Sandbox-token auth scopes function invocation tokens to the pod space, plus conversation spaces when a conversation claim is present.
- Existing sandbox action callback middleware continues to accept only complete conversation action token claims.

No endpoint behavior changes in this PR. The actual invoke path is stacked separately in #28123.

## Tests

Tested locally:
- `npx biome check` on touched files
- `front`: `lib/api/sandbox/access_tokens.test.ts`
- `front-api`: `routes/v1/w/[wId]/sandbox/actions/index.test.ts`
- `front` and `front-api`: `tsgo --noEmit`

## Risk

Existing conversation action tokens keep the same payload shape. Function invocation tokens are duck-typed from complete invocation claims instead of a discriminator, and the action callback middleware rejects tokens that do not include complete conversation action claims. Safe to rollback.

## Deploy Plan

Standard deploy. No migration or manual step.