### PR TITLE
[front] enh: add hint to use tool search on missing action catch

### DIFF
--- a/front/lib/api/actions/servers/missing_action_catcher/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/index.ts
@@ -11,7 +11,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("missing_action_catcher");
 
-  const tools = createMissingActionCatcherTools(agentLoopContext);
+  const tools = createMissingActionCatcherTools(auth, agentLoopContext);
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
       monitoringName: "missing_action_catcher",

--- a/front/lib/api/actions/servers/missing_action_catcher/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/index.ts
@@ -11,7 +11,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("missing_action_catcher");
 
-  const tools = createMissingActionCatcherTools(auth, agentLoopContext);
+  const tools = createMissingActionCatcherTools(agentLoopContext);
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
       monitoringName: "missing_action_catcher",

--- a/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
@@ -1,14 +1,11 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import type { Authenticator } from "@app/lib/auth";
-import { hasFeatureFlag } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
 
 // This server has dynamically created tools based on the agentLoopContext.
 // The tool name comes from the context at runtime.
 export function createMissingActionCatcherTools(
-  auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): ToolDefinition[] {
   if (agentLoopContext) {
@@ -31,17 +28,6 @@ export function createMissingActionCatcherTools(
           done: "Process action",
         },
         handler: async () => {
-          const toolSearchEnabled = await hasFeatureFlag(
-            auth,
-            "anthropic_tool_search"
-          );
-
-          const toolSearchHint = toolSearchEnabled
-            ? "  3. Search for the exact tool name with the tool search (a BM25 " +
-              "keyword search over available tools) instead of guessing, then retry " +
-              "with the precise name it returns.\n"
-            : "";
-
           return new Err(
             new MCPError(
               `Tool "${actionName}" not found. ` +
@@ -49,7 +35,8 @@ export function createMissingActionCatcherTools(
                 "  1. The function name needs to be checked to ensure it matches one of the tools " +
                 "available (case sensitivity, word separators, ...).\n" +
                 "  2. If the function comes from a skill, the skill needs to be enabled first.\n" +
-                toolSearchHint +
+                "  3. Search for the exact tool name instead of guessing, then retry with the " +
+                "precise name it returns.\n" +
                 "This action can safely be retried with another name or with the same name after " +
                 "enabling a skill.",
               { tracked: false }

--- a/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
@@ -36,7 +36,7 @@ export function createMissingActionCatcherTools(
                 "available (case sensitivity, word separators, ...).\n" +
                 "  2. If the function comes from a skill, the skill needs to be enabled first.\n" +
                 "  3. Search for the exact tool name instead of guessing, then retry with the " +
-                "precise name it returns.\n" +
+                "correct name.\n" +
                 "This action can safely be retried with another name or with the same name after " +
                 "enabling a skill.",
               { tracked: false }

--- a/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
@@ -1,11 +1,14 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
 
 // This server has dynamically created tools based on the agentLoopContext.
 // The tool name comes from the context at runtime.
 export function createMissingActionCatcherTools(
+  auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): ToolDefinition[] {
   if (agentLoopContext) {
@@ -28,6 +31,17 @@ export function createMissingActionCatcherTools(
           done: "Process action",
         },
         handler: async () => {
+          const toolSearchEnabled = await hasFeatureFlag(
+            auth,
+            "anthropic_tool_search"
+          );
+
+          const toolSearchHint = toolSearchEnabled
+            ? "  3. Search for the exact tool name with the tool search (a BM25 " +
+              "keyword search over available tools) instead of guessing, then retry " +
+              "with the precise name it returns.\n"
+            : "";
+
           return new Err(
             new MCPError(
               `Tool "${actionName}" not found. ` +
@@ -35,6 +49,7 @@ export function createMissingActionCatcherTools(
                 "  1. The function name needs to be checked to ensure it matches one of the tools " +
                 "available (case sensitivity, word separators, ...).\n" +
                 "  2. If the function comes from a skill, the skill needs to be enabled first.\n" +
+                toolSearchHint +
                 "This action can safely be retried with another name or with the same name after " +
                 "enabling a skill.",
               { tracked: false }


### PR DESCRIPTION
## Description

This PR adds a hint to search for exact tool name when a tool call name does not match any existing tool (behind the tool search feature flag). The goal is to have the model rely on tool search when available in this case.

We have seen failure cases (addressed separately) when the missing action fallback was triggered, and where the agent failed to recover unless specifically prompted to use tool search. This PR aims at making this recovery systematic.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
