### PR TITLE
Accept sandbox function result tokens

### DIFF
--- a/front-api/middlewares/ctx.ts
+++ b/front-api/middlewares/ctx.ts
@@ -1,4 +1,4 @@
-import type { SandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import type { SandboxTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import type { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import type { PokeRole } from "@app/lib/poke/roles";
@@ -33,12 +33,12 @@ export type PublicApiCtx = {
   };
 };
 
-// Sandbox action callback endpoints. Authenticated by `sandboxAuth`, which
-// also exposes the verified token claims so handlers don't re-verify the token.
+// Sandbox callback endpoints. Authenticated by `sandboxAuth`, which also
+// exposes the verified token claims so handlers don't re-verify the token.
 export type SandboxCtx = {
   Variables: {
     auth: Authenticator;
-    sandboxClaims: SandboxExecTokenPayload;
+    sandboxClaims: SandboxTokenPayload;
   };
 };
 

--- a/front-api/middlewares/sandbox_auth.ts
+++ b/front-api/middlewares/sandbox_auth.ts
@@ -1,5 +1,6 @@
 import {
   isSandboxExecTokenPayload,
+  isSandboxFunctionInvocationTokenPayload,
   verifySandboxExecToken,
 } from "@app/lib/api/sandbox/access_tokens";
 import {
@@ -10,10 +11,15 @@ import {
 import { getClientIp } from "@app/lib/utils/request";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import type { SandboxCtx } from "@front-api/middlewares/ctx";
-import type { Context } from "hono";
+import type { Context, MiddlewareHandler } from "hono";
 import { createMiddleware } from "hono/factory";
 
 import { apiError } from "./utils";
+
+type SandboxTokenKind = "action" | "function_invocation";
+type SandboxAuthOptions = {
+  tokenKind: SandboxTokenKind;
+};
 
 function readHeaders(ctx: Context): Record<string, string> {
   const headers: Record<string, string> = {};
@@ -24,88 +30,108 @@ function readHeaders(ctx: Context): Record<string, string> {
 }
 
 /**
- * Authenticates a sandbox action callback request. Requires a sandbox token in
- * the Authorization header, resolves the sandbox `Authenticator`, enforces the
- * `sandbox_tools` flag, and stashes both `auth` and the verified token
+ * Authenticates a sandbox callback request. Requires a sandbox token in the
+ * Authorization header, resolves the sandbox `Authenticator`, enforces the
+ * route token kind, and stashes both `auth` and the verified token
  * `sandboxClaims` on the context so handlers don't re-verify the token.
  *
  * Mirrors `withSandboxAuthentication` in `front/lib/api/auth_wrappers.ts`.
  */
-export const sandboxAuth = createMiddleware<SandboxCtx>(async (ctx, next) => {
-  const wId = ctx.req.param("wId");
-  if (!wId) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
-    });
-  }
+export function sandboxAuth({
+  tokenKind,
+}: SandboxAuthOptions): MiddlewareHandler<SandboxCtx> {
+  return createMiddleware<SandboxCtx>(async (ctx, next) => {
+    const wId = ctx.req.param("wId");
+    if (!wId) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_not_found",
+          message: "The workspace was not found.",
+        },
+      });
+    }
 
-  const token = ctx.req.header("authorization")?.replace("Bearer ", "");
-  if (!token) {
-    return apiError(ctx, {
-      status_code: 401,
-      api_error: {
-        type: "not_authenticated",
-        message: "The request does not have valid authentication credentials.",
-      },
-    });
-  }
-  if (getAuthTokenKind(token) !== "sandbox_token") {
-    return apiError(ctx, {
-      status_code: 401,
-      api_error: {
-        type: "not_authenticated",
-        message: "This endpoint requires a sandbox token.",
-      },
-    });
-  }
+    const token = ctx.req.header("authorization")?.replace("Bearer ", "");
+    if (!token) {
+      return apiError(ctx, {
+        status_code: 401,
+        api_error: {
+          type: "not_authenticated",
+          message:
+            "The request does not have valid authentication credentials.",
+        },
+      });
+    }
+    if (getAuthTokenKind(token) !== "sandbox_token") {
+      return apiError(ctx, {
+        status_code: 401,
+        api_error: {
+          type: "not_authenticated",
+          message: "This endpoint requires a sandbox token.",
+        },
+      });
+    }
 
-  const claims = await verifySandboxExecToken(token);
-  if (!claims) {
-    return apiError(ctx, {
-      status_code: 401,
-      api_error: {
-        type: "invalid_sandbox_token_error",
-        message: "The sandbox token is invalid or expired.",
-      },
-    });
-  }
-  if (!isSandboxExecTokenPayload(claims)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "invalid_request_error",
-        message: "This sandbox token cannot access sandbox actions.",
-      },
-    });
-  }
+    const claims = await verifySandboxExecToken(token);
+    if (!claims) {
+      return apiError(ctx, {
+        status_code: 401,
+        api_error: {
+          type: "invalid_sandbox_token_error",
+          message: "The sandbox token is invalid or expired.",
+        },
+      });
+    }
+    if (tokenKind === "action" && !isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot access sandbox actions.",
+        },
+      });
+    }
+    if (
+      tokenKind === "function_invocation" &&
+      !isSandboxFunctionInvocationTokenPayload(claims)
+    ) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "This sandbox token cannot access sandbox function invocations.",
+        },
+      });
+    }
 
-  const authRes = await Authenticator.fromSandboxToken(claims, wId);
-  if (authRes.isErr()) {
-    return apiError(ctx, authRes.error);
-  }
-  const auth = authRes.value;
+    const authRes = await Authenticator.fromSandboxToken(claims, wId);
+    if (authRes.isErr()) {
+      return apiError(ctx, authRes.error);
+    }
+    const auth = authRes.value;
 
-  const featureFlags = await getFeatureFlags(auth);
-  if (!isComputerFeatureEnabled(featureFlags)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Sandbox tools are not enabled for this workspace.",
-      },
-    });
-  }
+    if (tokenKind === "action") {
+      const featureFlags = await getFeatureFlags(auth);
+      if (!isComputerFeatureEnabled(featureFlags)) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Sandbox tools are not enabled for this workspace.",
+          },
+        });
+      }
+    }
 
-  const ip = getClientIp({ headers: readHeaders(ctx) });
-  if (ip !== "internal") {
-    auth.setClientIp(ip);
-  }
+    const ip = getClientIp({ headers: readHeaders(ctx) });
+    if (ip !== "internal") {
+      auth.setClientIp(ip);
+    }
 
-  ctx.set("auth", auth);
-  ctx.set("sandboxClaims", claims);
-  await next();
-});
+    ctx.set("auth", auth);
+    ctx.set("sandboxClaims", claims);
+    await next();
+  });
+}

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.ts
@@ -1,5 +1,6 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -32,9 +33,7 @@ export type FetchConversationMessageActionResponse =
   | CallToolPendingResponse
   | CallToolRejectedResponse;
 
-// Mounted at /api/v1/w/:wId/sandbox/actions/:aId. sandboxAuth is applied by
-// the parent sandbox sub-app, so ctx.get("auth") and ctx.get("sandboxClaims")
-// are always available here.
+// Mounted at /api/v1/w/:wId/sandbox/actions/:aId.
 const app = sandboxApp();
 
 /**
@@ -47,6 +46,15 @@ app.get(
   async (ctx): HandlerResult<FetchConversationMessageActionResponse> => {
     const auth = ctx.get("auth");
     const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot access sandbox actions.",
+        },
+      });
+    }
 
     const { aId } = ctx.req.valid("param");
 

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -1,3 +1,4 @@
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import { createSandboxChildAction } from "@app/lib/api/sandbox/create_child_action";
 import logger from "@app/logger/logger";
 import { CallMCPToolRequestBodySchema } from "@dust-tt/client";
@@ -11,9 +12,7 @@ type CallSandboxToolResponse = {
   actionId: string;
 };
 
-// Mounted at /api/v1/w/:wId/sandbox/actions/call. sandboxAuth is applied by
-// the parent sandbox sub-app, so ctx.get("auth") and ctx.get("sandboxClaims")
-// are always available here.
+// Mounted at /api/v1/w/:wId/sandbox/actions/call.
 const app = sandboxApp();
 
 /**
@@ -26,6 +25,15 @@ app.post(
   async (ctx): HandlerResult<CallSandboxToolResponse> => {
     const auth = ctx.get("auth");
     const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot access sandbox actions.",
+        },
+      });
+    }
 
     const {
       serverViewId,

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.test.ts
@@ -1,4 +1,7 @@
-import { createSandboxTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
+import {
+  createSandboxFunctionInvocationTokenTestContext,
+  createSandboxTokenTestContext,
+} from "@app/tests/utils/SandboxTokenFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
@@ -55,5 +58,22 @@ describe("GET /api/v1/w/[wId]/sandbox/actions", () => {
     for (const serverView of body.serverViews) {
       expect(serverView.server.availability).not.toBe("manual");
     }
+  });
+
+  it("rejects sandbox function invocation tokens", async () => {
+    const { token, workspace } =
+      await createSandboxFunctionInvocationTokenTestContext({
+        enableSandboxTools: true,
+      });
+
+    const response = await getSandboxActions(workspace, token);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "This sandbox token cannot access sandbox actions.",
+      },
+    });
   });
 });

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
@@ -6,8 +6,10 @@ import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { sandboxApp } from "@front-api/middlewares/ctx";
+import { sandboxAuth } from "@front-api/middlewares/sandbox_auth";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 
@@ -18,10 +20,10 @@ interface GetSandboxToolsResponseType {
   serverViews: MCPServerViewType[];
 }
 
-// Mounted at /api/v1/w/:wId/sandbox/actions. sandboxAuth is applied by the
-// parent sandbox sub-app, so ctx.get("auth") and ctx.get("sandboxClaims") are
-// always available here.
+// Mounted at /api/v1/w/:wId/sandbox/actions.
 const app = sandboxApp();
+
+app.use("*", sandboxAuth({ tokenKind: "action" }));
 
 /**
  * @ignoreswagger
@@ -29,7 +31,17 @@ const app = sandboxApp();
  */
 app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
   const auth = ctx.get("auth");
-  const { aId: agentId, cId } = ctx.get("sandboxClaims");
+  const claims = ctx.get("sandboxClaims");
+  if (!isSandboxExecTokenPayload(claims)) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "This sandbox token cannot access sandbox actions.",
+      },
+    });
+  }
+  const { aId: agentId, cId } = claims;
 
   // Fetch agent accessible servers.
   const agentConfig = await getAgentConfiguration(auth, {

--- a/front-api/routes/v1/w/[wId]/sandbox/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/index.ts
@@ -1,16 +1,13 @@
 import { sandboxApp } from "@front-api/middlewares/ctx";
-import { sandboxAuth } from "@front-api/middlewares/sandbox_auth";
 
 import actions from "./actions";
 import sandboxFunctions from "./sandbox-functions";
 
 // Mounted at /api/v1/w/:wId/sandbox. This sub-tree is mounted before
 // `publicWorkspaceApp` in `routes/v1/index.ts` so it does not inherit
-// `publicApiAuth`. Every route below authenticates via `sandboxAuth`, which
-// accepts only sandbox tokens and exposes the verified token claims on `ctx`.
+// `publicApiAuth`. Every route below mounts `sandboxAuth` with an explicit
+// token kind.
 const app = sandboxApp();
-
-app.use("*", sandboxAuth);
 
 app.route("/actions", actions);
 app.route("/sandbox-functions", sandboxFunctions);

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/index.ts
@@ -1,11 +1,12 @@
 import { sandboxApp } from "@front-api/middlewares/ctx";
+import { sandboxAuth } from "@front-api/middlewares/sandbox_auth";
 
 import result from "./result";
 
-// Mounted at /api/v1/w/:wId/sandbox/sandbox-functions. sandboxAuth is applied
-// by the parent sandbox sub-app, so ctx.get("auth") and ctx.get("sandboxClaims")
-// are always available here.
+// Mounted at /api/v1/w/:wId/sandbox/sandbox-functions.
 const app = sandboxApp();
+
+app.use("*", sandboxAuth({ tokenKind: "function_invocation" }));
 
 app.route("/result", result);
 

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
@@ -1,4 +1,7 @@
-import { createSandboxTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
+import {
+  createSandboxFunctionInvocationTokenTestContext,
+  createSandboxTokenTestContext,
+} from "@app/tests/utils/SandboxTokenFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
@@ -21,10 +24,22 @@ function postSandboxFunctionResult(
 }
 
 describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
-  it("returns success for sandbox-authenticated result callbacks", async () => {
-    const { token, workspace } = await createSandboxTokenTestContext({
-      enableSandboxTools: true,
+  it("returns success for sandbox function invocation result callbacks", async () => {
+    const { token, workspace } =
+      await createSandboxFunctionInvocationTokenTestContext();
+
+    const response = await postSandboxFunctionResult(workspace, token, {
+      function: "test_function",
+      result: { hello: "world" },
     });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+  });
+
+  it("keeps accepting callbacks without a function name", async () => {
+    const { token, workspace } =
+      await createSandboxFunctionInvocationTokenTestContext();
 
     const response = await postSandboxFunctionResult(workspace, token, {
       result: { hello: "world" },
@@ -32,5 +47,25 @@ describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ success: true });
+  });
+
+  it("rejects sandbox action tokens", async () => {
+    const { token, workspace } = await createSandboxTokenTestContext({
+      enableSandboxTools: true,
+    });
+
+    const response = await postSandboxFunctionResult(workspace, token, {
+      function: "test_function",
+      result: { hello: "world" },
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message:
+          "This sandbox token cannot access sandbox function invocations.",
+      },
+    });
   });
 });

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 
 const PostSandboxFunctionResultRequestBodySchema = z
   .object({
+    function: z.string().optional(),
     result: z.unknown(),
   })
   .strict();
@@ -25,10 +26,11 @@ app.post(
   async (ctx): HandlerResult<SuccessResponseBody> => {
     const auth = ctx.get("auth");
     const sandboxClaims = ctx.get("sandboxClaims");
-    const { result } = ctx.req.valid("json");
+    const { function: functionName, result } = ctx.req.valid("json");
 
     void auth;
     void sandboxClaims;
+    void functionName;
     void result;
 
     // TODO(spolu): Post the result event to the sandbox function invocation stream.

--- a/front/tests/utils/SandboxTokenFactory.ts
+++ b/front/tests/utils/SandboxTokenFactory.ts
@@ -1,5 +1,8 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { generateSandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
+import {
+  generateSandboxExecToken,
+  generateSandboxFunctionInvocationToken,
+} from "@app/lib/api/sandbox/access_tokens";
 import { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -106,6 +109,33 @@ export async function createSandboxTokenTestContext({
     conversation,
     sandbox,
     agentMessage,
+    token,
+  };
+}
+
+export async function createSandboxFunctionInvocationTokenTestContext({
+  enableSandboxTools = false,
+  disableComputerFeature = false,
+}: {
+  enableSandboxTools?: boolean;
+  disableComputerFeature?: boolean;
+} = {}) {
+  const context = await createSandboxTokenTestContext({
+    enableSandboxTools,
+    disableComputerFeature,
+  });
+  const token = await generateSandboxFunctionInvocationToken(context.auth, {
+    sandbox: context.sandbox,
+    sandboxFunction: {
+      sId: "sfn_test",
+      space: { sId: context.globalSpace.sId },
+    },
+    invocationId: `test-invocation-${context.sandbox.sId}`,
+    execId: `test-function-exec-${context.sandbox.sId}`,
+  });
+
+  return {
+    ...context,
     token,
   };
 }


### PR DESCRIPTION
## Description

Follow up of #28123.

Root cause: the result callback endpoint was still authenticated like a sandbox action callback, so a sandbox function invocation token could be rejected before the stub result handler ran. The callback path also inherited the `sandbox_tools`/Computer gate even though invocation is controlled before token minting, and the strict result body schema did not accept the `function` field now posted by `dsbx function run`.

This PR mounts sandbox auth with an explicit token kind for each sandbox subtree: `/sandbox/actions/*` requires sandbox exec tokens and keeps the Computer gate, while `/sandbox/sandbox-functions/*` requires sandbox function invocation tokens and relies on the signed token. It also accepts the optional `function` field on result callbacks.

## Tests

- `front-api`: `NODE_ENV=test npm test -- routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts routes/v1/w/[wId]/sandbox/actions/index.test.ts`
- `front-api`: `npx tsgo --noEmit`
- `front-api`: `npm run lint:swagger-annotations`
- Local smoke in `sandbox-function-smoke`: callback contract returned 200 and full `SandboxFunctionResource.invoke` returned `status: "created"` with `SBX_DEV_UNRESTRICTED_EGRESS=true` and `SBX_DEV_FRONT_URL` set to an HTTPS tunnel.

## Risk

Worst case, sandbox function result callbacks keep failing. Safe to rollback.

## Deploy Plan

- [ ] Merge this PR.
- [ ] Deploy front.