### PR TITLE
Invoke sandbox functions on pod sandboxes

### DIFF
--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -4,9 +4,10 @@ import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { sandboxFunctionContentType } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const inputSchema: JSONSchema = {
   type: "object",
@@ -21,6 +22,10 @@ const outputSchema: JSONSchema = {
     ok: { type: "boolean" },
   },
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 async function setupSandboxFunction({
   addCallerToSpace = true,
@@ -91,8 +96,19 @@ function postInvocation({
 }
 
 describe("POST /api/w/:wId/sandbox-functions/:functionId/invocations", () => {
-  it("creates a UUID-only invocation for a non-admin user with access to the function space", async () => {
+  it("creates an invocation through the sandbox function resource", async () => {
     const { workspace, sandboxFunction } = await setupSandboxFunction();
+    const createdAt = new Date().toISOString();
+    const invokeSpy = vi
+      .spyOn(SandboxFunctionResource.prototype, "invoke")
+      .mockResolvedValue(
+        new Ok({
+          id: "test-invocation-id",
+          functionId: sandboxFunction.sId,
+          status: "created",
+          createdAt,
+        })
+      );
 
     const response = await postInvocation({
       workspaceId: workspace.sId,
@@ -107,15 +123,16 @@ describe("POST /api/w/:wId/sandbox-functions/:functionId/invocations", () => {
     const body = await response.json();
     expect(body).toEqual({
       invocation: {
-        id: expect.stringMatching(
-          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
-        ),
+        id: "test-invocation-id",
         functionId: sandboxFunction.sId,
         status: "created",
-        createdAt: expect.any(String),
+        createdAt,
       },
     });
-    expect(Date.parse(body.invocation.createdAt)).not.toBeNaN();
+    expect(invokeSpy).toHaveBeenCalledWith(expect.anything(), {
+      input: { message: "hello" },
+      context: { frameFileId: sandboxFunction.file.sId },
+    });
   });
 
   it("returns 404 when the user cannot access the function space", async () => {
@@ -136,6 +153,14 @@ describe("POST /api/w/:wId/sandbox-functions/:functionId/invocations", () => {
 
   it("does not require the broader sandbox tools feature flag", async () => {
     const { workspace, sandboxFunction } = await setupSandboxFunction();
+    vi.spyOn(SandboxFunctionResource.prototype, "invoke").mockResolvedValue(
+      new Ok({
+        id: "test-invocation-id",
+        functionId: sandboxFunction.sId,
+        status: "created",
+        createdAt: new Date().toISOString(),
+      })
+    );
 
     const response = await postInvocation({
       workspaceId: workspace.sId,
@@ -143,6 +168,26 @@ describe("POST /api/w/:wId/sandbox-functions/:functionId/invocations", () => {
     });
 
     expect(response.status).toBe(201);
+  });
+
+  it("returns 500 when the resource invocation fails", async () => {
+    const { workspace, sandboxFunction } = await setupSandboxFunction();
+    vi.spyOn(SandboxFunctionResource.prototype, "invoke").mockResolvedValue(
+      new Err(new Error("sandbox failed"))
+    );
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionId: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      error: {
+        type: "internal_server_error",
+        message: "Sandbox function invocation failed.",
+      },
+    });
   });
 
   it("requires sandbox functions to be enabled", async () => {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type {
   PostSandboxFunctionInvocationRequestBody,
@@ -54,17 +53,24 @@ app.post(
       });
     }
 
-    // TODO(spolu): implement sandbox function invocation
-    void body;
+    const invocationResult = await sandboxFunction.invoke(auth, body);
+    if (invocationResult.isErr()) {
+      return apiError(
+        ctx,
+        {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Sandbox function invocation failed.",
+          },
+        },
+        invocationResult.error
+      );
+    }
 
     return ctx.json(
       {
-        invocation: {
-          id: randomUUID(),
-          functionId: sandboxFunction.sId,
-          status: "created",
-          createdAt: new Date().toISOString(),
-        },
+        invocation: invocationResult.value,
       },
       201
     );

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -1,6 +1,9 @@
+import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/access_tokens";
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -8,8 +11,23 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { sandboxFunctionContentType } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
+  ensurePodSandboxReady: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/sandbox/access_tokens", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/sandbox/access_tokens")>();
+
+  return {
+    ...actual,
+    generateSandboxFunctionInvocationToken: vi.fn(),
+  };
+});
 
 const inputSchema: JSONSchema = {
   type: "object",
@@ -26,6 +44,10 @@ const outputSchema: JSONSchema = {
   },
   required: ["commentId"],
 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("SandboxFunctionResource", () => {
   it("creates and fetches a sandbox function for a space", async () => {
@@ -337,6 +359,113 @@ describe("SandboxFunctionResource", () => {
         }),
       ])
     );
+  });
+
+  it("invokes the function on the pod sandbox", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const file = await FileFactory.create(authenticator, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: "comments.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+    const sandboxFunction = await SandboxFunctionResource.makeNew(
+      authenticator,
+      {
+        space,
+        file,
+        slug: "add-comment",
+        description: "Add a comment.",
+        inputSchema,
+        outputSchema,
+      }
+    );
+    const sandbox = await SandboxResource.makeNew(authenticator, {
+      providerId: "test-provider-id",
+      status: "running",
+      baseImage: "dust-base",
+      version: "0.0.0-test",
+    });
+    const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: "hello world\n",
+        stderr: "",
+      })
+    );
+    vi.mocked(ensurePodSandboxReady).mockResolvedValue(
+      new Ok({ sandbox, freshlyCreated: false })
+    );
+    vi.mocked(generateSandboxFunctionInvocationToken).mockResolvedValue(
+      "sbt-function-token"
+    );
+    const result = await sandboxFunction.invoke(authenticator, {
+      input: { message: "hello" },
+      context: { frameFileId: file.sId },
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value).toMatchObject({
+      functionId: sandboxFunction.sId,
+      status: "created",
+    });
+    expect(Date.parse(result.value.createdAt)).not.toBeNaN();
+    expect(ensurePodSandboxReady).toHaveBeenCalledWith(authenticator, space);
+    expect(generateSandboxFunctionInvocationToken).toHaveBeenCalledWith(
+      authenticator,
+      {
+        sandbox,
+        sandboxFunction,
+        invocationId: result.value.id,
+        execId: expect.any(String),
+      }
+    );
+    expect(execSpy).toHaveBeenCalledTimes(1);
+
+    const execCall = execSpy.mock.calls[0];
+    expect(execCall).toBeDefined();
+    if (!execCall) {
+      return;
+    }
+    const [, command, opts] = execCall;
+    const stagedFunctionsDir = `/tmp/dust-sandbox-functions/${result.value.id}`;
+    expect(command).toContain(
+      `cat > '${stagedFunctionsDir}/add-comment.ts' <<'DUST_SANDBOX_FUNCTION_EOF'`
+    );
+    expect(command).toContain("async fetch(_req: Request): Promise<Response>");
+    expect(command).toContain("return Response.json({ ok: true });");
+    expect(command).toContain("/opt/bin/dsbx function run 'add-comment'");
+    expect(opts?.envVars).toMatchObject({
+      DUST_FUNCTIONS_DIR: stagedFunctionsDir,
+      DUST_SANDBOX_TOKEN: "sbt-function-token",
+    });
+    expect(opts?.user).toBe("agent-proxied");
+    expect(opts?.workingDirectory).toBe("/home/agent");
+    expect(typeof opts?.stdin).toBe("string");
+    if (typeof opts?.stdin !== "string") {
+      return;
+    }
+    const inputEnvelope = JSON.parse(opts.stdin);
+    expect(inputEnvelope).toMatchObject({
+      method: "POST",
+      url: `https://dust.local/sandbox-functions/${sandboxFunction.sId}/invocations/${result.value.id}`,
+      headers: {
+        "content-type": "application/json",
+        "x-dust-frame-file-id": file.sId,
+        "x-dust-sandbox-function-id": sandboxFunction.sId,
+        "x-dust-sandbox-function-invocation-id": result.value.id,
+      },
+      body: JSON.stringify({ message: "hello" }),
+      encoding: "utf8",
+    });
   });
 
   it("deletes all sandbox functions for a space", async () => {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -1,3 +1,12 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import config from "@app/lib/api/config";
+import {
+  generateExecId,
+  generateSandboxFunctionInvocationToken,
+} from "@app/lib/api/sandbox/access_tokens";
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { shellEscape } from "@app/lib/api/sandbox/shell";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -14,13 +23,54 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type {
+  PostSandboxFunctionInvocationRequestBody,
+  SandboxFunctionInvocationType,
+} from "@app/types/api/sandbox/functions";
 import { sandboxFunctionContentType } from "@app/types/files";
+import { isDevelopment } from "@app/types/shared/env";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { Attributes, Transaction } from "sequelize";
+
+const SANDBOX_FUNCTION_WORKING_DIRECTORY = "/home/agent";
+const SANDBOX_FUNCTION_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
+const SANDBOX_FUNCTION_STAGING_ROOT = "/tmp/dust-sandbox-functions";
+const DSBX_BIN_PATH = "/opt/bin/dsbx";
+
+function dustAPIBaseUrlForSandbox(): string {
+  return isDevelopment() && config.getSandboxDevFrontHostName()
+    ? `https://${config.getSandboxDevFrontHostName()}`
+    : config.getApiBaseUrl();
+}
+
+function buildSandboxFunctionCommand({
+  stagedFunctionsDir,
+  slug,
+}: {
+  stagedFunctionsDir: string;
+  slug: string;
+}): string {
+  // dsbx resolves `function run <slug>` as `${DUST_FUNCTIONS_DIR}/<slug>.ts`.
+  const functionPath = path.posix.join(stagedFunctionsDir, `${slug}.ts`);
+
+  return [
+    "set -euo pipefail",
+    `rm -rf -- ${shellEscape(stagedFunctionsDir)}`,
+    `mkdir -p -- ${shellEscape(stagedFunctionsDir)}`,
+    `cat > ${shellEscape(functionPath)} <<'DUST_SANDBOX_FUNCTION_EOF'`,
+    "export default {",
+    "  async fetch(_req: Request): Promise<Response> {",
+    "    return Response.json({ ok: true });",
+    "  },",
+    "};",
+    "DUST_SANDBOX_FUNCTION_EOF",
+    `${DSBX_BIN_PATH} function run ${shellEscape(slug)}`,
+  ].join("\n");
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SandboxFunctionResource
@@ -240,6 +290,90 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     }
 
     return new Ok(sandboxFunctions.length);
+  }
+
+  async invoke(
+    auth: Authenticator,
+    body: PostSandboxFunctionInvocationRequestBody
+  ): Promise<Result<SandboxFunctionInvocationType, Error>> {
+    try {
+      if (!this.space.canReadOrAdministrate(auth)) {
+        return new Err(new Error("Sandbox function space is not accessible."));
+      }
+
+      const ensureResult = await ensurePodSandboxReady(auth, this.space);
+      if (ensureResult.isErr()) {
+        return ensureResult;
+      }
+
+      const invocationId = randomUUID();
+      const execId = generateExecId();
+      const token = await generateSandboxFunctionInvocationToken(auth, {
+        sandbox: ensureResult.value.sandbox,
+        sandboxFunction: this,
+        invocationId,
+        execId,
+      });
+
+      const stagedFunctionsDir = path.posix.join(
+        SANDBOX_FUNCTION_STAGING_ROOT,
+        invocationId
+      );
+      const command = buildSandboxFunctionCommand({
+        stagedFunctionsDir,
+        slug: this.slug,
+      });
+      const inputEnvelope = {
+        method: "POST",
+        url: `https://dust.local/sandbox-functions/${this.sId}/invocations/${invocationId}`,
+        headers: {
+          "content-type": "application/json",
+          "x-dust-sandbox-function-id": this.sId,
+          "x-dust-sandbox-function-invocation-id": invocationId,
+          ...(body.context?.frameFileId
+            ? { "x-dust-frame-file-id": body.context.frameFileId }
+            : {}),
+        },
+        ...(body.input === undefined
+          ? {}
+          : { body: JSON.stringify(body.input) }),
+        encoding: "utf8",
+      };
+
+      const execResult = await ensureResult.value.sandbox.exec(auth, command, {
+        workingDirectory: SANDBOX_FUNCTION_WORKING_DIRECTORY,
+        envVars: {
+          DUST_API_URL: `${dustAPIBaseUrlForSandbox()}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
+          DUST_FUNCTIONS_DIR: stagedFunctionsDir,
+          DUST_SANDBOX_TOKEN: token,
+        },
+        stdin: JSON.stringify(inputEnvelope),
+        timeoutMs: SANDBOX_FUNCTION_EXEC_TIMEOUT_MS,
+        user: "agent-proxied",
+      });
+      if (execResult.isErr()) {
+        return execResult;
+      }
+      if (execResult.value.exitCode !== 0) {
+        return new Err(
+          new Error(
+            `Sandbox function invocation failed with exit code ${execResult.value.exitCode}.`
+          )
+        );
+      }
+
+      // Keep the invocation token valid for its short TTL. The durable version
+      // of this flow will let dsbx post invocation results back to Dust with
+      // the same token, then revoke it once results are accepted.
+      return new Ok({
+        id: invocationId,
+        functionId: this.sId,
+        status: "created",
+        createdAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
   }
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {


### PR DESCRIPTION
## Description

Follow up of #28118.

Adds the first sandbox function invocation path for pod sandboxes:
- `SandboxFunctionResource.invoke` creates an ephemeral invocation id, ensures the pod sandbox is ready, writes a valid temporary `dsbx function run` stub in a per-invocation staging directory, mints a short-lived `sbt-` token with invocation claims, and runs it in the pod sandbox.
- The invocation endpoint delegates to the resource and keeps returning `status: "created"`.
- No invocation row is persisted yet. The token remains valid for its short TTL so a future durable callback can post results and revoke it after acceptance.

This intentionally does not read from the sandbox function file or a pod bundle mount yet. We will wire the mounted bundle path once that mount exists.

## Tests

Tested locally:
- `npx biome check` on touched files
- `front`: `lib/resources/sandbox_function_resource.test.ts`
- `front-api`: `routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts`
- `front` and `front-api`: `tsgo --noEmit`
- `npm -w front-api run docs` (no generated OpenAPI diff)

## Risk

Worst case, sandbox function invocation returns a 500 before any persisted state is created. Safe to rollback.

## Deploy Plan

Standard deploy. No migration or manual step.