### PR TITLE
fix(teams): list_messages pagination, createdDateTime range, and tool description

### DIFF
--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -99,7 +99,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   },
   list_messages: {
     description:
-      "List messages from a Teams channel or chat (1:1, group, or meeting chat). Provide either chatId (for chats) or both teamId + channelId (for channels). For channels, returns top-level messages only. To read a full thread, call again with a messageId. For chats, returns all messages. Supports pagination and date range filtering.",
+      "List messages from a Teams channel or chat (1:1, group, or meeting chat). Provide either chatId (for chats) or both teamId + channelId (for channels). For channels, returns top-level messages only; to read a full thread, call again with a messageId. messageId is supported for channels only, not for chats. For chats, returns all messages. Supports pagination and date range filtering.",
     schema: {
       chatId: z
         .string()
@@ -123,7 +123,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "Optional. The ID of a top-level message. When set, returns that message's thread replies instead of the channel's messages."
+          "Optional, channels only. The ID of a top-level channel message; when set, returns that message's thread replies instead of the channel's top-level messages. Not supported for chats."
         ),
       fromDate: z
         .string()

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -256,11 +256,10 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         );
       }
 
-      // Filter on createdDateTime, not lastModifiedDateTime: a message sent in
-      // the range but edited/reacted-to later (which bumps lastModifiedDateTime)
-      // must still count as in-range, and a message sent outside the range must
-      // not be pulled in by a later edit. "Messages between April and May" means
-      // sent then.
+      // Range on createdDateTime, not lastModifiedDateTime: a message sent
+      // in-range but edited/reacted-to later (which bumps lastModifiedDateTime)
+      // must still count, and one sent outside the range must not be pulled in
+      // by a later edit.
       const isMessageInDateRange = (message: TeamsMessage): boolean => {
         const messageDate = new Date(message.createdDateTime);
         const afterFromDate = !fromDateTime || messageDate >= fromDateTime;
@@ -275,14 +274,11 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
 
       let request = client.api(baseEndpoint).top(MESSAGES_PAGE_SIZE);
 
-      // The chat messages listing supports $orderby/$filter; the channel
-      // endpoint does not, and is always ordered by lastModifiedDateTime of the
-      // reply chain. We also don't push filters on the per-message replies
-      // endpoint (conservative — its filterability isn't documented). For chat
-      // listings we order by createdDateTime so the page order matches the field
-      // we range on; everywhere else we walk Graph's default lastModifiedDateTime
-      // order. The stop condition must compare whichever field actually orders
-      // the pages — see shouldContinuePagination.
+      // Only the chat messages listing supports $orderby/$filter; order it by
+      // createdDateTime so the page order matches the field we range on.
+      // Channels and the replies endpoint keep Graph's default
+      // lastModifiedDateTime order. The stop condition keys off whichever it is
+      // — see shouldContinuePagination.
       const isChatListing = Boolean(chatId) && !messageId;
       const orderingField = isChatListing
         ? "createdDateTime"
@@ -291,13 +287,11 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       if (isChatListing) {
         request = request.orderby(`${orderingField} desc`);
 
-        // Push the upper bound server-side so the server skips messages newer
-        // than toDate instead of us paging through and discarding them. Graph
-        // only supports the `lt` operator on createdDateTime (no `gt`), so the
-        // lower bound stays a client-side concern (handled by the walk + stop).
-        // Nudge +1ms so the exclusive server filter is a strict superset of the
-        // inclusive (<=) client-side filter and can never drop a boundary
-        // message. $filter only applies when $orderby targets the same property.
+        // Push the upper bound server-side so Graph skips messages newer than
+        // toDate instead of us fetching and discarding them. createdDateTime
+        // only supports `lt` (no `gt`), so the lower bound stays client-side.
+        // +1ms keeps the exclusive server filter a superset of the inclusive
+        // client filter; $filter needs $orderby on the same property (above).
         if (toDate) {
           const toBound = new Date(toDateTime.getTime() + 1);
           request = request.filter(
@@ -306,8 +300,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         }
       }
 
-      // Accumulate the in-range messages from a page, then defer the
-      // keep-paging decision to the pure (testable) helper.
+      // Accumulate in-range messages, then defer the keep-paging decision.
       const processMessages = (
         messages: TeamsMessage[] | undefined
       ): boolean => {
@@ -322,14 +315,11 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         });
       };
 
-      // First page
       let response = await request.get();
       let scannedCount = response.value?.length ?? 0;
 
       let shouldContinue = processMessages(response.value);
 
-      // Follow pagination links until no more pages, the date threshold is
-      // reached, or we hit the scan backstop.
       nextLink = response["@odata.nextLink"];
       while (
         nextLink &&
@@ -342,10 +332,9 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         nextLink = response["@odata.nextLink"];
       }
 
-      // We stopped scanning while more in-range pages were still available: the
-      // result is truncated by the backstop, not by the data. (shouldContinue
-      // is false when we instead reached fromDate or filled MAX_NUMBER_OF_
-      // MESSAGES — neither of which is a backstop truncation.)
+      // More pages were available and still in range when we stopped: truncated
+      // by the backstop, not the data. (Reaching fromDate or the message limit
+      // clears shouldContinue, so neither trips this.)
       const truncatedByScanLimit =
         !!nextLink && shouldContinue && scannedCount >= MAX_MESSAGES_TO_SCAN;
       if (truncatedByScanLimit) {
@@ -368,10 +357,8 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
           text: JSON.stringify(limitedMessages, null, 2),
         },
       ];
-      // Tell the caller when results are incomplete, so an agent can recover by
-      // narrowing the range instead of treating partial history as complete.
-      // The two cases are mutually exclusive: hitting the result limit sets
-      // shouldContinue false, which clears truncatedByScanLimit.
+      // Tell the caller when results are incomplete so an agent can narrow the
+      // range rather than treat partial history as complete.
       if (truncatedByScanLimit) {
         content.push({
           type: "text" as const,

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -18,11 +18,18 @@ import {
 } from "@app/lib/api/actions/servers/microsoft_teams/microsoft_teams_rendering";
 import config from "@app/lib/api/config";
 import { getConversationRoute } from "@app/lib/utils/router";
+import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import sanitizeHtml from "sanitize-html";
 
 const MAX_NUMBER_OF_MESSAGES = 200;
+// Safety bound on the number of pages we follow in a single list_messages call.
+// The channel endpoint supports no server-side date filtering, so a range whose
+// upper bound (toDate) is in the past forces us to walk newest-first through
+// history until we reach the window — this caps that walk. 50 pages * 50
+// messages/page = up to 2500 messages scanned before we bail out.
+const MAX_PAGES_TO_FETCH = 50;
 
 const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
   search_messages_content: async ({ query }, { authInfo }) => {
@@ -233,6 +240,24 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       const fromDateTime = fromDate ? new Date(fromDate) : null;
       const toDateTime = toDate ? new Date(toDate) : new Date();
 
+      // Reject malformed dates up front. Otherwise `new Date("garbage")` yields
+      // an Invalid Date, every comparison silently returns false, and the tool
+      // returns an empty result with no indication of why.
+      if (fromDateTime && isNaN(fromDateTime.getTime())) {
+        return new Err(
+          new MCPError(
+            `Invalid fromDate: "${fromDate}". Expected an ISO 8601 date.`
+          )
+        );
+      }
+      if (toDate && isNaN(toDateTime.getTime())) {
+        return new Err(
+          new MCPError(
+            `Invalid toDate: "${toDate}". Expected an ISO 8601 date.`
+          )
+        );
+      }
+
       // Filter function to check if message is in date range
       const isMessageInDateRange = (message: TeamsMessage): boolean => {
         const messageDate = new Date(message.lastModifiedDateTime);
@@ -242,16 +267,35 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       };
 
       // Process messages and update shouldContinue flag
-      const processMessages = (messages: TeamsMessage[]): boolean => {
+      const processMessages = (
+        messages: TeamsMessage[] | undefined
+      ): boolean => {
+        // A page may come back empty (e.g. a server-side filter matched nothing
+        // on this skiptoken page). Keep following nextLink unless we're full.
+        if (!messages || messages.length === 0) {
+          return allMessages.length < MAX_NUMBER_OF_MESSAGES;
+        }
+
         const messagesInDateRange = messages.filter(isMessageInDateRange);
         allMessages.push(...messagesInDateRange);
-        return (
-          // if the last message in the current page is in the date range, we should continue
-          messagesInDateRange
-            .map((message) => message.id)
-            .includes(messages[messages.length - 1].id) &&
-          allMessages.length < MAX_NUMBER_OF_MESSAGES
+
+        if (allMessages.length >= MAX_NUMBER_OF_MESSAGES) {
+          return false;
+        }
+
+        // Messages are returned newest-first, so the last message on the page is
+        // the oldest. Messages newer than toDate are simply skipped, not a reason
+        // to stop. Keep paginating until the oldest message on this page is older
+        // than fromDate — every subsequent (older) page would then be out of range
+        // too. With no lower bound, paginate until the message limit is hit.
+        const oldestMessageOnPage = messages[messages.length - 1];
+        if (!fromDateTime || !oldestMessageOnPage) {
+          return true;
+        }
+        const oldestMessageDate = new Date(
+          oldestMessageOnPage.lastModifiedDateTime
         );
+        return oldestMessageDate >= fromDateTime;
       };
 
       const messagesSuffix = messageId ? `/${messageId}/replies` : "";
@@ -259,17 +303,67 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         ? `/chats/${chatId}/messages${messagesSuffix}`
         : `/teams/${teamId}/channels/${channelId}/messages${messagesSuffix}`;
 
+      let request = client.api(baseEndpoint).top(50);
+
+      // The chat messages endpoint supports server-side date filtering, which
+      // lets the server skip messages outside the range instead of us paging
+      // through and discarding them client-side (the channel endpoint supports
+      // neither $filter nor $orderby — see MAX_PAGES_TO_FETCH). We gate this on
+      // !messageId because the optimization targets the chat messages listing,
+      // not the per-message replies endpoint. The client-side filter below
+      // stays authoritative; this is purely a fetch-reduction.
+      if (chatId && !messageId) {
+        const filterConditions: string[] = [];
+        // $filter uses exclusive gt/lt. Nudge the bounds outward by 1ms so the
+        // server filter is a strict superset of the inclusive (>=/<=)
+        // client-side filter and can never drop a boundary message.
+        if (fromDateTime) {
+          const fromBound = new Date(fromDateTime.getTime() - 1);
+          filterConditions.push(
+            `lastModifiedDateTime gt ${fromBound.toISOString()}`
+          );
+        }
+        if (toDate) {
+          const toBound = new Date(toDateTime.getTime() + 1);
+          filterConditions.push(
+            `lastModifiedDateTime lt ${toBound.toISOString()}`
+          );
+        }
+        if (filterConditions.length > 0) {
+          // $filter only takes effect when $orderby targets the same property.
+          request = request
+            .orderby("lastModifiedDateTime desc")
+            .filter(filterConditions.join(" and "));
+        }
+      }
+
       // First page
-      let response = await client.api(baseEndpoint).top(50).get();
+      let response = await request.get();
 
       let shouldContinue = processMessages(response.value);
 
-      // Follow pagination links until no more pages or date threshold reached
+      // Follow pagination links until no more pages, the date threshold is
+      // reached, or we hit the page-count safety bound.
+      let pageCount = 1;
       nextLink = response["@odata.nextLink"];
-      while (nextLink && shouldContinue) {
+      while (nextLink && shouldContinue && pageCount < MAX_PAGES_TO_FETCH) {
         response = await client.api(nextLink).get();
         shouldContinue = processMessages(response.value);
         nextLink = response["@odata.nextLink"];
+        pageCount++;
+      }
+
+      // We stopped with more pages still available and still in range: the
+      // result set is truncated by the safety bound, not by the data.
+      if (nextLink && shouldContinue) {
+        logger.warn(
+          {
+            endpoint: baseEndpoint,
+            pageCount,
+            collected: allMessages.length,
+          },
+          "[microsoft_teams.list_messages] Hit MAX_PAGES_TO_FETCH; results may be truncated."
+        );
       }
 
       const limitedMessages = allMessages.slice(0, MAX_NUMBER_OF_MESSAGES);

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -16,23 +16,18 @@ import {
   renderMeetings,
   renderUsers,
 } from "@app/lib/api/actions/servers/microsoft_teams/microsoft_teams_rendering";
+import {
+  MAX_MESSAGES_TO_SCAN,
+  MAX_NUMBER_OF_MESSAGES,
+  MESSAGES_PAGE_SIZE,
+  shouldContinuePagination,
+} from "@app/lib/api/actions/servers/microsoft_teams/tools/pagination";
 import config from "@app/lib/api/config";
 import { getConversationRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import sanitizeHtml from "sanitize-html";
-
-const MAX_NUMBER_OF_MESSAGES = 200;
-// Operational backstop on how many messages we'll scan in a single
-// list_messages call. The channel endpoint supports no server-side date
-// filtering, so a range whose upper bound (toDate) is in the past forces a
-// newest-first walk through history until we reach the window. This is NOT a
-// results limit (that's MAX_NUMBER_OF_MESSAGES) — it only guards against a
-// runaway loop / Graph throttling on very large channels, and is surfaced to
-// the caller when hit so they can narrow the range. Set high so it does not
-// truncate legitimate deep-history retrieval.
-const MAX_MESSAGES_TO_SCAN = 10000;
 
 const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
   search_messages_content: async ({ query }, { authInfo }) => {
@@ -261,44 +256,16 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         );
       }
 
-      // Filter function to check if message is in date range
+      // Filter on createdDateTime, not lastModifiedDateTime: a message sent in
+      // the range but edited/reacted-to later (which bumps lastModifiedDateTime)
+      // must still count as in-range, and a message sent outside the range must
+      // not be pulled in by a later edit. "Messages between April and May" means
+      // sent then.
       const isMessageInDateRange = (message: TeamsMessage): boolean => {
-        const messageDate = new Date(message.lastModifiedDateTime);
+        const messageDate = new Date(message.createdDateTime);
         const afterFromDate = !fromDateTime || messageDate >= fromDateTime;
         const beforeToDate = messageDate <= toDateTime;
         return afterFromDate && beforeToDate;
-      };
-
-      // Process messages and update shouldContinue flag
-      const processMessages = (
-        messages: TeamsMessage[] | undefined
-      ): boolean => {
-        // A page may come back empty (e.g. a server-side filter matched nothing
-        // on this skiptoken page). Keep following nextLink unless we're full.
-        if (!messages || messages.length === 0) {
-          return allMessages.length < MAX_NUMBER_OF_MESSAGES;
-        }
-
-        const messagesInDateRange = messages.filter(isMessageInDateRange);
-        allMessages.push(...messagesInDateRange);
-
-        if (allMessages.length >= MAX_NUMBER_OF_MESSAGES) {
-          return false;
-        }
-
-        // Messages are returned newest-first, so the last message on the page is
-        // the oldest. Messages newer than toDate are simply skipped, not a reason
-        // to stop. Keep paginating until the oldest message on this page is older
-        // than fromDate — every subsequent (older) page would then be out of range
-        // too. With no lower bound, paginate until the message limit is hit.
-        const oldestMessageOnPage = messages[messages.length - 1];
-        if (!fromDateTime || !oldestMessageOnPage) {
-          return true;
-        }
-        const oldestMessageDate = new Date(
-          oldestMessageOnPage.lastModifiedDateTime
-        );
-        return oldestMessageDate >= fromDateTime;
       };
 
       const messagesSuffix = messageId ? `/${messageId}/replies` : "";
@@ -306,39 +273,53 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         ? `/chats/${chatId}/messages${messagesSuffix}`
         : `/teams/${teamId}/channels/${channelId}/messages${messagesSuffix}`;
 
-      let request = client.api(baseEndpoint).top(50);
+      let request = client.api(baseEndpoint).top(MESSAGES_PAGE_SIZE);
 
-      // The chat messages endpoint supports server-side date filtering, which
-      // lets the server skip messages outside the range instead of us paging
-      // through and discarding them client-side (the channel endpoint supports
-      // neither $filter nor $orderby — see MAX_PAGES_TO_FETCH). We gate this on
-      // !messageId because the optimization targets the chat messages listing,
-      // not the per-message replies endpoint. The client-side filter below
-      // stays authoritative; this is purely a fetch-reduction.
-      if (chatId && !messageId) {
-        const filterConditions: string[] = [];
-        // $filter uses exclusive gt/lt. Nudge the bounds outward by 1ms so the
-        // server filter is a strict superset of the inclusive (>=/<=)
-        // client-side filter and can never drop a boundary message.
-        if (fromDateTime) {
-          const fromBound = new Date(fromDateTime.getTime() - 1);
-          filterConditions.push(
-            `lastModifiedDateTime gt ${fromBound.toISOString()}`
-          );
-        }
+      // The chat messages listing supports $orderby/$filter; the channel
+      // endpoint and the per-message replies endpoint do not (and channels are
+      // always ordered by lastModifiedDateTime of the reply chain). For chat
+      // listings we order by createdDateTime so the page order matches the
+      // field we range on; everywhere else we walk Graph's default
+      // lastModifiedDateTime order. The stop condition must compare whichever
+      // field actually orders the pages — see shouldContinuePagination.
+      const isChatListing = Boolean(chatId) && !messageId;
+      const orderingField = isChatListing
+        ? "createdDateTime"
+        : "lastModifiedDateTime";
+
+      if (isChatListing) {
+        request = request.orderby(`${orderingField} desc`);
+
+        // Push the upper bound server-side so the server skips messages newer
+        // than toDate instead of us paging through and discarding them. Graph
+        // only supports the `lt` operator on createdDateTime (no `gt`), so the
+        // lower bound stays a client-side concern (handled by the walk + stop).
+        // Nudge +1ms so the exclusive server filter is a strict superset of the
+        // inclusive (<=) client-side filter and can never drop a boundary
+        // message. $filter only applies when $orderby targets the same property.
         if (toDate) {
           const toBound = new Date(toDateTime.getTime() + 1);
-          filterConditions.push(
-            `lastModifiedDateTime lt ${toBound.toISOString()}`
+          request = request.filter(
+            `${orderingField} lt ${toBound.toISOString()}`
           );
         }
-        if (filterConditions.length > 0) {
-          // $filter only takes effect when $orderby targets the same property.
-          request = request
-            .orderby("lastModifiedDateTime desc")
-            .filter(filterConditions.join(" and "));
-        }
       }
+
+      // Accumulate the in-range messages from a page, then defer the
+      // keep-paging decision to the pure (testable) helper.
+      const processMessages = (
+        messages: TeamsMessage[] | undefined
+      ): boolean => {
+        if (messages && messages.length > 0) {
+          allMessages.push(...messages.filter(isMessageInDateRange));
+        }
+        return shouldContinuePagination({
+          pageMessages: messages,
+          fromDateTime,
+          collectedCount: allMessages.length,
+          orderingField,
+        });
+      };
 
       // First page
       let response = await request.get();
@@ -377,6 +358,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         );
       }
 
+      const matchedCount = allMessages.length;
       const limitedMessages = allMessages.slice(0, MAX_NUMBER_OF_MESSAGES);
 
       const content = [
@@ -385,15 +367,23 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
           text: JSON.stringify(limitedMessages, null, 2),
         },
       ];
-      // Tell the caller when the backstop cut the walk short, so an agent can
-      // recover by narrowing the range instead of treating partial history as
-      // complete.
+      // Tell the caller when results are incomplete, so an agent can recover by
+      // narrowing the range instead of treating partial history as complete.
+      // The two cases are mutually exclusive: hitting the result limit sets
+      // shouldContinue false, which clears truncatedByScanLimit.
       if (truncatedByScanLimit) {
         content.push({
           type: "text" as const,
           text:
             `Note: stopped after scanning ${scannedCount} messages before reaching the start of the requested date range, so older messages in the range may be missing. ` +
-            `Narrow the date range (a smaller fromDate–toDate window) to retrieve the rest.`,
+            `Narrow the date range (a smaller fromDate-toDate window) to retrieve the rest.`,
+        });
+      } else if (matchedCount > MAX_NUMBER_OF_MESSAGES) {
+        content.push({
+          type: "text" as const,
+          text:
+            `Note: more than ${MAX_NUMBER_OF_MESSAGES} messages match the requested range; showing the ${MAX_NUMBER_OF_MESSAGES} most recent. ` +
+            `Narrow the date range to retrieve older messages.`,
         });
       }
 

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -276,12 +276,13 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       let request = client.api(baseEndpoint).top(MESSAGES_PAGE_SIZE);
 
       // The chat messages listing supports $orderby/$filter; the channel
-      // endpoint and the per-message replies endpoint do not (and channels are
-      // always ordered by lastModifiedDateTime of the reply chain). For chat
-      // listings we order by createdDateTime so the page order matches the
-      // field we range on; everywhere else we walk Graph's default
-      // lastModifiedDateTime order. The stop condition must compare whichever
-      // field actually orders the pages — see shouldContinuePagination.
+      // endpoint does not, and is always ordered by lastModifiedDateTime of the
+      // reply chain. We also don't push filters on the per-message replies
+      // endpoint (conservative — its filterability isn't documented). For chat
+      // listings we order by createdDateTime so the page order matches the field
+      // we range on; everywhere else we walk Graph's default lastModifiedDateTime
+      // order. The stop condition must compare whichever field actually orders
+      // the pages — see shouldContinuePagination.
       const isChatListing = Boolean(chatId) && !messageId;
       const orderingField = isChatListing
         ? "createdDateTime"
@@ -382,8 +383,8 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         content.push({
           type: "text" as const,
           text:
-            `Note: more than ${MAX_NUMBER_OF_MESSAGES} messages match the requested range; showing the ${MAX_NUMBER_OF_MESSAGES} most recent. ` +
-            `Narrow the date range to retrieve older messages.`,
+            `Note: more than ${MAX_NUMBER_OF_MESSAGES} messages match the requested range; showing ${MAX_NUMBER_OF_MESSAGES} of them. ` +
+            `Narrow the date range to retrieve the rest.`,
         });
       }
 

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -24,12 +24,15 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import sanitizeHtml from "sanitize-html";
 
 const MAX_NUMBER_OF_MESSAGES = 200;
-// Safety bound on the number of pages we follow in a single list_messages call.
-// The channel endpoint supports no server-side date filtering, so a range whose
-// upper bound (toDate) is in the past forces us to walk newest-first through
-// history until we reach the window — this caps that walk. 50 pages * 50
-// messages/page = up to 2500 messages scanned before we bail out.
-const MAX_PAGES_TO_FETCH = 50;
+// Operational backstop on how many messages we'll scan in a single
+// list_messages call. The channel endpoint supports no server-side date
+// filtering, so a range whose upper bound (toDate) is in the past forces a
+// newest-first walk through history until we reach the window. This is NOT a
+// results limit (that's MAX_NUMBER_OF_MESSAGES) — it only guards against a
+// runaway loop / Graph throttling on very large channels, and is surfaced to
+// the caller when hit so they can narrow the range. Set high so it does not
+// truncate legitimate deep-history retrieval.
+const MAX_MESSAGES_TO_SCAN = 10000;
 
 const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
   search_messages_content: async ({ query }, { authInfo }) => {
@@ -339,41 +342,62 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
 
       // First page
       let response = await request.get();
+      let scannedCount = response.value?.length ?? 0;
 
       let shouldContinue = processMessages(response.value);
 
       // Follow pagination links until no more pages, the date threshold is
-      // reached, or we hit the page-count safety bound.
-      let pageCount = 1;
+      // reached, or we hit the scan backstop.
       nextLink = response["@odata.nextLink"];
-      while (nextLink && shouldContinue && pageCount < MAX_PAGES_TO_FETCH) {
+      while (
+        nextLink &&
+        shouldContinue &&
+        scannedCount < MAX_MESSAGES_TO_SCAN
+      ) {
         response = await client.api(nextLink).get();
+        scannedCount += response.value?.length ?? 0;
         shouldContinue = processMessages(response.value);
         nextLink = response["@odata.nextLink"];
-        pageCount++;
       }
 
-      // We stopped with more pages still available and still in range: the
-      // result set is truncated by the safety bound, not by the data.
-      if (nextLink && shouldContinue) {
+      // We stopped scanning while more in-range pages were still available: the
+      // result is truncated by the backstop, not by the data. (shouldContinue
+      // is false when we instead reached fromDate or filled MAX_NUMBER_OF_
+      // MESSAGES — neither of which is a backstop truncation.)
+      const truncatedByScanLimit =
+        !!nextLink && shouldContinue && scannedCount >= MAX_MESSAGES_TO_SCAN;
+      if (truncatedByScanLimit) {
         logger.warn(
           {
             endpoint: baseEndpoint,
-            pageCount,
+            scannedCount,
             collected: allMessages.length,
           },
-          "[microsoft_teams.list_messages] Hit MAX_PAGES_TO_FETCH; results may be truncated."
+          "[microsoft_teams.list_messages] Hit MAX_MESSAGES_TO_SCAN; results may be truncated."
         );
       }
 
       const limitedMessages = allMessages.slice(0, MAX_NUMBER_OF_MESSAGES);
 
-      return new Ok([
+      const content = [
         {
           type: "text" as const,
           text: JSON.stringify(limitedMessages, null, 2),
         },
-      ]);
+      ];
+      // Tell the caller when the backstop cut the walk short, so an agent can
+      // recover by narrowing the range instead of treating partial history as
+      // complete.
+      if (truncatedByScanLimit) {
+        content.push({
+          type: "text" as const,
+          text:
+            `Note: stopped after scanning ${scannedCount} messages before reaching the start of the requested date range, so older messages in the range may be missing. ` +
+            `Narrow the date range (a smaller fromDate–toDate window) to retrieve the rest.`,
+        });
+      }
+
+      return new Ok(content);
     } catch (err) {
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to list threads")

--- a/front/lib/api/actions/servers/microsoft_teams/tools/pagination.test.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/pagination.test.ts
@@ -1,0 +1,133 @@
+import type { MessageOrderingField } from "@app/lib/api/actions/servers/microsoft_teams/tools/pagination";
+import {
+  MAX_NUMBER_OF_MESSAGES,
+  shouldContinuePagination,
+} from "@app/lib/api/actions/servers/microsoft_teams/tools/pagination";
+import { describe, expect, it } from "vitest";
+
+// Graph returns messages newest-first, so a "page" here is ordered newest to
+// oldest by the ordering field; the last element is the oldest on the page.
+function page(field: MessageOrderingField, ...isoDates: string[]) {
+  return isoDates.map((value) => ({
+    createdDateTime: value,
+    lastModifiedDateTime: value,
+    [field]: value,
+  }));
+}
+
+describe("shouldContinuePagination", () => {
+  const fromDateTime = new Date("2026-04-01T00:00:00.000Z");
+
+  it("continues when the oldest message on the page is still within the range", () => {
+    // Oldest message (last element) is after fromDate, so older in-range
+    // messages may still be on later pages.
+    expect(
+      shouldContinuePagination({
+        pageMessages: page(
+          "createdDateTime",
+          "2026-05-10T00:00:00.000Z",
+          "2026-04-15T00:00:00.000Z"
+        ),
+        fromDateTime,
+        collectedCount: 2,
+        orderingField: "createdDateTime",
+      })
+    ).toBe(true);
+  });
+
+  it("stops once the oldest message on the page is older than fromDate", () => {
+    // Last element predates fromDate: every later (older) page is out of range.
+    expect(
+      shouldContinuePagination({
+        pageMessages: page(
+          "createdDateTime",
+          "2026-04-15T00:00:00.000Z",
+          "2026-03-20T00:00:00.000Z"
+        ),
+        fromDateTime,
+        collectedCount: 1,
+        orderingField: "createdDateTime",
+      })
+    ).toBe(false);
+  });
+
+  it("keeps paging when the whole page is newer than the range (toDate in the past)", () => {
+    // The regression: with a past toDate, page 1 is entirely newer than the
+    // window, nothing matches, yet we must keep walking back to reach it.
+    expect(
+      shouldContinuePagination({
+        pageMessages: page(
+          "createdDateTime",
+          "2026-06-20T00:00:00.000Z",
+          "2026-06-10T00:00:00.000Z"
+        ),
+        fromDateTime,
+        collectedCount: 0,
+        orderingField: "createdDateTime",
+      })
+    ).toBe(true);
+  });
+
+  it("pages until the message limit when there is no lower bound", () => {
+    expect(
+      shouldContinuePagination({
+        pageMessages: page("createdDateTime", "2020-01-01T00:00:00.000Z"),
+        fromDateTime: null,
+        collectedCount: 5,
+        orderingField: "createdDateTime",
+      })
+    ).toBe(true);
+  });
+
+  it("stops as soon as the message limit is reached, regardless of dates", () => {
+    expect(
+      shouldContinuePagination({
+        pageMessages: page("createdDateTime", "2026-05-01T00:00:00.000Z"),
+        fromDateTime,
+        collectedCount: MAX_NUMBER_OF_MESSAGES,
+        orderingField: "createdDateTime",
+      })
+    ).toBe(false);
+  });
+
+  it("continues on an empty page when under the limit", () => {
+    // A server-side filter can match nothing on a given skiptoken page.
+    expect(
+      shouldContinuePagination({
+        pageMessages: [],
+        fromDateTime,
+        collectedCount: 0,
+        orderingField: "createdDateTime",
+      })
+    ).toBe(true);
+
+    expect(
+      shouldContinuePagination({
+        pageMessages: undefined,
+        fromDateTime,
+        collectedCount: 0,
+        orderingField: "createdDateTime",
+      })
+    ).toBe(true);
+  });
+
+  it("compares the ordering field, not the other timestamp", () => {
+    // Channel page ordered by lastModifiedDateTime. The oldest message was
+    // created long before fromDate but edited recently (recent
+    // lastModifiedDateTime). Stopping must key off the ordering field
+    // (lastModifiedDateTime), so we keep paging — a naive createdDateTime stop
+    // would halt too early and drop in-range messages on later pages.
+    const message = {
+      createdDateTime: "2026-01-01T00:00:00.000Z",
+      lastModifiedDateTime: "2026-05-01T00:00:00.000Z",
+    };
+    expect(
+      shouldContinuePagination({
+        pageMessages: [message],
+        fromDateTime,
+        collectedCount: 0,
+        orderingField: "lastModifiedDateTime",
+      })
+    ).toBe(true);
+  });
+});

--- a/front/lib/api/actions/servers/microsoft_teams/tools/pagination.test.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/pagination.test.ts
@@ -1,4 +1,3 @@
-import type { MessageOrderingField } from "@app/lib/api/actions/servers/microsoft_teams/tools/pagination";
 import {
   MAX_NUMBER_OF_MESSAGES,
   shouldContinuePagination,
@@ -6,12 +5,12 @@ import {
 import { describe, expect, it } from "vitest";
 
 // Graph returns messages newest-first, so a "page" here is ordered newest to
-// oldest by the ordering field; the last element is the oldest on the page.
-function page(field: MessageOrderingField, ...isoDates: string[]) {
+// oldest; the last element is the oldest on the page. Both timestamps are set
+// equal — the case that distinguishes them builds its message inline.
+function page(...isoDates: string[]) {
   return isoDates.map((value) => ({
     createdDateTime: value,
     lastModifiedDateTime: value,
-    [field]: value,
   }));
 }
 
@@ -24,7 +23,6 @@ describe("shouldContinuePagination", () => {
     expect(
       shouldContinuePagination({
         pageMessages: page(
-          "createdDateTime",
           "2026-05-10T00:00:00.000Z",
           "2026-04-15T00:00:00.000Z"
         ),
@@ -40,7 +38,6 @@ describe("shouldContinuePagination", () => {
     expect(
       shouldContinuePagination({
         pageMessages: page(
-          "createdDateTime",
           "2026-04-15T00:00:00.000Z",
           "2026-03-20T00:00:00.000Z"
         ),
@@ -57,7 +54,6 @@ describe("shouldContinuePagination", () => {
     expect(
       shouldContinuePagination({
         pageMessages: page(
-          "createdDateTime",
           "2026-06-20T00:00:00.000Z",
           "2026-06-10T00:00:00.000Z"
         ),
@@ -71,7 +67,7 @@ describe("shouldContinuePagination", () => {
   it("pages until the message limit when there is no lower bound", () => {
     expect(
       shouldContinuePagination({
-        pageMessages: page("createdDateTime", "2020-01-01T00:00:00.000Z"),
+        pageMessages: page("2020-01-01T00:00:00.000Z"),
         fromDateTime: null,
         collectedCount: 5,
         orderingField: "createdDateTime",
@@ -82,7 +78,7 @@ describe("shouldContinuePagination", () => {
   it("stops as soon as the message limit is reached, regardless of dates", () => {
     expect(
       shouldContinuePagination({
-        pageMessages: page("createdDateTime", "2026-05-01T00:00:00.000Z"),
+        pageMessages: page("2026-05-01T00:00:00.000Z"),
         fromDateTime,
         collectedCount: MAX_NUMBER_OF_MESSAGES,
         orderingField: "createdDateTime",

--- a/front/lib/api/actions/servers/microsoft_teams/tools/pagination.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/pagination.ts
@@ -8,33 +8,23 @@ export const MAX_NUMBER_OF_MESSAGES = 200;
 // chat and channel message endpoints).
 export const MESSAGES_PAGE_SIZE = 50;
 
-// Operational backstop on how many messages we'll scan in a single
-// list_messages call. The channel endpoint supports no server-side date
-// filtering, so a range whose upper bound (toDate) is in the past forces a
-// newest-first walk through history until we reach the window. This is NOT a
-// results limit (that's MAX_NUMBER_OF_MESSAGES) — it only guards against a
-// runaway loop / Graph throttling on very large channels, and is surfaced to
-// the caller when hit so they can narrow the range. Set high so it does not
-// truncate legitimate deep-history retrieval.
+// Operational backstop on messages scanned per call — NOT a results limit
+// (that's MAX_NUMBER_OF_MESSAGES). Channels can't filter server-side, so a past
+// toDate forces a newest-first walk through history; this caps that walk and is
+// surfaced to the caller when hit. Set high so it doesn't truncate legitimate
+// deep-history retrieval.
 export const MAX_MESSAGES_TO_SCAN = 10_000;
 
-// The timestamp Graph sorts the page by. The stop decision must compare against
-// the *ordering* field, not the date-range filter field: only the ordering
-// field guarantees that later pages are strictly older. Chats can be ordered by
-// createdDateTime; channels are always ordered by lastModifiedDateTime (reply
-// chain) and cannot be changed.
+// The field Graph orders the page by. The stop decision must compare the
+// *ordering* field, not the date-range filter field — only the ordering field
+// guarantees later pages are strictly older. Chats can order by createdDateTime;
+// channels are always ordered by lastModifiedDateTime (reply chain).
 export type MessageOrderingField = "createdDateTime" | "lastModifiedDateTime";
 
-// Decide whether to fetch another page after processing the page just received.
-// Pure (no I/O, no shared state) so the stopping logic can be unit-tested — this
-// is where the past-toDate early-exit bug lived.
-//
-// Graph returns messages newest-first, so the last message on a page is the
-// oldest by `orderingField`. Messages outside the range are skipped by the
-// caller's filter, not a reason to stop. We keep paging until the oldest message
-// on the page is older than fromDate (every later, older page would then be out
-// of range too), or we have collected the message limit. With no lower bound,
-// page until the limit.
+// Pure (no I/O, no shared state) so the stop logic can be unit-tested — this is
+// where the past-toDate early-exit bug lived. Pages are newest-first, so we keep
+// going until the oldest message (last on the page) predates fromDate, or we've
+// hit the message limit; with no lower bound, page until the limit.
 export function shouldContinuePagination({
   pageMessages,
   fromDateTime,

--- a/front/lib/api/actions/servers/microsoft_teams/tools/pagination.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/pagination.ts
@@ -1,0 +1,65 @@
+import type { TeamsMessage } from "@app/lib/api/actions/servers/microsoft/utils";
+
+// Max messages returned by list_messages. This is the primary ceiling on the
+// context we hand back to the model.
+export const MAX_NUMBER_OF_MESSAGES = 200;
+
+// Page size requested from Microsoft Graph (its documented maximum for both the
+// chat and channel message endpoints).
+export const MESSAGES_PAGE_SIZE = 50;
+
+// Operational backstop on how many messages we'll scan in a single
+// list_messages call. The channel endpoint supports no server-side date
+// filtering, so a range whose upper bound (toDate) is in the past forces a
+// newest-first walk through history until we reach the window. This is NOT a
+// results limit (that's MAX_NUMBER_OF_MESSAGES) — it only guards against a
+// runaway loop / Graph throttling on very large channels, and is surfaced to
+// the caller when hit so they can narrow the range. Set high so it does not
+// truncate legitimate deep-history retrieval.
+export const MAX_MESSAGES_TO_SCAN = 10_000;
+
+// The timestamp Graph sorts the page by. The stop decision must compare against
+// the *ordering* field, not the date-range filter field: only the ordering
+// field guarantees that later pages are strictly older. Chats can be ordered by
+// createdDateTime; channels are always ordered by lastModifiedDateTime (reply
+// chain) and cannot be changed.
+export type MessageOrderingField = "createdDateTime" | "lastModifiedDateTime";
+
+// Decide whether to fetch another page after processing the page just received.
+// Pure (no I/O, no shared state) so the stopping logic can be unit-tested — this
+// is where the past-toDate early-exit bug lived.
+//
+// Graph returns messages newest-first, so the last message on a page is the
+// oldest by `orderingField`. Messages outside the range are skipped by the
+// caller's filter, not a reason to stop. We keep paging until the oldest message
+// on the page is older than fromDate (every later, older page would then be out
+// of range too), or we have collected the message limit. With no lower bound,
+// page until the limit.
+export function shouldContinuePagination({
+  pageMessages,
+  fromDateTime,
+  collectedCount,
+  orderingField,
+}: {
+  pageMessages: readonly Pick<TeamsMessage, MessageOrderingField>[] | undefined;
+  fromDateTime: Date | null;
+  collectedCount: number;
+  orderingField: MessageOrderingField;
+}): boolean {
+  if (collectedCount >= MAX_NUMBER_OF_MESSAGES) {
+    return false;
+  }
+
+  // Empty page (e.g. a server-side filter matched nothing on this skiptoken
+  // page): nothing to learn from it; keep following nextLink if there is one.
+  if (!pageMessages || pageMessages.length === 0) {
+    return true;
+  }
+
+  const oldestMessageOnPage = pageMessages[pageMessages.length - 1];
+  if (!fromDateTime || !oldestMessageOnPage) {
+    return true;
+  }
+
+  return new Date(oldestMessageOnPage[orderingField]) >= fromDateTime;
+}


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/9298#event-27339318795
## Description
Three bugs in list_messages, all in the pagination/date path:

1. Empty results when toDate is in the past. Pagination only continued if the oldest message on the page was in-range; since Graph returns newest-first, page 1 is all newer than the window → stopped on page 1, never walked back. → Fix: continue until the oldest message on the page is older than fromDate (or the message limit is hit).
2.  Date-ranged on lastModifiedDateTime. A message sent in-range but edited/reacted-to later was dropped; an old message edited in-range was wrongly included. → Fix: range on createdDateTime (filter, stop condition, and server-side $filter/$orderby).
3.  messageId documented as valid for chats. Agents passed it on chats, where it has no meaning. → Fix: metadata now states messageId is channels-only.

Plus three hardening changes:
1. Push the toDate upper bound server-side for chats (skips the now→toDate over-fetch; channels can't filter server-side).
2. Replace the unbounded pagination loop with a transparent scan backstop (MAX_MESSAGES_TO_SCAN) that tells the caller when results are truncated.
3. Validate fromDate/toDate, guard empty pages, and unit-test the stop logic (pagination.test.ts).


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manually verify
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, no schema/contract change. Worst case a huge channel range scans up to the backstop and returns partial history with a note saying so.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
