### PR TITLE
[front] API key credit cap: reconcile key state at end of agent loop

### DIFF
--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -1,4 +1,5 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { reconcileApiKey } from "@app/lib/api/metronome/reconcile_credit_state";
 import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import {
   isProgrammaticUsage,
@@ -27,11 +28,13 @@ import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import mainLogger from "@app/logger/logger";
 import logger from "@app/logger/logger";
+import { launchReconcileApiKeyCreditStateWorkflow } from "@app/temporal/usage_queue/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { isHiddenHelperSubAgentId } from "@app/types/assistant/assistant";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
@@ -329,6 +332,8 @@ export async function emitMetronomeUsageEventsActivity(
   // implementation detail, not a meaningful billing attribution. In those cases we
   // leave the API key name unset (it surfaces as "unknown" in the event).
   let apiKeyName: string | null = null;
+  // Retained for the post-ingest per-key cap reconcile below.
+  let apiKey: KeyResource | null = null;
   if (userMessage?.userContextApiKeyId) {
     const key = await KeyResource.fetchByWorkspaceAndId({
       workspace,
@@ -336,6 +341,7 @@ export async function emitMetronomeUsageEventsActivity(
     });
     if (key && !key.isSystem) {
       apiKeyName = key.name;
+      apiKey = key;
     }
   }
 
@@ -426,6 +432,30 @@ export async function emitMetronomeUsageEventsActivity(
   });
 
   await ingestMetronomeEvents([...llmEvents, ...toolEvents]);
+
+  // Per-key cap enforcement is pull-based: Metronome spend alerts can't
+  // attribute spend by `api_key_name` (it's not the products' presentation
+  // group key), so we reconcile the key's credit state from live usage instead
+  // (the usage API does attribute by `api_key_name`). Launch a debounced
+  // reconcile so it runs after Metronome has ingested the usage emitted above
+  // and coalesces bursts on the same key. Only for keys that carry a cap; the
+  // reconcile activity re-checks plan/contract/state at run time.
+  if (apiKey && apiKey.monthlyCapAwuCredits !== null) {
+    const launchResult = await launchReconcileApiKeyCreditStateWorkflow({
+      workspaceId: workspace.sId,
+      keyId: apiKey.id,
+    });
+    if (launchResult.isErr()) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          keyName: apiKey.name,
+          err: launchResult.error,
+        },
+        "[Metronome ApiKeyCap] failed to launch debounced reconcile"
+      );
+    }
+  }
 }
 
 /**
@@ -459,5 +489,50 @@ export async function syncMetronomeSeatCountActivity(
       "[Metronome] Failed to sync seat count for workspace"
     );
     throw result.error;
+  }
+}
+
+/**
+ * Reconcile a single API key's credit state from live Metronome usage. Launched
+ * (debounced) after a message that used a capped key emits its usage, so the
+ * key gets flipped to `capped` / `on_pool` without relying on Metronome spend
+ * alerts (which can't attribute by `api_key_name`). Best-effort: re-checks the
+ * workspace / contract / key state at run time and logs on failure.
+ */
+export async function reconcileApiKeyCreditStateActivity(
+  workspaceId: string,
+  keyId: number
+): Promise<void> {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace?.metronomeCustomerId) {
+    return;
+  }
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  const metronomeContractId = subscription?.metronomeContractId ?? null;
+  if (!metronomeContractId) {
+    return;
+  }
+  const key = await KeyResource.fetchByWorkspaceAndId({
+    workspace: renderLightWorkspaceType({ workspace }),
+    id: keyId,
+  });
+  if (!key || key.monthlyCapAwuCredits === null) {
+    return;
+  }
+
+  const result = await reconcileApiKey({
+    workspaceId: workspace.sId,
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    metronomeContractId,
+    key,
+    execute: true,
+  });
+  if (result.isErr()) {
+    logger.warn(
+      { workspaceId: workspace.sId, keyName: key.name, err: result.error },
+      "[Metronome ApiKeyCap] debounced reconcile failed"
+    );
   }
 }

--- a/front/temporal/usage_queue/client.ts
+++ b/front/temporal/usage_queue/client.ts
@@ -6,11 +6,16 @@ import { QUEUE_NAME } from "@app/temporal/usage_queue/config";
 import {
   makeMetronomeSeatCountSyncWorkflowId,
   makeMetronomeUsageEventsWorkflowId,
+  makeReconcileApiKeyCreditStateWorkflowId,
   makeTrackProgrammaticUsageWorkflowId,
 } from "@app/temporal/usage_queue/helpers";
-import { syncMetronomeSeatCountSignal } from "@app/temporal/usage_queue/signals";
+import {
+  reconcileApiKeyCreditStateSignal,
+  syncMetronomeSeatCountSignal,
+} from "@app/temporal/usage_queue/signals";
 import {
   emitMetronomeUsageEventsWorkflow,
+  reconcileApiKeyCreditStateWorkflow,
   syncMetronomeSeatCountWorkflow,
   trackProgrammaticUsageWorkflow,
   updateWorkspaceUsageWorkflow,
@@ -209,6 +214,48 @@ export async function launchMetronomeSeatCountSyncWorkflow({
         error: e,
       },
       "[Metronome] Failed to signal seat count sync workflow"
+    );
+    return new Err(normalizeError(e));
+  }
+}
+
+// Debounced per-API-key credit-state reconcile. signalWithStart on a stable
+// per-(workspace, key) workflow id coalesces repeated triggers within the
+// debounce window into a single reconcile run.
+export async function launchReconcileApiKeyCreditStateWorkflow({
+  workspaceId,
+  keyId,
+}: {
+  workspaceId: string;
+  keyId: number;
+}): Promise<Result<undefined, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = makeReconcileApiKeyCreditStateWorkflowId({
+    workspaceId,
+    keyId,
+  });
+
+  try {
+    await client.workflow.signalWithStart(reconcileApiKeyCreditStateWorkflow, {
+      args: [workspaceId, keyId],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      signal: reconcileApiKeyCreditStateSignal,
+      signalArgs: undefined,
+      memo: {
+        workspaceId,
+      },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    logger.error(
+      {
+        workflowId,
+        workspaceId,
+        keyId,
+        error: e,
+      },
+      "[Metronome ApiKeyCap] Failed to signal reconcile workflow"
     );
     return new Err(normalizeError(e));
   }

--- a/front/temporal/usage_queue/helpers.ts
+++ b/front/temporal/usage_queue/helpers.ts
@@ -29,3 +29,13 @@ export function makeMetronomeSeatCountSyncWorkflowId({
 }): string {
   return `metronome-seat-count-sync-${workspaceId}`;
 }
+
+export function makeReconcileApiKeyCreditStateWorkflowId({
+  workspaceId,
+  keyId,
+}: {
+  workspaceId: string;
+  keyId: number;
+}): string {
+  return `metronome-api-key-cap-reconcile-${workspaceId}-${keyId}`;
+}

--- a/front/temporal/usage_queue/signals.ts
+++ b/front/temporal/usage_queue/signals.ts
@@ -3,3 +3,7 @@ import { defineSignal } from "@temporalio/workflow";
 export const syncMetronomeSeatCountSignal = defineSignal<[void]>(
   "sync_metronome_seat_count_signal"
 );
+
+export const reconcileApiKeyCreditStateSignal = defineSignal<[void]>(
+  "reconcile_api_key_credit_state_signal"
+);

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -1,10 +1,18 @@
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/usage_queue/activities";
-import { syncMetronomeSeatCountSignal } from "@app/temporal/usage_queue/signals";
+import {
+  reconcileApiKeyCreditStateSignal,
+  syncMetronomeSeatCountSignal,
+} from "@app/temporal/usage_queue/signals";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
 
 const METRONOME_SEAT_COUNT_DEBOUNCE_MS = 15 * 1000;
+
+// Debounce the per-API-key reconcile after usage is emitted: gives Metronome
+// time to ingest the just-emitted events, and coalesces bursts of messages on
+// the same key into a single reconcile.
+const API_KEY_CREDIT_STATE_RECONCILE_DEBOUNCE_MS = 15 * 1000;
 
 const { recordUsageActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
@@ -27,6 +35,12 @@ const { syncMetronomeSeatCountActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
 });
 
+const { reconcileApiKeyCreditStateActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "5 minutes",
+});
+
 export async function updateWorkspaceUsageWorkflow(workspaceId: string) {
   // Sleep for one hour before computing usage.
   await sleep(60 * 60 * 1000);
@@ -47,6 +61,23 @@ export async function syncMetronomeSeatCountWorkflow(
     await sleep(METRONOME_SEAT_COUNT_DEBOUNCE_MS);
     pendingSync = false;
     await syncMetronomeSeatCountActivity(workspaceId);
+  }
+}
+
+export async function reconcileApiKeyCreditStateWorkflow(
+  workspaceId: string,
+  keyId: number
+): Promise<void> {
+  let pendingReconcile = true;
+
+  setHandler(reconcileApiKeyCreditStateSignal, () => {
+    pendingReconcile = true;
+  });
+
+  while (pendingReconcile) {
+    await sleep(API_KEY_CREDIT_STATE_RECONCILE_DEBOUNCE_MS);
+    pendingReconcile = false;
+    await reconcileApiKeyCreditStateActivity(workspaceId, keyId);
   }
 }
 


### PR DESCRIPTION
Part of the **per-API-key credit spend limit** work. Dedicated PR on top of the stack (builds on #28127).

### Why
Metronome `spend_threshold_reached` alerts don't attribute spend by `api_key_name` (it's only a billable-metric group key, not the AWU products' **presentation** group key — `user_id` is). Empirically the alert stays `customer_status: "ok"` even when a key is well over its cap, so we can't rely on the alert→webhook path to flip a key to `capped`.

### What
Switch to a **pull** trigger in the Metronome usage activity (`emitMetronomeUsageEventsActivity`, end of agent loop). Right after `ingestMetronomeEvents`, if the request used a **capped, non-system** API key on a **credit-priced** plan with an active contract, call `reconcileApiKey` — which reads live per-`api_key_name` usage (the usage API *does* attribute correctly) and flips `creditState`. The next API call with that key is then blocked by the enforcement gate (#28059).

- Non-fatal: a reconcile failure only logs; the next message (or the poke `api_key` reconcile / a manual one) converges.
- Reuses the `KeyResource` already fetched for `api_key_name` attribution, and only runs for keys that actually have a cap (no extra work for uncapped keys).

### Note
This runs once per agent message that uses a capped key (a usage-API call each). It's the trigger the alert was supposed to be; if it proves chatty we can add a short cache/throttle. Pairs with the set-time reconcile (#28057) and the poke per-key reconcile (#28127).

🤖 Generated with [Claude Code](https://claude.com/claude-code)