### PR TITLE
[dsbx] Add function build subcommand and bake the sandbox function toolchain

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/functions-runner/build.test.ts
+++ b/cli/dust-sandbox/functions-runner/build.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const runner = join(import.meta.dir, "runner.ts");
+const fx = (n: string) => join(import.meta.dir, "fixtures", n);
+
+async function run(args: string[]) {
+  const proc = Bun.spawn(["bun", runner, ...args], {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    proc.exited,
+  ]);
+
+  return { stdout, code };
+}
+
+async function withOutDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "dsbx-build-test-"));
+
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("runner build", () => {
+  test("bundles a function and writes the bundle + schema", async () => {
+    await withOutDir(async (dir) => {
+      const bundlePath = join(dir, "greet.ts");
+      const schemaPath = join(dir, "greet.schema.json");
+      const { stdout, code } = await run([
+        "build",
+        fx("greet.ts"),
+        bundlePath,
+        schemaPath,
+      ]);
+
+      expect(code).toBe(0);
+      expect(JSON.parse(stdout)).toEqual({ ok: true });
+
+      // External packages stay as imports, only relative code is inlined.
+      const bundle = await readFile(bundlePath, "utf8");
+      expect(bundle).toContain('from "zod"');
+
+      const schema = JSON.parse(await readFile(schemaPath, "utf8"));
+      expect(schema.description).toBe("Greet a user by name");
+      expect(schema.input_schema.required).toContain("name");
+      expect(schema.output_schema.required).toContain("greeting");
+    });
+  });
+
+  test("exits 1 with build_failed on a missing source", async () => {
+    await withOutDir(async (dir) => {
+      const { stdout, code } = await run([
+        "build",
+        fx("does-not-exist.ts"),
+        join(dir, "out.ts"),
+        join(dir, "out.json"),
+      ]);
+      expect(code).toBe(1);
+      expect(JSON.parse(stdout).error.kind).toBe("build_failed");
+    });
+  });
+
+  test("exits 1 with schema_extraction_failed when the function has no schema", async () => {
+    await withOutDir(async (dir) => {
+      const { stdout, code } = await run([
+        "build",
+        fx("no-schema.ts"),
+        join(dir, "out.ts"),
+        join(dir, "out.json"),
+      ]);
+      expect(code).toBe(1);
+      expect(JSON.parse(stdout).error.kind).toBe("schema_extraction_failed");
+    });
+  });
+
+  test("exits 2 with bad_args when output paths are missing", async () => {
+    const { stdout, code } = await run(["build", fx("greet.ts")]);
+    expect(code).toBe(2);
+    expect(JSON.parse(stdout).error.kind).toBe("bad_args");
+  });
+});

--- a/cli/dust-sandbox/functions-runner/build.ts
+++ b/cli/dust-sandbox/functions-runner/build.ts
@@ -1,0 +1,77 @@
+// Build a sandbox function: bundle its source with its relative imports into a single module and
+// extract its JSON-Schema I/O contract.
+//
+// External packages (zod and the rest of the sandbox "harness") are left as imports, not inlined:
+// the sandbox provides them at invocation time, which keeps bundles small and shares a single zod
+// instance with the runner.
+//
+// The bundle and schema are written to files rather than returned on stdout:
+// `dsbx function build` invocations are read back out-of-band by the caller
+// (sandbox results can be truncated). stdout only carries a small
+// `{ ok: true }` / `{ ok: false, error }` envelope.
+
+import { getFunctionSchema } from "./schema.ts";
+
+export type BuildErrorKind =
+  | "bad_args"
+  | "build_failed"
+  | "schema_extraction_failed";
+
+export type BuildResult =
+  | { ok: true }
+  | { ok: false; error: { kind: BuildErrorKind; message: string } };
+
+export async function build(
+  srcPath: string,
+  outBundlePath: string,
+  outSchemaPath: string
+): Promise<BuildResult> {
+  // 1. Bundle the source with its relative imports into one module. External packages stay
+  //    as imports (`packages: "external"`) for the sandbox harness to resolve at invocation time.
+  let bundled: string;
+  try {
+    const result = await Bun.build({
+      entrypoints: [srcPath],
+      target: "bun",
+      packages: "external",
+      splitting: false,
+    });
+    if (!result.success) {
+      return {
+        ok: false,
+        error: {
+          kind: "build_failed",
+          message: result.logs.map((log) => String(log)).join("\n"),
+        },
+      };
+    }
+
+    bundled = await result.outputs[0].text();
+  } catch (e) {
+    return {
+      ok: false,
+      error: { kind: "build_failed", message: errorMessage(e) },
+    };
+  }
+
+  await Bun.write(outBundlePath, bundled);
+
+  // 2. Extract the schema from the built artifact. Importing it also validates that the bundle
+  //    loads and exposes a well-formed `schema` export.
+  try {
+    const schema = await getFunctionSchema(outBundlePath);
+
+    await Bun.write(outSchemaPath, JSON.stringify(schema));
+  } catch (e) {
+    return {
+      ok: false,
+      error: { kind: "schema_extraction_failed", message: errorMessage(e) },
+    };
+  }
+
+  return { ok: true };
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/cli/dust-sandbox/functions-runner/build.ts
+++ b/cli/dust-sandbox/functions-runner/build.ts
@@ -28,7 +28,7 @@ export async function build(
 ): Promise<BuildResult> {
   // 1. Bundle the source with its relative imports into one module. External packages stay
   //    as imports (`packages: "external"`) for the sandbox harness to resolve at invocation time.
-  let bundled: string;
+  let bundle: Blob;
   try {
     const result = await Bun.build({
       entrypoints: [srcPath],
@@ -46,7 +46,7 @@ export async function build(
       };
     }
 
-    bundled = await result.outputs[0].text();
+    bundle = result.outputs[0];
   } catch (e) {
     return {
       ok: false,
@@ -54,7 +54,9 @@ export async function build(
     };
   }
 
-  await Bun.write(outBundlePath, bundled);
+  // The build artifact is an in-memory Blob. Hand it to Bun.write directly so its bytes go
+  // straight to the file instead of being decoded into a JS string first.
+  await Bun.write(outBundlePath, bundle);
 
   // 2. Extract the schema from the built artifact. Importing it also validates that the bundle
   //    loads and exposes a well-formed `schema` export.

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env bun
-// Embedded runner for `dsbx function`. Two subcommands:
-//   runner run <path>   stdin request envelope -> stdout Output JSON
-//   runner get <path>   -> stdout FunctionSchema JSON (or {error})
+// Embedded runner for `dsbx function`. Subcommands:
+//   runner run <path>                            stdin request envelope -> stdout Output JSON
+//   runner get <path>                            -> stdout FunctionSchema JSON (or {error})
+//   runner build <src> <outBundle> <outSchema>   bundle + extract schema to files
 
+import { build } from "./build.ts";
 import { invoke } from "./invoke.ts";
 import { BadInputError, parseInput, type RequestInput } from "./protocol.ts";
 import { getFunctionSchema } from "./schema.ts";
@@ -37,8 +39,32 @@ async function getHandler(handlerPath: string): Promise<number> {
   }
 }
 
+async function buildHandler(args: string[]): Promise<number> {
+  const [srcPath, outBundlePath, outSchemaPath] = args;
+  if (!srcPath || !outBundlePath || !outSchemaPath) {
+    process.stdout.write(
+      `${JSON.stringify({
+        ok: false,
+        error: {
+          kind: "bad_args",
+          message: "usage: runner build <src> <outBundle> <outSchema>",
+        },
+      })}\n`
+    );
+    return 2;
+  }
+  const result = await build(srcPath, outBundlePath, outSchemaPath);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  return result.ok ? 0 : 1;
+}
+
 async function main(): Promise<number> {
-  const [command, handlerPath] = process.argv.slice(2);
+  const [command, ...rest] = process.argv.slice(2);
+  if (command === "build") {
+    return buildHandler(rest);
+  }
+
+  const [handlerPath] = rest;
   if (!handlerPath) {
     process.stderr.write("usage: runner <run|get> <handler-path>\n");
     return 2;

--- a/cli/dust-sandbox/src/commands/function/build.rs
+++ b/cli/dust-sandbox/src/commands/function/build.rs
@@ -1,0 +1,24 @@
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+
+use super::{emit_error, spawn_build};
+
+/// Build a function: bundle the source at `src` with its relative imports and
+/// extract its JSON-Schema contract, writing the bundle to `out_bundle` and the
+/// schema to `out_schema`. External packages are left as imports for the sandbox
+/// harness to resolve at invocation time.
+///
+/// Bundling and the schema-extracting import (which runs the module top-level)
+/// run unprivileged (agent uid) when dsbx is invoked as root, like run/get.
+/// stdout carries the runner's small `{ok}` / `{ok:false,error}` envelope, and
+/// the caller reads the bundle and schema back from the output files.
+pub async fn cmd_function_build(src: &str, out_bundle: &str, out_schema: &str) -> Result<()> {
+    let src_path = Path::new(src);
+    if !src_path.is_file() {
+        return Err(emit_error(anyhow!("source not found: {src}")));
+    }
+
+    let code = spawn_build(src_path, Path::new(out_bundle), Path::new(out_schema)).await?;
+    std::process::exit(code);
+}

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -9,13 +9,23 @@ use tempfile::{TempDir, TempPath};
 use tokio::io::AsyncReadExt as _;
 use tokio::process::Command;
 
+mod build;
 mod get;
 mod run;
 
+pub use build::cmd_function_build;
 pub use get::cmd_function_get;
 pub use run::cmd_function_run;
 
 const FUNCTIONS_DIR_ENV: &str = "DUST_FUNCTIONS_DIR";
+
+/// The image's global npm modules (NPM_CONFIG_PREFIX=/opt/npm-global), holding the external
+/// packages (zod and the curated `npm install -g` set) that function bundles leave as imports
+/// rather than inlining. We point the runner's `bun` child at it via NODE_PATH so those imports
+/// resolve wherever the bundle lives. This is the same global node_modules both the conversation
+/// and pod sandboxes use for typescript/tsx, so functions share one toolchain.
+/// TODO(SANDBOX FUNCTION) Consider adding a dedicated node_modules dedicated to sandbox functions.
+const FUNCTIONS_GLOBAL_NODE_MODULES: &str = "/opt/npm-global/lib/node_modules";
 
 /// The function bundle runner, pre-bundled (Zod inlined) at dev time and
 /// committed. Embedded so `dsbx` is a single binary; cross-compilation does
@@ -39,6 +49,15 @@ pub enum FunctionCommand {
     Get {
         /// Function name (resolved to ${DUST_FUNCTIONS_DIR}/<name>.ts)
         name: String,
+    },
+    /// Bundle a function source and extract its JSON-Schema contract to files
+    Build {
+        /// Path to the function source file (its relative imports are bundled)
+        src: String,
+        /// Output path for the bundle
+        out_bundle: String,
+        /// Output path for the extracted JSON-Schema contract
+        out_schema: String,
     },
 }
 
@@ -160,6 +179,75 @@ pub(crate) async fn spawn_function(
         dir.close().ok();
     }
     Ok((status.code().unwrap_or(1), captured))
+}
+
+/// Bundle the function source at `src` and extract its schema, writing the
+/// bundle to `out_bundle` and the schema to `out_schema`. Returns the runner
+/// exit code.
+///
+/// Like [`spawn_function`], the `bun` child (runner harness plus the untrusted
+/// module it imports to read the schema) is dropped to `agent-proxied` via
+/// `runuser` whenever `dsbx` runs privileged, so its egress is forced through
+/// the proxy. The source is read in place (its relative imports must resolve
+/// next to it, so it is not staged): the agent user reaches it through the same
+/// group-based `/files` access agent code has, and writes the outputs into the
+/// caller-owned scratch dir. stdout is inherited so the runner's `{ok}` envelope
+/// reaches the caller.
+pub(crate) async fn spawn_build(src: &Path, out_bundle: &Path, out_schema: &Path) -> Result<i32> {
+    let runner = ensure_runner()?;
+    let as_agent = running_as_root();
+    if as_agent {
+        // The dropped child must read the runner dsbx wrote as root.
+        set_mode(&runner, 0o644)
+            .map_err(|e| emit_error(anyhow!("failed to prepare runner: {e}")))?;
+    }
+
+    let mut cmd = if as_agent {
+        let mut c = Command::new("runuser");
+        c.arg("-u")
+            .arg(AGENT_USER)
+            .arg("--")
+            .arg("bun")
+            .arg(&*runner)
+            .arg("build")
+            .arg(src)
+            .arg(out_bundle)
+            .arg(out_schema);
+        c
+    } else {
+        let mut c = Command::new("bun");
+        c.arg(&*runner)
+            .arg("build")
+            .arg(src)
+            .arg(out_bundle)
+            .arg(out_schema);
+        c
+    };
+    cmd.env("NODE_PATH", harness_node_path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    let status = cmd
+        .status()
+        .await
+        .map_err(|e| emit_error(anyhow!("failed to run bun: {e}")))?;
+
+    runner.close().ok();
+
+    Ok(status.code().unwrap_or(1))
+}
+
+/// NODE_PATH for the runner child: the global npm modules first, then any
+/// inherited entries. NODE_PATH is additive, so a missing dir (local dev) falls
+/// back to normal node_modules resolution.
+fn harness_node_path() -> String {
+    match std::env::var("NODE_PATH") {
+        Ok(existing) if !existing.is_empty() => {
+            format!("{FUNCTIONS_GLOBAL_NODE_MODULES}:{existing}")
+        }
+        _ => FUNCTIONS_GLOBAL_NODE_MODULES.to_string(),
+    }
 }
 
 /// Copy a function bundle into a fresh temp dir as `<name>.ts`, world-readable,

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -8,7 +8,7 @@ mod version;
 
 pub use env::cmd_env;
 pub use forward::cmd_forward;
-pub use function::{cmd_function_get, cmd_function_run};
+pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;
 pub use resolve::cmd_resolve;
 pub use tools::{cmd_exec, cmd_list_servers, cmd_list_tools};

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -72,6 +72,11 @@ async fn run() -> anyhow::Result<()> {
             commands::function::FunctionCommand::Get { name } => {
                 commands::cmd_function_get(&name).await?
             }
+            commands::function::FunctionCommand::Build {
+                src,
+                out_bundle,
+                out_schema,
+            } => commands::cmd_function_build(&src, &out_bundle, &out_schema).await?,
         },
         Commands::Tools {
             json,
@@ -179,6 +184,34 @@ mod tests {
             Commands::Function { command } => match command {
                 commands::function::FunctionCommand::Get { name } => assert_eq!(name, "greet"),
                 _ => panic!("expected get"),
+            },
+            _ => panic!("expected function"),
+        }
+    }
+
+    #[test]
+    fn function_build_parses() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "function",
+            "build",
+            "/files/pod-x/greet.ts",
+            "/tmp/out/greet.ts",
+            "/tmp/out/greet.schema.json",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Function { command } => match command {
+                commands::function::FunctionCommand::Build {
+                    src,
+                    out_bundle,
+                    out_schema,
+                } => {
+                    assert_eq!(src, "/files/pod-x/greet.ts");
+                    assert_eq!(out_bundle, "/tmp/out/greet.ts");
+                    assert_eq!(out_schema, "/tmp/out/greet.schema.json");
+                }
+                _ => panic!("expected build"),
             },
             _ => panic!("expected function"),
         }

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.41",
+      tag: "0.8.42",
     });
   });
 
@@ -341,7 +341,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.28/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.29/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -19,8 +19,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.41";
-const DSBX_CLI_VERSION = "0.1.28";
+const DUST_BASE_IMAGE_VERSION = "0.8.42";
+const DSBX_CLI_VERSION = "0.1.29";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.
@@ -338,8 +338,14 @@ SHELLEOF`,
         description: "PowerPoint generation library",
         runtime: "node",
       },
+      {
+        name: "zod",
+        version: "4.4.3",
+        description: "Schema validation (sandbox function contracts)",
+        runtime: "node",
+      },
     ],
-    { installCmd: "npm install -g typescript tsx pptxgenjs@4.0.1" }
+    { installCmd: "npm install -g typescript tsx pptxgenjs@4.0.1 zod@4.4.3" }
   )
   .runCmd(
     `curl -fsSL https://github.com/dust-tt/dust/releases/download/dsbx-v${DSBX_CLI_VERSION}/dsbx-linux-x86_64 -o /tmp/dsbx && ` +


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds the build half of the sandbox functions publish flow. A new `dsbx` function build subcommand bundles a function's source with its relative imports into a single self-contained module and extracts its JSON-Schema input/output contract, writing both to files. External packages like `zod` are left as imports rather than inlined, so bundles stay small and leverage harness at runtime. Bundling and the schema-extracting import run unprivileged (agent uid) when dsbx is invoked as root, matching run and get.

Results are written to files rather than returned over stdout, since sandbox command output can be truncated. stdout only carries a small ok/error envelope, and the caller (MCP tool) reads the artifacts back.

The function toolchain now resolves from the image's shared global `node_modules` rather than a bespoke directory. We can challenge this later but for now since we expect models to create function from the conversation's sandbox, it's nice to share the same libs. zod is added to the existing global install the conversation and pod sandboxes already use, and the runner's `NODE_PATH` points there so external imports resolve wherever a bundle lives.

This bumps the `dsbx` CLI to 0.1.27 and the sandbox base image to 0.8.40.

> [!WARNING]
> Note the image references the new CLI version, so the dsbx 0.1.27 release must be cut before the 0.8.40 image is built.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
