### PR TITLE
fix(usage): only surface SCIM-provisioned groups on the usage page

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -438,7 +438,7 @@ export function UsagePage() {
 
   const { groups } = useGroups({
     owner,
-    kinds: ["regular", "provisioned"],
+    kinds: ["provisioned"],
     disabled: !isWorkspaceAdmin || !pricingGroupsEnabled,
   });
   const selectedGroupName =

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1295,6 +1295,7 @@ export async function getMembersUsage({
     GroupResource.listGroupNamesByUserModelIdInWorkspace({
       workspace,
       userModelIds: users.map((u) => u.id),
+      groupKinds: ["provisioned"],
     }),
   ]);
   const freeCreditAlertIds =


### PR DESCRIPTION
## Description

Restrict the groups filter dropdown and the per-member Groups column to kind "provisioned" so manually-created regular groups no longer appear.
## Tests

Local
## Risk

None
## Deploy Plan

Front