### PR TITLE
[front] chore: improve pod manager tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -109,7 +109,9 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   [UPDATE_MEMBERS_TOOL_NAME]: {
     description:
-      "Add or remove Pod members and editors by user id. Requires Pod editor permissions. " +
+      "Update membership for an existing Pod: invite, add, remove, " +
+      "promote, or demote teammates as Pod members or editors by user id. " +
+      "Requires Pod editor permissions. " +
       "Editors and members are mutually exclusive: adding an editor removes them from members, " +
       "and adding a member is a no-op if the user is already an editor.",
     schema: {
@@ -135,10 +137,12 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   get_information: {
     description:
-      "Get information about the Pod: URL, title, description, pinned frame, and linked content nodes " +
-      "attached to the Pod context. Does NOT list Pod files. Pod files live under " +
-      `\`${SCOPED_PREFIX_POD}<id>/<rel>\` scoped paths and are discovered through the \`${FILES_SERVER_NAME}\` MCP server. ` +
-      "Pod files, metadata, and members are shared state across all conversations in this Pod.",
+      "Get metadata about the Pod: URL, title, description, pinned frame, " +
+      "and linked Company Data content-node references attached to the " +
+      "Pod context. This returns metadata only, not document bodies or " +
+      "transcript bodies. Scoped path operations live under " +
+      `\`${SCOPED_PREFIX_POD}<id>/<rel>\` paths in the ` +
+      `\`${FILES_SERVER_NAME}\` MCP server.`,
     schema: {
       dustPod: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD
@@ -156,7 +160,9 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   [LIST_MEMBERS_TOOL_NAME]: {
     description:
-      "List members of the Pod. Each entry includes user ID, name, email and status within the Pod.",
+      "List all people in the Pod, including members and editors. " +
+      "Each entry includes user ID, name, email, and role or status " +
+      "within the Pod.",
     schema: {
       limit: z
         .number()
@@ -278,7 +284,9 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   [SEMANTIC_SEARCH_TOOL_NAME]: {
     description:
-      "Search semantically over a Pod using the same retrieval pipeline as company data search. Scope selects the Pod data source slice (files vs conversation transcripts vs both) plus searchable context nodes for files/all.",
+      "Find and search for information about a topic or question across " +
+      "Pod files, linked context nodes, and Pod conversation transcripts " +
+      "using semantic retrieval. Scope selects files, conversations, or both.",
     schema: {
       query: z
         .string()
@@ -315,7 +323,12 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   create_conversation: {
     description:
-      "Create a new conversation in the Pod and post a user message. Default: always pass an agentName to delegate the task to an agent running inside the Pod. Do NOT do the work yourself. If work needs to be done, delegate it via agentName. Omit agentName only when posting a simple message that requires no intellectual work (e.g. a status update, a comment, a note) or when explicitly asked to post the final output.",
+      "Create or start a new Pod conversation and post a user message. " +
+      "Default for Pod work: pass an agentName so a Pod agent handles " +
+      "the task inside the new conversation. Do NOT do the work yourself. " +
+      "Omit agentName only when posting a simple message that requires " +
+      "no intellectual work (e.g. a status update, a comment, a note) " +
+      "or when explicitly asked to post the final output.",
     schema: {
       message: z
         .string()
@@ -327,7 +340,12 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "The name of the agent to trigger in the new conversation. The tool searches matching agent configurations and uses the best match. Use this whenever the user asks for work to be done in a Pod (research, analysis, drafting, etc.). When omitted, no agent is triggered and the message is posted as a static result. Use this only to deposit a finished artifact you have already fully produced."
+          "The name of the Pod agent to trigger in the new conversation. " +
+            "The tool searches matching agent configurations and uses the " +
+            "best match. Use this whenever the user asks for work to be " +
+            "done in a Pod. When omitted, no agent is triggered and the " +
+            "message is posted as a static result. Use this only to " +
+            "deposit a finished artifact you have already fully produced."
         ),
       dustPod:
         ConfigurableToolInputSchemas[
@@ -397,8 +415,15 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   add_message_to_conversation: {
     description:
-      "Post a user message to an existing conversation in this Pod. Default: always pass an agentName to delegate the task to an agent running inside the conversation. Do NOT do the work yourself. If work needs to be done, delegate it via agentName. Omit agentName only when posting a simple message that requires no intellectual work (e.g. a status update, a comment, a note) or when explicitly asked to post the final output." +
-      "The conversation must belong to the same Pod. If conversationId is omitted, the current agent conversation is used (when available).",
+      "Send or post a follow-up user message to an existing conversation " +
+      "in this Pod. Default for Pod work: pass an agentName so a Pod agent " +
+      "handles the task inside the conversation. Do NOT do the work " +
+      "yourself. " +
+      "Omit agentName only when posting a simple message that requires " +
+      "no intellectual work (e.g. a status update, a comment, a note) " +
+      "or when explicitly asked to post the final output. " +
+      "The conversation must belong to the same Pod. If conversationId is " +
+      "omitted, the current agent conversation is used (when available).",
     schema: {
       conversationId: z
         .string()
@@ -415,7 +440,12 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "The name of the agent to trigger in the conversation. The tool searches matching agent configurations and uses the best match. Use this whenever the user asks for work to be done in a Pod (research, analysis, drafting, etc.). When omitted, no agent is triggered and the message is posted as a static result. Use this only to deposit a finished artifact you have already fully produced."
+          "The name of the Pod agent to trigger in the conversation. " +
+            "The tool searches matching agent configurations and uses the " +
+            "best match. Use this whenever the user asks for work to be " +
+            "done in a Pod. When omitted, no agent is triggered and the " +
+            "message is posted as a static result. Use this only to " +
+            "deposit a finished artifact you have already fully produced."
         ),
       dustPod:
         ConfigurableToolInputSchemas[

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -778,6 +778,60 @@ export const QUERIES: LabeledQuery[] = [
     expected: "query_tables_v2.execute_database_query",
   },
 
+  // --- pod_manager ---
+  {
+    query: "show me the pods I belong to",
+    expected: "pod_manager.list_pods",
+  },
+  {
+    query: "create a new private pod for the launch plan",
+    expected: "pod_manager.create_pod",
+  },
+  {
+    query: "what is this pod's title description and linked content",
+    expected: "pod_manager.get_information",
+  },
+  {
+    query: "rename this pod and update its description",
+    expected: "pod_manager.edit_information",
+  },
+  {
+    query: "add a teammate as an editor to this pod",
+    expected: "pod_manager.update_members",
+  },
+  {
+    query: "list all members and editors in this pod",
+    expected: "pod_manager.list_members",
+  },
+  {
+    query: "attach this company data folder to the pod context",
+    expected: "pod_manager.add_content_node",
+  },
+  {
+    query: "remove this linked company data node from the pod",
+    expected: "pod_manager.remove_content_node",
+  },
+  {
+    query: "find pod files and conversations about pricing",
+    expected: "pod_manager.semantic_search",
+  },
+  {
+    query: "show the most recent pod documents from last week",
+    expected: "pod_manager.retrieve_recent_documents",
+  },
+  {
+    query: "start a new pod conversation with the research agent",
+    expected: "pod_manager.create_conversation",
+  },
+  {
+    query: "show unread conversations in this pod",
+    expected: "pod_manager.list_conversations",
+  },
+  {
+    query: "send a follow up message to an existing pod conversation",
+    expected: "pod_manager.add_message_to_conversation",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -23,6 +23,7 @@ import { INTERACTIVE_CONTENT_SERVER } from "@app/lib/api/actions/servers/interac
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
+import { POD_MANAGER_SERVER } from "@app/lib/api/actions/servers/pod_manager/metadata";
 import { QUERY_TABLES_V2_SERVER } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
 import {
   getRunAgentToolDescription,
@@ -108,6 +109,7 @@ const SERVERS: ServerEntry[] = [
   },
   { name: "data_warehouses", tools: DATA_WAREHOUSES_SERVER.tools },
   { name: "query_tables_v2", tools: QUERY_TABLES_V2_SERVER.tools },
+  { name: "pod_manager", tools: POD_MANAGER_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9167.

This PR tweaks the `pod_manager` tool descriptions so that the phrasing for each description ranks better to the intended tool in tool search and are better segregated with regard to the BM25 norm ([design doc](https://app.notion.com/p/dust-tt/Design-Doc-Anthropic-Token-Consumption-Cache-Efficiency-38728599d94180a2b7f8e101a776f564?source=copy_link#a7d3294f78444b25966d56efe3f3bd51), [tool-search doc](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)).

Also adds wakeups tools to the BM25 testing script
No behavior change.

## Tests

- Tested locally with BM25 samples.

## Risk

- Low.

## Deploy Plan

- Deploy front.
