### PR TITLE
[front] enh: improve data source read labels

### DIFF
--- a/front/lib/actions/data_source_file_system_read_targets.ts
+++ b/front/lib/actions/data_source_file_system_read_targets.ts
@@ -31,7 +31,6 @@ const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGET_PREFIXES = [
   { prefix: "intercom-help-center-", target: "Intercom help center" },
   { prefix: "intercom-teams-", target: "Intercom conversations" },
   { prefix: "intercom-team-", target: "Intercom team" },
-  { prefix: "zendesk-article-", target: "Zendesk article" },
   { prefix: "zendesk-category-", target: "Zendesk category" },
   { prefix: "zendesk-help-center-", target: "Zendesk help center" },
   { prefix: "zendesk-brand-", target: "Zendesk brand" },

--- a/front/lib/actions/data_source_file_system_read_targets.ts
+++ b/front/lib/actions/data_source_file_system_read_targets.ts
@@ -91,6 +91,13 @@ function getDataSourceFileSystemNodeReadTarget(nodeId: string): string | null {
     return `Zendesk ticket #${zendeskTicketId}`;
   }
 
+  const zendeskArticleId = getFirstRegexCapture(
+    nodeId.match(/^zendesk-article-\d+-\d+-(\d+)$/)
+  );
+  if (zendeskArticleId) {
+    return `Zendesk article #${zendeskArticleId}`;
+  }
+
   if (/^salesforce-synced-query-document-\d+-\d+-.+$/.test(nodeId)) {
     return "Salesforce record";
   }

--- a/front/lib/actions/data_source_file_system_read_targets.ts
+++ b/front/lib/actions/data_source_file_system_read_targets.ts
@@ -5,6 +5,13 @@ function getFirstRegexCapture(match: RegExpMatchArray | null) {
   return value && value.length > 0 ? value : null;
 }
 
+const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGETS_BY_ID = {
+  "gdrive-sharedWithMe": "Google Drive shared with me",
+  "notion-syncing": "Notion syncing resources",
+  "notion-unknown": "Notion orphaned resources",
+  "project-context-folder": "Dust project context",
+} satisfies Record<string, string>;
+
 const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGET_PREFIXES = [
   { prefix: "github-code-", target: "GitHub repository code" },
   { prefix: "github-issues-", target: "GitHub issues" },
@@ -22,15 +29,62 @@ const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGET_PREFIXES = [
   { prefix: "intercom-conversation-", target: "Intercom conversation" },
   { prefix: "intercom-collection-", target: "Intercom collection" },
   { prefix: "intercom-help-center-", target: "Intercom help center" },
+  { prefix: "intercom-teams-", target: "Intercom conversations" },
+  { prefix: "intercom-team-", target: "Intercom team" },
   { prefix: "zendesk-article-", target: "Zendesk article" },
   { prefix: "zendesk-category-", target: "Zendesk category" },
-  { prefix: "microsoft-", target: "Microsoft content" },
+  { prefix: "zendesk-help-center-", target: "Zendesk help center" },
+  { prefix: "zendesk-brand-", target: "Zendesk brand" },
+  { prefix: "zendesk-tickets-", target: "Zendesk tickets" },
+  { prefix: "gong-transcript-folder-", target: "Gong transcripts" },
   { prefix: "gong-transcript-", target: "Gong transcript" },
   { prefix: "salesforce-synced-query-", target: "Salesforce synced query" },
+  { prefix: "dpd_", target: "Dust project folder" },
   { prefix: "dpf_", target: "Dust project file" },
 ];
 
+const MICROSOFT_NODE_READ_TARGETS_BY_TYPE = {
+  "sites-root": "Microsoft sites",
+  site: "Microsoft site",
+  drive: "Microsoft drive",
+  folder: "Microsoft folder",
+  file: "Microsoft file",
+  page: "Microsoft page",
+  message: "Microsoft message",
+  worksheet: "Microsoft worksheet",
+} satisfies Record<string, string>;
+
+function getMicrosoftNodeReadTarget(nodeId: string): string | null {
+  if (!nodeId.startsWith("microsoft-")) {
+    return null;
+  }
+
+  try {
+    const decodedId = Buffer.from(
+      nodeId.slice("microsoft-".length),
+      "base64url"
+    ).toString();
+    const [nodeType] = decodedId.split("/");
+
+    return (
+      MICROSOFT_NODE_READ_TARGETS_BY_TYPE[
+        nodeType as keyof typeof MICROSOFT_NODE_READ_TARGETS_BY_TYPE
+      ] ?? "Microsoft content"
+    );
+  } catch {
+    return "Microsoft content";
+  }
+}
+
 function getDataSourceFileSystemNodeReadTarget(nodeId: string): string | null {
+  const target =
+    DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGETS_BY_ID[
+      nodeId as keyof typeof DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGETS_BY_ID
+    ];
+  if (target) {
+    return target;
+  }
+
   const githubIssueNumber = getFirstRegexCapture(
     nodeId.match(/^github-issue-\d+-(\d+)$/)
   );
@@ -82,6 +136,11 @@ function getDataSourceFileSystemNodeReadTarget(nodeId: string): string | null {
 
   if (/^dust-project-\d+-project-.+$/.test(nodeId)) {
     return "Dust project";
+  }
+
+  const microsoftTarget = getMicrosoftNodeReadTarget(nodeId);
+  if (microsoftTarget) {
+    return microsoftTarget;
   }
 
   for (const {

--- a/front/lib/actions/data_source_file_system_read_targets.ts
+++ b/front/lib/actions/data_source_file_system_read_targets.ts
@@ -1,0 +1,107 @@
+import { isString } from "@app/types/shared/utils/general";
+
+function getFirstRegexCapture(match: RegExpMatchArray | null) {
+  const value = match?.[1];
+  return value && value.length > 0 ? value : null;
+}
+
+const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGET_PREFIXES = [
+  { prefix: "github-code-", target: "GitHub repository code" },
+  { prefix: "github-issues-", target: "GitHub issues" },
+  { prefix: "github-discussions-", target: "GitHub discussions" },
+  { prefix: "github-repository-", target: "GitHub repository" },
+  { prefix: "confluence-page-", target: "Confluence page" },
+  { prefix: "confluence-folder-", target: "Confluence folder" },
+  { prefix: "confluence-space-", target: "Confluence space" },
+  { prefix: "google-spreadsheet-", target: "Google Sheets tab" },
+  { prefix: "gdrive-", target: "Google Drive file" },
+  { prefix: "notion-database-", target: "Notion database" },
+  { prefix: "notion-", target: "Notion content" },
+  { prefix: "slack-channel-", target: "Slack channel" },
+  { prefix: "intercom-article-", target: "Intercom article" },
+  { prefix: "intercom-conversation-", target: "Intercom conversation" },
+  { prefix: "intercom-collection-", target: "Intercom collection" },
+  { prefix: "intercom-help-center-", target: "Intercom help center" },
+  { prefix: "zendesk-article-", target: "Zendesk article" },
+  { prefix: "zendesk-category-", target: "Zendesk category" },
+  { prefix: "microsoft-", target: "Microsoft content" },
+  { prefix: "gong-transcript-", target: "Gong transcript" },
+  { prefix: "salesforce-synced-query-", target: "Salesforce synced query" },
+  { prefix: "dpf_", target: "Dust project file" },
+];
+
+function getDataSourceFileSystemNodeReadTarget(nodeId: string): string | null {
+  const githubIssueNumber = getFirstRegexCapture(
+    nodeId.match(/^github-issue-\d+-(\d+)$/)
+  );
+  if (githubIssueNumber) {
+    return `GitHub issue #${githubIssueNumber}`;
+  }
+
+  const githubDiscussionNumber = getFirstRegexCapture(
+    nodeId.match(/^github-discussion-\d+-(\d+)$/)
+  );
+  if (githubDiscussionNumber) {
+    return `GitHub discussion #${githubDiscussionNumber}`;
+  }
+
+  if (/^github-code-\d+-file-[a-f0-9]+$/.test(nodeId)) {
+    return "GitHub code file";
+  }
+
+  if (/^github-code-\d+-dir-[a-f0-9]+$/.test(nodeId)) {
+    return "GitHub code directory";
+  }
+
+  if (/^slack-[^-]+-thread-.+$/.test(nodeId)) {
+    return "Slack thread";
+  }
+
+  if (/^slack-[^-]+-messages-.+$/.test(nodeId)) {
+    return "Slack messages";
+  }
+
+  const zendeskTicketId = getFirstRegexCapture(
+    nodeId.match(/^zendesk-ticket-\d+-\d+-(\d+)$/)
+  );
+  if (zendeskTicketId) {
+    return `Zendesk ticket #${zendeskTicketId}`;
+  }
+
+  if (/^salesforce-synced-query-document-\d+-\d+-.+$/.test(nodeId)) {
+    return "Salesforce record";
+  }
+
+  if (/^dust-project-\d+-project-.+-conversation-.+$/.test(nodeId)) {
+    return "Dust project conversation";
+  }
+
+  if (/^dust-project-\d+-project-.+-metadata$/.test(nodeId)) {
+    return "Dust project metadata";
+  }
+
+  if (/^dust-project-\d+-project-.+$/.test(nodeId)) {
+    return "Dust project";
+  }
+
+  for (const {
+    prefix,
+    target,
+  } of DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGET_PREFIXES) {
+    if (nodeId.startsWith(prefix)) {
+      return target;
+    }
+  }
+
+  return null;
+}
+
+export function getDataSourceFileSystemCatReadTarget(
+  inputs: Record<string, unknown>
+) {
+  if (!isString(inputs.nodeId)) {
+    return "file";
+  }
+
+  return getDataSourceFileSystemNodeReadTarget(inputs.nodeId) ?? "file";
+}

--- a/front/lib/actions/data_source_file_system_read_targets.ts
+++ b/front/lib/actions/data_source_file_system_read_targets.ts
@@ -5,12 +5,12 @@ function getFirstRegexCapture(match: RegExpMatchArray | null) {
   return value && value.length > 0 ? value : null;
 }
 
-const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGETS_BY_ID = {
-  "gdrive-sharedWithMe": "Google Drive shared with me",
-  "notion-syncing": "Notion syncing resources",
-  "notion-unknown": "Notion orphaned resources",
-  "project-context-folder": "Dust project context",
-} satisfies Record<string, string>;
+const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGETS = [
+  { nodeId: "gdrive-sharedWithMe", target: "Google Drive shared with me" },
+  { nodeId: "notion-syncing", target: "Notion syncing resources" },
+  { nodeId: "notion-unknown", target: "Notion orphaned resources" },
+  { nodeId: "project-context-folder", target: "Dust project context" },
+];
 
 const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGET_PREFIXES = [
   { prefix: "github-code-", target: "GitHub repository code" },
@@ -36,6 +36,7 @@ const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGET_PREFIXES = [
   { prefix: "zendesk-help-center-", target: "Zendesk help center" },
   { prefix: "zendesk-brand-", target: "Zendesk brand" },
   { prefix: "zendesk-tickets-", target: "Zendesk tickets" },
+  { prefix: "microsoft-", target: "Microsoft content" },
   { prefix: "gong-transcript-folder-", target: "Gong transcripts" },
   { prefix: "gong-transcript-", target: "Gong transcript" },
   { prefix: "salesforce-synced-query-", target: "Salesforce synced query" },
@@ -43,46 +44,14 @@ const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGET_PREFIXES = [
   { prefix: "dpf_", target: "Dust project file" },
 ];
 
-const MICROSOFT_NODE_READ_TARGETS_BY_TYPE = {
-  "sites-root": "Microsoft sites",
-  site: "Microsoft site",
-  drive: "Microsoft drive",
-  folder: "Microsoft folder",
-  file: "Microsoft file",
-  page: "Microsoft page",
-  message: "Microsoft message",
-  worksheet: "Microsoft worksheet",
-} satisfies Record<string, string>;
-
-function getMicrosoftNodeReadTarget(nodeId: string): string | null {
-  if (!nodeId.startsWith("microsoft-")) {
-    return null;
-  }
-
-  try {
-    const decodedId = Buffer.from(
-      nodeId.slice("microsoft-".length),
-      "base64url"
-    ).toString();
-    const [nodeType] = decodedId.split("/");
-
-    return (
-      MICROSOFT_NODE_READ_TARGETS_BY_TYPE[
-        nodeType as keyof typeof MICROSOFT_NODE_READ_TARGETS_BY_TYPE
-      ] ?? "Microsoft content"
-    );
-  } catch {
-    return "Microsoft content";
-  }
-}
-
 function getDataSourceFileSystemNodeReadTarget(nodeId: string): string | null {
-  const target =
-    DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGETS_BY_ID[
-      nodeId as keyof typeof DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGETS_BY_ID
-    ];
-  if (target) {
-    return target;
+  for (const {
+    nodeId: knownNodeId,
+    target,
+  } of DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGETS) {
+    if (nodeId === knownNodeId) {
+      return target;
+    }
   }
 
   const githubIssueNumber = getFirstRegexCapture(
@@ -136,11 +105,6 @@ function getDataSourceFileSystemNodeReadTarget(nodeId: string): string | null {
 
   if (/^dust-project-\d+-project-.+$/.test(nodeId)) {
     return "Dust project";
-  }
-
-  const microsoftTarget = getMicrosoftNodeReadTarget(nodeId);
-  if (microsoftTarget) {
-    return microsoftTarget;
   }
 
   for (const {

--- a/front/lib/actions/data_source_file_system_read_targets.ts
+++ b/front/lib/actions/data_source_file_system_read_targets.ts
@@ -5,14 +5,44 @@ function getFirstRegexCapture(match: RegExpMatchArray | null) {
   return value && value.length > 0 ? value : null;
 }
 
-const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGETS = [
+const EXACT_NODE_READ_TARGETS = [
   { nodeId: "gdrive-sharedWithMe", target: "Google Drive shared with me" },
   { nodeId: "notion-syncing", target: "Notion syncing resources" },
   { nodeId: "notion-unknown", target: "Notion orphaned resources" },
   { nodeId: "project-context-folder", target: "Dust project context" },
 ];
 
-const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGET_PREFIXES = [
+const NUMBERED_NODE_READ_TARGETS = [
+  { pattern: /^github-issue-\d+-(\d+)$/, target: "GitHub issue" },
+  { pattern: /^github-discussion-\d+-(\d+)$/, target: "GitHub discussion" },
+  { pattern: /^zendesk-ticket-\d+-\d+-(\d+)$/, target: "Zendesk ticket" },
+  { pattern: /^zendesk-article-\d+-\d+-(\d+)$/, target: "Zendesk article" },
+];
+
+const PATTERN_NODE_READ_TARGETS = [
+  { pattern: /^github-code-\d+-file-[a-f0-9]+$/, target: "GitHub code file" },
+  {
+    pattern: /^github-code-\d+-dir-[a-f0-9]+$/,
+    target: "GitHub code directory",
+  },
+  { pattern: /^slack-[^-]+-thread-.+$/, target: "Slack thread" },
+  { pattern: /^slack-[^-]+-messages-.+$/, target: "Slack messages" },
+  {
+    pattern: /^salesforce-synced-query-document-\d+-\d+-.+$/,
+    target: "Salesforce record",
+  },
+  {
+    pattern: /^dust-project-\d+-project-.+-conversation-.+$/,
+    target: "Dust project conversation",
+  },
+  {
+    pattern: /^dust-project-\d+-project-.+-metadata$/,
+    target: "Dust project metadata",
+  },
+  { pattern: /^dust-project-\d+-project-.+$/, target: "Dust project" },
+];
+
+const PREFIX_NODE_READ_TARGETS = [
   { prefix: "github-code-", target: "GitHub repository code" },
   { prefix: "github-issues-", target: "GitHub issues" },
   { prefix: "github-discussions-", target: "GitHub discussions" },
@@ -44,81 +74,30 @@ const DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGET_PREFIXES = [
 ];
 
 function getDataSourceFileSystemNodeReadTarget(nodeId: string): string | null {
-  for (const {
-    nodeId: knownNodeId,
-    target,
-  } of DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGETS) {
-    if (nodeId === knownNodeId) {
-      return target;
+  for (const exactTarget of EXACT_NODE_READ_TARGETS) {
+    if (nodeId === exactTarget.nodeId) {
+      return exactTarget.target;
     }
   }
 
-  const githubIssueNumber = getFirstRegexCapture(
-    nodeId.match(/^github-issue-\d+-(\d+)$/)
-  );
-  if (githubIssueNumber) {
-    return `GitHub issue #${githubIssueNumber}`;
+  for (const numberedTarget of NUMBERED_NODE_READ_TARGETS) {
+    const itemNumber = getFirstRegexCapture(
+      nodeId.match(numberedTarget.pattern)
+    );
+    if (itemNumber) {
+      return `${numberedTarget.target} #${itemNumber}`;
+    }
   }
 
-  const githubDiscussionNumber = getFirstRegexCapture(
-    nodeId.match(/^github-discussion-\d+-(\d+)$/)
-  );
-  if (githubDiscussionNumber) {
-    return `GitHub discussion #${githubDiscussionNumber}`;
+  for (const patternTarget of PATTERN_NODE_READ_TARGETS) {
+    if (patternTarget.pattern.test(nodeId)) {
+      return patternTarget.target;
+    }
   }
 
-  if (/^github-code-\d+-file-[a-f0-9]+$/.test(nodeId)) {
-    return "GitHub code file";
-  }
-
-  if (/^github-code-\d+-dir-[a-f0-9]+$/.test(nodeId)) {
-    return "GitHub code directory";
-  }
-
-  if (/^slack-[^-]+-thread-.+$/.test(nodeId)) {
-    return "Slack thread";
-  }
-
-  if (/^slack-[^-]+-messages-.+$/.test(nodeId)) {
-    return "Slack messages";
-  }
-
-  const zendeskTicketId = getFirstRegexCapture(
-    nodeId.match(/^zendesk-ticket-\d+-\d+-(\d+)$/)
-  );
-  if (zendeskTicketId) {
-    return `Zendesk ticket #${zendeskTicketId}`;
-  }
-
-  const zendeskArticleId = getFirstRegexCapture(
-    nodeId.match(/^zendesk-article-\d+-\d+-(\d+)$/)
-  );
-  if (zendeskArticleId) {
-    return `Zendesk article #${zendeskArticleId}`;
-  }
-
-  if (/^salesforce-synced-query-document-\d+-\d+-.+$/.test(nodeId)) {
-    return "Salesforce record";
-  }
-
-  if (/^dust-project-\d+-project-.+-conversation-.+$/.test(nodeId)) {
-    return "Dust project conversation";
-  }
-
-  if (/^dust-project-\d+-project-.+-metadata$/.test(nodeId)) {
-    return "Dust project metadata";
-  }
-
-  if (/^dust-project-\d+-project-.+$/.test(nodeId)) {
-    return "Dust project";
-  }
-
-  for (const {
-    prefix,
-    target,
-  } of DATA_SOURCE_FILE_SYSTEM_NODE_READ_TARGET_PREFIXES) {
-    if (nodeId.startsWith(prefix)) {
-      return target;
+  for (const prefixTarget of PREFIX_NODE_READ_TARGETS) {
+    if (nodeId.startsWith(prefixTarget.prefix)) {
+      return prefixTarget.target;
     }
   }
 

--- a/front/lib/actions/tool_display_labels.test.ts
+++ b/front/lib/actions/tool_display_labels.test.ts
@@ -20,9 +20,6 @@ describe("getToolNameFromFunctionCallName", () => {
 });
 
 describe("getToolDisplayLabels", () => {
-  const getMicrosoftNodeId = (decodedId: string) =>
-    `microsoft-${Buffer.from(decodedId).toString("base64url")}`;
-
   it("resolves labels for internal tools", () => {
     expect(
       getToolDisplayLabels({
@@ -104,6 +101,7 @@ describe("getToolDisplayLabels", () => {
     ["intercom-teams-12", "Intercom conversations"],
     ["intercom-team-12-team_abc", "Intercom team"],
     ["zendesk-brand-12-34", "Zendesk brand"],
+    ["microsoft-anything-opaque", "Microsoft content"],
     ["gong-transcript-folder-12", "Gong transcripts"],
     ["dpd_1234567890abcdef", "Dust project folder"],
   ])("uses provider labels for data source file node ID %s", (nodeId, target) => {
@@ -118,36 +116,6 @@ describe("getToolDisplayLabels", () => {
     ).toEqual({
       running: `Reading ${target}`,
       done: `Read ${target}`,
-    });
-  });
-
-  it("decodes Microsoft data source file targets without showing Graph IDs", () => {
-    expect(
-      getToolDisplayLabels({
-        internalMCPServerName: "data_sources_file_system",
-        toolName: "cat",
-        inputs: {
-          nodeId: getMicrosoftNodeId(
-            "worksheet//drives/drive-id/items/item-id/workbook/worksheets/sheet-id"
-          ),
-        },
-      })
-    ).toEqual({
-      running: "Reading Microsoft worksheet",
-      done: "Read Microsoft worksheet",
-    });
-
-    expect(
-      getToolDisplayLabels({
-        internalMCPServerName: "data_sources_file_system",
-        toolName: "cat",
-        inputs: {
-          nodeId: getMicrosoftNodeId("file//drives/drive-id/items/item-id"),
-        },
-      })
-    ).toEqual({
-      running: "Reading Microsoft file",
-      done: "Read Microsoft file",
     });
   });
 

--- a/front/lib/actions/tool_display_labels.test.ts
+++ b/front/lib/actions/tool_display_labels.test.ts
@@ -45,6 +45,111 @@ describe("getToolDisplayLabels", () => {
       done: "List issues on Linear",
     });
   });
+
+  it("infers data source file reads from GitHub issue node IDs", () => {
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "data_sources_file_system",
+        toolName: "cat",
+        inputs: {
+          nodeId: "github-issue-693580871-9196",
+        },
+      })
+    ).toEqual({
+      running: "Reading GitHub issue #9196",
+      done: "Read GitHub issue #9196",
+    });
+  });
+
+  it("keeps pagination details when the data source file target is inferred", () => {
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "data_sources_file_system",
+        toolName: "cat",
+        inputs: {
+          nodeId: "github-issue-693580871-9196",
+          limit: 100,
+        },
+      })
+    ).toEqual({
+      running: "Reading GitHub issue #9196 (first ~100 characters)",
+      done: "Read GitHub issue #9196 (first ~100 characters)",
+    });
+  });
+
+  it("uses inferred data source file targets for grep labels", () => {
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "data_sources_file_system",
+        toolName: "cat",
+        inputs: {
+          nodeId: "zendesk-ticket-12-34-567",
+          grep: "timeout",
+        },
+      })
+    ).toEqual({
+      running: "Searching for “timeout” in Zendesk ticket #567",
+      done: "Search for “timeout” in Zendesk ticket #567",
+    });
+  });
+
+  it("uses provider labels when data source file node IDs are opaque", () => {
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "data_sources_file_system",
+        toolName: "cat",
+        inputs: {
+          nodeId: "gdrive-abc123",
+        },
+      })
+    ).toEqual({
+      running: "Reading Google Drive file",
+      done: "Read Google Drive file",
+    });
+  });
+
+  it("does not show opaque IDs in data source file labels", () => {
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "data_sources_file_system",
+        toolName: "cat",
+        inputs: {
+          nodeId: "slack-channel-C05V0P20A72",
+        },
+      })
+    ).toEqual({
+      running: "Reading Slack channel",
+      done: "Read Slack channel",
+    });
+
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "data_sources_file_system",
+        toolName: "cat",
+        inputs: {
+          nodeId: "salesforce-synced-query-document-12-34-001ABC",
+        },
+      })
+    ).toEqual({
+      running: "Reading Salesforce record",
+      done: "Read Salesforce record",
+    });
+  });
+
+  it("keeps generic data source file labels for unrecognized node IDs", () => {
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "data_sources_file_system",
+        toolName: "cat",
+        inputs: {
+          nodeId: "unknown-node",
+        },
+      })
+    ).toEqual({
+      running: "Reading file",
+      done: "Read file",
+    });
+  });
 });
 
 describe("getStaticToolDisplayLabelsFromFunctionCallName", () => {

--- a/front/lib/actions/tool_display_labels.test.ts
+++ b/front/lib/actions/tool_display_labels.test.ts
@@ -20,6 +20,9 @@ describe("getToolNameFromFunctionCallName", () => {
 });
 
 describe("getToolDisplayLabels", () => {
+  const getMicrosoftNodeId = (decodedId: string) =>
+    `microsoft-${Buffer.from(decodedId).toString("base64url")}`;
+
   it("resolves labels for internal tools", () => {
     expect(
       getToolDisplayLabels({
@@ -93,18 +96,58 @@ describe("getToolDisplayLabels", () => {
     });
   });
 
-  it("uses provider labels when data source file node IDs are opaque", () => {
+  it.each([
+    ["gdrive-abc123", "Google Drive file"],
+    ["gdrive-sharedWithMe", "Google Drive shared with me"],
+    ["notion-unknown", "Notion orphaned resources"],
+    ["project-context-folder", "Dust project context"],
+    ["intercom-teams-12", "Intercom conversations"],
+    ["intercom-team-12-team_abc", "Intercom team"],
+    ["zendesk-brand-12-34", "Zendesk brand"],
+    ["gong-transcript-folder-12", "Gong transcripts"],
+    ["dpd_1234567890abcdef", "Dust project folder"],
+  ])("uses provider labels for data source file node ID %s", (nodeId, target) => {
     expect(
       getToolDisplayLabels({
         internalMCPServerName: "data_sources_file_system",
         toolName: "cat",
         inputs: {
-          nodeId: "gdrive-abc123",
+          nodeId,
         },
       })
     ).toEqual({
-      running: "Reading Google Drive file",
-      done: "Read Google Drive file",
+      running: `Reading ${target}`,
+      done: `Read ${target}`,
+    });
+  });
+
+  it("decodes Microsoft data source file targets without showing Graph IDs", () => {
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "data_sources_file_system",
+        toolName: "cat",
+        inputs: {
+          nodeId: getMicrosoftNodeId(
+            "worksheet//drives/drive-id/items/item-id/workbook/worksheets/sheet-id"
+          ),
+        },
+      })
+    ).toEqual({
+      running: "Reading Microsoft worksheet",
+      done: "Read Microsoft worksheet",
+    });
+
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "data_sources_file_system",
+        toolName: "cat",
+        inputs: {
+          nodeId: getMicrosoftNodeId("file//drives/drive-id/items/item-id"),
+        },
+      })
+    ).toEqual({
+      running: "Reading Microsoft file",
+      done: "Read Microsoft file",
     });
   });
 

--- a/front/lib/actions/tool_display_labels.test.ts
+++ b/front/lib/actions/tool_display_labels.test.ts
@@ -91,6 +91,19 @@ describe("getToolDisplayLabels", () => {
       running: "Searching for “timeout” in Zendesk ticket #567",
       done: "Search for “timeout” in Zendesk ticket #567",
     });
+
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "data_sources_file_system",
+        toolName: "cat",
+        inputs: {
+          nodeId: "zendesk-article-12-34-987654321",
+        },
+      })
+    ).toEqual({
+      running: "Reading Zendesk article #987654321",
+      done: "Read Zendesk article #987654321",
+    });
   });
 
   it.each([

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -1,4 +1,5 @@
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
+import { getDataSourceFileSystemCatReadTarget } from "@app/lib/actions/data_source_file_system_read_targets";
 import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
   getInternalMCPServerToolDisplayLabels,
@@ -153,11 +154,13 @@ function getDynamicToolDisplayLabels({
         };
       }
       if (toolName === "cat") {
+        const target = getDataSourceFileSystemCatReadTarget(inputs);
+
         if (isString(inputs.grep)) {
           const g = truncateQuery(inputs.grep);
           return {
-            running: `Searching for “${g}” in file`,
-            done: `Search for “${g}” in file`,
+            running: `Searching for “${g}” in ${target}`,
+            done: `Search for “${g}” in ${target}`,
           };
         }
         const offset = isNumber(inputs.offset)
@@ -169,23 +172,23 @@ function getDynamicToolDisplayLabels({
 
         if (offset && limit) {
           return {
-            running: `Reading file (next ~${limit} characters)`,
-            done: `Read file (next ~${limit} characters)`,
+            running: `Reading ${target} (next ~${limit} characters)`,
+            done: `Read ${target} (next ~${limit} characters)`,
           };
         } else if (limit) {
           return {
-            running: `Reading file (first ~${limit} characters)`,
-            done: `Read file (first ~${limit} characters)`,
+            running: `Reading ${target} (first ~${limit} characters)`,
+            done: `Read ${target} (first ~${limit} characters)`,
           };
         } else if (offset) {
           return {
-            running: `Reading file (from character ${offset})`,
-            done: `Read file (from character ${offset})`,
+            running: `Reading ${target} (from character ${offset})`,
+            done: `Read ${target} (from character ${offset})`,
           };
         }
         return {
-          running: `Reading file`,
-          done: `Read file`,
+          running: `Reading ${target}`,
+          done: `Read ${target}`,
         };
       }
       return null;


### PR DESCRIPTION
## Description

This PR makes data source filesystem read labels identify the kind of content being read instead of always falling back to `Read file`.

The label resolver now infers human-friendly targets from known content node ID shapes, such as GitHub issue numbers and Zendesk ticket numbers, while keeping opaque IDs out of the UI. The parsing logic is isolated in a small helper so `tool_display_labels.ts` keeps only the display-label composition.

## Tests

- Updated existing tests.

## Risk

- Low. Display labels only.

## Deploy Plan

- Deploy front.