### PR TITLE
fix(docker): copy front migration SQL files into workers runtime image for pre-deploy checks

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -109,6 +109,8 @@ COPY --from=base-deps /app/front/package.json ./package.json
 COPY --from=base-deps /app/front/node_modules ./node_modules
 # Copy scripts directory
 COPY --from=base-deps /app/front/scripts ./scripts
+# Copy migration SQL files so the helm pre-deploy hook can run migration:check commands.
+COPY --from=base-deps /app/front/migrations ./migrations
 # Shared migration tooling lives at the repo root; front/package.json runs `node ../scripts/db/run-migrate.cjs`.
 COPY --from=base-deps /app/scripts/db /app/scripts/db
 # Copy built SDK


### PR DESCRIPTION
## Description

Fixes the helm pre-deploy hook for `front`: the `workers` runtime image was missing the `front/migrations/` directory. The migration runner globs `migrations/{phase}/*.sql` relative to the working directory (`/app/front`), so without this copy the pre-deploy check always sees zero pending migrations regardless of what's in the image.

**connectors is not affected** — `connectors.Dockerfile` is a single-stage build and `COPY /connectors/ .` already includes `migrations/pre-deploy/` and `migrations/post-deploy/`. The esbuild config also explicitly produces `dist/migrate.js` via the "Migration" target, so the full migration check path works end-to-end.

## Tests

Verified by tracing the migration check path in both images:
- `front` workers image: `dist/migrate.js` ✓, `scripts/db/run-migrate.cjs` ✓, `migrations/` now ✓
- `connectors` image: all three already present via `COPY /connectors/ .` + `npm run build`

## Risk

Low — adds two lines to the Dockerfile, no code change, no runtime behaviour change. Only affects the pre-deploy hook job.
