### PR TITLE
Test that self improvement correctly targets the child nested skill when necessary

### DIFF
--- a/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
@@ -49,34 +49,6 @@ function makeInstructionSuggestion(input: {
   };
 }
 
-function makeToolSuggestion(input: {
-  sId: string;
-  analysis: string;
-  action: "add" | "remove";
-  toolId: string;
-  skillConfigurationId?: string;
-  source?: "reinforcement" | "synthetic";
-}): SkillSuggestionType {
-  return {
-    sId: input.sId,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-    skillConfigurationId: input.skillConfigurationId ?? SKILL_SID,
-    analysis: input.analysis,
-    title: null,
-    state: "pending",
-    source: input.source ?? "synthetic",
-    sourceConversationsCount: 0,
-    visibleSourceConversationIds: [],
-    notificationConversationId: null,
-    updatedBy: null,
-    kind: "edit",
-    suggestion: {
-      toolEdits: [{ action: input.action, toolId: input.toolId }],
-    },
-  };
-}
-
 function makeAgentFacingDescriptionSuggestion(input: {
   sId: string;
   analysis: string;
@@ -196,29 +168,44 @@ Score 3 if well-merged with all themes, clear structure, and analysis referencin
           "Help engineers with their daily work. Assist with task management and process questions.",
       },
       syntheticSuggestions: [
-        makeToolSuggestion({
+        makeInstructionSuggestion({
           sId: "sug-1",
           skillConfigurationId: "skill_engineering",
           analysis:
             "User asked to create a JIRA ticket but the skill couldn't. Adding JIRA would enable direct ticket creation.",
-          action: "add",
-          toolId: "mcp_jira",
+          instructionEdits: [
+            {
+              targetBlockId: "block-jira",
+              content:
+                'Use <tool id="mcp_jira" name="JIRA" /> to create JIRA tickets directly for engineers.',
+            },
+          ],
         }),
-        makeToolSuggestion({
+        makeInstructionSuggestion({
           sId: "sug-2",
           skillConfigurationId: "skill_engineering",
           analysis:
             "User wanted to check sprint status in JIRA. The skill had no way to query JIRA data.",
-          action: "add",
-          toolId: "mcp_jira",
+          instructionEdits: [
+            {
+              targetBlockId: "block-jira",
+              content:
+                'Use <tool id="mcp_jira" name="JIRA" /> to query sprint status and ticket data.',
+            },
+          ],
         }),
-        makeToolSuggestion({
+        makeInstructionSuggestion({
           sId: "sug-3",
           skillConfigurationId: "skill_engineering",
           analysis:
             "User asked to assign a JIRA ticket to a teammate. Without the JIRA tool, the skill could only suggest doing it manually.",
-          action: "add",
-          toolId: "mcp_jira",
+          instructionEdits: [
+            {
+              targetBlockId: "block-jira",
+              content:
+                'Use <tool id="mcp_jira" name="JIRA" /> to assign tickets to teammates.',
+            },
+          ],
         }),
       ],
       workspaceContext: WORKSPACE_CONTEXT,
@@ -234,7 +221,7 @@ as an inline <tool id="mcp_jira" name="JIRA" /> reference to skill "skill_engine
 - Merge the 3 individual suggestions into a single recommendation
 - Mention that 3 conversations support this suggestion
 - Include a comprehensive analysis covering the different use cases (ticket creation, sprint status, assignment)
-- Convert the legacy source toolEdits into an instruction edit with an inline <tool> tag; it MUST NOT include toolEdits
+- Merge the 3 inline <tool> instruction edits into a single instruction edit that keeps exactly one inline <tool id="mcp_jira" name="JIRA" /> reference; it MUST NOT include toolEdits
 
 Score 0 if no edit_skill call or if it creates 3 separate calls.
 Score 0 if the final edit_skill call uses toolEdits instead of an inline <tool> instruction edit.
@@ -485,13 +472,18 @@ Score 3 if no edit_skill suggestion is created AND reject_suggestion is not call
           content:
             "For payment failures and chargeback disputes only. Skip this skill for invoice or receipt requests — those are handled elsewhere.",
         }),
-        makeToolSuggestion({
+        makeInstructionSuggestion({
           sId: "sug-tool-1",
           skillConfigurationId: "skill_payment_resolver",
           analysis:
             "User asked the skill to file an internal incident ticket for a flagged chargeback. The skill had no JIRA tool to do so, it's crucial to add it.",
-          action: "add",
-          toolId: "mcp_jira",
+          instructionEdits: [
+            {
+              targetBlockId: "block-jira",
+              content:
+                'Use <tool id="mcp_jira" name="JIRA" /> to file an internal incident ticket for a flagged chargeback.',
+            },
+          ],
         }),
       ],
       workspaceContext: WORKSPACE_CONTEXT,
@@ -508,7 +500,7 @@ Score 3 if no edit_skill suggestion is created AND reject_suggestion is not call
       judgeCriteria: `Two of the three drafts target the agent-facing description (both about narrowing routing), and one is unrelated tooling work (adding JIRA). Aggregation rules require:
 - ONE description-edit suggestion per skill, merging both description drafts (sug-desc-1 + sug-desc-2). The merged description must explicitly limit the skill to payment failures + chargebacks AND steer the agent away from generic billing/invoice/account-management requests.
 - The description edit MUST be its own standalone edit_skill call. Do NOT bundle it with the tool addition (different topic, different fix).
-- A separate edit_skill call that converts the legacy JIRA tool addition (sug-tool-1) into an instruction edit with an inline <tool id="mcp_jira" name="JIRA" /> reference. It MUST NOT include toolEdits.
+- A separate edit_skill call that keeps the JIRA tool addition (sug-tool-1) as its own instruction edit with an inline <tool id="mcp_jira" name="JIRA" /> reference. It MUST NOT include toolEdits.
 
 Score 0 if no edit_skill call carries an agentFacingDescriptionEdit for skill_payment_resolver.
 Score 0 if the description edit and the tool addition are bundled into a single edit_skill call.

--- a/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
@@ -63,8 +63,66 @@ const LINKEDIN_MCP_DESCRIPTION: MockMcpDescription = {
   ],
 };
 
+const JIRA_MCP_DESCRIPTION: MockMcpDescription = {
+  sId: "mcp_jira",
+  description: "Search and manage JIRA issues and projects",
+  tools: [
+    {
+      name: "jira-create-issue",
+      description: "Create a new JIRA ticket",
+      inputs: [
+        {
+          name: "project",
+          type: "string",
+          description: "The JIRA project key the ticket belongs to",
+        },
+        {
+          name: "summary",
+          type: "string",
+          description: "Short summary of the ticket",
+        },
+        {
+          name: "description",
+          type: "string",
+          description: "Detailed description of the ticket",
+        },
+        {
+          name: "issueType",
+          type: "string",
+          description:
+            'The issue type (e.g. "Task", "Bug"). Defaults to "Task"',
+          required: false,
+        },
+      ],
+    },
+    {
+      name: "jira-search-issues",
+      description: "Search for issues using a JQL query",
+      inputs: [
+        {
+          name: "jql",
+          type: "string",
+          description: "The JQL query used to filter issues",
+        },
+      ],
+    },
+    {
+      name: "jira-get-sprint-status",
+      description:
+        "Retrieve the current sprint's progress, including ticket counts by status",
+      inputs: [
+        {
+          name: "board",
+          type: "string",
+          description: 'The board to read the sprint from (e.g. "Engineering")',
+        },
+      ],
+    },
+  ],
+};
+
 const WORKSPACE_CONTEXT: WorkspaceContext = {
-  mcpDescriptions: [LINKEDIN_MCP_DESCRIPTION],
+  mcpDescriptions: [LINKEDIN_MCP_DESCRIPTION, JIRA_MCP_DESCRIPTION],
   tools: [
     mockTool("Slack", "Read and send Slack messages"),
     mockTool("Notion", "Search Notion workspace"),

--- a/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
@@ -677,6 +677,116 @@ Score 1 if edit_skill is called only for skill_github_reporter but the suggestio
 Score 3 if edit_skill is called only for skill_github_reporter, the suggestion adds DevCode to the project list, and no other skills are modified.`,
     },
     {
+      scenarioId: "nested-skill-targeted-attribution",
+      type: "analysis",
+      skillConfigs: [
+        {
+          name: "Report Orchestrator",
+          sId: "skill_report_orchestrator",
+          description:
+            "Orchestrates building and publishing financial reports by gathering data and delegating formatting before posting the result",
+          instructions: [
+            "You are the Report Orchestrator skill for Acme Corp's finance team. Use this skill to build and publish financial reports.",
+            "",
+            "## Workflow",
+            "",
+            "Follow these steps in order:",
+            "1. Use `notion-get-page` to retrieve the raw financial figures from the source page the user references.",
+            "2. Hand the raw figures to the Data Formatter skill, which owns all table and number formatting rules. Always delegate formatting to it rather than formatting numbers yourself.",
+            "3. Use `slack-post-message` to publish the formatted report to the channel the user specifies.",
+            "",
+            "## Delegation",
+            "",
+            "Formatting of the report contents (tables, columns, and how figures are rendered) is the responsibility of the Data Formatter skill referenced below. Pass it the raw figures and use its output verbatim.",
+            "",
+            '<skill id="skill_data_formatter" name="Data Formatter" />',
+          ].join("\n"),
+          tools: [
+            { name: "Notion", sId: "mcp_notion" },
+            { name: "Slack", sId: "mcp_slack" },
+          ],
+        },
+        {
+          name: "Data Formatter",
+          sId: "skill_data_formatter",
+          description:
+            "Formats raw financial figures into clean Markdown tables for inclusion in reports",
+          instructions: `You are the Data Formatter skill for Acme Corp. Use this skill to turn raw financial figures into a clean Markdown table that other skills can publish.
+
+## Formatting rules
+
+- Render the figures as a Markdown table with one row per line item.
+- Use the columns: "Line Item", "Amount", and "Change vs. Prior Period".
+- Right-align the "Amount" and "Change vs. Prior Period" columns.
+- Use thousands separators for large numbers (e.g., 1,200,000).
+- Express "Change vs. Prior Period" as a signed percentage (e.g., +12%, -4%).
+- Sort rows from largest to smallest amount.`,
+        },
+      ],
+      conversation: [
+        {
+          role: "user",
+          content:
+            "Build the Q2 revenue report from the figures on our finance Notion page and post it to the #finance channel.",
+        },
+        {
+          role: "agent",
+          content:
+            "I'll pull the Q2 figures from Notion, format them into the report table, and post it to #finance.",
+          actions: [
+            {
+              functionCallName: "notion-get-page",
+              status: "succeeded",
+              params: { pageId: "page_q2_finance" },
+              output:
+                '{"figures": [{"lineItem": "Subscriptions", "amount": 1200000, "changePct": 12}, {"lineItem": "Professional Services", "amount": 850000, "changePct": -4}, {"lineItem": "Support Contracts", "amount": 320000, "changePct": 7}]}',
+            },
+            {
+              functionCallName: "slack-post-message",
+              status: "succeeded",
+              params: {
+                channel: "#finance",
+                text: "*Q2 Revenue Report*\n\n| Line Item | Amount | Change vs. Prior Period |\n|---|--:|--:|\n| Subscriptions | 1,200,000 | +12% |\n| Professional Services | 850,000 | -4% |\n| Support Contracts | 320,000 | +7% |",
+              },
+              output: '{"ts": "1712750400.000100", "channel": "#finance"}',
+            },
+          ],
+        },
+        {
+          role: "agent",
+          content:
+            "I've posted the Q2 revenue report to #finance. It lists Subscriptions (1,200,000, +12%), Professional Services (850,000, -4%), and Support Contracts (320,000, +7%).",
+        },
+        {
+          role: "user",
+          content:
+            "The amounts in that table are just bare numbers — there's no currency on them at all. I can't tell whether these are dollars or euros, and finance can't post an ambiguous report like that.",
+          feedback: {
+            direction: "down",
+            comment:
+              "The amounts in the report table have no currency — they're ambiguous numbers, so nobody can tell if they're dollars or euros.",
+          },
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [editSkillWithInstructions("skill_data_formatter")],
+      judgeCriteria: `The analyst MUST call edit_skill with instructionEdits for the child skill "skill_data_formatter" ONLY.
+The failure originates in the Data Formatter skill's formatting rules: they describe the table columns and number formatting but never require a currency to be shown on the "Amount" column, which produced the ambiguous bare numbers the user complained about. The Report Orchestrator delegated correctly and its own instructions are complete and correct.
+The suggestion should:
+- Add a formatting rule to the Data Formatter requiring monetary amounts to be rendered with an explicit currency (a symbol or ISO currency code, e.g. $1,200,000 or 1,200,000 USD)
+- Reference that the current rules omit currency, causing the ambiguous numbers in the posted report
+- Preserve the existing formatting rules (columns, thousands separators, signed percentages, sort order)
+
+CRITICAL constraints:
+- The analyst MUST target the child skill "skill_data_formatter" with instructionEdits
+- There MUST NOT be any edit_skill call targeting the parent "skill_report_orchestrator"
+- The fix must address the specific child-owned defect (missing currency on amounts); the parent's instructions are correct and its delegation to the Data Formatter worked as intended
+
+Score 0 if no edit_skill with instructionEdits call is made for skill_data_formatter, or if edit_skill targets the parent skill_report_orchestrator.
+Score 1 if edit_skill targets only skill_data_formatter but the edit doesn't specifically address requiring a currency on the amounts.
+Score 3 if edit_skill targets skill_data_formatter only, adds a rule requiring an explicit currency on monetary amounts, and leaves the parent skill_report_orchestrator untouched.`,
+    },
+    {
       scenarioId: "misleading-agent-facing-description",
       type: "analysis",
       skillConfigs: [


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9087
 
 - Add an eval test to make sure we target the child skill when skill are nested
 - FIx some old eval test using deprecated tool suggestion to use new format
 - Add JIRA tool description to eval test context to fix an old test flakiness

Can be reviewed by commit

## Tests

```
 ✓ tests/reinforcement-evals/reinforcement-eval.test.ts (18 tests) 72071ms
   ✓ Reinforced Skills Evaluation Tests (18)
     ✓ analyze-conversation (11)
       ✓ unclear-instructions  34960ms
       ✓ missing-tool  25942ms
       ✓ unused-tool  25652ms
       ✓ instruction-and-tool-gap  29964ms
       ✓ successful-conversation  42762ms
       ✓ user-feedback-driven  31220ms
       ✓ wrong-tool-order-linkedin-enrich  26964ms
       ✓ multi-skill-targeted-feedback  24320ms
       ✓ nested-skill-targeted-attribution  21948ms
       ✓ misleading-agent-facing-description  21671ms
       ✓ knowledge-tag-vague-runbook-instructions  33026ms
     ✓ aggregate-suggestions (7)
       ✓ merge-duplicate-instructions  19547ms
       ✓ merge-duplicate-tools  19679ms
       ✓ dedup-vs-pending  8237ms
       ✓ dedup-vs-rejected  11653ms
       ✓ split-unrelated-topics  24949ms
       ✓ drop-minor-single  11398ms
       ✓ merge-description-edits-keep-tool-separate  29241ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  14:18:54
   Duration  77.92s (transform 2.23s, setup 313ms, import 5.47s, tests 72.07s, environment 0ms)
```

## Risk

low, only tests

## Deploy Plan

None
