### PR TITLE
dsbx function run: deliver response to the Dust result API

### DIFF
--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -234,4 +234,32 @@ impl DustApiClient {
 
         self.poll_action_result(&action_id).await
     }
+
+    /// Deliver a completed function's response to the sandbox-functions result
+    /// endpoint (`/api/v1/sandbox/sandbox-functions/result`, relative to
+    /// `DUST_API_URL`). The body carries the function name and the runner's
+    /// response JSON. Returns `Ok` on a 2xx; the response body is ignored, so an
+    /// empty/ack response is fine.
+    pub async fn post_function_result(
+        &self,
+        function: &str,
+        result: &serde_json::Value,
+    ) -> anyhow::Result<()> {
+        let url = self.url("sandbox/sandbox-functions/result");
+        let body = serde_json::json!({ "function": function, "result": result });
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .context(format!("POST {url}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            bail!("POST {url} returned {status}: {text}");
+        }
+        Ok(())
+    }
 }

--- a/cli/dust-sandbox/src/commands/function/get.rs
+++ b/cli/dust-sandbox/src/commands/function/get.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
 
-use super::run_bun;
+use super::spawn_function;
 
 /// Print a function's JSON-Schema contract. No stdin; stdout/exit code pass
 /// through from the runner. The bundle import (which executes the module's
 /// top-level code) runs unprivileged (agent uid) when dsbx is invoked as root.
 pub async fn cmd_function_get(name: &str) -> Result<()> {
-    run_bun("get", name, false).await
+    let (code, _) = spawn_function("get", name, false, false).await?;
+    std::process::exit(code);
 }

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -6,6 +6,7 @@ use std::process::Stdio;
 use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use tempfile::{TempDir, TempPath};
+use tokio::io::AsyncReadExt as _;
 use tokio::process::Command;
 
 mod get;
@@ -113,7 +114,10 @@ fn resolve_drop_target() -> Result<Option<DropTarget>> {
 }
 
 /// Spawn the embedded runner under `bun` for `subcommand` (`run` or `get`)
-/// against the resolved function, and exit with the child's status code.
+/// against the resolved function. Returns `(exit_code, captured_stdout)`; when
+/// `capture_stdout` is set the child's stdout is captured (piped) and returned
+/// instead of inherited, so the caller can deliver it somewhere (e.g. the Dust
+/// result API). Does not exit the process — the caller decides.
 ///
 /// The `bun` child (runner harness + the untrusted function bundle) is
 /// downgraded to the agent uid/gid (clearing supplementary groups) whenever
@@ -121,7 +125,12 @@ fn resolve_drop_target() -> Result<Option<DropTarget>> {
 /// stay root: it chowns the runner and stages the bundle into a uid-owned temp
 /// dir (named `<name>.ts` so `get`'s schema name is preserved), so the dropped
 /// child can read both even when the originals are root-only.
-pub(crate) async fn run_bun(subcommand: &str, name: &str, inherit_stdin: bool) -> Result<()> {
+pub(crate) async fn spawn_function(
+    subcommand: &str,
+    name: &str,
+    inherit_stdin: bool,
+    capture_stdout: bool,
+) -> Result<(i32, Option<String>)> {
     let path = resolve_existing(name)?;
     // The function runs with $DUST_FUNCTIONS_DIR as its working directory (the
     // parent of the resolved <name>.ts), not wherever dsbx was invoked from.
@@ -155,7 +164,11 @@ pub(crate) async fn run_bun(subcommand: &str, name: &str, inherit_stdin: bool) -
         } else {
             Stdio::null()
         })
-        .stdout(Stdio::inherit())
+        .stdout(if capture_stdout {
+            Stdio::piped()
+        } else {
+            Stdio::inherit()
+        })
         .stderr(Stdio::inherit());
     if let Some(dir) = &functions_dir {
         // chdir happens before the pre_exec privilege drop, i.e. while still
@@ -185,15 +198,33 @@ pub(crate) async fn run_bun(subcommand: &str, name: &str, inherit_stdin: bool) -
         }
     }
 
-    let status = cmd
-        .status()
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| emit_error(anyhow!("failed to run bun: {e}")))?;
+
+    // Capturing reads stdout to EOF (child closes it on exit) before waiting.
+    // Only stdout is piped; stderr/stdin are inherited, so there is no deadlock.
+    let captured = if capture_stdout {
+        let mut buf = Vec::new();
+        if let Some(mut out) = child.stdout.take() {
+            out.read_to_end(&mut buf)
+                .await
+                .map_err(|e| emit_error(anyhow!("failed to read function output: {e}")))?;
+        }
+        Some(String::from_utf8_lossy(&buf).into_owned())
+    } else {
+        None
+    };
+
+    let status = child
+        .wait()
         .await
         .map_err(|e| emit_error(anyhow!("failed to run bun: {e}")))?;
     runner.close().ok();
     if let Some(dir) = staged {
         dir.close().ok();
     }
-    std::process::exit(status.code().unwrap_or(1));
+    Ok((status.code().unwrap_or(1), captured))
 }
 
 /// Copy a function bundle into a fresh temp dir owned by `uid`/`gid`, as

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -1,11 +1,46 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
-use super::run_bun;
+use super::{emit_error, spawn_function};
+use crate::api::DustApiClient;
 
-/// Execute a function. The request envelope is read from stdin and the response
-/// JSON is written to stdout (both inherited so they stream straight through the
-/// runner); the runner's exit code becomes ours. The function runs unprivileged
-/// (agent uid) when dsbx is invoked as root.
+const SANDBOX_TOKEN_ENV: &str = "DUST_SANDBOX_TOKEN";
+
+/// Execute a function and deliver its response.
+///
+/// The request envelope is read from stdin and the function runs unprivileged
+/// (agent uid) when dsbx is invoked as root. The response is then delivered to
+/// the Dust result API. As a testing/local convenience, when there is no sandbox
+/// token (`DUST_SANDBOX_TOKEN` unset/empty) the API call is skipped and the
+/// response is written to dsbx's stdout instead (the previous behavior).
 pub async fn cmd_function_run(name: &str) -> Result<()> {
-    run_bun("run", name, true).await
+    let (code, captured) = spawn_function("run", name, true, true).await?;
+    let response = captured.unwrap_or_default();
+
+    let have_token = std::env::var(SANDBOX_TOKEN_ENV)
+        .map(|t| !t.is_empty())
+        .unwrap_or(false);
+
+    // No sandbox token: local/testing — emit the response on stdout, as before.
+    if !have_token {
+        print!("{response}");
+        std::process::exit(code);
+    }
+
+    // Sandbox: deliver the response to the Dust result API instead of stdout.
+    if response.trim().is_empty() {
+        return Err(emit_error(anyhow!(
+            "function produced no output to deliver to the result API"
+        )));
+    }
+    // The runner always emits a single JSON line; forward it as structured JSON
+    // (fall back to a string if it somehow isn't valid JSON).
+    let result: serde_json::Value = serde_json::from_str(response.trim())
+        .unwrap_or_else(|_| serde_json::Value::String(response.clone()));
+
+    let client = DustApiClient::from_env()?;
+    client
+        .post_function_result(name, &result)
+        .await
+        .map_err(emit_error)?;
+    std::process::exit(0);
 }


### PR DESCRIPTION
## Description

After `dsbx function run` executes a function, deliver its response to the Dust result API (**`POST /api/v1/sandbox/sandbox-functions/result`**, relative to `DUST_API_URL`) instead of writing it to stdout. This is the (A) direction discussed: `dsbx` itself brokers the call, reusing the existing `DustApiClient` (Bearer `DUST_SANDBOX_TOKEN`, JSON, timeout) — the same plumbing `dsbx tools` uses.

- **`spawn_function`** (refactored from `run_bun`): optionally captures the runner's stdout and returns `(exit_code, Option<stdout>)` rather than `process::exit`ing, so the caller decides what to do with the response. Only stdout is piped (stderr/stdin inherited), so there's no deadlock. `get` behavior is unchanged.
- **`cmd_function_run`**:
  - **`DUST_SANDBOX_TOKEN` set** → POST the captured response to the result API; exit `0` on delivery, `{ "error": … }` on stdout + nonzero on failure. Nothing else on stdout.
  - **unset/empty (local/testing)** → fall back to writing the response to stdout and exit with the function's code (the previous behavior), so functions can still be run/tested locally without the API.
- **`DustApiClient::post_function_result(function, result)`**: posts `{ "function": <name>, "result": <runner Output JSON> }` and treats any 2xx as success (response body ignored, so an empty ack is fine).

## Status / assumptions

The endpoint **does not exist yet** — this is the client side, looking ahead. Provisional and easy to adjust when the API is designed:
- `DUST_API_URL` is assumed to include the `/api/v1` prefix (consistent with the existing `sandbox/actions` calls), so the relative path resolves to `/api/v1/sandbox/sandbox-functions/result`.
- Request body shape `{ function, result }` and the 2xx-ignored-body response.
- Exit `0` on successful delivery (the function's own ok/error is carried in the delivered payload).

## Tests

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (240) all pass.
- Manually verified: **no token** → response on stdout, exit 0; **token set + dead API URL** → response captured (not on stdout), POST attempted to `…/api/v1/sandbox/sandbox-functions/result`, failure surfaced as `{error}` + nonzero exit.

## Risk

Low / self-contained, behind the `function run` path. No-token behavior is unchanged, so local/testing flows are unaffected. Builds on the merged `dsbx function` feature.

## Deploy Plan

None — developer/sandbox tooling in `dsbx`. Becomes live once the result endpoint exists and `DUST_SANDBOX_TOKEN`/`DUST_API_URL` are present in the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)