### PR TITLE
fix(llm): align new-router Gemini/Anthropic requests with legacy

### DIFF
--- a/front/lib/api/llm/tests/parity/allowlist.ts
+++ b/front/lib/api/llm/tests/parity/allowlist.ts
@@ -1,4 +1,5 @@
 import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
+import { isRecord } from "@app/types/shared/utils/general";
 
 /**
  * Known-intentional differences between the legacy router and the new
@@ -39,13 +40,93 @@ function clone(request: unknown): Record<string, unknown> {
   return isObjectLike(cleaned) && !Array.isArray(cleaned) ? cleaned : {};
 }
 
+function stripCacheControlTtl(value: unknown): void {
+  if (Array.isArray(value)) {
+    value.forEach(stripCacheControlTtl);
+    return;
+  }
+  if (isObjectLike(value) && isRecord(value)) {
+    const cacheControl = value.cache_control;
+    if (isObjectLike(cacheControl) && isRecord(cacheControl)) {
+      delete cacheControl.ttl;
+    }
+    for (const v of Object.values(value)) {
+      stripCacheControlTtl(v);
+    }
+  }
+}
+
+function stripMessageCacheControl(messages: unknown): void {
+  if (!Array.isArray(messages)) {
+    return;
+  }
+  for (const message of messages) {
+    if (
+      isObjectLike(message) &&
+      isRecord(message) &&
+      Array.isArray(message.content)
+    ) {
+      for (const block of message.content) {
+        if (isObjectLike(block) && isRecord(block)) {
+          delete block.cache_control;
+        }
+      }
+    }
+  }
+}
+
+function toolResultBlockToString(messages: unknown): void {
+  if (!Array.isArray(messages)) {
+    return;
+  }
+  for (const message of messages) {
+    if (
+      !isObjectLike(message) ||
+      !isRecord(message) ||
+      !Array.isArray(message.content)
+    ) {
+      continue;
+    }
+    for (const block of message.content) {
+      if (
+        isObjectLike(block) &&
+        isRecord(block) &&
+        block.type === "tool_result" &&
+        Array.isArray(block.content) &&
+        block.content.every(
+          (b) => isObjectLike(b) && isRecord(b) && b.type === "text"
+        )
+      ) {
+        block.content = block.content
+          .map((b) => (isObjectLike(b) && isRecord(b) ? b.text : ""))
+          .join("");
+      }
+    }
+  }
+}
+
 const anthropicNormalizer: Normalizer = (request) => {
   const r = clone(request);
 
-  // Server-side fallback is a legacy-only beta feature; the new router does not
-  // (yet) emit `fallbacks` nor the accompanying `betas` header param.
+  // Legacy-only server-side fallback.
   delete r.betas;
   delete r.fallbacks;
+
+  // New router also caches the latest user turn; legacy caches only the system.
+  stripMessageCacheControl(r.messages);
+
+  // New router sets an explicit ttl:"5m"; legacy relies on the implicit default.
+  stripCacheControlTtl(r);
+
+  // New router sends tool_result content as a text-block array, legacy a string.
+  toolResultBlockToString(r.messages);
+
+  // Reasoning/temperature mapping differs by design (adaptive vs extended
+  // thinking, light->minimal vs disabled, temperature passthrough when thinking
+  // is off); covered by the model_constructors integration tests.
+  delete r.thinking;
+  delete r.output_config;
+  delete r.temperature;
 
   return r;
 };

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -10,12 +10,16 @@ import { z } from "zod";
 
 const DEFAULT_REASONING_EFFORT = "high";
 
-// Pro supports the low/medium/high thinking levels (no `minimal`) and strongly
-// recommends `temperature: 1`, so we coerce temperature to 1.
+// `none` maps to the minimum thinking budget (no "off" level on Gemini 3).
+const GEMINI_3_1_PRO_REASONING_EFFORTS = [
+  "none",
+  ...GEMINI_PRO_SUPPORTED_REASONING_EFFORTS,
+] as const;
+
 const configSchema = googleAiStudioConfigSchema.extend({
   reasoning: z
     .object({
-      effort: z.enum(GEMINI_PRO_SUPPORTED_REASONING_EFFORTS),
+      effort: z.enum(GEMINI_3_1_PRO_REASONING_EFFORTS),
     })
     .default({ effort: DEFAULT_REASONING_EFFORT }),
 });

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.test.ts
@@ -805,35 +805,35 @@ describe("reasoningToThinkingConfig", () => {
   it("enables adaptive thinking for 'xhigh'", () => {
     expect(reasoningToThinkingConfig({ effort: "xhigh" })).toEqual({
       output_config: { effort: "xhigh" },
-      thinking: { type: "adaptive" },
+      thinking: { type: "adaptive", display: "summarized" },
     });
   });
 
   it("enables adaptive thinking for 'low'", () => {
     expect(reasoningToThinkingConfig({ effort: "low" })).toEqual({
       output_config: { effort: "low" },
-      thinking: { type: "adaptive" },
+      thinking: { type: "adaptive", display: "summarized" },
     });
   });
 
   it("enables adaptive thinking for 'medium'", () => {
     expect(reasoningToThinkingConfig({ effort: "medium" })).toEqual({
       output_config: { effort: "medium" },
-      thinking: { type: "adaptive" },
+      thinking: { type: "adaptive", display: "summarized" },
     });
   });
 
   it("enables adaptive thinking for 'high'", () => {
     expect(reasoningToThinkingConfig({ effort: "high" })).toEqual({
       output_config: { effort: "high" },
-      thinking: { type: "adaptive" },
+      thinking: { type: "adaptive", display: "summarized" },
     });
   });
 
   it("maps 'maximal' effort to Anthropic's 'max'", () => {
     expect(reasoningToThinkingConfig({ effort: "maximal" })).toEqual({
       output_config: { effort: "max" },
-      thinking: { type: "adaptive" },
+      thinking: { type: "adaptive", display: "summarized" },
     });
   });
 });

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
@@ -1,5 +1,6 @@
 import type {
   CacheControlEphemeral,
+  ContentBlockParam,
   ImageBlockParam,
   MessageParam,
   OutputConfig,
@@ -279,11 +280,19 @@ export function assistantMessageToContentBlocks(
   }
 }
 
-export function conversationToMessages(
+function contentToBlocks(
+  content: MessageParam["content"]
+): ContentBlockParam[] {
+  return typeof content === "string"
+    ? [{ type: "text", text: content }]
+    : content;
+}
+
+export async function conversationToMessages(
   conversation: BaseConversation,
   converters: MessageBlockConverters
 ): Promise<MessageParam[]> {
-  return concurrentExecutor(
+  const messages = await concurrentExecutor(
     conversation.messages,
     async (message): Promise<MessageParam> => {
       switch (message.role) {
@@ -303,6 +312,26 @@ export function conversationToMessages(
     },
     { concurrency: MESSAGE_CONVERSION_CONCURRENCY }
   );
+
+  // Anthropic rejects consecutive same-role messages, so merge them: one
+  // logical turn arrives split into a message per content block (e.g. text +
+  // image).
+  return messages.reduce<MessageParam[]>((merged, message) => {
+    const previous = merged[merged.length - 1];
+    if (previous && previous.role === message.role) {
+      return [
+        ...merged.slice(0, -1),
+        {
+          ...previous,
+          content: [
+            ...contentToBlocks(previous.content),
+            ...contentToBlocks(message.content),
+          ],
+        },
+      ];
+    }
+    return [...merged, message];
+  }, []);
 }
 
 export function systemMessagesToSystemParam(
@@ -406,7 +435,7 @@ export const reasoningToThinkingConfig: ReasoningToThinkingConfig = (
 
   return {
     output_config: { effort: effortToAnthropicEffort(reasoning.effort) },
-    thinking: { type: "adaptive" },
+    thinking: { type: "adaptive", display: "summarized" },
   };
 };
 

--- a/front/lib/model_constructors/sdk/google_genai/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/index.ts
@@ -20,7 +20,7 @@ import type {
   Payload,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
-import type { Content, GenerateContentParameters } from "@google/genai";
+import type { Content, GenerateContentParameters, Part } from "@google/genai";
 
 type AbstractConstructor<T> = abstract new (...args: any[]) => T;
 
@@ -51,7 +51,7 @@ export function WithGoogleGenAIInputConverter<
 
     systemMessagesToSystemInstruction(
       system: SystemTextMessage[]
-    ): Content | undefined {
+    ): Part | undefined {
       return systemMessagesToSystemInstruction(system, this);
     }
 
@@ -81,12 +81,11 @@ export function WithGoogleGenAIInputConverter<
           tools:
             tools.length > 0
               ? [{ functionDeclarations: tools.map(toFunctionDeclaration) }]
-              : undefined,
+              : [],
           toolConfig: forceToolNameToToolConfig(tools, forceTool),
           thinkingConfig: reasoning
             ? effortToThinkingConfig(reasoning.effort)
             : { includeThoughts: true },
-          maxOutputTokens: this.constructor.maxOutputTokens,
           ...(outputFormat
             ? {
                 responseMimeType: "application/json",

--- a/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
@@ -282,13 +282,16 @@ export async function conversationToContents(
 export function systemMessagesToSystemInstruction(
   system: SystemTextMessage[],
   converters: ContentBlockConverters
-): Content | undefined {
+): Part | undefined {
   if (system.length === 0) {
     return undefined;
   }
+  // Single `{ text }` part, matching legacy (not a `{ role, parts }` Content).
   return {
-    role: "user",
-    parts: system.map((message) => converters.systemMessageToPart(message)),
+    text: system
+      .map((message) => converters.systemMessageToPart(message).text ?? "")
+      .filter(Boolean)
+      .join("\n"),
   };
 }
 

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
@@ -14,23 +14,23 @@ const setup: StreamSetup = {
   // `null` runs the case with its default checkers; a checker array overrides
   // them. Every case always runs.
   tests: {
-    // Pro supports low/medium/high only. `minimal`, `none`, and `maximal` are
-    // unsupported and rejected by the config schema.
+    // Pro supports none/low/medium/high; `minimal` and `maximal` are rejected.
     "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
-    "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
-    "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-none": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+    "reasoning/no-tools/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-none": null,
 
     "simple/no-tools/t-default/r-default": null,
     "simple/no-tools/t-default/r-low": null,


### PR DESCRIPTION
## Description

Brings the new router's request payloads in line with legacy, keeping the intentional Anthropic differences.

Gemini
- Match legacy `systemInstruction` shape, send `tools: []` when empty, drop the explicit `maxOutputTokens`.
- gemini-3.1-pro accepts `none` reasoning (maps to minimum thinking), like legacy.

Anthropic
- Emit `display: "summarized"` on adaptive thinking.
- Merge consecutive same-role turns (Anthropic rejects them; a text+image turn arrives split).
- Allowlist the intentional drift in the parity test: extra user-turn cache breakpoint + `ttl`, `tool_result` block-array, and the reasoning/temperature mapping (covered by the per-endpoint integration tests).

## Tests

`router_parity.test.ts` green (266/266). Updated the Anthropic converter unit tests and the gemini-3.1-pro endpoint test cases (`r-none` now accepted).

## Risk

Low. Payload shapes now match legacy; the only intentional Anthropic divergences are explicitly allowlisted and covered by per-endpoint integration tests. Rollback is reverting the converter changes.

## Deploy Plan

Standard deploy, no ordering constraints.