### PR TITLE
[front] chore: standardize MCP tool description wording

### DIFF
--- a/.claude/skills/dust-mcp-server/SKILL.md
+++ b/.claude/skills/dust-mcp-server/SKILL.md
@@ -37,6 +37,8 @@ front/lib/api/actions/servers/{provider}/
 - Do not forget to add the server to `AVAILABLE_INTERNAL_MCP_SERVER_NAMES` array
 - Server IDs must be stable and unique; never change them once deployed
 - Tool stakes must be configured appropriately (`never_ask`, `low`, `medium`, `high`)
+- Tool descriptions should start with a bare infinitive/base verb like `List`, `Get`, `Search`,
+  `Create`, or `Update`
 - Always implement proper error handling with `Result` types
 - Handle OAuth token refresh automatically through the `withAuth` pattern
 
@@ -163,6 +165,9 @@ Key points:
 
 - `createToolsRecord` automatically adds the `name` property from the object key
 - tool keys become the source of truth
+- tool descriptions start with a bare infinitive/base verb such as `List`, `Get`, `Search`,
+  `Create`, `Update`, or `Retrieve`; avoid noun phrases, articles, gerunds, and third-person
+  verbs because descriptions are part of the BM25 tool-search corpus
 - `stake` values map to review/approval expectations
 
 ### 2. Create `tools/index.ts`
@@ -436,6 +441,7 @@ Validate every external response to catch API drift and unexpected payloads earl
 Before marking implementation complete:
 
 - `metadata.ts` exists and uses `createToolsRecord`
+- tool descriptions start with a bare infinitive/base verb
 - `tools/index.ts` exists and uses `ToolHandlers<typeof METADATA>`
 - `index.ts` default-exports the server factory
 - the server is in `AVAILABLE_INTERNAL_MCP_SERVER_NAMES`

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -470,6 +470,27 @@ processing the tool output, a type guard that checks the output against the sche
 can be used to identify this output type. In the code of the internal server the type inferred
 from the `zod` schema should be used to type the tool output.
 
+### [MCP3] Tool descriptions start with a bare infinitive verb
+
+Internal MCP tool descriptions must start with a bare infinitive/base verb such as `List`, `Get`,
+`Search`, `Create`, `Update`, or `Retrieve`. Avoid noun phrases, articles, gerunds, and
+third-person verbs at the start of the description. Prefer verbs and wording that match how users
+search for the tool, because these descriptions are part of the BM25 tool-search corpus.
+
+Examples:
+
+```
+// BAD
+Lists available Jira projects.
+The tool retrieves a Zendesk ticket.
+Searching Slack messages by keyword.
+
+// GOOD
+List available Jira projects.
+Retrieve a Zendesk ticket.
+Search Slack messages by keyword.
+```
+
 ## TESTING
 
 ### [TEST1] Functionally test endpoints

--- a/front/lib/api/actions/servers/agent_router/metadata.ts
+++ b/front/lib/api/actions/servers/agent_router/metadata.ts
@@ -13,7 +13,7 @@ export const SUGGEST_AGENTS_TOOL_NAME = "suggest_agents_for_content" as const;
 export const AGENT_ROUTER_TOOLS_METADATA = createToolsRecord({
   list_all_published_agents: {
     description:
-      "Returns a complete list of all agents accessible to the user in the workspace, " +
+      "Return a complete list of all agents accessible to the user in the workspace, " +
       "including their personal (unpublished) agents. " +
       "Each agent includes its name, description, and mention directive " +
       "(e.g., `:mention[agent-name]{sId=xyz}`) to display a clickable link to the agent.",
@@ -27,7 +27,7 @@ export const AGENT_ROUTER_TOOLS_METADATA = createToolsRecord({
   },
   suggest_agents_for_content: {
     description:
-      "Analyzes a user query and returns relevant specialized agents that might be better " +
+      "Analyze a user query and return relevant specialized agents that might be better " +
       "suited to handling specific requests. The tool uses semantic matching to find agents " +
       "whose capabilities align with the query content. Each suggested agent includes its " +
       "mention directive (e.g., `:mention[agent-name]{sId=xyz}`) to display a clickable link, " +

--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -8,7 +8,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const ASK_USER_QUESTION_TOOLS_METADATA = createToolsRecord({
   ask_user_question: {
     description:
-      "Asks the user a question during execution.\n\n" +
+      "Ask the user a question during execution.\n\n" +
       "This tool can serve multiple purposes:\n" +
       "- Clarify ambiguous instructions where multiple interpretations are plausible\n" +
       "- Validate major decisions before moving forward\n" +

--- a/front/lib/api/actions/servers/file_generation/metadata.ts
+++ b/front/lib/api/actions/servers/file_generation/metadata.ts
@@ -51,7 +51,7 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
     },
   },
   convert_file_format: {
-    description: "Converts a file from one format to another.",
+    description: "Convert a file from one format to another.",
     schema: {
       file_name: z
         .string()

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -21,7 +21,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   // Ticket operations
   list_tickets: {
     description:
-      "Lists or shows Freshservice tickets, with optional filtering (e.g. by status, requester, or update time) and pagination. Returns minimal fields (id, subject, status) by default for performance.",
+      "List or show Freshservice tickets, with optional filtering (e.g. by status, requester, or update time) and pagination. Returns minimal fields (id, subject, status) by default for performance.",
     schema: {
       filter: z
         .object({
@@ -57,7 +57,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   get_ticket: {
     description:
-      "Gets a specific Freshservice ticket by its ID. By default returns essential fields for performance. Pass the fields parameter to request others.",
+      "Get Freshservice ticket details by ID. Returns essential fields by default; pass the fields parameter to request more.",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       fields: z
@@ -77,7 +77,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   get_ticket_read_fields: {
     description:
-      "Lists the field ids available when reading a Freshservice ticket. Use only to discover field names.",
+      "List the field ids available when reading a Freshservice ticket. Use only to discover field names.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -87,7 +87,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   get_ticket_write_fields: {
     description:
-      "Lists all Freshservice ticket fields (standard and custom) available when creating or updating a ticket. Use only to discover field names.",
+      "List all Freshservice ticket fields (standard and custom) available when creating or updating a ticket. Use only to discover field names.",
     schema: {
       search: z
         .string()
@@ -102,7 +102,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   create_ticket: {
     description:
-      "Creates a new Freshservice ticket. For example to log an incident, submit an IT support request, or report a problem. Required fields vary by ticket type. Pass them in custom_fields.",
+      "Create a new Freshservice ticket. For example to log an incident, submit an IT support request, or report a problem. Required fields vary by ticket type. Pass them in custom_fields.",
     schema: {
       email: z.string().describe("Requester email address"),
       subject: z.string().describe("Ticket subject"),
@@ -129,7 +129,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   update_ticket: {
-    description: "Updates an existing Freshservice ticket.",
+    description: "Update an existing Freshservice ticket.",
     schema: {
       ticket_id: z.string().describe("Ticket ID to update"),
       subject: z.string().optional().describe("Updated ticket subject"),
@@ -156,7 +156,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   add_ticket_note: {
     description:
-      "Adds a private or public note to an existing Freshservice ticket.",
+      "Add a private or public note to an existing Freshservice ticket.",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       body: z.string().describe("Content of the note in HTML format"),
@@ -173,7 +173,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   add_ticket_reply: {
-    description: "Adds a reply to a Freshservice ticket conversation.",
+    description:
+      "Reply to the requester in a Freshservice ticket conversation.",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       body: z.string().describe("Content of the note in HTML format"),
@@ -188,7 +189,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   // Service request items
   list_ticket_requested_items: {
     description:
-      "Lists the service request items nested under a Service Request ticket. Returns each item's metadata along with its custom fields. Use this after get_ticket when the ticket is a Service Request and you need values from custom fields on the nested items.",
+      "List the service request items nested under a Service Request ticket. Returns each item's metadata along with its custom fields. Use this after get_ticket when the ticket is a Service Request and you need values from custom fields on the nested items.",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
     },
@@ -201,7 +202,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
 
   // Ticket tasks
   list_ticket_tasks: {
-    description: "Lists all tasks associated with a ticket",
+    description: "List all tasks associated with a ticket",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
     },
@@ -212,7 +213,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_ticket_task: {
-    description: "Gets detailed information about a specific task on a ticket",
+    description: "Get detailed information about a specific task on a ticket",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       task_id: z.number().describe("The ID of the task"),
@@ -225,7 +226,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   create_ticket_task: {
     description:
-      "Adds a new task or subtask to a Freshservice ticket, to break the ticket into smaller pieces of work.",
+      "Add a new task or subtask to a Freshservice ticket, to break the ticket into smaller pieces of work.",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       title: z.string().describe("Task title"),
@@ -249,7 +250,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   update_ticket_task: {
-    description: "Updates an existing task on a ticket",
+    description: "Update an existing task on a ticket",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       task_id: z.number().describe("The ID of the task to update"),
@@ -283,7 +284,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   delete_ticket_task: {
-    description: "Deletes a task from a ticket",
+    description: "Delete a task from a ticket",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       task_id: z.number().describe("The ID of the task to delete"),
@@ -297,7 +298,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
 
   // Ticket approvals
   get_ticket_approval: {
-    description: "Gets detailed information about a specific ticket approval",
+    description: "Get detailed information about a specific ticket approval",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       approval_id: z.number().describe("The ID of the approval to retrieve"),
@@ -309,7 +310,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   list_ticket_approvals: {
-    description: "Lists all approvals for a specific ticket",
+    description: "List all approvals for a specific ticket",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
     },
@@ -321,7 +322,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   request_service_approval: {
     description:
-      "Requests approval for a ticket. This creates an approval request that needs to be approved before the ticket can be fulfilled. Only works on tickets that have approval workflow configured.",
+      "Request approval for a ticket. This creates an approval request that needs to be approved before the ticket can be fulfilled. Only works on tickets that have approval workflow configured.",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
       approver_id: z
@@ -348,7 +349,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
 
   // Departments, Products, On-call schedules
   list_departments: {
-    description: "Lists all departments in Freshservice",
+    description: "List all departments in Freshservice",
     schema: {
       page: z.number().optional().default(1),
       per_page: z.number().optional().default(30),
@@ -360,7 +361,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   list_products: {
-    description: "Lists all products in Freshservice",
+    description: "List all products in Freshservice",
     schema: {
       page: z.number().optional().default(1),
       per_page: z.number().optional().default(30),
@@ -372,7 +373,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   list_oncall_schedules: {
-    description: "Lists on-call schedules",
+    description: "List on-call schedules",
     schema: {
       page: z.number().optional().default(1),
       per_page: z.number().optional().default(30),
@@ -387,7 +388,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   // Service catalog
   list_service_categories: {
     description:
-      "Lists service catalog categories. Use this first to get category IDs for filtering service items.",
+      "List service catalog categories. Use this first to get category IDs for filtering service items.",
     schema: {
       page: z.number().optional().default(1),
       per_page: z.number().optional().default(30),
@@ -400,7 +401,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   list_service_items: {
     description:
-      "Lists service catalog items. To filter by category: 1) Use list_service_categories to get category IDs, 2) Use the category_id parameter here.",
+      "List service catalog items. To filter by category: 1) Use list_service_categories to get category IDs, 2) Use the category_id parameter here.",
     schema: {
       category_id: z
         .number()
@@ -419,7 +420,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   search_service_items: {
     description:
-      "Searches for service items from the service catalog for a given search term. Only use this when specifically searching for items by keyword.",
+      "Search for service items from the service catalog for a given search term. Only use this when specifically searching for items by keyword.",
     schema: {
       search_term: z
         .string()
@@ -450,7 +451,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   get_service_item: {
     description:
-      "Gets detailed information about a specific service catalog item including fields and pricing",
+      "Get detailed information about a specific service catalog item including fields and pricing",
     schema: {
       display_id: z
         .number()
@@ -464,7 +465,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   get_service_item_fields: {
     description:
-      "Gets the field configuration for a service catalog item. You must call this before request_service_item to get required fields. Returns required_fields and hidden_required_fields that must be provided.",
+      "Get the field configuration for a service catalog item. You must call this before request_service_item to get required fields. Returns required_fields and hidden_required_fields that must be provided.",
     schema: {
       display_id: z
         .number()
@@ -478,7 +479,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   request_service_item: {
     description:
-      "Creates a service request for a catalog item. This creates a new ticket. You MUST call get_service_item_fields first to get required fields, then provide all required field values in the fields parameter.",
+      "Create a service request for a catalog item. This creates a new ticket. You MUST call get_service_item_fields first to get required fields, then provide all required field values in the fields parameter.",
     schema: {
       display_id: z
         .number()
@@ -510,7 +511,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   // Solutions (Knowledge Base)
   list_solution_categories: {
     description:
-      "Lists solution categories. These are used to organize solution folders, which are mandatory for ticket listing.",
+      "List solution categories. These are used to organize solution folders, which are mandatory for ticket listing.",
     schema: {
       page: z.number().optional().default(1),
       per_page: z.number().optional().default(30),
@@ -523,7 +524,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   list_solution_folders: {
     description:
-      "Lists solution folders within categories. Solution folders are mandatory for ticket listing. Use list_solution_categories first to get category IDs, then filter folders by category_id.",
+      "List solution folders within categories. Solution folders are mandatory for ticket listing. Use list_solution_categories first to get category IDs, then filter folders by category_id.",
     schema: {
       category_id: z.number().optional().describe("Filter by category ID"),
       page: z.number().optional().default(1),
@@ -537,7 +538,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   list_solution_articles: {
     description:
-      "Lists the Freshservice knowledge base articles (solution articles) in a folder. Returns metadata only. Fetch an article by id for its full content.",
+      "List the Freshservice knowledge base articles (solution articles) in a folder. Returns metadata only. Fetch an article by id for its full content.",
     schema: {
       folder_id: z
         .number()
@@ -559,7 +560,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   get_solution_article: {
     description:
-      "Gets a Freshservice knowledge base article (also called a solution article), including its full content.",
+      "Get a Freshservice knowledge base article (also called a solution article), including its full content.",
     schema: {
       article_id: z.number().describe("The ID of the solution article"),
     },
@@ -571,7 +572,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
   create_solution_article: {
     description:
-      "Creates a new solution article in a specific folder. To get folder_id: 1) Use list_solution_categories to get category IDs, 2) Use list_solution_folders with category_id to get folder IDs, 3) Use the folder_id here.",
+      "Create a new solution article in a specific folder. To get folder_id: 1) Use list_solution_categories to get category IDs, 2) Use list_solution_folders with category_id to get folder IDs, 3) Use the folder_id here.",
     schema: {
       title: z.string().describe("Article title"),
       description: z.string().describe("Article content"),
@@ -596,7 +597,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   // Requesters
   list_requesters: {
     description:
-      "Lists Freshservice requesters: the person or people who submitted a ticket (the end users who report issues). Filter by email, phone, or mobile.",
+      "List Freshservice requesters: the person or people who submitted a ticket (the end users who report issues). Filter by email, phone, or mobile.",
     schema: {
       email: z.string().optional().describe("Filter by email"),
       mobile: z.string().optional().describe("Filter by mobile"),
@@ -611,7 +612,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_requester: {
-    description: "Gets detailed information about a specific requester",
+    description: "Get detailed information about a specific requester",
     schema: {
       requester_id: z.number().describe("The ID of the requester"),
     },
@@ -624,7 +625,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
 
   // Purchase Orders
   list_purchase_orders: {
-    description: "Lists purchase orders",
+    description: "List purchase orders",
     schema: {
       page: z.number().optional().default(1),
       per_page: z.number().optional().default(30),
@@ -638,7 +639,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
 
   // SLA Policies
   list_sla_policies: {
-    description: "Lists SLA policies",
+    description: "List SLA policies",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -649,7 +650,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
 
   // Canned responses
   list_canned_responses: {
-    description: "Lists all canned responses available in Freshservice",
+    description: "List all canned responses available in Freshservice",
     schema: {
       search: z
         .string()
@@ -671,7 +672,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_canned_response: {
-    description: "Gets detailed information about a specific canned response",
+    description: "Get detailed information about a specific canned response",
     schema: {
       response_id: z.number().describe("The ID of the canned response"),
     },

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -65,7 +65,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   // Read operations
   get_object_properties: {
     description:
-      "Lists all available properties for a Hubspot object. When creatableOnly is true, returns only properties that can be modified through forms (excludes hidden, calculated, read-only and file upload fields).",
+      "List all available properties for a Hubspot object. When creatableOnly is true, returns only properties that can be modified through forms (excludes hidden, calculated, read-only and file upload fields).",
     schema: {
       objectType: z.enum(ALL_OBJECTS),
       creatableOnly: z.boolean().optional(),
@@ -77,7 +77,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_object_by_email: {
-    description: `Retrieves a Hubspot object using an email address. Supports ${ALL_OBJECTS.join(", ")}.`,
+    description: `Retrieve a Hubspot object using an email address. Supports ${ALL_OBJECTS.join(", ")}.`,
     schema: {
       objectType: z.enum(ALL_OBJECTS),
       email: z.string().describe("The email address of the object."),
@@ -90,7 +90,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   list_owners: {
     description:
-      "Lists all owners (users) in the HubSpot account with their IDs, names, and email addresses. " +
+      "List all owners (users) in the HubSpot account with their IDs, names, and email addresses. " +
       "Use this to find owner IDs for get_user_activity calls when you want to get activity for other users. " +
       "For your own activity, use get_current_user_id instead.",
     schema: {},
@@ -102,7 +102,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   search_owners: {
     description:
-      "Searches for specific owners (users) in the HubSpot account by email, name, ID, or user ID. " +
+      "Search for specific owners (users) in the HubSpot account by email, name, ID, or user ID. " +
       "Supports partial matching for names and emails, and exact matching for IDs. " +
       "Use this to find owner information when you have partial details about a user.",
     schema: {
@@ -195,7 +195,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_meeting: {
-    description: "Retrieves a Hubspot meeting (engagement) by its ID.",
+    description: "Retrieve a Hubspot meeting (engagement) by its ID.",
     schema: {
       meetingId: z
         .string()
@@ -208,7 +208,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_file_public_url: {
-    description: "Retrieves a publicly available URL for a file in HubSpot.",
+    description: "Retrieve a publicly available URL for a file in HubSpot.",
     schema: {
       fileId: z.string().describe("The ID of the file."),
     },
@@ -220,7 +220,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   get_associated_meetings: {
     description:
-      "Retrieves meetings associated with a specific object (contact, company, or deal).",
+      "Retrieve meetings associated with a specific object (contact, company, or deal).",
     schema: {
       fromObjectType: z
         .enum(["contacts", "companies", "deals"])
@@ -264,7 +264,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   export_crm_objects_csv: {
     description:
-      "Exports CRM objects of a given type to CSV, with filters, property selection, and row limits. The resulting file is available for table queries.",
+      "Export CRM objects of a given type to CSV, with filters, property selection, and row limits. The resulting file is available for table queries.",
     schema: {
       objectType: z.enum(searchableObjectTypes),
       propertiesToExport: z
@@ -287,7 +287,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   get_hubspot_link: {
     description:
-      "Purpose: Generates HubSpot UI links for different pages based on object types and IDs. " +
+      "Generate HubSpot UI links for different pages based on object types and IDs. " +
       "Supports both index pages (lists of objects) and record pages (specific object details). " +
       "Prerequisites: Use the hubspot-get-portal-id tool to get the PortalId and UiDomain. " +
       "Usage Guidance: Use to generate links to HubSpot UI pages when users need to reference specific HubSpot records. " +
@@ -305,7 +305,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   get_hubspot_portal_id: {
     description:
-      "Gets the current user's portal ID. To use before calling get_hubspot_link",
+      "Get the current user's portal ID. To use before calling get_hubspot_link",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -315,7 +315,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   list_associations: {
     description:
-      "Lists all associations for a given HubSpot object (e.g., list all contacts associated with a company).",
+      "List all associations for a given HubSpot object (e.g., list all contacts associated with a company).",
     schema: {
       objectType: z
         .enum(["contacts", "companies", "deals"])
@@ -347,7 +347,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   get_user_activity: {
     description:
-      "Comprehensively retrieves user activity across ALL HubSpot engagement types (tasks, notes, meetings, calls, emails) " +
+      "Retrieve comprehensive user activity across ALL HubSpot engagement types (tasks, notes, meetings, calls, emails) " +
       "for any time period. Solves the problem of getting complete user activity data by automatically trying multiple " +
       "owner property variations and gracefully handling object types that don't support owner filtering. " +
       "Perfect for queries like 'show my activity for the last week' or 'what did I do this month'. " +
@@ -387,7 +387,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   // Marketing email operations
   list_marketing_emails: {
     description:
-      "Lists marketing emails from HubSpot. Supports filtering by state (e.g., DRAFT, PUBLISHED, AUTOMATED) and pagination. " +
+      "List marketing emails from HubSpot. Supports filtering by state (e.g., DRAFT, PUBLISHED, AUTOMATED) and pagination. " +
       "Returns email name, subject, state, publish date, and other metadata.",
     schema: {
       limit: z
@@ -414,7 +414,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   get_marketing_email: {
     description:
-      "Retrieves a single marketing email by its ID. Returns full email details including name, subject, state, content, and metadata.",
+      "Retrieve a single marketing email by its ID. Returns full email details including name, subject, state, content, and metadata.",
     schema: {
       emailId: z
         .string()
@@ -428,7 +428,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   get_marketing_email_statistics: {
     description:
-      "Retrieves deliverability statistics histogram for a marketing email (open rates, click rates, bounces, unsubscribes, etc.). " +
+      "Retrieve deliverability statistics histogram for a marketing email (open rates, click rates, bounces, unsubscribes, etc.). " +
       "Provides time-bucketed data for analyzing email performance over time.",
     schema: {
       emailId: z
@@ -449,7 +449,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   list_email_events: {
     description:
-      "Lists email events (deliveries, opens, clicks, bounces, unsubscribes, etc.) from HubSpot. " +
+      "List email events (deliveries, opens, clicks, bounces, unsubscribes, etc.) from HubSpot. " +
       "Supports filtering by event type, campaign ID, and time range. " +
       "Event types include: SENT, DELIVERED, OPEN, CLICK, BOUNCE, DEFERRED, DROPPED, STATUSCHANGE, SPAMREPORT, UNBOUNCE.",
     schema: {
@@ -493,7 +493,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   list_email_campaigns: {
     description:
-      "Lists email campaigns from HubSpot. Returns campaign IDs and basic metadata. " +
+      "List email campaigns from HubSpot. Returns campaign IDs and basic metadata. " +
       "Use get_email_campaign to get full details including deliverability counters for a specific campaign.",
     schema: {
       limit: z
@@ -531,8 +531,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
 
   // Create operations
   create_contact: {
-    description:
-      "Creates a new contact in Hubspot, with optional associations.",
+    description: "Create a new contact in Hubspot, with optional associations.",
     schema: {
       properties: z
         .record(z.string())
@@ -549,8 +548,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_company: {
-    description:
-      "Creates a new company in Hubspot, with optional associations.",
+    description: "Create a new company in Hubspot, with optional associations.",
     schema: {
       properties: z
         .record(z.string())
@@ -567,7 +565,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_deal: {
-    description: "Creates a new deal in Hubspot, with optional associations.",
+    description: "Create a new deal in Hubspot, with optional associations.",
     schema: {
       properties: z
         .record(z.string())
@@ -585,7 +583,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   create_lead: {
     description:
-      "Creates a new lead in Hubspot (as a Deal), with optional associations. Ensure properties correctly define it as a lead.",
+      "Create a new lead in Hubspot (as a Deal), with optional associations. Ensure properties correctly define it as a lead.",
     schema: {
       properties: z
         .record(z.string())
@@ -604,7 +602,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_task: {
-    description: "Creates a new task in Hubspot, with optional associations.",
+    description: "Create a new task in Hubspot, with optional associations.",
     schema: {
       properties: z
         .record(z.string())
@@ -623,7 +621,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_note: {
-    description: "Creates a new note in Hubspot, with optional associations.",
+    description: "Create a new note in Hubspot, with optional associations.",
     schema: {
       properties: z
         .object({
@@ -652,7 +650,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   create_communication: {
     description:
-      "Creates a new communication (WhatsApp, LinkedIn, SMS) in Hubspot. Requires hs_communication_channel_type in properties.",
+      "Create a new communication (WhatsApp, LinkedIn, SMS) in Hubspot. Requires hs_communication_channel_type in properties.",
     schema: {
       properties: z
         .record(z.any())
@@ -671,7 +669,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   create_meeting: {
     description:
-      "Creates a new meeting in Hubspot. Meeting details are in properties.",
+      "Create a new meeting in Hubspot. Meeting details are in properties.",
     schema: {
       properties: z
         .record(z.any())
@@ -690,7 +688,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   create_association: {
     description:
-      "Creates an association between two existing HubSpot objects (e.g., associate a contact with a company).",
+      "Create an association between two existing HubSpot objects (e.g., associate a contact with a company).",
     schema: {
       fromObjectType: z
         .enum(["contacts", "companies", "deals"])
@@ -710,7 +708,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
 
   // Update operations
   update_contact: {
-    description: "Updates properties of a HubSpot contact by ID.",
+    description: "Update properties of a HubSpot contact by ID.",
     schema: {
       contactId: z.string().describe("The ID of the contact to update."),
       properties: z
@@ -726,7 +724,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
   },
   update_company: {
-    description: "Updates properties of a HubSpot company by ID.",
+    description: "Update properties of a HubSpot company by ID.",
     schema: {
       companyId: z.string().describe("The ID of the company to update."),
       properties: z
@@ -742,7 +740,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
   },
   update_deal: {
-    description: "Updates properties of a HubSpot deal by ID.",
+    description: "Update properties of a HubSpot deal by ID.",
     schema: {
       dealId: z.string().describe("The ID of the deal to update."),
       properties: z
@@ -758,7 +756,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
   },
   remove_association: {
-    description: "Removes an association between two HubSpot objects.",
+    description: "Remove an association between two HubSpot objects.",
     schema: {
       fromObjectType: z
         .enum(["contacts", "companies", "deals"])

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -16,7 +16,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   // Read operations
   get_issue_read_fields: {
     description:
-      "Lists the field keys, ids, and names that can be requested when reading an issue.",
+      "List the field keys, ids, and names that can be requested when reading an issue.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -26,7 +26,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_issue: {
     description:
-      "Looks up and retrieves a single Jira issue (ticket) by its key (e.g., 'PROJ-123'). Returns a minimal set of fields by default. Pass the fields parameter to request others.",
+      "Look up and retrieve a single Jira issue (ticket) by its key (e.g., 'PROJ-123'). Returns a minimal set of fields by default. Pass the fields parameter to request others.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       fields: z
@@ -43,7 +43,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_projects: {
-    description: "Retrieves all Jira projects (the full list).",
+    description: "List Jira projects available in the workspace.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -52,7 +52,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_project: {
-    description: "Retrieves a single Jira project by its key (e.g., 'PROJ').",
+    description: "Retrieve one Jira project by project key (e.g., 'PROJ').",
     schema: {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
     },
@@ -64,7 +64,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_project_versions: {
     description:
-      "Retrieves all versions (releases) for a JIRA project. Useful for getting release reports and understanding which versions are available for filtering issues.",
+      "Retrieve all versions (releases) for a JIRA project. Useful for getting release reports and understanding which versions are available for filtering issues.",
     schema: {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
     },
@@ -76,7 +76,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_transitions: {
     description:
-      "Lists which status changes a Jira issue is currently allowed to make.",
+      "List which status changes a Jira issue is currently allowed to make.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
     },
@@ -139,7 +139,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_issue_types: {
-    description: "Retrieves available issue types for a JIRA project.",
+    description: "Retrieve available issue types for a JIRA project.",
     schema: {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
     },
@@ -151,7 +151,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_issue_create_fields: {
     description:
-      "Lists the field metadata (names and ids) on the screens used to create or update an issue, for a given project and issue type. Use it to discover valid field names beforehand.",
+      "List field metadata (names and ids) for a given Jira project and issue type. Use it to discover valid field names before creating or updating issues.",
     schema: {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
       issueTypeId: z
@@ -166,7 +166,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_connection_info: {
     description:
-      "Gets comprehensive connection information including user details, cloud ID, and site URL for the currently authenticated JIRA instance. This tool is used when the user is referring about themselves. Also use it to authenticate when another tool reports that no access token was found.",
+      "Get comprehensive connection information including user details, cloud ID, and site URL for the currently authenticated JIRA instance. This tool is used when the user is referring about themselves. Also use it to authenticate when another tool reports that no access token was found.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -176,7 +176,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_issue_link_types: {
     description:
-      "Retrieves all available issue link types that can be used when creating issue links.",
+      "Retrieve all available issue link types that can be used when creating issue links.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -185,7 +185,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_users: {
-    description: "Search for Jira users by email address or display name.",
+    description: "Find or search Jira users by email address or display name.",
     schema: {
       emailAddress: z
         .string()
@@ -246,7 +246,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   // Write operations
   create_comment: {
     description:
-      "Adds a comment or note to an existing Jira issue. Accepts plain text or rich ADF formatting.",
+      "Leave a comment or note on an existing Jira issue. Accepts plain text or rich ADF formatting.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       comment: z
@@ -271,7 +271,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   transition_issue: {
     description:
-      "Moves or changes a Jira issue (ticket) to a different status (e.g. to In Progress or Done). Performs a workflow transition.",
+      "Move or change a Jira issue (ticket) to a different status (e.g. to In Progress or Done). Performs a workflow transition.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       transitionId: z.string().describe("The ID of the transition to perform"),
@@ -284,7 +284,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   create_issue: {
     description:
-      "Creates a new Jira issue, or ticket, in a project. Use it to log a bug, raise a request, or open a task or story. Description fields accept plain text or rich ADF. Required fields vary by project and issue type.",
+      "Create a new Jira issue, or ticket, in a project. Use it to log a bug, raise a request, or open a task or story. Description fields accept plain text or rich ADF. Required fields vary by project and issue type.",
     schema: {
       issueData: JiraCreateIssueRequestSchema.describe(
         "The description of the issue"
@@ -298,7 +298,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   update_issue: {
     description:
-      "Updates or changes field values on an existing Jira issue, such as its summary, description, priority, or assignee. Description accepts plain text or rich ADF. Issue links and attachments are not changed here.",
+      "Update or change field values on an existing Jira issue, such as its summary, description, priority, or assignee. Description accepts plain text or rich ADF. Issue links and attachments are not changed here.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       updateData: JiraCreateIssueRequestSchema.partial().describe(
@@ -313,7 +313,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   create_issue_link: {
     description:
-      "Links or marks two Jira issues as related, with a relationship type such as blocks, relates to, or duplicates.",
+      "Link or mark two Jira issues as related, with a relationship type such as blocks, relates to, or duplicates.",
     schema: {
       linkData: JiraCreateIssueLinkRequestSchema.describe(
         "Link configuration including type and issues to link"
@@ -326,7 +326,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
   },
   delete_issue_link: {
-    description: "Deletes an existing link between JIRA issues.",
+    description: "Delete an existing link between JIRA issues.",
     schema: {
       linkId: z.string().describe("The ID of the issue link to delete"),
     },

--- a/front/lib/api/actions/servers/jit_testing/metadata.ts
+++ b/front/lib/api/actions/servers/jit_testing/metadata.ts
@@ -11,7 +11,7 @@ export const JIT_TESTING_TOOL_NAME = "jit_testing" as const;
 export const JIT_TESTING_TOOLS_METADATA = createToolsRecord({
   jit_all_optionals_and_defaults: {
     description:
-      "A single tool aggregating optional/default configs for TIME_FRAME, JSON_SCHEMA, DATA_SOURCE, and AGENT for JIT testing.",
+      "Aggregate optional/default configs for TIME_FRAME, JSON_SCHEMA, DATA_SOURCE, and AGENT for JIT testing.",
     schema: {
       // TIME_FRAME: default and optional variants
       timeFrameDefault: ConfigurableToolInputSchemas[

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -9,7 +9,7 @@ export const MICROSOFT_TEAMS_SERVER_NAME = "microsoft_teams" as const;
 export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   search_messages_content: {
     description:
-      "Full-text keyword search across Microsoft Teams messages. Returns matching messages ranked by relevance. Use this to find a message by its words, not to browse or enumerate a conversation.",
+      "Search Microsoft Teams messages by full-text keyword. Returns matching messages ranked by relevance. Use this to find a message by its words, not to browse or enumerate a conversation.",
     schema: {
       query: z
         .string()

--- a/front/lib/api/actions/servers/monday/metadata.ts
+++ b/front/lib/api/actions/servers/monday/metadata.ts
@@ -7,7 +7,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const MONDAY_TOOLS_METADATA = createToolsRecord({
   get_boards: {
     description:
-      "Lists all accessible boards in Monday.com workspace. Returns up to 100 boards.",
+      "List all accessible boards in Monday.com workspace. Returns up to 100 boards.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -17,7 +17,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
   },
   get_board_items: {
     description:
-      "Retrieves items from a specific Monday.com board. Returns up to 100 items.",
+      "Retrieve items from a specific Monday.com board. Returns up to 100 items.",
     schema: {
       boardId: z.string().describe("The board ID to retrieve items from"),
     },
@@ -29,7 +29,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
   },
   get_item_details: {
     description:
-      "Retrieves detailed information about a specific Monday.com item",
+      "Retrieve detailed information about a specific Monday.com item",
     schema: {
       itemId: z.string().describe("The item ID to retrieve details for"),
     },
@@ -41,7 +41,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
   },
   search_items: {
     description:
-      "Searches for items in Monday.com with advanced filtering options. Returns up to 100 items.",
+      "Search for items in Monday.com with advanced filtering options. Returns up to 100 items.",
     schema: {
       query: z
         .string()
@@ -78,7 +78,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_items_by_column_value: {
-    description: "Retrieves items from a board by column value",
+    description: "Retrieve items from a board by column value",
     schema: {
       boardId: z.string().describe("The board ID to search in"),
       columnId: z.string().describe("The column ID to filter by"),
@@ -91,7 +91,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   find_user_by_name: {
-    description: "Finds a Monday.com user by name",
+    description: "Find a Monday.com user by name",
     schema: {
       name: z.string().describe("The name of the user to find"),
     },
@@ -103,7 +103,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
   },
   get_board_values: {
     description:
-      "Retrieves detailed information about a Monday.com board including columns and groups",
+      "Retrieve detailed information about a Monday.com board including columns and groups",
     schema: {
       boardId: z.string().describe("The board ID to retrieve details for"),
     },
@@ -114,7 +114,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_column_values: {
-    description: "Retrieves column values for a specific item and column",
+    description: "Retrieve column values for a specific item and column",
     schema: {
       boardId: z.string().describe("The board ID containing the item"),
       itemId: z.string().describe("The item ID to get column values from"),
@@ -127,7 +127,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_file_column_values: {
-    description: "Retrieves file column values for a specific item and column",
+    description: "Retrieve file column values for a specific item and column",
     schema: {
       itemId: z.string().describe("The item ID to get file column values from"),
       columnId: z
@@ -142,7 +142,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
   },
   get_group_details: {
     description:
-      "Retrieves details about a specific group in a Monday.com board",
+      "Retrieve details about a specific group in a Monday.com board",
     schema: {
       boardId: z.string().describe("The board ID containing the group"),
       groupId: z.string().describe("The group ID to retrieve details for"),
@@ -154,7 +154,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_subitem_values: {
-    description: "Retrieves subitems for a specific Monday.com item",
+    description: "Retrieve subitems for a specific Monday.com item",
     schema: {
       itemId: z.string().describe("The item ID to retrieve subitems for"),
     },
@@ -165,7 +165,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_user_details: {
-    description: "Retrieves details about a specific Monday.com user",
+    description: "Retrieve details about a specific Monday.com user",
     schema: {
       userId: z.string().describe("The user ID to retrieve details for"),
     },
@@ -177,7 +177,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
   },
   get_activity_logs: {
     description:
-      "Retrieves activity logs for a board. Useful for tracking pipeline velocity and user actions.",
+      "Retrieve activity logs for a board. Useful for tracking pipeline velocity and user actions.",
     schema: {
       boardId: z
         .string()
@@ -203,7 +203,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
   },
   get_board_analytics: {
     description:
-      "Retrieves analytics and statistics for a board including item counts by status, group, and assignee. Useful for CRM reporting.",
+      "Retrieve analytics and statistics for a board including item counts by status, group, and assignee. Useful for CRM reporting.",
     schema: {
       boardId: z.string().describe("The board ID to retrieve analytics for"),
     },
@@ -214,7 +214,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_item: {
-    description: "Creates a new item in a Monday.com board",
+    description: "Create a new item in a Monday.com board",
     schema: {
       boardId: z.string().describe("The board ID to create the item in"),
       itemName: z.string().describe("The name of the new item"),
@@ -236,7 +236,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   update_item: {
-    description: "Updates column values of an existing Monday.com item",
+    description: "Update column values of an existing Monday.com item",
     schema: {
       itemId: z.string().describe("The item ID to update"),
       columnValues: z
@@ -252,7 +252,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   update_item_name: {
-    description: "Updates the name of a Monday.com item",
+    description: "Update the name of a Monday.com item",
     schema: {
       itemId: z.string().describe("The item ID to update"),
       name: z.string().describe("The new name for the item"),
@@ -264,7 +264,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_update: {
-    description: "Adds an update (comment) to a Monday.com item",
+    description: "Add an update (comment) to a Monday.com item",
     schema: {
       itemId: z.string().describe("The item ID to add the update to"),
       body: z.string().describe("The content of the update/comment"),
@@ -276,7 +276,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_board: {
-    description: "Creates a new board in Monday.com",
+    description: "Create a new board in Monday.com",
     schema: {
       boardName: z.string().describe("The name of the new board"),
       boardKind: z
@@ -299,7 +299,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_column: {
-    description: "Creates a new column in a Monday.com board",
+    description: "Create a new column in a Monday.com board",
     schema: {
       boardId: z.string().describe("The board ID to create the column in"),
       title: z.string().describe("The title of the new column"),
@@ -318,7 +318,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_group: {
-    description: "Creates a new group in a Monday.com board",
+    description: "Create a new group in a Monday.com board",
     schema: {
       boardId: z.string().describe("The board ID to create the group in"),
       groupName: z.string().describe("The name of the new group"),
@@ -334,7 +334,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_subitem: {
-    description: "Creates a new subitem for a Monday.com item",
+    description: "Create a new subitem for a Monday.com item",
     schema: {
       parentItemId: z.string().describe("The parent item ID"),
       itemName: z.string().describe("The name of the new subitem"),
@@ -350,7 +350,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   update_subitem: {
-    description: "Updates column values of a Monday.com subitem",
+    description: "Update column values of a Monday.com subitem",
     schema: {
       subitemId: z.string().describe("The subitem ID to update"),
       columnValues: z
@@ -364,7 +364,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   duplicate_group: {
-    description: "Duplicates a group in a Monday.com board",
+    description: "Duplicate a group in a Monday.com board",
     schema: {
       boardId: z.string().describe("The board ID containing the group"),
       groupId: z.string().describe("The group ID to duplicate"),
@@ -384,7 +384,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   upload_file_to_column: {
-    description: "Uploads a file to a Monday.com column",
+    description: "Upload a file to a Monday.com column",
     schema: {
       itemId: z.string().describe("The item ID to upload the file to"),
       columnId: z.string().describe("The column ID to upload the file to"),
@@ -397,7 +397,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   delete_item: {
-    description: "Deletes a Monday.com item",
+    description: "Delete a Monday.com item",
     schema: {
       itemId: z.string().describe("The item ID to delete"),
     },
@@ -408,7 +408,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
   },
   delete_group: {
-    description: "Deletes a group from a Monday.com board",
+    description: "Delete a group from a Monday.com board",
     schema: {
       boardId: z.string().describe("The board ID containing the group"),
       groupId: z.string().describe("The group ID to delete"),
@@ -421,7 +421,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
   },
   move_item_to_board: {
     description:
-      "Moves an item from one board to another. Useful for converting leads to opportunities in CRM workflows.",
+      "Move an item from one board to another. Useful for converting leads to opportunities in CRM workflows.",
     schema: {
       itemId: z.string().describe("The item ID to move"),
       targetBoardId: z
@@ -450,7 +450,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
   },
   create_multiple_items: {
     description:
-      "Creates multiple items in one or more boards in a single operation. Useful for bulk importing leads or opportunities.",
+      "Create multiple items in one or more boards in a single operation. Useful for bulk importing leads or opportunities.",
     schema: {
       items: z
         .array(

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -278,7 +278,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   [SEMANTIC_SEARCH_TOOL_NAME]: {
     description:
-      "Semantic search over a Pod using the same retrieval pipeline as company data search. Scope selects the Pod data source slice (files vs conversation transcripts vs both) plus searchable context nodes for files/all.",
+      "Search semantically over a Pod using the same retrieval pipeline as company data search. Scope selects the Pod data source slice (files vs conversation transcripts vs both) plus searchable context nodes for files/all.",
     schema: {
       query: z
         .string()

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -188,7 +188,7 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
 
   [GET_CONVERSATION_DETAILS_TOOL_NAME]: {
     description:
-      "Full conversation with messages, tool calls, agent actions, and errors.",
+      "Get the full conversation with messages, tool calls, agent actions, and errors.",
     schema: {
       ...workspaceIdSchema,
       conversation_id: z.string().describe("The sId of the conversation."),

--- a/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
@@ -81,7 +81,7 @@ const passThroughSchema = {
 // Tools metadata
 export const PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA = createToolsRecord({
   tool_without_user_config: {
-    description: "This tool is used to test the tool without user config.",
+    description: "Test the tool without user config.",
     schema: toolWithoutUserConfigSchema,
     stake: "high",
     displayLabels: {
@@ -90,7 +90,7 @@ export const PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA = createToolsRecord({
     },
   },
   pass_through: {
-    description: "Super useful tool that should be used at all times.",
+    description: "Pass through inputs for primitive type debugging.",
     schema: passThroughSchema,
     stake: "high",
     displayLabels: {

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -47,7 +47,7 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
   },
   [GET_DATABASE_SCHEMA_TOOL_NAME]: {
     description:
-      "Retrieves the database schema for a subset of tables. You MUST call list_tables first to discover " +
+      "Retrieve the database schema for a subset of tables. You MUST call list_tables first to discover " +
       "available tables, then call this tool with the URIs of the tables you need before attempting to query. " +
       "This tool provides essential information about table columns, types, and relationships needed to write accurate SQL queries.",
     schema: {
@@ -62,7 +62,7 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
   },
   [EXECUTE_DATABASE_QUERY_TOOL_NAME]: {
     description:
-      "Executes a query on the database. You MUST call get_database_schema for the tables involved in your query " +
+      "Execute a query on the database. You MUST call get_database_schema for the tables involved in your query " +
       "at least once before attempting to execute a query. The query must respect the guidelines and schema " +
       "provided by the get_database_schema tool.",
     schema: {

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -51,7 +51,7 @@ const MAX_CHANNEL_SEARCH_RESULTS = 20;
 export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
   search_messages: {
     description:
-      "Keyword search for Slack messages across public channels, private channels, DMs, and group DMs where the current user is a member",
+      "Search Slack messages by keyword across public channels, private channels, DMs, and group DMs where the current user is a member",
     schema: {
       keywords: z
         .string()

--- a/front/lib/api/actions/servers/val_town/metadata.ts
+++ b/front/lib/api/actions/servers/val_town/metadata.ts
@@ -7,7 +7,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   create_val: {
     description:
-      "Creates a new val (project) in Val Town: a serverless TypeScript/JavaScript container that can hold HTTP endpoints, scripts, email handlers, or scheduled tasks. Use create_file to add files to the val.",
+      "Create a new val (project) in Val Town: a serverless TypeScript/JavaScript container that can hold HTTP endpoints, scripts, email handlers, or scheduled tasks. Use create_file to add files to the val.",
     schema: {
       name: z
         .string()
@@ -42,7 +42,7 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   },
   get_val: {
     description:
-      "Gets a specific Val Town val (serverless script or project) by its ID, including its files and metadata.",
+      "Get a specific Val Town val (serverless script or project) by its ID, including its files and metadata.",
     schema: {
       valId: z.string().describe("The ID of the val to retrieve"),
     },
@@ -54,7 +54,7 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   },
   list_vals: {
     description:
-      "Lists Val Town vals (serverless TypeScript/JavaScript functions and projects) available to the user's account.",
+      "List Val Town vals (serverless TypeScript/JavaScript functions and projects) available to the user's account.",
     schema: {
       limit: z
         .number()
@@ -84,7 +84,7 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   },
   search_vals: {
     description:
-      "Searches for Val Town vals (serverless scripts and projects) by name, description, or code content.",
+      "Search for Val Town vals (serverless scripts and projects) by name, description, or code content.",
     schema: {
       query: z.string().describe("Search query to find vals"),
       limit: z
@@ -111,7 +111,7 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   },
   list_val_files: {
     description:
-      "Lists all files in a specific Val Town val (serverless project).",
+      "List all files in a specific Val Town val (serverless project).",
     schema: {
       valId: z.string().describe("The ID of the val to list files for"),
       path: z
@@ -141,7 +141,7 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   },
   get_file_content: {
     description:
-      "Gets the content of a specific file in a val using the Val Town API",
+      "Get the content of a specific file in a val using the Val Town API",
     schema: {
       valId: z.string().describe("The ID of the val containing the file"),
       filePath: z
@@ -155,7 +155,7 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     },
   },
   delete_file: {
-    description: "Deletes a specific file from a val using the Val Town API",
+    description: "Delete a specific file from a val using the Val Town API",
     schema: {
       valId: z.string().describe("The ID of the val containing the file"),
       filePath: z
@@ -170,7 +170,7 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   },
   update_file_content: {
     description:
-      "Updates the content of a specific file in a val. Note: To change file type (e.g., to HTTP), use the file_update tool instead.",
+      "Update the content of a specific file in a val. Note: To change file type (e.g., to HTTP), use the file_update tool instead.",
     schema: {
       valId: z.string().describe("The ID of the val containing the file"),
       filePath: z
@@ -189,7 +189,7 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   },
   write_file: {
     description:
-      "The primary function for writing content to files and updating file metadata. Use this to add content, change file type, rename files, or move files. For HTTP type: return value from serve handler must be a response or a promise resolving to a response.",
+      "Write content to files and update file metadata. Use this to add content, change file type, rename files, or move files. For HTTP type: return value from serve handler must be a response or a promise resolving to a response.",
     schema: {
       valId: z.string().describe("The ID of the val containing the file"),
       filePath: z
@@ -218,7 +218,7 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   },
   create_file: {
     description:
-      "Creates a new empty file in an existing val. Use write_file to add content and set the file type.",
+      "Create a new empty file in an existing val. Use write_file to add content and set the file type.",
     schema: {
       valId: z.string().describe("The ID of the val to create the file in"),
       filePath: z
@@ -233,7 +233,7 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   },
   call_http_endpoint: {
     description:
-      "Runs an HTTP val endpoint by getting the file's endpoint link and making a request to it",
+      "Run an HTTP val endpoint by getting the file's endpoint link and making a request to it",
     schema: {
       valId: z.string().describe("The ID of the val containing the file"),
       filePath: z

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -15,8 +15,7 @@ export const WEB_SEARCH_BROWSE_ACTION_DESCRIPTION =
 
 export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
   websearch: {
-    description:
-      "A tool that performs a Google web search based on a string query.",
+    description: "Search Google web results based on a string query.",
     schema: WebsearchInputSchema.shape,
     stake: "never_ask",
     enableAlerting: true,
@@ -26,7 +25,7 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
     },
   },
   webbrowser: {
-    description: `A tool to browse websites, you can provide a list of up to ${MAX_BROWSE_URLS} urls to browse all at once.`,
+    description: `Browse websites; provide a list of up to ${MAX_BROWSE_URLS} URLs to browse all at once.`,
     schema: WebbrowseInputSchema.shape,
     stake: "never_ask",
     enableAlerting: true,

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -65,7 +65,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   },
   list_ticket_fields: {
     description:
-      "Lists Zendesk ticket field definitions. Both built-in fields (Subject, Priority, Status) and custom fields. With their id, title, type, and active state.",
+      "List Zendesk ticket field definitions. Both built-in fields (Subject, Priority, Status) and custom fields. With their id, title, type, and active state.",
     schema: {
       includeInactive: z
         .boolean()


### PR DESCRIPTION
## Description

- This PR normalizes internal MCP tool descriptions so they start with bare infinitive/base verbs like `List`, `Get`, `Create`, and `Search`.
- The wording is tuned for lexical tool-search matching and BM25 recall, with targeted additions for Freshservice/Jira terms.
- Adds an MCP coding rule and updates the new MCP server runbook so future tool descriptions stay consistent.
- BM25 recall improved on the original query set from `119/144` to `125/144` top-1, and from `121/144` to `127/144` within maxRank. After rebasing on main, the current harness result is `163/187` top-1 and `168/187` within maxRank.

## Tests

- Covered by existing MCP metadata snapshot test.
- Tested locally with the BM25 harness.

## Risk

- Low. Metadata and documentation only.

## Deploy Plan

- Deploy front.