### PR TITLE
Add column in plans for advanced LLM models support

### DIFF
--- a/extension/ui/components/auth/AuthProvider.tsx
+++ b/extension/ui/components/auth/AuthProvider.tsx
@@ -88,6 +88,7 @@ const EXTENSION_SUBSCRIPTION: SubscriptionType = {
     trialPeriodDays: 0,
     isByok: false,
     isAuditLogsAllowed: false,
+    hasAdvancedModelAccess: false,
   },
   requestCancelAt: null,
 };

--- a/front-api/routes/poke/plans.ts
+++ b/front-api/routes/poke/plans.ts
@@ -76,6 +76,7 @@ app.post(
       trialPeriodDays: body.trialPeriodDays,
       canUseProduct: body.limits.canUseProduct,
       isByok: body.isByok,
+      hasAdvancedModelAccess: body.hasAdvancedModelAccess,
     };
 
     let plan = await PlanModel.findOne({ where: { code: body.code } });

--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -139,6 +139,7 @@ async function ensureEnterprisePlan(): Promise<void> {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
+    hasAdvancedModelAccess: true,
   });
 }
 

--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -40,6 +40,7 @@ export type EditingPlanType = {
   isSCIMAllowed: boolean;
   isByok: boolean;
   isAuditLogsAllowed: boolean;
+  hasAdvancedModelAccess: boolean;
   maxImagesPerWeek: string | number;
   maxMessages: string | number;
   maxMessagesTimeframe: string;
@@ -71,6 +72,7 @@ export const fromPlanType = (plan: PlanType): EditingPlanType => {
     isSCIMAllowed: plan.limits.users.isSCIMAllowed,
     isByok: plan.isByok,
     isAuditLogsAllowed: plan.isAuditLogsAllowed,
+    hasAdvancedModelAccess: plan.hasAdvancedModelAccess,
     maxMessages: plan.limits.assistant.maxMessages,
     maxMessagesTimeframe: plan.limits.assistant.maxMessagesTimeframe,
     maxAwuCredits: plan.limits.assistant.maxAwuCredits,
@@ -153,6 +155,7 @@ export const toPlanType = (editingPlan: EditingPlanType): PlanType => {
     trialPeriodDays: parseMaybeNumber(editingPlan.trialPeriodDays),
     isByok: editingPlan.isByok,
     isAuditLogsAllowed: editingPlan.isAuditLogsAllowed,
+    hasAdvancedModelAccess: editingPlan.hasAdvancedModelAccess,
   };
 };
 
@@ -175,6 +178,7 @@ const getEmptyPlan = (): EditingPlanType => ({
   isSCIMAllowed: false,
   isByok: false,
   isAuditLogsAllowed: false,
+  hasAdvancedModelAccess: false,
   maxImagesPerWeek: "",
   maxMessages: "",
   maxMessagesTimeframe: "day",
@@ -368,6 +372,11 @@ export const PLAN_FIELDS = {
     type: "boolean",
     width: "tiny",
     title: "Audit",
+  },
+  hasAdvancedModelAccess: {
+    type: "boolean",
+    width: "tiny",
+    title: "Adv. Models",
   },
   maxVaults: {
     type: "number",

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -79,6 +79,7 @@ function createMockPlan(code: string): PlanType {
     },
     isByok: false,
     isAuditLogsAllowed: false,
+    hasAdvancedModelAccess: false,
   };
 }
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -13,6 +13,8 @@ import type { PlanType } from "@app/types/plan";
 import type { RegionType } from "@app/types/region";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
+// TODO(fabien): replace this check with `plan.hasAdvancedModelAccess` once
+// all plans have been configured via Poke.
 export function isPlanForAdvancedModels(plan: PlanType | null): boolean {
   return (
     plan !== null &&

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -57,6 +57,7 @@ export class PlanModel extends BaseModel<PlanModel> {
   declare isSCIMAllowed: boolean;
   declare isAuditLogsAllowed: boolean;
   declare isByok: boolean;
+  declare hasAdvancedModelAccess: boolean;
   declare maxDataSourcesCount: number;
   declare maxDataSourcesDocumentsCount: number;
   declare maxDataSourcesDocumentsSizeMb: number;
@@ -190,6 +191,10 @@ PlanModel.init(
       defaultValue: false,
     },
     isByok: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    hasAdvancedModelAccess: {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
     },

--- a/front/lib/plans/credit_priced_plans.ts
+++ b/front/lib/plans/credit_priced_plans.ts
@@ -56,6 +56,7 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 14,
     canUseProduct: true,
     isByok: false,
+    hasAdvancedModelAccess: false,
   });
   CREDIT_PRICED_PLANS_DATA.push({
     code: CREDIT_PRICED_FREE_PLAN_CODE,
@@ -88,6 +89,7 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
+    hasAdvancedModelAccess: false,
   });
   CREDIT_PRICED_PLANS_DATA.push({
     code: CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
@@ -120,6 +122,7 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
+    hasAdvancedModelAccess: false,
   });
 }
 

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -58,6 +58,7 @@ export const FREE_NO_PLAN_DATA: PlanAttributes = {
   trialPeriodDays: 0,
   canUseProduct: false,
   isByok: false,
+  hasAdvancedModelAccess: false,
 };
 
 /**
@@ -96,6 +97,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     trialPeriodDays: 0,
     canUseProduct: false,
     isByok: false,
+    hasAdvancedModelAccess: false,
   },
   {
     code: FREE_UPGRADED_PLAN_CODE,
@@ -128,6 +130,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
+    hasAdvancedModelAccess: false,
   },
   {
     code: FREE_TRIAL_PHONE_PLAN_CODE,
@@ -160,6 +163,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
+    hasAdvancedModelAccess: false,
   },
 ];
 

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -62,6 +62,7 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 14,
     canUseProduct: true,
     isByok: false,
+    hasAdvancedModelAccess: false,
   });
   PRO_PLANS_DATA.push({
     code: PRO_PLAN_SEAT_39_CODE,
@@ -94,6 +95,7 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 14,
     canUseProduct: true,
     isByok: false,
+    hasAdvancedModelAccess: false,
   });
   PRO_PLANS_DATA.push({
     code: FREE_BYOK_PLAN_CODE,
@@ -126,6 +128,7 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: true,
+    hasAdvancedModelAccess: false,
   });
   PRO_PLANS_DATA.push({
     code: FREE_BYOK_TRANSITIONING_PLAN_CODE,
@@ -158,6 +161,7 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: true,
+    hasAdvancedModelAccess: false,
   });
 }
 

--- a/front/lib/plans/renderers.ts
+++ b/front/lib/plans/renderers.ts
@@ -57,6 +57,7 @@ export function renderPlanFromModel({
     trialPeriodDays: plan.trialPeriodDays,
     isByok: plan.isByok,
     isAuditLogsAllowed: plan.isAuditLogsAllowed,
+    hasAdvancedModelAccess: plan.hasAdvancedModelAccess,
   };
 }
 

--- a/front/migrations/pre-deploy/20260629173806_add_has_advanced_model_access_to_plans.sql
+++ b/front/migrations/pre-deploy/20260629173806_add_has_advanced_model_access_to_plans.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."plans" ADD COLUMN "hasAdvancedModelAccess" boolean DEFAULT false;

--- a/front/scripts/seed/byok/seed.ts
+++ b/front/scripts/seed/byok/seed.ts
@@ -39,6 +39,7 @@ const FREE_BYOK_PLAN_DATA: PlanAttributes = {
   trialPeriodDays: 0,
   canUseProduct: true,
   isByok: true,
+  hasAdvancedModelAccess: false,
 };
 
 makeScript({}, async ({ execute }, logger) => {

--- a/front/tests/utils/PlanFactory.ts
+++ b/front/tests/utils/PlanFactory.ts
@@ -41,6 +41,7 @@ export class PlanFactory {
       trialPeriodDays: 0,
       canUseProduct: true,
       isByok: false,
+      hasAdvancedModelAccess: true,
       ...overrides,
     });
     return plan;

--- a/front/types/api/poke/plans.ts
+++ b/front/types/api/poke/plans.ts
@@ -54,6 +54,7 @@ export const PlanTypeSchema = z.object({
   trialPeriodDays: z.number(),
   isByok: z.boolean(),
   isAuditLogsAllowed: z.boolean(),
+  hasAdvancedModelAccess: z.boolean(),
 });
 
 export type UpsertPokePlanResponseBody = {

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -89,6 +89,7 @@ export type PlanType = {
   trialPeriodDays: number;
   isByok: boolean;
   isAuditLogsAllowed: boolean;
+  hasAdvancedModelAccess: boolean;
 };
 
 export type SubscriptionType = {


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9128
Introduce a new field for plans about whether they support advanced LLM models.

This can be edited per plan from POKE:

<img width="1222" height="844" alt="image" src="https://github.com/user-attachments/assets/5c96e095-77d5-4709-b765-7a6d13f6f79f" />

Let's first merge this, setup the plans correctly from poke, then actually use the value by implementing the TODO in a followup PR.

## Tests

tested locally

## Risk

low

## Deploy Plan

lock front
merge
apply migration
deploy
unlock front
