### PR TITLE
Support .eml and .har file uploads (recognize as text)

### DIFF
--- a/front/types/files.test.ts
+++ b/front/types/files.test.ts
@@ -144,6 +144,18 @@ describe("resolveFileContentType", () => {
       resolveFileContentType("application/octet-stream", "data.xlsx")
     ).toBe("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
   });
+
+  it("normalizes .eml files reported as octet-stream to message/rfc822", () => {
+    expect(resolveFileContentType("application/octet-stream", "mail.eml")).toBe(
+      "message/rfc822"
+    );
+  });
+
+  it("normalizes .har files reported as octet-stream to application/json", () => {
+    expect(
+      resolveFileContentType("application/octet-stream", "capture.har")
+    ).toBe("application/json");
+  });
 });
 
 describe("sandboxFunctionContentType", () => {

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -465,7 +465,11 @@ export const FILE_FORMATS = {
     isSafeToDisplay: true,
   },
   "text/calendar": { cat: "data", exts: [".ics"], isSafeToDisplay: true },
-  "application/json": { cat: "data", exts: [".json"], isSafeToDisplay: true },
+  "application/json": {
+    cat: "data",
+    exts: [".json", ".har"],
+    isSafeToDisplay: true,
+  },
   "application/msword": {
     cat: "data",
     exts: [".doc", ".docx"],
@@ -937,6 +941,10 @@ const EXTENSION_CONTENT_TYPE_OVERRIDES: Record<
   ".ttf": "font/ttf",
   ".ttc": "font/collection",
   ".otc": "font/collection",
+  // Browsers report .eml and .har as application/octet-stream; map them to the
+  // text-based types they actually are so the content is readable.
+  ".eml": "message/rfc822",
+  ".har": "application/json",
 };
 
 export function stripMimeParameters(contentType: string): string {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -192,7 +192,7 @@ export const supportedOtherFileFormats = {
   "text/css": [".css"],
   "text/javascript": [".js", ".mjs", ".jsx"],
   "text/typescript": [".ts", ".tsx"],
-  "application/json": [".json"],
+  "application/json": [".json", ".har"],
   "application/xml": [".xml"],
   "application/x-sh": [".sh"],
   "text/x-sh": [".sh"],


### PR DESCRIPTION
## Problem

Uploading a `.eml` (raw email) or `.har` (browser network capture) file to a conversation does not work today: browsers report both as `application/octet-stream`, `resolveFileContentType` returns that (octet-stream is itself a supported type, so it never falls through to extension inference), and the file is stored as octet-stream with no readable text for the agent. The only workaround is to manually rename `.eml` -> `.txt` and `.har` -> `.json` before upload.

Both formats are plain text under the hood (EML is RFC 822 text, HAR is JSON), and they are two of the most useful artifacts in support / technical-diagnosis workflows (email headers, MIME, SPF/DKIM; HTTP requests, auth errors, add-in deployment).

## Change

- Add extension overrides so the correct content type is used even when the browser reports octet-stream:
  - `.eml` -> `message/rfc822`
  - `.har` -> `application/json`
- Add `.har` to the `application/json` extension lists (`FILE_FORMATS` and the public SDK `supportedOtherFileFormats`) so it shows up in the file picker and is inferrable from the file name.
- Tests for both in `resolveFileContentType`.

`message/rfc822` is already declared in `FILE_FORMATS`, the conversation supported content types, and the SDK; only the extension override was missing. It is category `data` (like `application/json`) and is served as-is, which makes the raw email readable by the agent (and preserves headers/MIME, which matters for diagnosis).

## Scope / note

I deliberately did **not** add `message/rfc822` to the Tika `supportedContentTypes` list (`front/types/shared/text_extraction/index.ts`), because that file says new content types must be tested against the Tika server first, which I can't do from outside. RFC822 is natively supported by Tika (`RFC822Parser` is not excluded in `tika-config.xml`), so wiring it through extraction for data-source indexing would be a small follow-up if desired.

## Test plan

- `front/types/files.test.ts` covers the two new overrides.
- Manual: uploading a `.eml` or `.har` to a conversation now yields a readable file instead of an unreadable octet-stream blob.
