### PR TITLE
Limit skill description suggestion to 750 characters

### DIFF
--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -1,5 +1,6 @@
 import { actionSchema } from "@app/components/shared/tools_picker/types";
 import {
+  AGENT_FACING_DESCRIPTION_MAX_LENGTH,
   SKILL_REINFORCEMENT_MODES,
   SkillWithoutInstructionsAndToolsSchema,
 } from "@app/types/assistant/skill_configuration";
@@ -7,8 +8,6 @@ import { editorUserSchema } from "@app/types/editors";
 import { createContext } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { z } from "zod";
-
-const AGENT_FACING_DESCRIPTION_MAX_LENGTH = 750;
 
 export const attachedKnowledgeSchema = z.object({
   dataSourceViewId: z.string(),

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -16,7 +16,10 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import {
+  AGENT_FACING_DESCRIPTION_MAX_LENGTH,
+  type SkillType,
+} from "@app/types/assistant/skill_configuration";
 import { escapeXml } from "@app/types/shared/utils/string_utils";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import type { UserType } from "@app/types/user";
@@ -53,7 +56,7 @@ It is ok to simply call no tool if all suggestions are minor.
 Start by grouping suggestions by skill, then within each skill group by topic:
 - For instruction edits, group by coherent theme within the skill (e.g. tone, tool usage, formatting). Suggestions that address different topics MUST be kept as separate suggestions — do NOT merge unrelated topics into one suggestion.
 - For inline tool reference changes, group by the target <tool> reference within each skill. Tool references are instruction edits, so NEVER output separate tool edits.
-- For agent-facing description edits, create AT MOST ONE description-edit suggestion per skill. When multiple drafts target the description, merge them into a single coherent replacement.
+- For agent-facing description edits, create AT MOST ONE description-edit suggestion per skill. When multiple drafts target the description, merge them into a single coherent replacement. Max description size is ${AGENT_FACING_DESCRIPTION_MAX_LENGTH} characters.
 NEVER create more than one suggestion per (skill, topic) pair.
 
 Rank the groups based on impact to the skill. Use these heuristics in priority order to determine highest impact:

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -6,7 +6,10 @@ import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinf
 import { SKILL_INSTRUCTION_HTML_EDIT_PROMPT } from "@app/lib/reinforcement/skill_instruction_edit_prompt";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import {
+  AGENT_FACING_DESCRIPTION_MAX_LENGTH,
+  type SkillType,
+} from "@app/types/assistant/skill_configuration";
 
 const ASSEMBLY_ORDER = [
   "primary_goal",
@@ -121,6 +124,7 @@ Suggest editing it only when the conversation surfaces clear evidence of a routi
 
 When suggesting a description edit:
 - Provide the FULL replacement text in \`agentFacingDescriptionEdit.content\` — it overwrites the existing description.
+- Max description size is ${AGENT_FACING_DESCRIPTION_MAX_LENGTH} characters.
 - Preserve the skill's actual purpose. Sharpen the trigger conditions; do not redefine the skill.
 - Keep it focused on routing signals (when to use, what scenarios). Do not duplicate the instructions.
 - Use the same language as the existing description.`,

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -31,6 +31,7 @@ import type { ConversationResource } from "@app/lib/resources/conversation_resou
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import logger from "@app/logger/logger";
+import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/types/assistant/skill_configuration";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
@@ -476,6 +477,20 @@ async function createSkillSuggestionsFromToolCall({
           type: "error",
           errorMessage:
             "edit_skill requires at least one instruction edit or description edit.",
+        };
+      }
+
+      if (
+        hasAgentFacingDescriptionEdit &&
+        parsed.data.agentFacingDescriptionEdit.content.length >
+          AGENT_FACING_DESCRIPTION_MAX_LENGTH
+      ) {
+        return {
+          type: "error",
+          errorMessage:
+            `The suggested agent-facing description is too long ` +
+            `(${parsed.data.agentFacingDescriptionEdit.content.length} characters). ` +
+            `It must be ${AGENT_FACING_DESCRIPTION_MAX_LENGTH} characters or less.`,
         };
       }
 

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -9,6 +9,9 @@ export type SkillStatus = (typeof SKILL_STATUSES)[number];
 export const SKILL_REINFORCEMENT_MODES = ["auto", "on", "off"] as const;
 export type SkillReinforcementMode = (typeof SKILL_REINFORCEMENT_MODES)[number];
 
+// Maximum length (in characters) of a skill's agent-facing description.
+export const AGENT_FACING_DESCRIPTION_MAX_LENGTH = 750;
+
 export const SKILL_VIEWS = ["full", "summary"] as const;
 export type SkillViewType = (typeof SKILL_VIEWS)[number];
 


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9299

Throw if the description suggestion is more than 750 characters
The reinforcement LLM will see the error and will be able to retry.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
low

## Deploy Plan

deploy front
