### PR TITLE
chore(mcp): improve workspace_analytics tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -117,11 +117,11 @@ const getUsageTimeseriesSchema = {
 export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
   get_top_agents: {
     description:
-      "Return the workspace's agents over a time window (defaults to the " +
-      "current calendar month), ranked by number of messages, with the number " +
-      "of unique users for each. Each row includes the agent's id. Optionally " +
-      "filter by source (context_origin), agent, or user. Use this to answer " +
-      "which agents are used most. Admin-only.",
+      "Return the workspace's most-used and most active agents over a time " +
+      "window (defaults to the current calendar month), ranked by message " +
+      "count, with unique user count for each. Each row includes the agent's " +
+      "id. Use this to answer which agents are most popular, most used, or " +
+      "most active. Admin-only.",
     schema: getTopAgentsSchema,
     stake: "never_ask",
     displayLabels: {
@@ -131,11 +131,11 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
   },
   get_top_users: {
     description:
-      "Return the workspace's most active users over a time window (defaults " +
-      "to the current calendar month), ranked by number of messages sent, " +
-      "with the count of distinct agents each used. Each row includes the " +
-      "user's id. Optionally filter by source (context_origin), agent, or " +
-      "user. Use this to answer who the most active users are. Admin-only.",
+      "Return the workspace's most active users and members over a time " +
+      "window (defaults to the current calendar month), ranked by number of " +
+      "messages sent, with the count of distinct agents each used. Each row " +
+      "includes the user's id. Use this to answer who the most active users " +
+      "are, rank members by usage, or find your top contributors. Admin-only.",
     schema: getTopUsersSchema,
     stake: "never_ask",
     displayLabels: {
@@ -146,10 +146,9 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
   get_agent_details: {
     description:
       "Return an agent's full configuration: name, description, scope, model, " +
-      "equipped skills and tools, and its complete instructions (system " +
-      "prompt). Use this after a usage tool to explain what a heavily-used " +
-      "agent actually does. Takes the agent id returned by other tools. " +
-      "Admin-only.",
+      "equipped skills and capabilities, and its complete system prompt and " +
+      "instructions. Use this to inspect what a heavily-used agent actually " +
+      "does. Admin-only.",
     schema: getAgentDetailsSchema,
     stake: "never_ask",
     displayLabels: {
@@ -172,10 +171,12 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
   },
   get_top_tools: {
     description:
-      "Return the workspace's most-used tools (by MCP server) over a time " +
-      "window (defaults to the current calendar month), ranked by execution " +
-      "count. Optionally filter by source (context_origin), agent, or user. " +
-      "Use this to answer which tools are used most. Admin-only.",
+      "Return the workspace's most-used MCP tools and integrations over a " +
+      "time window (defaults to the current calendar month), ranked by " +
+      "execution count. Shows which MCP server tools are called most. Optionally " +
+      "filter by source (context_origin), agent, or user. Use this to answer " +
+      "which tools are used most or which integrations agents " +
+      "rely on. Admin-only.",
     schema: getTopToolsSchema,
     stake: "never_ask",
     displayLabels: {
@@ -241,11 +242,10 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
   get_usage_timeseries: {
     description:
       "Return a usage time series over a window (defaults to the last 30 " +
-      "days). The metric parameter selects what is plotted: messages " +
-      "(messages/conversations/active users, default), skills, or tools " +
-      "(executions/unique users). Use this for any trend over time — it is a " +
-      "single call, do not call other tools once per day. Combine with the " +
-      "source/agent/user filters to narrow. Chart the result. Admin-only.",
+      "days). Plot message volume (messages, conversations, active users), " +
+      "skill executions, or tool calls over time. Use this for any activity " +
+      "or usage trend — it is a single call, do not call other tools once per " +
+      "day. Combine with filters to narrow. Chart the result. Admin-only.",
     schema: getUsageTimeseriesSchema,
     stake: "never_ask",
     displayLabels: {

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -894,6 +894,65 @@ export const QUERIES: LabeledQuery[] = [
     expected: "pod_manager.add_message_to_conversation",
   },
 
+  // --- workspace_analytics ---
+  {
+    query: "which agents are used most in the workspace",
+    expected: "workspace_analytics.get_top_agents",
+  },
+  {
+    query: "show me the top 10 most active agents this month",
+    expected: "workspace_analytics.get_top_agents",
+  },
+  {
+    query: "who are the most active users this month",
+    expected: "workspace_analytics.get_top_users",
+  },
+  {
+    query: "rank workspace members by messages sent",
+    expected: "workspace_analytics.get_top_users",
+  },
+  {
+    query:
+      "what does the support agent actually do - show its configuration and prompt",
+    expected: "workspace_analytics.get_agent_details",
+  },
+  {
+    query: "inspect an agent's full system prompt and tools",
+    expected: "workspace_analytics.get_agent_details",
+  },
+  {
+    query: "which skills are executed most in the workspace",
+    expected: "workspace_analytics.get_top_skills",
+  },
+  {
+    query: "what are the top MCP tools used by agents",
+    expected: "workspace_analytics.get_top_tools",
+  },
+  {
+    query: "where do workspace messages come from - slack, api, or browser",
+    expected: "workspace_analytics.get_source_breakdown",
+  },
+  {
+    query: "how many AWU credits did the workspace consume this month",
+    expected: "workspace_analytics.get_credit_usage",
+  },
+  {
+    query: "break down credit spending by agent",
+    expected: "workspace_analytics.get_credit_usage",
+  },
+  {
+    query: "show the credit spending trend over the last 30 days",
+    expected: "workspace_analytics.get_credit_timeseries",
+  },
+  {
+    query: "chart message and conversation volume over time",
+    expected: "workspace_analytics.get_usage_timeseries",
+  },
+  {
+    query: "how has agent activity changed over the last 30 days",
+    expected: "workspace_analytics.get_usage_timeseries",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -37,6 +37,7 @@ import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadat
 import { SLACK_PERSONAL_SERVER } from "@app/lib/api/actions/servers/slack_personal/metadata";
 import { SNOWFLAKE_SERVER } from "@app/lib/api/actions/servers/snowflake/metadata";
 import { WAKEUPS_SERVER } from "@app/lib/api/actions/servers/wakeups/metadata";
+import { WORKSPACE_ANALYTICS_SERVER } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import { buildIndex, rank } from "@app/scripts/mcp_bm25/bm25";
 import type { ServerEntry } from "@app/scripts/mcp_bm25/corpus";
@@ -116,6 +117,10 @@ const SERVERS: ServerEntry[] = [
   { name: "data_warehouses", tools: DATA_WAREHOUSES_SERVER.tools },
   { name: "query_tables_v2", tools: QUERY_TABLES_V2_SERVER.tools },
   { name: "pod_manager", tools: POD_MANAGER_SERVER.tools },
+  {
+    name: "workspace_analytics",
+    tools: WORKSPACE_ANALYTICS_SERVER.tools,
+  },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

Improves the `workspace_analytics` MCP tool descriptions for BM25 lexical tool-search recall, and registers the server in the `mcp_bm25` harness with 14 labeled queries.

Before: server was not in the harness. After adding it, 5 of 14 queries missed:

- **`get_top_agents`**: lacked "active" and "most-used" density — losing to `get_top_skills`/`get_top_users` which had the phrase twice. Fix: added "most-used and most active agents" and "most popular".
- **`get_top_users`**: lacked "members" and "rank" — losing to `pod_manager.list_pods` on "rank workspace members". Fix: added "members", "rank members by usage", "top contributors".
- **`get_agent_details`**: described "equipped skills and **tools**" (4× "tool" in a very short doc), stealing MCP tool queries from `get_top_tools` via BM25 length normalization. Fix: replaced with "equipped skills and capabilities".
- **`get_top_tools`**: MCP vocabulary was buried. Fix: moved "MCP tools" to the front, added "integrations", "called most", "agents rely on".
- **`get_usage_timeseries`**: lacked "volume" while `get_source_breakdown` had "message volume". Fix: added "Plot message volume (messages, conversations, active users)".

All 14 workspace_analytics queries now rank #1.

## Tests

```
npx tsx scripts/mcp_bm25/run.ts
```

All workspace_analytics queries pass at rank 1. No regressions in previously passing queries.

## Risk

Low. Description-only changes with no runtime behavior impact.
