### PR TITLE
[front] API key credit cap: poke per-key reconcile target

### DIFF
--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -66,6 +66,7 @@ export const RECONCILE_CREDIT_STATE_TARGETS = [
   "pool",
   "programmatic",
   "user",
+  "api_key",
 ] as const;
 
 export type ReconcileCreditStateTarget =
@@ -117,10 +118,19 @@ type UserReconcileReport = {
   consumedAwuCredits: number | null;
 };
 
+// Names aren't unique, so reconciling a key name covers every active key
+// sharing it (each reconciled per its own cap, matching the webhook/backfill).
+type ApiKeyTargetReconcileReport = {
+  target: "api_key";
+  keyName: string;
+  keys: ApiKeyReconcileReport[];
+};
+
 export type ReconcileCreditStateReport =
   | PoolReconcileReport
   | ProgrammaticReconcileReport
-  | UserReconcileReport;
+  | UserReconcileReport
+  | ApiKeyTargetReconcileReport;
 
 // Treat the legacy "normal" alias as its canonical "on_pool" value when
 // comparing the persisted state with the expected one (see USER_CREDIT_STATES).
@@ -144,6 +154,7 @@ export async function reconcileCreditState({
   metronomeCustomerId,
   target,
   userId,
+  keyName,
   execute,
 }: {
   auth: Authenticator;
@@ -151,6 +162,7 @@ export async function reconcileCreditState({
   metronomeCustomerId: string;
   target: ReconcileCreditStateTarget;
   userId: string | null;
+  keyName: string | null;
   execute: boolean;
 }): Promise<Result<ReconcileCreditStateReport, Error>> {
   switch (target) {
@@ -176,6 +188,39 @@ export async function reconcileCreditState({
         userId,
         execute,
       });
+    case "api_key": {
+      if (!keyName) {
+        return new Err(
+          new Error("A key name is required to reconcile the per-key state.")
+        );
+      }
+      const metronomeContractId =
+        auth.subscription()?.metronomeContractId ?? null;
+      const keys = await KeyResource.listActiveByWorkspaceAndName(
+        renderLightWorkspaceType({ workspace }),
+        keyName
+      );
+      if (keys.length === 0) {
+        return new Err(
+          new Error(`No active API key named '${keyName}' in this workspace.`)
+        );
+      }
+      const reports: ApiKeyReconcileReport[] = [];
+      for (const key of keys) {
+        const result = await reconcileApiKey({
+          workspaceId: workspace.sId,
+          metronomeCustomerId,
+          metronomeContractId,
+          key,
+          execute,
+        });
+        if (result.isErr()) {
+          return new Err(result.error);
+        }
+        reports.push(result.value);
+      }
+      return new Ok({ target: "api_key", keyName, keys: reports });
+    }
     default:
       return assertNever(target);
   }

--- a/front/lib/api/poke/plugins/workspaces/reconcile_credit_state.ts
+++ b/front/lib/api/poke/plugins/workspaces/reconcile_credit_state.ts
@@ -21,8 +21,10 @@ export const reconcileCreditStatePlugin = createPlugin({
       "workspace *should* be in from the live source of truth and compares " +
       "it with the persisted state. Pick the target: 'pool' (live Metronome " +
       "AWU balance + PAYG), 'programmatic' (programmatic cap alert evaluation " +
-      "states), or 'user' (effective per-user cap vs. usage — requires a User " +
-      "sId; only the capped/uncapped dimension is recomputed). 'check' reports " +
+      "states), 'user' (effective per-user cap vs. usage — requires a User " +
+      "sId; only the capped/uncapped dimension is recomputed), or 'api_key' " +
+      "(per-key cap vs. usage — requires a key name; reconciles every active " +
+      "key with that name). 'check' reports " +
       "drift without writing; 'execute' reconciles through the same machinery " +
       "the webhooks use, then reports the before/after states.",
     resourceTypes: ["workspaces"],
@@ -54,6 +56,12 @@ export const reconcileCreditStatePlugin = createPlugin({
         description: "The user sId to reconcile.",
         dependsOn: { field: "target", value: "user" },
       },
+      keyName: {
+        type: "string",
+        label: "API key name",
+        description: "The API key name to reconcile.",
+        dependsOn: { field: "target", value: "api_key" },
+      },
     },
     requiredRoles: ["billing"],
   },
@@ -77,6 +85,14 @@ export const reconcileCreditStatePlugin = createPlugin({
       );
     }
 
+    const trimmedKeyName = args.keyName.trim();
+    const keyName = trimmedKeyName === "" ? null : trimmedKeyName;
+    if (targetArg === "api_key" && !keyName) {
+      return new Err(
+        new Error("A key name is required when the target is 'api_key'.")
+      );
+    }
+
     const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
     if (!workspaceResource) {
       return new Err(new Error(`Workspace not found: wId='${workspace.sId}'`));
@@ -97,6 +113,7 @@ export const reconcileCreditStatePlugin = createPlugin({
       metronomeCustomerId,
       target: targetArg,
       userId,
+      keyName,
       execute,
     });
     if (result.isErr()) {


### PR DESCRIPTION
Adds an **`api_key`** target to the existing **"Check & Reconcile Credit State"** poke plugin, so an admin can reconcile a single API key's credit state from live Metronome usage — the per-key analogue of the existing `user` target.

- New `keyName` arg (shown when target = `api_key`).
- Reconciles **every active key with that name** (names aren't unique; each is reconciled per its own cap via `reconcileApiKey`, matching the webhook/backfill behavior), reporting before/after state per key.
- `check` reports drift without writing; `execute` writes through the same authoritative reconcile setter.

Stacked on top of #28065 (the cap stack). Pure addition — no schema/contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)