### PR TITLE
[front] fix: scope analytics API-key lookup to the workspace

### DIFF
--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -233,7 +233,10 @@ export async function storeAgentAnalytics(
   let apiKeyName: string | undefined;
   const storedKeyId = userMessageModel.userContextApiKeyId;
   if (storedKeyId) {
-    const keyResource = await KeyResource.fetchByModelId(storedKeyId);
+    const keyResource = await KeyResource.fetchByWorkspaceAndId({
+      workspace: auth.getNonNullableWorkspace(),
+      id: storedKeyId,
+    });
     if (keyResource) {
       apiKeyName = keyResource.name;
     }


### PR DESCRIPTION
### Bug
In dev, posting a message fails the `storeAgentAnalytics` Temporal activity with:

> Query attempted without workspaceId on keys. All workspace-aware model queries must be scoped to a specific workspaceId…

`storeAgentAnalytics` resolves the API key name from the stored key id via `KeyResource.fetchByModelId(storedKeyId)`, a bare `findByPk` on the workspace-aware `keys` table — rejected by the workspace-isolation guard.

### Fix
Scope the lookup to the activity's workspace via `KeyResource.fetchByWorkspaceAndId({ workspace: auth.getNonNullableWorkspace(), id: storedKeyId })`. A deleted key still resolves to `null`, preserving the existing fallback.

Pre-existing bug from #20746, independent of the API-key credit-cap stack — standalone PR off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)