### PR TITLE
Fix plan card and panel intermittently not appearing after plan creation

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -52,6 +52,7 @@ import {
 import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
+import { planFileKey } from "@app/hooks/conversations/usePlanFile";
 import { useAgentMessageStream } from "@app/hooks/useAgentMessageStream";
 import { useDeleteAgentMessage } from "@app/hooks/useDeleteAgentMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -132,6 +133,7 @@ import {
 } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
+import { mutate } from "swr";
 
 const RUN_AGENT_TOOL_NAME = "run_agent";
 
@@ -447,6 +449,14 @@ export function AgentMessage({
             ) {
               void mutateSandboxFiles();
             }
+            if (action.internalMCPServerName === "plan_mode") {
+              // The conversation-channel `plan_updated` event can be lost (flaky SSE + small replay
+              // buffer), leaving the plan card/panel stale until turn end. The tool action rides the
+              // reliable per-message stream, so revalidate the plan here for a timely update.
+              void mutate(
+                planFileKey({ workspaceId: owner.sId, conversationId })
+              );
+            }
             break;
           }
           case "end-of-stream":
@@ -465,6 +475,7 @@ export function AgentMessage({
         sId,
         removeAllBlockedActionsForMessage,
         conversationId,
+        owner,
         mutateConversationAttachments,
         mutateSandboxStatus,
         mutateSandboxFiles,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -339,10 +339,6 @@ export const ConversationViewer = ({
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
   const isMobile = useIsMobile();
-  const isMobileRef = useRef(isMobile);
-  useEffect(() => {
-    isMobileRef.current = isMobile;
-  }, [isMobile]);
   const isAutoScrollEnabledRef = useRef(true);
   const prevScrollLocationRef = useRef({
     scrollHeight: 0,
@@ -595,10 +591,8 @@ export const ConversationViewer = ({
 
   // Sync the virtuoso ref with the side panel context.
   const {
-    closePanel,
     data: panelData,
     currentPanel,
-    openPanel,
     setVirtuosoMsg,
   } = useConversationSidePanelContext();
 
@@ -731,19 +725,6 @@ export const ConversationViewer = ({
   );
 
   const eventIds = useRef<string[]>([]);
-
-  // Whether we have already auto-opened the plan panel for this conversation, so we open it once
-  // (on the first non-closed plan update) rather than on every edit. ConversationViewer is keyed
-  // on conversationId by its parent, so the ref is naturally reset on conversation switch.
-  const planAutoOpenedRef = useRef(false);
-
-  // `onEventCallback` is bound by `useConversationEvents` once at mount and does not re-subscribe
-  // on identity changes (see useEventSource intentional behavior). Any state read from the
-  // closure would go stale, so we mirror `currentPanel` into a ref.
-  const currentPanelRef = useRef(currentPanel);
-  useEffect(() => {
-    currentPanelRef.current = currentPanel;
-  }, [currentPanel]);
 
   // Only conversation related events are handled here.
   const onEventCallback = useCallback(
@@ -1058,25 +1039,24 @@ export const ConversationViewer = ({
             window.dispatchEvent(new CompactionCompletedEvent());
             break;
           case "plan_updated": {
+            // The acting client already updates via the per-message plan tool action; this handles
+            // cross-client propagation (e.g. another viewer) and is a backstop. PlanCard opens/closes
+            // the panel in reaction to the content change.
             const planKey = planFileKey({
               workspaceId: owner.sId,
               conversationId: event.conversationId,
             });
-            void handlePlanUpdatedEvent(event, {
-              isMobile: isMobileRef.current,
-              isPlanPanelOpen: currentPanelRef.current === "plan",
-              autoOpenedRef: planAutoOpenedRef,
-              // Cache-only write (revalidate: false): resolves without a fetch, cannot reject.
+            handlePlanUpdatedEvent(event, {
+              // Close is authoritative: write null directly (no fetch, cannot reject).
               writeClosedToCache: () =>
                 void mutate<GetConversationPlanModeResponseBody>(
                   planKey,
                   { content: null },
                   { revalidate: false }
                 ),
-              revalidate: () =>
-                mutate<GetConversationPlanModeResponseBody>(planKey),
-              openPlanPanel: () => openPanel({ type: "plan" }),
-              closePanel,
+              // SWR owns request ordering, so a revalidation that resolves after a later close is
+              // discarded.
+              revalidatePlan: () => void mutate(planKey),
             });
             break;
           }
@@ -1106,7 +1086,6 @@ export const ConversationViewer = ({
       }
     },
     [
-      closePanel,
       conversationId,
       debouncedMarkAsRead,
       mutateContextUsage,
@@ -1116,7 +1095,6 @@ export const ConversationViewer = ({
       mutateConversations,
       mutateMessages,
       mutateWakeUps,
-      openPanel,
       owner.sId,
       user.sId,
     ]

--- a/front/components/assistant/conversation/plan_mode/PlanCard.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanCard.tsx
@@ -1,17 +1,22 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import { extractPlanTitle } from "@app/components/assistant/conversation/plan_mode/utils";
+import type { PlanPresence } from "@app/components/assistant/conversation/plan_mode/utils";
+import {
+  extractPlanTitle,
+  planPanelDecision,
+} from "@app/components/assistant/conversation/plan_mode/utils";
 import {
   useClosePlan,
   usePlanFile,
 } from "@app/hooks/conversations/usePlanFile";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import {
   ContentMessageAction,
   ContentMessageInline,
   ListSelect,
   Trash04,
 } from "@dust-tt/sparkle";
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 
 interface PlanCardProps {
   conversationId: string | null;
@@ -42,16 +47,39 @@ export const PlanCard = React.memo(function PlanCard({
 }: PlanCardProps) {
   const { hasFeature } = useFeatureFlags();
   const isPlanModeEnabled = hasFeature("plan_mode");
-  const { content } = usePlanFile({
+  const { content, isPlanLoading } = usePlanFile({
     // Skip the fetch entirely for workspaces without the plan_mode feature flag.
     conversationId: isPlanModeEnabled ? conversationId : null,
     workspaceId,
   });
-  const { togglePanel } = useConversationSidePanelContext();
+  const { currentPanel, openPanel, togglePanel, closePanel } =
+    useConversationSidePanelContext();
+  const isMobile = useIsMobile();
   const { closePlan, isClosing } = useClosePlan({
     workspaceId,
     conversationId,
   });
+
+  // Single owner of the plan panel: open when the plan appears, close when it goes away. Driving
+  // this off `content` (not a specific event) keeps it correct however the change arrived (live
+  // action event, cross-client `plan_updated`, reconnect refetch). Must stay above the early return
+  // so the close transition is observed when the card unmounts its content.
+  const planPresenceRef = useRef<PlanPresence>("unknown");
+  useEffect(() => {
+    const { next, action } = planPanelDecision({
+      isLoading: isPlanLoading,
+      hasContent: !!content,
+      isMobile,
+      isPanelOpen: currentPanel === "plan",
+      prev: planPresenceRef.current,
+    });
+    planPresenceRef.current = next;
+    if (action === "open") {
+      openPanel({ type: "plan" });
+    } else if (action === "close") {
+      closePanel();
+    }
+  }, [content, isMobile, isPlanLoading, currentPanel, openPanel, closePanel]);
 
   const title = useMemo(() => extractPlanTitle(content), [content]);
   const progress = useMemo(() => countProgress(content), [content]);

--- a/front/components/assistant/conversation/plan_mode/handle_plan_updated.test.ts
+++ b/front/components/assistant/conversation/plan_mode/handle_plan_updated.test.ts
@@ -14,107 +14,28 @@ function makeEvent(isClosed: boolean): PlanUpdatedEvent {
 
 function makeDeps(overrides: Partial<PlanUpdatedDeps> = {}): PlanUpdatedDeps {
   return {
-    isMobile: false,
-    isPlanPanelOpen: false,
-    autoOpenedRef: { current: false },
     writeClosedToCache: vi.fn(),
-    revalidate: vi.fn().mockResolvedValue({ content: "# Plan" }),
-    openPlanPanel: vi.fn(),
-    closePanel: vi.fn(),
+    revalidatePlan: vi.fn(),
     ...overrides,
   };
 }
 
 describe("handlePlanUpdatedEvent", () => {
-  it("on close, drops the cache, closes the plan panel, and re-arms auto-open", async () => {
-    const deps = makeDeps({
-      isPlanPanelOpen: true,
-      autoOpenedRef: { current: true },
-    });
-
-    await handlePlanUpdatedEvent(makeEvent(true), deps);
-
-    expect(deps.writeClosedToCache).toHaveBeenCalledTimes(1);
-    expect(deps.closePanel).toHaveBeenCalledTimes(1);
-    expect(deps.autoOpenedRef.current).toBe(false);
-    expect(deps.revalidate).not.toHaveBeenCalled();
-    expect(deps.openPlanPanel).not.toHaveBeenCalled();
-  });
-
-  it("on close, leaves the panel alone when the plan panel is not open", async () => {
-    const deps = makeDeps({ isPlanPanelOpen: false });
-
-    await handlePlanUpdatedEvent(makeEvent(true), deps);
-
-    expect(deps.writeClosedToCache).toHaveBeenCalledTimes(1);
-    expect(deps.closePanel).not.toHaveBeenCalled();
-  });
-
-  it("on create, revalidates and opens the plan panel once content arrives", async () => {
+  it("on close, drops the cache to null and does not revalidate", () => {
     const deps = makeDeps();
 
-    await handlePlanUpdatedEvent(makeEvent(false), deps);
+    handlePlanUpdatedEvent(makeEvent(true), deps);
 
-    expect(deps.revalidate).toHaveBeenCalledTimes(1);
-    expect(deps.openPlanPanel).toHaveBeenCalledTimes(1);
-    expect(deps.autoOpenedRef.current).toBe(true);
+    expect(deps.writeClosedToCache).toHaveBeenCalledTimes(1);
+    expect(deps.revalidatePlan).not.toHaveBeenCalled();
   });
 
-  it("on edit (already auto-opened), refreshes but does not reopen the panel", async () => {
-    const deps = makeDeps({ autoOpenedRef: { current: true } });
+  it("on create/edit, revalidates the plan and does not touch the cache", () => {
+    const deps = makeDeps();
 
-    await handlePlanUpdatedEvent(makeEvent(false), deps);
+    handlePlanUpdatedEvent(makeEvent(false), deps);
 
-    expect(deps.revalidate).toHaveBeenCalledTimes(1);
-    expect(deps.openPlanPanel).not.toHaveBeenCalled();
-    expect(deps.autoOpenedRef.current).toBe(true);
-  });
-
-  it("on create, does not auto-open on mobile", async () => {
-    const deps = makeDeps({ isMobile: true });
-
-    await handlePlanUpdatedEvent(makeEvent(false), deps);
-
-    expect(deps.openPlanPanel).not.toHaveBeenCalled();
-    expect(deps.autoOpenedRef.current).toBe(false);
-  });
-
-  it("on create, releases the latch when the fetch returns no content", async () => {
-    const deps = makeDeps({
-      revalidate: vi.fn().mockResolvedValue({ content: null }),
-    });
-
-    await handlePlanUpdatedEvent(makeEvent(false), deps);
-
-    expect(deps.openPlanPanel).not.toHaveBeenCalled();
-    expect(deps.autoOpenedRef.current).toBe(false);
-  });
-
-  it("on create, does not reopen when a close reset the latch mid-revalidation", async () => {
-    const autoOpenedRef = { current: false };
-    const deps = makeDeps({
-      autoOpenedRef,
-      // Simulate a close event landing (resetting the latch) while the revalidation is in flight,
-      // then this stale revalidation resolving with content.
-      revalidate: vi.fn().mockImplementation(async () => {
-        autoOpenedRef.current = false;
-        return { content: "# Plan" };
-      }),
-    });
-
-    await handlePlanUpdatedEvent(makeEvent(false), deps);
-
-    expect(deps.openPlanPanel).not.toHaveBeenCalled();
-  });
-
-  it("on create, releases the latch when the fetch fails", async () => {
-    const deps = makeDeps({
-      revalidate: vi.fn().mockRejectedValue(new Error("boom")),
-    });
-
-    await handlePlanUpdatedEvent(makeEvent(false), deps);
-
-    expect(deps.openPlanPanel).not.toHaveBeenCalled();
-    expect(deps.autoOpenedRef.current).toBe(false);
+    expect(deps.revalidatePlan).toHaveBeenCalledTimes(1);
+    expect(deps.writeClosedToCache).not.toHaveBeenCalled();
   });
 });

--- a/front/components/assistant/conversation/plan_mode/handle_plan_updated.ts
+++ b/front/components/assistant/conversation/plan_mode/handle_plan_updated.ts
@@ -1,62 +1,25 @@
-import type { GetConversationPlanModeResponseBody } from "@app/types/api/assistant/plan_mode";
 import type { PlanUpdatedEvent } from "@app/types/assistant/conversation";
 
 export interface PlanUpdatedDeps {
-  isMobile: boolean;
-  isPlanPanelOpen: boolean;
-  // Latch: true once the panel has auto-opened for the current plan, so edits don't reopen it.
-  autoOpenedRef: { current: boolean };
-  // Drop the cached plan to null without revalidating.
+  // Drop the cached plan to null without revalidating (close is authoritative, and keeps cross-client
+  // close independent of endpoint timing).
   writeClosedToCache: () => void;
-  // Revalidate the plan and resolve with the fresh body.
-  revalidate: () => Promise<GetConversationPlanModeResponseBody | undefined>;
-  openPlanPanel: () => void;
-  closePanel: () => void;
+  // Trigger an SWR revalidation of the plan key (SWR owns request ordering, so a stale revalidation
+  // resolving after a later close is discarded).
+  revalidatePlan: () => void;
 }
 
-// Decides how the UI reacts to a `plan_updated` event. Pulled out of ConversationViewer so the
-// close→reopen behavior this guards is unit-testable without rendering the conversation. Never
-// rejects (the create path catches), so callers can `void` it.
-export async function handlePlanUpdatedEvent(
+// Reacts to a `plan_updated` event: on close, drop the cache to null; on create/edit, revalidate.
+// Opening and closing the panel is owned by PlanCard, which reacts to the resulting content change.
+// Pulled out of ConversationViewer to be unit-testable.
+export function handlePlanUpdatedEvent(
   event: PlanUpdatedEvent,
   deps: PlanUpdatedDeps
-): Promise<void> {
+): void {
   if (event.isClosed) {
-    // Authoritative close: drop the cache to null (no refetch, which could race a quick subsequent
-    // create) and re-arm auto-open for the next plan.
-    deps.autoOpenedRef.current = false;
     deps.writeClosedToCache();
-    if (deps.isPlanPanelOpen) {
-      deps.closePanel();
-    }
     return;
   }
 
-  // Create/edit: claim auto-open synchronously so rapid edits don't double-open; release it if the
-  // fetch is empty or fails so a later update can still open.
-  const shouldAutoOpen = !deps.autoOpenedRef.current && !deps.isMobile;
-  if (shouldAutoOpen) {
-    deps.autoOpenedRef.current = true;
-  }
-  try {
-    const data = await deps.revalidate();
-    if (!shouldAutoOpen) {
-      return;
-    }
-    // A close that landed while this revalidation was in flight resets the latch; bail so a stale
-    // result can't reopen the panel for a plan that is no longer active. (SWR already discards the
-    // stale revalidation's cache write, so the card stays closed too.)
-    if (!deps.autoOpenedRef.current) {
-      return;
-    }
-    if (data?.content) {
-      deps.openPlanPanel();
-    } else {
-      deps.autoOpenedRef.current = false;
-    }
-  } catch {
-    if (shouldAutoOpen && deps.autoOpenedRef.current) {
-      deps.autoOpenedRef.current = false;
-    }
-  }
+  deps.revalidatePlan();
 }

--- a/front/components/assistant/conversation/plan_mode/utils.test.ts
+++ b/front/components/assistant/conversation/plan_mode/utils.test.ts
@@ -1,0 +1,94 @@
+import { planPanelDecision } from "@app/components/assistant/conversation/plan_mode/utils";
+import { describe, expect, it } from "vitest";
+
+const base = {
+  isLoading: false,
+  hasContent: false,
+  isMobile: false,
+  isPanelOpen: false,
+  prev: "unknown" as const,
+};
+
+describe("planPanelDecision", () => {
+  it("does nothing while the plan is still loading", () => {
+    expect(
+      planPanelDecision({ ...base, isLoading: true, prev: "empty" })
+    ).toEqual({ next: "empty", action: null });
+  });
+
+  it("settles to empty (no action) when loaded without a plan", () => {
+    expect(planPanelDecision(base)).toEqual({ next: "empty", action: null });
+  });
+
+  it("opens once on the empty -> present transition (creation)", () => {
+    expect(
+      planPanelDecision({ ...base, hasContent: true, prev: "empty" })
+    ).toEqual({ next: "present", action: "open" });
+  });
+
+  it("does not reopen on an edit (present -> present)", () => {
+    expect(
+      planPanelDecision({ ...base, hasContent: true, prev: "present" })
+    ).toEqual({ next: "present", action: null });
+  });
+
+  it("does not open a plan already present on load (unknown -> present)", () => {
+    expect(planPanelDecision({ ...base, hasContent: true })).toEqual({
+      next: "present",
+      action: null,
+    });
+  });
+
+  it("does not auto-open on mobile", () => {
+    expect(
+      planPanelDecision({
+        ...base,
+        hasContent: true,
+        prev: "empty",
+        isMobile: true,
+      })
+    ).toEqual({ next: "present", action: null });
+  });
+
+  it("closes the panel on the present -> empty transition (close)", () => {
+    expect(
+      planPanelDecision({ ...base, prev: "present", isPanelOpen: true })
+    ).toEqual({ next: "empty", action: "close" });
+  });
+
+  it("does not close when the plan panel is not the open one", () => {
+    expect(
+      planPanelDecision({ ...base, prev: "present", isPanelOpen: false })
+    ).toEqual({ next: "empty", action: null });
+  });
+
+  it("still closes on mobile (panel would otherwise show an empty plan)", () => {
+    expect(
+      planPanelDecision({
+        ...base,
+        prev: "present",
+        isPanelOpen: true,
+        isMobile: true,
+      })
+    ).toEqual({ next: "empty", action: "close" });
+  });
+
+  it("re-opens after a close -> recreate cycle", () => {
+    // Create + open.
+    let state = planPanelDecision({ ...base, hasContent: true, prev: "empty" });
+    expect(state).toEqual({ next: "present", action: "open" });
+
+    // Close (panel open) -> close.
+    state = planPanelDecision({
+      ...base,
+      hasContent: false,
+      isPanelOpen: true,
+      prev: state.next,
+    });
+    expect(state).toEqual({ next: "empty", action: "close" });
+
+    // Recreate -> open again.
+    state = planPanelDecision({ ...base, hasContent: true, prev: state.next });
+    expect(state).toEqual({ next: "present", action: "open" });
+  });
+});

--- a/front/components/assistant/conversation/plan_mode/utils.tsx
+++ b/front/components/assistant/conversation/plan_mode/utils.tsx
@@ -17,3 +17,40 @@ export function contentHash(content: string): string {
   }
   return (hash >>> 0).toString(36);
 }
+
+export type PlanPresence = "unknown" | "empty" | "present";
+
+// Drives the plan panel from the plan's presence, so open/close work however the change arrived
+// (live action event, cross-client `plan_updated`, reconnect refetch) rather than depending on any
+// single (possibly dropped) signal. The caller carries `prev` across renders.
+//
+// - Open on empty -> present (a freshly created plan). "unknown" is the pre-settle state, so a plan
+//   already present on load does not auto-open. Never auto-opens on mobile.
+// - Close on present -> empty (the plan was closed), but only when the plan panel is the open one.
+export function planPanelDecision({
+  isLoading,
+  hasContent,
+  isMobile,
+  isPanelOpen,
+  prev,
+}: {
+  isLoading: boolean;
+  hasContent: boolean;
+  isMobile: boolean;
+  isPanelOpen: boolean;
+  prev: PlanPresence;
+}): { next: PlanPresence; action: "open" | "close" | null } {
+  if (isLoading) {
+    return { next: prev, action: null };
+  }
+  if (hasContent) {
+    return {
+      next: "present",
+      action: prev === "empty" && !isMobile ? "open" : null,
+    };
+  }
+  return {
+    next: "empty",
+    action: prev === "present" && isPanelOpen ? "close" : null,
+  };
+}


### PR DESCRIPTION
## Plan card and panel sometimes don't show up (and the panel won't close)

Follow up of #27974. After creating a plan the card and side panel sometimes never appeared, and after closing a plan the panel could stay open showing "No active plan". You had to refresh.

### Root cause

The plan card and panel react to a single signal: the `plan_updated` event. It rides the conversation-channel SSE, which keeps a replay buffer of exactly `5` events (`front/lib/api/assistant/streaming/events.ts:51`) and drops/reconnects constantly (`ERR_INCOMPLETE_CHUNKED_ENCODING`). When it dies around the moment `create_plan` fires, the event
is lost, the reconnect does not replay it, and nothing recovers until a page refresh. Close is on the same single thread of fate: nothing closes the panel except that one flaky event.

### Fix

Stop leaning on the unreliable channel, and stop driving the UI off a specific event. Revalidate the plan on the per-message `agent_action_success` event (`internalMCPServerName === "plan_mode"`), which rides the channel that delivers the tokens you can see (10 min retention, `lastEventId` replay + dedup). Then let the UI react to plan content:

- `PlanCard` (always mounted, the stable SWR subscriber) owns open and close via a pure `planPanelDecision` helper tracking one `PlanPresence` state (`unknown | empty | present`): open on `empty -> present`, close on `present -> empty`, `unknown` suppresses both on first load. This pulls open/close out of the `ConversationViewer` event handler, dropping the refs it needed.
- `handle_plan_updated` slimmed to `isClosed -> write null, else revalidate`.

Open and close now work however the change arrived, not just when one event happens to land. Net front only.

### Risk

Front only, gated by the `plan_mode` flag. Worst case the timing regresses to the old behavior.

Safe to rollback.