### PR TITLE
feat(usage): add multi-select + batch banner to the members usage table

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -9,6 +9,7 @@ import {
 } from "@app/components/workspace/billing/seatTypeUtils";
 import { ChangeSeatModal } from "@app/components/workspace/ChangeSeatModal";
 import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitModal";
+import { MembersSelectionBanner } from "@app/components/workspace/MembersSelectionBanner";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
 import { UpgradeRequestsTable } from "@app/components/workspace/UpgradeRequestsTable";
@@ -16,6 +17,8 @@ import { LockedSection } from "@app/components/workspace/usage/LockedSection";
 import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNotificationsCard";
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
+import { useMembersSelection } from "@app/hooks/useMembersSelection";
+import { useSendNotification } from "@app/hooks/useNotification";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import {
   useAuth,
@@ -150,6 +153,7 @@ export function UsagePage() {
   const { subscription } = useAuth();
   const router = useAppRouter();
   const { hasFeature } = useFeatureFlags();
+  const sendNotification = useSendNotification();
   const isCreditPriced = isCreditPricedPlan(subscription.plan);
   // Legacy-contract workspaces can view this page in read-only mode behind a
   // flag: analytics and member spend render as usual, but every action (top up,
@@ -469,6 +473,28 @@ export function UsagePage() {
   const selectedGroupName =
     groups.find((g) => g.sId === groupFilter)?.name ?? null;
 
+  // Cross-page selection for batch actions on the members table. Resets when the
+  // filter identity changes (the "all matching" set is no longer the same).
+  const pageItemIds = useMemo(
+    () => membersUsage.map((m) => m.sId),
+    [membersUsage]
+  );
+  const selection = useMembersSelection({
+    pageItemIds,
+    totalCount: totalMembersUsage,
+    resetKey: `${searchTerm}|${seatTypeFilter ?? ""}|${groupFilter ?? ""}`,
+  });
+
+  const handleBatchEditSpendLimit = useCallback(() => {
+    // TODO(bulk-spend-limit): open the bulk EditSpendLimitModal (PR 6) wired to
+    // the bulk endpoint (PR 4) using selection.descriptor().
+    sendNotification({
+      type: "info",
+      title: "Coming soon",
+      description: `Batch spend-limit editing for ${selection.selectedCount} members is not wired up yet.`,
+    });
+  }, [sendNotification, selection]);
+
   const { hasAvailableSeats } = useWorkspaceSeatAvailability({
     workspaceId: owner.sId,
   });
@@ -615,7 +641,7 @@ export function UsagePage() {
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
-          label={selectedGroupName ?? "Groups"}
+          label={selectedGroupName ?? "All groups"}
           size="sm"
           isSelect
         />
@@ -653,7 +679,24 @@ export function UsagePage() {
       totalRowCount={totalMembersUsage}
       sorting={sorting}
       setSorting={handleSetSorting}
-      showGroupsColumn={pricingGroupsEnabled}
+      showGroupsColumn={pricingGroupsEnabled && groups.length > 0}
+      enableSelection={pricingGroupsEnabled && isWorkspaceAdmin && !isReadOnly}
+      rowSelection={selection.rowSelection}
+      onRowSelectionChange={selection.onRowSelectionChange}
+    />
+  );
+
+  const selectionBanner = (
+    <MembersSelectionBanner
+      selectedCount={selection.selectedCount}
+      pageCount={membersUsage.length}
+      totalCount={totalMembersUsage}
+      isAllAcrossPagesSelected={selection.isAllAcrossPagesSelected}
+      hasMorePagesToSelect={selection.hasMorePagesToSelect}
+      onSelectAllAcrossPages={selection.selectAllAcrossPages}
+      onClear={selection.clearSelection}
+      onBatchEditSpendLimit={handleBatchEditSpendLimit}
+      disabled={isReadOnly}
     />
   );
 
@@ -808,9 +851,12 @@ export function UsagePage() {
                       </div>
                     )}
                   </div>
-                  <div className="pt-2">
+                  <div className="flex flex-col gap-2 pt-2">
                     {membersTab === "members" ? (
-                      membersTable
+                      <>
+                        {selectionBanner}
+                        {membersTable}
+                      </>
                     ) : (
                       <UpgradeRequestsTable
                         requests={filteredUpgradeRequests}

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -232,39 +232,6 @@ export function UsagePage() {
       }),
     []
   );
-  const onRemoveSeat = useCallback(
-    async (member: MemberUsageType) => {
-      // Free seats carry no renewing allowance to preserve, so removing one is
-      // immediate; paid seats keep access until the end of the current billing
-      // period.
-      const message =
-        member.seatType === "free"
-          ? `Are you sure you want to remove ${member.name}'s seat? They will immediately lose the ability to send messages, and the Free seat cannot be re-granted.`
-          : `Are you sure you want to remove ${member.name}'s seat? They will keep access until the end of the current billing period, then lose the ability to send messages.`;
-      const confirmed = await confirm({
-        title: "Remove seat",
-        message,
-        validateLabel: "Remove seat",
-        validateVariant: "warning",
-      });
-      if (!confirmed) {
-        return;
-      }
-      handleSeatChangePendingChange(member.sId, true);
-      try {
-        await doUpdateSeatType({
-          memberId: member.sId,
-          memberName: member.name,
-          seatType: "none",
-          isCancellingScheduledChange: false,
-          hasSeatPool: false,
-        });
-      } finally {
-        handleSeatChangePendingChange(member.sId, false);
-      }
-    },
-    [confirm, doUpdateSeatType, handleSeatChangePendingChange]
-  );
   const [editSpendLimitMember, setEditSpendLimitMember] =
     useState<MemberUsageType | null>(null);
   const [
@@ -494,6 +461,51 @@ export function UsagePage() {
       description: `Batch spend-limit editing for ${selection.selectedCount} members is not wired up yet.`,
     });
   }, [sendNotification, selection]);
+
+  const onRemoveSeat = useCallback(
+    async (member: MemberUsageType) => {
+      // Free seats carry no renewing allowance to preserve, so removing one is
+      // immediate; paid seats keep access until the end of the current billing
+      // period.
+      const message =
+        member.seatType === "free"
+          ? `Are you sure you want to remove ${member.name}'s seat? They will immediately lose the ability to send messages, and the Free seat cannot be re-granted.`
+          : `Are you sure you want to remove ${member.name}'s seat? They will keep access until the end of the current billing period, then lose the ability to send messages.`;
+      const confirmed = await confirm({
+        title: "Remove seat",
+        message,
+        validateLabel: "Remove seat",
+        validateVariant: "warning",
+      });
+      if (!confirmed) {
+        return;
+      }
+      handleSeatChangePendingChange(member.sId, true);
+      try {
+        const ok = await doUpdateSeatType({
+          memberId: member.sId,
+          memberName: member.name,
+          seatType: "none",
+          isCancellingScheduledChange: false,
+          hasSeatPool: false,
+        });
+        if (ok) {
+          selection.clearSelection();
+        }
+      } finally {
+        handleSeatChangePendingChange(member.sId, false);
+      }
+    },
+    [confirm, doUpdateSeatType, handleSeatChangePendingChange, selection]
+  );
+
+  const handleSeatMutationSaved = useCallback(() => {
+    // Seat mutations can move a member in or out of the currently filtered set
+    // (for example with the seat filter), which makes the cross-page selection
+    // stale.
+    selection.clearSelection();
+    handleApproveOnModalSaved();
+  }, [handleApproveOnModalSaved, selection]);
 
   const { hasAvailableSeats } = useWorkspaceSeatAvailability({
     workspaceId: owner.sId,
@@ -929,7 +941,7 @@ export function UsagePage() {
         owner={owner}
         seatPlans={seatPlans}
         onSavingChange={handleSeatChangePendingChange}
-        onSaved={handleApproveOnModalSaved}
+        onSaved={handleSeatMutationSaved}
       />
 
       <EditSpendLimitModal

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -420,17 +420,21 @@ export function UsagePage() {
     [awuUsageData]
   );
 
-  const { membersUsage, isMembersUsageLoading, totalMembersUsage } =
-    useMembersUsage({
-      workspaceId: owner.sId,
-      searchTerm,
-      pageIndex: pagination.pageIndex,
-      pageSize: pagination.pageSize,
-      orderColumn: membersOrderColumn,
-      orderDirection: membersOrderDirection,
-      seatType: seatTypeFilter ?? undefined,
-      groupId: groupFilter ?? undefined,
-    });
+  const {
+    membersUsage,
+    isMembersUsageLoading,
+    isMembersUsageRefreshing,
+    totalMembersUsage,
+  } = useMembersUsage({
+    workspaceId: owner.sId,
+    searchTerm,
+    pageIndex: pagination.pageIndex,
+    pageSize: pagination.pageSize,
+    orderColumn: membersOrderColumn,
+    orderDirection: membersOrderDirection,
+    seatType: seatTypeFilter ?? undefined,
+    groupId: groupFilter ?? undefined,
+  });
 
   const { groups } = useGroups({
     owner,
@@ -451,16 +455,15 @@ export function UsagePage() {
     totalCount: totalMembersUsage,
     resetKey: `${searchTerm}|${seatTypeFilter ?? ""}|${groupFilter ?? ""}`,
   });
+  const { clearSelection, selectedCount } = selection;
 
   const handleBatchEditSpendLimit = useCallback(() => {
-    // TODO(bulk-spend-limit): open the bulk EditSpendLimitModal (PR 6) wired to
-    // the bulk endpoint (PR 4) using selection.descriptor().
     sendNotification({
       type: "info",
       title: "Coming soon",
-      description: `Batch spend-limit editing for ${selection.selectedCount} members is not wired up yet.`,
+      description: `Batch spend-limit editing for ${selectedCount} members is not wired up yet.`,
     });
-  }, [sendNotification, selection]);
+  }, [sendNotification, selectedCount]);
 
   const onRemoveSeat = useCallback(
     async (member: MemberUsageType) => {
@@ -490,22 +493,22 @@ export function UsagePage() {
           hasSeatPool: false,
         });
         if (ok) {
-          selection.clearSelection();
+          clearSelection();
         }
       } finally {
         handleSeatChangePendingChange(member.sId, false);
       }
     },
-    [confirm, doUpdateSeatType, handleSeatChangePendingChange, selection]
+    [confirm, doUpdateSeatType, handleSeatChangePendingChange, clearSelection]
   );
 
   const handleSeatMutationSaved = useCallback(() => {
     // Seat mutations can move a member in or out of the currently filtered set
     // (for example with the seat filter), which makes the cross-page selection
     // stale.
-    selection.clearSelection();
+    clearSelection();
     handleApproveOnModalSaved();
-  }, [handleApproveOnModalSaved, selection]);
+  }, [handleApproveOnModalSaved, clearSelection]);
 
   const { hasAvailableSeats } = useWorkspaceSeatAvailability({
     workspaceId: owner.sId,
@@ -678,6 +681,7 @@ export function UsagePage() {
     <MembersUsageTable
       members={membersUsage}
       isLoading={isMembersUsageLoading}
+      isRefreshing={isMembersUsageRefreshing}
       readOnly={isReadOnly}
       showSpendLimit={!isFreePlanWorkspace}
       totalAllowedUsagePendingMemberIds={totalAllowedUsagePendingMemberIds}

--- a/front/components/workspace/MembersSelectionBanner.tsx
+++ b/front/components/workspace/MembersSelectionBanner.tsx
@@ -2,9 +2,7 @@ import { Button } from "@dust-tt/sparkle";
 
 interface MembersSelectionBannerProps {
   selectedCount: number;
-  // Number of rows on the current page.
   pageCount: number;
-  // Total rows matching the current filter (across all pages).
   totalCount: number;
   isAllAcrossPagesSelected: boolean;
   hasMorePagesToSelect: boolean;

--- a/front/components/workspace/MembersSelectionBanner.tsx
+++ b/front/components/workspace/MembersSelectionBanner.tsx
@@ -1,4 +1,8 @@
-import { Button } from "@dust-tt/sparkle";
+import {
+  ContentMessageAction,
+  ContentMessageInline,
+  Hoverable,
+} from "@dust-tt/sparkle";
 
 interface MembersSelectionBannerProps {
   selectedCount: number;
@@ -32,8 +36,8 @@ export function MembersSelectionBanner({
   }
 
   return (
-    <div className="flex flex-row items-center justify-between gap-3 rounded-xl bg-info-50 px-4 py-3 dark:bg-info-950">
-      <div className="flex flex-row flex-wrap items-center gap-x-2 gap-y-1 text-sm text-foreground dark:text-foreground-night">
+    <ContentMessageInline variant="info">
+      <div className="flex flex-row flex-wrap items-center gap-x-2 gap-y-1">
         {isAllAcrossPagesSelected ? (
           <span>
             {selectedCount} {membersLabel(selectedCount)} are selected.
@@ -44,13 +48,9 @@ export function MembersSelectionBanner({
               All {pageCount} {membersLabel(pageCount)} on this page are
               selected.
             </span>
-            <button
-              type="button"
-              className="font-medium text-highlight hover:underline"
-              onClick={onSelectAllAcrossPages}
-            >
+            <Hoverable variant="highlight" onClick={onSelectAllAcrossPages}>
               Select all {totalCount} {membersLabel(totalCount)}
-            </button>
+            </Hoverable>
           </>
         ) : (
           <span>
@@ -58,22 +58,18 @@ export function MembersSelectionBanner({
           </span>
         )}
       </div>
-      <div className="flex flex-shrink-0 flex-row items-center gap-2">
-        <Button
-          size="sm"
-          variant="ghost"
-          label="Clear"
-          onClick={onClear}
-          disabled={disabled}
-        />
-        <Button
-          size="sm"
-          variant="primary"
-          label="Batch edit spend limit"
-          onClick={onBatchEditSpendLimit}
-          disabled={disabled}
-        />
-      </div>
-    </div>
+      <ContentMessageAction
+        variant="ghost"
+        label="Clear"
+        onClick={onClear}
+        disabled={disabled}
+      />
+      <ContentMessageAction
+        variant="primary"
+        label="Batch edit spend limit"
+        onClick={onBatchEditSpendLimit}
+        disabled={disabled}
+      />
+    </ContentMessageInline>
   );
 }

--- a/front/components/workspace/MembersSelectionBanner.tsx
+++ b/front/components/workspace/MembersSelectionBanner.tsx
@@ -1,0 +1,81 @@
+import { Button } from "@dust-tt/sparkle";
+
+interface MembersSelectionBannerProps {
+  selectedCount: number;
+  // Number of rows on the current page.
+  pageCount: number;
+  // Total rows matching the current filter (across all pages).
+  totalCount: number;
+  isAllAcrossPagesSelected: boolean;
+  hasMorePagesToSelect: boolean;
+  onSelectAllAcrossPages: () => void;
+  onClear: () => void;
+  onBatchEditSpendLimit: () => void;
+  disabled?: boolean;
+}
+
+function membersLabel(count: number): string {
+  return count === 1 ? "member" : "members";
+}
+
+export function MembersSelectionBanner({
+  selectedCount,
+  pageCount,
+  totalCount,
+  isAllAcrossPagesSelected,
+  hasMorePagesToSelect,
+  onSelectAllAcrossPages,
+  onClear,
+  onBatchEditSpendLimit,
+  disabled = false,
+}: MembersSelectionBannerProps) {
+  if (selectedCount === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-row items-center justify-between gap-3 rounded-xl bg-info-50 px-4 py-3 dark:bg-info-950">
+      <div className="flex flex-row flex-wrap items-center gap-x-2 gap-y-1 text-sm text-foreground dark:text-foreground-night">
+        {isAllAcrossPagesSelected ? (
+          <span>
+            {selectedCount} {membersLabel(selectedCount)} are selected.
+          </span>
+        ) : hasMorePagesToSelect ? (
+          <>
+            <span>
+              All {pageCount} {membersLabel(pageCount)} on this page are
+              selected.
+            </span>
+            <button
+              type="button"
+              className="font-medium text-highlight hover:underline"
+              onClick={onSelectAllAcrossPages}
+            >
+              Select all {totalCount} {membersLabel(totalCount)}
+            </button>
+          </>
+        ) : (
+          <span>
+            {selectedCount} {membersLabel(selectedCount)} selected
+          </span>
+        )}
+      </div>
+      <div className="flex flex-shrink-0 flex-row items-center gap-2">
+        <Button
+          size="sm"
+          variant="ghost"
+          label="Clear"
+          onClick={onClear}
+          disabled={disabled}
+        />
+        <Button
+          size="sm"
+          variant="primary"
+          label="Batch edit spend limit"
+          onClick={onBatchEditSpendLimit}
+          disabled={disabled}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -18,6 +18,7 @@ import {
 } from "@app/types/memberships";
 import {
   Clock,
+  createSelectionColumn,
   DataTable,
   Icon,
   LoadingBlock,
@@ -29,6 +30,7 @@ import type {
   CellContext,
   ColumnDef,
   PaginationState,
+  RowSelectionState,
   SortingState,
 } from "@tanstack/react-table";
 import { useMemo } from "react";
@@ -437,8 +439,15 @@ const actionsColumn: ColumnDef<RowData, string> = {
   },
 };
 
-function buildColumns(showGroupsColumn: boolean): ColumnDef<RowData, string>[] {
+function buildColumns({
+  enableSelection,
+  showGroupsColumn,
+}: {
+  enableSelection: boolean;
+  showGroupsColumn: boolean;
+}): ColumnDef<RowData, string>[] {
   return [
+    ...(enableSelection ? [createSelectionColumn<RowData>()] : []),
     nameColumn,
     ...(showGroupsColumn ? [groupsColumn] : []),
     seatTypeColumn,
@@ -464,6 +473,9 @@ interface MembersUsageTableProps {
   sorting: SortingState;
   setSorting: (sorting: SortingState) => void;
   showGroupsColumn?: boolean;
+  enableSelection?: boolean;
+  rowSelection?: RowSelectionState;
+  onRowSelectionChange?: (selection: RowSelectionState) => void;
 }
 
 export function MembersUsageTable({
@@ -483,6 +495,9 @@ export function MembersUsageTable({
   sorting,
   setSorting,
   showGroupsColumn = false,
+  enableSelection = false,
+  rowSelection,
+  onRowSelectionChange,
 }: MembersUsageTableProps) {
   const rows: RowData[] = useMemo(
     () =>
@@ -570,8 +585,8 @@ export function MembersUsageTable({
   );
 
   const columns = useMemo(
-    () => buildColumns(showGroupsColumn),
-    [showGroupsColumn]
+    () => buildColumns({ enableSelection, showGroupsColumn }),
+    [enableSelection, showGroupsColumn]
   );
 
   if (isLoading) {
@@ -594,6 +609,10 @@ export function MembersUsageTable({
       sorting={sorting}
       setSorting={setSorting}
       isServerSideSorting
+      enableRowSelection={enableSelection}
+      rowSelection={rowSelection}
+      setRowSelection={onRowSelectionChange}
+      getRowId={(row) => row.sId}
     />
   );
 }

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -459,6 +459,7 @@ function buildColumns({
 interface MembersUsageTableProps {
   members: MemberUsageType[];
   isLoading: boolean;
+  isRefreshing?: boolean;
   totalAllowedUsagePendingMemberIds: ReadonlySet<string>;
   seatChangePendingMemberIds: ReadonlySet<string>;
   isSeatBased: boolean;
@@ -481,6 +482,7 @@ interface MembersUsageTableProps {
 export function MembersUsageTable({
   members,
   isLoading,
+  isRefreshing = false,
   totalAllowedUsagePendingMemberIds,
   seatChangePendingMemberIds,
   isSeatBased,
@@ -600,19 +602,34 @@ export function MembersUsageTable({
   }
 
   return (
-    <DataTable
-      data={rows}
-      columns={columns}
-      pagination={pagination}
-      setPagination={setPagination}
-      totalRowCount={totalRowCount}
-      sorting={sorting}
-      setSorting={setSorting}
-      isServerSideSorting
-      enableRowSelection={enableSelection}
-      rowSelection={rowSelection}
-      setRowSelection={onRowSelectionChange}
-      getRowId={(row) => row.sId}
-    />
+    <div className="relative">
+      <div
+        className={
+          isRefreshing
+            ? "pointer-events-none opacity-50 transition-opacity"
+            : "transition-opacity"
+        }
+      >
+        <DataTable
+          data={rows}
+          columns={columns}
+          pagination={pagination}
+          setPagination={setPagination}
+          totalRowCount={totalRowCount}
+          sorting={sorting}
+          setSorting={setSorting}
+          isServerSideSorting
+          enableRowSelection={enableSelection}
+          rowSelection={rowSelection}
+          setRowSelection={onRowSelectionChange}
+          getRowId={(row) => row.sId}
+        />
+      </div>
+      {isRefreshing && (
+        <div className="absolute inset-x-0 top-16 flex justify-center">
+          <Spinner size="sm" />
+        </div>
+      )}
+    </div>
   );
 }

--- a/front/hooks/useMembersSelection.ts
+++ b/front/hooks/useMembersSelection.ts
@@ -1,16 +1,10 @@
 import type { RowSelectionState } from "@tanstack/react-table";
 import { useCallback, useMemo, useState } from "react";
 
-// Cross-page selection model for a server-paginated table. Either an explicit
-// set of selected ids (states "some selected" / "all on this page"), or
-// "everything matching the current filter" with an exclude set (state "select
-// all across pages, minus a few").
 type MembersSelection =
   | { mode: "ids"; ids: Set<string> }
   | { mode: "all"; excludedIds: Set<string> };
 
-// Shape handed to the (future) bulk endpoint: explicit ids, or the active
-// filter with per-row exclusions resolved server-side.
 export type MembersSelectionDescriptor =
   | { mode: "ids"; userIds: string[] }
   | { mode: "all"; excludeUserIds: string[] };
@@ -22,12 +16,8 @@ export function useMembersSelection({
   totalCount,
   resetKey,
 }: {
-  // sIds of the rows on the current page.
   pageItemIds: string[];
-  // Total number of rows matching the current filter (across all pages).
   totalCount: number;
-  // Changes whenever the matching set changes (search / filters). The selection
-  // resets when it changes, since the "all matching" set is no longer the same.
   resetKey: string;
 }) {
   const [selection, setSelection] = useState<MembersSelection>(EMPTY_SELECTION);
@@ -45,8 +35,6 @@ export function useMembersSelection({
       ? selection.ids.size
       : Math.max(0, totalCount - selection.excludedIds.size);
 
-  // Per-page selection state DataTable consumes (keyed by the current page's
-  // sIds), derived from the cross-page model.
   const rowSelection: RowSelectionState = useMemo(() => {
     const state: RowSelectionState = {};
     for (const id of pageItemIds) {
@@ -63,15 +51,11 @@ export function useMembersSelection({
 
   const isAllAcrossPagesSelected = selection.mode === "all";
 
-  // There are more rows than the current page, so "select all across pages" is
-  // a meaningful next step once the whole page is selected.
   const hasMorePagesToSelect =
     isAllOnPageSelected &&
     !isAllAcrossPagesSelected &&
     totalCount > pageItemIds.length;
 
-  // DataTable reports the new selection state for the current page; fold it back
-  // into the cross-page model.
   const onRowSelectionChange = useCallback(
     (next: RowSelectionState) => {
       setSelection((prev) => {

--- a/front/hooks/useMembersSelection.ts
+++ b/front/hooks/useMembersSelection.ts
@@ -1,0 +1,129 @@
+import type { RowSelectionState } from "@tanstack/react-table";
+import { useCallback, useMemo, useState } from "react";
+
+// Cross-page selection model for a server-paginated table. Either an explicit
+// set of selected ids (states "some selected" / "all on this page"), or
+// "everything matching the current filter" with an exclude set (state "select
+// all across pages, minus a few").
+type MembersSelection =
+  | { mode: "ids"; ids: Set<string> }
+  | { mode: "all"; excludedIds: Set<string> };
+
+// Shape handed to the (future) bulk endpoint: explicit ids, or the active
+// filter with per-row exclusions resolved server-side.
+export type MembersSelectionDescriptor =
+  | { mode: "ids"; userIds: string[] }
+  | { mode: "all"; excludeUserIds: string[] };
+
+const EMPTY_SELECTION: MembersSelection = { mode: "ids", ids: new Set() };
+
+export function useMembersSelection({
+  pageItemIds,
+  totalCount,
+  resetKey,
+}: {
+  // sIds of the rows on the current page.
+  pageItemIds: string[];
+  // Total number of rows matching the current filter (across all pages).
+  totalCount: number;
+  // Changes whenever the matching set changes (search / filters). The selection
+  // resets when it changes, since the "all matching" set is no longer the same.
+  resetKey: string;
+}) {
+  const [selection, setSelection] = useState<MembersSelection>(EMPTY_SELECTION);
+
+  // Reset during render when the filter identity changes (the React-recommended
+  // alternative to an effect for adjusting state on input change).
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
+  if (resetKey !== prevResetKey) {
+    setPrevResetKey(resetKey);
+    setSelection(EMPTY_SELECTION);
+  }
+
+  const selectedCount =
+    selection.mode === "ids"
+      ? selection.ids.size
+      : Math.max(0, totalCount - selection.excludedIds.size);
+
+  // Per-page selection state DataTable consumes (keyed by the current page's
+  // sIds), derived from the cross-page model.
+  const rowSelection: RowSelectionState = useMemo(() => {
+    const state: RowSelectionState = {};
+    for (const id of pageItemIds) {
+      state[id] =
+        selection.mode === "ids"
+          ? selection.ids.has(id)
+          : !selection.excludedIds.has(id);
+    }
+    return state;
+  }, [pageItemIds, selection]);
+
+  const isAllOnPageSelected =
+    pageItemIds.length > 0 && pageItemIds.every((id) => rowSelection[id]);
+
+  const isAllAcrossPagesSelected = selection.mode === "all";
+
+  // There are more rows than the current page, so "select all across pages" is
+  // a meaningful next step once the whole page is selected.
+  const hasMorePagesToSelect =
+    isAllOnPageSelected &&
+    !isAllAcrossPagesSelected &&
+    totalCount > pageItemIds.length;
+
+  // DataTable reports the new selection state for the current page; fold it back
+  // into the cross-page model.
+  const onRowSelectionChange = useCallback(
+    (next: RowSelectionState) => {
+      setSelection((prev) => {
+        if (prev.mode === "all") {
+          const excludedIds = new Set(prev.excludedIds);
+          for (const id of pageItemIds) {
+            if (next[id]) {
+              excludedIds.delete(id);
+            } else {
+              excludedIds.add(id);
+            }
+          }
+          return { mode: "all", excludedIds };
+        }
+        const ids = new Set(prev.ids);
+        for (const id of pageItemIds) {
+          if (next[id]) {
+            ids.add(id);
+          } else {
+            ids.delete(id);
+          }
+        }
+        return { mode: "ids", ids };
+      });
+    },
+    [pageItemIds]
+  );
+
+  const selectAllAcrossPages = useCallback(() => {
+    setSelection({ mode: "all", excludedIds: new Set() });
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelection(EMPTY_SELECTION);
+  }, []);
+
+  const descriptor = useCallback((): MembersSelectionDescriptor => {
+    if (selection.mode === "all") {
+      return { mode: "all", excludeUserIds: [...selection.excludedIds] };
+    }
+    return { mode: "ids", userIds: [...selection.ids] };
+  }, [selection]);
+
+  return {
+    rowSelection,
+    onRowSelectionChange,
+    selectedCount,
+    isAllOnPageSelected,
+    isAllAcrossPagesSelected,
+    hasMorePagesToSelect,
+    selectAllAcrossPages,
+    clearSelection,
+    descriptor,
+  };
+}

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -282,13 +282,14 @@ export function useMembersUsage({
     searchParams.set("groupId", groupId);
   }
 
-  const { data, error } = useSWRWithDefaults(
+  const { data, error, isLoading } = useSWRWithDefaults(
     `${membersUsageUrl(workspaceId)}?${searchParams.toString()}`,
     membersUsageFetcher,
     {
       keepPreviousData: true,
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
+      dedupingInterval: 60_000,
       disabled,
     }
   );
@@ -296,6 +297,7 @@ export function useMembersUsage({
   return {
     membersUsage: data?.members ?? emptyArray(),
     isMembersUsageLoading: !error && !data && !disabled,
+    isMembersUsageRefreshing: isLoading && !!data && !disabled,
     isMembersUsageError: !!error,
     totalMembersUsage: data?.total ?? 0,
   };


### PR DESCRIPTION
## Description

Add cross-page selection to the members usage table: a useMembersSelection hook modeling either an explicit id set or "all matching filter minus excludes", an optional selection checkbox column on MembersUsageTable, and a three-state MembersSelectionBanner (some selected / all on page + select-all across pages / all selected).

Show a loading state when loading is long in case of cache miss (cache ttl is 60 secs).


https://github.com/user-attachments/assets/cfe9cb54-9409-4668-8da2-2551727f7acf


## Tests

Local

## Risk

Low, feature flagged under `pricing_groups`

## Deploy Plan

Front