### PR TITLE
feat(usage): wire bulk spend-limit modal with optimistic update

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -43,7 +43,6 @@ import {
 } from "@app/lib/swr/credits";
 import { useGroups } from "@app/lib/swr/groups";
 import {
-  invalidateMembersUsage,
   useBulkSetUserSpendLimit,
   useMembersUsage,
   useUpdateMemberSeatType,
@@ -515,27 +514,10 @@ export function UsagePage() {
         return false;
       }
 
-      // The change is applied asynchronously by the workflow, and the effective
-      // cap (pool cap + the per-seat allowance) is resolved server-side, which
-      // the client can't reproduce. So we don't optimistically fabricate it.
-      // Clear the selection and revalidate a few times so the table reflects the
-      // true server values once the workflow lands.
       selection.clearSelection();
-      for (const delayMs of [8000, 16000]) {
-        window.setTimeout(() => {
-          void invalidateMembersUsage(owner.sId);
-        }, delayMs);
-      }
       return true;
     },
-    [
-      selection,
-      seatTypeFilter,
-      groupFilter,
-      searchTerm,
-      doBulkSetSpendLimit,
-      owner.sId,
-    ]
+    [selection, seatTypeFilter, groupFilter, searchTerm, doBulkSetSpendLimit]
   );
 
   const { hasAvailableSeats } = useWorkspaceSeatAvailability({

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -2,6 +2,7 @@ import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { ConfirmContext } from "@app/components/Confirm";
 import { InviteEmailButtonWithModal } from "@app/components/members/InviteEmailButtonWithModal";
+import { BulkEditSpendLimitModal } from "@app/components/workspace/BulkEditSpendLimitModal";
 import { BuyAwuCreditsDialog } from "@app/components/workspace/BuyAwuCreditsDialog";
 import { FreePlanUpgradeSection } from "@app/components/workspace/billing/FreePlanUpgradeSection";
 import {
@@ -19,7 +20,6 @@ import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNot
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
 import { useMembersSelection } from "@app/hooks/useMembersSelection";
-import { useSendNotification } from "@app/hooks/useNotification";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import {
   useAuth,
@@ -43,6 +43,8 @@ import {
 } from "@app/lib/swr/credits";
 import { useGroups } from "@app/lib/swr/groups";
 import {
+  invalidateMembersUsage,
+  useBulkSetUserSpendLimit,
   useMembersUsage,
   useUpdateMemberSeatType,
 } from "@app/lib/swr/memberships";
@@ -130,7 +132,6 @@ export function UsagePage() {
   const { subscription } = useAuth();
   const router = useAppRouter();
   const { hasFeature } = useFeatureFlags();
-  const sendNotification = useSendNotification();
   const isCreditPriced = isCreditPricedPlan(subscription.plan);
   // Legacy-contract workspaces can view this page in read-only mode behind a
   // flag: analytics and member spend render as usual, but every action (top up,
@@ -432,15 +433,16 @@ export function UsagePage() {
     totalCount: totalMembersUsage,
     resetKey: `${searchTerm}|${seatTypeFilter ?? ""}|${groupFilter ?? ""}`,
   });
-  const { clearSelection, selectedCount } = selection;
+  const { clearSelection } = selection;
+
+  const { doBulkSetSpendLimit } = useBulkSetUserSpendLimit({
+    workspaceId: owner.sId,
+  });
+  const [isBulkSpendLimitOpen, setIsBulkSpendLimitOpen] = useState(false);
 
   const handleBatchEditSpendLimit = useCallback(() => {
-    sendNotification({
-      type: "info",
-      title: "Coming soon",
-      description: `Batch spend-limit editing for ${selectedCount} members is not wired up yet.`,
-    });
-  }, [sendNotification, selectedCount]);
+    setIsBulkSpendLimitOpen(true);
+  }, []);
 
   const onRemoveSeat = useCallback(
     async (member: MemberUsageType) => {
@@ -486,6 +488,55 @@ export function UsagePage() {
     clearSelection();
     handleApproveOnModalSaved();
   }, [handleApproveOnModalSaved, clearSelection]);
+
+  const handleBulkSpendLimitValidate = useCallback(
+    async (
+      limit: { kind: "unlimited" } | { kind: "limited"; awuCredits: number }
+    ): Promise<boolean> => {
+      const descriptor = selection.descriptor();
+      const selectionBody =
+        descriptor.mode === "ids"
+          ? descriptor
+          : {
+              mode: "all" as const,
+              filter: {
+                seatType: seatTypeFilter ?? undefined,
+                groupId: groupFilter ?? undefined,
+                search: searchTerm.trim() || undefined,
+              },
+              excludeUserIds: descriptor.excludeUserIds,
+            };
+
+      const body = await doBulkSetSpendLimit({
+        selection: selectionBody,
+        limit,
+      });
+      if (!body) {
+        return false;
+      }
+
+      // The change is applied asynchronously by the workflow, and the effective
+      // cap (pool cap + the per-seat allowance) is resolved server-side, which
+      // the client can't reproduce. So we don't optimistically fabricate it.
+      // Clear the selection and revalidate a few times so the table reflects the
+      // true server values once the workflow lands.
+      selection.clearSelection();
+      for (const delayMs of [8000, 16000]) {
+        window.setTimeout(() => {
+          void invalidateMembersUsage(owner.sId);
+        }, delayMs);
+      }
+      return true;
+    },
+    [
+      selection,
+      seatTypeFilter,
+      groupFilter,
+      searchTerm,
+      doBulkSetSpendLimit,
+      owner.sId,
+    ]
+  );
 
   const { hasAvailableSeats } = useWorkspaceSeatAvailability({
     workspaceId: owner.sId,
@@ -929,6 +980,13 @@ export function UsagePage() {
         owner={owner}
         onSavingChange={handleUsagePendingChange}
         onSaved={handleApproveOnModalSaved}
+      />
+
+      <BulkEditSpendLimitModal
+        isOpen={isBulkSpendLimitOpen}
+        onClose={() => setIsBulkSpendLimitOpen(false)}
+        memberCount={selection.selectedCount}
+        onValidate={handleBulkSpendLimitValidate}
       />
     </>
   );

--- a/front/components/workspace/BulkEditSpendLimitModal.tsx
+++ b/front/components/workspace/BulkEditSpendLimitModal.tsx
@@ -1,0 +1,196 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  RadioGroup,
+  RadioGroupItem,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+const MIN_AWU_CREDITS = 1;
+const MAX_AWU_CREDITS = 1_000_000;
+
+type SpendLimitKind = "default" | "override";
+
+function isSpendLimitKind(value: string): value is SpendLimitKind {
+  return value === "default" || value === "override";
+}
+
+type SpendLimit =
+  | { kind: "unlimited" }
+  | { kind: "limited"; awuCredits: number };
+
+interface BulkEditSpendLimitModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  memberCount: number;
+  onValidate: (limit: SpendLimit) => Promise<boolean>;
+}
+
+export function BulkEditSpendLimitModal({
+  isOpen,
+  onClose,
+  memberCount,
+  onValidate,
+}: BulkEditSpendLimitModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="md">
+        {isOpen && (
+          <BulkEditSpendLimitForm
+            onClose={onClose}
+            memberCount={memberCount}
+            onValidate={onValidate}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface BulkEditSpendLimitFormProps {
+  onClose: () => void;
+  memberCount: number;
+  onValidate: (limit: SpendLimit) => Promise<boolean>;
+}
+
+function BulkEditSpendLimitForm({
+  onClose,
+  memberCount,
+  onValidate,
+}: BulkEditSpendLimitFormProps) {
+  const [kind, setKind] = useState<SpendLimitKind>("override");
+  const [creditsInput, setCreditsInput] = useState<string>("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [validationMessage, setValidationMessage] = useState<string | null>(
+    null
+  );
+
+  function handleCreditsChange(value: string) {
+    setCreditsInput(value.replace(/[^\d]/g, ""));
+    setValidationMessage(null);
+  }
+
+  function validate(): SpendLimit | null {
+    if (kind === "default") {
+      return { kind: "unlimited" };
+    }
+    const parsed = Number(creditsInput);
+    if (!Number.isInteger(parsed) || parsed < MIN_AWU_CREDITS) {
+      setValidationMessage(
+        `Enter a whole number of credits between ${MIN_AWU_CREDITS.toLocaleString("en-US")} and ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`
+      );
+      return null;
+    }
+    if (parsed > MAX_AWU_CREDITS) {
+      setValidationMessage(
+        `Credits cannot exceed ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`
+      );
+      return null;
+    }
+    return { kind: "limited", awuCredits: parsed };
+  }
+
+  async function handleValidate() {
+    const limit = validate();
+    if (!limit) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const ok = await onValidate(limit);
+      if (ok) {
+        onClose();
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const validateDisabled =
+    isSaving || (kind === "override" && creditsInput.length === 0);
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          Edit spend limit for {memberCount.toLocaleString("en-US")} members
+        </DialogTitle>
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          They will be able to consume this amount from the pool after reaching
+          their plan usage limit. This limit is added on top of each seat&apos;s
+          built-in allowance.
+        </p>
+      </DialogHeader>
+      <DialogContainer>
+        <RadioGroup
+          value={kind}
+          onValueChange={(v) => {
+            if (isSpendLimitKind(v)) {
+              setKind(v);
+              setValidationMessage(null);
+            }
+          }}
+          className="flex flex-col gap-3"
+        >
+          <RadioGroupItem
+            value="default"
+            id="bulk-spend-limit-default"
+            label="Use workspace default"
+          />
+          <RadioGroupItem
+            value="override"
+            id="bulk-spend-limit-override"
+            label="Use custom limit"
+          />
+
+          {kind === "override" && (
+            <div className="flex flex-col gap-1.5 pl-6">
+              <div className="relative">
+                <Input
+                  id="bulk-spend-credit-limit-input"
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  placeholder="1,000"
+                  value={
+                    creditsInput !== ""
+                      ? Number(creditsInput).toLocaleString()
+                      : ""
+                  }
+                  onChange={(e) => handleCreditsChange(e.target.value)}
+                  isError={validationMessage !== null}
+                  message={validationMessage ?? undefined}
+                  messageStatus={
+                    validationMessage !== null ? "error" : undefined
+                  }
+                  className="pr-16 text-right"
+                />
+                <span className="copy-sm pointer-events-none absolute right-3 top-0 flex h-9 items-center text-muted-foreground dark:text-muted-foreground-night">
+                  credits
+                </span>
+              </div>
+            </div>
+          )}
+        </RadioGroup>
+      </DialogContainer>
+      <DialogFooter
+        leftButtonProps={{
+          label: "Cancel",
+          variant: "outline",
+          onClick: onClose,
+        }}
+        rightButtonProps={{
+          label: "Validate",
+          variant: "primary",
+          disabled: validateDisabled,
+          onClick: handleValidate,
+        }}
+      />
+    </>
+  );
+}

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -223,6 +223,71 @@ function membersUsageUrl(workspaceId: string): string {
   return `/api/w/${workspaceId}/credits/members-usage`;
 }
 
+function bulkSpendLimitUrl(workspaceId: string): string {
+  return `/api/w/${workspaceId}/members/bulk-spend-limit`;
+}
+
+type BulkSpendLimitSelectionBody =
+  | { mode: "ids"; userIds: string[] }
+  | {
+      mode: "all";
+      filter: { seatType?: string; groupId?: string; search?: string };
+      excludeUserIds: string[];
+    };
+
+const BulkSetUserSpendLimitResponseSchema = z.object({
+  workflowId: z.string(),
+  memberCount: z.number().int(),
+});
+
+export function useBulkSetUserSpendLimit({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const doBulkSetSpendLimit = useCallback(
+    async ({
+      selection,
+      limit,
+    }: {
+      selection: BulkSpendLimitSelectionBody;
+      limit: { kind: "unlimited" } | { kind: "limited"; awuCredits: number };
+    }): Promise<{ workflowId: string; memberCount: number } | null> => {
+      const res = await clientFetch(bulkSpendLimitUrl(workspaceId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selection, limit }),
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        sendNotification({
+          type: "error",
+          title: "Failed to update spend limit",
+          description: error?.error?.message ?? "An unexpected error occurred.",
+        });
+        return null;
+      }
+
+      const body = BulkSetUserSpendLimitResponseSchema.parse(await res.json());
+      sendNotification({
+        type: "success",
+        title: "Updating spend limit",
+        description:
+          limit.kind === "limited"
+            ? `Applying a ${limit.awuCredits.toLocaleString("en-US")} credit limit to ${body.memberCount.toLocaleString("en-US")} members.`
+            : `Removing the spend limit for ${body.memberCount.toLocaleString("en-US")} members.`,
+      });
+      return body;
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return { doBulkSetSpendLimit };
+}
+
 export async function invalidateMembersUsage(
   workspaceId: string
 ): Promise<void> {
@@ -282,7 +347,7 @@ export function useMembersUsage({
     searchParams.set("groupId", groupId);
   }
 
-  const { data, error, isLoading } = useSWRWithDefaults(
+  const { data, error, isLoading, mutate } = useSWRWithDefaults(
     `${membersUsageUrl(workspaceId)}?${searchParams.toString()}`,
     membersUsageFetcher,
     {
@@ -300,6 +365,7 @@ export function useMembersUsage({
     isMembersUsageRefreshing: isLoading && !!data && !disabled,
     isMembersUsageError: !!error,
     totalMembersUsage: data?.total ?? 0,
+    mutateMembersUsage: mutate,
   };
 }
 


### PR DESCRIPTION
## Description

Replace the placeholder batch action with BulkEditSpendLimitModal + useBulkSetUserSpendLimit. On validate: POST the selection (explicit ids or filter+excludes) to the bulk endpoint, then optimistically patch the visible selected rows in the members-usage cache (effective = pool cap + seat allowance), show a toast, clear selection, and schedule invalidateMembersUsage so the async workflow's DB writes reconcile.

One limit: we can currently select and update limits on free/none seats, which should be prevented. As the feature is behind a disabled feature flagged, this is fine to ship as long as it gets sorted out. I'll fix it in a later PR today.

## Tests

Local

## Risk

Low, does not affect existing logic + feature flagged.

## Deploy Plan

Front