### PR TITLE
feat(front): entitle free seat by default on enterprise seat-based plans

### DIFF
--- a/front/lib/metronome/setup_new_pricing.ts
+++ b/front/lib/metronome/setup_new_pricing.ts
@@ -596,6 +596,7 @@ export function getNewPackages(): PackageDef[] {
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: getAllSeatRecurringCredits(),
       // Enterprise contracts are yearly-only: only the annual seats are entitled.
+      // The free starter seat is entitled by default.
       overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_USD_ID, [
         {
           product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
@@ -605,6 +606,7 @@ export function getNewPackages(): PackageDef[] {
           product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           price: (CP_ENTERPRISE_BASIS + CP_MAX_SEAT_COST_YEARLY) * 12 * 100,
         },
+        { product_name: FREE_SEAT_PRODUCT_NAME, price: 0 },
       ]),
       ...BILLING_CYCLE_CONFIG,
     },
@@ -616,6 +618,7 @@ export function getNewPackages(): PackageDef[] {
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: getAllSeatRecurringCredits(),
       // Enterprise contracts are yearly-only: only the annual seats are entitled.
+      // The free starter seat is entitled by default.
       overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_EUR_ID, [
         {
           product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
@@ -625,6 +628,7 @@ export function getNewPackages(): PackageDef[] {
           product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           price: (CP_ENTERPRISE_BASIS + CP_MAX_SEAT_COST_YEARLY) * 12,
         },
+        { product_name: FREE_SEAT_PRODUCT_NAME, price: 0 },
       ]),
       ...BILLING_CYCLE_CONFIG,
     },


### PR DESCRIPTION
## Description

The Enterprise Seat-based USD/EUR packages previously entitled only the `pro_yearly` and `max_yearly` seats, so the free starter seat had to be toggled on manually in Poke when switching a contract. This adds `{ product_name: FREE_SEAT_PRODUCT_NAME, price: 0 }` to both packages' entitlement overrides — matching the existing Business packages — so new enterprise seat-based contracts entitle the free seat out of the box.

## Tests

Type-check passes (`npx tsgo --noEmit`). The package definitions are synced to Metronome via `metronome_setup.ts`; the change takes effect for new/re-synced contracts once that script runs.

## Risk

Low. Existing contracts are unaffected (only new/re-switched contracts pick up the new entitlement). The free seat is priced at 0 and gated by the workspace free-seat caps. Safe to roll back by reverting the entitlement entries.

## Deploy Plan

Standard deploy. Run the Metronome setup script against the target environment to sync the updated enterprise seat-based packages.