### PR TITLE
Persist and replay provider tool-search blocks so Anthropic thinking signatures stay valid

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -358,6 +358,8 @@ async function countTokensForMessages(
             text += c.value;
           } else if (c.type === "function_call") {
             text += `${c.value.name} ${c.value.arguments}`;
+          } else if (c.type === "provider_passthrough") {
+            // Opaque provider block, not counted here.
           } else {
             assertNever(c);
           }

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -499,6 +499,7 @@ function eventToStoredStepContent(
     case "token_usage":
     case "tool_call_started":
     case "tool_call_delta":
+    case "provider_passthrough":
       return null;
     default:
       assertNever(event);

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -499,6 +499,9 @@ function eventToStoredStepContent(
     case "token_usage":
     case "tool_call_started":
     case "tool_call_delta":
+    // Provider passthrough blocks are only persisted on the streaming path.
+    // Anthropic tool search runs streaming-only, so the batch path never needs
+    // to round-trip them; drop here as nothing is stored from batch results.
     case "provider_passthrough":
       return null;
     default:

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -232,7 +232,8 @@ function* handleContentBlockStart(
         accumulatorType: blockType === "text" ? "text" : "reasoning",
       };
       return;
-    case "tool_use": {
+
+    case "tool_use":
       stateContainer.state = {
         currentBlockIndex: event.index,
         accumulator: "",
@@ -252,7 +253,7 @@ function* handleContentBlockStart(
         metadata,
       };
       return;
-    }
+
     case "redacted_thinking":
       // "Redacted thinking" provides no actionable information, as everything is encrypted
       return;
@@ -300,6 +301,7 @@ function* handleContentBlockStart(
     case "fallback":
       // We don't use these Anthropic tools
       return;
+
     default:
       // New content block types may appear (e.g. via a new beta) before the
       // SDK types and this client are updated. Ignore rather than crash.

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -9,6 +9,7 @@ import type {
   Message,
   MessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
+import { ANTHROPIC_PROVIDER_ID } from "@app/lib/api/llm/clients/anthropic/types";
 import { validateContentBlockIndex } from "@app/lib/api/llm/clients/anthropic/utils/predicates";
 import type { StreamState } from "@app/lib/api/llm/clients/anthropic/utils/types";
 import { SuccessAggregate } from "@app/lib/api/llm/types/aggregates";
@@ -16,6 +17,7 @@ import type {
   CacheMissReason,
   LLMEvent,
   LLMOutputItem,
+  ProviderPassthroughEvent,
   ReasoningDeltaEvent,
   ReasoningGeneratedEvent,
   TextDeltaEvent,
@@ -264,16 +266,25 @@ function* handleContentBlockStart(
         accumulator: "",
         accumulatorType: "tool_search",
         toolName: event.content_block.name,
+        toolId: event.content_block.id,
       };
       return;
 
     case "tool_search_tool_result":
-      // The discovered tool references arrive inline in this block (no deltas),
-      // so log them here. State stays null and the matching stop is a no-op.
+      // Emit a passthrough so the block replays verbatim, and log the discovered
+      // references. State stays null, so the matching stop is a no-op.
       logToolSearchResult({
         content: event.content_block.content,
         logFields: metadata,
       });
+      yield providerPassthrough(
+        {
+          type: "tool_search_tool_result",
+          tool_use_id: event.content_block.tool_use_id,
+          content: event.content_block.content,
+        },
+        metadata
+      );
       return;
 
     case "web_search_tool_result":
@@ -408,14 +419,28 @@ function* handleContentBlockStop(
       break;
     }
 
-    case "tool_search":
+    case "tool_search": {
       logToolSearchQuery({
         rawInput: stateContainer.state.accumulator,
         toolName: stateContainer.state.toolName,
         tags: toolSearchTags(metadata),
         logFields: metadata,
       });
+      // Replay the server_tool_use block verbatim so interleaved thinking
+      // signatures stay valid, falling back to an empty input if the query
+      // failed to parse.
+      const parsedInput = safeParseJSON(stateContainer.state.accumulator);
+      yield providerPassthrough(
+        {
+          type: "server_tool_use",
+          id: stateContainer.state.toolId,
+          name: stateContainer.state.toolName,
+          input: parsedInput.isOk() ? parsedInput.value : {},
+        },
+        metadata
+      );
       break;
+    }
   }
   stateContainer.state = null;
 }
@@ -529,6 +554,20 @@ function textGenerated(
     content: {
       text,
     },
+    metadata,
+  };
+}
+
+// Wraps an Anthropic tool-search block (server_tool_use or
+// tool_search_tool_result) for verbatim round-trip. The block is opaque to the
+// generic pipeline and only re-typed by the Anthropic replay path.
+function providerPassthrough(
+  block: unknown,
+  metadata: LLMClientMetadata
+): ProviderPassthroughEvent {
+  return {
+    type: "provider_passthrough",
+    content: { provider: ANTHROPIC_PROVIDER_ID, block },
     metadata,
   };
 }

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -1,19 +1,24 @@
 import type {
   ImageBlockParam,
   MessageParam,
+  ServerToolUseBlockParam,
   TextBlockParam,
   ThinkingBlockParam,
   Tool,
   ToolResultBlockParam,
+  ToolSearchToolResultBlockParam,
   ToolUseBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { ANTHROPIC_PROVIDER_ID } from "@app/lib/api/llm/clients/anthropic/types";
+import { parseAnthropicToolSearchBlock } from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
 import { extractEncryptedContentFromMetadata } from "@app/lib/api/llm/utils";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
 import { TOOL_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   AgentFunctionCallContentType,
+  AgentProviderPassthroughContentType,
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
@@ -103,13 +108,16 @@ function assistantContentToParam(
   content:
     | AgentTextContentType
     | AgentReasoningContentType
-    | AgentFunctionCallContentType,
+    | AgentFunctionCallContentType
+    | AgentProviderPassthroughContentType,
   omittedThinking: boolean
 ):
   | TextBlockParam
   | ImageBlockParam
   | ThinkingBlockParam
   | ToolUseBlockParam
+  | ServerToolUseBlockParam
+  | ToolSearchToolResultBlockParam
   | undefined {
   switch (content.type) {
     case "text_content":
@@ -137,6 +145,15 @@ function assistantContentToParam(
         name: content.value.name,
         input: parseToolArguments(content.value.arguments, content.value.name),
       };
+    }
+    case "provider_passthrough": {
+      // Replay the provider's own tool-search blocks verbatim so interleaved
+      // thinking signatures stay valid. Skip blocks tagged for another provider
+      // or that fail to parse.
+      if (content.value.provider !== ANTHROPIC_PROVIDER_ID) {
+        return undefined;
+      }
+      return parseAnthropicToolSearchBlock(content.value.block) ?? undefined;
     }
   }
 }

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -148,9 +148,11 @@ function assistantContentToParam(
     }
     case "provider_passthrough": {
       // Replay the provider's own tool-search blocks verbatim so interleaved
-      // thinking signatures stay valid. Skip blocks tagged for another provider
-      // or that fail to parse.
-      if (content.value.provider !== ANTHROPIC_PROVIDER_ID) {
+      // thinking signatures stay valid. When thinking is omitted there are no
+      // signatures to protect, so drop the server blocks too rather than send
+      // them orphaned from the thinking they were emitted with. Also skip blocks
+      // tagged for another provider or that fail to parse.
+      if (omittedThinking || content.value.provider !== ANTHROPIC_PROVIDER_ID) {
         return undefined;
       }
       return parseAnthropicToolSearchBlock(content.value.block) ?? undefined;

--- a/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
@@ -11,6 +11,7 @@ import { toolUseLLMEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/
 import { emptyToolCallModelEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/empty_tool_call";
 import { reasoningModelEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/reasoning";
 import { toolUseModelEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/tool_use";
+import type { ProviderPassthroughEvent } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { createAsyncGenerator } from "@app/lib/api/llm/utils";
 import { CLAUDE_4_SONNET_20250514_MODEL_ID } from "@app/types/assistant/models/anthropic";
@@ -218,15 +219,43 @@ describe("streamLLMEvents", () => {
       result.push(event);
     }
 
-    // The search itself yields no tool_call; only the heartbeat deltas, then the
-    // usual end-of-turn events.
+    // The search yields no tool_call: heartbeat deltas, then the two server-tool
+    // blocks captured as passthrough for verbatim replay, then end-of-turn events.
     expect(result.map((e) => e.type)).toEqual([
       "tool_call_delta",
       "tool_call_delta",
+      "provider_passthrough",
+      "provider_passthrough",
       "token_usage",
       "success",
     ]);
     expect(result.some((e) => e.type === "tool_call")).toBe(false);
+
+    const passthroughs = result.filter(
+      (e): e is ProviderPassthroughEvent => e.type === "provider_passthrough"
+    );
+    expect(passthroughs[0].content).toEqual({
+      provider: "anthropic",
+      block: {
+        type: "server_tool_use",
+        id: "srvtoolu_01ABC",
+        name: "tool_search_tool_bm25",
+        input: { query: "send a slack message" },
+      },
+    });
+    expect(passthroughs[1].content).toEqual({
+      provider: "anthropic",
+      block: {
+        type: "tool_search_tool_result",
+        tool_use_id: "srvtoolu_01ABC",
+        content: {
+          type: "tool_search_tool_search_result",
+          tool_references: [
+            { type: "tool_reference", tool_name: "slack__post_message" },
+          ],
+        },
+      },
+    });
   });
 });
 

--- a/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
@@ -293,5 +293,24 @@ describe("toMessage", () => {
 
       expect(result.content).toEqual([{ type: "text", text: "hello" }]);
     });
+
+    it("drops passthrough blocks when thinking is omitted", async () => {
+      // With thinking omitted there are no signatures to protect, so the server
+      // blocks must not be sent orphaned from their thinking.
+      const result = await toMessage(assistantMessage, {
+        isFirst: false,
+        omittedThinking: true,
+      });
+
+      expect(result.content).toEqual([
+        { type: "text", text: "Let me find a tool." },
+        {
+          type: "tool_use",
+          id: "toolu_1",
+          name: "github__create_issue",
+          input: {},
+        },
+      ]);
+    });
   });
 });

--- a/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
@@ -3,6 +3,7 @@ import { conversationMessages } from "@app/lib/api/llm/clients/anthropic/utils/t
 import { reasoningConversationMessages } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/conversation_messages/reasoning";
 import { inputMessages } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/model_input";
 import { reasoningInputMessages } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/model_input/reasoning";
+import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
 import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
 import { describe, expect, it, vi } from "vitest";
 
@@ -209,6 +210,88 @@ describe("toMessage", () => {
           },
         ],
       });
+    });
+  });
+
+  describe("provider passthrough (tool search blocks)", () => {
+    const serverToolUseBlock = {
+      type: "server_tool_use",
+      id: "srvtoolu_1",
+      name: "tool_search_tool_bm25",
+      input: { query: "create github issue" },
+    };
+    const toolSearchResultBlock = {
+      type: "tool_search_tool_result",
+      tool_use_id: "srvtoolu_1",
+      content: {
+        type: "tool_search_tool_search_result",
+        tool_references: [
+          { type: "tool_reference", tool_name: "github__create_issue" },
+        ],
+      },
+    };
+
+    const assistantMessage: ModelMessageTypeMultiActionsWithoutContentFragment =
+      {
+        role: "assistant",
+        name: "agent",
+        contents: [
+          { type: "text_content", value: "Let me find a tool." },
+          {
+            type: "provider_passthrough",
+            value: { provider: "anthropic", block: serverToolUseBlock },
+          },
+          {
+            type: "provider_passthrough",
+            value: { provider: "anthropic", block: toolSearchResultBlock },
+          },
+          {
+            type: "function_call",
+            value: {
+              id: "toolu_1",
+              name: "github__create_issue",
+              arguments: "{}",
+            },
+          },
+        ],
+      };
+
+    it("replays anthropic passthrough blocks verbatim, in order", async () => {
+      const result = await toMessage(assistantMessage, {
+        isFirst: false,
+        omittedThinking: false,
+      });
+
+      expect(result.content).toEqual([
+        { type: "text", text: "Let me find a tool." },
+        serverToolUseBlock,
+        toolSearchResultBlock,
+        {
+          type: "tool_use",
+          id: "toolu_1",
+          name: "github__create_issue",
+          input: {},
+        },
+      ]);
+    });
+
+    it("skips passthrough blocks tagged for another provider", async () => {
+      const result = await toMessage(
+        {
+          role: "assistant",
+          name: "agent",
+          contents: [
+            { type: "text_content", value: "hello" },
+            {
+              type: "provider_passthrough",
+              value: { provider: "openai", block: serverToolUseBlock },
+            },
+          ],
+        },
+        { isFirst: false, omittedThinking: false }
+      );
+
+      expect(result.content).toEqual([{ type: "text", text: "hello" }]);
     });
   });
 });

--- a/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.test.ts
@@ -1,0 +1,54 @@
+import { parseAnthropicToolSearchBlock } from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
+import { describe, expect, it } from "vitest";
+
+describe("parseAnthropicToolSearchBlock", () => {
+  it("parses a server_tool_use block verbatim", () => {
+    const block = {
+      type: "server_tool_use",
+      id: "srvtoolu_1",
+      name: "tool_search_tool_bm25",
+      input: { query: "create github issue" },
+    };
+
+    expect(parseAnthropicToolSearchBlock(block)).toEqual(block);
+  });
+
+  it("parses a tool_search_tool_result block verbatim", () => {
+    const block = {
+      type: "tool_search_tool_result",
+      tool_use_id: "srvtoolu_1",
+      content: {
+        type: "tool_search_tool_search_result",
+        tool_references: [
+          { type: "tool_reference", tool_name: "github__create_issue" },
+        ],
+      },
+    };
+
+    expect(parseAnthropicToolSearchBlock(block)).toEqual(block);
+  });
+
+  it("parses a tool_search_tool_result error block", () => {
+    const block = {
+      type: "tool_search_tool_result",
+      tool_use_id: "srvtoolu_1",
+      content: {
+        type: "tool_search_tool_result_error",
+        error_code: "unavailable",
+        error_message: "transient",
+      },
+    };
+
+    expect(parseAnthropicToolSearchBlock(block)).toEqual(block);
+  });
+
+  it("returns null for an unrecognized or malformed block", () => {
+    expect(parseAnthropicToolSearchBlock({ type: "text", text: "hi" })).toBe(
+      null
+    );
+    expect(parseAnthropicToolSearchBlock({ type: "server_tool_use" })).toBe(
+      null
+    );
+    expect(parseAnthropicToolSearchBlock(null)).toBe(null);
+  });
+});

--- a/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.test.ts
@@ -1,5 +1,10 @@
+import type {
+  ServerToolUseBlockParam,
+  ToolSearchToolResultBlockParam,
+} from "@anthropic-ai/sdk/resources/messages/messages.mjs";
+import type { AnthropicToolSearchBlock } from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
 import { parseAnthropicToolSearchBlock } from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 
 describe("parseAnthropicToolSearchBlock", () => {
   it("parses a server_tool_use block verbatim", () => {
@@ -50,5 +55,28 @@ describe("parseAnthropicToolSearchBlock", () => {
       null
     );
     expect(parseAnthropicToolSearchBlock(null)).toBe(null);
+  });
+});
+
+describe("schema matches the Anthropic SDK param types", () => {
+  // Compile-time guard against SDK drift: each zod-inferred block must stay
+  // assignable to its SDK param. A newly required SDK field, a renamed field, or
+  // a changed enum value breaks these (tsgo type-checks test files). It is
+  // assignability, not equality, on purpose: we omit the optional caller /
+  // cache_control fields the params allow, and treat `input` as present (the
+  // param requires it where z.unknown() infers it optional), matching how
+  // parseAnthropicToolSearchBlock reconstructs the block.
+  it("keeps server_tool_use assignable to ServerToolUseBlockParam", () => {
+    expectTypeOf<
+      Extract<AnthropicToolSearchBlock, { type: "server_tool_use" }> & {
+        input: unknown;
+      }
+    >().toMatchTypeOf<ServerToolUseBlockParam>();
+  });
+
+  it("keeps tool_search_tool_result assignable to ToolSearchToolResultBlockParam", () => {
+    expectTypeOf<
+      Extract<AnthropicToolSearchBlock, { type: "tool_search_tool_result" }>
+    >().toMatchTypeOf<ToolSearchToolResultBlockParam>();
   });
 });

--- a/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.ts
@@ -2,6 +2,7 @@ import type {
   ServerToolUseBlockParam,
   ToolSearchToolResultBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
+import logger from "@app/logger/logger";
 import { z } from "zod";
 
 // Anthropic runs tool search server-side inside a single assistant turn, emitting
@@ -56,6 +57,10 @@ export type AnthropicToolSearchBlock = z.infer<
   typeof anthropicToolSearchBlockSchema
 >;
 
+function hasBlockType(value: unknown): value is { type: unknown } {
+  return typeof value === "object" && value !== null && "type" in value;
+}
+
 // Parses an opaque persisted block back into a typed Anthropic block param.
 // Returns null when the block is not a recognized tool-search block so the
 // caller can skip it rather than send a malformed request.
@@ -64,6 +69,13 @@ export function parseAnthropicToolSearchBlock(
 ): ServerToolUseBlockParam | ToolSearchToolResultBlockParam | null {
   const r = anthropicToolSearchBlockSchema.safeParse(block);
   if (!r.success) {
+    // We only ever store blocks we captured ourselves, so a parse failure means
+    // storage drift or a newly enabled server tool the schema does not know.
+    // Surface it: dropping the block would re-break interleaved thinking.
+    logger.warn(
+      { blockType: hasBlockType(block) ? block.type : undefined },
+      "[tool-search] Dropping unparseable Anthropic passthrough block"
+    );
     return null;
   }
   // Reconstruct the param explicitly so required fields (e.g. `input`) are

--- a/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.ts
@@ -1,0 +1,84 @@
+import type {
+  ServerToolUseBlockParam,
+  ToolSearchToolResultBlockParam,
+} from "@anthropic-ai/sdk/resources/messages/messages.mjs";
+import { z } from "zod";
+
+// Anthropic runs tool search server-side inside a single assistant turn, emitting
+// `server_tool_use` and `tool_search_tool_result` blocks interleaved with the
+// thinking blocks. Those blocks must be replayed verbatim on the next request or
+// the thinking-block signatures are rejected. We persist them opaquely in the
+// generic content layer (as provider passthrough) and parse them back here with
+// full typing.
+//
+// The schemas mirror the Anthropic SDK param shapes so a parsed block is directly
+// assignable to BetaContentBlockParam, no cast required.
+
+const toolReferenceSchema = z.object({
+  type: z.literal("tool_reference"),
+  tool_name: z.string(),
+});
+
+const serverToolUseSchema = z.object({
+  type: z.literal("server_tool_use"),
+  id: z.string(),
+  name: z.enum(["tool_search_tool_bm25", "tool_search_tool_regex"]),
+  input: z.unknown(),
+});
+
+const toolSearchToolResultSchema = z.object({
+  type: z.literal("tool_search_tool_result"),
+  tool_use_id: z.string(),
+  content: z.union([
+    z.object({
+      type: z.literal("tool_search_tool_result_error"),
+      error_code: z.enum([
+        "invalid_tool_input",
+        "unavailable",
+        "too_many_requests",
+        "execution_time_exceeded",
+      ]),
+      error_message: z.string().nullish(),
+    }),
+    z.object({
+      type: z.literal("tool_search_tool_search_result"),
+      tool_references: z.array(toolReferenceSchema),
+    }),
+  ]),
+});
+
+export const anthropicToolSearchBlockSchema = z.discriminatedUnion("type", [
+  serverToolUseSchema,
+  toolSearchToolResultSchema,
+]);
+
+export type AnthropicToolSearchBlock = z.infer<
+  typeof anthropicToolSearchBlockSchema
+>;
+
+// Parses an opaque persisted block back into a typed Anthropic block param.
+// Returns null when the block is not a recognized tool-search block so the
+// caller can skip it rather than send a malformed request.
+export function parseAnthropicToolSearchBlock(
+  block: unknown
+): ServerToolUseBlockParam | ToolSearchToolResultBlockParam | null {
+  const r = anthropicToolSearchBlockSchema.safeParse(block);
+  if (!r.success) {
+    return null;
+  }
+  // Reconstruct the param explicitly so required fields (e.g. `input`) are
+  // present, since zod infers `z.unknown()` keys as optional.
+  if (r.data.type === "server_tool_use") {
+    return {
+      type: "server_tool_use",
+      id: r.data.id,
+      name: r.data.name,
+      input: r.data.input,
+    };
+  }
+  return {
+    type: "tool_search_tool_result",
+    tool_use_id: r.data.tool_use_id,
+    content: r.data.content,
+  };
+}

--- a/front/lib/api/llm/clients/anthropic/utils/types.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/types.ts
@@ -26,6 +26,8 @@ export type ToolUseState = BaseState & {
 export type ToolSearchState = BaseState & {
   accumulatorType: "tool_search";
   toolName: string;
+  // The server_tool_use block id, needed to replay the block verbatim.
+  toolId: string;
 };
 
 export type StreamState =

--- a/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
+++ b/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
@@ -5,6 +5,7 @@ import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   AgentFunctionCallContentType,
+  AgentProviderPassthroughContentType,
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
@@ -18,6 +19,7 @@ import type {
 } from "@app/types/assistant/generation";
 import type { ModelIdType } from "@app/types/assistant/models/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { removeNulls } from "@app/types/shared/utils/general";
 import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
 import type {
   Content,
@@ -144,7 +146,8 @@ function assistantContentToPart(
     | AgentReasoningContentType
     | AgentTextContentType
     | AgentFunctionCallContentType
-): Part {
+    | AgentProviderPassthroughContentType
+): Part | null {
   switch (content.type) {
     case "reasoning":
       assert(content.value.reasoning, "Reasoning content is missing reasoning");
@@ -169,6 +172,9 @@ function assistantContentToPart(
         thoughtSignature: content.value.metadata?.thoughtSignature,
       };
     }
+    case "provider_passthrough":
+      // Opaque block owned by another provider. Skip.
+      return null;
     default:
       assertNever(content);
   }
@@ -181,7 +187,9 @@ async function assistantMessageToParts(
 ): Promise<Content> {
   assert(message.contents, "Assistant message is missing contents");
 
-  const parts = await Promise.all(message.contents.map(assistantContentToPart));
+  const parts = removeNulls(
+    await Promise.all(message.contents.map(assistantContentToPart))
+  );
 
   return {
     role: "model",

--- a/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
+++ b/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
@@ -90,7 +90,7 @@ function toAssistantMessage(
   const textContents = message.contents
     .filter(
       (c): c is AgentTextContentType | AgentReasoningContentType =>
-        c.type !== "function_call"
+        c.type === "text_content" || c.type === "reasoning"
     )
     .map(toContentChunk);
   const toolCalls = message.contents

--- a/front/lib/api/llm/transitionLLM.test.ts
+++ b/front/lib/api/llm/transitionLLM.test.ts
@@ -1,0 +1,71 @@
+import {
+  convertToOldEvent,
+  toBaseMessages,
+} from "@app/lib/api/llm/transitionLLM";
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type { ProviderPassthroughEvent } from "@app/lib/model_constructors/types/output/events";
+import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
+import { describe, expect, it } from "vitest";
+
+const llmMetadata: LLMClientMetadata = {
+  clientId: "anthropic",
+  inferenceProvider: "anthropic",
+  inferenceRegion: "global",
+  modelId: "claude-sonnet-4-6",
+};
+
+const endpointMetadata: EndpointMetadata = {
+  providerId: "anthropic",
+  api: "anthropic",
+  region: "us",
+  modelId: "claude-sonnet-4-6",
+};
+
+const serverToolUseBlock = {
+  type: "server_tool_use",
+  id: "srvtoolu_1",
+  name: "tool_search_tool_bm25",
+  input: { query: "x" },
+};
+
+describe("toBaseMessages", () => {
+  it("maps a provider_passthrough content to a passthrough BaseMessage", () => {
+    const message: ModelMessageTypeMultiActionsWithoutContentFragment = {
+      role: "assistant",
+      name: "agent",
+      contents: [
+        { type: "text_content", value: "hi" },
+        {
+          type: "provider_passthrough",
+          value: { provider: "anthropic", block: serverToolUseBlock },
+        },
+      ],
+    };
+
+    expect(toBaseMessages(message)).toEqual([
+      { role: "assistant", type: "text", content: { value: "hi" } },
+      {
+        role: "assistant",
+        type: "provider_passthrough",
+        content: { provider: "anthropic", block: serverToolUseBlock },
+      },
+    ]);
+  });
+});
+
+describe("convertToOldEvent", () => {
+  it("forwards a provider_passthrough event with its content and the old metadata", () => {
+    const event: ProviderPassthroughEvent = {
+      type: "provider_passthrough",
+      content: { provider: "anthropic", block: serverToolUseBlock },
+      metadata: endpointMetadata,
+    };
+
+    expect(convertToOldEvent(event, llmMetadata)).toEqual({
+      type: "provider_passthrough",
+      content: { provider: "anthropic", block: serverToolUseBlock },
+      metadata: llmMetadata,
+    });
+  });
+});

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -84,7 +84,7 @@ function mapReasoningEffort(
 /**
  * Converts an old-system message to new BaseMessage(s).
  */
-function toBaseMessages(
+export function toBaseMessages(
   message: ModelMessageTypeMultiActionsWithoutContentFragment
 ): BaseMessage[] {
   switch (message.role) {
@@ -171,8 +171,16 @@ function toBaseMessages(
                 },
               ];
             case "provider_passthrough":
-              // Opaque provider block, not yet round-tripped through this router.
-              return [];
+              return [
+                {
+                  role: "assistant",
+                  type: "provider_passthrough",
+                  content: {
+                    provider: c.value.provider,
+                    block: c.value.block,
+                  },
+                },
+              ];
             default:
               assertNever(c);
           }
@@ -282,7 +290,7 @@ function mapErrorType(errorType: ErrorType): {
 /**
  * Converts a single new model event to its old LLM event equivalent.
  */
-function convertToOldEvent(
+export function convertToOldEvent(
   event: ModelResponseEvent,
   metadata: LLMClientMetadata
 ): LLMEvent {
@@ -407,6 +415,13 @@ function convertToOldEvent(
         metadata,
       };
     }
+
+    case "provider_passthrough":
+      return {
+        type: "provider_passthrough",
+        content: event.content,
+        metadata,
+      };
 
     case "error": {
       const { type: errorType, isRetryable } = mapErrorType(event.content.type);

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -52,6 +52,7 @@ import type {
 } from "@app/lib/model_constructors/types/output/events";
 import type {
   AgentFunctionCallContentType,
+  AgentProviderPassthroughContentType,
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
@@ -131,6 +132,7 @@ function toBaseMessages(
             | AgentTextContentType
             | AgentReasoningContentType
             | AgentFunctionCallContentType
+            | AgentProviderPassthroughContentType
         ): BaseMessage[] => {
           switch (c.type) {
             case "text_content":
@@ -168,6 +170,9 @@ function toBaseMessages(
                   signature: c.value.metadata?.thoughtSignature,
                 },
               ];
+            case "provider_passthrough":
+              // Opaque provider block, not yet round-tripped through this router.
+              return [];
             default:
               assertNever(c);
           }

--- a/front/lib/api/llm/types/events.ts
+++ b/front/lib/api/llm/types/events.ts
@@ -1,6 +1,7 @@
 import type { LLMErrorInfo } from "@app/lib/api/llm/types/errors";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import type { AgentMessagePhase } from "@app/types/assistant/agent_message_content";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 
 export type Delta = {
   delta: string;
@@ -80,6 +81,15 @@ export interface ReasoningGeneratedEvent {
   metadata: LLMClientMetadata & { id?: string; encrypted_content?: string };
 }
 
+// Opaque provider-specific block that must be persisted and replayed verbatim
+// to the producing provider. The generic pipeline forwards `block` without
+// interpreting it.
+export interface ProviderPassthroughEvent {
+  type: "provider_passthrough";
+  content: { provider: ModelProviderIdType; block: unknown };
+  metadata: LLMClientMetadata;
+}
+
 export type LLMOutputItem =
   | TextGeneratedEvent
   | ReasoningGeneratedEvent
@@ -136,6 +146,7 @@ export type LLMEvent =
   | ToolCallEvent
   | TextGeneratedEvent
   | ReasoningGeneratedEvent
+  | ProviderPassthroughEvent
   | TokenUsageEvent
   | SuccessCompletionEvent
   | EventError;

--- a/front/lib/api/llm/utils/openai_like/chat/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/conversation_to_openai.ts
@@ -81,6 +81,9 @@ function toAssistantMessages(
       case "error":
         assistantContent.push(content.value.message);
         break;
+      case "provider_passthrough":
+        // Opaque block owned by another provider. Skip.
+        break;
       default:
         assertNever(content);
     }

--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -104,6 +104,9 @@ function toAssistantInputItem(
         type: "message",
         content: content.value.message,
       };
+    case "provider_passthrough":
+      // Opaque block owned by another provider. Skip.
+      return null;
     default:
       assertNever(content);
   }

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
@@ -11,6 +11,7 @@ import {
   TOOL_SEARCH_INSTRUCTION,
 } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
 import {
+  assistantProviderPassthroughMessageToBlocks,
   assistantReasoningMessageToThinkingBlocks,
   assistantTextMessageToTextBlock,
   assistantToolCallRequestToToolUseBlock,
@@ -52,6 +53,8 @@ export function WithAnthropicAIInputConverter<
       assistantReasoningMessageToThinkingBlocks;
     assistantToolCallRequestToToolUseBlock =
       assistantToolCallRequestToToolUseBlock;
+    assistantProviderPassthroughMessageToBlocks =
+      assistantProviderPassthroughMessageToBlocks;
     reasoningToThinkingConfig = reasoningToThinkingConfig;
     modelIdToApiModelId = (modelId: ModelId): Model => modelId;
 

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.test.ts
@@ -6,6 +6,7 @@ import type {
 import type { MessageBlockConverters } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
 import {
   assistantMessageToContentBlocks,
+  assistantProviderPassthroughMessageToBlocks,
   assistantReasoningMessageToThinkingBlocks,
   assistantTextMessageToTextBlock,
   assistantToolCallRequestToToolUseBlock,
@@ -30,6 +31,7 @@ import type {
   ToolSpecification,
 } from "@app/lib/model_constructors/types/input/configuration";
 import type {
+  BaseAssistantProviderPassthroughMessage,
   BaseAssistantReasoningMessage,
   BaseAssistantTextMessage,
   BaseAssistantToolCallRequestMessage,
@@ -55,6 +57,7 @@ const realConverters: MessageBlockConverters = {
   assistantTextMessageToTextBlock,
   assistantReasoningMessageToThinkingBlocks,
   assistantToolCallRequestToToolUseBlock,
+  assistantProviderPassthroughMessageToBlocks,
 };
 
 // A fully stubbed converters object, so composites can be checked for pure
@@ -86,6 +89,7 @@ function makeStubConverters(): MessageBlockConverters {
           input: {},
         }) as ToolUseBlockParam
     ),
+    assistantProviderPassthroughMessageToBlocks: vi.fn(() => []),
   };
 }
 
@@ -624,6 +628,76 @@ describe("assistantMessageToContentBlocks", () => {
     expect(result).toEqual([
       { type: "tool_use", id: "stub-id", name: "stub-name", input: {} },
     ]);
+  });
+
+  it("delegates provider_passthrough messages to assistantProviderPassthroughMessageToBlocks", () => {
+    const stub = makeStubConverters();
+    const message: BaseAssistantProviderPassthroughMessage = {
+      role: "assistant",
+      type: "provider_passthrough",
+      content: { provider: "anthropic", block: { type: "x" } },
+    };
+    assistantMessageToContentBlocks(message, stub);
+    expect(
+      stub.assistantProviderPassthroughMessageToBlocks
+    ).toHaveBeenCalledWith(message);
+  });
+});
+
+describe("assistantProviderPassthroughMessageToBlocks", () => {
+  const serverToolUseBlock = {
+    type: "server_tool_use",
+    id: "srvtoolu_1",
+    name: "tool_search_tool_bm25",
+    input: { query: "x" },
+  };
+  const toolSearchResultBlock = {
+    type: "tool_search_tool_result",
+    tool_use_id: "srvtoolu_1",
+    content: {
+      type: "tool_search_tool_search_result",
+      tool_references: [{ type: "tool_reference", tool_name: "slack__post" }],
+    },
+  };
+
+  it("replays an anthropic server_tool_use block verbatim", () => {
+    const message: BaseAssistantProviderPassthroughMessage = {
+      role: "assistant",
+      type: "provider_passthrough",
+      content: { provider: "anthropic", block: serverToolUseBlock },
+    };
+    expect(assistantProviderPassthroughMessageToBlocks(message)).toEqual([
+      serverToolUseBlock,
+    ]);
+  });
+
+  it("replays an anthropic tool_search_tool_result block verbatim", () => {
+    const message: BaseAssistantProviderPassthroughMessage = {
+      role: "assistant",
+      type: "provider_passthrough",
+      content: { provider: "anthropic", block: toolSearchResultBlock },
+    };
+    expect(assistantProviderPassthroughMessageToBlocks(message)).toEqual([
+      toolSearchResultBlock,
+    ]);
+  });
+
+  it("skips a block tagged for another provider", () => {
+    const message: BaseAssistantProviderPassthroughMessage = {
+      role: "assistant",
+      type: "provider_passthrough",
+      content: { provider: "openai", block: serverToolUseBlock },
+    };
+    expect(assistantProviderPassthroughMessageToBlocks(message)).toEqual([]);
+  });
+
+  it("skips an anthropic block that fails to parse", () => {
+    const message: BaseAssistantProviderPassthroughMessage = {
+      role: "assistant",
+      type: "provider_passthrough",
+      content: { provider: "anthropic", block: { type: "text", text: "no" } },
+    };
+    expect(assistantProviderPassthroughMessageToBlocks(message)).toEqual([]);
   });
 });
 

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
@@ -14,6 +14,7 @@ import type {
   ToolResultBlockParam,
   ToolUseBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages";
+import { parseAnthropicToolSearchBlock } from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
 import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import type { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
 import { TOOL_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
@@ -23,6 +24,7 @@ import type {
 } from "@app/lib/model_constructors/types/input/configuration";
 import type {
   BaseAssistantMessage,
+  BaseAssistantProviderPassthroughMessage,
   BaseAssistantReasoningMessage,
   BaseAssistantTextMessage,
   BaseAssistantToolCallRequestMessage,
@@ -34,6 +36,7 @@ import type {
   CacheOption,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
+import { ANTHROPIC_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -83,6 +86,9 @@ export interface MessageBlockConverters {
   assistantToolCallRequestToToolUseBlock(
     message: BaseAssistantToolCallRequestMessage
   ): ToolUseBlockParam;
+  assistantProviderPassthroughMessageToBlocks(
+    message: BaseAssistantProviderPassthroughMessage
+  ): MessageParam["content"];
 }
 
 // -- Small, reusable building blocks --
@@ -208,6 +214,20 @@ export function assistantToolCallRequestToToolUseBlock(
   };
 }
 
+export function assistantProviderPassthroughMessageToBlocks(
+  message: BaseAssistantProviderPassthroughMessage
+): MessageParam["content"] {
+  // Replay the provider's own tool-search blocks verbatim so interleaved
+  // thinking signatures stay valid. Skip blocks tagged for another provider or
+  // that fail to parse.
+  if (message.content.provider !== ANTHROPIC_PROVIDER_ID) {
+    return [];
+  }
+
+  const parsed = parseAnthropicToolSearchBlock(message.content.block);
+  return parsed ? [parsed] : [];
+}
+
 // -- Composite message converters (depend on the leaf converters) --
 
 export async function userImageMessageToImageBlock(
@@ -274,6 +294,8 @@ export function assistantMessageToContentBlocks(
       return converters.assistantReasoningMessageToThinkingBlocks(message);
     case "tool_call_request":
       return [converters.assistantToolCallRequestToToolUseBlock(message)];
+    case "provider_passthrough":
+      return converters.assistantProviderPassthroughMessageToBlocks(message);
     default:
       assertNever(message);
   }

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/index.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/index.ts
@@ -9,6 +9,7 @@ import {
   messageStartToResponseIdEvent,
   type OutputEventConverters,
   reasoningDeltaToReasoningDeltaEvent,
+  serverToolBlockToProviderPassthroughEvent,
   stopReasonToErrorEvent,
   streamErrorToErrorEvent,
   textDeltaToTextDeltaEvent,
@@ -37,6 +38,8 @@ export function WithAnthropicAIOutputConverter<
     inputJsonDeltaToToolCallDeltaEvent = inputJsonDeltaToToolCallDeltaEvent;
     accumulatedToolCallToToolCallEvent = accumulatedToolCallToToolCallEvent;
     invalidJsonToolCallToToolCallEvent = invalidJsonToolCallToToolCallEvent;
+    serverToolBlockToProviderPassthroughEvent =
+      serverToolBlockToProviderPassthroughEvent;
     messageDeltaUsageToTokenUsageEvent = messageDeltaUsageToTokenUsageEvent;
     stopReasonToErrorEvent = stopReasonToErrorEvent;
     streamErrorToErrorEvent = streamErrorToErrorEvent;

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
@@ -33,6 +33,7 @@ import {
   messageToEvents,
   rawOutputToEvents,
   reasoningDeltaToReasoningDeltaEvent,
+  serverToolBlockToProviderPassthroughEvent,
   stopReasonToErrorEvent,
   streamErrorToErrorEvent,
   textDeltaToTextDeltaEvent,
@@ -61,6 +62,7 @@ const realConverters: OutputEventConverters = {
   inputJsonDeltaToToolCallDeltaEvent,
   accumulatedToolCallToToolCallEvent,
   invalidJsonToolCallToToolCallEvent,
+  serverToolBlockToProviderPassthroughEvent,
   messageDeltaUsageToTokenUsageEvent,
   stopReasonToErrorEvent,
   streamErrorToErrorEvent,
@@ -116,6 +118,11 @@ function makeStubConverters(): OutputEventConverters {
         name: "stub-tool",
         arguments: { INVALID_JSON: "stub-invalid" },
       },
+      metadata,
+    })),
+    serverToolBlockToProviderPassthroughEvent: vi.fn(() => ({
+      type: "provider_passthrough" as const,
+      content: { provider: "anthropic" as const, block: {} },
       metadata,
     })),
     messageDeltaUsageToTokenUsageEvent: vi.fn(() => ({
@@ -635,10 +642,11 @@ describe("contentBlockStartToEvents", () => {
       accumulator: "",
       type: "tool_search",
       toolName: "tool_search_tool_bm25",
+      toolId: "srvtoolu_1",
     });
   });
 
-  it("consumes a tool search result block without opening a cursor", () => {
+  it("emits a tool search result block as passthrough without opening a cursor", () => {
     const event = {
       type: "content_block_start",
       index: 6,
@@ -659,7 +667,25 @@ describe("contentBlockStartToEvents", () => {
       metadata,
       realConverters
     );
-    expect(events).toEqual([]);
+    expect(events).toEqual([
+      {
+        type: "provider_passthrough",
+        content: {
+          provider: "anthropic",
+          block: {
+            type: "tool_search_tool_result",
+            tool_use_id: "srvtoolu_1",
+            content: {
+              type: "tool_search_tool_search_result",
+              tool_references: [
+                { type: "tool_reference", tool_name: "slack__post_message" },
+              ],
+            },
+          },
+        },
+        metadata,
+      },
+    ]);
     expect(state).toBeNull();
   });
 });
@@ -953,16 +979,65 @@ describe("contentBlockStopToEvents", () => {
     ]);
   });
 
-  it("closes a tool_search block without emitting a tool_call", () => {
+  it("closes a tool_search block by emitting the server_tool_use as passthrough", () => {
     const state = {
       index: 0,
       accumulator: '{"query":"send a slack message"}',
       type: "tool_search" as const,
-      toolName: "tool_search_tool_bm25",
+      toolName: "tool_search_tool_bm25" as const,
+      toolId: "srvtoolu_1",
     };
     expect(
       contentBlockStopToEvents(stopEvent, state, metadata, realConverters)
-    ).toEqual([[], null]);
+    ).toEqual([
+      [
+        {
+          type: "provider_passthrough",
+          content: {
+            provider: "anthropic",
+            block: {
+              type: "server_tool_use",
+              id: "srvtoolu_1",
+              name: "tool_search_tool_bm25",
+              input: { query: "send a slack message" },
+            },
+          },
+          metadata,
+        },
+      ],
+      null,
+    ]);
+  });
+
+  it("falls back to an empty input when the tool_search query did not parse", () => {
+    const state = {
+      index: 0,
+      accumulator: "{not json",
+      type: "tool_search" as const,
+      toolName: "tool_search_tool_bm25" as const,
+      toolId: "srvtoolu_1",
+    };
+    const [events] = contentBlockStopToEvents(
+      stopEvent,
+      state,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([
+      {
+        type: "provider_passthrough",
+        content: {
+          provider: "anthropic",
+          block: {
+            type: "server_tool_use",
+            id: "srvtoolu_1",
+            name: "tool_search_tool_bm25",
+            input: {},
+          },
+        },
+        metadata,
+      },
+    ]);
   });
 });
 
@@ -1288,6 +1363,39 @@ describe("messageToEvents", () => {
       "response_id",
       "token_usage",
       "success",
+    ]);
+  });
+
+  it("emits server_tool_use and tool_search_tool_result as passthrough", () => {
+    const serverToolUseBlock = {
+      type: "server_tool_use",
+      id: "srvtoolu_1",
+      name: "tool_search_tool_bm25",
+      input: { query: "x" },
+    };
+    const toolSearchResultBlock = {
+      type: "tool_search_tool_result",
+      tool_use_id: "srvtoolu_1",
+      content: {
+        type: "tool_search_tool_search_result",
+        tool_references: [{ type: "tool_reference", tool_name: "slack__post" }],
+      },
+    };
+    const message = messageWith({
+      content: [serverToolUseBlock, toolSearchResultBlock],
+    } as Partial<Message>);
+    const events = messageToEvents(message, metadata, realConverters);
+    expect(events.filter((e) => e.type === "provider_passthrough")).toEqual([
+      {
+        type: "provider_passthrough",
+        content: { provider: "anthropic", block: serverToolUseBlock },
+        metadata,
+      },
+      {
+        type: "provider_passthrough",
+        content: { provider: "anthropic", block: toolSearchResultBlock },
+        metadata,
+      },
     ]);
   });
 });

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -25,6 +25,7 @@ import type {
   ErrorEvent,
   ModelResponseEvent,
   NonDeltaResponseEvent,
+  ProviderPassthroughEvent,
   ReasoningDeltaEvent,
   ReasoningEvent,
   ResponseIdEvent,
@@ -122,6 +123,8 @@ export type BlockState =
       accumulator: string;
       type: "tool_search";
       toolName: string;
+      // The server_tool_use block id, needed to replay the block verbatim.
+      toolId: string;
     };
 
 // The per-signal leaf converters. Composites below take an object satisfying
@@ -170,6 +173,10 @@ export interface OutputEventConverters {
     name: string,
     invalidJson: string
   ): ToolCallEvent;
+  serverToolBlockToProviderPassthroughEvent(
+    metadata: EndpointMetadata,
+    block: unknown
+  ): ProviderPassthroughEvent;
   messageDeltaUsageToTokenUsageEvent(
     metadata: EndpointMetadata,
     usage: MessageDeltaUsage,
@@ -278,6 +285,17 @@ export function invalidJsonToolCallToToolCallEvent(
   return {
     type: "tool_call",
     content: { id, name, arguments: { INVALID_JSON: invalidJson } },
+    metadata,
+  };
+}
+
+export function serverToolBlockToProviderPassthroughEvent(
+  metadata: EndpointMetadata,
+  block: unknown
+): ProviderPassthroughEvent {
+  return {
+    type: "provider_passthrough",
+    content: { provider: metadata.providerId, block },
     metadata,
   };
 }
@@ -522,8 +540,8 @@ export function contentBlockStartToEvents(
       ];
 
     case "server_tool_use":
-      // The only server tool we enable is tool search. Track its state so the
-      // query deltas accumulate, then log the query at content_block_stop.
+      // The only server tool we enable is tool search. Accumulate the query
+      // deltas, then emit the block as passthrough at content_block_stop.
       return [
         [],
         {
@@ -531,17 +549,27 @@ export function contentBlockStartToEvents(
           accumulator: "",
           type: "tool_search",
           toolName: block.name,
+          toolId: block.id,
         },
       ];
 
     case "tool_search_tool_result":
-      // The discovered tool references arrive inline here (no deltas), so log
-      // them now. State stays null and the matching stop is a no-op.
+      // Discovered references arrive inline (no deltas). Emit a passthrough for
+      // verbatim replay and log them. State stays null, so the stop is a no-op.
       logToolSearchResult({
         content: block.content,
         logFields: toolSearchLogFields(metadata),
       });
-      return [[], null];
+      return [
+        [
+          converters.serverToolBlockToProviderPassthroughEvent(metadata, {
+            type: "tool_search_tool_result",
+            tool_use_id: block.tool_use_id,
+            content: block.content,
+          }),
+        ],
+        null,
+      ];
 
     // Block types we don't surface: redacted thinking, other server tools, and
     // their result / container blocks. Listed explicitly so the default stays
@@ -678,7 +706,7 @@ export function contentBlockStopToEvents(
       ];
     }
 
-    case "tool_search":
+    case "tool_search": {
       logToolSearchQuery({
         rawInput: block.accumulator,
         toolName: block.toolName,
@@ -689,7 +717,22 @@ export function contentBlockStopToEvents(
         ],
         logFields: toolSearchLogFields(metadata),
       });
-      return [[], null];
+      // Replay the server_tool_use block verbatim so interleaved thinking
+      // signatures stay valid, falling back to an empty input if the query
+      // failed to parse.
+      const parsedInput = safeParseJSON(block.accumulator);
+      return [
+        [
+          converters.serverToolBlockToProviderPassthroughEvent(metadata, {
+            type: "server_tool_use",
+            id: block.toolId,
+            name: block.toolName,
+            input: parsedInput.isOk() ? parsedInput.value : {},
+          }),
+        ],
+        null,
+      ];
+    }
 
     default:
       assertNever(block);
@@ -925,17 +968,23 @@ export function messageToEvents(
         events.push(event);
         break;
       }
-      // Block types we don't surface: redacted thinking, server tools, and
-      // their result / container blocks. Listed explicitly so the default
-      // stays exhaustive.
-      case "redacted_thinking":
       case "server_tool_use":
+      case "tool_search_tool_result":
+        // Replay tool-search blocks verbatim so interleaved thinking signatures
+        // stay valid.
+        events.push(
+          converters.serverToolBlockToProviderPassthroughEvent(metadata, block)
+        );
+        break;
+      // Block types we don't surface: redacted thinking, other server tools, and
+      // their result / container blocks. Listed explicitly so the default stays
+      // exhaustive.
+      case "redacted_thinking":
       case "web_search_tool_result":
       case "web_fetch_tool_result":
       case "code_execution_tool_result":
       case "bash_code_execution_tool_result":
       case "text_editor_code_execution_tool_result":
-      case "tool_search_tool_result":
       case "container_upload":
         break;
       default:

--- a/front/lib/model_constructors/sdk/google_genai/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/utils.test.ts
@@ -1,0 +1,51 @@
+import type { ContentBlockConverters } from "@app/lib/model_constructors/sdk/google_genai/converters/input/utils";
+import {
+  assistantReasoningMessageToPart,
+  assistantTextMessageToPart,
+  assistantToolCallRequestToPart,
+  conversationToContents,
+  systemMessageToPart,
+  toolCallResultMessageToContent,
+  userImageMessageToPart,
+  userTextMessageToPart,
+} from "@app/lib/model_constructors/sdk/google_genai/converters/input/utils";
+import type { BaseConversation } from "@app/lib/model_constructors/types/input/messages";
+import { describe, expect, it } from "vitest";
+
+const converters: ContentBlockConverters = {
+  systemMessageToPart,
+  userTextMessageToPart,
+  userImageMessageToPart,
+  toolCallResultMessageToContent,
+  assistantTextMessageToPart,
+  assistantReasoningMessageToPart,
+  assistantToolCallRequestToPart,
+};
+
+describe("conversationToContents — provider_passthrough", () => {
+  it("drops a passthrough message without injecting an empty part or breaking the same-role merge", async () => {
+    const conversation: BaseConversation = {
+      system: [],
+      messages: [
+        { role: "assistant", type: "text", content: { value: "before" } },
+        {
+          role: "assistant",
+          type: "provider_passthrough",
+          content: {
+            provider: "anthropic",
+            block: { type: "server_tool_use", id: "x", name: "y", input: {} },
+          },
+        },
+        { role: "assistant", type: "text", content: { value: "after" } },
+      ],
+    };
+
+    const contents = await conversationToContents(conversation, converters);
+
+    // The two text turns merge into one model Content; the passthrough produces
+    // no part (no empty `{ text: "" }` slips in).
+    expect(contents).toEqual([
+      { role: "model", parts: [{ text: "before" }, { text: "after" }] },
+    ]);
+  });
+});

--- a/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
@@ -17,7 +17,7 @@ import type {
 } from "@app/lib/model_constructors/types/input/messages";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { isRecord } from "@app/types/shared/utils/general";
+import { isRecord, removeNulls } from "@app/types/shared/utils/general";
 import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import type {
@@ -207,7 +207,7 @@ async function userMessageToContent(
 function assistantMessageToContent(
   message: BaseAssistantMessage,
   converters: ContentBlockConverters
-): Content {
+): Content | null {
   switch (message.type) {
     case "text":
       return {
@@ -224,6 +224,9 @@ function assistantMessageToContent(
         role: "model",
         parts: [converters.assistantToolCallRequestToPart(message)],
       };
+    case "provider_passthrough":
+      // Opaque block owned by another provider. Dropped at the loop, not sent.
+      return null;
     default:
       assertNever(message);
   }
@@ -235,21 +238,23 @@ export async function conversationToContents(
 ): Promise<Content[]> {
   // User messages may fan out to external image fetches, so convert with
   // bounded concurrency instead of an unbounded `Promise.all` ([BACK7]).
-  const contents = await concurrentExecutor(
-    conversation.messages,
-    (message) => {
-      switch (message.role) {
-        case "user":
-          return userMessageToContent(message, converters);
-        case "assistant":
-          return Promise.resolve(
-            assistantMessageToContent(message, converters)
-          );
-        default:
-          assertNever(message);
-      }
-    },
-    { concurrency: MESSAGE_CONVERSION_CONCURRENCY }
+  const contents = removeNulls(
+    await concurrentExecutor(
+      conversation.messages,
+      (message) => {
+        switch (message.role) {
+          case "user":
+            return userMessageToContent(message, converters);
+          case "assistant":
+            return Promise.resolve(
+              assistantMessageToContent(message, converters)
+            );
+          default:
+            assertNever(message);
+        }
+      },
+      { concurrency: MESSAGE_CONVERSION_CONCURRENCY }
+    )
   );
 
   // Merge consecutive same-role turns into a single Content. This serves two

--- a/front/lib/model_constructors/sdk/mistralai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/mistralai/converters/input/utils.ts
@@ -15,6 +15,7 @@ import type {
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type {
   ChatCompletionStreamRequest,
   ResponseFormat,
@@ -170,7 +171,7 @@ function userMessageToMessage(
 function assistantMessageToMessage(
   message: BaseAssistantMessage,
   converters: MistralMessageConverters
-): MistralMessage {
+): MistralMessage | null {
   switch (message.type) {
     case "text":
       return converters.assistantTextMessageToMessage(message);
@@ -178,6 +179,9 @@ function assistantMessageToMessage(
       return converters.assistantReasoningMessageToMessage(message);
     case "tool_call_request":
       return converters.assistantToolCallRequestToMessage(message);
+    case "provider_passthrough":
+      // Opaque block owned by another provider. Dropped at the loop, not sent.
+      return null;
     default:
       assertNever(message);
   }
@@ -190,16 +194,18 @@ export function conversationToMistralAIMessages(
   const system = conversation.system.map((message) =>
     converters.systemMessageToMessage(message)
   );
-  const messages = conversation.messages.map((message) => {
-    switch (message.role) {
-      case "user":
-        return userMessageToMessage(message, converters);
-      case "assistant":
-        return assistantMessageToMessage(message, converters);
-      default:
-        assertNever(message);
-    }
-  });
+  const messages = removeNulls(
+    conversation.messages.map((message) => {
+      switch (message.role) {
+        case "user":
+          return userMessageToMessage(message, converters);
+        case "assistant":
+          return assistantMessageToMessage(message, converters);
+        default:
+          assertNever(message);
+      }
+    })
+  );
   return [...system, ...messages];
 }
 

--- a/front/lib/model_constructors/sdk/openai_completions/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/input/utils.ts
@@ -16,7 +16,7 @@ import type {
 } from "@app/lib/model_constructors/types/input/messages";
 import type { ReasoningEffort } from "@app/lib/model_constructors/types/reasoning_efforts";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { isRecord } from "@app/types/shared/utils/general";
+import { isRecord, removeNulls } from "@app/types/shared/utils/general";
 import type {
   ChatCompletionMessageParam,
   ChatCompletionTool,
@@ -164,7 +164,7 @@ function userMessageToMessage(
 function assistantMessageToMessage(
   message: BaseAssistantMessage,
   converters: OpenAICompletionsMessageConverters
-): ChatCompletionMessageParam {
+): ChatCompletionMessageParam | null {
   switch (message.type) {
     case "text":
       return converters.assistantTextMessageToMessage(message);
@@ -172,6 +172,9 @@ function assistantMessageToMessage(
       return converters.assistantReasoningMessageToMessage(message);
     case "tool_call_request":
       return converters.assistantToolCallRequestToMessage(message);
+    case "provider_passthrough":
+      // Opaque block owned by another provider. Dropped at the loop, not sent.
+      return null;
     default:
       assertNever(message);
   }
@@ -184,16 +187,18 @@ export function conversationToOpenAICompletionsMessages(
   const system = conversation.system.map((message) =>
     converters.systemMessageToMessage(message)
   );
-  const messages = conversation.messages.map((message) => {
-    switch (message.role) {
-      case "user":
-        return userMessageToMessage(message, converters);
-      case "assistant":
-        return assistantMessageToMessage(message, converters);
-      default:
-        assertNever(message);
-    }
-  });
+  const messages = removeNulls(
+    conversation.messages.map((message) => {
+      switch (message.role) {
+        case "user":
+          return userMessageToMessage(message, converters);
+        case "assistant":
+          return assistantMessageToMessage(message, converters);
+        default:
+          assertNever(message);
+      }
+    })
+  );
   return [...system, ...messages];
 }
 

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -167,6 +167,9 @@ export function assistantMessageToInputItems(
       return converters.assistantReasoningMessageToInputItems(message);
     case "tool_call_request":
       return [converters.assistantToolCallRequestToInputItem(message)];
+    case "provider_passthrough":
+      // Opaque block owned by another provider. Skip.
+      return [];
     default:
       assertNever(message);
   }

--- a/front/lib/model_constructors/types/input/messages.ts
+++ b/front/lib/model_constructors/types/input/messages.ts
@@ -1,3 +1,5 @@
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+
 const CACHE_OPTIONS = ["short", "long"] as const;
 export type CacheOption = (typeof CACHE_OPTIONS)[number];
 
@@ -62,10 +64,22 @@ export type BaseAssistantToolCallRequestMessage = {
   signature?: string;
 };
 
+// Opaque, provider-specific block carried verbatim so the producing provider
+// can replay it. Every other consumer skips it. The block is kept opaque here.
+export type BaseAssistantProviderPassthroughMessage = {
+  role: "assistant";
+  type: "provider_passthrough";
+  content: {
+    provider: ModelProviderIdType;
+    block: unknown;
+  };
+};
+
 export type BaseAssistantMessage =
   | BaseAssistantTextMessage
   | BaseAssistantReasoningMessage
-  | BaseAssistantToolCallRequestMessage;
+  | BaseAssistantToolCallRequestMessage
+  | BaseAssistantProviderPassthroughMessage;
 
 export type BaseMessage = BaseUserMessage | BaseAssistantMessage;
 

--- a/front/lib/model_constructors/types/output/events.ts
+++ b/front/lib/model_constructors/types/output/events.ts
@@ -1,4 +1,5 @@
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 
 export type ResponseIdContent = { responseId: string };
 
@@ -60,6 +61,18 @@ export type ReasoningContent = { value: string };
 export interface ReasoningEvent {
   type: "reasoning";
   content: ReasoningContent;
+  metadata: EndpointMetadata;
+}
+
+// Opaque provider-specific block (e.g. an Anthropic server-tool block) captured
+// for verbatim replay. The block stays opaque to the generic pipeline.
+export type ProviderPassthroughContent = {
+  provider: ModelProviderIdType;
+  block: unknown;
+};
+export interface ProviderPassthroughEvent {
+  type: "provider_passthrough";
+  content: ProviderPassthroughContent;
   metadata: EndpointMetadata;
 }
 
@@ -126,6 +139,7 @@ export type ModelResponseEvent =
   | ToolCallStartedEvent
   | ToolCallDeltaEvent
   | ToolCallEvent
+  | ProviderPassthroughEvent
   | TokenUsageEvent
   | SuccessEvent
   | ErrorEvent;

--- a/front/lib/models/agent/agent_step_content.ts
+++ b/front/lib/models/agent/agent_step_content.ts
@@ -56,7 +56,15 @@ AgentStepContentModel.init(
       type: DataTypes.STRING,
       allowNull: false,
       validate: {
-        isIn: [["text_content", "reasoning", "function_call", "error"]],
+        isIn: [
+          [
+            "text_content",
+            "reasoning",
+            "function_call",
+            "error",
+            "provider_passthrough",
+          ],
+        ],
       },
     },
     value: {

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -456,6 +456,18 @@ export async function getOutputFromLLMStream(
           nativeChainOfThought += "\n\n";
           continue;
         }
+        case "provider_passthrough": {
+          // Opaque provider block stored in stream order so the producing
+          // provider can replay it verbatim.
+          contents.push({
+            type: "provider_passthrough",
+            value: {
+              provider: event.content.provider,
+              block: event.content.block,
+            },
+          });
+          continue;
+        }
         default:
           break;
       }

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -7,6 +7,7 @@ import type { AgentMessageContentParser } from "@app/lib/llms/agent_message_cont
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentFunctionCallContentType,
+  AgentProviderPassthroughContentType,
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
@@ -30,6 +31,7 @@ export type Output = {
     | AgentTextContentType
     | AgentFunctionCallContentType
     | AgentReasoningContentType
+    | AgentProviderPassthroughContentType
   >;
 };
 

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -42,11 +42,24 @@ export type AgentErrorContentType = {
   };
 };
 
+// Opaque, provider-specific content that must round-trip verbatim to the
+// provider that produced it. The generic layer keeps `block` opaque: it
+// forwards the item only to the matching provider and every other consumer
+// skips it. Each provider client owns the typed schema for its own blocks.
+export type AgentProviderPassthroughContentType = {
+  type: "provider_passthrough";
+  value: {
+    provider: ModelProviderIdType;
+    block: unknown;
+  };
+};
+
 export type AgentContentItemType =
   | AgentTextContentType
   | AgentReasoningContentType
   | AgentFunctionCallContentType
-  | AgentErrorContentType;
+  | AgentErrorContentType
+  | AgentProviderPassthroughContentType;
 
 export function isAgentTextContent(
   content: AgentContentItemType
@@ -70,6 +83,12 @@ export function isAgentErrorContent(
   content: AgentContentItemType
 ): content is AgentErrorContentType {
   return content.type === "error";
+}
+
+export function isAgentProviderPassthroughContent(
+  content: AgentContentItemType
+): content is AgentProviderPassthroughContentType {
+  return content.type === "provider_passthrough";
 }
 
 export type AgentStepContentType = {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
With tool search enabled, Anthropic runs the search inside a single assistant turn and emits its own server-side blocks interleaved with the model's thinking. We were dropping those blocks when reconstructing the turn for the next request, which invalidated the thinking-block signatures and caused intermittent 400s whenever the model searched, reasoned, and then called a discovered tool.

These blocks are now captured and stored in stream order alongside the rest of the turn, and replayed verbatim to Anthropic so the reconstructed turn matches what was originally returned and the signatures validate.

The blocks are stored as an opaque, provider-tagged passthrough so the provider-agnostic layer never learns anything Anthropic-specific. Every other model provider, token accounting, and the message rendering simply skip a passthrough that isn't theirs, which also keeps cross-provider conversations safe. All knowledge of what the blocks actually are stays inside the Anthropic client, which parses them back with full typing and runtime validation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

No migration required just some sequelize validation logic.