### PR TITLE
Initialize OpenTelemetry so Langfuse traces start at the HTTP request

### DIFF
--- a/front-api/lib/instrumentation-config.ts
+++ b/front-api/lib/instrumentation-config.ts
@@ -1,0 +1,8 @@
+import { initializeOpenTelemetryInstrumentation } from "@app/lib/api/instrumentation/init";
+
+// Initialize OpenTelemetry / Langfuse instrumentation for the front-api process.
+// Without this, any `startActiveObservation` created while handling an HTTP
+// request has no registered OTEL SDK / span processor, so the root spans are
+// dropped and Langfuse traces only "begin" once they reach the agent-loop
+// worker (which initializes its own instrumentation).
+initializeOpenTelemetryInstrumentation({ serviceName: "dust-front" });

--- a/front-api/server.ts
+++ b/front-api/server.ts
@@ -1,4 +1,5 @@
 import "./lib/tracer-config";
+import "./lib/instrumentation-config";
 
 import { Server } from "node:http";
 import { performance } from "node:perf_hooks";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Since we moved to Hono, the `front-api` never initialized OpenTelemetry, unlike the Temporal workers which set it up at startup. As a result, any observation created while serving an HTTP request had no registered span processor and was silently dropped, so Langfuse traces appeared to begin only once execution reached the agent-loop worker, missing the originating request.

This wires up the same initialization the workers already use, registering the OTEL SDK and Langfuse span processor under the `dust-front` service name at boot, before requests are served. It is a no-op when Langfuse is disabled and uses the proven dd-trace + OTEL ordering that already runs in production. No explicit shutdown flush is needed since the prestop drain period comfortably exceeds the batch span processor's flush interval.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
