### PR TITLE
Bump sandbox image for dsbx 0.1.27

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2021"
 
 [[bin]]

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.39",
+      tag: "0.8.40",
     });
   });
 
@@ -341,7 +341,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.26/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.27/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -19,8 +19,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.39";
-const DSBX_CLI_VERSION = "0.1.26";
+const DUST_BASE_IMAGE_VERSION = "0.8.40";
+const DSBX_CLI_VERSION = "0.1.27";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.


### PR DESCRIPTION
## Description

Bumps `dust-sandbox` to `0.1.27` and points `dust-base` at `0.8.40`, so the sandbox image build downloads `dsbx-v0.1.27`.

## Tests

- `cargo metadata --locked --no-deps --format-version 1`
- `npx biome check lib/api/sandbox/image/registry.ts lib/api/sandbox/image/registry.test.ts`
- `NODE_ENV=test npm test -- lib/api/sandbox/image/registry.test.ts`

## Risk

Low code risk. The main risk is running the image build before the `dsbx-v0.1.27` release asset exists. Worst case, do not deploy the new image and keep creating `dust-base_0-8-39` sandboxes.

## Deploy Plan

- [ ] Merge this PR.
- [ ] Publish `dsbx-v0.1.27` from main.
- [ ] Run the sandbox image registry workflow to build `dust-base_0-8-40` in EU and US E2B.
- [ ] Deploy front so new sandboxes are created from `dust-base_0-8-40`.
- [ ] After deploy, open `/poke/kill` and request a kill of older `dust-base` versions so existing conversations get fresh sandboxes.
- [ ] Recreate the smoke-test pod sandbox before rerunning the end-to-end sandbox function smoke.