### PR TITLE
Upgrade banner for free plans on Usage page

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -721,16 +721,16 @@ export function UsagePage() {
 
         {!isReadOnly && isCreditPricedFreePlan(subscription.plan.code) && (
           <FreePlanUpgradeSection
-              action={
-                <Button
-                  label="Change my seat"
-                  variant="highlight"
-                  size="sm"
-                  onClick={() => setChangeSeatMember(myUsage)}
-                />
-              }
-            />
-          )}
+            action={
+              <Button
+                label="Change my seat"
+                variant="highlight"
+                size="sm"
+                onClick={() => setChangeSeatMember(myUsage)}
+              />
+            }
+          />
+        )}
 
         {showPoolSection && (
           <Page.Vertical gap="xs" align="stretch">

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -3,6 +3,7 @@ import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { ConfirmContext } from "@app/components/Confirm";
 import { InviteEmailButtonWithModal } from "@app/components/members/InviteEmailButtonWithModal";
 import { BuyAwuCreditsDialog } from "@app/components/workspace/BuyAwuCreditsDialog";
+import { FreePlanUpgradeSection } from "@app/components/workspace/billing/FreePlanUpgradeSection";
 import {
   SEAT_TYPE_ICONS,
   seatTypeDisplayName,
@@ -64,7 +65,6 @@ import {
   toBaseSeatType,
 } from "@app/types/memberships";
 import { isCreditPricedPlan } from "@app/types/plan";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { isAdmin } from "@app/types/user";
 import {
   AlertCircle,
@@ -123,30 +123,6 @@ function memberFromUpgradeRequest(
 }
 
 const DEFAULT_PAGE_SIZE = 25;
-
-function noOrFreeSeatTitle(seatType: "none" | "free"): string {
-  switch (seatType) {
-    case "none":
-      return "You don't have a seat";
-    case "free":
-      return "You're on the Free seat";
-    default:
-      assertNeverAndIgnore(seatType);
-      return "";
-  }
-}
-
-function noOrFreeSeatBody(seatType: "none" | "free"): string {
-  switch (seatType) {
-    case "none":
-      return "Assign yourself a seat to send messages.";
-    case "free":
-      return "The Free seat has limited usage. Upgrade your seat to get more credits.";
-    default:
-      assertNeverAndIgnore(seatType);
-      return "";
-  }
-}
 
 export function UsagePage() {
   const owner = useWorkspace();
@@ -744,21 +720,16 @@ export function UsagePage() {
 
         {!isReadOnly &&
           (myUsage?.seatType === "free" || myUsage?.seatType === "none") && (
-            <ContentMessage
-              title={noOrFreeSeatTitle(myUsage.seatType)}
-              icon={AlertCircle}
-              variant="blue"
-            >
-              <div className="flex items-center justify-between gap-4">
-                <span>{noOrFreeSeatBody(myUsage.seatType)}</span>
+            <FreePlanUpgradeSection
+              action={
                 <Button
                   label="Change my seat"
-                  variant="primary"
-                  size="xs"
+                  variant="highlight"
+                  size="sm"
                   onClick={() => setChangeSeatMember(myUsage)}
                 />
-              </div>
-            </ContentMessage>
+              }
+            />
           )}
 
         {showPoolSection && (

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -28,6 +28,7 @@ import {
 } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
 import {
+  isCreditPricedFreePlan,
   isEnterprisePlanPrefix,
   isFreePlan,
   isUpgraded,
@@ -718,9 +719,8 @@ export function UsagePage() {
           )}
         </div>
 
-        {!isReadOnly &&
-          (myUsage?.seatType === "free" || myUsage?.seatType === "none") && (
-            <FreePlanUpgradeSection
+        {!isReadOnly && isCreditPricedFreePlan(subscription.plan.code) && (
+          <FreePlanUpgradeSection
               action={
                 <Button
                   label="Change my seat"

--- a/front/components/workspace/billing/FreePlanBilling.tsx
+++ b/front/components/workspace/billing/FreePlanBilling.tsx
@@ -3,6 +3,7 @@ import { FreePlanUpgradeSection } from "@app/components/workspace/billing/FreePl
 import { SubscriptionStatusChip } from "@app/components/workspace/billing/SubscriptionStatusChip";
 import type { SubscriptionType } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
+import { Button } from "@dust-tt/sparkle";
 
 interface FreePlanBillingProps {
   owner: LightWorkspaceType;
@@ -19,7 +20,16 @@ export function FreePlanBilling({ owner, subscription }: FreePlanBillingProps) {
         <SubscriptionStatusChip />
       </div>
       <FreePlanSeatsSection owner={owner} subscription={subscription} />
-      <FreePlanUpgradeSection owner={owner} />
+      <FreePlanUpgradeSection
+        action={
+          <Button
+            label="Upgrade a member"
+            size="sm"
+            variant="highlight"
+            href={`/w/${owner.sId}/usage`}
+          />
+        }
+      />
     </div>
   );
 }

--- a/front/components/workspace/billing/FreePlanUpgradeSection.tsx
+++ b/front/components/workspace/billing/FreePlanUpgradeSection.tsx
@@ -1,5 +1,5 @@
-import type { LightWorkspaceType } from "@app/types/user";
-import { Button, Check, Icon } from "@dust-tt/sparkle";
+import { Check, Icon } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 
 const UPGRADE_FEATURES = [
   "Invite members beyond the 5-seat cap",
@@ -8,10 +8,12 @@ const UPGRADE_FEATURES = [
 ] as const;
 
 interface FreePlanUpgradeSectionProps {
-  owner: LightWorkspaceType;
+  action: ReactNode;
 }
 
-export function FreePlanUpgradeSection({ owner }: FreePlanUpgradeSectionProps) {
+export function FreePlanUpgradeSection({
+  action,
+}: FreePlanUpgradeSectionProps) {
   return (
     <div className="flex flex-col gap-4 rounded-lg bg-muted-background p-4 dark:bg-muted-background-night">
       <div className="flex items-center justify-between gap-4">
@@ -23,12 +25,7 @@ export function FreePlanUpgradeSection({ owner }: FreePlanUpgradeSectionProps) {
             One paid seat opens up the whole workspace
           </span>
         </div>
-        <Button
-          label="Upgrade a member"
-          size="sm"
-          variant="highlight"
-          href={`/w/${owner.sId}/usage`}
-        />
+        {action}
       </div>
 
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9001

Use the same banner as the billing page but with a different button to upgrade yourself directly.

<img width="1256" height="687" alt="Screenshot 2026-06-29 at 17 06 45" src="https://github.com/user-attachments/assets/f92050d0-4582-4634-9afa-2965ba09425f" />
<img width="1305" height="787" alt="Screenshot 2026-06-29 at 17 06 50" src="https://github.com/user-attachments/assets/7b06bf4a-acf4-484b-a738-e5914085ed56" />


## Tests

tested locally 

## Risk

low, it's only UI

## Deploy Plan

deploy front
