### PR TITLE
[Pods] Pods Default skills UI & client-side functionality

### DIFF
--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -115,6 +115,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       archivedAt: null,
       createdAt: expect.anything(),
       defaultAgentId: null,
+      defaultSkillIds: [],
       description: "Test project description",
       lastTodoAnalysisAt: null,
       pinnedFramePath: null,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -18,7 +18,9 @@ vi.mock("@app/temporal/project_task/client", () => ({
 }));
 
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 
 import { honoApp } from "@front-api/app";
@@ -159,6 +161,82 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
     expect(data.projectMetadata.todoGenerationEnabled).toBe(true);
     expect(mockLaunchOrSignalProjectTodoWorkflow).toHaveBeenCalledTimes(1);
     expect(mockStartImmediateProjectTodoWorkflowOnce).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets, returns, replaces, and clears default skills (custom + global)", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "pod_default_skills");
+
+    const projectSpace = await SpaceFactory.project(workspace);
+    const skillA = await SkillFactory.create(auth, { name: "Skill A" });
+    const skillB = await SkillFactory.create(auth, { name: "Skill B" });
+    // A code-defined global skill, addressed by its fixed sId (no "skl_" prefix).
+    const globalSkillId = "frames";
+
+    // Set two custom skills and one global skill.
+    const setResponse = await patchMetadata(workspace, projectSpace.sId, {
+      defaultSkillIds: [skillA.sId, skillB.sId, globalSkillId],
+    });
+    expect(setResponse.status).toBe(200);
+    expect(
+      (await setResponse.json()).projectMetadata.defaultSkillIds.sort()
+    ).toEqual([skillA.sId, skillB.sId, globalSkillId].sort());
+
+    // GET reflects the stored set.
+    const getResponse = await getMetadata(workspace, projectSpace.sId);
+    expect(
+      (await getResponse.json()).projectMetadata.defaultSkillIds.sort()
+    ).toEqual([skillA.sId, skillB.sId, globalSkillId].sort());
+
+    // Replacing drops the omitted skills; keep one custom + the global one.
+    const replaceResponse = await patchMetadata(workspace, projectSpace.sId, {
+      defaultSkillIds: [skillB.sId, globalSkillId],
+    });
+    expect(
+      (await replaceResponse.json()).projectMetadata.defaultSkillIds.sort()
+    ).toEqual([skillB.sId, globalSkillId].sort());
+
+    // An empty array clears all default skills.
+    const clearResponse = await patchMetadata(workspace, projectSpace.sId, {
+      defaultSkillIds: [],
+    });
+    expect(
+      (await clearResponse.json()).projectMetadata.defaultSkillIds
+    ).toEqual([]);
+  });
+
+  it("rejects unknown default skill ids", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "pod_default_skills");
+
+    const projectSpace = await SpaceFactory.project(workspace);
+
+    const response = await patchMetadata(workspace, projectSpace.sId, {
+      defaultSkillIds: ["skill_does_not_exist"],
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("ignores default skills when the feature flag is off", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const projectSpace = await SpaceFactory.project(workspace);
+    const skill = await SkillFactory.create(auth, { name: "Skill A" });
+
+    const response = await patchMetadata(workspace, projectSpace.sId, {
+      defaultSkillIds: [skill.sId],
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).projectMetadata.defaultSkillIds).toEqual([]);
   });
 
   it("restarts project tasks workflow when unarchiving a project", async () => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -2,6 +2,7 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { getFeatureFlags } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import {
   launchOrSignalProjectTodoWorkflow,
   startImmediateProjectTodoWorkflowOnce,
@@ -79,6 +80,7 @@ app.patch(
 
     const featureFlags = await getFeatureFlags(auth);
     const defaultAgentEnabled = featureFlags.includes("pod_default_agent");
+    const defaultSkillsEnabled = featureFlags.includes("pod_default_skills");
 
     if (body.pinnedFramePath !== undefined) {
       const validation = await validatePinnedFramePath(
@@ -116,6 +118,34 @@ app.patch(
       }
     }
 
+    // Validate the requested default skills exist and are active. Both global and
+    // custom (workspace) skills are supported — the mapping table stores each via
+    // its skillReference ({ globalSkillId } or { customSkillId }). Full
+    // replacement: an empty array clears all default skills. Gated behind the
+    // pod_default_skills feature flag.
+    let resolvedDefaultSkills: SkillResource[] | null = null;
+    if (defaultSkillsEnabled && body.defaultSkillIds !== undefined) {
+      const requestedSkillIds = [...new Set(body.defaultSkillIds)];
+      const skills = await SkillResource.fetchByIds(auth, requestedSkillIds);
+      const skillBySId = new Map(skills.map((skill) => [skill.sId, skill]));
+
+      const validatedSkills: SkillResource[] = [];
+      for (const skillId of requestedSkillIds) {
+        const skill = skillBySId.get(skillId);
+        if (!skill || skill.status !== "active") {
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Skill "${skillId}" was not found, is not active, or is not usable as a default skill.`,
+            },
+          });
+        }
+        validatedSkills.push(skill);
+      }
+      resolvedDefaultSkills = validatedSkills;
+    }
+
     let metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
 
     const priorLastTodoAnalysisAt = metadata?.lastTodoAnalysisAt ?? null;
@@ -137,6 +167,9 @@ app.patch(
           ? (body.defaultAgentId ?? null)
           : null,
       });
+      if (resolvedDefaultSkills) {
+        await metadata.setDefaultSkills(resolvedDefaultSkills);
+      }
       if (!body.archive) {
         void launchOrSignalProjectTodoWorkflow({
           workspaceId: auth.getNonNullableWorkspace().sId,
@@ -185,6 +218,9 @@ app.patch(
       if (defaultAgentEnabled && body.defaultAgentId !== undefined) {
         await metadata.updateDefaultAgentId(body.defaultAgentId);
       }
+      if (resolvedDefaultSkills) {
+        await metadata.setDefaultSkills(resolvedDefaultSkills);
+      }
       if (body.todoGenerationEnabled === true && !priorTodoGenerationEnabled) {
         void launchOrSignalProjectTodoWorkflow({
           workspaceId: auth.getNonNullableWorkspace().sId,
@@ -196,6 +232,16 @@ app.patch(
           workspaceId: auth.getNonNullableWorkspace().sId,
           spaceId: space.sId,
         });
+      }
+    }
+
+    // The default skills live in a separate mapping table, so the in-memory
+    // resource still holds the pre-update set. Re-fetch to reflect the new set
+    // in the response.
+    if (resolvedDefaultSkills) {
+      const refreshed = await ProjectMetadataResource.fetchBySpace(auth, space);
+      if (refreshed) {
+        metadata = refreshed;
       }
     }
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -163,7 +163,7 @@ app.patch(
           : null,
       });
       if (resolvedDefaultSkills) {
-        await metadata.setDefaultSkills(resolvedDefaultSkills);
+        await metadata.setDefaultSkills(auth, resolvedDefaultSkills);
       }
       if (!body.archive) {
         void launchOrSignalProjectTodoWorkflow({
@@ -214,7 +214,7 @@ app.patch(
         await metadata.updateDefaultAgentId(body.defaultAgentId);
       }
       if (resolvedDefaultSkills) {
-        await metadata.setDefaultSkills(resolvedDefaultSkills);
+        await metadata.setDefaultSkills(auth, resolvedDefaultSkills);
       }
       if (body.todoGenerationEnabled === true && !priorTodoGenerationEnabled) {
         void launchOrSignalProjectTodoWorkflow({

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -118,11 +118,6 @@ app.patch(
       }
     }
 
-    // Validate the requested default skills exist and are active. Both global and
-    // custom (workspace) skills are supported — the mapping table stores each via
-    // its skillReference ({ globalSkillId } or { customSkillId }). Full
-    // replacement: an empty array clears all default skills. Gated behind the
-    // pod_default_skills feature flag.
     let resolvedDefaultSkills: SkillResource[] | null = null;
     if (defaultSkillsEnabled && body.defaultSkillIds !== undefined) {
       const requestedSkillIds = [...new Set(body.defaultSkillIds)];
@@ -235,9 +230,6 @@ app.patch(
       }
     }
 
-    // The default skills live in a separate mapping table, so the in-memory
-    // resource still holds the pre-update set. Re-fetch to reflect the new set
-    // in the response.
     if (resolvedDefaultSkills) {
       const refreshed = await ProjectMetadataResource.fetchBySpace(auth, space);
       if (refreshed) {

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -63,6 +63,8 @@ interface InputBarProps {
   stickyMentions?: RichMention[];
   defaultAgentId?: string | null;
   isDefaultAgentLoading?: boolean;
+  defaultSkills?: InputBarContainerProps["defaultSkills"];
+  isDefaultSkillsLoading?: boolean;
   actions?: InputBarContainerProps["actions"];
   disableAutoFocus: boolean;
   disableUserMentions?: boolean;
@@ -90,6 +92,8 @@ export const InputBar = React.memo(function InputBar({
   stickyMentions,
   defaultAgentId,
   isDefaultAgentLoading,
+  defaultSkills,
+  isDefaultSkillsLoading,
   actions = DEFAULT_INPUT_BAR_ACTIONS,
   disableAutoFocus = false,
   disableUserMentions,
@@ -499,6 +503,8 @@ export const InputBar = React.memo(function InputBar({
             stickyMentions={stickyMentions}
             defaultAgentId={defaultAgentId}
             isDefaultAgentLoading={isDefaultAgentLoading}
+            defaultSkills={defaultSkills}
+            isDefaultSkillsLoading={isDefaultSkillsLoading}
             fileUploaderService={fileUploaderService}
             isSubmitting={
               isLocalSubmitting ||

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -96,7 +96,7 @@ import {
   Type01,
   VoicePicker,
 } from "@dust-tt/sparkle";
-import type { Editor } from "@tiptap/react";
+import type { Editor, JSONContent } from "@tiptap/react";
 import { EditorContent } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
 import React, {
@@ -143,6 +143,60 @@ export const INPUT_BAR_ACTIONS = [
 
 export type InputBarAction = (typeof INPUT_BAR_ACTIONS)[number];
 
+export interface DefaultSkillReference {
+  sId: string;
+  name: string;
+  icon: string | null;
+}
+
+// Walks the input-bar editor JSON to classify its contents for default-skill
+// syncing. Used to decide whether the pod's default skills can be
+// re-seeded without clobbering what the member has started composing.
+function inspectDefaultSkillEditorState(node: JSONContent | undefined): {
+  skillIds: string[];
+  hasUserContent: boolean;
+} {
+  if (!node) {
+    return { skillIds: [], hasUserContent: false };
+  }
+
+  switch (node.type) {
+    case "skill": {
+      const skillId = node.attrs?.skillId;
+      return {
+        skillIds: typeof skillId === "string" ? [skillId] : [],
+        hasUserContent: false,
+      };
+    }
+    case "text":
+      return {
+        skillIds: [],
+        hasUserContent: (node.text ?? "").trim().length > 0,
+      };
+    case undefined:
+    case "doc":
+    case "paragraph":
+    case "hardBreak":
+      break;
+    default:
+      // Any other node kind (mention, pasted attachment, ...) is user content.
+      return { skillIds: [], hasUserContent: true };
+  }
+
+  let skillIds: string[] = [];
+  let hasUserContent = false;
+  for (const child of node.content ?? []) {
+    const result = inspectDefaultSkillEditorState(child);
+    skillIds = skillIds.concat(result.skillIds);
+    hasUserContent = hasUserContent || result.hasUserContent;
+  }
+  return { skillIds, hasUserContent };
+}
+
+function sameSkillIds(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
+}
+
 export interface InputBarContainerProps {
   actions: InputBarAction[];
   allAgents: LightAgentConfigurationType[];
@@ -168,6 +222,9 @@ export interface InputBarContainerProps {
   } | null;
   defaultAgentId?: string | null;
   isDefaultAgentLoading?: boolean;
+  // Skills pre-inserted into a new conversation's editor, as if manually added.
+  defaultSkills?: DefaultSkillReference[];
+  isDefaultSkillsLoading?: boolean;
   isAgentBuilder?: boolean;
   isCompact?: boolean;
   onExpandInputBar?: () => void;
@@ -207,6 +264,8 @@ const InputBarContainer = ({
   getDraft,
   defaultAgentId,
   isDefaultAgentLoading,
+  defaultSkills,
+  isDefaultSkillsLoading,
   isAgentBuilder = false,
   onNodeSelect,
   onNodeUnselect,
@@ -1283,6 +1342,80 @@ const InputBarContainer = ({
     selectedAgent,
     stickyMentions,
   });
+
+  // Keep a new conversation's editor in sync with the pod's default skills,
+  // including right after switching back from the Settings tab.
+  useEffect(() => {
+    if (defaultSkills === undefined) {
+      return;
+    }
+    if (conversation || isAgentBuilder) {
+      return;
+    }
+    // Hold off until the defaults have loaded so we don't reconcile to a empty
+    // set first.
+    if (isDefaultSkillsLoading) {
+      return;
+    }
+    if (
+      !editor ||
+      editor.isDestroyed ||
+      !editor.isEditable ||
+      !editor.isInitialized
+    ) {
+      return;
+    }
+
+    const desiredSkillIds = defaultSkills.map((skill) => skill.sId);
+
+    // Reconcile in a microtask so we run after the draft-restore effect's own
+    // microtask (it is declared above this one).
+    queueMicrotask(() => {
+      if (
+        !editor ||
+        editor.isDestroyed ||
+        !editor.isEditable ||
+        !editor.isInitialized
+      ) {
+        return;
+      }
+
+      const { skillIds: editorSkillIds, hasUserContent } =
+        inspectDefaultSkillEditorState(editor.getJSON());
+
+      // The member has started writing: leave their draft — skills included — untouched.
+      if (hasUserContent) {
+        return;
+      }
+      // Already reflects the current pod defaults.
+      if (sameSkillIds(editorSkillIds, desiredSkillIds)) {
+        return;
+      }
+
+      // The editor holds only default skills and/or whitespace:
+      // replace them with the current defaults.
+      let chain = editor.chain();
+      if (editorSkillIds.length > 0) {
+        chain = chain.clearContent();
+      }
+      for (const skill of defaultSkills) {
+        chain = chain.insertSkillNode({
+          skillId: skill.sId,
+          skillName: skill.name,
+          skillIcon: skill.icon,
+        });
+      }
+      chain.run();
+    });
+  }, [
+    conversation,
+    defaultSkills,
+    isDefaultSkillsLoading,
+    isAgentBuilder,
+    editor,
+    editor?.isInitialized,
+    editor?.isEditable,
+  ]);
 
   const buttonSize = useMemo(() => {
     return isMobile ? "sm" : "xs";

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -96,7 +96,7 @@ import {
   Type01,
   VoicePicker,
 } from "@dust-tt/sparkle";
-import type { Editor, JSONContent } from "@tiptap/react";
+import type { Editor } from "@tiptap/react";
 import { EditorContent } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
 import React, {
@@ -147,54 +147,6 @@ export interface DefaultSkillReference {
   sId: string;
   name: string;
   icon: string | null;
-}
-
-// Walks the input-bar editor JSON to classify its contents for default-skill
-// syncing. Used to decide whether the pod's default skills can be
-// re-seeded without clobbering what the member has started composing.
-function inspectDefaultSkillEditorState(node: JSONContent | undefined): {
-  skillIds: string[];
-  hasUserContent: boolean;
-} {
-  if (!node) {
-    return { skillIds: [], hasUserContent: false };
-  }
-
-  switch (node.type) {
-    case "skill": {
-      const skillId = node.attrs?.skillId;
-      return {
-        skillIds: typeof skillId === "string" ? [skillId] : [],
-        hasUserContent: false,
-      };
-    }
-    case "text":
-      return {
-        skillIds: [],
-        hasUserContent: (node.text ?? "").trim().length > 0,
-      };
-    case undefined:
-    case "doc":
-    case "paragraph":
-    case "hardBreak":
-      break;
-    default:
-      // Any other node kind (mention, pasted attachment, ...) is user content.
-      return { skillIds: [], hasUserContent: true };
-  }
-
-  let skillIds: string[] = [];
-  let hasUserContent = false;
-  for (const child of node.content ?? []) {
-    const result = inspectDefaultSkillEditorState(child);
-    skillIds = skillIds.concat(result.skillIds);
-    hasUserContent = hasUserContent || result.hasUserContent;
-  }
-  return { skillIds, hasUserContent };
-}
-
-function sameSkillIds(a: string[], b: string[]): boolean {
-  return a.length === b.length && a.every((id, index) => id === b[index]);
 }
 
 export interface InputBarContainerProps {
@@ -1343,17 +1295,13 @@ const InputBarContainer = ({
     stickyMentions,
   });
 
-  // Keep a new conversation's editor in sync with the pod's default skills,
-  // including right after switching back from the Settings tab.
   useEffect(() => {
-    if (defaultSkills === undefined) {
+    if (defaultSkills === undefined || defaultSkills.length === 0) {
       return;
     }
     if (conversation || isAgentBuilder) {
       return;
     }
-    // Hold off until the defaults have loaded so we don't reconcile to a empty
-    // set first.
     if (isDefaultSkillsLoading) {
       return;
     }
@@ -1366,10 +1314,6 @@ const InputBarContainer = ({
       return;
     }
 
-    const desiredSkillIds = defaultSkills.map((skill) => skill.sId);
-
-    // Reconcile in a microtask so we run after the draft-restore effect's own
-    // microtask (it is declared above this one).
     queueMicrotask(() => {
       if (
         !editor ||
@@ -1379,25 +1323,11 @@ const InputBarContainer = ({
       ) {
         return;
       }
-
-      const { skillIds: editorSkillIds, hasUserContent } =
-        inspectDefaultSkillEditorState(editor.getJSON());
-
-      // The member has started writing: leave their draft — skills included — untouched.
-      if (hasUserContent) {
-        return;
-      }
-      // Already reflects the current pod defaults.
-      if (sameSkillIds(editorSkillIds, desiredSkillIds)) {
+      if (!editorService.isEmpty()) {
         return;
       }
 
-      // The editor holds only default skills and/or whitespace:
-      // replace them with the current defaults.
       let chain = editor.chain();
-      if (editorSkillIds.length > 0) {
-        chain = chain.clearContent();
-      }
       for (const skill of defaultSkills) {
         chain = chain.insertSkillNode({
           skillId: skill.sId,
@@ -1415,6 +1345,7 @@ const InputBarContainer = ({
     editor,
     editor?.isInitialized,
     editor?.isEditable,
+    editorService,
   ]);
 
   const buttonSize = useMemo(() => {
@@ -1429,13 +1360,6 @@ const InputBarContainer = ({
 
   const hideCapabilities = startsWithUserMention && !selectedSingleAgent;
 
-  // A pod can pre-select a default agent that the current member can't access
-  // (e.g. an unpublished agent). `allAgents` only contains agents the member
-  // can read, so when the configured default is missing from it, the
-  // resolution in `useHandleMentions` silently falls back to @dust. Surface a
-  // notice on the agent pill so the member understands why the pod's default
-  // isn't the one shown. (We can't distinguish "no access" from "deleted"
-  // client-side, so the copy stays neutral.)
   const isDefaultAgentUnavailable =
     !conversation &&
     !isAgentBuilder &&

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -17,6 +17,7 @@ import {
   getAvailableInputBarSlashCommands,
   type InputBarSlashCommand,
 } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
+import { SKILL_NODE_TYPE } from "@app/components/editor/extensions/input_bar/SkillNode";
 import {
   isRunCommandSlashCommand,
   isSkillSlashCommand,
@@ -147,6 +148,35 @@ export interface DefaultSkillReference {
   sId: string;
   name: string;
   icon: string | null;
+}
+
+function readDefaultSkillEditorState(editor: Editor): {
+  skillIds: string[];
+  hasUserContent: boolean;
+} {
+  const skillIds: string[] = [];
+  let hasUserContent = false;
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === SKILL_NODE_TYPE) {
+      if (typeof node.attrs.skillId === "string") {
+        skillIds.push(node.attrs.skillId);
+      }
+      return false;
+    }
+    if (node.isText) {
+      if ((node.text ?? "").trim().length > 0) {
+        hasUserContent = true;
+      }
+    } else if (node.isInline && node.type.name !== "hardBreak") {
+      hasUserContent = true;
+    }
+    return true;
+  });
+  return { skillIds, hasUserContent };
+}
+
+function sameSkillIds(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
 }
 
 export interface InputBarContainerProps {
@@ -1296,12 +1326,13 @@ const InputBarContainer = ({
   });
 
   useEffect(() => {
-    if (defaultSkills === undefined || defaultSkills.length === 0) {
+    if (defaultSkills === undefined) {
       return;
     }
     if (conversation || isAgentBuilder) {
       return;
     }
+
     if (isDefaultSkillsLoading) {
       return;
     }
@@ -1314,6 +1345,8 @@ const InputBarContainer = ({
       return;
     }
 
+    const desiredSkillIds = defaultSkills.map((skill) => skill.sId);
+
     queueMicrotask(() => {
       if (
         !editor ||
@@ -1323,11 +1356,21 @@ const InputBarContainer = ({
       ) {
         return;
       }
-      if (!editorService.isEmpty()) {
+
+      const { skillIds, hasUserContent } = readDefaultSkillEditorState(editor);
+
+      if (hasUserContent) {
+        return;
+      }
+
+      if (sameSkillIds(skillIds, desiredSkillIds)) {
         return;
       }
 
       let chain = editor.chain();
+      if (skillIds.length > 0) {
+        chain = chain.clearContent();
+      }
       for (const skill of defaultSkills) {
         chain = chain.insertSkillNode({
           skillId: skill.sId,
@@ -1345,7 +1388,6 @@ const InputBarContainer = ({
     editor,
     editor?.isInitialized,
     editor?.isEditable,
-    editorService,
   ]);
 
   const buttonSize = useMemo(() => {

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -15,6 +15,7 @@ import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import { useAppRouter } from "@app/lib/platform";
 import { usePodMetadata } from "@app/lib/swr/pods";
+import { useSkills } from "@app/lib/swr/skill_configurations";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetSpaceResponseBody } from "@app/types/api/spaces";
 import type {
@@ -120,6 +121,30 @@ export function PodConversationsTab({
     hasPodDefaultAgentFeature: hasFeature("pod_default_agent"),
   });
 
+  // This pod's default skills, pre-inserted into new conversations started here.
+  // Insertion happens downstream in the input bar's editor.
+  const hasPodDefaultSkillsFeature = hasFeature("pod_default_skills");
+  const { skills, isSkillsLoading } = useSkills({
+    owner,
+    status: "active",
+    globalSpaceOnly: true,
+    disabled: !hasPodDefaultSkillsFeature,
+  });
+  // `undefined` when the feature is off.
+  const defaultSkills = useMemo(() => {
+    if (!hasPodDefaultSkillsFeature) {
+      return undefined;
+    }
+    const skillBySId = new Map(skills.map((skill) => [skill.sId, skill]));
+    // Preserve the stored order.
+    return (podMetadata?.defaultSkillIds ?? []).flatMap((skillId) => {
+      const skill = skillBySId.get(skillId);
+      return skill
+        ? [{ sId: skill.sId, name: skill.name, icon: skill.icon }]
+        : [];
+    });
+  }, [hasPodDefaultSkillsFeature, skills, podMetadata?.defaultSkillIds]);
+
   const [isSearchPopoverOpen, setIsSearchPopoverOpen] = useState(false);
 
   const noConversationsForFilterMessage = useMemo(() => {
@@ -222,6 +247,8 @@ export function PodConversationsTab({
                 placeholder={`Get work done in ${podInfo.name}`}
                 defaultAgentId={defaultAgentId}
                 isDefaultAgentLoading={isPodMetadataLoading}
+                defaultSkills={defaultSkills}
+                isDefaultSkillsLoading={isPodMetadataLoading || isSkillsLoading}
               />
             ) : (
               <PodJoinCTA

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -120,8 +120,10 @@ export function PodConversationsTab({
     hasPodDefaultAgentFeature: hasFeature("pod_default_agent"),
   });
 
-  const { defaultSkills, isDefaultSkillsLoading, defaultSkillsKey } =
-    usePodDefaultSkills({ owner, podId: podInfo.sId });
+  const { defaultSkills, isDefaultSkillsLoading } = usePodDefaultSkills({
+    owner,
+    podId: podInfo.sId,
+  });
 
   const [isSearchPopoverOpen, setIsSearchPopoverOpen] = useState(false);
 
@@ -216,7 +218,6 @@ export function PodConversationsTab({
               </div>
             ) : podInfo.isMember ? (
               <InputBar
-                key={defaultSkillsKey}
                 owner={owner}
                 user={user}
                 onSubmit={onSubmit}

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -14,8 +14,7 @@ import { useSearchPodConversations } from "@app/hooks/useSearchPodConversations"
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import { useAppRouter } from "@app/lib/platform";
-import { usePodMetadata } from "@app/lib/swr/pods";
-import { useSkills } from "@app/lib/swr/skill_configurations";
+import { usePodDefaultSkills, usePodMetadata } from "@app/lib/swr/pods";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetSpaceResponseBody } from "@app/types/api/spaces";
 import type {
@@ -121,29 +120,8 @@ export function PodConversationsTab({
     hasPodDefaultAgentFeature: hasFeature("pod_default_agent"),
   });
 
-  // This pod's default skills, pre-inserted into new conversations started here.
-  // Insertion happens downstream in the input bar's editor.
-  const hasPodDefaultSkillsFeature = hasFeature("pod_default_skills");
-  const { skills, isSkillsLoading } = useSkills({
-    owner,
-    status: "active",
-    globalSpaceOnly: true,
-    disabled: !hasPodDefaultSkillsFeature,
-  });
-  // `undefined` when the feature is off.
-  const defaultSkills = useMemo(() => {
-    if (!hasPodDefaultSkillsFeature) {
-      return undefined;
-    }
-    const skillBySId = new Map(skills.map((skill) => [skill.sId, skill]));
-    // Preserve the stored order.
-    return (podMetadata?.defaultSkillIds ?? []).flatMap((skillId) => {
-      const skill = skillBySId.get(skillId);
-      return skill
-        ? [{ sId: skill.sId, name: skill.name, icon: skill.icon }]
-        : [];
-    });
-  }, [hasPodDefaultSkillsFeature, skills, podMetadata?.defaultSkillIds]);
+  const { defaultSkills, isDefaultSkillsLoading, defaultSkillsKey } =
+    usePodDefaultSkills({ owner, podId: podInfo.sId });
 
   const [isSearchPopoverOpen, setIsSearchPopoverOpen] = useState(false);
 
@@ -238,6 +216,7 @@ export function PodConversationsTab({
               </div>
             ) : podInfo.isMember ? (
               <InputBar
+                key={defaultSkillsKey}
                 owner={owner}
                 user={user}
                 onSubmit={onSubmit}
@@ -248,7 +227,7 @@ export function PodConversationsTab({
                 defaultAgentId={defaultAgentId}
                 isDefaultAgentLoading={isPodMetadataLoading}
                 defaultSkills={defaultSkills}
-                isDefaultSkillsLoading={isPodMetadataLoading || isSkillsLoading}
+                isDefaultSkillsLoading={isDefaultSkillsLoading}
               />
             ) : (
               <PodJoinCTA

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -13,12 +13,14 @@ import {
   POD_AGENTS_MD_MAX_CHARACTER_COUNT,
 } from "@app/lib/api/projects/constants";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
   useCheckPodName,
   usePodMetadata,
   useUpdatePodMetadata,
 } from "@app/lib/swr/pods";
+import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaceInfo, useUpdateSpace } from "@app/lib/swr/spaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { areOpenPodsAllowed } from "@app/lib/workspace_policies";
@@ -39,12 +41,19 @@ import {
   ChevronDown,
   ContentMessage,
   cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
   Globe01,
   Icon,
   InfoCircle,
   Input,
   ScrollArea,
   SearchInput,
+  ShapesPlus,
   SliderToggle,
   TextArea,
   Tooltip,
@@ -53,7 +62,7 @@ import {
   XCircle,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 
 interface PodSettingsTabProps {
@@ -64,6 +73,11 @@ interface PodSettingsTabProps {
 
 const OPEN_POD_DISABLED_TOOLTIP =
   "Open Pods are disabled by your workspace admin.";
+
+const DEFAULT_PILL_BASE_CLASSNAME =
+  "inline-flex box-border w-fit items-center rounded-xl h-9 px-3 gap-2 border border-border dark:border-border-night bg-background dark:bg-background-night text-sm text-primary dark:text-primary-night transition-colors duration-200";
+const DEFAULT_PILL_INTERACTIVE_CLASSNAME =
+  "cursor-pointer hover:bg-primary-100 hover:border-primary-150 dark:hover:bg-primary-900 dark:hover:border-border-night";
 
 export function PodSettingsTab({
   owner,
@@ -84,6 +98,7 @@ export function PodSettingsTab({
   const hasWorkspaceDefaultAgentFeature = hasFeature("workspace_default_agent");
   const isDefaultAgentEnabled =
     hasFeature("pod_default_agent") || hasWorkspaceDefaultAgentFeature;
+  const isDefaultSkillsEnabled = hasFeature("pod_default_skills");
 
   const { podMetadata, isPodMetadataLoading } = usePodMetadata({
     workspaceId: owner.sId,
@@ -152,6 +167,79 @@ export function PodSettingsTab({
     [confirm, doUpdateMetadata]
   );
 
+  // Default skills for new conversations started in this pod. Stored on pod
+  // metadata and pre-inserted into the input bar of every new conversation
+  // by `useHandleMentions`, as if manually added.
+  const { skills } = useSkills({
+    owner,
+    status: "active",
+    globalSpaceOnly: true,
+    disabled: !isDefaultSkillsEnabled,
+  });
+  const [skillSearchText, setSkillSearchText] = useState("");
+  const [isSkillPickerOpen, setIsSkillPickerOpen] = useState(false);
+
+  const defaultSkillIds = useMemo(
+    () => podMetadata?.defaultSkillIds ?? [],
+    [podMetadata]
+  );
+  const selectedDefaultSkillIdSet = new Set(defaultSkillIds);
+  // Resolve the stored ids to skills the current user can see. Ids that no longer resolve
+  // (archived / out of scope) are not rendered; saving the current
+  // selection then drops them.
+  const skillBySId = new Map(skills.map((skill) => [skill.sId, skill]));
+  const selectedDefaultSkills = defaultSkillIds.flatMap((skillId) => {
+    const skill = skillBySId.get(skillId);
+    return skill ? [skill] : [];
+  });
+  const normalizedSkillSearch = skillSearchText.trim().toLowerCase();
+  const addableSkills = skills
+    .filter(
+      (skill) =>
+        !selectedDefaultSkillIdSet.has(skill.sId) &&
+        (normalizedSkillSearch.length === 0 ||
+          skill.name.toLowerCase().includes(normalizedSkillSearch) ||
+          (skill.userFacingDescription ?? "")
+            .toLowerCase()
+            .includes(normalizedSkillSearch))
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const addDefaultSkill = useCallback(
+    async (skillId: string) => {
+      await doUpdateMetadata({
+        defaultSkillIds: [...defaultSkillIds, skillId],
+      });
+    },
+    [doUpdateMetadata, defaultSkillIds]
+  );
+
+  const removeDefaultSkill = useCallback(
+    async (skillId: string) => {
+      await doUpdateMetadata({
+        defaultSkillIds: defaultSkillIds.filter((id) => id !== skillId),
+      });
+    },
+    [doUpdateMetadata, defaultSkillIds]
+  );
+
+  // Memoized so the (memoized) DropdownMenuContent doesn't re-render on every
+  // parent render from a fresh JSX prop. Only changes when the search text does.
+  const skillPickerDropdownHeaders = useMemo(
+    () => (
+      <>
+        <DropdownMenuSearchbar
+          name="search-default-skills"
+          placeholder="Search skills"
+          value={skillSearchText}
+          onChange={setSkillSearchText}
+        />
+        <DropdownMenuSeparator />
+      </>
+    ),
+    [skillSearchText]
+  );
+
   // Trigger pill for the default agent, mirroring the conversations input bar:
   const renderDefaultAgentPill = (interactive: boolean) => (
     <div
@@ -164,9 +252,9 @@ export function PodSettingsTab({
       }
       aria-disabled={!interactive}
       className={cn(
-        "inline-flex box-border w-fit items-center rounded-xl h-9 px-3 gap-2 border border-border dark:border-border-night bg-background dark:bg-background-night text-sm text-primary dark:text-primary-night transition-colors duration-200",
+        DEFAULT_PILL_BASE_CLASSNAME,
         interactive
-          ? "cursor-pointer hover:bg-primary-100 hover:border-primary-150 dark:hover:bg-primary-900 dark:hover:border-border-night"
+          ? DEFAULT_PILL_INTERACTIVE_CLASSNAME
           : "opacity-50 pointer-events-none"
       )}
     >
@@ -494,6 +582,106 @@ export function PodSettingsTab({
                 </>
               ) : (
                 renderDefaultAgentPill(false)
+              )}
+            </div>
+          </div>
+        )}
+
+        {isDefaultSkillsEnabled && (
+          <div className="flex w-full flex-col gap-2">
+            <div className="heading-lg">Default Skills</div>
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              The skills pre-selected when anyone starts a new conversation in
+              this Pod. Members can still edit the skills in each conversation.
+            </p>
+            <div className="flex flex-wrap items-center gap-2">
+              {/* Selected skills, each rendered as a pill matching conversation styling.
+               Editors get an inline remove control. */}
+              {selectedDefaultSkills.map((skill) => (
+                <div
+                  key={skill.sId}
+                  aria-label={`Default skill: ${skill.name}`}
+                  className={cn(
+                    DEFAULT_PILL_BASE_CLASSNAME,
+                    !isPodEditor && "opacity-50"
+                  )}
+                >
+                  <Avatar size="xs" icon={getSkillAvatarIcon(skill)} />
+                  <span className="grow truncate notranslate">
+                    {skill.name}
+                  </span>
+                  {isPodEditor && (
+                    <button
+                      type="button"
+                      aria-label={`Remove ${skill.name}`}
+                      className="-mr-1 flex items-center text-faint hover:text-primary dark:text-faint-night dark:hover:text-primary-night"
+                      onClick={() => void removeDefaultSkill(skill.sId)}
+                    >
+                      <Icon visual={XCircle} size="xs" />
+                    </button>
+                  )}
+                </div>
+              ))}
+              {isPodEditor && (
+                <DropdownMenu
+                  open={isSkillPickerOpen}
+                  onOpenChange={(open) => {
+                    setIsSkillPickerOpen(open);
+                    if (open) {
+                      setSkillSearchText("");
+                    }
+                  }}
+                >
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label="Add a default skill"
+                      className={cn(
+                        DEFAULT_PILL_BASE_CLASSNAME,
+                        DEFAULT_PILL_INTERACTIVE_CLASSNAME
+                      )}
+                    >
+                      <Icon visual={ShapesPlus} size="xs" />
+                      <span className="grow truncate">Add skill</span>
+                      <Icon
+                        visual={ChevronDown}
+                        size="xs"
+                        className="-mr-1 text-faint dark:text-faint-night"
+                      />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    className="w-80"
+                    align="start"
+                    dropdownHeaders={skillPickerDropdownHeaders}
+                  >
+                    {addableSkills.length === 0 ? (
+                      <div className="px-2 py-4 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+                        {normalizedSkillSearch.length > 0
+                          ? "No skills found"
+                          : "No more skills to add"}
+                      </div>
+                    ) : (
+                      addableSkills.map((skill) => (
+                        <DropdownMenuItem
+                          key={skill.sId}
+                          icon={getSkillAvatarIcon(skill)}
+                          label={skill.name}
+                          description={skill.userFacingDescription ?? undefined}
+                          truncateText
+                          onClick={() => {
+                            void addDefaultSkill(skill.sId);
+                          }}
+                        />
+                      ))
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+              {!isPodEditor && selectedDefaultSkills.length === 0 && (
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                  No default skills configured.
+                </p>
               )}
             </div>
           </div>

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -1,6 +1,9 @@
 import { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types/user";
@@ -116,6 +119,108 @@ describe("ProjectMetadataResource", () => {
       expect(json.todoGenerationEnabled).toBe(false);
       expect(json.lastTodoAnalysisAt).toBeNull();
       expect(json.pinnedFramePath).toBeNull();
+      expect(json.defaultSkillIds).toEqual([]);
+    });
+  });
+
+  describe("default skills", () => {
+    it("persists, loads (sIds), replaces, and clears default skills (custom + global)", async () => {
+      // Needs a user-backed auth so SkillFactory can record an editor.
+      const { workspace: skillWorkspace, authenticator } =
+        await createResourceTest({ role: "admin" });
+      const space = await SpaceFactory.project(skillWorkspace);
+      const skillA = await SkillFactory.create(authenticator, { name: "A" });
+      const skillB = await SkillFactory.create(authenticator, { name: "B" });
+      // A code-defined global skill — stored via globalSkillId
+      const [globalSkill] = await SkillResource.fetchByIds(authenticator, [
+        "frames",
+      ]);
+      expect(globalSkill).toBeDefined();
+
+      const metadata = await ProjectMetadataResource.makeNew(
+        authenticator,
+        space,
+        { description: "d" }
+      );
+
+      await metadata.setDefaultSkills([skillA, skillB, globalSkill]);
+
+      const reloaded = await ProjectMetadataResource.fetchBySpace(
+        authenticator,
+        space
+      );
+      expect([...reloaded!.defaultSkillIds].sort()).toEqual(
+        [skillA.sId, skillB.sId, globalSkill.sId].sort()
+      );
+      // toJSON surfaces the same sIds for the front-end.
+      expect([...reloaded!.toJSON().defaultSkillIds].sort()).toEqual(
+        [skillA.sId, skillB.sId, globalSkill.sId].sort()
+      );
+
+      // Full replacement drops the omitted skills (keep only the global one).
+      await metadata.setDefaultSkills([globalSkill]);
+      const afterReplace = await ProjectMetadataResource.fetchBySpace(
+        authenticator,
+        space
+      );
+      expect(afterReplace!.defaultSkillIds).toEqual([globalSkill.sId]);
+
+      // Empty set clears everything and stores null.
+      await metadata.setDefaultSkills([]);
+      const afterClear = await ProjectMetadataResource.fetchBySpace(
+        authenticator,
+        space
+      );
+      expect(afterClear!.defaultSkillIds).toEqual([]);
+      expect(afterClear!.defaultSkillsIds).toBeNull();
+    });
+
+    it("de-duplicates skills", async () => {
+      const { workspace: skillWorkspace, authenticator } =
+        await createResourceTest({ role: "admin" });
+      const space = await SpaceFactory.project(skillWorkspace);
+      const skill = await SkillFactory.create(authenticator, { name: "A" });
+
+      const metadata = await ProjectMetadataResource.makeNew(
+        authenticator,
+        space,
+        { description: "d" }
+      );
+
+      // The (workspace, project, skill) unique index would reject a duplicate;
+      // setDefaultSkills de-dupes before inserting.
+      await metadata.setDefaultSkills([skill, skill]);
+
+      const reloaded = await ProjectMetadataResource.fetchBySpace(
+        authenticator,
+        space
+      );
+      expect(reloaded!.defaultSkillIds).toEqual([skill.sId]);
+    });
+
+    it("removes default skill mappings when the project is deleted", async () => {
+      const { workspace: skillWorkspace, authenticator } =
+        await createResourceTest({ role: "admin" });
+      const space = await SpaceFactory.project(skillWorkspace);
+      const skill = await SkillFactory.create(authenticator, { name: "A" });
+
+      const metadata = await ProjectMetadataResource.makeNew(
+        authenticator,
+        space,
+        { description: "d" }
+      );
+      await metadata.setDefaultSkills([skill]);
+
+      // Default skills are stored inline as the `defaultSkillsIds` array on the
+      // project_metadata row, so delete() removes them along with the row.
+      const result = await metadata.delete(authenticator, {});
+      expect(result.isOk()).toBe(true);
+
+      const deleted = await ProjectMetadataResource.fetchBySpace(
+        authenticator,
+        space
+      );
+      expect(deleted).toBeNull();
     });
   });
 });

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -143,7 +143,11 @@ describe("ProjectMetadataResource", () => {
         { description: "d" }
       );
 
-      await metadata.setDefaultSkills([skillA, skillB, globalSkill]);
+      await metadata.setDefaultSkills(authenticator, [
+        skillA,
+        skillB,
+        globalSkill,
+      ]);
 
       const reloaded = await ProjectMetadataResource.fetchBySpace(
         authenticator,
@@ -158,7 +162,7 @@ describe("ProjectMetadataResource", () => {
       );
 
       // Full replacement drops the omitted skills (keep only the global one).
-      await metadata.setDefaultSkills([globalSkill]);
+      await metadata.setDefaultSkills(authenticator, [globalSkill]);
       const afterReplace = await ProjectMetadataResource.fetchBySpace(
         authenticator,
         space
@@ -166,13 +170,45 @@ describe("ProjectMetadataResource", () => {
       expect(afterReplace!.defaultSkillIds).toEqual([globalSkill.sId]);
 
       // Empty set clears everything and stores null.
-      await metadata.setDefaultSkills([]);
+      await metadata.setDefaultSkills(authenticator, []);
       const afterClear = await ProjectMetadataResource.fetchBySpace(
         authenticator,
         space
       );
       expect(afterClear!.defaultSkillIds).toEqual([]);
       expect(afterClear!.defaultSkillsIds).toBeNull();
+    });
+
+    it("drops skills that are not usable in the global space", async () => {
+      const { workspace: skillWorkspace, authenticator } =
+        await createResourceTest({ role: "admin" });
+      const space = await SpaceFactory.project(skillWorkspace);
+      const restrictedSpace = await SpaceFactory.regular(skillWorkspace);
+
+      const globalSkill = await SkillFactory.create(authenticator, {
+        name: "global",
+      });
+      const restrictedSkill = await SkillFactory.create(authenticator, {
+        name: "restricted",
+        requestedSpaceIds: [restrictedSpace.id],
+      });
+
+      const metadata = await ProjectMetadataResource.makeNew(
+        authenticator,
+        space,
+        { description: "d" }
+      );
+
+      await metadata.setDefaultSkills(authenticator, [
+        globalSkill,
+        restrictedSkill,
+      ]);
+
+      const reloaded = await ProjectMetadataResource.fetchBySpace(
+        authenticator,
+        space
+      );
+      expect(reloaded!.defaultSkillIds).toEqual([globalSkill.sId]);
     });
 
     it("de-duplicates skills", async () => {
@@ -189,7 +225,7 @@ describe("ProjectMetadataResource", () => {
 
       // The (workspace, project, skill) unique index would reject a duplicate;
       // setDefaultSkills de-dupes before inserting.
-      await metadata.setDefaultSkills([skill, skill]);
+      await metadata.setDefaultSkills(authenticator, [skill, skill]);
 
       const reloaded = await ProjectMetadataResource.fetchBySpace(
         authenticator,
@@ -209,10 +245,8 @@ describe("ProjectMetadataResource", () => {
         space,
         { description: "d" }
       );
-      await metadata.setDefaultSkills([skill]);
+      await metadata.setDefaultSkills(authenticator, [skill]);
 
-      // Default skills are stored inline as the `defaultSkillsIds` array on the
-      // project_metadata row, so delete() removes them along with the row.
       const result = await metadata.delete(authenticator, {});
       expect(result.isOk()).toBe(true);
 

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -40,6 +41,10 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       model.get(),
       spaceId
     );
+  }
+
+  get defaultSkillIds(): string[] {
+    return this.defaultSkillsIds ?? [];
   }
 
   get sId(): string {
@@ -85,6 +90,8 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       },
     });
 
+    // Default skills ride along on each row (`defaultSkillsIds`), so no extra
+    // query is needed.
     return models.map((model) =>
       ProjectMetadataResource.fromModel(model, model.spaceId)
     );
@@ -182,14 +189,37 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     await this.update({ defaultAgentId }, transaction);
   }
 
+  // Replaces the pod's default skills with the given set (full replacement, not a
+  // merge). Works for both global and custom skills, stored as their sIds inline
+  // on the pod row. The caller is responsible for validating that the skills
+  // exist and are usable in the workspace — see the PATCH project_metadata route,
+  // which uses SkillResource.fetchByIds() for that.
+  async setDefaultSkills(
+    skills: SkillResource[],
+    transaction?: Transaction
+  ): Promise<void> {
+    // De-duplicate by sId, preserving order.
+    const defaultSkillsIds = [...new Map(skills.map((s) => [s.sId, s])).keys()];
+
+    // Store null rather than an empty array when the pod has no default skills.
+    await this.update(
+      {
+        defaultSkillsIds: defaultSkillsIds.length > 0 ? defaultSkillsIds : null,
+      },
+      transaction
+    );
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction }
   ): Promise<Result<undefined, Error>> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
     await ProjectMetadataModel.destroy({
       where: {
         id: this.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId,
       },
       transaction,
     });
@@ -211,6 +241,7 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       lastTodoAnalysisAt: this.lastTodoAnalysisAt?.getTime() ?? null,
       pinnedFramePath: this.pinnedFramePath ?? null,
       defaultAgentId: this.defaultAgentId ?? null,
+      defaultSkillIds: this.defaultSkillIds,
     };
   }
 }

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -189,19 +189,20 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     await this.update({ defaultAgentId }, transaction);
   }
 
-  // Replaces the pod's default skills with the given set (full replacement, not a
-  // merge). Works for both global and custom skills, stored as their sIds inline
-  // on the pod row. The caller is responsible for validating that the skills
-  // exist and are usable in the workspace — see the PATCH project_metadata route,
-  // which uses SkillResource.fetchByIds() for that.
   async setDefaultSkills(
+    auth: Authenticator,
     skills: SkillResource[],
     transaction?: Transaction
   ): Promise<void> {
-    // De-duplicate by sId, preserving order.
-    const defaultSkillsIds = [...new Map(skills.map((s) => [s.sId, s])).keys()];
+    const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+    const globalSpaceSkills = skills.filter((skill) =>
+      skill.requestedSpaceIds.every((id) => id === globalSpace.id)
+    );
 
-    // Store null rather than an empty array when the pod has no default skills.
+    const defaultSkillsIds = [
+      ...new Map(globalSpaceSkills.map((s) => [s.sId, s])).keys(),
+    ];
+
     await this.update(
       {
         defaultSkillsIds: defaultSkillsIds.length > 0 ? defaultSkillsIds : null,

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -1126,12 +1126,9 @@ export function usePodDefaultSkills({
     });
   }, [hasPodDefaultSkillsFeature, skills, podMetadata?.defaultSkillIds]);
 
-  const defaultSkillsKey = (podMetadata?.defaultSkillIds ?? []).join(",");
-
   return {
     defaultSkills,
     isDefaultSkillsLoading: isPodMetadataLoading || isSkillsLoading,
-    defaultSkillsKey,
   };
 }
 

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -10,9 +10,11 @@ import type {
   GetProjectContextResponseBody,
   PostProjectContextContentNodeResponseBody as PostPodContextContentNodeResponseBody,
 } from "@app/lib/api/projects/context";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { flattenPodTasksWithStableAssigneeOrder } from "@app/lib/project_task/display_order";
 import type { PostSeedInitialPodTasksResponseBody } from "@app/lib/project_task/seed_initial_pod_tasks";
+import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import {
   emptyArray,
@@ -1082,6 +1084,54 @@ export function usePodMetadata({
     isPodMetadataLoading: !error && !data && !disabled,
     isPodMetadataError: error,
     mutatePodMetadata: mutate,
+  };
+}
+
+export function usePodDefaultSkills({
+  owner,
+  podId,
+  disabled = false,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+  disabled?: boolean;
+}) {
+  const { hasFeature } = useFeatureFlags();
+  const hasPodDefaultSkillsFeature = hasFeature("pod_default_skills");
+  const enabled = hasPodDefaultSkillsFeature && !disabled;
+
+  const { podMetadata, isPodMetadataLoading } = usePodMetadata({
+    workspaceId: owner.sId,
+    podId,
+    disabled: !enabled,
+  });
+  const { skills, isSkillsLoading } = useSkills({
+    owner,
+    status: "active",
+    globalSpaceOnly: true,
+    disabled: !enabled,
+  });
+
+  const defaultSkills = useMemo(() => {
+    if (!hasPodDefaultSkillsFeature) {
+      return undefined;
+    }
+    const skillBySId = new Map(skills.map((skill) => [skill.sId, skill]));
+    // Preserve the stored order.
+    return (podMetadata?.defaultSkillIds ?? []).flatMap((skillId) => {
+      const skill = skillBySId.get(skillId);
+      return skill
+        ? [{ sId: skill.sId, name: skill.name, icon: skill.icon }]
+        : [];
+    });
+  }, [hasPodDefaultSkillsFeature, skills, podMetadata?.defaultSkillIds]);
+
+  const defaultSkillsKey = (podMetadata?.defaultSkillIds ?? []).join(",");
+
+  return {
+    defaultSkills,
+    isDefaultSkillsLoading: isPodMetadataLoading || isSkillsLoading,
+    defaultSkillsKey,
   };
 }
 

--- a/front/types/api/spaces.ts
+++ b/front/types/api/spaces.ts
@@ -43,6 +43,7 @@ export const PatchPodMetadataBodySchema = z.object({
   initialTodoAnalysisLookback: z.enum(["now", "last_24h", "max"]).optional(),
   pinnedFramePath: z.string().nullable().optional(),
   defaultAgentId: z.string().nullable().optional(),
+  defaultSkillIds: z.array(z.string()).optional(),
 });
 
 export type PatchPodMetadataBodyType = z.infer<

--- a/front/types/project_metadata.ts
+++ b/front/types/project_metadata.ts
@@ -9,4 +9,5 @@ export interface PodMetadataType {
   lastTodoAnalysisAt: number | null;
   pinnedFramePath: string | null;
   defaultAgentId: string | null;
+  defaultSkillIds: string[];
 }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -345,6 +345,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Per-pod default agent: pre-select an agent for new conversations started in a project (pod).",
     stage: "dust_only",
   },
+  pod_default_skills: {
+    description:
+      "Per-pod default skills: pre-insert skills into new conversations started in a pod.",
+    stage: "dust_only",
+  },
   workspace_default_agent: {
     description:
       "Workspace default agent: admins can pre-select a workspace-wide default agent for new conversations.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -751,6 +751,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "legacy_billing"
   | "plan_mode"
   | "pod_default_agent"
+  | "pod_default_skills"
   | "poke_mcp"
   | "restrict_agents_publishing"
   | "restrict_agents_publishing_to_admins"


### PR DESCRIPTION
## Description
The functioning UI for the default skills feature in Pods. Includes
- UI in the Pods settings & conversations pages
- Default skill ids are stored in the "defaultSkillsIds" column in "project_metadata"
- Default skills function like manually added skills
- Previous edits from when the feature used a mapping table are corrected

<img width="1434" height="785" alt="Screenshot 2026-06-29 at 16 45 31" src="https://github.com/user-attachments/assets/7788be65-2c76-4b78-b922-41195f0c3cd2" />
<img width="1297" height="268" alt="Screenshot 2026-06-29 at 16 46 04" src="https://github.com/user-attachments/assets/2c901f55-5c28-483c-9e00-2061174c4ce2" />

## Tests
Manual tests locally
- Archived skills disappear from dropdown options
- If the user manually edits the default skills in the conversation page and leaves the page before typing, the skills revert to the default. If the user has started typing, the users changes are saved
- General skills permissions are reflected in the feature

Tests added to project_metadata_resource.ts
- Persists, loads, replaces, and clears default skills — covering both custom and global skills
- De-duplicates skills before storing
- Clears default skills when the Pod is deleted

Tests added to project_metadata.ts
- Sets, returns, replaces, and clears default skills (custom + global)
- Rejects unknown / invalid default skill ids
- Ignores defaultSkillIds when the pod_default_skills feature flag is off

## Risk
Low risk. Behind the feature-flag "pod_default_skills".

## Deploy Plan
1. Merge the UI and client-side functionality
2. Merge the server-side agentic loop injection to ensure these default skills are included when conversations not started through the conversation input bar too.
