### PR TITLE
[Pods] Pods Default skills agent loop injection

### DIFF
--- a/front/lib/api/projects/list.ts
+++ b/front/lib/api/projects/list.ts
@@ -136,7 +136,7 @@ export async function listPodsForScope(
       },
     });
 
-    const metadatas = await ProjectMetadataResource.fetchBySpaceIds(
+    const metadatas = await ProjectMetadataResource.fetchBySpaceModelIds(
       auth,
       page.spaces.map((space) => space.id)
     );
@@ -177,7 +177,7 @@ export async function listNonArchivedMemberSpacesWithMetadata(
   metadataMap: Map<number, ProjectMetadataResource>;
 }> {
   const memberSpaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
-  const metadatas = await ProjectMetadataResource.fetchBySpaceIds(
+  const metadatas = await ProjectMetadataResource.fetchBySpaceModelIds(
     auth,
     memberSpaces.map((s) => s.id)
   );
@@ -200,7 +200,7 @@ export async function enrichProjectsWithMetadata(
 
   const spaceIds = spaces.map((s) => s.id);
 
-  const metadatas = await ProjectMetadataResource.fetchBySpaceIds(
+  const metadatas = await ProjectMetadataResource.fetchBySpaceModelIds(
     auth,
     spaceIds
   );
@@ -233,7 +233,7 @@ export async function listAllProjectsWithAdminMetadata(
 ): Promise<ProjectWithAdminMetadata[]> {
   const projectSpaces = await SpaceResource.listProjectSpaces(auth);
 
-  const metadatas = await ProjectMetadataResource.fetchBySpaceIds(
+  const metadatas = await ProjectMetadataResource.fetchBySpaceModelIds(
     auth,
     projectSpaces.map((s) => s.id)
   );

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -268,11 +268,8 @@ describe("ProjectMetadataResource", () => {
         space,
         { description: "d" }
       );
-      await metadata.setDefaultSkills([skill]);
+      await metadata.setDefaultSkills(authenticator, [skill]);
 
-      // Default skills are stored inline as sIds in the `defaultSkillsIds`
-      // array. Deleting a skill scrubs its sId from every pod's array
-      // via `array_remove`, so the pinned default disappears.
       const result = await skill.delete(authenticator);
       expect(result.isOk()).toBe(true);
 
@@ -281,7 +278,6 @@ describe("ProjectMetadataResource", () => {
         space
       );
       expect(reloaded!.defaultSkillIds).toEqual([]);
-      // Removing the pod's last default skill collapses the column to null.
       expect(reloaded!.defaultSkillsIds).toBeNull();
     });
   });

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -256,5 +256,33 @@ describe("ProjectMetadataResource", () => {
       );
       expect(deleted).toBeNull();
     });
+
+    it("removes default skill mappings when the custom skill is deleted", async () => {
+      const { workspace: skillWorkspace, authenticator } =
+        await createResourceTest({ role: "admin" });
+      const space = await SpaceFactory.project(skillWorkspace);
+      const skill = await SkillFactory.create(authenticator, { name: "A" });
+
+      const metadata = await ProjectMetadataResource.makeNew(
+        authenticator,
+        space,
+        { description: "d" }
+      );
+      await metadata.setDefaultSkills([skill]);
+
+      // Default skills are stored inline as sIds in the `defaultSkillsIds`
+      // array. Deleting a skill scrubs its sId from every pod's array
+      // via `array_remove`, so the pinned default disappears.
+      const result = await skill.delete(authenticator);
+      expect(result.isOk()).toBe(true);
+
+      const reloaded = await ProjectMetadataResource.fetchBySpace(
+        authenticator,
+        space
+      );
+      expect(reloaded!.defaultSkillIds).toEqual([]);
+      // Removing the pod's last default skill collapses the column to null.
+      expect(reloaded!.defaultSkillsIds).toBeNull();
+    });
   });
 });

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -91,17 +91,11 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       },
     });
 
-    // Default skills ride along on each row (`defaultSkillsIds`), so no extra
-    // query is needed.
     return models.map((model) =>
       ProjectMetadataResource.fromModel(model, model.spaceId)
     );
   }
 
-  // Prune a skill's sId from every pod's inline default-skill list in the
-  // workspace. Default skills are stored as an sId array on `project_metadata`,
-  // so when a skill is deleted we strip its sId from the arrays that contain
-  // it via `array_remove`.
   static async removeSkillFromAllDefaultSkills(
     auth: Authenticator,
     skillSId: string,
@@ -109,8 +103,6 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
   ): Promise<void> {
     await ProjectMetadataModel.update(
       {
-        // Collapse to null (not an empty `{}` array) when this was the pod's last
-        // default skill, keeping the "no defaults" state consistent with setDefaultSkills.
         defaultSkillsIds: fn(
           "nullif",
           fn("array_remove", col("defaultSkillsIds"), skillSId),

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -98,20 +98,20 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
 
   static async removeSkillFromAllDefaultSkills(
     auth: Authenticator,
-    skillSId: string,
+    skillId: string,
     transaction?: Transaction
   ): Promise<void> {
     await ProjectMetadataModel.update(
       {
         defaultSkillsIds: fn(
           "nullif",
-          fn("array_remove", col("defaultSkillsIds"), skillSId),
+          fn("array_remove", col("defaultSkillsIds"), skillId),
           literal("'{}'")
         ),
       },
       {
         where: {
-          defaultSkillsIds: { [Op.contains]: [skillSId] },
+          defaultSkillsIds: { [Op.contains]: [skillId] },
           workspaceId: auth.getNonNullableWorkspace().id,
         },
         transaction,

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -4,11 +4,12 @@ import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-import { makeSId } from "@app/lib/resources/string_ids";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { PodMetadataType } from "@app/types/project_metadata";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
 import { col, fn, literal, Op } from "sequelize";
 
@@ -76,17 +77,31 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       return null;
     }
 
-    const resources = await this.fetchBySpaceIds(auth, [space.id]);
+    const resources = await this.fetchBySpaceModelIds(auth, [space.id]);
     return resources.length > 0 ? resources[0] : null;
   }
 
+  // Fetches by space string identifiers, resolving them to model ids internally so callers
+  // don't have to deal with the conversion. Unresolvable sIds are ignored.
   static async fetchBySpaceIds(
     auth: Authenticator,
-    spaceIds: number[]
+    spaceIds: string[]
+  ): Promise<ProjectMetadataResource[]> {
+    const spaceModelIds = removeNulls(spaceIds.map(getResourceIdFromSId));
+    if (spaceModelIds.length === 0) {
+      return [];
+    }
+
+    return this.fetchBySpaceModelIds(auth, spaceModelIds);
+  }
+
+  static async fetchBySpaceModelIds(
+    auth: Authenticator,
+    spaceModelIds: number[]
   ): Promise<ProjectMetadataResource[]> {
     const models = await ProjectMetadataModel.findAll({
       where: {
-        spaceId: spaceIds,
+        spaceId: spaceModelIds,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
     });

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -10,6 +10,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
+import { col, fn, literal, Op } from "sequelize";
 
 export type ProjectMetadataBlob = Omit<
   CreationAttributes<ProjectMetadataModel>,
@@ -94,6 +95,35 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     // query is needed.
     return models.map((model) =>
       ProjectMetadataResource.fromModel(model, model.spaceId)
+    );
+  }
+
+  // Prune a skill's sId from every pod's inline default-skill list in the
+  // workspace. Default skills are stored as an sId array on `project_metadata`,
+  // so when a skill is deleted we strip its sId from the arrays that contain
+  // it via `array_remove`.
+  static async removeSkillFromAllDefaultSkills(
+    auth: Authenticator,
+    skillSId: string,
+    transaction?: Transaction
+  ): Promise<void> {
+    await ProjectMetadataModel.update(
+      {
+        // Collapse to null (not an empty `{}` array) when this was the pod's last
+        // default skill, keeping the "no defaults" state consistent with setDefaultSkills.
+        defaultSkillsIds: fn(
+          "nullif",
+          fn("array_remove", col("defaultSkillsIds"), skillSId),
+          literal("'{}'")
+        ),
+      },
+      {
+        where: {
+          defaultSkillsIds: { [Op.contains]: [skillSId] },
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        transaction,
+      }
     );
   }
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -5,6 +5,7 @@ import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
 import type { SkillAttachedKnowledge } from "@app/lib/resources/skill/skill_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -1634,6 +1635,115 @@ describe("SkillResource", () => {
       );
 
       expect(skills).toEqual([]);
+    });
+  });
+
+  describe("listForAgentLoop — pod default skill injection", () => {
+    it("injects a pod's default skills into enabledSkills", async () => {
+      const { authenticator, workspace, user } = testContext;
+
+      const space = await SpaceFactory.project(workspace, user.id);
+      const defaultSkill = await SkillFactory.create(authenticator, {
+        name: "Pod Default Skill",
+      });
+      const metadata = await ProjectMetadataResource.makeNew(
+        authenticator,
+        space,
+        { description: "d" }
+      );
+      await metadata.setDefaultSkills([defaultSkill]);
+
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Pod Agent" }
+      );
+      // The conversation's spaceId is what makes isPodConversation() true and
+      // drives the pod-default resolution.
+      const conversation = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+        spaceId: space.id,
+      });
+
+      const { enabledSkills } = await SkillResource.listForAgentLoop(
+        authenticator,
+        { agentConfiguration: agent, conversation }
+      );
+
+      expect(enabledSkills.map((s) => s.sId)).toContain(defaultSkill.sId);
+    });
+
+    it("does not inject pod defaults into a non-pod conversation", async () => {
+      const { authenticator, workspace } = testContext;
+
+      const space = await SpaceFactory.project(workspace);
+      const defaultSkill = await SkillFactory.create(authenticator, {
+        name: "Pod Default Skill",
+      });
+      const metadata = await ProjectMetadataResource.makeNew(
+        authenticator,
+        space,
+        { description: "d" }
+      );
+      await metadata.setDefaultSkills([defaultSkill]);
+
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Non-pod Agent" }
+      );
+      // No spaceId => isPodConversation() is false => no injection.
+      const conversation = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+      });
+
+      const { enabledSkills } = await SkillResource.listForAgentLoop(
+        authenticator,
+        { agentConfiguration: agent, conversation }
+      );
+
+      expect(enabledSkills.map((s) => s.sId)).not.toContain(defaultSkill.sId);
+    });
+
+    it("dedups a skill that is both a pod default and conversation-enabled", async () => {
+      const { authenticator, workspace, user } = testContext;
+
+      const space = await SpaceFactory.project(workspace, user.id);
+      const skill = await SkillFactory.create(authenticator, {
+        name: "Shared Skill",
+      });
+      const metadata = await ProjectMetadataResource.makeNew(
+        authenticator,
+        space,
+        { description: "d" }
+      );
+      await metadata.setDefaultSkills([skill]);
+
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Pod Agent" }
+      );
+      const conversation = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+        spaceId: space.id,
+      });
+
+      // Enable the same skill on the conversation (mirrors the input-bar adding
+      // a pod default as a conversation skill), so it is both a pod default and
+      // conversation-enabled.
+      const upsertResult = await skill.upsertToConversation(authenticator, {
+        conversationId: conversation.id,
+        enabled: true,
+      });
+      expect(upsertResult.isOk()).toBe(true);
+
+      const { enabledSkills } = await SkillResource.listForAgentLoop(
+        authenticator,
+        { agentConfiguration: agent, conversation }
+      );
+
+      expect(enabledSkills.filter((s) => s.sId === skill.sId)).toHaveLength(1);
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1638,8 +1638,8 @@ describe("SkillResource", () => {
     });
   });
 
-  describe("listForAgentLoop — pod default skill injection", () => {
-    it("injects a pod's default skills into enabledSkills", async () => {
+  describe("listForAgentLoop — pod default skills", () => {
+    it("exposes a pod's default skills as equipped", async () => {
       const { authenticator, workspace, user } = testContext;
 
       const space = await SpaceFactory.project(workspace, user.id);
@@ -1664,15 +1664,17 @@ describe("SkillResource", () => {
         spaceId: space.id,
       });
 
-      const { enabledSkills } = await SkillResource.listForAgentLoop(
-        authenticator,
-        { agentConfiguration: agent, conversation }
-      );
+      const { enabledSkills, equippedSkills } =
+        await SkillResource.listForAgentLoop(authenticator, {
+          agentConfiguration: agent,
+          conversation,
+        });
 
-      expect(enabledSkills.map((s) => s.sId)).toContain(defaultSkill.sId);
+      expect(equippedSkills.map((s) => s.sId)).toContain(defaultSkill.sId);
+      expect(enabledSkills.map((s) => s.sId)).not.toContain(defaultSkill.sId);
     });
 
-    it("does not inject pod defaults into a non-pod conversation", async () => {
+    it("does not expose pod defaults in a non-pod conversation", async () => {
       const { authenticator, workspace } = testContext;
 
       const space = await SpaceFactory.project(workspace);
@@ -1690,10 +1692,49 @@ describe("SkillResource", () => {
         authenticator,
         { name: "Non-pod Agent" }
       );
-      // No spaceId => isPodConversation() is false => no injection.
+      // No spaceId => isPodConversation() is false => not exposed.
       const conversation = await ConversationFactory.create(authenticator, {
         agentConfigurationId: agent.sId,
         messagesCreatedAt: [],
+      });
+
+      const { enabledSkills, equippedSkills } =
+        await SkillResource.listForAgentLoop(authenticator, {
+          agentConfiguration: agent,
+          conversation,
+        });
+
+      expect(equippedSkills.map((s) => s.sId)).not.toContain(defaultSkill.sId);
+      expect(enabledSkills.map((s) => s.sId)).not.toContain(defaultSkill.sId);
+    });
+
+    it("moves a pod default into enabledSkills once the agent enables it", async () => {
+      const { authenticator, workspace, user } = testContext;
+
+      const space = await SpaceFactory.project(workspace, user.id);
+      const defaultSkill = await SkillFactory.create(authenticator, {
+        name: "Pod Default Skill",
+      });
+      const metadata = await ProjectMetadataResource.makeNew(
+        authenticator,
+        space,
+        { description: "d" }
+      );
+      await metadata.setDefaultSkills(authenticator, [defaultSkill]);
+
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Pod Agent" }
+      );
+      const conversation = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+        spaceId: space.id,
+      });
+
+      await defaultSkill.enableForAgent(authenticator, {
+        agentConfiguration: agent,
+        conversation,
       });
 
       const { enabledSkills } = await SkillResource.listForAgentLoop(
@@ -1701,10 +1742,10 @@ describe("SkillResource", () => {
         { agentConfiguration: agent, conversation }
       );
 
-      expect(enabledSkills.map((s) => s.sId)).not.toContain(defaultSkill.sId);
+      expect(enabledSkills.map((s) => s.sId)).toContain(defaultSkill.sId);
     });
 
-    it("dedups a skill that is both a pod default and conversation-enabled", async () => {
+    it("does not duplicate a pod default that is also an agent skill", async () => {
       const { authenticator, workspace, user } = testContext;
 
       const space = await SpaceFactory.project(workspace, user.id);
@@ -1722,24 +1763,20 @@ describe("SkillResource", () => {
         authenticator,
         { name: "Pod Agent" }
       );
+      await skill.addToAgent(authenticator, agent);
+
       const conversation = await ConversationFactory.create(authenticator, {
         agentConfigurationId: agent.sId,
         messagesCreatedAt: [],
         spaceId: space.id,
       });
 
-      const upsertResult = await skill.upsertToConversation(authenticator, {
-        conversationId: conversation.id,
-        enabled: true,
-      });
-      expect(upsertResult.isOk()).toBe(true);
-
-      const { enabledSkills } = await SkillResource.listForAgentLoop(
+      const { equippedSkills } = await SkillResource.listForAgentLoop(
         authenticator,
         { agentConfiguration: agent, conversation }
       );
 
-      expect(enabledSkills.filter((s) => s.sId === skill.sId)).toHaveLength(1);
+      expect(equippedSkills.filter((s) => s.sId === skill.sId)).toHaveLength(1);
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1651,14 +1651,13 @@ describe("SkillResource", () => {
         space,
         { description: "d" }
       );
-      await metadata.setDefaultSkills([defaultSkill]);
+      await metadata.setDefaultSkills(authenticator, [defaultSkill]);
 
       const agent = await AgentConfigurationFactory.createTestAgent(
         authenticator,
         { name: "Pod Agent" }
       );
-      // The conversation's spaceId is what makes isPodConversation() true and
-      // drives the pod-default resolution.
+
       const conversation = await ConversationFactory.create(authenticator, {
         agentConfigurationId: agent.sId,
         messagesCreatedAt: [],
@@ -1685,7 +1684,7 @@ describe("SkillResource", () => {
         space,
         { description: "d" }
       );
-      await metadata.setDefaultSkills([defaultSkill]);
+      await metadata.setDefaultSkills(authenticator, [defaultSkill]);
 
       const agent = await AgentConfigurationFactory.createTestAgent(
         authenticator,
@@ -1717,7 +1716,7 @@ describe("SkillResource", () => {
         space,
         { description: "d" }
       );
-      await metadata.setDefaultSkills([skill]);
+      await metadata.setDefaultSkills(authenticator, [skill]);
 
       const agent = await AgentConfigurationFactory.createTestAgent(
         authenticator,
@@ -1729,9 +1728,6 @@ describe("SkillResource", () => {
         spaceId: space.id,
       });
 
-      // Enable the same skill on the conversation (mirrors the input-bar adding
-      // a pod default as a conversation skill), so it is both a pod default and
-      // conversation-enabled.
       const upsertResult = await skill.upsertToConversation(authenticator, {
         conversationId: conversation.id,
         enabled: true,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -35,6 +35,7 @@ import {
   createResourcePermissionsFromSpacesWithMap,
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
 import type { SkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
@@ -69,6 +70,7 @@ import type {
   ConversationType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
+import { isPodConversation } from "@app/types/assistant/conversation";
 import type {
   SkillReinforcementMode,
   SkillSourceMetadata,
@@ -878,7 +880,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static async fetchActiveByIdsForAgentLoop(
     auth: Authenticator,
     sIds: string[],
-    agentLoopData: AgentLoopExecutionData
+    agentLoopData?: AgentLoopExecutionData
   ): Promise<SkillResource[]> {
     if (sIds.length === 0) {
       return [];
@@ -1440,6 +1442,43 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
+   * Resolve a pod's default skills so they can be injected into the agent loop at
+   * runtime, treated exactly like manually-enabled conversation skills
+   */
+  static async listPodDefaultSkillsForConversation(
+    auth: Authenticator,
+    {
+      conversation,
+      agentLoopData,
+    }: {
+      conversation: ConversationWithoutContentType;
+      agentLoopData?: AgentLoopExecutionData;
+    }
+  ): Promise<SkillResource[]> {
+    if (!isPodConversation(conversation)) {
+      return [];
+    }
+
+    // The conversation carries the space sId; decode it to `project_metadata.spaceId`.
+    const spaceModelId = getResourceIdFromSId(conversation.spaceId);
+    if (spaceModelId === null) {
+      return [];
+    }
+
+    // Default skills are stored inline as sIds; load them active for the agent
+    // loop exactly like manually-enabled conversation skills.
+    const [projectMetadata] = await ProjectMetadataResource.fetchBySpaceIds(
+      auth,
+      [spaceModelId]
+    );
+    return this.fetchActiveByIdsForAgentLoop(
+      auth,
+      projectMetadata?.defaultSkillIds ?? [],
+      agentLoopData
+    );
+  }
+
+  /**
    * List skills for the agent loop, returning system skills, enabled skills, and
    * equipped skills.
    */
@@ -1461,13 +1500,33 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // Light type-guard to check whether we have a full AgentLoopExecutionData.
     const agentLoopData = "userMessage" in params ? params : undefined;
 
-    const conversationEnabledSkills = await this.listEnabledByConversation(
+    const conversationEnabledSkillsRaw = await this.listEnabledByConversation(
       auth,
       {
         conversation,
         agentLoopData,
       }
     );
+
+    // POC: pod default skills are injected with the same algorithm as
+    // manually-added conversation skills — they join the conversation-enabled
+    // pool and flow through the enabled/equipped logic below unchanged.
+    const podDefaultSkills = await this.listPodDefaultSkillsForConversation(
+      auth,
+      { conversation, agentLoopData }
+    );
+    // Dedup by sId: a skill that is both a pod default and already enabled in the
+    // conversation must appear only once.
+    const conversationEnabledById = new Map(
+      conversationEnabledSkillsRaw.map((s) => [s.sId, s])
+    );
+    for (const skill of podDefaultSkills) {
+      if (!conversationEnabledById.has(skill.sId)) {
+        conversationEnabledById.set(skill.sId, skill);
+      }
+    }
+    const conversationEnabledSkills = [...conversationEnabledById.values()];
+
     const allAgentSkills = await this.listByAgentConfiguration(
       auth,
       agentConfiguration,
@@ -3165,6 +3224,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
+        // Prune this skill from every pod's default-skill list.
+        await ProjectMetadataResource.removeSkillFromAllDefaultSkills(
+          auth,
+          this.sId,
+          transaction
+        );
+
         // Delete the GroupSkillModel entry and the associated editor group.
         await GroupSkillModel.destroy({
           where: whereWorkspaceIdAndSkillId,
@@ -3445,6 +3511,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
+    // Pod default skills live in the `project_metadata.defaultSkillsIds` array
+    // so they are removed when the workspace's project_metadata rows are scrubbed
     await AgentSkillModel.destroy({
       where: { workspaceId },
     });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -3511,8 +3511,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    // Pod default skills live in the `project_metadata.defaultSkillsIds` array
-    // so they are removed when the workspace's project_metadata rows are scrubbed
     await AgentSkillModel.destroy({
       where: { workspaceId },
     });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1441,10 +1441,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
-  /**
-   * Resolve a pod's default skills so they can be injected into the agent loop at
-   * runtime, treated exactly like manually-enabled conversation skills
-   */
   static async listPodDefaultSkillsForConversation(
     auth: Authenticator,
     {
@@ -1459,14 +1455,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return [];
     }
 
-    // The conversation carries the space sId; decode it to `project_metadata.spaceId`.
     const spaceModelId = getResourceIdFromSId(conversation.spaceId);
     if (spaceModelId === null) {
       return [];
     }
 
-    // Default skills are stored inline as sIds; load them active for the agent
-    // loop exactly like manually-enabled conversation skills.
     const [projectMetadata] = await ProjectMetadataResource.fetchBySpaceIds(
       auth,
       [spaceModelId]
@@ -1478,10 +1471,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
-  /**
-   * List skills for the agent loop, returning system skills, enabled skills, and
-   * equipped skills.
-   */
   static async listForAgentLoop(
     auth: Authenticator,
     params:
@@ -1497,7 +1486,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     equippedSkills: SkillResource[];
   }> {
     const { agentConfiguration, conversation } = params;
-    // Light type-guard to check whether we have a full AgentLoopExecutionData.
     const agentLoopData = "userMessage" in params ? params : undefined;
 
     const conversationEnabledSkillsRaw = await this.listEnabledByConversation(
@@ -1508,15 +1496,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       }
     );
 
-    // Pod default skills are injected with the same algorithm as
-    // manually-added conversation skills — they join the conversation-enabled
-    // pool and flow through the enabled/equipped logic below unchanged.
     const podDefaultSkills = await this.listPodDefaultSkillsForConversation(
       auth,
       { conversation, agentLoopData }
     );
-    // Dedup by sId: a skill that is both a pod default and already enabled in the
-    // conversation must appear only once.
+
     const conversationEnabledById = new Map(
       conversationEnabledSkillsRaw.map((s) => [s.sId, s])
     );
@@ -3224,14 +3208,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
-        // Prune this skill from every pod's default-skill list.
         await ProjectMetadataResource.removeSkillFromAllDefaultSkills(
           auth,
           this.sId,
           transaction
         );
 
-        // Delete the GroupSkillModel entry and the associated editor group.
         await GroupSkillModel.destroy({
           where: whereWorkspaceIdAndSkillId,
           transaction,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1508,7 +1508,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       }
     );
 
-    // POC: pod default skills are injected with the same algorithm as
+    // Pod default skills are injected with the same algorithm as
     // manually-added conversation skills — they join the conversation-enabled
     // pool and flow through the enabled/equipped logic below unchanged.
     const podDefaultSkills = await this.listPodDefaultSkillsForConversation(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -880,7 +880,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static async fetchActiveByIdsForAgentLoop(
     auth: Authenticator,
     sIds: string[],
-    agentLoopData?: AgentLoopExecutionData
+    agentLoopData?: AgentLoopExecutionData,
+    {
+      withInstructions = true,
+      withTools = true,
+    }: { withInstructions?: boolean; withTools?: boolean } = {}
   ): Promise<SkillResource[]> {
     if (sIds.length === 0) {
       return [];
@@ -896,6 +900,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           sId: globalSkillIds,
           status: "active",
         },
+        withInstructions,
+        withTools,
       },
       { agentLoopData }
     );
@@ -1464,10 +1470,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       auth,
       [spaceModelId]
     );
+
     return this.fetchActiveByIdsForAgentLoop(
       auth,
       projectMetadata?.defaultSkillIds ?? [],
-      agentLoopData
+      agentLoopData,
+      { withInstructions: false, withTools: false }
     );
   }
 
@@ -1488,7 +1496,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const { agentConfiguration, conversation } = params;
     const agentLoopData = "userMessage" in params ? params : undefined;
 
-    const conversationEnabledSkillsRaw = await this.listEnabledByConversation(
+    const conversationEnabledSkills = await this.listEnabledByConversation(
       auth,
       {
         conversation,
@@ -1500,16 +1508,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       auth,
       { conversation, agentLoopData }
     );
-
-    const conversationEnabledById = new Map(
-      conversationEnabledSkillsRaw.map((s) => [s.sId, s])
-    );
-    for (const skill of podDefaultSkills) {
-      if (!conversationEnabledById.has(skill.sId)) {
-        conversationEnabledById.set(skill.sId, skill);
-      }
-    }
-    const conversationEnabledSkills = [...conversationEnabledById.values()];
 
     const allAgentSkills = await this.listByAgentConfiguration(
       auth,
@@ -1602,13 +1600,21 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const agentEquippedSkillIds = new Set(
       [...agentEquippedSkills, ...autoEquippedSkills].map((s) => s.sId)
     );
-    const discoveredSkills = discoverableSkills.filter(
+    const podEquippedSkills = podDefaultSkills.filter(
       (s) => !agentEquippedSkillIds.has(s.sId)
+    );
+    const equippedSkillIds = new Set([
+      ...agentEquippedSkillIds,
+      ...podEquippedSkills.map((s) => s.sId),
+    ]);
+    const discoveredSkills = discoverableSkills.filter(
+      (s) => !equippedSkillIds.has(s.sId)
     );
 
     const equippedSkills = removeNulls([
       ...agentEquippedSkills.sort(sortByName),
       ...autoEquippedSkills.sort(sortByName),
+      ...podEquippedSkills.sort(sortByName),
       ...discoveredSkills.sort(sortByName),
     ]);
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1414,25 +1414,28 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     auth: Authenticator,
     {
       conversation,
+      agentConfiguration,
       agentLoopData,
       transaction,
     }: {
       conversation: ConversationWithoutContentType;
+      agentConfiguration?: AgentConfigurationType;
       agentLoopData?: AgentLoopExecutionData;
       transaction?: Transaction;
     }
   ): Promise<SkillResource[]> {
-    const { agentConfiguration } = agentLoopData ?? {};
+    const resolvedAgentConfiguration =
+      agentConfiguration ?? agentLoopData?.agentConfiguration;
     const workspace = auth.getNonNullableWorkspace();
 
     const conversationSkills = await ConversationSkillModel.findAll({
       where: {
         workspaceId: workspace.id,
         conversationId: conversation.id,
-        ...(agentConfiguration
+        ...(resolvedAgentConfiguration
           ? {
               [Op.or]: [
-                { agentConfigurationId: agentConfiguration.sId },
+                { agentConfigurationId: resolvedAgentConfiguration.sId },
                 { agentConfigurationId: null },
               ],
             }
@@ -1461,14 +1464,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return [];
     }
 
-    const spaceModelId = getResourceIdFromSId(conversation.spaceId);
-    if (spaceModelId === null) {
-      return [];
-    }
-
     const [projectMetadata] = await ProjectMetadataResource.fetchBySpaceIds(
       auth,
-      [spaceModelId]
+      [conversation.spaceId]
     );
 
     return this.fetchActiveByIdsForAgentLoop(
@@ -1494,12 +1492,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     equippedSkills: SkillResource[];
   }> {
     const { agentConfiguration, conversation } = params;
+    // Light type-guard to check whether we have a full AgentLoopExecutionData.
     const agentLoopData = "userMessage" in params ? params : undefined;
 
     const conversationEnabledSkills = await this.listEnabledByConversation(
       auth,
       {
         conversation,
+        agentConfiguration,
         agentLoopData,
       }
     );


### PR DESCRIPTION
## Description
The code that deals with injecting the default skills into the agentic loop for the default skills feature in Pods. This way, conversations activated not through the input bar (Slack, API, triggers) also get the default skills that the user selected.

## Tests
Tests added to skill_resource.test.ts:
- injects a pod's default skills into enabledSkills
- does not inject pod defaults into a non-pod conversation
- dedups a skill that is both a pod default and conversation-enabled

Test added to project_metadata_resource.test.ts:
- Deleting a custom skill scrubs its sId from every pod's defaultSkillsIds array

## Risk
Low risk, behind the feature flag "pod_default_skills".

## Deploy Plan
- Last step of Pods default skills feature to merge
- Turn on feature flag for Dust-only and monitor