### PR TITLE
[front] enh: list newly available tools in toolset enable tool result

### DIFF
--- a/front/lib/actions/tool_name_utils.ts
+++ b/front/lib/actions/tool_name_utils.ts
@@ -5,15 +5,20 @@ import { slugify } from "@app/types/shared/utils/string_utils";
 
 const MAX_TOOL_NAME_LENGTH = 64;
 
+// Slugify a server name into the prefix prepended to every one of its tool names. Each part is
+// slugified separately to preserve separators (used for space disambiguation notably).
+export function getToolNamePrefix(serverName: string): string {
+  return serverName
+    .split(TOOL_NAME_SEPARATOR)
+    .map(slugify)
+    .join(TOOL_NAME_SEPARATOR);
+}
+
 export function tryGetPrefixedToolName(
   serverName: string,
   originalName: string
 ): Result<string, Error> {
-  // Slugify each part separately to preserve separators (used for space disambiguation notably).
-  const slugifiedConfigName = serverName
-    .split(TOOL_NAME_SEPARATOR)
-    .map(slugify)
-    .join(TOOL_NAME_SEPARATOR);
+  const slugifiedConfigName = getToolNamePrefix(serverName);
   const slugifiedOriginalName = slugify(originalName).replaceAll(
     // Remove anything that is not a-zA-Z0-9_.- because it's not supported by the LLMs.
     /[^a-zA-Z0-9_.-]/g,

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -6,10 +6,12 @@ import {
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
+import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { TOOLSETS_TOOLS_METADATA } from "@app/lib/api/actions/servers/toolsets/metadata";
 import apiConfig from "@app/lib/api/config";
 import { getApiKeyNameHeader, prodAPICredentialsForOwner } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
@@ -122,10 +124,51 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
       );
     }
 
+    // List the tools that just became available so the model can clearly tell which functions
+    // it can now call (the bare success message made this ambiguous).
+    const enabledViewResource = await MCPServerViewResource.fetchById(
+      auth,
+      toolsetId
+    );
+    if (!enabledViewResource) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Successfully enabled toolset ${toolsetId}.`,
+        },
+      ]);
+    }
+    const enabledView = enabledViewResource.toJSON();
+
+    const toolsetName = getMcpServerViewDisplayName(enabledView);
+
+    // If there is no toolsMetadata (= undefined or empty array), every tool is enabled.
+    const disabledToolNames =
+      enabledView.toolsMetadata
+        ?.filter((tool) => tool.enabled === false)
+        .map((tool) => tool.toolName) ?? [];
+    const enabledTools = enabledView.server.tools.filter(
+      (tool) => !disabledToolNames.includes(tool.name)
+    );
+
+    // Prefix the tool names the same way the agent loop does, so the names listed here match the
+    // ones the model will actually call.
+    const serverName = enabledView.name ?? enabledView.server.name;
+    const toolNames = enabledTools.flatMap((tool) => {
+      const prefixedNameRes = tryGetPrefixedToolName(serverName, tool.name);
+      return prefixedNameRes.isOk() ? [prefixedNameRes.value] : [];
+    });
+
+    const text =
+      toolNames.length > 0
+        ? `Successfully enabled toolset "${toolsetName}". The following tools are now available:\n` +
+          `${toolNames.map((name) => `- \`${name}\``).join("\n")}`
+        : `Successfully enabled toolset "${toolsetName}".`;
+
     return new Ok([
       {
         type: "text" as const,
-        text: `Successfully enabled toolset ${toolsetId}`,
+        text,
       },
     ]);
   },

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -162,7 +162,7 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
     const text =
       toolNames.length > 0
         ? `Successfully enabled toolset "${toolsetName}". The following tools are now available:\n` +
-        `${toolNames.map((name) => `- \`${name}\``).join("\n")}`
+          `${toolNames.map((name) => `- \`${name}\``).join("\n")}`
         : `Successfully enabled toolset "${toolsetName}", but it does not expose any tool.`;
 
     return new Ok([

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -162,8 +162,8 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
     const text =
       toolNames.length > 0
         ? `Successfully enabled toolset "${toolsetName}". The following tools are now available:\n` +
-          `${toolNames.map((name) => `- \`${name}\``).join("\n")}`
-        : `Successfully enabled toolset "${toolsetName}".`;
+        `${toolNames.map((name) => `- \`${name}\``).join("\n")}`
+        : `Successfully enabled toolset "${toolsetName}", but it does not expose any tool.`;
 
     return new Ok([
       {

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -1,3 +1,4 @@
+import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   getMcpServerViewDescription,
@@ -6,7 +7,7 @@ import {
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
-import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import { getToolNamePrefix } from "@app/lib/actions/tool_name_utils";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { TOOLSETS_TOOLS_METADATA } from "@app/lib/api/actions/servers/toolsets/metadata";
 import apiConfig from "@app/lib/api/config";
@@ -124,51 +125,23 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
       );
     }
 
-    // List the tools that just became available so the model can clearly tell which functions
-    // it can now call (the bare success message made this ambiguous).
-    const enabledViewResource = await MCPServerViewResource.fetchById(
-      auth,
-      toolsetId
-    );
-    if (!enabledViewResource) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `Successfully enabled toolset ${toolsetId}.`,
-        },
-      ]);
-    }
-    const enabledView = enabledViewResource.toJSON();
+    const enabledView = await MCPServerViewResource.fetchById(auth, toolsetId);
 
-    const toolsetName = getMcpServerViewDisplayName(enabledView);
+    const prefixHint = enabledView
+      ? ` Their names share the \`${getToolNamePrefix(
+          enabledView?.toJSON().name ?? enabledView?.toJSON().server.name
+        )}${TOOL_NAME_SEPARATOR}\` prefix.`
+      : "";
 
-    // If there is no toolsMetadata (= undefined or empty array), every tool is enabled.
-    const disabledToolNames =
-      enabledView.toolsMetadata
-        ?.filter((tool) => tool.enabled === false)
-        .map((tool) => tool.toolName) ?? [];
-    const enabledTools = enabledView.server.tools.filter(
-      (tool) => !disabledToolNames.includes(tool.name)
-    );
-
-    // Prefix the tool names the same way the agent loop does, so the names listed here match the
-    // ones the model will actually call.
-    const serverName = enabledView.name ?? enabledView.server.name;
-    const toolNames = enabledTools.flatMap((tool) => {
-      const prefixedNameRes = tryGetPrefixedToolName(serverName, tool.name);
-      return prefixedNameRes.isOk() ? [prefixedNameRes.value] : [];
-    });
-
-    const text =
-      toolNames.length > 0
-        ? `Successfully enabled toolset "${toolsetName}". The following tools are now available:\n` +
-          `${toolNames.map((name) => `- \`${name}\``).join("\n")}`
-        : `Successfully enabled toolset "${toolsetName}", but it does not expose any tool.`;
-
+    // The newly enabled tools are not necessarily surfaced directly in the model's context (can
+    // be deferred behind tool search), so nudge it to look them up instead of guessing which
+    // tools exist.
     return new Ok([
       {
         type: "text" as const,
-        text,
+        text:
+          `Successfully enabled toolset ${toolsetId}. Its tools are now available.${prefixHint} ` +
+          "Do not assume which tools exist; look them up before calling them.",
       },
     ]);
   },

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -129,7 +129,7 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
 
     const prefixHint = enabledView
       ? ` Their names share the \`${getToolNamePrefix(
-          enabledView?.toJSON().name ?? enabledView?.toJSON().server.name
+          enabledView.toJSON().name ?? enabledView.toJSON().server.name
         )}${TOOL_NAME_SEPARATOR}\` prefix.`
       : "";
 


### PR DESCRIPTION
## Description

This PR adds a nudge to lookup the names of the tools enabled after a toolset enable tool call + a hint on how to find them.

We have seen error cases with tool-search enabled where the agent enables a tool, then randomly guesses tool names due to the tool names not being directly available in the specifications.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.