### PR TITLE
fix(llm): correct new-router OpenAI reasoning replay

### DIFF
--- a/front/lib/api/llm/transitionLLM.test.ts
+++ b/front/lib/api/llm/transitionLLM.test.ts
@@ -4,6 +4,7 @@ import {
   toBaseMessages,
 } from "@app/lib/api/llm/transitionLLM";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import { assistantReasoningMessageToInputItems } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type { ProviderPassthroughEvent } from "@app/lib/model_constructors/types/output/events";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
@@ -132,6 +133,31 @@ describe("toBaseMessages — reasoning signatures", () => {
         content: { value: "let me think" },
         signature: "rs_123",
         encryptedContent: "gAAAA-encrypted-blob",
+      },
+    ]);
+  });
+});
+
+describe("OpenAI reasoning round-trip — persisted metadata to Responses input", () => {
+  it("resends the original reasoning item id and its encrypted content", () => {
+    const [baseMessage] = toBaseMessages(
+      reasoningMessage({
+        provider: "openai",
+        metadata: JSON.stringify({
+          id: "rs_123",
+          encrypted_content: "gAAAA-encrypted-blob",
+        }),
+      })
+    );
+    if (baseMessage.type !== "reasoning") {
+      throw new Error("Expected a reasoning BaseMessage.");
+    }
+    expect(assistantReasoningMessageToInputItems(baseMessage)).toEqual([
+      {
+        id: "rs_123",
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: "let me think" }],
+        encrypted_content: "gAAAA-encrypted-blob",
       },
     ]);
   });

--- a/front/lib/api/llm/transitionLLM.test.ts
+++ b/front/lib/api/llm/transitionLLM.test.ts
@@ -1,11 +1,13 @@
 import {
   convertToOldEvent,
+  reasoningContentToLegacyMetadata,
   toBaseMessages,
 } from "@app/lib/api/llm/transitionLLM";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type { ProviderPassthroughEvent } from "@app/lib/model_constructors/types/output/events";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { describe, expect, it } from "vitest";
 
 const llmMetadata: LLMClientMetadata = {
@@ -28,6 +30,30 @@ const serverToolUseBlock = {
   name: "tool_search_tool_bm25",
   input: { query: "x" },
 };
+
+function reasoningMessage({
+  provider,
+  metadata,
+}: {
+  provider: ModelProviderIdType;
+  metadata: string;
+}) {
+  return {
+    role: "assistant" as const,
+    name: "agent",
+    contents: [
+      {
+        type: "reasoning" as const,
+        value: {
+          reasoning: "let me think",
+          metadata,
+          tokens: 10,
+          provider,
+        },
+      },
+    ],
+  };
+}
 
 describe("toBaseMessages", () => {
   it("maps a provider_passthrough content to a passthrough BaseMessage", () => {
@@ -54,6 +80,63 @@ describe("toBaseMessages", () => {
   });
 });
 
+describe("toBaseMessages — reasoning signatures", () => {
+  it("keeps the Anthropic signature (stored under encrypted_content) in `signature`", () => {
+    const result = toBaseMessages(
+      reasoningMessage({
+        provider: "anthropic",
+        metadata: JSON.stringify({ encrypted_content: "anthropic-sig" }),
+      })
+    );
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        type: "reasoning",
+        content: { value: "let me think" },
+        signature: "anthropic-sig",
+      },
+    ]);
+  });
+
+  it("keeps the Gemini thoughtSignature (stored under encrypted_content) in `signature`", () => {
+    const result = toBaseMessages(
+      reasoningMessage({
+        provider: "google_ai_studio",
+        metadata: JSON.stringify({ encrypted_content: "gemini-thought-sig" }),
+      })
+    );
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        type: "reasoning",
+        content: { value: "let me think" },
+        signature: "gemini-thought-sig",
+      },
+    ]);
+  });
+
+  it("splits OpenAI metadata into the short id (`signature`) and `encryptedContent`", () => {
+    const result = toBaseMessages(
+      reasoningMessage({
+        provider: "openai",
+        metadata: JSON.stringify({
+          id: "rs_123",
+          encrypted_content: "gAAAA-encrypted-blob",
+        }),
+      })
+    );
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        type: "reasoning",
+        content: { value: "let me think" },
+        signature: "rs_123",
+        encryptedContent: "gAAAA-encrypted-blob",
+      },
+    ]);
+  });
+});
+
 describe("convertToOldEvent", () => {
   it("forwards a provider_passthrough event with its content and the old metadata", () => {
     const event: ProviderPassthroughEvent = {
@@ -67,5 +150,32 @@ describe("convertToOldEvent", () => {
       content: { provider: "anthropic", block: serverToolUseBlock },
       metadata: llmMetadata,
     });
+  });
+});
+
+describe("reasoningContentToLegacyMetadata — persistence write path", () => {
+  it("lifts OpenAI id + encryptedContent to the legacy top-level shape", () => {
+    expect(
+      reasoningContentToLegacyMetadata({
+        id: "rs_123",
+        encryptedContent: "gAAAA-encrypted-blob",
+      })
+    ).toEqual({ id: "rs_123", encrypted_content: "gAAAA-encrypted-blob" });
+  });
+
+  it("lifts an Anthropic/Gemini signature to top-level encrypted_content", () => {
+    expect(
+      reasoningContentToLegacyMetadata({ signature: "anthropic-sig" })
+    ).toEqual({ encrypted_content: "anthropic-sig" });
+  });
+
+  it("keeps the id alone when there is no encrypted content", () => {
+    expect(reasoningContentToLegacyMetadata({ id: "rs_123" })).toEqual({
+      id: "rs_123",
+    });
+  });
+
+  it("returns an empty object when content is missing", () => {
+    expect(reasoningContentToLegacyMetadata(undefined)).toEqual({});
   });
 });

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -20,7 +20,7 @@ import type {
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
 import {
   extractEncryptedContentFromMetadata,
-  extractIdFromMetadata,
+  parseReasoningMetadata,
   parseResponseFormatSchema,
 } from "@app/lib/api/llm/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -165,15 +165,16 @@ export function toBaseMessages(
                   },
                 ];
               }
+              const { id, encryptedContent } = parseReasoningMetadata(
+                c.value.metadata
+              );
               return [
                 {
                   role: "assistant",
                   type: "reasoning",
                   content: { value: c.value.reasoning },
-                  signature: extractIdFromMetadata(c.value.metadata),
-                  encryptedContent: extractEncryptedContentFromMetadata(
-                    c.value.metadata
-                  ),
+                  signature: id,
+                  encryptedContent,
                 },
               ];
             }

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -20,6 +20,7 @@ import type {
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
 import {
   extractEncryptedContentFromMetadata,
+  extractIdFromMetadata,
   parseResponseFormatSchema,
 } from "@app/lib/api/llm/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -59,6 +60,7 @@ import type {
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
 
 /**
  * Maps old reasoning effort values to the new model's effort values.
@@ -143,20 +145,38 @@ export function toBaseMessages(
                   content: { value: c.value },
                 },
               ];
-            case "reasoning":
+            case "reasoning": {
               if (!c.value.reasoning) {
                 return [];
+              }
+              // OpenAI Responses stores a short reasoning item `id` (kept in
+              // `signature`) separately from the long `encrypted_content`. Every
+              // other provider stores its thinking signature under
+              // `encrypted_content`, which we carry directly in `signature`.
+              if (c.value.provider !== "openai") {
+                return [
+                  {
+                    role: "assistant",
+                    type: "reasoning",
+                    content: { value: c.value.reasoning },
+                    signature: extractEncryptedContentFromMetadata(
+                      c.value.metadata
+                    ),
+                  },
+                ];
               }
               return [
                 {
                   role: "assistant",
                   type: "reasoning",
                   content: { value: c.value.reasoning },
-                  signature: extractEncryptedContentFromMetadata(
+                  signature: extractIdFromMetadata(c.value.metadata),
+                  encryptedContent: extractEncryptedContentFromMetadata(
                     c.value.metadata
                   ),
                 },
               ];
+            }
             case "function_call":
               return [
                 {
@@ -199,6 +219,23 @@ export function toBaseMessages(
   }
 }
 
+// The new router nests reasoning replay state under `metadata.content`: OpenAI
+// uses `id` + `encryptedContent`, Anthropic/Gemini use `signature`. Persist it in
+// the legacy top-level shape (`id` / `encrypted_content`) the replay path reads,
+// matching what the old router writes.
+export function reasoningContentToLegacyMetadata(
+  content: Record<string, unknown> | undefined
+): { id?: string; encrypted_content?: string } {
+  const id = isString(content?.id) ? content.id : undefined;
+  const encryptedContent = content?.encryptedContent ?? content?.signature;
+  return {
+    ...(id ? { id } : {}),
+    ...(isString(encryptedContent)
+      ? { encrypted_content: encryptedContent }
+      : {}),
+  };
+}
+
 /**
  * Converts a new model aggregated item to the old LLMOutputItem format.
  */
@@ -219,9 +256,7 @@ function convertAggregatedItem(
         content: { text: item.content.value },
         metadata: {
           ...metadata,
-          ...(typeof item.metadata.content?.signature === "string"
-            ? { encrypted_content: item.metadata.content.signature }
-            : {}),
+          ...reasoningContentToLegacyMetadata(item.metadata.content),
         },
       };
     case "tool_call":
@@ -329,9 +364,7 @@ export function convertToOldEvent(
         content: { text: event.content.value },
         metadata: {
           ...metadata,
-          ...(typeof event.metadata.content?.signature === "string"
-            ? { encrypted_content: event.metadata.content.signature }
-            : {}),
+          ...reasoningContentToLegacyMetadata(event.metadata.content),
         },
       };
 

--- a/front/lib/api/llm/utils/index.ts
+++ b/front/lib/api/llm/utils/index.ts
@@ -29,7 +29,12 @@ export function extractEncryptedContentFromMetadata(metadata: string): string {
   return encryptedContent;
 }
 
-export function extractIdFromMetadata(metadata: string): string {
+// OpenAI Responses replays a reasoning item by its short `id` and (for ZDR
+// regions) its long `encrypted_content`.
+export function parseReasoningMetadata(metadata: string): {
+  id: string;
+  encryptedContent: string;
+} {
   const parsed = safeParseJSON(metadata);
   if (parsed.isErr()) {
     throw new Error(
@@ -40,7 +45,13 @@ export function extractIdFromMetadata(metadata: string): string {
     parsed.value && "id" in parsed.value && isString(parsed.value.id)
       ? parsed.value.id
       : "";
-  return id;
+  const encryptedContent =
+    parsed.value &&
+    "encrypted_content" in parsed.value &&
+    isString(parsed.value.encrypted_content)
+      ? parsed.value.encrypted_content
+      : "";
+  return { id, encryptedContent };
 }
 
 export function parseResponseFormatSchema(

--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -6,8 +6,7 @@ import {
 } from "@app/lib/api/llm/clients/openai/types";
 import type { XaiWhitelistedModelId } from "@app/lib/api/llm/clients/xai/types";
 import {
-  extractEncryptedContentFromMetadata,
-  extractIdFromMetadata,
+  parseReasoningMetadata,
   parseResponseFormatSchema,
 } from "@app/lib/api/llm/utils";
 import { config } from "@app/lib/api/regions/config";
@@ -87,8 +86,7 @@ function toAssistantInputItem(
       }
 
       const reasoning = content.value.reasoning;
-      const id = extractIdFromMetadata(content.value.metadata);
-      const encryptedContent = extractEncryptedContentFromMetadata(
+      const { id, encryptedContent } = parseReasoningMetadata(
         content.value.metadata
       );
       return {

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
@@ -1,0 +1,70 @@
+import { assistantReasoningMessageToInputItems } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
+import type { BaseAssistantReasoningMessage } from "@app/lib/model_constructors/types/input/messages";
+import { describe, expect, it } from "vitest";
+
+describe("assistantReasoningMessageToInputItems", () => {
+  it("returns an empty array when there is no signature", () => {
+    const message: BaseAssistantReasoningMessage = {
+      role: "assistant",
+      type: "reasoning",
+      content: { value: "let me think" },
+    };
+    expect(assistantReasoningMessageToInputItems(message)).toEqual([]);
+  });
+
+  it("returns an empty array for an empty-string signature", () => {
+    const message: BaseAssistantReasoningMessage = {
+      role: "assistant",
+      type: "reasoning",
+      content: { value: "let me think" },
+      signature: "",
+    };
+    expect(assistantReasoningMessageToInputItems(message)).toEqual([]);
+  });
+
+  it("puts the signature in the `id` field, not the encrypted content", () => {
+    const message: BaseAssistantReasoningMessage = {
+      role: "assistant",
+      type: "reasoning",
+      content: { value: "deep thoughts" },
+      signature: "rs_123",
+    };
+    expect(assistantReasoningMessageToInputItems(message)).toEqual([
+      {
+        id: "rs_123",
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: "deep thoughts" }],
+      },
+    ]);
+  });
+
+  it("emits `encrypted_content` alongside the id when present", () => {
+    const message: BaseAssistantReasoningMessage = {
+      role: "assistant",
+      type: "reasoning",
+      content: { value: "deep thoughts" },
+      signature: "rs_123",
+      encryptedContent: "gAAAA-encrypted-blob",
+    };
+    expect(assistantReasoningMessageToInputItems(message)).toEqual([
+      {
+        id: "rs_123",
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: "deep thoughts" }],
+        encrypted_content: "gAAAA-encrypted-blob",
+      },
+    ]);
+  });
+
+  it("omits the summary when the reasoning value is empty", () => {
+    const message: BaseAssistantReasoningMessage = {
+      role: "assistant",
+      type: "reasoning",
+      content: { value: "" },
+      signature: "rs_123",
+    };
+    expect(assistantReasoningMessageToInputItems(message)).toEqual([
+      { id: "rs_123", type: "reasoning", summary: [] },
+    ]);
+  });
+});

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -112,7 +112,8 @@ export function assistantReasoningMessageToInputItems(
 ): ResponseInputItem[] {
   // The Responses API keys a replayed reasoning item by its original id, which
   // we carry in `signature`; drop unsigned items (mirrors dropping unsigned
-  // Anthropic thinking blocks).
+  // Anthropic thinking blocks). The region guard for `encryptedContent` lives in
+  // the transition layer, where region config is available.
   if (!message.signature) {
     return [];
   }
@@ -123,6 +124,9 @@ export function assistantReasoningMessageToInputItems(
       summary: message.content.value
         ? [{ type: "summary_text", text: message.content.value }]
         : [],
+      ...(message.encryptedContent
+        ? { encrypted_content: message.encryptedContent }
+        : {}),
     },
   ];
 }

--- a/front/lib/model_constructors/types/input/messages.ts
+++ b/front/lib/model_constructors/types/input/messages.ts
@@ -50,7 +50,10 @@ export type BaseAssistantReasoningMessage = {
   role: "assistant";
   type: "reasoning";
   content: { value: string };
+  // The original reasoning item id, used to key the replayed item.
   signature?: string;
+  // OpenAI encrypted reasoning content, resent alongside the id on replay.
+  encryptedContent?: string;
 };
 
 export type BaseAssistantToolCallRequestMessage = {


### PR DESCRIPTION
## Description

Under `use_new_llm_router`, gpt-5.5 failed with `400 Invalid 'input[N].id': string too long ... got a string with length 4044`. The old router was fine. Two bugs in the new router's reasoning round-trip; this fixes both.

Reasoning replay state is persisted as top-level `{ id, encrypted_content }` (the old router's shape). The new router carries it nested under `metadata.content` and bridges to/from that shape in `transitionLLM`.

**Read side (the 400):** on replay, `signature` was filled with the `encrypted_content` blob for every provider, and the OpenAI converter uses `signature` as the item `id` (64-char max) → 4044-char id. Now branches on provider: OpenAI puts the short `id` in `signature` and the blob in a new `encryptedContent` field (and skips cross-region items); Anthropic/Gemini keep their signature in `signature` as before.

**Write side (silent loss):** the bridges only lifted `content.signature` to top-level `encrypted_content`. OpenAI emits `content.{id, encryptedContent}`, so its reasoning persisted with neither key and was dropped on replay. New shared `reasoningContentToLegacyMetadata` helper writes the old-router shape, used by both the streaming and batch bridges.

## Tests

`transitionLLM.test.ts` (read + write mappings) and `openai_responses/converters/input/utils.test.ts` (converter). 14 tests, all green; `tsgo` clean.

## Risk

Low — behind `use_new_llm_router`. Non-OpenAI paths unchanged; OpenAI paths now mirror the legacy router. Safe to rollback.

## Deploy Plan

- [ ] Deploy `front`. No migration.