### PR TITLE
feat(front): sticky cross-group filtering on usage credit chart

### DIFF
--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -1,5 +1,6 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { AnalyticsEntityFilter } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
 import { WorkspaceAgentCreditsTable } from "@app/components/workspace/analytics/WorkspaceAgentCreditsTable";
 import { WorkspaceAnalyticsOverviewCards } from "@app/components/workspace/analytics/WorkspaceAnalyticsOverviewCards";
 import { WorkspaceAnalyticsTimeRangeSelector } from "@app/components/workspace/analytics/WorkspaceAnalyticsTimeRangeSelector";
@@ -70,6 +71,16 @@ export function AnalyticsPage() {
   const [period, setPeriod] =
     useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
 
+  // Sticky scope filters shared between the credit usage chart and the tables:
+  // clicking a user/agent row (or a legend item) scopes the top chart, and the
+  // selection persists across groupBy changes until cleared via its chip.
+  const [userFilter, setUserFilter] = useState<AnalyticsEntityFilter | null>(
+    null
+  );
+  const [agentFilter, setAgentFilter] = useState<AnalyticsEntityFilter | null>(
+    null
+  );
+
   return (
     <Page.Vertical align="stretch" gap="xl">
       <Page.Header
@@ -95,10 +106,25 @@ export function AnalyticsPage() {
       />
       <div className="flex flex-col pb-8 gap-8">
         <SafeSuspense fallback={<ChartFallback />}>
-          <AwuUsageFromAnalyticsChart workspaceId={owner.sId} period={period} />
+          <AwuUsageFromAnalyticsChart
+            workspaceId={owner.sId}
+            period={period}
+            userFilter={userFilter}
+            agentFilter={agentFilter}
+            onUserFilterChange={setUserFilter}
+            onAgentFilterChange={setAgentFilter}
+          />
         </SafeSuspense>
-        <WorkspaceUserCreditsTable workspaceId={owner.sId} period={period} />
-        <WorkspaceAgentCreditsTable workspaceId={owner.sId} period={period} />
+        <WorkspaceUserCreditsTable
+          workspaceId={owner.sId}
+          period={period}
+          onSelectUser={setUserFilter}
+        />
+        <WorkspaceAgentCreditsTable
+          workspaceId={owner.sId}
+          period={period}
+          onSelectAgent={setAgentFilter}
+        />
         <SafeSuspense fallback={<ChartFallback />}>
           <WorkspaceUsageChart workspaceId={owner.sId} period={period} />
         </SafeSuspense>

--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -1,6 +1,7 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type { AnalyticsEntityFilter } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
+import type { AnalyticsFilter } from "@app/components/workspace/analytics/analyticsFilter";
+import { toggleScopeEntity } from "@app/components/workspace/analytics/analyticsFilter";
 import { WorkspaceAgentCreditsTable } from "@app/components/workspace/analytics/WorkspaceAgentCreditsTable";
 import { WorkspaceAnalyticsOverviewCards } from "@app/components/workspace/analytics/WorkspaceAnalyticsOverviewCards";
 import { WorkspaceAnalyticsTimeRangeSelector } from "@app/components/workspace/analytics/WorkspaceAnalyticsTimeRangeSelector";
@@ -71,15 +72,7 @@ export function AnalyticsPage() {
   const [period, setPeriod] =
     useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
 
-  // Sticky scope filters shared between the credit usage chart and the tables:
-  // clicking a user/agent row (or a legend item) scopes the top chart, and the
-  // selection persists across groupBy changes until cleared via its chip.
-  const [userFilter, setUserFilter] = useState<AnalyticsEntityFilter | null>(
-    null
-  );
-  const [agentFilter, setAgentFilter] = useState<AnalyticsEntityFilter | null>(
-    null
-  );
+  const [filter, setFilter] = useState<AnalyticsFilter>({});
 
   return (
     <Page.Vertical align="stretch" gap="xl">
@@ -109,21 +102,23 @@ export function AnalyticsPage() {
           <AwuUsageFromAnalyticsChart
             workspaceId={owner.sId}
             period={period}
-            userFilter={userFilter}
-            agentFilter={agentFilter}
-            onUserFilterChange={setUserFilter}
-            onAgentFilterChange={setAgentFilter}
+            filter={filter}
+            onFilterChange={setFilter}
           />
         </SafeSuspense>
         <WorkspaceUserCreditsTable
           workspaceId={owner.sId}
           period={period}
-          onSelectUser={setUserFilter}
+          onSelectUser={(entity) =>
+            setFilter((prev) => toggleScopeEntity(prev, "user", entity))
+          }
         />
         <WorkspaceAgentCreditsTable
           workspaceId={owner.sId}
           period={period}
-          onSelectAgent={setAgentFilter}
+          onSelectAgent={(entity) =>
+            setFilter((prev) => toggleScopeEntity(prev, "agent", entity))
+          }
         />
         <SafeSuspense fallback={<ChartFallback />}>
           <WorkspaceUsageChart workspaceId={owner.sId} period={period} />

--- a/front/components/poke/credits/PokeAwuUsageFromAnalyticsChart.tsx
+++ b/front/components/poke/credits/PokeAwuUsageFromAnalyticsChart.tsx
@@ -1,9 +1,10 @@
 import type {
-  AnalyticsEntityFilter,
   AnalyticsGroupBy,
   Granularity,
 } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
 import { BaseAwuUsageFromAnalyticsChart } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
+import type { AnalyticsFilter } from "@app/components/workspace/analytics/analyticsFilter";
+import { scopeFilterToIds } from "@app/components/workspace/analytics/analyticsFilter";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import { usePokeAwuUsageFromAnalytics } from "@app/poke/swr/credits";
 import type { WorkspaceType } from "@app/types/user";
@@ -23,12 +24,7 @@ export function PokeAwuUsageFromAnalyticsChart({
     undefined
   );
   const [groupByCount, setGroupByCount] = useState<number>(5);
-  const [userFilter, setUserFilter] = useState<AnalyticsEntityFilter | null>(
-    null
-  );
-  const [agentFilter, setAgentFilter] = useState<AnalyticsEntityFilter | null>(
-    null
-  );
+  const [filter, setFilter] = useState<AnalyticsFilter>({});
 
   const now = new Date();
   const { cycleStart } = getBillingCycleFromDay(
@@ -48,8 +44,7 @@ export function PokeAwuUsageFromAnalyticsChart({
       groupByCount,
       granularity,
       days,
-      userId: userFilter?.id,
-      agentId: agentFilter?.id,
+      filter: scopeFilterToIds(filter),
     });
 
   return (
@@ -65,10 +60,8 @@ export function PokeAwuUsageFromAnalyticsChart({
       setGroupByCount={setGroupByCount}
       days={days}
       exportUrlPrefix={`/api/poke/workspaces/${owner.sId}/analytics/awu-usage-analytics`}
-      userFilter={userFilter}
-      agentFilter={agentFilter}
-      onUserFilterChange={setUserFilter}
-      onAgentFilterChange={setAgentFilter}
+      filter={filter}
+      onFilterChange={setFilter}
     />
   );
 }

--- a/front/components/poke/credits/PokeAwuUsageFromAnalyticsChart.tsx
+++ b/front/components/poke/credits/PokeAwuUsageFromAnalyticsChart.tsx
@@ -1,4 +1,5 @@
 import type {
+  AnalyticsEntityFilter,
   AnalyticsGroupBy,
   Granularity,
 } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
@@ -22,6 +23,12 @@ export function PokeAwuUsageFromAnalyticsChart({
     undefined
   );
   const [groupByCount, setGroupByCount] = useState<number>(5);
+  const [userFilter, setUserFilter] = useState<AnalyticsEntityFilter | null>(
+    null
+  );
+  const [agentFilter, setAgentFilter] = useState<AnalyticsEntityFilter | null>(
+    null
+  );
 
   const now = new Date();
   const { cycleStart } = getBillingCycleFromDay(
@@ -41,6 +48,8 @@ export function PokeAwuUsageFromAnalyticsChart({
       groupByCount,
       granularity,
       days,
+      userId: userFilter?.id,
+      agentId: agentFilter?.id,
     });
 
   return (
@@ -56,6 +65,10 @@ export function PokeAwuUsageFromAnalyticsChart({
       setGroupByCount={setGroupByCount}
       days={days}
       exportUrlPrefix={`/api/poke/workspaces/${owner.sId}/analytics/awu-usage-analytics`}
+      userFilter={userFilter}
+      agentFilter={agentFilter}
+      onUserFilterChange={setUserFilter}
+      onAgentFilterChange={setAgentFilter}
     />
   );
 }

--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -12,6 +12,15 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import type { AnalyticsFilter } from "@app/components/workspace/analytics/analyticsFilter";
+import {
+  isScopeDimension,
+  removeScopeEntity,
+  SCOPE_DIMENSION_LABEL,
+  SCOPE_DIMENSIONS,
+  scopeFilterToIds,
+  toggleScopeEntity,
+} from "@app/components/workspace/analytics/analyticsFilter";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import type { AwuUsageAnalyticsResponse } from "@app/lib/api/analytics/awu_usage_analytics";
@@ -32,24 +41,14 @@ import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 interface AwuUsageFromAnalyticsChartProps {
   workspaceId: string;
   period: ObservabilityTimeRangeType;
-  userFilter: AnalyticsEntityFilter | null;
-  agentFilter: AnalyticsEntityFilter | null;
-  onUserFilterChange: (filter: AnalyticsEntityFilter | null) => void;
-  onAgentFilterChange: (filter: AnalyticsEntityFilter | null) => void;
+  filter: AnalyticsFilter;
+  onFilterChange: (next: AnalyticsFilter) => void;
 }
 
 export type Granularity = "day" | "week" | "month";
 export type AnalyticsGroupBy = "usage_type" | "agent" | "user" | "origin";
 
 type GroupByOption = { value: AnalyticsGroupBy | undefined; label: string };
-
-// A sticky scope filter on the credit usage chart: restricts every series to a
-// single user or agent (by sId). Persists across groupBy changes so that, e.g.,
-// scoping to a user then switching to "By Agent" shows that user's agents.
-export interface AnalyticsEntityFilter {
-  id: string;
-  name: string;
-}
 
 const GROUP_BY_OPTIONS: GroupByOption[] = [
   { value: undefined, label: "Total" },
@@ -117,13 +116,12 @@ export interface BaseAwuUsageFromAnalyticsChartProps {
   exportUrlPrefix: string;
   // Available group-by options; defaults to the full workspace-wide list.
   groupByOptions?: GroupByOption[];
-  // Sticky scope filters. When set, the chart is restricted to that user/agent
-  // and a removable chip is shown. Legend clicks in "user"/"agent" mode set the
-  // matching filter when the corresponding setter is provided.
-  userFilter?: AnalyticsEntityFilter | null;
-  agentFilter?: AnalyticsEntityFilter | null;
-  onUserFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
-  onAgentFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
+  // Sticky per-dimension scope filter. When set, the chart is restricted to the
+  // selected entities and a removable chip is shown per selection. Legend clicks
+  // in a scope-dimension groupBy (agent/user/origin) toggle the matching
+  // selection when onFilterChange is provided.
+  filter?: AnalyticsFilter;
+  onFilterChange?: (next: AnalyticsFilter) => void;
 }
 
 interface UsageChartControlsProps {
@@ -134,10 +132,8 @@ interface UsageChartControlsProps {
   groupByCount: number;
   onGroupByCountChange: (v: number) => void;
   groupByOptions: GroupByOption[];
-  userFilter?: AnalyticsEntityFilter | null;
-  agentFilter?: AnalyticsEntityFilter | null;
-  onUserFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
-  onAgentFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
+  filter?: AnalyticsFilter;
+  onFilterChange?: (next: AnalyticsFilter) => void;
   hasDrilldown: boolean;
   onClearDrilldown: () => void;
   csvDownload: ReturnType<typeof useDownloadCsv>;
@@ -151,30 +147,28 @@ function UsageChartControls({
   groupByCount,
   onGroupByCountChange,
   groupByOptions,
-  userFilter,
-  agentFilter,
-  onUserFilterChange,
-  onAgentFilterChange,
+  filter,
+  onFilterChange,
   hasDrilldown,
   onClearDrilldown,
   csvDownload,
 }: UsageChartControlsProps) {
   return (
     <div className="flex items-center gap-2">
-      {userFilter && (
-        <Chip
-          size="xs"
-          label={`User: ${userFilter.name}`}
-          onRemove={() => onUserFilterChange?.(null)}
-        />
-      )}
-      {agentFilter && (
-        <Chip
-          size="xs"
-          label={`Agent: ${agentFilter.name}`}
-          onRemove={() => onAgentFilterChange?.(null)}
-        />
-      )}
+      {filter &&
+        onFilterChange &&
+        SCOPE_DIMENSIONS.flatMap((dimension) =>
+          (filter[dimension] ?? []).map((entity) => (
+            <Chip
+              key={`${dimension}:${entity.id}`}
+              size="xs"
+              label={`${SCOPE_DIMENSION_LABEL[dimension]}: ${entity.name}`}
+              onRemove={() =>
+                onFilterChange(removeScopeEntity(filter, dimension, entity.id))
+              }
+            />
+          ))
+        )}
       {hasDrilldown && (
         <Button
           label="Clear filters"
@@ -259,6 +253,11 @@ interface UsageChartBarsProps {
   groupBy: AnalyticsGroupBy | undefined;
   groups: { groupKey: string; name: string }[];
   granularity: Granularity;
+  // Injected by the parent ResponsiveContainer (via cloneElement) and forwarded
+  // to BarChart. Without forwarding, BarChart has no dimensions and renders
+  // blank.
+  width?: number;
+  height?: number;
 }
 
 function UsageChartBars({
@@ -268,10 +267,14 @@ function UsageChartBars({
   groupBy,
   groups,
   granularity,
+  width,
+  height,
 }: UsageChartBarsProps) {
   return (
     <BarChart
       data={chartData}
+      width={width}
+      height={height}
       margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
     >
       <CartesianGrid
@@ -332,10 +335,8 @@ interface UseUsageLegendItemsParams {
   allKeys: string[];
   effectiveEnabledKeys: string[] | null;
   toggleGroup: (key: string) => void;
-  userFilter?: AnalyticsEntityFilter | null;
-  agentFilter?: AnalyticsEntityFilter | null;
-  onUserFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
-  onAgentFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
+  filter?: AnalyticsFilter;
+  onFilterChange?: (next: AnalyticsFilter) => void;
 }
 
 function useUsageLegendItems({
@@ -344,16 +345,11 @@ function useUsageLegendItems({
   allKeys,
   effectiveEnabledKeys,
   toggleGroup,
-  userFilter,
-  agentFilter,
-  onUserFilterChange,
-  onAgentFilterChange,
+  filter,
+  onFilterChange,
 }: UseUsageLegendItemsParams): LegendItem[] {
-  // In "user"/"agent" mode, legend clicks set the sticky scope filter (a server
-  // refetch) rather than toggling client-side series visibility, so the choice
-  // survives groupBy changes.
-  const userScopeMode = groupBy === "user" && !!onUserFilterChange;
-  const agentScopeMode = groupBy === "agent" && !!onAgentFilterChange;
+  const scopeDimension =
+    isScopeDimension(groupBy) && filter && onFilterChange ? groupBy : null;
 
   return useMemo(
     () =>
@@ -372,31 +368,21 @@ function useUsageLegendItems({
           allKeys
         );
 
-        if (canFilter && userScopeMode) {
-          const isSelected = userFilter?.id === group.groupKey;
+        if (canFilter && scopeDimension && filter && onFilterChange) {
+          const selected = filter[scopeDimension] ?? [];
+          const isSelected = selected.some((e) => e.id === group.groupKey);
           return {
             key: group.groupKey,
             label,
             colorClassName,
             onClick: () =>
-              onUserFilterChange?.(
-                isSelected ? null : { id: group.groupKey, name: group.name }
+              onFilterChange(
+                toggleScopeEntity(filter, scopeDimension, {
+                  id: group.groupKey,
+                  name: group.name,
+                })
               ),
-            isActive: !userFilter || isSelected,
-          };
-        }
-
-        if (canFilter && agentScopeMode) {
-          const isSelected = agentFilter?.id === group.groupKey;
-          return {
-            key: group.groupKey,
-            label,
-            colorClassName,
-            onClick: () =>
-              onAgentFilterChange?.(
-                isSelected ? null : { id: group.groupKey, name: group.name }
-              ),
-            isActive: !agentFilter || isSelected,
+            isActive: selected.length === 0 || isSelected,
           };
         }
 
@@ -416,12 +402,9 @@ function useUsageLegendItems({
       allKeys,
       effectiveEnabledKeys,
       toggleGroup,
-      userScopeMode,
-      agentScopeMode,
-      userFilter,
-      agentFilter,
-      onUserFilterChange,
-      onAgentFilterChange,
+      scopeDimension,
+      filter,
+      onFilterChange,
     ]
   );
 }
@@ -432,8 +415,7 @@ interface BuildExportUrlParams {
   granularity: Granularity;
   groupBy: AnalyticsGroupBy | undefined;
   groupByCount: number;
-  userFilter?: AnalyticsEntityFilter | null;
-  agentFilter?: AnalyticsEntityFilter | null;
+  filter?: AnalyticsFilter;
   effectiveEnabledKeys: string[] | null;
 }
 
@@ -443,8 +425,7 @@ function buildExportUrl({
   granularity,
   groupBy,
   groupByCount,
-  userFilter,
-  agentFilter,
+  filter,
   effectiveEnabledKeys,
 }: BuildExportUrlParams): string {
   const exportParams = new URLSearchParams({
@@ -456,12 +437,12 @@ function buildExportUrl({
     exportParams.set("groupBy", groupBy);
     exportParams.set("groupByCount", groupByCount.toString());
   }
-  // Mirror the sticky scope filters so the export matches the chart.
-  if (userFilter) {
-    exportParams.set("userId", userFilter.id);
-  }
-  if (agentFilter) {
-    exportParams.set("agentId", agentFilter.id);
+  // Mirror the sticky scope filter so the export matches the chart.
+  if (filter) {
+    const ids = scopeFilterToIds(filter);
+    if (Object.keys(ids).length > 0) {
+      exportParams.set("filter", JSON.stringify(ids));
+    }
   }
   // Mirror the legend drilldown: export only the series currently shown.
   if (effectiveEnabledKeys) {
@@ -483,10 +464,8 @@ export function BaseAwuUsageFromAnalyticsChart({
   days,
   exportUrlPrefix,
   groupByOptions = GROUP_BY_OPTIONS,
-  userFilter,
-  agentFilter,
-  onUserFilterChange,
-  onAgentFilterChange,
+  filter,
+  onFilterChange,
 }: BaseAwuUsageFromAnalyticsChartProps) {
   // Legend-driven drilldown: when non-null, only these series are shown.
   const [enabledKeys, setEnabledKeys] = useState<string[] | null>(null);
@@ -539,10 +518,8 @@ export function BaseAwuUsageFromAnalyticsChart({
     allKeys,
     effectiveEnabledKeys,
     toggleGroup,
-    userFilter,
-    agentFilter,
-    onUserFilterChange,
-    onAgentFilterChange,
+    filter,
+    onFilterChange,
   });
 
   const visibleKeys = useMemo(
@@ -560,8 +537,7 @@ export function BaseAwuUsageFromAnalyticsChart({
       granularity,
       groupBy,
       groupByCount,
-      userFilter,
-      agentFilter,
+      filter,
       effectiveEnabledKeys,
     }),
     filename: `dust_credit_usage_last_${days}_days.csv`,
@@ -585,10 +561,8 @@ export function BaseAwuUsageFromAnalyticsChart({
           groupByCount={groupByCount}
           onGroupByCountChange={handleGroupByCountChange}
           groupByOptions={groupByOptions}
-          userFilter={userFilter}
-          agentFilter={agentFilter}
-          onUserFilterChange={onUserFilterChange}
-          onAgentFilterChange={onAgentFilterChange}
+          filter={filter}
+          onFilterChange={onFilterChange}
           hasDrilldown={!!effectiveEnabledKeys}
           onClearDrilldown={() => setEnabledKeys(null)}
           csvDownload={csvDownload}
@@ -613,10 +587,8 @@ export function BaseAwuUsageFromAnalyticsChart({
 export function AwuUsageFromAnalyticsChart({
   workspaceId,
   period,
-  userFilter,
-  agentFilter,
-  onUserFilterChange,
-  onAgentFilterChange,
+  filter,
+  onFilterChange,
 }: AwuUsageFromAnalyticsChartProps) {
   const [granularity, setGranularity] = useState<Granularity>("day");
   const [groupBy, setGroupBy] = useState<AnalyticsGroupBy | undefined>(
@@ -631,8 +603,7 @@ export function AwuUsageFromAnalyticsChart({
       groupByCount,
       granularity,
       days: period,
-      userId: userFilter?.id,
-      agentId: agentFilter?.id,
+      filter: scopeFilterToIds(filter),
     });
 
   return (
@@ -648,10 +619,8 @@ export function AwuUsageFromAnalyticsChart({
       setGroupByCount={setGroupByCount}
       days={period}
       exportUrlPrefix={`/api/w/${workspaceId}/analytics/awu-usage-analytics`}
-      userFilter={userFilter}
-      agentFilter={agentFilter}
-      onUserFilterChange={onUserFilterChange}
-      onAgentFilterChange={onAgentFilterChange}
+      filter={filter}
+      onFilterChange={onFilterChange}
     />
   );
 }

--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -19,6 +19,7 @@ import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import { useAwuUsageFromAnalytics } from "@app/lib/swr/workspaces";
 import {
   Button,
+  Chip,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -31,12 +32,24 @@ import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 interface AwuUsageFromAnalyticsChartProps {
   workspaceId: string;
   period: ObservabilityTimeRangeType;
+  userFilter: AnalyticsEntityFilter | null;
+  agentFilter: AnalyticsEntityFilter | null;
+  onUserFilterChange: (filter: AnalyticsEntityFilter | null) => void;
+  onAgentFilterChange: (filter: AnalyticsEntityFilter | null) => void;
 }
 
 export type Granularity = "day" | "week" | "month";
 export type AnalyticsGroupBy = "usage_type" | "agent" | "user" | "origin";
 
 type GroupByOption = { value: AnalyticsGroupBy | undefined; label: string };
+
+// A sticky scope filter on the credit usage chart: restricts every series to a
+// single user or agent (by sId). Persists across groupBy changes so that, e.g.,
+// scoping to a user then switching to "By Agent" shows that user's agents.
+export interface AnalyticsEntityFilter {
+  id: string;
+  name: string;
+}
 
 const GROUP_BY_OPTIONS: GroupByOption[] = [
   { value: undefined, label: "Total" },
@@ -104,6 +117,13 @@ export interface BaseAwuUsageFromAnalyticsChartProps {
   exportUrlPrefix: string;
   // Available group-by options; defaults to the full workspace-wide list.
   groupByOptions?: GroupByOption[];
+  // Sticky scope filters. When set, the chart is restricted to that user/agent
+  // and a removable chip is shown. Legend clicks in "user"/"agent" mode set the
+  // matching filter when the corresponding setter is provided.
+  userFilter?: AnalyticsEntityFilter | null;
+  agentFilter?: AnalyticsEntityFilter | null;
+  onUserFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
+  onAgentFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
 }
 
 export function BaseAwuUsageFromAnalyticsChart({
@@ -119,6 +139,10 @@ export function BaseAwuUsageFromAnalyticsChart({
   days,
   exportUrlPrefix,
   groupByOptions = GROUP_BY_OPTIONS,
+  userFilter,
+  agentFilter,
+  onUserFilterChange,
+  onAgentFilterChange,
 }: BaseAwuUsageFromAnalyticsChartProps) {
   // Legend-driven drilldown: when non-null, only these series are shown.
   const [enabledKeys, setEnabledKeys] = useState<string[] | null>(null);
@@ -165,6 +189,12 @@ export function BaseAwuUsageFromAnalyticsChart({
     [points]
   );
 
+  // In "user"/"agent" mode, legend clicks set the sticky scope filter (a server
+  // refetch) rather than toggling client-side series visibility, so the choice
+  // survives groupBy changes.
+  const userScopeMode = groupBy === "user" && !!onUserFilterChange;
+  const agentScopeMode = groupBy === "agent" && !!onAgentFilterChange;
+
   const legendItems: LegendItem[] = useMemo(
     () =>
       groups.map((group) => {
@@ -176,17 +206,63 @@ export function BaseAwuUsageFromAnalyticsChart({
           !!groupBy &&
           group.groupKey !== "others" &&
           group.groupKey !== "total";
+        const colorClassName = getColorClassName(
+          groupBy,
+          group.groupKey,
+          allKeys
+        );
+
+        if (canFilter && userScopeMode) {
+          const isSelected = userFilter?.id === group.groupKey;
+          return {
+            key: group.groupKey,
+            label,
+            colorClassName,
+            onClick: () =>
+              onUserFilterChange?.(
+                isSelected ? null : { id: group.groupKey, name: group.name }
+              ),
+            isActive: !userFilter || isSelected,
+          };
+        }
+
+        if (canFilter && agentScopeMode) {
+          const isSelected = agentFilter?.id === group.groupKey;
+          return {
+            key: group.groupKey,
+            label,
+            colorClassName,
+            onClick: () =>
+              onAgentFilterChange?.(
+                isSelected ? null : { id: group.groupKey, name: group.name }
+              ),
+            isActive: !agentFilter || isSelected,
+          };
+        }
+
         return {
           key: group.groupKey,
           label,
-          colorClassName: getColorClassName(groupBy, group.groupKey, allKeys),
+          colorClassName,
           onClick: canFilter ? () => toggleGroup(group.groupKey) : undefined,
           isActive:
             !effectiveEnabledKeys ||
             effectiveEnabledKeys.includes(group.groupKey),
         };
       }),
-    [groups, groupBy, allKeys, effectiveEnabledKeys, toggleGroup]
+    [
+      groups,
+      groupBy,
+      allKeys,
+      effectiveEnabledKeys,
+      toggleGroup,
+      userScopeMode,
+      agentScopeMode,
+      userFilter,
+      agentFilter,
+      onUserFilterChange,
+      onAgentFilterChange,
+    ]
   );
 
   const visibleKeys = useMemo(
@@ -205,6 +281,13 @@ export function BaseAwuUsageFromAnalyticsChart({
   if (groupBy) {
     exportParams.set("groupBy", groupBy);
     exportParams.set("groupByCount", groupByCount.toString());
+  }
+  // Mirror the sticky scope filters so the export matches the chart.
+  if (userFilter) {
+    exportParams.set("userId", userFilter.id);
+  }
+  if (agentFilter) {
+    exportParams.set("agentId", agentFilter.id);
   }
   // Mirror the legend drilldown: export only the series currently shown.
   if (effectiveEnabledKeys) {
@@ -226,6 +309,20 @@ export function BaseAwuUsageFromAnalyticsChart({
       }
       additionalControls={
         <div className="flex items-center gap-2">
+          {userFilter && (
+            <Chip
+              size="xs"
+              label={`User: ${userFilter.name}`}
+              onRemove={() => onUserFilterChange?.(null)}
+            />
+          )}
+          {agentFilter && (
+            <Chip
+              size="xs"
+              label={`Agent: ${agentFilter.name}`}
+              onRemove={() => onAgentFilterChange?.(null)}
+            />
+          )}
           {effectiveEnabledKeys && (
             <Button
               label="Clear filters"
@@ -366,6 +463,10 @@ export function BaseAwuUsageFromAnalyticsChart({
 export function AwuUsageFromAnalyticsChart({
   workspaceId,
   period,
+  userFilter,
+  agentFilter,
+  onUserFilterChange,
+  onAgentFilterChange,
 }: AwuUsageFromAnalyticsChartProps) {
   const [granularity, setGranularity] = useState<Granularity>("day");
   const [groupBy, setGroupBy] = useState<AnalyticsGroupBy | undefined>(
@@ -380,6 +481,8 @@ export function AwuUsageFromAnalyticsChart({
       groupByCount,
       granularity,
       days: period,
+      userId: userFilter?.id,
+      agentId: agentFilter?.id,
     });
 
   return (
@@ -395,6 +498,10 @@ export function AwuUsageFromAnalyticsChart({
       setGroupByCount={setGroupByCount}
       days={period}
       exportUrlPrefix={`/api/w/${workspaceId}/analytics/awu-usage-analytics`}
+      userFilter={userFilter}
+      agentFilter={agentFilter}
+      onUserFilterChange={onUserFilterChange}
+      onAgentFilterChange={onAgentFilterChange}
     />
   );
 }

--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -126,76 +126,236 @@ export interface BaseAwuUsageFromAnalyticsChartProps {
   onAgentFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
 }
 
-export function BaseAwuUsageFromAnalyticsChart({
-  awuUsageData,
-  isAwuUsageLoading,
-  isAwuUsageError,
+interface UsageChartControlsProps {
+  granularity: Granularity;
+  setGranularity: (v: Granularity) => void;
+  groupBy: AnalyticsGroupBy | undefined;
+  onGroupByChange: (v: AnalyticsGroupBy | undefined) => void;
+  groupByCount: number;
+  onGroupByCountChange: (v: number) => void;
+  groupByOptions: GroupByOption[];
+  userFilter?: AnalyticsEntityFilter | null;
+  agentFilter?: AnalyticsEntityFilter | null;
+  onUserFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
+  onAgentFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
+  hasDrilldown: boolean;
+  onClearDrilldown: () => void;
+  csvDownload: ReturnType<typeof useDownloadCsv>;
+}
+
+function UsageChartControls({
   granularity,
   setGranularity,
   groupBy,
-  setGroupBy,
+  onGroupByChange,
   groupByCount,
-  setGroupByCount,
-  days,
-  exportUrlPrefix,
-  groupByOptions = GROUP_BY_OPTIONS,
+  onGroupByCountChange,
+  groupByOptions,
   userFilter,
   agentFilter,
   onUserFilterChange,
   onAgentFilterChange,
-}: BaseAwuUsageFromAnalyticsChartProps) {
-  // Legend-driven drilldown: when non-null, only these series are shown.
-  const [enabledKeys, setEnabledKeys] = useState<string[] | null>(null);
-
-  const handleGroupByChange = (value: AnalyticsGroupBy | undefined) => {
-    setGroupBy(value);
-    setEnabledKeys(null);
-  };
-
-  const handleGroupByCountChange = (value: number) => {
-    setGroupByCount(value);
-    setEnabledKeys(null);
-  };
-
-  const toggleGroup = useCallback((key: string) => {
-    setEnabledKeys((prev) => {
-      const current = prev ?? [];
-      if (current.includes(key)) {
-        const next = current.filter((k) => k !== key);
-        return next.length === 0 ? null : next;
-      }
-      return [...current, key];
-    });
-  }, []);
-
-  const groups = useMemo(() => awuUsageData?.groups ?? [], [awuUsageData]);
-  const points = useMemo(() => awuUsageData?.points ?? [], [awuUsageData]);
-  const allKeys = useMemo(() => groups.map((g) => g.groupKey), [groups]);
-
-  // Intersect the drilldown selection with the keys actually returned: a series
-  // that drops out of the top-N (e.g. after a period change) must not blank the
-  // chart, so an empty intersection falls back to showing everything.
-  const effectiveEnabledKeys = useMemo(() => {
-    if (!enabledKeys) {
-      return null;
-    }
-    const available = enabledKeys.filter((key) => allKeys.includes(key));
-    return available.length > 0 ? available : null;
-  }, [enabledKeys, allKeys]);
-
-  const chartData = useMemo(
-    () =>
-      points.map((point) => ({ timestamp: point.timestamp, ...point.values })),
-    [points]
+  hasDrilldown,
+  onClearDrilldown,
+  csvDownload,
+}: UsageChartControlsProps) {
+  return (
+    <div className="flex items-center gap-2">
+      {userFilter && (
+        <Chip
+          size="xs"
+          label={`User: ${userFilter.name}`}
+          onRemove={() => onUserFilterChange?.(null)}
+        />
+      )}
+      {agentFilter && (
+        <Chip
+          size="xs"
+          label={`Agent: ${agentFilter.name}`}
+          onRemove={() => onAgentFilterChange?.(null)}
+        />
+      )}
+      {hasDrilldown && (
+        <Button
+          label="Clear filters"
+          size="xs"
+          variant="ghost"
+          onClick={onClearDrilldown}
+        />
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            label={
+              GRANULARITY_OPTIONS.find((o) => o.value === granularity)?.label ??
+              "Daily"
+            }
+            size="xs"
+            variant="outline"
+            isSelect
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {GRANULARITY_OPTIONS.map((o) => (
+            <DropdownMenuItem
+              key={o.value}
+              label={o.label}
+              onClick={() => setGranularity(o.value)}
+            />
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            label={
+              groupByOptions.find((o) => o.value === groupBy)?.label ?? "Total"
+            }
+            size="xs"
+            variant="outline"
+            isSelect
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {groupByOptions.map((o) => (
+            <DropdownMenuItem
+              key={o.value ?? "total"}
+              label={o.label}
+              onClick={() => onGroupByChange(o.value)}
+            />
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {groupBy && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              label={`Top ${groupByCount}`}
+              size="xs"
+              variant="outline"
+              isSelect
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {TOP_K_OPTIONS.map((value) => (
+              <DropdownMenuItem
+                key={value}
+                label={`Top ${value}`}
+                onClick={() => onGroupByCountChange(value)}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      <CsvDownloadButton {...csvDownload} />
+    </div>
   );
+}
 
+interface UsageChartBarsProps {
+  chartData: { timestamp: number; [key: string]: number }[];
+  visibleKeys: string[];
+  allKeys: string[];
+  groupBy: AnalyticsGroupBy | undefined;
+  groups: { groupKey: string; name: string }[];
+  granularity: Granularity;
+}
+
+function UsageChartBars({
+  chartData,
+  visibleKeys,
+  allKeys,
+  groupBy,
+  groups,
+  granularity,
+}: UsageChartBarsProps) {
+  return (
+    <BarChart
+      data={chartData}
+      margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+    >
+      <CartesianGrid
+        vertical={false}
+        className="stroke-border dark:stroke-border-night"
+      />
+      <XAxis
+        dataKey="timestamp"
+        type="category"
+        className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+        tickLine={true}
+        axisLine={false}
+        tickMargin={8}
+        minTickGap={16}
+        tickFormatter={(value) => formatTimestamp(value, granularity)}
+      />
+      <YAxis
+        className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+        tickLine={false}
+        axisLine={false}
+        tickMargin={8}
+        tickFormatter={(value) => formatCreditsCompact(value)}
+      />
+      <Tooltip
+        content={(props: TooltipContentProps<number, string>) => (
+          <CreditTooltip
+            {...props}
+            groupBy={groupBy}
+            groups={groups}
+            granularity={granularity}
+          />
+        )}
+        cursor={false}
+        wrapperStyle={{ outline: "none" }}
+        contentStyle={{
+          background: "transparent",
+          border: "none",
+          padding: 0,
+          boxShadow: "none",
+        }}
+      />
+      {visibleKeys.map((groupKey) => (
+        <Bar
+          key={groupKey}
+          dataKey={groupKey}
+          stackId="usage"
+          fill="currentColor"
+          className={getColorClassName(groupBy, groupKey, allKeys)}
+        />
+      ))}
+    </BarChart>
+  );
+}
+
+interface UseUsageLegendItemsParams {
+  groups: { groupKey: string; name: string }[];
+  groupBy: AnalyticsGroupBy | undefined;
+  allKeys: string[];
+  effectiveEnabledKeys: string[] | null;
+  toggleGroup: (key: string) => void;
+  userFilter?: AnalyticsEntityFilter | null;
+  agentFilter?: AnalyticsEntityFilter | null;
+  onUserFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
+  onAgentFilterChange?: (filter: AnalyticsEntityFilter | null) => void;
+}
+
+function useUsageLegendItems({
+  groups,
+  groupBy,
+  allKeys,
+  effectiveEnabledKeys,
+  toggleGroup,
+  userFilter,
+  agentFilter,
+  onUserFilterChange,
+  onAgentFilterChange,
+}: UseUsageLegendItemsParams): LegendItem[] {
   // In "user"/"agent" mode, legend clicks set the sticky scope filter (a server
   // refetch) rather than toggling client-side series visibility, so the choice
   // survives groupBy changes.
   const userScopeMode = groupBy === "user" && !!onUserFilterChange;
   const agentScopeMode = groupBy === "agent" && !!onAgentFilterChange;
 
-  const legendItems: LegendItem[] = useMemo(
+  return useMemo(
     () =>
       groups.map((group) => {
         let label = group.name;
@@ -264,15 +424,29 @@ export function BaseAwuUsageFromAnalyticsChart({
       onAgentFilterChange,
     ]
   );
+}
 
-  const visibleKeys = useMemo(
-    () =>
-      allKeys.filter(
-        (key) => !effectiveEnabledKeys || effectiveEnabledKeys.includes(key)
-      ),
-    [allKeys, effectiveEnabledKeys]
-  );
+interface BuildExportUrlParams {
+  exportUrlPrefix: string;
+  days: number;
+  granularity: Granularity;
+  groupBy: AnalyticsGroupBy | undefined;
+  groupByCount: number;
+  userFilter?: AnalyticsEntityFilter | null;
+  agentFilter?: AnalyticsEntityFilter | null;
+  effectiveEnabledKeys: string[] | null;
+}
 
+function buildExportUrl({
+  exportUrlPrefix,
+  days,
+  granularity,
+  groupBy,
+  groupByCount,
+  userFilter,
+  agentFilter,
+  effectiveEnabledKeys,
+}: BuildExportUrlParams): string {
   const exportParams = new URLSearchParams({
     days: days.toString(),
     granularity,
@@ -293,8 +467,103 @@ export function BaseAwuUsageFromAnalyticsChart({
   if (effectiveEnabledKeys) {
     exportParams.set("series", effectiveEnabledKeys.join(","));
   }
+  return `${exportUrlPrefix}?${exportParams.toString()}`;
+}
+
+export function BaseAwuUsageFromAnalyticsChart({
+  awuUsageData,
+  isAwuUsageLoading,
+  isAwuUsageError,
+  granularity,
+  setGranularity,
+  groupBy,
+  setGroupBy,
+  groupByCount,
+  setGroupByCount,
+  days,
+  exportUrlPrefix,
+  groupByOptions = GROUP_BY_OPTIONS,
+  userFilter,
+  agentFilter,
+  onUserFilterChange,
+  onAgentFilterChange,
+}: BaseAwuUsageFromAnalyticsChartProps) {
+  // Legend-driven drilldown: when non-null, only these series are shown.
+  const [enabledKeys, setEnabledKeys] = useState<string[] | null>(null);
+
+  const handleGroupByChange = (value: AnalyticsGroupBy | undefined) => {
+    setGroupBy(value);
+    setEnabledKeys(null);
+  };
+
+  const handleGroupByCountChange = (value: number) => {
+    setGroupByCount(value);
+    setEnabledKeys(null);
+  };
+
+  const toggleGroup = useCallback((key: string) => {
+    setEnabledKeys((prev) => {
+      const current = prev ?? [];
+      if (current.includes(key)) {
+        const next = current.filter((k) => k !== key);
+        return next.length === 0 ? null : next;
+      }
+      return [...current, key];
+    });
+  }, []);
+
+  const groups = useMemo(() => awuUsageData?.groups ?? [], [awuUsageData]);
+  const points = useMemo(() => awuUsageData?.points ?? [], [awuUsageData]);
+  const allKeys = useMemo(() => groups.map((g) => g.groupKey), [groups]);
+
+  // Intersect the drilldown selection with the keys actually returned: a series
+  // that drops out of the top-N (e.g. after a period change) must not blank the
+  // chart, so an empty intersection falls back to showing everything.
+  const effectiveEnabledKeys = useMemo(() => {
+    if (!enabledKeys) {
+      return null;
+    }
+    const available = enabledKeys.filter((key) => allKeys.includes(key));
+    return available.length > 0 ? available : null;
+  }, [enabledKeys, allKeys]);
+
+  const chartData = useMemo(
+    () =>
+      points.map((point) => ({ timestamp: point.timestamp, ...point.values })),
+    [points]
+  );
+
+  const legendItems = useUsageLegendItems({
+    groups,
+    groupBy,
+    allKeys,
+    effectiveEnabledKeys,
+    toggleGroup,
+    userFilter,
+    agentFilter,
+    onUserFilterChange,
+    onAgentFilterChange,
+  });
+
+  const visibleKeys = useMemo(
+    () =>
+      allKeys.filter(
+        (key) => !effectiveEnabledKeys || effectiveEnabledKeys.includes(key)
+      ),
+    [allKeys, effectiveEnabledKeys]
+  );
+
   const csvDownload = useDownloadCsv({
-    url: `${exportUrlPrefix}?${exportParams.toString()}`,
+    url: buildExportUrl({
+      exportUrlPrefix,
+      days,
+      granularity,
+      groupBy,
+      groupByCount,
+      userFilter,
+      agentFilter,
+      effectiveEnabledKeys,
+    }),
     filename: `dust_credit_usage_last_${days}_days.csv`,
     disabled: isAwuUsageLoading || !!isAwuUsageError || chartData.length === 0,
   });
@@ -308,154 +577,35 @@ export function BaseAwuUsageFromAnalyticsChart({
         chartData.length === 0 ? "No usage data for this period." : undefined
       }
       additionalControls={
-        <div className="flex items-center gap-2">
-          {userFilter && (
-            <Chip
-              size="xs"
-              label={`User: ${userFilter.name}`}
-              onRemove={() => onUserFilterChange?.(null)}
-            />
-          )}
-          {agentFilter && (
-            <Chip
-              size="xs"
-              label={`Agent: ${agentFilter.name}`}
-              onRemove={() => onAgentFilterChange?.(null)}
-            />
-          )}
-          {effectiveEnabledKeys && (
-            <Button
-              label="Clear filters"
-              size="xs"
-              variant="ghost"
-              onClick={() => setEnabledKeys(null)}
-            />
-          )}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                label={
-                  GRANULARITY_OPTIONS.find((o) => o.value === granularity)
-                    ?.label ?? "Daily"
-                }
-                size="xs"
-                variant="outline"
-                isSelect
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {GRANULARITY_OPTIONS.map((o) => (
-                <DropdownMenuItem
-                  key={o.value}
-                  label={o.label}
-                  onClick={() => setGranularity(o.value)}
-                />
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                label={
-                  groupByOptions.find((o) => o.value === groupBy)?.label ??
-                  "Total"
-                }
-                size="xs"
-                variant="outline"
-                isSelect
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {groupByOptions.map((o) => (
-                <DropdownMenuItem
-                  key={o.value ?? "total"}
-                  label={o.label}
-                  onClick={() => handleGroupByChange(o.value)}
-                />
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          {groupBy && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  label={`Top ${groupByCount}`}
-                  size="xs"
-                  variant="outline"
-                  isSelect
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {TOP_K_OPTIONS.map((value) => (
-                  <DropdownMenuItem
-                    key={value}
-                    label={`Top ${value}`}
-                    onClick={() => handleGroupByCountChange(value)}
-                  />
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-          <CsvDownloadButton {...csvDownload} />
-        </div>
+        <UsageChartControls
+          granularity={granularity}
+          setGranularity={setGranularity}
+          groupBy={groupBy}
+          onGroupByChange={handleGroupByChange}
+          groupByCount={groupByCount}
+          onGroupByCountChange={handleGroupByCountChange}
+          groupByOptions={groupByOptions}
+          userFilter={userFilter}
+          agentFilter={agentFilter}
+          onUserFilterChange={onUserFilterChange}
+          onAgentFilterChange={onAgentFilterChange}
+          hasDrilldown={!!effectiveEnabledKeys}
+          onClearDrilldown={() => setEnabledKeys(null)}
+          csvDownload={csvDownload}
+        />
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}
       isAllowFullScreen
     >
-      <BarChart
-        data={chartData}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-      >
-        <CartesianGrid
-          vertical={false}
-          className="stroke-border dark:stroke-border-night"
-        />
-        <XAxis
-          dataKey="timestamp"
-          type="category"
-          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
-          tickLine={true}
-          axisLine={false}
-          tickMargin={8}
-          minTickGap={16}
-          tickFormatter={(value) => formatTimestamp(value, granularity)}
-        />
-        <YAxis
-          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
-          tickLine={false}
-          axisLine={false}
-          tickMargin={8}
-          tickFormatter={(value) => formatCreditsCompact(value)}
-        />
-        <Tooltip
-          content={(props: TooltipContentProps<number, string>) => (
-            <CreditTooltip
-              {...props}
-              groupBy={groupBy}
-              groups={groups}
-              granularity={granularity}
-            />
-          )}
-          cursor={false}
-          wrapperStyle={{ outline: "none" }}
-          contentStyle={{
-            background: "transparent",
-            border: "none",
-            padding: 0,
-            boxShadow: "none",
-          }}
-        />
-        {visibleKeys.map((groupKey) => (
-          <Bar
-            key={groupKey}
-            dataKey={groupKey}
-            stackId="usage"
-            fill="currentColor"
-            className={getColorClassName(groupBy, groupKey, allKeys)}
-          />
-        ))}
-      </BarChart>
+      <UsageChartBars
+        chartData={chartData}
+        visibleKeys={visibleKeys}
+        allKeys={allKeys}
+        groupBy={groupBy}
+        groups={groups}
+        granularity={granularity}
+      />
     </ChartContainer>
   );
 }

--- a/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
@@ -1,4 +1,5 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import type { AnalyticsEntityFilter } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
 import { CreditsTableCard } from "@app/components/workspace/analytics/CreditsTableCard";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import {
@@ -147,11 +148,13 @@ const columns: ColumnDef<AgentCreditRowData>[] = [
 interface WorkspaceAgentCreditsTableProps {
   workspaceId: string;
   period: ObservabilityTimeRangeType;
+  onSelectAgent?: (filter: AnalyticsEntityFilter) => void;
 }
 
 export function WorkspaceAgentCreditsTable({
   workspaceId,
   period,
+  onSelectAgent,
 }: WorkspaceAgentCreditsTableProps) {
   const { inputValue, debouncedValue, setValue } = useDebounce("", {
     delay: 300,
@@ -165,6 +168,13 @@ export function WorkspaceAgentCreditsTable({
       search: debouncedValue || undefined,
       disabled: !workspaceId,
     });
+
+  const rows: AgentCreditRowData[] = onSelectAgent
+    ? agentCredits.map((row) => ({
+        ...row,
+        onClick: () => onSelectAgent({ id: row.agentId, name: row.name }),
+      }))
+    : agentCredits;
 
   const exportParams = new URLSearchParams({
     days: period.toString(),
@@ -201,7 +211,7 @@ export function WorkspaceAgentCreditsTable({
           : "No agent activity for this selection."
       }
       columns={columns}
-      data={agentCredits}
+      data={rows}
     />
   );
 }

--- a/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
@@ -1,5 +1,5 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
-import type { AnalyticsEntityFilter } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
+import type { AnalyticsEntityFilter } from "@app/components/workspace/analytics/analyticsFilter";
 import { CreditsTableCard } from "@app/components/workspace/analytics/CreditsTableCard";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import {

--- a/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
@@ -1,5 +1,5 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
-import type { AnalyticsEntityFilter } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
+import type { AnalyticsEntityFilter } from "@app/components/workspace/analytics/analyticsFilter";
 import { CreditsTableCard } from "@app/components/workspace/analytics/CreditsTableCard";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import {

--- a/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
@@ -1,4 +1,5 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import type { AnalyticsEntityFilter } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
 import { CreditsTableCard } from "@app/components/workspace/analytics/CreditsTableCard";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import {
@@ -111,11 +112,13 @@ const columns: ColumnDef<UserCreditRowData>[] = [
 interface WorkspaceUserCreditsTableProps {
   workspaceId: string;
   period: ObservabilityTimeRangeType;
+  onSelectUser?: (filter: AnalyticsEntityFilter) => void;
 }
 
 export function WorkspaceUserCreditsTable({
   workspaceId,
   period,
+  onSelectUser,
 }: WorkspaceUserCreditsTableProps) {
   const { inputValue, debouncedValue, setValue } = useDebounce("", {
     delay: 300,
@@ -129,6 +132,13 @@ export function WorkspaceUserCreditsTable({
       search: debouncedValue || undefined,
       disabled: !workspaceId,
     });
+
+  const rows: UserCreditRowData[] = onSelectUser
+    ? userCredits.map((row) => ({
+        ...row,
+        onClick: () => onSelectUser({ id: row.userId, name: row.name }),
+      }))
+    : userCredits;
 
   const exportParams = new URLSearchParams({
     days: period.toString(),
@@ -165,7 +175,7 @@ export function WorkspaceUserCreditsTable({
           : "No user activity for this selection."
       }
       columns={columns}
-      data={userCredits}
+      data={rows}
     />
   );
 }

--- a/front/components/workspace/analytics/analyticsFilter.ts
+++ b/front/components/workspace/analytics/analyticsFilter.ts
@@ -1,0 +1,65 @@
+import type {
+  AnalyticsScopeDimension,
+  AnalyticsScopeFilter,
+} from "@app/lib/api/analytics/awu_usage_analytics";
+
+export type { AnalyticsScopeDimension, AnalyticsScopeFilter };
+
+export interface AnalyticsEntityFilter {
+  id: string;
+  name: string;
+}
+
+export type AnalyticsFilter = Partial<
+  Record<AnalyticsScopeDimension, AnalyticsEntityFilter[]>
+>;
+
+export const SCOPE_DIMENSION_LABEL: Record<AnalyticsScopeDimension, string> = {
+  agent: "Agent",
+  user: "User",
+  origin: "Source",
+};
+
+export const SCOPE_DIMENSIONS = Object.keys(
+  SCOPE_DIMENSION_LABEL
+) as AnalyticsScopeDimension[];
+
+export function isScopeDimension(
+  groupBy: string | undefined
+): groupBy is AnalyticsScopeDimension {
+  return groupBy !== undefined && groupBy in SCOPE_DIMENSION_LABEL;
+}
+
+export function scopeFilterToIds(
+  filter: AnalyticsFilter
+): AnalyticsScopeFilter {
+  const ids: AnalyticsScopeFilter = {};
+  for (const dimension of SCOPE_DIMENSIONS) {
+    const entities = filter[dimension];
+    if (entities && entities.length > 0) {
+      ids[dimension] = entities.map((entity) => entity.id);
+    }
+  }
+  return ids;
+}
+
+export function toggleScopeEntity(
+  filter: AnalyticsFilter,
+  dimension: AnalyticsScopeDimension,
+  entity: AnalyticsEntityFilter
+): AnalyticsFilter {
+  const current = filter[dimension] ?? [];
+  const next = current.some((e) => e.id === entity.id)
+    ? current.filter((e) => e.id !== entity.id)
+    : [...current, entity];
+  return { ...filter, [dimension]: next.length > 0 ? next : undefined };
+}
+
+export function removeScopeEntity(
+  filter: AnalyticsFilter,
+  dimension: AnalyticsScopeDimension,
+  id: string
+): AnalyticsFilter {
+  const next = (filter[dimension] ?? []).filter((e) => e.id !== id);
+  return { ...filter, [dimension]: next.length > 0 ? next : undefined };
+}

--- a/front/lib/api/analytics/awu_usage_analytics.ts
+++ b/front/lib/api/analytics/awu_usage_analytics.ts
@@ -26,6 +26,10 @@ export const AwuUsageAnalyticsQuerySchema = z.object({
   groupByCount: z.coerce.number().optional().default(5),
   granularity: z.enum(["day", "week", "month"]).optional().default("day"),
   days: z.coerce.number().int().positive().optional().default(30),
+  // Optional scope filters: restrict the whole series to a single user and/or
+  // agent (by sId). Sticky across groupBy changes on the client.
+  userId: z.string().optional(),
+  agentId: z.string().optional(),
 });
 
 export type AwuUsageAnalyticsQuery = z.infer<
@@ -62,9 +66,11 @@ export async function getAwuUsageFromAnalytics(
   query: AwuUsageAnalyticsQuery,
   options: { userIds?: string[] } = {}
 ): Promise<Result<AwuUsageAnalyticsResponse, AwuUsageAnalyticsError>> {
-  const { groupBy, groupByCount, granularity, days } = query;
-  const { userIds } = options;
+  const { groupBy, groupByCount, granularity, days, userId, agentId } = query;
   const { startDate, endDate } = daysToInstantRange(days, "UTC");
+
+  const userIds = options.userIds ?? (userId ? [userId] : undefined);
+  const agentIds = agentId ? [agentId] : undefined;
 
   if (!groupBy) {
     const result = await fetchCreditTimeseries(auth, {
@@ -72,8 +78,9 @@ export async function getAwuUsageFromAnalytics(
       endDate,
       granularity,
       timezone: "UTC",
-      userIds,
       fillWindow: true,
+      userIds,
+      agentIds,
     });
     if (result.isErr()) {
       return new Err(toError(result.error));
@@ -97,8 +104,9 @@ export async function getAwuUsageFromAnalytics(
       endDate,
       granularity,
       timezone: "UTC",
-      userIds,
       fillWindow: true,
+      userIds,
+      agentIds,
     });
     if (result.isErr()) {
       return new Err(toError(result.error));
@@ -129,8 +137,9 @@ export async function getAwuUsageFromAnalytics(
     timezone: "UTC",
     breakdownBy: groupBy,
     limit: groupByCount,
-    userIds,
     fillWindow: true,
+    userIds,
+    agentIds,
   });
   if (result.isErr()) {
     return new Err(toError(result.error));

--- a/front/lib/api/analytics/awu_usage_analytics.ts
+++ b/front/lib/api/analytics/awu_usage_analytics.ts
@@ -21,15 +21,38 @@ const TERMS_GROUP_BY_KEYS = [
 // user_id. The other groupings map directly to CreditBreakdownBy.
 const ANALYTICS_GROUP_BY_KEYS = ["usage_type", ...TERMS_GROUP_BY_KEYS] as const;
 
+export const ANALYTICS_SCOPE_DIMENSIONS = TERMS_GROUP_BY_KEYS;
+export type AnalyticsScopeDimension =
+  (typeof ANALYTICS_SCOPE_DIMENSIONS)[number];
+
+export type AnalyticsScopeFilter = Partial<
+  Record<AnalyticsScopeDimension, string[]>
+>;
+
+const FilterSchema = z.record(
+  z.enum(ANALYTICS_SCOPE_DIMENSIONS),
+  z.string().array()
+);
+
 export const AwuUsageAnalyticsQuerySchema = z.object({
   groupBy: z.enum(ANALYTICS_GROUP_BY_KEYS).optional(),
   groupByCount: z.coerce.number().optional().default(5),
   granularity: z.enum(["day", "week", "month"]).optional().default("day"),
   days: z.coerce.number().int().positive().optional().default(30),
-  // Optional scope filters: restrict the whole series to a single user and/or
-  // agent (by sId). Sticky across groupBy changes on the client.
-  userId: z.string().optional(),
-  agentId: z.string().optional(),
+  filter: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (!val) {
+        return undefined;
+      }
+      try {
+        return JSON.parse(val);
+      } catch {
+        return val; // Return original to trigger validation error.
+      }
+    })
+    .pipe(FilterSchema.optional()),
 });
 
 export type AwuUsageAnalyticsQuery = z.infer<
@@ -66,11 +89,12 @@ export async function getAwuUsageFromAnalytics(
   query: AwuUsageAnalyticsQuery,
   options: { userIds?: string[] } = {}
 ): Promise<Result<AwuUsageAnalyticsResponse, AwuUsageAnalyticsError>> {
-  const { groupBy, groupByCount, granularity, days, userId, agentId } = query;
+  const { groupBy, groupByCount, granularity, days, filter } = query;
   const { startDate, endDate } = daysToInstantRange(days, "UTC");
 
-  const userIds = options.userIds ?? (userId ? [userId] : undefined);
-  const agentIds = agentId ? [agentId] : undefined;
+  const userIds = options.userIds ?? filter?.user;
+  const agentIds = filter?.agent;
+  const contextOrigin = filter?.origin;
 
   if (!groupBy) {
     const result = await fetchCreditTimeseries(auth, {
@@ -81,6 +105,7 @@ export async function getAwuUsageFromAnalytics(
       fillWindow: true,
       userIds,
       agentIds,
+      contextOrigin,
     });
     if (result.isErr()) {
       return new Err(toError(result.error));
@@ -107,6 +132,7 @@ export async function getAwuUsageFromAnalytics(
       fillWindow: true,
       userIds,
       agentIds,
+      contextOrigin,
     });
     if (result.isErr()) {
       return new Err(toError(result.error));
@@ -140,6 +166,7 @@ export async function getAwuUsageFromAnalytics(
     fillWindow: true,
     userIds,
     agentIds,
+    contextOrigin,
   });
   if (result.isErr()) {
     return new Err(toError(result.error));

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -4,7 +4,10 @@ import type {
   AwuUsageGroupByType,
   GetAwuUsageResponse,
 } from "@app/lib/api/analytics/awu_usage";
-import type { AwuUsageAnalyticsResponse } from "@app/lib/api/analytics/awu_usage_analytics";
+import type {
+  AnalyticsScopeFilter,
+  AwuUsageAnalyticsResponse,
+} from "@app/lib/api/analytics/awu_usage_analytics";
 import type {
   GetWorkspaceProgrammaticCostResponse,
   GroupByType,
@@ -655,8 +658,7 @@ export function useAwuUsageFromAnalytics({
   groupByCount,
   granularity,
   days,
-  userId,
-  agentId,
+  filter,
   disabled,
   urlPrefix,
 }: {
@@ -665,8 +667,7 @@ export function useAwuUsageFromAnalytics({
   groupByCount?: number;
   granularity?: "day" | "week" | "month";
   days?: number;
-  userId?: string;
-  agentId?: string;
+  filter?: AnalyticsScopeFilter;
   disabled?: boolean;
   urlPrefix?: string;
 }) {
@@ -686,11 +687,8 @@ export function useAwuUsageFromAnalytics({
   if (days !== undefined) {
     queryParams.set("days", days.toString());
   }
-  if (userId) {
-    queryParams.set("userId", userId);
-  }
-  if (agentId) {
-    queryParams.set("agentId", agentId);
+  if (filter && Object.keys(filter).length > 0) {
+    queryParams.set("filter", JSON.stringify(filter));
   }
   const queryString = queryParams.toString();
   const prefix =

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -655,6 +655,8 @@ export function useAwuUsageFromAnalytics({
   groupByCount,
   granularity,
   days,
+  userId,
+  agentId,
   disabled,
   urlPrefix,
 }: {
@@ -663,6 +665,8 @@ export function useAwuUsageFromAnalytics({
   groupByCount?: number;
   granularity?: "day" | "week" | "month";
   days?: number;
+  userId?: string;
+  agentId?: string;
   disabled?: boolean;
   urlPrefix?: string;
 }) {
@@ -681,6 +685,12 @@ export function useAwuUsageFromAnalytics({
   }
   if (days !== undefined) {
     queryParams.set("days", days.toString());
+  }
+  if (userId) {
+    queryParams.set("userId", userId);
+  }
+  if (agentId) {
+    queryParams.set("agentId", agentId);
   }
   const queryString = queryParams.toString();
   const prefix =

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -94,12 +94,16 @@ export function usePokeAwuUsageFromAnalytics({
   groupByCount,
   granularity,
   days,
+  userId,
+  agentId,
   disabled,
 }: PokeConditionalFetchProps & {
   groupBy?: "usage_type" | "agent" | "user" | "origin";
   groupByCount?: number;
   granularity?: "day" | "week" | "month";
   days?: number;
+  userId?: string;
+  agentId?: string;
 }) {
   const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<AwuUsageAnalyticsResponse> = fetcher;
@@ -116,6 +120,12 @@ export function usePokeAwuUsageFromAnalytics({
   }
   if (days !== undefined) {
     queryParams.set("days", days.toString());
+  }
+  if (userId) {
+    queryParams.set("userId", userId);
+  }
+  if (agentId) {
+    queryParams.set("agentId", agentId);
   }
   const queryString = queryParams.toString();
   const key = `/api/poke/workspaces/${owner.sId}/analytics/awu-usage-analytics?${queryString}`;

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -1,4 +1,7 @@
-import type { AwuUsageAnalyticsResponse } from "@app/lib/api/analytics/awu_usage_analytics";
+import type {
+  AnalyticsScopeFilter,
+  AwuUsageAnalyticsResponse,
+} from "@app/lib/api/analytics/awu_usage_analytics";
 import type {
   GetWorkspaceProgrammaticCostResponse,
   GroupByType,
@@ -94,16 +97,14 @@ export function usePokeAwuUsageFromAnalytics({
   groupByCount,
   granularity,
   days,
-  userId,
-  agentId,
+  filter,
   disabled,
 }: PokeConditionalFetchProps & {
   groupBy?: "usage_type" | "agent" | "user" | "origin";
   groupByCount?: number;
   granularity?: "day" | "week" | "month";
   days?: number;
-  userId?: string;
-  agentId?: string;
+  filter?: AnalyticsScopeFilter;
 }) {
   const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<AwuUsageAnalyticsResponse> = fetcher;
@@ -121,11 +122,8 @@ export function usePokeAwuUsageFromAnalytics({
   if (days !== undefined) {
     queryParams.set("days", days.toString());
   }
-  if (userId) {
-    queryParams.set("userId", userId);
-  }
-  if (agentId) {
-    queryParams.set("agentId", agentId);
+  if (filter && Object.keys(filter).length > 0) {
+    queryParams.set("filter", JSON.stringify(filter));
   }
   const queryString = queryParams.toString();
   const key = `/api/poke/workspaces/${owner.sId}/analytics/awu-usage-analytics?${queryString}`;


### PR DESCRIPTION
## Description

Make the credit usage chart's user/agent filter sticky across groupBy changes and shared with the credit tables.

## Tests

Local
## Risk

Low
## Deploy Plan

Front