### PR TITLE
fix: wire Metronome contract for CP_FREE_PLAN workspaces created via Poke

### DIFF
--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -19,6 +19,7 @@ import { CREDIT_PRICED_FREE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { terminateScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
@@ -49,9 +50,9 @@ export async function isMetronomeBillingEnabled(
  * - Unpauses all connectors (including webcrawler connectors)
  * - Re-enables all triggers that point to non-archived agents
  */
-export async function activateCreditPricedFreePlan(
+async function provisionCreditPricedFreePlan(
   auth: Authenticator,
-  countryCode?: string
+  { user, countryCode }: { user?: UserResource; countryCode?: string }
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
   const lightWorkspace = renderLightWorkspaceType({ workspace: owner });
@@ -88,7 +89,6 @@ export async function activateCreditPricedFreePlan(
   }
   const { metronomeCustomerId } = customerResult.value;
 
-  const user = auth.user();
   if (user) {
     const seatResult = await updateMembershipSeatAndTrack({
       user,
@@ -137,6 +137,28 @@ export async function activateCreditPricedFreePlan(
 
   await invalidateContractCache(owner.sId);
   await restoreWorkspaceAfterSubscription(auth);
+}
+
+// Called during normal user signup (/trial/start). Provisions the Metronome
+// contract and assigns a "free" seat to the workspace creator.
+export async function activateCreditPricedFreePlan(
+  auth: Authenticator,
+  countryCode?: string
+): Promise<void> {
+  await provisionCreditPricedFreePlan(auth, {
+    user: auth.getNonNullableUser(),
+    countryCode,
+  });
+}
+
+// Called during workspace creation via the Poke plugin. No user is present yet
+// (the workspace was just created and no member has joined), so seat assignment
+// is skipped. Invited users receive a seat type through the membership flow.
+export async function activateCreditPricedFreePlanForWorkspace(
+  auth: Authenticator,
+  countryCode?: string
+): Promise<void> {
+  await provisionCreditPricedFreePlan(auth, { countryCode });
 }
 
 export async function restoreWorkspaceAfterSubscription(auth: Authenticator) {

--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -88,17 +88,19 @@ export async function activateCreditPricedFreePlan(
   }
   const { metronomeCustomerId } = customerResult.value;
 
-  const user = auth.getNonNullableUser();
-  const seatResult = await updateMembershipSeatAndTrack({
-    user,
-    workspace: lightWorkspace,
-    newSeatType: "free",
-    author: "no-author",
-  });
-  if (seatResult.isErr()) {
-    throw new Error(
-      `Failed to update user to free seat: ${seatResult.error.type}`
-    );
+  const user = auth.user();
+  if (user) {
+    const seatResult = await updateMembershipSeatAndTrack({
+      user,
+      workspace: lightWorkspace,
+      newSeatType: "free",
+      author: "no-author",
+    });
+    if (seatResult.isErr()) {
+      throw new Error(
+        `Failed to update user to free seat: ${seatResult.error.type}`
+      );
+    }
   }
 
   const contractResult = await provisionMetronomeContract({

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -1,7 +1,4 @@
-import {
-  activateCreditPricedFreePlan,
-  isMetronomeBillingEnabled,
-} from "@app/lib/api/subscription";
+import { activateCreditPricedFreePlanForWorkspace } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -103,11 +100,8 @@ export async function createWorkspaceInternal({
   await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
   if (planCode) {
-    if (
-      isCreditPricedFreePlan(planCode) &&
-      (await isMetronomeBillingEnabled(auth))
-    ) {
-      await activateCreditPricedFreePlan(auth);
+    if (isCreditPricedFreePlan(planCode)) {
+      await activateCreditPricedFreePlanForWorkspace(auth);
     } else {
       const newSubscription =
         await SubscriptionResource.internalSubscribeWorkspaceToFreePlan({

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -1,8 +1,16 @@
+import {
+  activateCreditPricedFreePlan,
+  isMetronomeBillingEnabled,
+} from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { PlanModel } from "@app/lib/models/plan";
-import { isFreePlan, isUpgraded } from "@app/lib/plans/plan_codes";
+import {
+  isCreditPricedFreePlan,
+  isFreePlan,
+  isUpgraded,
+} from "@app/lib/plans/plan_codes";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -95,20 +103,27 @@ export async function createWorkspaceInternal({
   await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
   if (planCode) {
-    const newSubscription =
-      await SubscriptionResource.internalSubscribeWorkspaceToFreePlan({
-        workspaceId: workspace.sId,
-        planCode,
-        endDate,
-      });
+    if (
+      isCreditPricedFreePlan(planCode) &&
+      (await isMetronomeBillingEnabled(auth))
+    ) {
+      await activateCreditPricedFreePlan(auth);
+    } else {
+      const newSubscription =
+        await SubscriptionResource.internalSubscribeWorkspaceToFreePlan({
+          workspaceId: workspace.sId,
+          planCode,
+          endDate,
+        });
 
-    if (isUpgraded(newSubscription.getPlan())) {
-      const orgRes = await getOrCreateWorkOSOrganization(lightWorkspace);
-      if (orgRes.isErr()) {
-        logger.error(
-          { error: orgRes.error, workspaceId: workspace.sId },
-          "Failed to create WorkOS organization during workspace creation"
-        );
+      if (isUpgraded(newSubscription.getPlan())) {
+        const orgRes = await getOrCreateWorkOSOrganization(lightWorkspace);
+        if (orgRes.isErr()) {
+          logger.error(
+            { error: orgRes.error, workspaceId: workspace.sId },
+            "Failed to create WorkOS organization during workspace creation"
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- `createWorkspaceInternal` (used by the Poke create_workspace plugin) was calling `internalSubscribeWorkspaceToFreePlan` for `CP_FREE_PLAN` workspaces, which only ensured a Metronome customer but never provisioned a contract. This left `metronomeContractId` null on the subscription, causing users who joined those workspaces to land in `on_pool` state.
- When `planCode` is `CP_FREE_PLAN` and Metronome billing is enabled, `createWorkspaceInternal` now calls `activateCreditPricedFreePlan` directly, which provisions the customer + contract + subscription with the contract ID wired in.
- Made the user seat-assignment step in `activateCreditPricedFreePlan` conditional on `auth.user()` being present. When called from `internalAdminForWorkspace` (no user, as at workspace creation time), the seat step is skipped — seat types are assigned when members join via the normal membership flow. Existing callers (e.g. `trial/start`) always have a user and are unaffected.

## Risk

Low. The change only affects Poke-created workspaces on `CP_FREE_PLAN` with Metronome enabled

## Testing

Use Poke create_workspace with `CP_FREE_PLAN` on staging