### PR TITLE
dsbx function: drop privileges via runuser (remove all unsafe)

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -326,6 +326,7 @@ dependencies = [
  "lru",
  "rcgen",
  "reqwest",
+ "rustix",
  "rustls",
  "rustls-native-certs",
  "serde",

--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -21,6 +21,7 @@ httparse = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+rustix = { version = "1", features = ["process"] }
 rustls = { version = "0.23", features = ["ring"] }
 rustls-native-certs = "0.8"
 rcgen = { version = "0.13", default-features = false, features = ["pem", "ring", "x509-parser"] }

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -1,5 +1,5 @@
 use std::io::Write;
-use std::os::unix::fs::chown;
+use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
@@ -22,16 +22,11 @@ const FUNCTIONS_DIR_ENV: &str = "DUST_FUNCTIONS_DIR";
 /// not need `bun`.
 const RUNNER_JS: &str = include_str!("../../../functions-runner/runner.js");
 
-/// The unprivileged, egress-proxied uid the sandbox runs agent code as — the
-/// `agent-proxied` user (`SANDBOX_AGENT_PROXIED_UID` in front), whose `skuid` is
-/// what `dsbx healthcheck`'s nftables rules force through the egress proxy.
-/// Untrusted function code must run here too, so when `dsbx` is invoked
-/// privileged (as root, by the sandbox resource) the `bun` child is downgraded
-/// to this uid (its gid + supplementary groups are looked up, not assumed — the
-/// user's primary group is `agent`, not 1003).
-// Only referenced by the Linux privilege-drop path.
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-const AGENT_UID: u32 = 1003;
+/// The unprivileged, egress-proxied user the sandbox runs agent code as (the
+/// `agent-proxied` user created in the sandbox image; its `skuid` is what
+/// `dsbx healthcheck`'s nftables rules force through the egress proxy). Untrusted
+/// function code must run as this user too.
+const AGENT_USER: &str = "agent-proxied";
 
 #[derive(Subcommand)]
 pub enum FunctionCommand {
@@ -47,70 +42,16 @@ pub enum FunctionCommand {
     },
 }
 
-/// The identity to downgrade the `bun` child to: the agent uid plus its real
-/// primary gid and supplementary groups (resolved from /etc/passwd + /etc/group).
-// Only constructed on Linux (privilege dropping is a Linux-sandbox concept); the
-// fields are still read by run_bun on every platform.
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-struct DropTarget {
-    uid: libc::uid_t,
-    gid: libc::gid_t,
-    groups: Vec<libc::gid_t>,
-}
-
-/// Resolve how to downgrade the `bun` child, or `None` to run it as the current
-/// user.
+/// Whether `dsbx` is running privileged (effective uid 0).
 ///
-/// The function (runner harness + bundle) is untrusted, so when `dsbx` runs
-/// privileged — as root, e.g. invoked by the sandbox resource — it is dropped to
-/// the agent-proxied user so its network is forced through the egress proxy
-/// (domain allowlisting + DSEC secret substitution) like agent code. When `dsbx`
-/// is already unprivileged (local dev), there is nothing to contain and no
-/// privilege to `setuid`, so the child runs as-is.
-///
-/// The gid and supplementary groups are looked up here, in the parent, because
-/// `getpwuid`/`getgrouplist` are not async-signal-safe and must not run between
-/// fork and exec; `pre_exec` then applies only `setgroups`/`setgid`/`setuid`.
-#[cfg(target_os = "linux")]
-fn resolve_drop_target() -> Result<Option<DropTarget>> {
-    // SAFETY: geteuid only reads the caller's effective uid.
-    if unsafe { libc::geteuid() } != 0 {
-        return Ok(None);
-    }
-
-    // SAFETY: getpwuid returns a pointer into static storage valid until the
-    // next getpw* call; we read the fields we need immediately.
-    let pw = unsafe { libc::getpwuid(AGENT_UID as libc::uid_t) };
-    if pw.is_null() {
-        return Err(emit_error(anyhow!(
-            "agent uid {AGENT_UID} not found (getpwuid); cannot drop privileges safely"
-        )));
-    }
-    let gid = unsafe { (*pw).pw_gid };
-    let name = unsafe { (*pw).pw_name };
-
-    // getgrouplist fills the groups `agent-proxied` belongs to (incl. `agent`).
-    // It returns -1 when the buffer is too small, setting `n` to the size needed.
-    let mut n: libc::c_int = 32;
-    let mut groups: Vec<libc::gid_t> = vec![0; n as usize];
-    // SAFETY: `name` is valid (from pw); the buffer matches `n`.
-    while unsafe { libc::getgrouplist(name, gid, groups.as_mut_ptr(), &mut n) } < 0 {
-        groups.resize(n as usize, 0);
-    }
-    groups.truncate(n.max(0) as usize);
-
-    Ok(Some(DropTarget {
-        uid: AGENT_UID as libc::uid_t,
-        gid,
-        groups,
-    }))
-}
-
-/// Non-Linux (dev) builds never drop privileges — the agent uid and its egress
-/// containment are a Linux-sandbox concept.
-#[cfg(not(target_os = "linux"))]
-fn resolve_drop_target() -> Result<Option<DropTarget>> {
-    Ok(None)
+/// When it is — i.e. invoked by the sandbox resource as root — the untrusted
+/// function must be dropped to the `agent-proxied` user so its network is forced
+/// through the egress proxy (domain allowlisting + DSEC secret substitution)
+/// like agent code. When `dsbx` is already unprivileged (local dev), there is
+/// nothing to contain and no privilege to drop, so the function runs as the
+/// current user.
+fn running_as_root() -> bool {
+    rustix::process::geteuid().is_root()
 }
 
 /// Spawn the embedded runner under `bun` for `subcommand` (`run` or `get`)
@@ -120,11 +61,15 @@ fn resolve_drop_target() -> Result<Option<DropTarget>> {
 /// result API). Does not exit the process — the caller decides.
 ///
 /// The `bun` child (runner harness + the untrusted function bundle) is
-/// downgraded to the agent uid/gid (clearing supplementary groups) whenever
-/// `dsbx` runs privileged — see [`privilege_drop_target`]. `dsbx` itself may
-/// stay root: it chowns the runner and stages the bundle into a uid-owned temp
-/// dir (named `<name>.ts` so `get`'s schema name is preserved), so the dropped
-/// child can read both even when the originals are root-only.
+/// downgraded to the `agent-proxied` user whenever `dsbx` runs privileged: the
+/// child is launched via `runuser`, which resolves that user's uid/gid/
+/// supplementary groups and drops privileges before exec — so `dsbx` needs no
+/// unsafe privilege-dropping syscalls. `dsbx` may stay root to read bundles: it
+/// stages the bundle into a temp dir (named `<name>.ts` so `get`'s schema name
+/// is preserved) and makes both it and the runner world-readable, so the dropped
+/// child can read them even when the originals are root-only. The contents are
+/// not secret (the runner is embedded in the binary; the bundle is the function
+/// being executed) and the temp names are random.
 pub(crate) async fn spawn_function(
     subcommand: &str,
     name: &str,
@@ -136,71 +81,61 @@ pub(crate) async fn spawn_function(
     // parent of the resolved <name>.ts), not wherever dsbx was invoked from.
     let functions_dir = path.parent().map(Path::to_path_buf);
     let runner = ensure_runner()?;
-    let drop = resolve_drop_target()?;
+    let as_agent = running_as_root();
 
     // Hold the staged temp dir alive until after the child exits.
     let mut staged: Option<TempDir> = None;
-    let handler: PathBuf = match &drop {
-        None => path,
-        Some(t) => {
-            chown(&runner, Some(t.uid), Some(t.gid)).map_err(|e| {
-                emit_error(anyhow!("failed to prepare runner for uid {}: {e}", t.uid))
-            })?;
-            staged = Some(stage_bundle(&path, name, t.uid, t.gid)?);
-            staged
-                .as_ref()
-                .expect("just set")
-                .path()
-                .join(format!("{name}.ts"))
-        }
+    let handler: PathBuf = if as_agent {
+        // The dropped child must read the runner and the bundle, which dsbx (as
+        // root) created — make them world-readable rather than chowning, so no
+        // uid lookup is needed.
+        set_mode(&runner, 0o644)
+            .map_err(|e| emit_error(anyhow!("failed to prepare runner: {e}")))?;
+        let dir = stage_bundle(&path, name)?;
+        let handler = dir.path().join(format!("{name}.ts"));
+        staged = Some(dir);
+        handler
+    } else {
+        path
     };
 
-    let mut cmd = Command::new("bun");
-    cmd.arg(&*runner)
-        .arg(subcommand)
-        .arg(&handler)
-        .stdin(if inherit_stdin {
-            Stdio::inherit()
-        } else {
-            Stdio::null()
-        })
-        .stdout(if capture_stdout {
-            Stdio::piped()
-        } else {
-            Stdio::inherit()
-        })
-        .stderr(Stdio::inherit());
+    // When privileged, run the function as `agent-proxied` via `runuser`
+    // (util-linux), which drops to that user (uid + primary gid + supplementary
+    // groups) and execs `bun` — no privileged code in dsbx. Otherwise run `bun`
+    // directly as the current (already unprivileged) user.
+    let mut cmd = if as_agent {
+        let mut c = Command::new("runuser");
+        c.arg("-u")
+            .arg(AGENT_USER)
+            .arg("--")
+            .arg("bun")
+            .arg(&*runner)
+            .arg(subcommand)
+            .arg(&handler);
+        c
+    } else {
+        let mut c = Command::new("bun");
+        c.arg(&*runner).arg(subcommand).arg(&handler);
+        c
+    };
+    cmd.stdin(if inherit_stdin {
+        Stdio::inherit()
+    } else {
+        Stdio::null()
+    })
+    .stdout(if capture_stdout {
+        Stdio::piped()
+    } else {
+        Stdio::inherit()
+    })
+    .stderr(Stdio::inherit());
     if let Some(dir) = &functions_dir {
-        // chdir happens before the pre_exec privilege drop, i.e. while still
-        // root, so it works even when the dir is root-only.
         cmd.current_dir(dir);
-    }
-
-    if let Some(t) = drop {
-        // Drop privileges in the forked child before exec, in order, while still
-        // privileged: set the supplementary groups, then gid, then uid. The
-        // closure runs post-fork/pre-exec, so it uses only async-signal-safe
-        // syscalls (the group lookup already happened in the parent).
-        let DropTarget { uid, gid, groups } = t;
-        unsafe {
-            cmd.pre_exec(move || {
-                if libc::setgroups(groups.len() as _, groups.as_ptr()) != 0 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                if libc::setgid(gid) != 0 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                if libc::setuid(uid) != 0 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                Ok(())
-            });
-        }
     }
 
     let mut child = cmd
         .spawn()
-        .map_err(|e| emit_error(anyhow!("failed to run bun: {e}")))?;
+        .map_err(|e| emit_error(anyhow!("failed to run function: {e}")))?;
 
     // Capturing reads stdout to EOF (child closes it on exit) before waiting.
     // Only stdout is piped; stderr/stdin are inherited, so there is no deadlock.
@@ -219,7 +154,7 @@ pub(crate) async fn spawn_function(
     let status = child
         .wait()
         .await
-        .map_err(|e| emit_error(anyhow!("failed to run bun: {e}")))?;
+        .map_err(|e| emit_error(anyhow!("failed to run function: {e}")))?;
     runner.close().ok();
     if let Some(dir) = staged {
         dir.close().ok();
@@ -227,24 +162,30 @@ pub(crate) async fn spawn_function(
     Ok((status.code().unwrap_or(1), captured))
 }
 
-/// Copy a function bundle into a fresh temp dir owned by `uid`/`gid`, as
-/// `<name>.ts`, so a privileged dsbx can hand a (possibly root-only) bundle to
-/// an unprivileged child. Returns the temp dir (kept alive by the caller).
-fn stage_bundle(path: &Path, name: &str, uid: u32, gid: u32) -> Result<TempDir> {
+/// Copy a function bundle into a fresh temp dir as `<name>.ts`, world-readable,
+/// so a privileged dsbx can hand a (possibly root-only) bundle to the
+/// unprivileged `agent-proxied` child. Returns the temp dir (kept alive by the
+/// caller). Making the copy world-readable avoids needing the agent uid/gid.
+fn stage_bundle(path: &Path, name: &str) -> Result<TempDir> {
+    let stage_err = |e: std::io::Error| emit_error(anyhow!("failed to stage function {name}: {e}"));
     let bytes = std::fs::read(path)
         .map_err(|e| emit_error(anyhow!("failed to read function {name}: {e}")))?;
     let dir = tempfile::Builder::new()
         .prefix("dsbx-fn-")
         .tempdir()
-        .map_err(|e| emit_error(anyhow!("failed to stage function {name}: {e}")))?;
+        .map_err(stage_err)?;
+    // The dropped child must traverse the dir and read the bundle.
+    set_mode(dir.path(), 0o755).map_err(stage_err)?;
     let staged = dir.path().join(format!("{name}.ts"));
-    std::fs::write(&staged, &bytes)
-        .map_err(|e| emit_error(anyhow!("failed to stage function {name}: {e}")))?;
-    // The child must own/traverse the dir and read the file.
-    chown(dir.path(), Some(uid), Some(gid))
-        .and_then(|()| chown(&staged, Some(uid), Some(gid)))
-        .map_err(|e| emit_error(anyhow!("failed to stage function {name}: {e}")))?;
+    std::fs::write(&staged, &bytes).map_err(stage_err)?;
+    set_mode(&staged, 0o644).map_err(stage_err)?;
     Ok(dir)
+}
+
+/// Set a path's permission bits (used to make temp runner/bundle files readable
+/// by the dropped child without a uid lookup).
+fn set_mode(path: impl AsRef<Path>, mode: u32) -> std::io::Result<()> {
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
 }
 
 /// Write the embedded runner to a fresh uniquely-named temp file (mode 0600)

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -341,7 +341,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.27/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.28/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.40",
+      tag: "0.8.41",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -20,7 +20,7 @@ import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
 const DUST_BASE_IMAGE_VERSION = "0.8.40";
-const DSBX_CLI_VERSION = "0.1.27";
+const DSBX_CLI_VERSION = "0.1.28";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.40";
+const DUST_BASE_IMAGE_VERSION = "0.8.41";
 const DSBX_CLI_VERSION = "0.1.28";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that


### PR DESCRIPTION
## Description

Addresses the review on #28088 ("no way around the unsafes?"). Removes **all** `unsafe` from the function privilege-drop path.

Previously, running the function as the unprivileged `agent-proxied` user required: `libc::getpwuid`/`getgrouplist` (FFI) to resolve its gid + supplementary groups, and a `pre_exec` closure doing `setgroups`/`setgid`/`setuid` in the forked child — four `unsafe` blocks, plus a `cfg(target_os = "linux")` gate because of libc signature differences.

This replaces that with a fully-safe approach: when `dsbx` runs as root, the function is executed via **`runuser -u agent-proxied -- bun …`** (util-linux), which resolves the user's uid/primary-gid/supplementary-groups and drops privileges before exec. No `unsafe`, no FFI, no fork/exec hook.

- **Root check**: `rustix::process::geteuid().is_root()` (safe). `rustix` was already in the tree (via `tempfile`); this just enables its `process` feature — no new crate downloaded.
- **Bundle access**: bundles can be root-only, so `dsbx` (still root) stages the bundle into a temp dir and makes it + the runner **world-readable** (`0644`/`0755`) rather than `chown`ing — so the dropped child can read them without a uid lookup. Contents aren't secret (the runner is embedded in the binary; the bundle is the function being executed) and temp names are random.
- The code is **no longer `cfg(linux)`-only** and has **no `libc`** usage, so it compiles and is testable on macOS dev too. Net −57 lines.

## Why an external tool

Setting supplementary groups (needed so the dropped child doesn't inherit root's groups) can't be done with a safe builder method: `std`'s `Command::groups` is unstable (`setgroups`, #90747) and `tokio` doesn't expose it — only `pre_exec` (unsafe) could. So the only `pre_exec`-free, fully-safe route is to delegate the whole drop to `runuser`, which also handles initgroups.

## Tests

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (240) all pass.
- `grep` confirms no `unsafe`/`libc::`/`getpwuid`/`pre_exec`/`cfg(target_os)` remain in the function module (only the word "unsafe" in a doc comment).
- Non-root e2e (local): runs `bun` directly, function executes, `cwd` = `$DUST_FUNCTIONS_DIR`.

## Risk / things to confirm

- **Runtime dependency on `runuser`** (util-linux). The sandbox image is apt-based (Debian/Ubuntu), which ships it; if the image were ever slimmed, the root path would fail-closed (function won't run as root rather than running privileged). Worth an explicit guarantee in the image build if you want certainty — happy to add it.
- The actual root→`agent-proxied` drop **can't be exercised on a non-root dev machine**; I verified compile/lint/tests and the non-root path locally. Needs a sandbox run to confirm the drop, egress containment, and group-based `/files` access.
- `runuser` (non-login) preserves the environment and cwd we set; flag if your image's PAM config (`/etc/pam.d/runuser`) differs.

## Deploy Plan

None — `dsbx` tooling. Behavior change only when `dsbx function run/get` is invoked as root in the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)