### PR TITLE
fix(mobile): conversation, auth, and tool-approval improvements

### DIFF
--- a/x/adrsimon/mobile/Dust/Models/Attachment.swift
+++ b/x/adrsimon/mobile/Dust/Models/Attachment.swift
@@ -38,6 +38,10 @@ struct Attachment: Identifiable {
         contentType.hasPrefix(frameContentTypePrefix)
     }
 
+    static func isImage(_ contentType: String) -> Bool {
+        contentType.hasPrefix("image/")
+    }
+
     static func sfSymbol(for contentType: String) -> String {
         if contentType.hasPrefix(frameContentTypePrefix) { return "rectangle.on.rectangle" }
         if contentType.hasPrefix("image/") { return "photo" }

--- a/x/adrsimon/mobile/Dust/Models/Conversation.swift
+++ b/x/adrsimon/mobile/Dust/Models/Conversation.swift
@@ -143,11 +143,16 @@ struct ConversationsResponse: Decodable {
 
 extension Notification.Name {
     static let conversationTitleDidChange = Notification.Name("ConversationTitleDidChange")
+    static let conversationDidMarkRead = Notification.Name("ConversationDidMarkRead")
 }
 
 enum ConversationTitleNotification {
     static let conversationIdKey = "conversationId"
     static let titleKey = "title"
+}
+
+enum ConversationReadNotification {
+    static let conversationIdKey = "conversationId"
 }
 
 extension [Conversation] {
@@ -173,6 +178,32 @@ final class ConversationTitleObserver {
 
             Task { @MainActor in
                 onTitleChange(conversationId, title)
+            }
+        }
+    }
+
+    deinit {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+}
+
+final class ConversationReadObserver {
+    private var observer: NSObjectProtocol?
+
+    init(onMarkRead: @escaping @MainActor (_ conversationId: String) -> Void) {
+        self.observer = NotificationCenter.default.addObserver(
+            forName: .conversationDidMarkRead,
+            object: nil,
+            queue: .main
+        ) { notification in
+            guard let conversationId = notification
+                .userInfo?[ConversationReadNotification.conversationIdKey] as? String
+            else { return }
+
+            Task { @MainActor in
+                onMarkRead(conversationId)
             }
         }
     }

--- a/x/adrsimon/mobile/Dust/Models/Message.swift
+++ b/x/adrsimon/mobile/Dust/Models/Message.swift
@@ -77,7 +77,10 @@ struct ContentFragment: Codable, Identifiable, Hashable {
 // MARK: - Generated File (attached to AgentMessage)
 
 struct GeneratedFile: Codable, Identifiable, Hashable {
-    let fileId: String
+    // Files backed by a Dust FileResource carry a `fileId`; path-only files
+    // (oversized tool output offloaded to disk) carry `filePath` and a null `fileId`.
+    let fileId: String?
+    let filePath: String?
     let title: String
     let contentType: String
     let createdAt: Double?
@@ -85,7 +88,7 @@ struct GeneratedFile: Codable, Identifiable, Hashable {
     let hidden: Bool?
 
     var id: String {
-        fileId
+        fileId ?? filePath ?? title
     }
 
     var isVisible: Bool {
@@ -184,6 +187,8 @@ struct ToolApprovalInfo: Equatable {
     let actionId: String
     let messageId: String
     let conversationId: String
+    /// sId of the user whose turn triggered the action; only they may approve it.
+    let triggeringUserId: String?
     let toolName: String?
     let mcpServerName: String?
     let agentName: String?
@@ -202,6 +207,7 @@ struct ToolApprovalInfo: Equatable {
         actionId: String,
         messageId: String,
         conversationId: String,
+        triggeringUserId: String?,
         toolName: String?,
         mcpServerName: String?,
         agentName: String?,
@@ -212,6 +218,7 @@ struct ToolApprovalInfo: Equatable {
         self.actionId = actionId
         self.messageId = messageId
         self.conversationId = conversationId
+        self.triggeringUserId = triggeringUserId
         self.toolName = toolName
         self.mcpServerName = mcpServerName
         self.agentName = agentName
@@ -238,6 +245,7 @@ struct ToolApprovalInfo: Equatable {
             actionId: event.actionId ?? "",
             messageId: event.messageId ?? fallbackMessageId,
             conversationId: event.conversationId ?? fallbackConversationId,
+            triggeringUserId: event.userId,
             toolName: event.metadata?.toolName,
             mcpServerName: event.metadata?.mcpServerName,
             agentName: event.metadata?.agentName,
@@ -252,6 +260,7 @@ struct ToolApprovalInfo: Equatable {
             actionId: action.actionId ?? "",
             messageId: action.messageId ?? "",
             conversationId: action.conversationId ?? fallbackConversationId,
+            triggeringUserId: action.userId,
             toolName: action.metadata?.toolName,
             mcpServerName: action.metadata?.mcpServerName,
             agentName: action.metadata?.agentName,
@@ -310,12 +319,15 @@ struct UserQuestionInfo: Equatable {
     let actionId: String
     let messageId: String
     let conversationId: String
+    /// sId of the user whose turn triggered the question; only they may answer it.
+    let triggeringUserId: String?
     let question: UserQuestion
 
     init(from event: ToolAskUserQuestionEvent, fallbackMessageId: String, fallbackConversationId: String) {
         self.actionId = event.actionId ?? ""
         self.messageId = event.messageId ?? fallbackMessageId
         self.conversationId = event.conversationId ?? fallbackConversationId
+        self.triggeringUserId = event.userId
         self.question = event.question
     }
 
@@ -323,8 +335,16 @@ struct UserQuestionInfo: Equatable {
         self.actionId = action.actionId ?? ""
         self.messageId = action.messageId ?? ""
         self.conversationId = action.conversationId ?? fallbackConversationId
+        self.triggeringUserId = action.userId
         self.question = question
     }
+}
+
+/// Mirrors front's `canCurrentUserRespondToParentUserMessage`: a viewer may respond to a
+/// blocked action only when it has no associated user (API-key run) or the action was
+/// triggered by that same viewer. Prevents one teammate from approving another's tool calls.
+func canRespondToBlockedAction(triggeringUserId: String?, currentUserSId: String?) -> Bool {
+    triggeringUserId == nil || triggeringUserId == currentUserSId
 }
 
 /// Derived view projection of `Activity` overlaid with any `BlockedState`. Not stored.

--- a/x/adrsimon/mobile/Dust/Models/StreamingEvent.swift
+++ b/x/adrsimon/mobile/Dust/Models/StreamingEvent.swift
@@ -252,6 +252,8 @@ struct ToolApproveExecutionEvent: Decodable {
     let conversationId: String?
     let messageId: String?
     let actionId: String?
+    // sId of the user whose turn triggered the action. Null for API-key runs.
+    let userId: String?
     let configurationId: String?
     let stake: String?
     let metadata: ToolApprovalMetadata?
@@ -269,6 +271,7 @@ struct ToolAskUserQuestionEvent: Decodable {
     let conversationId: String?
     let messageId: String?
     let actionId: String?
+    let userId: String?
     let question: UserQuestion
 }
 
@@ -351,6 +354,8 @@ struct BlockedAction: Decodable {
     let conversationId: String?
     let messageId: String?
     let actionId: String?
+    // sId of the user whose turn triggered the action. Null for API-key runs.
+    let userId: String?
     let configurationId: String?
     let stake: String?
     let metadata: ToolApprovalMetadata?

--- a/x/adrsimon/mobile/Dust/ViewModels/AuthViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/AuthViewModel.swift
@@ -86,7 +86,10 @@ final class AuthViewModel: NSObject, ObservableObject, ASWebAuthenticationPresen
             }
 
             session.presentationContextProvider = self
-            session.prefersEphemeralWebBrowserSession = false
+            // Use a private, ephemeral cookie store: the WorkOS web session must not
+            // persist on-device, otherwise logout (which only clears our tokens) leaves
+            // the in-app browser logged in and the next login silently re-authenticates.
+            session.prefersEphemeralWebBrowserSession = true
             session.start()
             webAuthSession = session
         } catch {

--- a/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
@@ -169,7 +169,16 @@ final class ConversationDetailViewModel: ObservableObject {
     // MARK: - Mark as Read
 
     private func markAsRead() {
-        guard conversation.unread else { return }
+        // `actionRequired` conversations also surface in the unread inbox; the server's
+        // read:true path self-heals a stale actionRequired flag, so mark those too.
+        guard conversation.unread || conversation.actionRequired else { return }
+
+        // Optimistically clear the list's unread indicator right away.
+        NotificationCenter.default.post(
+            name: .conversationDidMarkRead,
+            object: nil,
+            userInfo: [ConversationReadNotification.conversationIdKey: conversation.sId]
+        )
 
         markAsReadTask = Task { [weak self] in
             guard let self else { return }

--- a/x/adrsimon/mobile/Dust/ViewModels/ConversationListViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/ConversationListViewModel.swift
@@ -81,21 +81,34 @@ final class ConversationListViewModel: ObservableObject {
     @Published var workspaces: [Workspace] = []
     @Published var pods: [Space] = []
     @Published var isPodsExpanded: Bool = true
+    /// Dust sId of the signed-in user, used to scope tool-approval prompts to their own turns.
+    @Published var currentUserSId: String?
 
     private let tokenProvider: TokenProvider
     private var titleObserver: ConversationTitleObserver?
+    private var readObserver: ConversationReadObserver?
+    private var hasLoaded = false
 
     init(tokenProvider: TokenProvider) {
         self.tokenProvider = tokenProvider
         self.titleObserver = ConversationTitleObserver { [weak self] conversationId, title in
             self?.conversations.updateTitle(conversationId: conversationId, title: title)
         }
+        self.readObserver = ConversationReadObserver { [weak self] conversationId in
+            self?.markConversationsAsRead([conversationId])
+        }
     }
 
     func load() async {
+        // Initial load only. The view re-renders into the loading state on every
+        // workspace switch, which re-triggers the load `.task`; without this guard
+        // that re-fetches /api/user and reverts `workspace` to the session's default,
+        // sending us back to the previous workspace's endpoints.
+        guard !hasLoaded else { return }
         state = .loading
         do {
             let dustUser = try await AuthService.fetchDustUser(tokenProvider: tokenProvider)
+            currentUserSId = dustUser.sId
             workspaces = dustUser.workspaces
 
             let workspaceId = dustUser.selectedWorkspace ?? dustUser.workspaces.first?.sId
@@ -109,6 +122,7 @@ final class ConversationListViewModel: ObservableObject {
             async let podsTask: Void = loadPods()
             try await convosTask
             await podsTask
+            hasLoaded = true
         } catch {
             logger.error("Failed to load conversations: \(error)")
             state = .error(error.localizedDescription)

--- a/x/adrsimon/mobile/Dust/Views/Components/AttachmentImagePreview.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/AttachmentImagePreview.swift
@@ -1,0 +1,98 @@
+import SparkleTokens
+import SwiftUI
+
+/// Context needed to load an authenticated attachment image. Injected once at the
+/// conversation level so message bubbles can render image previews without each
+/// view threading the workspace id and token provider through its initializer.
+struct AttachmentImageContext {
+    let workspaceId: String
+    let tokenProvider: TokenProvider
+}
+
+private struct AttachmentImageContextKey: EnvironmentKey {
+    static let defaultValue: AttachmentImageContext? = nil
+}
+
+extension EnvironmentValues {
+    var attachmentImageContext: AttachmentImageContext? {
+        get { self[AttachmentImageContextKey.self] }
+        set { self[AttachmentImageContextKey.self] = newValue }
+    }
+}
+
+private enum AttachmentImageCache {
+    static let shared = NSCache<NSString, UIImage>()
+}
+
+/// A square thumbnail for an image attachment, matching the input bar's
+/// `AttachmentChipView`. Falls back to `FileChip` when no loading context is
+/// available or the image can't be decoded.
+struct AttachmentImagePreview: View {
+    let fileId: String
+    let title: String
+    let contentType: String
+    let isTappable: Bool
+    let onTap: () -> Void
+
+    @Environment(\.attachmentImageContext) private var context
+    @State private var image: UIImage?
+    @State private var didFail = false
+
+    private let side: CGFloat = 64
+
+    var body: some View {
+        if didFail || context == nil {
+            FileChip(title: title, contentType: contentType, isTappable: isTappable, onTap: onTap)
+        } else {
+            Button(action: onTap) {
+                imageContent
+                    .frame(width: side, height: side)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(Color.dustForeground.opacity(0.15), lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(!isTappable)
+            .task(id: fileId) { await load() }
+        }
+    }
+
+    @ViewBuilder
+    private var imageContent: some View {
+        if let image {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } else {
+            Color.dustMutedBackground
+                .overlay { ProgressView().scaleEffect(0.7) }
+        }
+    }
+
+    private func load() async {
+        guard image == nil, let context else { return }
+
+        if let cached = AttachmentImageCache.shared.object(forKey: fileId as NSString) {
+            image = cached
+            return
+        }
+
+        do {
+            let data = try await FileContentService.fetchFileData(
+                workspaceId: context.workspaceId,
+                fileId: fileId,
+                tokenProvider: context.tokenProvider
+            )
+            guard let uiImage = UIImage(data: data) else {
+                didFail = true
+                return
+            }
+            AttachmentImageCache.shared.setObject(uiImage, forKey: fileId as NSString)
+            image = uiImage
+        } catch {
+            didFail = true
+        }
+    }
+}

--- a/x/adrsimon/mobile/Dust/Views/Components/MessageBubbleView.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/MessageBubbleView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct MessageBubbleView: View {
     let message: ConversationMessage
     let currentUserEmail: String
+    var currentUserSId: String?
     var streamingPhase: AgentStreamingPhase = .idle
     var activeActions: [ActiveAction] = []
     var completedSteps: [ActivityStep] = []
@@ -31,6 +32,7 @@ struct MessageBubbleView: View {
         case let .agent(msg):
             AgentMessageBubble(
                 message: msg,
+                currentUserSId: currentUserSId,
                 streamingPhase: streamingPhase,
                 activeActions: activeActions,
                 completedSteps: completedSteps,
@@ -107,6 +109,7 @@ struct OtherUserMessageBubble: View {
 
 struct AgentMessageBubble: View {
     let message: AgentMessage
+    var currentUserSId: String?
     var streamingPhase: AgentStreamingPhase = .idle
     var activeActions: [ActiveAction] = []
     var completedSteps: [ActivityStep] = []
@@ -190,6 +193,10 @@ struct AgentMessageBubble: View {
                     ToolApprovalInlineView(
                         approval: approval,
                         isLoading: isValidatingAction,
+                        canRespond: canRespondToBlockedAction(
+                            triggeringUserId: approval.triggeringUserId,
+                            currentUserSId: currentUserSId
+                        ),
                         onValidate: onValidateAction
                     )
                 case let .personalAuthRequired(provider, _):
@@ -206,6 +213,10 @@ struct AgentMessageBubble: View {
                     UserQuestionInlineView(
                         question: info.question,
                         isLoading: isValidatingAction,
+                        canRespond: canRespondToBlockedAction(
+                            triggeringUserId: info.triggeringUserId,
+                            currentUserSId: currentUserSId
+                        ),
                         onAnswer: onAnswerQuestion
                     )
                 case .idle, .thinking, .generating:
@@ -289,12 +300,22 @@ struct ContentFragmentList: View {
     var body: some View {
         FlowLayout(spacing: 4) {
             ForEach(fragments) { fragment in
-                FileChip(
-                    title: fragment.title,
-                    contentType: fragment.contentType,
-                    isTappable: fragment.fileId != nil && onTap != nil,
-                    onTap: { onTap?(fragment) }
-                )
+                if Attachment.isImage(fragment.contentType), let fileId = fragment.fileId {
+                    AttachmentImagePreview(
+                        fileId: fileId,
+                        title: fragment.title,
+                        contentType: fragment.contentType,
+                        isTappable: onTap != nil,
+                        onTap: { onTap?(fragment) }
+                    )
+                } else {
+                    FileChip(
+                        title: fragment.title,
+                        contentType: fragment.contentType,
+                        isTappable: fragment.fileId != nil && onTap != nil,
+                        onTap: { onTap?(fragment) }
+                    )
+                }
             }
         }
     }
@@ -309,12 +330,22 @@ struct GeneratedFilesList: View {
     var body: some View {
         FlowLayout(spacing: 4, alignment: .leading) {
             ForEach(files) { file in
-                FileChip(
-                    title: file.title,
-                    contentType: file.contentType,
-                    isTappable: onTap != nil,
-                    onTap: { onTap?(file) }
-                )
+                if Attachment.isImage(file.contentType), let fileId = file.fileId {
+                    AttachmentImagePreview(
+                        fileId: fileId,
+                        title: file.title,
+                        contentType: file.contentType,
+                        isTappable: onTap != nil,
+                        onTap: { onTap?(file) }
+                    )
+                } else {
+                    FileChip(
+                        title: file.title,
+                        contentType: file.contentType,
+                        isTappable: file.fileId != nil && onTap != nil,
+                        onTap: { onTap?(file) }
+                    )
+                }
             }
         }
     }
@@ -750,6 +781,7 @@ struct ThinkingStepView: View {
 struct ToolApprovalInlineView: View {
     let approval: ToolApprovalInfo
     var isLoading: Bool = false
+    var canRespond: Bool = true
     var onValidate: ((ActionApproval) -> Void)?
 
     @State private var showDetails = false
@@ -804,11 +836,15 @@ struct ToolApprovalInlineView: View {
             Divider()
                 .foregroundStyle(Color.dustBorder)
 
-            ToolApprovalActionButtons(
-                canAlwaysAllow: approval.canAlwaysAllow,
-                isLoading: isLoading,
-                onValidate: onValidate
-            )
+            if canRespond {
+                ToolApprovalActionButtons(
+                    canAlwaysAllow: approval.canAlwaysAllow,
+                    isLoading: isLoading,
+                    onValidate: onValidate
+                )
+            } else {
+                BlockedWaitingView(label: "Waiting for a teammate to approve this.")
+            }
         }
         .padding(12)
         .liquidGlassRoundedRect()
@@ -882,6 +918,23 @@ struct ToolApprovalActionButtons: View {
     }
 }
 
+/// Shown in place of action buttons when the current user isn't the one whose turn
+/// triggered the blocked action, so they can see what's pending without acting on it.
+struct BlockedWaitingView: View {
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .scaleEffect(0.7)
+            Text(label)
+                .sparkleCopyXs()
+                .foregroundStyle(Color.dustFaint)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
 // MARK: - Auth / File Access Required
 
 struct AuthRequiredView: View {
@@ -933,6 +986,7 @@ struct AuthRequiredView: View {
 struct UserQuestionInlineView: View {
     let question: UserQuestion
     var isLoading: Bool = false
+    var canRespond: Bool = true
     var onAnswer: ((UserQuestionAnswer) -> Void)?
 
     @State private var selectedOptions: Set<Int> = []
@@ -953,45 +1007,49 @@ struct UserQuestionInlineView: View {
                 .foregroundStyle(Color.dustForeground)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            VStack(spacing: 6) {
-                ForEach(Array(question.options.enumerated()), id: \.offset) { index, option in
-                    optionRow(index: index, option: option)
+            if canRespond {
+                VStack(spacing: 6) {
+                    ForEach(Array(question.options.enumerated()), id: \.offset) { index, option in
+                        optionRow(index: index, option: option)
+                    }
                 }
+
+                TextField("Type something else", text: $customResponse, axis: .vertical)
+                    .sparkleCopyXs()
+                    .lineLimit(1 ... 4)
+                    .padding(10)
+                    .background(Color.dustMutedBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                Divider()
+                    .foregroundStyle(Color.dustBorder)
+
+                VStack(spacing: 8) {
+                    Button { onAnswer?(buildAnswer()) } label: {
+                        Text("Send")
+                            .sparkleLabelXs()
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(Color.highlight)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                    .disabled(!canSend)
+                    .opacity(canSend ? 1.0 : 0.5)
+
+                    Button { onAnswer?(UserQuestionAnswer(selectedOptions: [], customResponse: nil)) } label: {
+                        Text("Skip")
+                            .sparkleLabelXs()
+                            .foregroundStyle(Color.dustForeground)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                    }
+                }
+                .disabled(isLoading)
+                .opacity(isLoading ? 0.5 : 1.0)
+            } else {
+                BlockedWaitingView(label: "Waiting for a teammate to respond.")
             }
-
-            TextField("Type something else", text: $customResponse, axis: .vertical)
-                .sparkleCopyXs()
-                .lineLimit(1 ... 4)
-                .padding(10)
-                .background(Color.dustMutedBackground)
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-
-            Divider()
-                .foregroundStyle(Color.dustBorder)
-
-            VStack(spacing: 8) {
-                Button { onAnswer?(buildAnswer()) } label: {
-                    Text("Send")
-                        .sparkleLabelXs()
-                        .foregroundStyle(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 12)
-                        .background(Color.highlight)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                }
-                .disabled(!canSend)
-                .opacity(canSend ? 1.0 : 0.5)
-
-                Button { onAnswer?(UserQuestionAnswer(selectedOptions: [], customResponse: nil)) } label: {
-                    Text("Skip")
-                        .sparkleLabelXs()
-                        .foregroundStyle(Color.dustForeground)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 12)
-                }
-            }
-            .disabled(isLoading)
-            .opacity(isLoading ? 0.5 : 1.0)
         }
         .padding(12)
         .liquidGlassRoundedRect()

--- a/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
+++ b/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct ConversationDetailView: View {
     let conversation: Conversation
     let currentUserEmail: String
+    let currentUserSId: String?
 
     private let workspaceId: String
     private let tokenProvider: TokenProvider
@@ -21,10 +22,12 @@ struct ConversationDetailView: View {
         workspaceId: String,
         tokenProvider: TokenProvider,
         user: User,
-        currentUserEmail: String
+        currentUserEmail: String,
+        currentUserSId: String?
     ) {
         self.conversation = conversation
         self.currentUserEmail = currentUserEmail
+        self.currentUserSId = currentUserSId
         self.workspaceId = workspaceId
         self.tokenProvider = tokenProvider
         _viewModel = StateObject(
@@ -46,6 +49,10 @@ struct ConversationDetailView: View {
     var body: some View {
         VStack(spacing: 0) {
             messageList
+                .environment(
+                    \.attachmentImageContext,
+                    AttachmentImageContext(workspaceId: workspaceId, tokenProvider: tokenProvider)
+                )
             InputBarView(
                 viewModel: inputBarViewModel,
                 conversationId: conversation.sId,
@@ -127,14 +134,16 @@ struct ConversationDetailView: View {
             }
         }
         .sheet(item: $selectedGeneratedFile) { file in
-            AttachmentViewerView(
-                title: file.title,
-                contentType: file.contentType,
-                fileId: file.fileId,
-                workspaceId: workspaceId,
-                tokenProvider: tokenProvider,
-                sourceUrl: nil
-            )
+            if let fileId = file.fileId {
+                AttachmentViewerView(
+                    title: file.title,
+                    contentType: file.contentType,
+                    fileId: fileId,
+                    workspaceId: workspaceId,
+                    tokenProvider: tokenProvider,
+                    sourceUrl: nil
+                )
+            }
         }
     }
 
@@ -152,6 +161,20 @@ struct ConversationDetailView: View {
     }
 
     // MARK: - Message List
+
+    private static let bottomAnchorId = "conversation-bottom-anchor"
+
+    /// Scrolls to the bottom marker on the next runloop tick. Deferring lets the
+    /// just-appended row lay out and any in-flight keyboard inset settle first;
+    /// otherwise an animated scroll started mid-keyboard-transition lands against
+    /// the pre-resize viewport and overshoots, pushing messages off the top.
+    private func scrollToBottom(_ proxy: ScrollViewProxy) {
+        DispatchQueue.main.async {
+            withAnimation {
+                proxy.scrollTo(Self.bottomAnchorId, anchor: .bottom)
+            }
+        }
+    }
 
     private var messageList: some View {
         Group {
@@ -199,6 +222,7 @@ struct ConversationDetailView: View {
                                 MessageBubbleView(
                                     message: viewModel.renderMessage(message),
                                     currentUserEmail: currentUserEmail,
+                                    currentUserSId: currentUserSId,
                                     streamingPhase: isStreaming ? viewModel.streamingPhase : .idle,
                                     activeActions: isStreaming ? viewModel.activeActions : [],
                                     completedSteps: isStreaming ? viewModel.completedSteps : [],
@@ -211,6 +235,7 @@ struct ConversationDetailView: View {
                                         selectedFragment = fragment
                                     },
                                     onGeneratedFileTap: { file in
+                                        guard file.fileId != nil else { return }
                                         selectedGeneratedFile = file
                                     },
                                     onCitationTap: { citation in
@@ -237,17 +262,20 @@ struct ConversationDetailView: View {
                                 )
                                 .id(message.id)
                             }
+
+                            // Zero-height bottom marker. Scrolling targets this rather
+                            // than the last message so the destination is always the true
+                            // content end, even while the keyboard is animating.
+                            Color.clear
+                                .frame(height: 1)
+                                .id(Self.bottomAnchorId)
                         }
                         .padding(.horizontal, 16)
                         .padding(.bottom, 16)
                     }
                     .defaultScrollAnchor(.bottom)
                     .onChange(of: viewModel.messages.last?.id) {
-                        if let last = viewModel.messages.last {
-                            withAnimation {
-                                proxy.scrollTo(last.id, anchor: .bottom)
-                            }
-                        }
+                        scrollToBottom(proxy)
                     }
                 }
             }

--- a/x/adrsimon/mobile/Dust/Views/MainContainerView.swift
+++ b/x/adrsimon/mobile/Dust/Views/MainContainerView.swift
@@ -149,7 +149,8 @@ struct MainContainerView: View {
                     workspaceId: workspaceId,
                     tokenProvider: tokenProvider,
                     user: user,
-                    currentUserEmail: user.email
+                    currentUserEmail: user.email,
+                    currentUserSId: viewModel.currentUserSId
                 )
             }
 


### PR DESCRIPTION
## Description

A batch of independent mobile fixes bundled into one PR. **Two of these are security/authorization-relevant** and worth a closer look:

- **🔒 Auth — ephemeral web session.** Logout only clears our tokens; the in-app browser previously kept its WorkOS cookies, so the next login silently re-authenticated the same account. Switches to an ephemeral cookie store so logout actually signs the user out.
- **🔒 Tool approvals — scope to the triggering user.** Approval and "ask user a question" prompts are now scoped to the user whose turn triggered the action. The triggering user's sId is carried through the stream events (`ToolApproveExecutionEvent`, `ToolAskUserQuestionEvent`, `BlockedAction`) and only that user may respond — other participants in a shared conversation can no longer approve someone else's tool call. API-key runs (null userId) are unaffected.

The rest are behavioral/cosmetic:

- **Messages — inline image previews** for image attachments in the thread.
- **Conversations — mark action-required as read.** `actionRequired` conversations also surface in the unread inbox; the server's read path self-heals a stale flag, so we mark those read too and optimistically clear the list's unread indicator via a notification.
- **Conversation list — reload guard.** The list re-triggered its initial load on every workspace switch, re-fetching `/api/user` and reverting the active workspace to the session default. Guarded so the initial load runs once.
- **Generated files — path-only files.** Handle files with a `filePath` and null `fileId` (oversized tool output offloaded to disk); they no longer crash the id/viewer path.

## Tests

Built for the simulator (`make build`, green). Manually exercised: logout/login no longer auto-signs-in; tool-approval prompt only actionable by the triggering user in a shared conversation; image attachments render inline; action-required conversations clear from the unread list; workspace switching stays on the selected workspace.

## Risk

The two authorization changes are the main risk surface:
- Ephemeral session: users will need to re-enter credentials more often (expected, and the point of the fix). Safe to roll back.
- Approval scoping relies on the server populating `userId` on the stream events; when null (API-key runs) the prompt remains actionable, preserving current behavior. No state migration; revertable per-file.

The remaining changes are additive/local to their views and low-risk.

## Deploy Plan

Standard mobile build. No backend or schema changes; depends on the server already emitting `userId` on tool-approval stream events (already present in the web flow).