### PR TITLE
Add bun to the sandbox base image

### DIFF
--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.38",
+      tag: "0.8.39",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.38";
+const DUST_BASE_IMAGE_VERSION = "0.8.39";
 const DSBX_CLI_VERSION = "0.1.26";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
@@ -28,6 +28,9 @@ const AGENT_PROXIED_UID = SANDBOX_AGENT_PROXIED_UID;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.
 const APPLY_PATCH_VERSION = "0.1.0";
+// Modern x86_64 build (requires AVX2). Switch to the baseline variant if a
+// future sandbox CPU lacks it.
+const BUN_VERSION = "1.3.14";
 const EGRESS_LOCAL_DIR = path.resolve(__dirname, "egress");
 const PROFILE_LOCAL_DIR = path.resolve(__dirname, "profile");
 const TELEMETRY_LOCAL_DIR = path.resolve(__dirname, "telemetry");
@@ -370,6 +373,20 @@ SHELLEOF`,
     returns: "Summary of applied changes (A/M/D per file)",
     runtime: "system",
     profile: "openai",
+  })
+  .runCmd(
+    `curl -fsSL https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip -o /tmp/bun.zip && ` +
+      `curl -fsSL https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/SHASUMS256.txt -o /tmp/bun-checksums.txt && ` +
+      "grep 'bun-linux-x64.zip' /tmp/bun-checksums.txt | awk '{print $1 \"  /tmp/bun.zip\"}' | sha256sum -c - && " +
+      "unzip -j /tmp/bun.zip bun-linux-x64/bun -d /tmp && " +
+      "mv /tmp/bun /opt/bin/bun && " +
+      "chown root:root /opt/bin/bun && chmod 755 /opt/bin/bun",
+    { user: "root" }
+  )
+  .registerTool({
+    name: "bun",
+    description: "Fast JavaScript/TypeScript runtime and package manager",
+    runtime: "node",
   })
   .runCmd(`mkdir -p ${PROFILE_DIR}`, { user: "root" })
   // Core: compiled dust-tools binary + shared shell infra


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Adds the `bun` runtime to the sandbox base image so agents and upcoming sandbox functions have a fast JavaScript and TypeScript runtime available alongside the existing node tooling.

`bun` is installed from a pinned release (1.3.14) using the same download-and-verify pattern already used for the other prebuilt binaries in the image: the release archive is fetched, checked against the published sha256 sums, and the binary is placed in a root-owned location that sandbox workloads cannot write to. The release assets, the path inside the archive, and the checksum step were all verified against the actual published release before pinning.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
