### PR TITLE
Do not hide the steps when conversation errors

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1309,23 +1309,6 @@ function AgentMessageContent({
     );
   }
 
-  if (agentMessage.status === "failed") {
-    return (
-      <ErrorMessage
-        error={
-          agentMessage.error ?? {
-            message: "Unexpected Error",
-            code: "unexpected_error",
-            metadata: {},
-          }
-        }
-        retryHandler={async () =>
-          retryHandler({ conversationId, messageId: agentMessage.sId })
-        }
-      />
-    );
-  }
-
   // Extract file IDs already referenced inline (to avoid duplicate rendering).
   // Match file IDs only in markdown IMAGE syntax: ![...](url containing fil_XXX)
   // NOT plain text mentions or links, to avoid filtering out images from the grid.
@@ -1486,6 +1469,20 @@ function AgentMessageContent({
               />
             </div>
           </div>
+        )}
+        {agentMessage.status === "failed" && (
+          <ErrorMessage
+            error={
+              agentMessage.error ?? {
+                message: "Unexpected Error",
+                code: "unexpected_error",
+                metadata: {},
+              }
+            }
+            retryHandler={async () =>
+              retryHandler({ conversationId, messageId: agentMessage.sId })
+            }
+          />
         )}
       </div>
     </CitationsContext.Provider>


### PR DESCRIPTION
## Description

When an agent message errored, we dropped all inline activity steps — you could no longer see what the agent did before it failed.

**Root cause:** `failed` was the only terminal status that hit an early `return <ErrorMessage>` before the main render, so `<InlineActivitySteps>` never mounted. The step data was never lost (loaded on reload, flushed on live error) — purely a render gap.

**What this PR does:** drops the `failed` early-return and renders `<ErrorMessage>` at the bottom of the normal render, like `cancelled` / `interrupted` already do.

> [!NOTE]
> Side-effects of the fall-through, both consistent with `cancelled`: partial content the agent wrote before erroring now renders, and a tool-less error shows a short "Errored after Xs" line above the error card.

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 