### PR TITLE
Remove temporary debug

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -27,7 +27,6 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import logger from "@app/logger/logger";
 import {
   isContentFragmentInput,
   isContentFragmentInputWithContentNode,
@@ -143,18 +142,6 @@ app.post(
       blocking,
       spaceId,
     } = ctx.req.valid("json");
-
-    // Extremely temporary debug.
-    if (auth.getNonNullableWorkspace().sId === "ba367d3014") {
-      logger.info(
-        {
-          message: "conversations/index",
-          body: ctx.req.valid("json"),
-          rawBody: await ctx.req.text(),
-        },
-        "conversations/index"
-      );
-    }
 
     const origin = message?.context.origin ?? "api";
 


### PR DESCRIPTION
## Description

Removes the temporary workspace-gated `logger.info` block from `front-api/routes/v1/w/[wId]/assistant/conversations/index.ts` that was logging both the validated JSON body and raw body (`ctx.req.text()`) for workspace `ba367d3014`. Also drops the now-unused `logger` import.

## Tests

No functional change — deletion only. Verified the surrounding `app.post` handler logic is unaffected.

## Risk

Low. Pure removal of a debug-only code path that was never executed in production for any workspace other than `ba367d3014`. No behaviour change for any other tenant.

## Deploy Plan

Deploy front-api.
