### PR TITLE
feat: check if migration directory exists during pending migration check

### DIFF
--- a/scripts/db/migration-runner.ts
+++ b/scripts/db/migration-runner.ts
@@ -167,6 +167,14 @@ async function runCheckPhase(
   logger: MigrationLogger,
   phase: Phase
 ): Promise<void> {
+  const dir = `migrations/${phase}`;
+  if (!existsSync(dir)) {
+    logger.error(
+      { phase, dir, cwd: process.cwd() },
+      "Migrations directory missing — refusing to pass check."
+    );
+    process.exit(1);
+  }
   const pending = await createUmzug(
     sequelize,
     getDatabaseURI,


### PR DESCRIPTION
## Description

This PR adds a guard in the migration runner to verify that the migrations directory exists before checking for pending migrations, preventing false-negatives when the directory is missing.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.