### PR TITLE
[front] debug: log command output when runWithStdin fails. For debugging only.

### DIFF
--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -139,6 +139,26 @@ async function runWithStdin(
     });
     return await handle.wait();
   } catch (err) {
+    // Capture whatever the backgrounded command produced before it
+    // died, to understand why sendStdin/closeStdin fail with a missing pid.
+    // wait() throws on non-zero exit / missing process — we only call it to
+    // force the event stream to drain so handle.stdout/stderr are populated.
+    try {
+      await handle.wait();
+    } catch {
+      // Ignore: we just want the buffered output below.
+    }
+    logger.info(
+      {
+        command,
+        pid: handle.pid,
+        exitCode: handle.exitCode,
+        stdout: handle.stdout,
+        stderr: handle.stderr,
+        error: handle.error,
+      },
+      "[sandbox] runWithStdin failed; command output"
+    );
     try {
       await handle.kill();
     } catch {


### PR DESCRIPTION
## Description

When `sandbox.commands.sendStdin` / `closeStdin` fail in `runWithStdin` (E2B provider), we currently surface only the opaque E2B error:

```
[not_found] process with pid 2603 not found
```

This happens because the backgrounded command has already exited by the time we try to write to its stdin, so we never learn *why* the process died early.

This PR adds temporary debug instrumentation to the `catch` path: it drains the command handle (via a throwaway `handle.wait()`) so the buffered output is populated, then logs the command, pid, exit code, stdout, stderr, and the daemon's error message before re-throwing the original error.

## Notes

- No behavior change — the original error is still re-thrown and the handle is still killed best-effort.
- This is diagnostic logging to investigate the missing-pid failures; intended to be removed once the root cause is understood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)