### PR TITLE
[front] enh: improve wakeups tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -10,8 +10,8 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
   schedule_wakeup: {
     description:
       "Schedule a wake-up that posts a user message at a future time to re-invoke " +
-      "the agent. Use this to check back on something later, remind the user, poll until a " +
-      "condition is met or schedule recurring work. The `when` field accepts three formats: " +
+      "the agent. Useful for requests to check back on something later, remind the user, poll " +
+      "until a condition is met, or schedule recurring work. The `when` field accepts three formats: " +
       '(1) relative duration like "in 2h", "in 30m", "in 1d";\n' +
       '(2) absolute ISO 8601 timestamp like "2026-04-16T16:00:00Z";\n' +
       '(3) 5-field cron expression like "0 9 * * MON-FRI". (# and L are not supported).\n' +
@@ -49,9 +49,10 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
   },
   list_wakeups: {
     description:
-      "List wake-ups with their status, schedule, and reason. " +
-      "Useful for checking what's already scheduled before creating a new wake-up, or for " +
-      "finding the wake-up ID needed to cancel a wake-up.",
+      "List wake-ups and reminders with their status, schedule, and reason, including " +
+      "pending reminders and already-fired, cancelled, or expired wake-ups. Useful for checking " +
+      "what's already scheduled before creating a new wake-up, or for finding the wake-up ID " +
+      "needed to cancel a wake-up.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -61,8 +62,10 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
   },
   cancel_wakeup: {
     description:
-      "Cancel a previously scheduled wake-up by ID. " +
-      "Cancelling an already-fired, cancelled, or expired wake-up is a no-op.",
+      "Cancel or stop a previously scheduled wake-up or reminder by ID. " +
+      "Useful for requests to stop a reminder set earlier, remove a scheduled follow-up, or cancel " +
+      "a wake-up. Cancelling an already-fired, cancelled, or expired wake-up " +
+      "is a no-op.",
     schema: {
       wakeUpId: z
         .string()

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -457,6 +457,32 @@ export const QUERIES: LabeledQuery[] = [
     expected: "microsoft_teams.list_messages",
   },
 
+  // --- wakeups ---
+  {
+    query: "remind me tomorrow morning to check the launch",
+    expected: "wakeups.schedule_wakeup",
+  },
+  {
+    query: "check back in 2 hours to see if the import finished",
+    expected: "wakeups.schedule_wakeup",
+  },
+  {
+    query: "what wake-ups are scheduled in this conversation",
+    expected: "wakeups.list_wakeups",
+  },
+  {
+    query: "show my pending reminders",
+    expected: "wakeups.list_wakeups",
+  },
+  {
+    query: "cancel the scheduled wake-up",
+    expected: "wakeups.cancel_wakeup",
+  },
+  {
+    query: "stop the reminder I set earlier",
+    expected: "wakeups.cancel_wakeup",
+  },
+
   // --- confluence ---
   {
     query: "search confluence for pages about onboarding",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -32,6 +32,7 @@ import { SALESFORCE_SERVER } from "@app/lib/api/actions/servers/salesforce/metad
 import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadata";
 import { SLACK_PERSONAL_SERVER } from "@app/lib/api/actions/servers/slack_personal/metadata";
 import { SNOWFLAKE_SERVER } from "@app/lib/api/actions/servers/snowflake/metadata";
+import { WAKEUPS_SERVER } from "@app/lib/api/actions/servers/wakeups/metadata";
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import { buildIndex, rank } from "@app/scripts/mcp_bm25/bm25";
 import type { ServerEntry } from "@app/scripts/mcp_bm25/corpus";
@@ -96,6 +97,7 @@ const SERVERS: ServerEntry[] = [
   { name: "slack", tools: SLACK_PERSONAL_SERVER.tools },
   { name: "slack_bot", tools: SLACK_BOT_SERVER.tools },
   { name: "microsoft_teams", tools: MICROSOFT_TEAMS_SERVER.tools },
+  { name: "wakeups", tools: WAKEUPS_SERVER.tools },
   { name: "confluence", tools: CONFLUENCE_SERVER.tools },
   { name: "hubspot", tools: HUBSPOT_SERVER.tools },
   { name: "salesforce", tools: SALESFORCE_SERVER.tools },


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9167.

This PR tweaks the wakeups tool descriptions so that the phrasing for reminder, pending-reminder, stop, and cancel ranks better to the intended tool in tool search and are better segregated with regard to the BM25 norm ([design doc](https://app.notion.com/p/dust-tt/Design-Doc-Anthropic-Token-Consumption-Cache-Efficiency-38728599d94180a2b7f8e101a776f564?source=copy_link#a7d3294f78444b25966d56efe3f3bd51), [tool-search doc](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)).

Also adds wakeups tools to the BM25 testing script
No behavior change.

## Tests

- Tested locally with BM25 samples.

## Risk

- Low.

## Deploy Plan

- Deploy front.