### PR TITLE
chore(mcp): improve web_search_browse tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -15,7 +15,9 @@ export const WEB_SEARCH_BROWSE_ACTION_DESCRIPTION =
 
 export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
   websearch: {
-    description: "Search Google web results based on a string query.",
+    description:
+      "Search Google for web results, news, and current online information. " +
+      "Look up any topic on the internet using a search query.",
     schema: WebsearchInputSchema.shape,
     stake: "never_ask",
     enableAlerting: true,
@@ -25,7 +27,10 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
     },
   },
   webbrowser: {
-    description: `Browse websites; provide a list of up to ${MAX_BROWSE_URLS} URLs to browse all at once.`,
+    description:
+      `Fetch and read the content of web pages and webpages from given URLs. ` +
+      `Open and browse websites to extract text, or take a viewport or ` +
+      `full-page screenshot. Accepts up to ${MAX_BROWSE_URLS} URLs at once.`,
     schema: WebbrowseInputSchema.shape,
     stake: "never_ask",
     enableAlerting: true,

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -953,6 +953,40 @@ export const QUERIES: LabeledQuery[] = [
     expected: "workspace_analytics.get_usage_timeseries",
   },
 
+  // --- web_search_&_browse ---
+  {
+    query: "search the web for the latest AI research papers",
+    expected: "web_search_&_browse.websearch",
+  },
+  {
+    query: "google this topic for me",
+    expected: "web_search_&_browse.websearch",
+  },
+  {
+    query: "find recent news about the acquisition online",
+    expected: "web_search_&_browse.websearch",
+  },
+  {
+    query: "look up current information on the internet",
+    expected: "web_search_&_browse.websearch",
+  },
+  {
+    query: "fetch the content of this URL",
+    expected: "web_search_&_browse.webbrowser",
+  },
+  {
+    query: "open and read these web pages",
+    expected: "web_search_&_browse.webbrowser",
+  },
+  {
+    query: "take a full page screenshot of this website",
+    expected: "web_search_&_browse.webbrowser",
+  },
+  {
+    query: "browse this webpage and summarize it",
+    expected: "web_search_&_browse.webbrowser",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -37,6 +37,7 @@ import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadat
 import { SLACK_PERSONAL_SERVER } from "@app/lib/api/actions/servers/slack_personal/metadata";
 import { SNOWFLAKE_SERVER } from "@app/lib/api/actions/servers/snowflake/metadata";
 import { WAKEUPS_SERVER } from "@app/lib/api/actions/servers/wakeups/metadata";
+import { WEB_SEARCH_BROWSE_SERVER } from "@app/lib/api/actions/servers/web_search_browse/metadata";
 import { WORKSPACE_ANALYTICS_SERVER } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import { buildIndex, rank } from "@app/scripts/mcp_bm25/bm25";
@@ -120,6 +121,10 @@ const SERVERS: ServerEntry[] = [
   {
     name: "workspace_analytics",
     tools: WORKSPACE_ANALYTICS_SERVER.tools,
+  },
+  {
+    name: "web_search_&_browse",
+    tools: WEB_SEARCH_BROWSE_SERVER.tools,
   },
 ];
 


### PR DESCRIPTION
## Description

Improves the `web_search_browse` MCP tool descriptions for BM25 lexical tool-search recall, and registers the server in the `mcp_bm25` harness with 8 labeled queries.

Both descriptions were too sparse (6 and 5 meaningful tokens respectively), causing 6 of 8 queries to miss:

- **`websearch`**: lacked "news", "online", "internet", "look up", "google" (as a verb). Queries like "find recent news about X online" ranked at position 121. Fix: "Search Google for web results, news, and current online information. Look up any topic on the internet using a search query."

- **`webbrowser`**: lacked "fetch", "read", "content", "open", "webpage". Fix: "Fetch and read the content of web pages and webpages from given URLs. Open and browse websites to extract text, or take a viewport or full-page screenshot." Note: "webpages" (one word) was added explicitly because the BM25 tokenizer treats "webpage" as a single token while "web pages" produces two separate tokens ("web" + "page"), causing a miss for queries that use the compound form.

All 8 queries now rank #1.

## Tests

```
npx tsx scripts/mcp_bm25/run.ts
```

All web_search_browse queries pass at rank 1. No regressions.

## Risk

Low. Description-only changes with no runtime behavior impact.
