### PR TITLE
fix(llm): route non-BYOK Gemini through Vertex via api-level filter

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -34,12 +34,14 @@ import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { getStreamEndpoints } from "@app/lib/llms/stream";
 import type {
   EndpointConfig,
+  LogicalFilters,
   ValueFilter,
   Where,
   WorkspaceConfig,
 } from "@app/lib/llms/types/filter";
 import { sortEndpointsByPreferredRegion } from "@app/lib/llms/utils/sort_endpoints";
 import { isModelId } from "@app/lib/model_constructors/types/model_ids";
+import { GOOGLE_AI_STUDIO_API } from "@app/lib/model_constructors/types/provider_apis";
 import {
   isProviderId,
   type ProviderId,
@@ -305,12 +307,21 @@ function getProviderIdFilter(auth: Authenticator): ValueFilter<ProviderId> {
   const byok = auth.getNonNullablePlan().isByok;
   const providerIds = byok
     ? intersection(whitelistedProviderIds, BYOK_MODEL_PROVIDER_IDS)
-    : whitelistedProviderIds.filter(
-        // We route all non-byok gemini requests to agent platform
-        (providerId) => providerId !== "google_ai_studio"
-      );
+    : whitelistedProviderIds;
 
   return { in: providerIds };
+}
+
+// Non-BYOK routes Gemini through the agent platform (Vertex), never the direct
+// AI-Studio API with Dust's managed key. Excluded by `api` rather than provider
+// id because the Vertex endpoints share the `google_ai_studio` provider id.
+function getDirectAiStudioExclusion(
+  auth: Authenticator
+): Pick<LogicalFilters<EndpointConfig>, "not"> | undefined {
+  if (auth.getNonNullablePlan().isByok) {
+    return undefined;
+  }
+  return { not: { api: { eq: GOOGLE_AI_STUDIO_API } } };
 }
 
 // Temporary helper while we have both systems
@@ -318,6 +329,7 @@ export function getWorkspaceFilter(auth: Authenticator): Where<EndpointConfig> {
   return {
     providerId: getProviderIdFilter(auth),
     region: getRegionFilter(auth),
+    ...getDirectAiStudioExclusion(auth),
   };
 }
 

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -119,7 +119,7 @@ export type LLMParameterOverwrites = Partial<
 export type LLMClientMetadata = {
   clientId: ModelProviderIdType;
   // Holds the inference provider for legacy clients (e.g. "google_vertex_ai")
-  // and the new router's `providerApi` value (e.g. "agent-platform").
+  // and the new router's `api` value (e.g. "agent-platform").
   inferenceProvider: string;
   inferenceRegion: InferenceRegionType;
   region?: Region;

--- a/front/lib/llms/types/filter.ts
+++ b/front/lib/llms/types/filter.ts
@@ -14,7 +14,7 @@ export type EndpointConfig = {
   region: Region;
   providerId: ProviderId;
   modelId: ModelId;
-  providerApi: ProviderApi;
+  api: ProviderApi;
 };
 
 export type ArrayValueFilter<T> = {

--- a/front/lib/llms/utils/matches_where.test.ts
+++ b/front/lib/llms/utils/matches_where.test.ts
@@ -221,7 +221,7 @@ describe("matchesWhere", () => {
       region: ["eu", "global"],
       providerId: ["anthropic"],
       modelId: ["claude-sonnet-4-6"],
-      providerApi: ["anthropic", "agent-platform"],
+      api: ["anthropic", "agent-platform"],
     };
 
     it("matches provider and region membership", () => {
@@ -240,14 +240,14 @@ describe("matchesWhere", () => {
       expect(
         matchesWhere(description, {
           providerId: { contains: "anthropic" },
-          providerApi: { containsAll: ["anthropic", "agent-platform"] },
+          api: { containsAll: ["anthropic", "agent-platform"] },
           region: { containsAny: ["eu"] },
         })
       ).toBe(true);
       expect(
         matchesWhere(description, {
           providerId: { contains: "anthropic" },
-          providerApi: { contains: "openai-responses" },
+          api: { contains: "openai-responses" },
         })
       ).toBe(false);
     });
@@ -346,6 +346,27 @@ describe("matchesWhere", () => {
           or: [{ featureFlags: { contains: "anthropic_vertex_fallback" } }],
         })
       ).toBe(false);
+    });
+
+    it("excludes the direct AI-Studio endpoint via a sibling `not` (non-BYOK Gemini routing)", () => {
+      // The shape `getWorkspaceFilter` produces for non-BYOK Gemini: a top-level
+      // `not` on `api` must AND with the field filters so Vertex stays reachable
+      // while the direct AI-Studio endpoint (same providerId) is excluded.
+      const where: Where<EndpointConfig> = {
+        providerId: { eq: "google_ai_studio" },
+        region: { eq: "global" },
+        not: { api: { eq: "google-ai-studio" } },
+      };
+      const vertexEndpoint = {
+        providerId: "google_ai_studio",
+        api: "agent-platform",
+        modelId: "gemini-3.1-pro",
+        region: "global",
+      };
+      const directEndpoint = { ...vertexEndpoint, api: "google-ai-studio" };
+
+      expect(matchesWhere(vertexEndpoint, where)).toBe(true);
+      expect(matchesWhere(directEndpoint, where)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Description

Non-BYOK workspaces couldn't reach the agent-platform (Vertex) Gemini endpoints in the new router. `getProviderIdFilter` stripped `google_ai_studio` entirely, which also excluded the Vertex endpoints (they share that provider id), so non-BYOK fell back to legacy.

- Keep `google_ai_studio` in the provider filter for non-BYOK.
- Exclude only the direct AI-Studio API (`api = google-ai-studio`) for non-BYOK, so Vertex stays reachable but Dust's managed AI-Studio key isn't used.
- Rename `EndpointConfig.providerApi` → `api` to match the endpoint's static field (api-level filtering was a no-op before).

### Legacy equivalent

In the legacy router this is the `useVertex: !plan.isByok` line in the Google branch of `getLegacyLLM` (`front/lib/api/llm/index.ts`): non-BYOK → Vertex (GCP project creds, not the direct AI-Studio key), BYOK → direct AI Studio. The same model maps to two new-router endpoints sharing `providerId: "google_ai_studio"` — one `api: "vertex"`, one `api: "google-ai-studio"`. Legacy picks between them with the `useVertex` flag; the new router picks via endpoint filtering. This change makes the `api`-level exclusion the direct analog of `!plan.isByok`.

## Tests

`router_parity.test.ts` unaffected. `getWorkspaceFilter` isn't unit-tested yet — verified manually against the endpoint configs.

## Risk

Low. The change widens routing for non-BYOK to the Vertex Gemini endpoints; the direct AI-Studio key stays excluded. Rollback is reverting the filter change — non-BYOK falls back to legacy as before.

## Deploy Plan

Standard deploy, no ordering constraints.