### PR TITLE
Add sandbox readFile provider and route function bundles to a dedicated prefix

### DIFF
--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -4,6 +4,7 @@ import {
   getConversationFilePath,
   getConversationFilesBasePath,
   getPodFilesBasePath,
+  getPodSandboxFunctionsBasePath,
   isAgentScopedPath,
   isCanonicalScopedPath,
   isLegacyScopedPath,
@@ -51,6 +52,14 @@ describe("mount_path helpers", () => {
       expect(getPodFilesBasePath({ workspaceId: "ws1", podId: "spc1" })).toBe(
         "w/ws1/pods/spc1/files/"
       );
+    });
+  });
+
+  describe("getPodSandboxFunctionsBasePath", () => {
+    it("should return a dedicated prefix separate from pod files", () => {
+      expect(
+        getPodSandboxFunctionsBasePath({ workspaceId: "ws1", podId: "spc1" })
+      ).toBe("w/ws1/pods/spc1/sandbox_functions/");
     });
   });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -72,6 +72,22 @@ export function getPodFilesBasePath({
 }
 
 /**
+ * Dedicated prefix for published sandbox function bundles, separate from the R/W pod files prefix.
+ * `front` is the sole writer here, via the GCS API. The invocation path later mounts this prefix
+ * read-only into sandboxes as DUST_FUNCTIONS_DIR, so a function can be executed but never
+ * overwritten by a sandbox.
+ */
+export function getPodSandboxFunctionsBasePath({
+  workspaceId,
+  podId,
+}: {
+  workspaceId: string;
+  podId: string;
+}): string {
+  return `${getBaseMountPathForWorkspace({ workspaceId })}pods/${podId}/sandbox_functions/`;
+}
+
+/**
  * Given a mount file path like "w/.../files/report.pdf",
  * returns "w/.../files/report.processed.pdf".
  * For files without extension: "w/.../files/Makefile" -> "w/.../files/Makefile.processed".

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -547,11 +547,34 @@ export class E2BSandboxProvider implements SandboxProvider {
   }
 
   async readFile(
-    _providerId: string,
-    _path: string,
-    _tracingOpts: { workspaceId: string }
+    providerId: string,
+    path: string,
+    tracingOpts: { workspaceId: string }
   ): Promise<Buffer> {
-    throw new Error("readFile is not implemented yet.");
+    return traceSandboxOperation(
+      "readFile",
+      async () => {
+        let sandbox: Sandbox;
+        try {
+          sandbox = await Sandbox.connect(providerId, {
+            ...this.connectionOpts(),
+            timeoutMs: SANDBOX_LIFETIME_MS,
+          });
+        } catch (err) {
+          if (err instanceof NotFoundError) {
+            throw new SandboxNotFoundError(providerId);
+          }
+          throw normalizeError(err);
+        }
+
+        const bytes = await sandbox.files.read(path, { format: "bytes" });
+        return Buffer.from(bytes);
+      },
+      {
+        provider_id: providerId,
+        workspace_id: tracingOpts.workspaceId,
+      }
+    );
   }
 
   async listFiles(

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -19,6 +19,7 @@ import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   frameContentType,
   isUnverifiableFrameFileRefsShareError,
+  sandboxFunctionContentType,
 } from "@app/types/files";
 import { Readable } from "stream";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
@@ -1430,6 +1431,54 @@ describe("FileResource", () => {
           },
         ]);
       }
+    });
+  });
+
+  describe("sandbox function mount routing", () => {
+    it("resolves a sandbox function bundle under the dedicated prefix", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+      const space = await SpaceFactory.regular(workspace);
+
+      const bundleFile = await FileFactory.create(auth, null, {
+        contentType: sandboxFunctionContentType,
+        fileName: "greet.ts",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: space.sId },
+      });
+
+      const row = await FileModel.findOne({
+        where: { id: bundleFile.id, workspaceId: workspace.id },
+      });
+      expect(row?.mountFilePath).toBe(
+        `w/${workspace.sId}/pods/${space.sId}/sandbox_functions/greet.ts`
+      );
+    });
+
+    it("keeps regular project files under the pod files prefix", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+      const space = await SpaceFactory.regular(workspace);
+
+      const projectFile = await FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName: "notes.txt",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: space.sId },
+      });
+
+      const row = await FileModel.findOne({
+        where: { id: projectFile.id, workspaceId: workspace.id },
+      });
+      expect(row?.mountFilePath).toBe(
+        `w/${workspace.sId}/pods/${space.sId}/files/notes.txt`
+      );
     });
   });
 });

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -14,6 +14,7 @@ import {
   getConversationFilePath,
   getConversationFilesBasePath,
   getPodFilesBasePath,
+  getPodSandboxFunctionsBasePath,
   isLegacyScopedPath,
   makeProcessedMountFileName,
   resolveCanonicalScopedPath,
@@ -84,6 +85,7 @@ import {
   frameSlideshowContentType,
   isConversationFileUseCase,
   isInteractiveContentType,
+  isSandboxFunctionContentType,
 } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -1157,10 +1159,17 @@ export class FileResource extends BaseResource<FileModel> {
     { podId }: { podId: string }
   ): Promise<{ path: string; fallbackPath: string }> {
     const owner = auth.getNonNullableWorkspace();
-    const basePath = getPodFilesBasePath({
-      workspaceId: owner.sId,
-      podId,
-    });
+    // Sandbox function bundles route to their own front-owned prefix (see
+    // getPodSandboxFunctionsBasePath). Regular project files keep the R/W pod files prefix.
+    const basePath = isSandboxFunctionContentType(this.contentType)
+      ? getPodSandboxFunctionsBasePath({
+          workspaceId: owner.sId,
+          podId,
+        })
+      : getPodFilesBasePath({
+          workspaceId: owner.sId,
+          podId,
+        });
 
     const desiredPath = `${basePath}${this.fileName}`;
     const fallbackPath = `${basePath}${disambiguateFileName(this)}`;

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1016,6 +1016,40 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   }
 
   /**
+   * Read a file from the sandbox filesystem.
+   */
+  async readFile(
+    auth: Authenticator,
+    path: string
+  ): Promise<Result<Buffer, Error>> {
+    const provider = getSandboxProvider();
+    if (!provider) {
+      return new Err(new Error("Sandbox provider not configured."));
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+
+    try {
+      const data = await provider.readFile(this.providerId, path, {
+        workspaceId,
+      });
+
+      return new Ok(data);
+    } catch (err) {
+      if (err instanceof SandboxNotFoundError) {
+        logger.error(
+          { sandbox: this.toLogJSON() },
+          "Sandbox not found at provider during readFile — marking as deleted"
+        );
+
+        await this.updateStatus("deleted");
+      }
+
+      return new Err(normalizeError(err));
+    }
+  }
+
+  /**
    * Write a file to the sandbox filesystem.
    */
   async writeFile(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
On the same line as https://github.com/dust-tt/dust/pull/28165.

This PR implements file reads from the e2b sandbox provider, which previously threw, so callers can pull artifacts off a sandbox after they are written. Also introduces a dedicated storage prefix for published sandbox function bundles, separate from the read-write pod files prefix. Bundles are written only by front via the GCS API into a location that will be mounted as read-only on the function's sandbox. This is the storage and read plumbing the publish flow builds on. The publish tool and the read-only mount of this prefix for invocation come in the next PR.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
