### PR TITLE
feat(usage): add groups filter to the members usage table

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -36,6 +36,7 @@ import {
   useMyUsage,
   useSeatPlan,
 } from "@app/lib/swr/credits";
+import { useGroups } from "@app/lib/swr/groups";
 import {
   useMembersUsage,
   useUpdateMemberSeatType,
@@ -160,6 +161,7 @@ export function UsagePage() {
   const [seatTypeFilter, setSeatTypeFilter] = useState<
     MembershipSeatType | "none" | null
   >(null);
+  const [groupFilter, setGroupFilter] = useState<string | null>(null);
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
@@ -184,6 +186,11 @@ export function UsagePage() {
     },
     []
   );
+
+  const handleSetGroupFilter = useCallback((next: string | null) => {
+    setGroupFilter(next);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  }, []);
 
   // Name/email search is also applied server-side before pagination, so reset
   // to the first page whenever the search term changes.
@@ -451,7 +458,16 @@ export function UsagePage() {
       orderColumn: membersOrderColumn,
       orderDirection: membersOrderDirection,
       seatType: seatTypeFilter ?? undefined,
+      groupId: groupFilter ?? undefined,
     });
+
+  const { groups } = useGroups({
+    owner,
+    kinds: ["regular", "provisioned"],
+    disabled: !isWorkspaceAdmin || !pricingGroupsEnabled,
+  });
+  const selectedGroupName =
+    groups.find((g) => g.sId === groupFilter)?.name ?? null;
 
   const { hasAvailableSeats } = useWorkspaceSeatAvailability({
     workspaceId: owner.sId,
@@ -588,6 +604,32 @@ export function UsagePage() {
               />
             }
             onClick={() => handleSetSeatTypeFilter(seatType)}
+          />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  const groupsFilterDropdown = pricingGroupsEnabled && groups.length > 0 && (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          label={selectedGroupName ?? "Groups"}
+          size="sm"
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          label="All groups"
+          onClick={() => handleSetGroupFilter(null)}
+        />
+        {groups.map((group) => (
+          <DropdownMenuItem
+            key={group.sId}
+            label={group.name}
+            onClick={() => handleSetGroupFilter(group.sId)}
           />
         ))}
       </DropdownMenuContent>
@@ -759,7 +801,12 @@ export function UsagePage() {
                         }
                       />
                     </ButtonsSwitchList>
-                    {membersTab === "members" && seatFilterDropdown}
+                    {membersTab === "members" && (
+                      <div className="flex flex-row items-center gap-2">
+                        {groupsFilterDropdown}
+                        {seatFilterDropdown}
+                      </div>
+                    )}
                   </div>
                   <div className="pt-2">
                     {membersTab === "members" ? (

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -174,6 +174,9 @@ export const MembersUsagePaginationSchema = z.object({
   // Optional seat-type filter. A base seat type (e.g. "pro") matches its
   // monthly and yearly variants; "none" matches members with no seat.
   seatType: z.enum(MEMBERSHIP_SEAT_TYPES).optional().catch(undefined),
+  // Optional group filter (group sId). Restricts the table to the active
+  // members of that group. Combined with `seatType` as an intersection.
+  groupId: z.string().optional().catch(undefined),
 });
 
 export type MembersUsagePaginationInput = z.infer<
@@ -1003,6 +1006,24 @@ async function resolveSeatTypeFilterUserIds({
   );
 }
 
+// Resolve the active member user sIds of a group (by sId). Handed to
+// Elasticsearch as an allowlist, like the seat-type filter. An unknown or
+// unreadable group resolves to an empty set (empty page).
+async function resolveGroupFilterUserIds({
+  auth,
+  groupId,
+}: {
+  auth: Authenticator;
+  groupId: string;
+}): Promise<string[]> {
+  const groupRes = await GroupResource.fetchById(auth, groupId);
+  if (groupRes.isErr()) {
+    return [];
+  }
+  const members = await groupRes.value.getActiveMembers(auth);
+  return members.map((u) => u.sId);
+}
+
 // "name"/"email" live in the user search index, which owns sort + pagination
 // for those columns. "consumedAwuCredits" is not indexed, so to sort by it we
 // fetch the full matching set with Elasticsearch `search_after`, rank it by
@@ -1108,15 +1129,35 @@ export async function getMembersUsage({
   const { metronomeCustomerId } = workspace;
   const metronomeContractId = subscription?.metronomeContractId ?? null;
 
-  // When a seat-type filter is active, resolve the matching user sIds up front
-  // and restrict the search to them so pagination and the returned `total`
-  // reflect the filtered set. No match means an empty page.
-  let restrictToUserIds: string[] | undefined;
+  // When a seat-type and/or group filter is active, resolve the matching user
+  // sIds up front and restrict the search to their intersection, so pagination
+  // and the returned `total` reflect the filtered set. No match (in any active
+  // filter) means an empty page.
+  const restrictionSets: string[][] = [];
   if (paginationParams.seatType) {
-    restrictToUserIds = await resolveSeatTypeFilterUserIds({
-      workspace,
-      seatType: paginationParams.seatType,
-    });
+    restrictionSets.push(
+      await resolveSeatTypeFilterUserIds({
+        workspace,
+        seatType: paginationParams.seatType,
+      })
+    );
+  }
+  if (paginationParams.groupId) {
+    restrictionSets.push(
+      await resolveGroupFilterUserIds({
+        auth,
+        groupId: paginationParams.groupId,
+      })
+    );
+  }
+
+  let restrictToUserIds: string[] | undefined;
+  if (restrictionSets.length > 0) {
+    const [firstSet, ...otherSets] = restrictionSets;
+    restrictToUserIds = otherSets.reduce((acc, set) => {
+      const allowed = new Set(set);
+      return acc.filter((sId) => allowed.has(sId));
+    }, firstSet);
     if (restrictToUserIds.length === 0) {
       return { members: [], total: 0 };
     }

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -240,6 +240,7 @@ export function useMembersUsage({
   orderColumn,
   orderDirection,
   seatType,
+  groupId,
   disabled,
 }: {
   workspaceId: string;
@@ -249,6 +250,7 @@ export function useMembersUsage({
   orderColumn?: "name" | "email" | "consumedAwuCredits";
   orderDirection?: "asc" | "desc";
   seatType?: MembershipSeatType | "none";
+  groupId?: string;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -275,6 +277,9 @@ export function useMembersUsage({
   }
   if (seatType) {
     searchParams.set("seatType", seatType);
+  }
+  if (groupId) {
+    searchParams.set("groupId", groupId);
   }
 
   const { data, error } = useSWRWithDefaults(


### PR DESCRIPTION
## Description

Add an optional groupId query param to the members-usage endpoint that restricts the table to a group's active members, intersected with the existing seat-type filter. Surface it as a "All groups" dropdown next to "All seats" (hidden when the workspace has no org groups).

Feature flagged under pricing_groups.

<img width="1139" height="418" alt="Screenshot 2026-06-29 at 13 26 31" src="https://github.com/user-attachments/assets/0ac97042-d7dc-4514-ad76-291b3609074f" />

## Tests

Local

## Risk

Low, feature flagged

## Deploy Plan

Front