### PR TITLE
[front] enh: improve conversation files tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -16,15 +16,22 @@ export const CONVERSATION_LIST_CONTENT_NODES_AND_TABLES_ACTION_NAME =
 export const CONVERSATION_CAT_FILE_ACTION_NAME = "cat";
 export const CONVERSATION_SEARCH_FILES_ACTION_NAME = "semantic_search";
 
+const CONVERSATION_LIST_FILES_TOOL_NAME = getPrefixedToolName(
+  CONVERSATION_FILES_SERVER_NAME,
+  CONVERSATION_LIST_FILES_ACTION_NAME
+);
+
 const CAT_FILE_TOOL = {
   description:
-    "Read the contents of a large file from conversation attachments with offset/limit and optional grep filtering (named after the 'cat' unix tool). " +
-    "Use this when files are too large to read in full, or when you need to search for specific patterns within a file.",
+    "Read the contents of an attached conversation file by fileId, with " +
+    "offset/limit and optional grep filtering. Useful for files too large " +
+    "to read in full, or for searching specific patterns within a file.",
   schema: {
     fileId: z
       .string()
       .describe(
-        `The fileId of the attachment to read, as returned by \`${getPrefixedToolName(CONVERSATION_FILES_SERVER_NAME, CONVERSATION_LIST_FILES_ACTION_NAME)}\``
+        "The fileId of the conversation attachment to retrieve and read, as " +
+          `returned by \`${CONVERSATION_LIST_FILES_TOOL_NAME}\``
       ),
     offset: z
       .number()
@@ -57,7 +64,10 @@ const CAT_FILE_TOOL = {
 
 export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
   [CONVERSATION_LIST_FILES_ACTION_NAME]: {
-    description: "List all files attached to the conversation.",
+    description:
+      "List all files attached to the current conversation, including " +
+      "available conversation file attachments, fileIds, titles, and " +
+      "attachment flags.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -68,9 +78,15 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
   [CONVERSATION_CAT_FILE_ACTION_NAME]: CAT_FILE_TOOL,
   [CONVERSATION_SEARCH_FILES_ACTION_NAME]: {
     description:
-      "Perform a semantic search within the files and content nodes attached to the conversation.",
+      "Search conversation files and content nodes semantically to find " +
+      "relevant passages by meaning-based topic, concept, or terms.",
     schema: {
-      query: z.string().describe("The query to search for."),
+      query: z
+        .string()
+        .describe(
+          "The natural-language topic, concept, or terms to search for " +
+            "conversation files and content nodes."
+        ),
     },
     stake: "never_ask",
     displayLabels: {
@@ -88,8 +104,9 @@ export const CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM =
   createToolsRecord({
     [CONVERSATION_LIST_CONTENT_NODES_AND_TABLES_ACTION_NAME]: {
       description:
-        "List content nodes (e.g. Notion pages, Slack threads) and queryable tables attached " +
-        "to the conversation. Regular files attached to the conversation are not listed here; " +
+        "List content-node references (for example Notion pages and Slack " +
+        "threads) and queryable tables available " +
+        "in the current conversation. Regular files are not listed here; " +
         `they are accessible via the \`${FILES_SERVER_NAME}\` MCP server.`,
       schema: {},
       stake: "never_ask",
@@ -113,7 +130,9 @@ export const CONVERSATION_FILES_SERVER = {
   serverInfo: {
     name: CONVERSATION_FILES_SERVER_NAME,
     version: "1.0.0",
-    description: "List, read and search files in the conversation.",
+    description:
+      "List, read, and semantically search files and content nodes attached " +
+      "to the conversation.",
     icon: "ActionDocumentTextIcon",
     authorization: null,
     documentationUrl: null,

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -35,6 +35,32 @@ export const QUERIES: LabeledQuery[] = [
     expected: "agent_memory.compact_memory",
   },
 
+  // --- conversation_files ---
+  {
+    query: "list the files attached to this conversation",
+    expected: "conversation_files.list",
+  },
+  {
+    query: "show the Notion pages and queryable tables attached here",
+    expected: "conversation_files.list_content_nodes_and_tables",
+  },
+  {
+    query: "read the attached conversation file by file id",
+    expected: "conversation_files.cat",
+  },
+  {
+    query: "grep an attached file for a specific error code",
+    expected: "conversation_files.cat",
+  },
+  {
+    query: "semantically search the conversation files for pricing terms",
+    expected: "conversation_files.semantic_search",
+  },
+  {
+    query: "search across the attached files by meaning",
+    expected: "conversation_files.semantic_search",
+  },
+
   // --- google_drive ---
   {
     query: "search google drive for the Q3 report",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -13,6 +13,7 @@
 
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
+import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_warehouses/metadata";
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
@@ -88,6 +89,7 @@ const RUN_AGENT_SAMPLE_TOOLS: ServerEntry["tools"] = [
 
 const SERVERS: ServerEntry[] = [
   { name: "agent_memory", tools: AGENT_MEMORY_SERVER.tools },
+  { name: "conversation_files", tools: CONVERSATION_FILES_SERVER.tools },
   { name: "google_drive", tools: GOOGLE_DRIVE_SERVER.tools },
   { name: "google_sheets", tools: GOOGLE_SHEETS_SERVER.tools },
   { name: "microsoft_drive", tools: MICROSOFT_DRIVE_SERVER.tools },


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9167.

This PR tweaks the `conversation_files` tool descriptions so tool search can distinguish the intent between listing attachments, reading a known attachment by `fileId`, and semantic search across conversation files/content nodes.

Also adds the tools to the BM25 testing script with samples for each tool.
No behavior changes, only descriptions and testcoverage.

## Tests

- Added BM25 harness samples.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
