### PR TITLE
Publish sandbox functions from the pod sandbox

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -580,6 +580,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "sandbox_functions": {
     "get": "never_ask",
     "list": "never_ask",
+    "publish": "low",
   },
   "schedules_management": {
     "create_schedule": "high",

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -1,6 +1,6 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { SANDBOX_FUNCTION_SLUG_REGEX } from "@app/types/api/sandbox/functions";
+import { SANDBOX_FUNCTION_SLUG_REGEX } from "@app/types/api/sandbox_functions";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -1,5 +1,6 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { SANDBOX_FUNCTION_SLUG_REGEX } from "@app/types/api/sandbox/functions";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
@@ -36,7 +37,41 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
       done: "Got sandbox function",
     },
   },
-  // TODO(SANDBOX_FUNCTION) Add publish tool once we have pod's sandboxes.
+  publish: {
+    description:
+      "Publish a sandbox function from a TypeScript source file in the current pod. The source " +
+      "must default-export a `fetch(request: Request): Promise<Response>` handler and export a " +
+      "`schema` with zod `input` and `output`. It is bundled on the pod sandbox (only `zod` is " +
+      "available to import) and its input and output JSON schemas are extracted from the `schema` " +
+      "export. Re-publishing the same slug replaces the previous version.",
+    schema: {
+      slug: z
+        .string()
+        .regex(SANDBOX_FUNCTION_SLUG_REGEX)
+        .describe(
+          "Unique function identifier within the pod: lowercase alphanumeric with single hyphen " +
+            "separators (e.g. `send-slack-message`)."
+        ),
+      description: z
+        .string()
+        .min(1)
+        .describe(
+          "Short description of what the function does, shown by the list tool."
+        ),
+      path: z
+        .string()
+        .min(1)
+        .describe(
+          "Scoped path to the function's TypeScript source in the pod, as shown by the files " +
+            "tools (e.g. `pod-<id>/greet.ts`)."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Publishing sandbox function...",
+      done: "Published sandbox function",
+    },
+  },
 });
 
 export const SANDBOX_FUNCTIONS_SERVER = {

--- a/front/lib/api/actions/servers/sandbox_functions/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/index.ts
@@ -2,10 +2,12 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { SANDBOX_FUNCTIONS_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { getHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/get";
 import { listHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/list";
+import { publishHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/publish";
 
 const HANDLERS = {
   list: listHandler,
   get: getHandler,
+  publish: publishHandler,
 };
 
 export const TOOLS = buildTools(SANDBOX_FUNCTIONS_TOOLS_METADATA, HANDLERS);

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -1,0 +1,61 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getWritablePodContext } from "@app/lib/api/actions/servers/pod_manager/helpers";
+import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export async function publishHandler(
+  {
+    description,
+    path,
+    slug,
+  }: {
+    description: string;
+    path: string;
+    slug: string;
+  },
+  { auth, agentLoopContext }: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const podResult = await getWritablePodContext(auth, { agentLoopContext });
+  if (podResult.isErr()) {
+    return new Err(podResult.error);
+  }
+
+  const result = await publishSandboxFunction(auth, {
+    space: podResult.value.pod,
+    slug,
+    description,
+    path,
+  });
+  if (result.isErr()) {
+    return new Err(toMCPError(result.error));
+  }
+
+  return new Ok([
+    {
+      type: "text",
+      text: `Published sandbox function "${result.value.slug}".`,
+    },
+  ]);
+}
+
+function toMCPError(error: SandboxFunctionError): MCPError {
+  switch (error.code) {
+    case "invalid_path":
+    case "build_failed":
+    case "schema_extraction_failed":
+    case "invalid_contract":
+      // The model controls the path and the function source, so surface the detail to let it fix.
+      return new MCPError(error.message, { tracked: false });
+    case "sandbox_unavailable":
+    case "internal":
+      return new MCPError(error.message);
+    default:
+      return assertNever(error.code);
+  }
+}

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -1569,3 +1569,52 @@ describe("DustFileSystem.normalizeScopedPath strips control characters", () => {
     ).toBeNull();
   });
 });
+
+describe("DustFileSystem.toSandboxPath", () => {
+  it("resolves a scoped pod path to its absolute sandbox mount path", async () => {
+    const { workspace, user } = await createResourceTest({ role: "admin" });
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    assert(auth);
+
+    const fsResult = await DustFileSystem.forPod(auth, projectSpace);
+    assert(fsResult.isOk());
+    const fs = fsResult.value;
+
+    expect(fs.toSandboxPath(`pod-${projectSpace.sId}/greet.ts`)).toEqual(
+      new Ok(`/files/pod-${projectSpace.sId}/greet.ts`)
+    );
+    expect(fs.toSandboxPath(`pod-${projectSpace.sId}/dir/greet.ts`)).toEqual(
+      new Ok(`/files/pod-${projectSpace.sId}/dir/greet.ts`)
+    );
+  });
+
+  it("rejects traversal, foreign mounts, and bare roots", async () => {
+    const { workspace, user } = await createResourceTest({ role: "admin" });
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    assert(auth);
+
+    const fsResult = await DustFileSystem.forPod(auth, projectSpace);
+    assert(fsResult.isOk());
+    const fs = fsResult.value;
+
+    const traversal = fs.toSandboxPath(`pod-${projectSpace.sId}/../escape.ts`);
+    assert(traversal.isErr());
+    expect(traversal.error.code).toBe("invalid_path");
+
+    const foreign = fs.toSandboxPath("pod-other/greet.ts");
+    assert(foreign.isErr());
+    expect(foreign.error.code).toBe("invalid_path");
+
+    const bareRoot = fs.toSandboxPath(`pod-${projectSpace.sId}`);
+    assert(bareRoot.isErr());
+    expect(bareRoot.error.code).toBe("invalid_path");
+  });
+});

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -953,6 +953,33 @@ export class DustFileSystem {
     return null;
   }
 
+  /**
+   * Translate a canonical scoped path to its absolute path inside a mounted sandbox (the mount's
+   * gcsfuse mount point), e.g. `pod-{pId}/greet.ts` -> `/files/pod-{pId}/greet.ts`.
+   *
+   * Applies the same traversal, mount-membership, and read-permission checks as `read`. Returns
+   * `Err("invalid_path")` for a bare mount root (no file component).
+   */
+  toSandboxPath(scopedPath: string): Result<string, DustFileSystemError> {
+    const resolved = this.requireReadMount(scopedPath);
+    if (resolved.isErr()) {
+      return resolved;
+    }
+
+    const { mount, path: normalized } = resolved.value;
+    if (normalized === mount.scopedPrefix) {
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `Path has no file component: ${scopedPath}`
+        )
+      );
+    }
+
+    const rel = normalized.slice(mount.scopedPrefix.length + 1);
+    return new Ok(`${mount.sandboxMountPoint}/${rel}`);
+  }
+
   /** No-ops when the sandbox image does not support the required capability. */
   async setupSandboxMount(
     sandbox: SandboxResource,

--- a/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
@@ -1,8 +1,15 @@
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
+  ensurePodSandboxReady: vi.fn(),
+}));
 
 const SRC = "/files/pod-spc123/greet.ts";
 
@@ -18,16 +25,28 @@ const validSchemaFile = JSON.stringify({
   },
 });
 
-async function setup() {
-  const { authenticator } = await createResourceTest({ role: "admin" });
+async function setup(): Promise<{
+  authenticator: Awaited<
+    ReturnType<typeof createResourceTest>
+  >["authenticator"];
+  sandbox: SandboxResource;
+  space: SpaceResource;
+}> {
+  const { authenticator, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const space = await SpaceFactory.project(workspace);
   const sandbox = await SandboxResource.makeNew(authenticator, {
     providerId: "test-provider-id",
     status: "running",
     baseImage: "dust-base",
     version: "0.0.0-test",
   });
+  vi.mocked(ensurePodSandboxReady).mockResolvedValue(
+    new Ok({ sandbox, freshlyCreated: false })
+  );
 
-  return { authenticator, sandbox };
+  return { authenticator, sandbox, space };
 }
 
 beforeEach(() => {
@@ -36,7 +55,7 @@ beforeEach(() => {
 
 describe("buildSandboxFunctionOnSandbox", () => {
   it("builds the bundle and returns the extracted contract", async () => {
-    const { authenticator, sandbox } = await setup();
+    const { authenticator, sandbox, space } = await setup();
     const execSpy = vi
       .spyOn(sandbox, "exec")
       .mockResolvedValue(
@@ -50,7 +69,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
       .mockResolvedValueOnce(new Ok(Buffer.from(validSchemaFile)));
 
     const result = await buildSandboxFunctionOnSandbox(authenticator, {
-      sandbox,
+      space,
       srcSandboxPath: SRC,
     });
 
@@ -98,7 +117,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
   });
 
   it("surfaces a build failure from the envelope without reading files", async () => {
-    const { authenticator, sandbox } = await setup();
+    const { authenticator, sandbox, space } = await setup();
     vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Ok({
         exitCode: 1,
@@ -112,7 +131,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
     const readSpy = vi.spyOn(sandbox, "readFile");
 
     const result = await buildSandboxFunctionOnSandbox(authenticator, {
-      sandbox,
+      space,
       srcSandboxPath: SRC,
     });
 
@@ -126,7 +145,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
   });
 
   it("maps an unknown error kind to internal", async () => {
-    const { authenticator, sandbox } = await setup();
+    const { authenticator, sandbox, space } = await setup();
     vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Ok({
         exitCode: 2,
@@ -139,7 +158,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
     );
 
     const result = await buildSandboxFunctionOnSandbox(authenticator, {
-      sandbox,
+      space,
       srcSandboxPath: SRC,
     });
 
@@ -151,7 +170,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
   });
 
   it("rejects a function missing an input or output schema", async () => {
-    const { authenticator, sandbox } = await setup();
+    const { authenticator, sandbox, space } = await setup();
     vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Ok({ exitCode: 0, stdout: okEnvelope, stderr: "" })
     );
@@ -171,7 +190,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
       );
 
     const result = await buildSandboxFunctionOnSandbox(authenticator, {
-      sandbox,
+      space,
       srcSandboxPath: SRC,
     });
 
@@ -183,13 +202,13 @@ describe("buildSandboxFunctionOnSandbox", () => {
   });
 
   it("returns an internal error when the exec itself fails", async () => {
-    const { authenticator, sandbox } = await setup();
+    const { authenticator, sandbox, space } = await setup();
     vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Err(new Error("provider unavailable"))
     );
 
     const result = await buildSandboxFunctionOnSandbox(authenticator, {
-      sandbox,
+      space,
       srcSandboxPath: SRC,
     });
 
@@ -202,13 +221,13 @@ describe("buildSandboxFunctionOnSandbox", () => {
   });
 
   it("returns an internal error when dsbx produces no output", async () => {
-    const { authenticator, sandbox } = await setup();
+    const { authenticator, sandbox, space } = await setup();
     vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Ok({ exitCode: 0, stdout: "", stderr: "" })
     );
 
     const result = await buildSandboxFunctionOnSandbox(authenticator, {
-      sandbox,
+      space,
       srcSandboxPath: SRC,
     });
 
@@ -217,5 +236,23 @@ describe("buildSandboxFunctionOnSandbox", () => {
       return;
     }
     expect(result.error.code).toBe("internal");
+  });
+
+  it("maps a sandbox failure to sandbox_unavailable", async () => {
+    const { authenticator, space } = await setup();
+    vi.mocked(ensurePodSandboxReady).mockResolvedValue(
+      new Err(new Error("sandbox down"))
+    );
+
+    const result = await buildSandboxFunctionOnSandbox(authenticator, {
+      space,
+      srcSandboxPath: SRC,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("sandbox_unavailable");
   });
 });

--- a/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
@@ -1,0 +1,221 @@
+import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const SRC = "/files/pod-spc123/greet.ts";
+
+const okEnvelope = JSON.stringify({ ok: true });
+
+const validSchemaFile = JSON.stringify({
+  name: "greet",
+  description: "Greet someone.",
+  input_schema: { type: "object", properties: { name: { type: "string" } } },
+  output_schema: {
+    type: "object",
+    properties: { greeting: { type: "string" } },
+  },
+});
+
+async function setup() {
+  const { authenticator } = await createResourceTest({ role: "admin" });
+  const sandbox = await SandboxResource.makeNew(authenticator, {
+    providerId: "test-provider-id",
+    status: "running",
+    baseImage: "dust-base",
+    version: "0.0.0-test",
+  });
+
+  return { authenticator, sandbox };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("buildSandboxFunctionOnSandbox", () => {
+  it("builds the bundle and returns the extracted contract", async () => {
+    const { authenticator, sandbox } = await setup();
+    const execSpy = vi
+      .spyOn(sandbox, "exec")
+      .mockResolvedValue(
+        new Ok({ exitCode: 0, stdout: okEnvelope, stderr: "" })
+      );
+    const readSpy = vi
+      .spyOn(sandbox, "readFile")
+      .mockResolvedValueOnce(
+        new Ok(Buffer.from("export default {/*bundle*/};"))
+      )
+      .mockResolvedValueOnce(new Ok(Buffer.from(validSchemaFile)));
+
+    const result = await buildSandboxFunctionOnSandbox(authenticator, {
+      sandbox,
+      srcSandboxPath: SRC,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.bundleCode).toBe("export default {/*bundle*/};");
+    expect(result.value.inputSchema).toEqual({
+      type: "object",
+      properties: { name: { type: "string" } },
+    });
+    expect(result.value.outputSchema).toEqual({
+      type: "object",
+      properties: { greeting: { type: "string" } },
+    });
+
+    // Command shape: absolute dsbx, build subcommand, `--` then the escaped source path, and the
+    // egress-controlled user.
+    expect(execSpy).toHaveBeenCalledTimes(1);
+    const execCall = execSpy.mock.calls[0];
+    expect(execCall).toBeDefined();
+    if (!execCall) {
+      return;
+    }
+    const [, command, opts] = execCall;
+    expect(command).toContain("set -euo pipefail");
+    expect(command).toContain(
+      "/opt/bin/dsbx function build -- '/files/pod-spc123/greet.ts'"
+    );
+    expect(opts?.user).toBe("agent-proxied");
+
+    // Reads the bundle first, then the schema, both from the scratch dir the command created.
+    expect(readSpy).toHaveBeenCalledTimes(2);
+    const bundleReadPath = readSpy.mock.calls[0]?.[1];
+    const schemaReadPath = readSpy.mock.calls[1]?.[1];
+    expect(bundleReadPath).toMatch(
+      /^\/tmp\/dust-sandbox-function-builds\/.+\/bundle\.js$/
+    );
+    expect(schemaReadPath).toMatch(
+      /^\/tmp\/dust-sandbox-function-builds\/.+\/schema\.json$/
+    );
+    expect(command).toContain(bundleReadPath);
+    expect(command).toContain(schemaReadPath);
+  });
+
+  it("surfaces a build failure from the envelope without reading files", async () => {
+    const { authenticator, sandbox } = await setup();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 1,
+        stdout: JSON.stringify({
+          ok: false,
+          error: { kind: "build_failed", message: "Unexpected token" },
+        }),
+        stderr: "",
+      })
+    );
+    const readSpy = vi.spyOn(sandbox, "readFile");
+
+    const result = await buildSandboxFunctionOnSandbox(authenticator, {
+      sandbox,
+      srcSandboxPath: SRC,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("build_failed");
+    expect(result.error.message).toContain("Unexpected token");
+    expect(readSpy).not.toHaveBeenCalled();
+  });
+
+  it("maps an unknown error kind to internal", async () => {
+    const { authenticator, sandbox } = await setup();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 2,
+        stdout: JSON.stringify({
+          ok: false,
+          error: { kind: "bad_args", message: "missing operand" },
+        }),
+        stderr: "",
+      })
+    );
+
+    const result = await buildSandboxFunctionOnSandbox(authenticator, {
+      sandbox,
+      srcSandboxPath: SRC,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("internal");
+  });
+
+  it("rejects a function missing an input or output schema", async () => {
+    const { authenticator, sandbox } = await setup();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: okEnvelope, stderr: "" })
+    );
+    vi.spyOn(sandbox, "readFile")
+      .mockResolvedValueOnce(new Ok(Buffer.from("bundle")))
+      .mockResolvedValueOnce(
+        new Ok(
+          Buffer.from(
+            JSON.stringify({
+              name: "greet",
+              description: null,
+              input_schema: null,
+              output_schema: { type: "object" },
+            })
+          )
+        )
+      );
+
+    const result = await buildSandboxFunctionOnSandbox(authenticator, {
+      sandbox,
+      srcSandboxPath: SRC,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("invalid_contract");
+  });
+
+  it("returns an internal error when the exec itself fails", async () => {
+    const { authenticator, sandbox } = await setup();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Err(new Error("provider unavailable"))
+    );
+
+    const result = await buildSandboxFunctionOnSandbox(authenticator, {
+      sandbox,
+      srcSandboxPath: SRC,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("internal");
+    expect(result.error.message).toContain("provider unavailable");
+  });
+
+  it("returns an internal error when dsbx produces no output", async () => {
+    const { authenticator, sandbox } = await setup();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: "", stderr: "" })
+    );
+
+    const result = await buildSandboxFunctionOnSandbox(authenticator, {
+      sandbox,
+      srcSandboxPath: SRC,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("internal");
+  });
+});

--- a/front/lib/api/sandbox_functions/build_on_sandbox.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.ts
@@ -1,0 +1,208 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { shellEscape } from "@app/lib/api/sandbox/shell";
+import type { SandboxFunctionErrorCode } from "@app/lib/api/sandbox_functions/errors";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+
+const DSBX_BIN_PATH = "/opt/bin/dsbx";
+// Non-mounted scratch root, so a build never writes into the pod files mount.
+const BUILD_STAGING_ROOT = "/tmp/dust-sandbox-function-builds";
+const BUILD_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
+
+export interface SandboxFunctionBuildResult {
+  bundleCode: string;
+  inputSchema: JSONSchema;
+  outputSchema: JSONSchema;
+}
+
+// dsbx writes the bundle and schema to files (sandbox stdout can be truncated) and prints only
+// this envelope. Mirrors BuildResult in cli/dust-sandbox/functions-runner/build.ts.
+const buildEnvelopeSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true) }),
+  z.object({
+    ok: z.literal(false),
+    error: z.object({ kind: z.string(), message: z.string() }),
+  }),
+]);
+
+// z.custom brands the parsed value as JSONSchema, avoiding an unsafe cast.
+const jsonSchemaValue = z.custom<JSONSchema>(
+  (v) => typeof v === "object" && v !== null
+);
+
+// Mirrors FunctionSchema in cli/dust-sandbox/functions-runner/schema.ts.
+const functionSchemaFileSchema = z.object({
+  name: z.string(),
+  description: z.string().nullable(),
+  input_schema: jsonSchemaValue.nullable(),
+  output_schema: jsonSchemaValue.nullable(),
+});
+
+function mapBuildErrorKind(kind: string): SandboxFunctionErrorCode {
+  switch (kind) {
+    case "build_failed":
+      return "build_failed";
+    case "schema_extraction_failed":
+      return "schema_extraction_failed";
+    default:
+      // bad_args means our own argv is wrong, not the function.
+      return "internal";
+  }
+}
+
+/**
+ * Build a sandbox function on a ready pod sandbox: bundle the source at `srcSandboxPath` (absolute,
+ * under the pod mount) via `dsbx function build`, then read back the bundle and its extracted I/O
+ * contract from a non-mounted scratch dir.
+ *
+ * Runs as `agent-proxied` (the egress-controlled invocation user) because extracting the schema
+ * imports the module and runs its untrusted top-level code.
+ */
+export async function buildSandboxFunctionOnSandbox(
+  auth: Authenticator,
+  {
+    sandbox,
+    srcSandboxPath,
+  }: {
+    sandbox: SandboxResource;
+    srcSandboxPath: string;
+  }
+): Promise<Result<SandboxFunctionBuildResult, SandboxFunctionError>> {
+  const buildDir = path.posix.join(BUILD_STAGING_ROOT, randomUUID());
+  const bundlePath = path.posix.join(buildDir, "bundle.js");
+  const schemaPath = path.posix.join(buildDir, "schema.json");
+
+  const command = [
+    "set -euo pipefail",
+    `rm -rf -- ${shellEscape(buildDir)}`,
+    `mkdir -p -- ${shellEscape(buildDir)}`,
+    // `--` stops the model-supplied source path from being read as a dsbx flag.
+    `${DSBX_BIN_PATH} function build -- ${shellEscape(srcSandboxPath)} ${shellEscape(bundlePath)} ${shellEscape(schemaPath)}`,
+  ].join("\n");
+
+  const execResult = await sandbox.exec(auth, command, {
+    timeoutMs: BUILD_EXEC_TIMEOUT_MS,
+    user: "agent-proxied",
+  });
+  if (execResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("internal", execResult.error.message)
+    );
+  }
+
+  const envelope = parseBuildEnvelope(execResult.value.stdout);
+  if (envelope.isErr()) {
+    return envelope;
+  }
+  if (!envelope.value.ok) {
+    const { kind, message } = envelope.value.error;
+    return new Err(new SandboxFunctionError(mapBuildErrorKind(kind), message));
+  }
+
+  // Success means dsbx wrote both files.
+  const bundleResult = await sandbox.readFile(auth, bundlePath);
+  if (bundleResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("internal", bundleResult.error.message)
+    );
+  }
+  const schemaResult = await sandbox.readFile(auth, schemaPath);
+  if (schemaResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("internal", schemaResult.error.message)
+    );
+  }
+
+  return parseSchemaFile(
+    schemaResult.value.toString("utf8"),
+    bundleResult.value.toString("utf8")
+  );
+}
+
+function parseBuildEnvelope(
+  stdout: string
+): Result<z.infer<typeof buildEnvelopeSchema>, SandboxFunctionError> {
+  // dsbx prints one JSON envelope. Take the last non-empty line to ignore any shell noise.
+  const lastLine =
+    stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .at(-1) ?? "";
+  if (lastLine.length === 0) {
+    return new Err(
+      new SandboxFunctionError(
+        "internal",
+        "dsbx function build produced no output."
+      )
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(lastLine);
+  } catch (err) {
+    return new Err(
+      new SandboxFunctionError(
+        "internal",
+        `Unparseable dsbx output: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  const parsed = buildEnvelopeSchema.safeParse(json);
+  if (!parsed.success) {
+    return new Err(
+      new SandboxFunctionError("internal", "Unexpected dsbx output shape.")
+    );
+  }
+
+  return new Ok(parsed.data);
+}
+
+function parseSchemaFile(
+  rawSchema: string,
+  bundleCode: string
+): Result<SandboxFunctionBuildResult, SandboxFunctionError> {
+  let json: unknown;
+  try {
+    json = JSON.parse(rawSchema);
+  } catch (err) {
+    return new Err(
+      new SandboxFunctionError(
+        "schema_extraction_failed",
+        `Unparseable schema file: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  const parsed = functionSchemaFileSchema.safeParse(json);
+  if (!parsed.success) {
+    return new Err(
+      new SandboxFunctionError(
+        "schema_extraction_failed",
+        "Unexpected schema file shape."
+      )
+    );
+  }
+
+  const { input_schema: inputSchema, output_schema: outputSchema } =
+    parsed.data;
+  if (inputSchema === null || outputSchema === null) {
+    return new Err(
+      new SandboxFunctionError(
+        "invalid_contract",
+        "The function must export both an `input` and an `output` schema."
+      )
+    );
+  }
+
+  return new Ok({ bundleCode, inputSchema, outputSchema });
+}

--- a/front/lib/api/sandbox_functions/build_on_sandbox.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import type { SandboxFunctionErrorCode } from "@app/lib/api/sandbox_functions/errors";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
-import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -58,9 +59,9 @@ function mapBuildErrorKind(kind: string): SandboxFunctionErrorCode {
 }
 
 /**
- * Build a sandbox function on a ready pod sandbox: bundle the source at `srcSandboxPath` (absolute,
- * under the pod mount) via `dsbx function build`, then read back the bundle and its extracted I/O
- * contract from a non-mounted scratch dir.
+ * Build a sandbox function on the pod sandbox: ensure the pod's sandbox is up, bundle the source at
+ * `srcSandboxPath` (absolute, under the pod mount) via `dsbx function build`, then read back the
+ * bundle and its extracted I/O contract from a non-mounted scratch dir.
  *
  * Runs as `agent-proxied` (the egress-controlled invocation user) because extracting the schema
  * imports the module and runs its untrusted top-level code.
@@ -68,13 +69,24 @@ function mapBuildErrorKind(kind: string): SandboxFunctionErrorCode {
 export async function buildSandboxFunctionOnSandbox(
   auth: Authenticator,
   {
-    sandbox,
+    space,
     srcSandboxPath,
   }: {
-    sandbox: SandboxResource;
+    space: SpaceResource;
     srcSandboxPath: string;
   }
 ): Promise<Result<SandboxFunctionBuildResult, SandboxFunctionError>> {
+  const ensureResult = await ensurePodSandboxReady(auth, space);
+  if (ensureResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError(
+        "sandbox_unavailable",
+        ensureResult.error.message
+      )
+    );
+  }
+  const { sandbox } = ensureResult.value;
+
   const buildDir = path.posix.join(BUILD_STAGING_ROOT, randomUUID());
   const bundlePath = path.posix.join(buildDir, "bundle.js");
   const schemaPath = path.posix.join(buildDir, "schema.json");

--- a/front/lib/api/sandbox_functions/errors.ts
+++ b/front/lib/api/sandbox_functions/errors.ts
@@ -1,0 +1,17 @@
+export type SandboxFunctionErrorCode =
+  | "invalid_path"
+  | "sandbox_unavailable"
+  | "build_failed"
+  | "schema_extraction_failed"
+  | "invalid_contract"
+  | "internal";
+
+export class SandboxFunctionError extends Error {
+  constructor(
+    readonly code: SandboxFunctionErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "SandboxFunctionError";
+  }
+}

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -1,10 +1,8 @@
-import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
 import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -16,10 +14,6 @@ import type { LightWorkspaceType } from "@app/types/user";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
-  ensurePodSandboxReady: vi.fn(),
-}));
 
 vi.mock(
   "@app/lib/api/sandbox_functions/build_on_sandbox",
@@ -63,20 +57,6 @@ async function setupPod(): Promise<{
   return { workspace, space, auth };
 }
 
-async function mockReadySandbox(auth: Authenticator): Promise<SandboxResource> {
-  const sandbox = await SandboxResource.makeNew(auth, {
-    providerId: "test-provider-id",
-    status: "running",
-    baseImage: "dust-base",
-    version: "0.0.0-test",
-  });
-  vi.mocked(ensurePodSandboxReady).mockResolvedValue(
-    new Ok({ sandbox, freshlyCreated: false })
-  );
-
-  return sandbox;
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
   fileStorageMock.reset();
@@ -85,7 +65,6 @@ beforeEach(() => {
 describe("publishSandboxFunction", () => {
   it("publishes a new function with one bundle file under the dedicated prefix", async () => {
     const { workspace, space, auth } = await setupPod();
-    const sandbox = await mockReadySandbox(auth);
     vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
       new Ok({ bundleCode: "export default {};", inputSchema, outputSchema })
     );
@@ -108,7 +87,7 @@ describe("publishSandboxFunction", () => {
     expect(fn.outputSchema).toEqual(outputSchema);
 
     expect(buildSandboxFunctionOnSandbox).toHaveBeenCalledWith(auth, {
-      sandbox,
+      space,
       srcSandboxPath: `/files/pod-${space.sId}/greet.ts`,
     });
 
@@ -133,7 +112,6 @@ describe("publishSandboxFunction", () => {
 
   it("overwrites the bundle in place on re-publish, keeping one row and the same file", async () => {
     const { workspace, space, auth } = await setupPod();
-    await mockReadySandbox(auth);
 
     vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
       new Ok({ bundleCode: "v1", inputSchema, outputSchema })
@@ -207,14 +185,13 @@ describe("publishSandboxFunction", () => {
       return;
     }
     expect(result.error.code).toBe("invalid_path");
-    expect(ensurePodSandboxReady).not.toHaveBeenCalled();
     expect(buildSandboxFunctionOnSandbox).not.toHaveBeenCalled();
   });
 
-  it("maps a sandbox failure to sandbox_unavailable", async () => {
-    const { space, auth } = await setupPod();
-    vi.mocked(ensurePodSandboxReady).mockResolvedValue(
-      new Err(new Error("sandbox down"))
+  it("surfaces a sandbox_unavailable build failure", async () => {
+    const { workspace, space, auth } = await setupPod();
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Err(new SandboxFunctionError("sandbox_unavailable", "sandbox down"))
     );
 
     const result = await publishSandboxFunction(auth, {
@@ -229,12 +206,16 @@ describe("publishSandboxFunction", () => {
       return;
     }
     expect(result.error.code).toBe("sandbox_unavailable");
-    expect(buildSandboxFunctionOnSandbox).not.toHaveBeenCalled();
+
+    // No file is created when the build never succeeds.
+    const files = await FileModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+    expect(files).toHaveLength(0);
   });
 
   it("passes a build failure through and creates no file", async () => {
     const { workspace, space, auth } = await setupPod();
-    await mockReadySandbox(auth);
     vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
       new Err(new SandboxFunctionError("build_failed", "boom"))
     );

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -131,7 +131,7 @@ describe("publishSandboxFunction", () => {
     expect(listed.map(({ id }) => id)).toEqual([fn.id]);
   });
 
-  it("replaces the bundle on re-publish, keeping one row and one file", async () => {
+  it("overwrites the bundle in place on re-publish, keeping one row and the same file", async () => {
     const { workspace, space, auth } = await setupPod();
     await mockReadySandbox(auth);
 
@@ -149,6 +149,10 @@ describe("publishSandboxFunction", () => {
       return;
     }
     const firstFileId = first.value.fileId;
+    const [firstBundle] = await FileModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+    const firstVersion = firstBundle.version;
 
     const newOutputSchema: JSONSchema = {
       type: "object",
@@ -172,14 +176,20 @@ describe("publishSandboxFunction", () => {
     expect(second.value.id).toBe(first.value.id);
     expect(second.value.description).toBe("v2");
     expect(second.value.outputSchema).toEqual(newOutputSchema);
-    expect(second.value.fileId).not.toBe(firstFileId);
+    // The bundle file is reused in place, not replaced: same row, canonical mount path retained, and
+    // its version bumped by the re-upload.
+    expect(second.value.fileId).toBe(firstFileId);
 
     const listed = await SandboxFunctionResource.listBySpace(auth, space);
     expect(listed).toHaveLength(1);
     const files = await FileModel.findAll({
       where: { workspaceId: workspace.id },
     });
-    expect(files.map((file) => file.id)).toEqual([second.value.fileId]);
+    expect(files.map((file) => file.id)).toEqual([firstFileId]);
+    expect(files[0].mountFilePath).toBe(
+      `w/${workspace.sId}/pods/${space.sId}/sandbox_functions/greet.ts`
+    );
+    expect(files[0].version).toBeGreaterThan(firstVersion ?? 0);
   });
 
   it("rejects a path that escapes the pod mount", async () => {

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -1,0 +1,252 @@
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
+import { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FileModel } from "@app/lib/resources/storage/models/files";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { sandboxFunctionContentType } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+import assert from "assert";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
+  ensurePodSandboxReady: vi.fn(),
+}));
+
+vi.mock(
+  "@app/lib/api/sandbox_functions/build_on_sandbox",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@app/lib/api/sandbox_functions/build_on_sandbox")
+      >();
+
+    return { ...actual, buildSandboxFunctionOnSandbox: vi.fn() };
+  }
+);
+
+const inputSchema: JSONSchema = {
+  type: "object",
+  properties: { name: { type: "string" } },
+  required: ["name"],
+};
+
+const outputSchema: JSONSchema = {
+  type: "object",
+  properties: { greeting: { type: "string" } },
+  required: ["greeting"],
+};
+
+// The publisher must be a pod member so DustFileSystem.forPod grants read access, matching the
+// write gate the MCP tool enforces in production.
+async function setupPod(): Promise<{
+  workspace: LightWorkspaceType;
+  space: SpaceResource;
+  auth: Authenticator;
+}> {
+  const { workspace, user } = await createResourceTest({ role: "admin" });
+  const space = await SpaceFactory.project(workspace, user.id);
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  assert(auth);
+
+  return { workspace, space, auth };
+}
+
+async function mockReadySandbox(auth: Authenticator): Promise<SandboxResource> {
+  const sandbox = await SandboxResource.makeNew(auth, {
+    providerId: "test-provider-id",
+    status: "running",
+    baseImage: "dust-base",
+    version: "0.0.0-test",
+  });
+  vi.mocked(ensurePodSandboxReady).mockResolvedValue(
+    new Ok({ sandbox, freshlyCreated: false })
+  );
+
+  return sandbox;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fileStorageMock.reset();
+});
+
+describe("publishSandboxFunction", () => {
+  it("publishes a new function with one bundle file under the dedicated prefix", async () => {
+    const { workspace, space, auth } = await setupPod();
+    const sandbox = await mockReadySandbox(auth);
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({ bundleCode: "export default {};", inputSchema, outputSchema })
+    );
+
+    const result = await publishSandboxFunction(auth, {
+      space,
+      slug: "greet",
+      description: "Greet someone.",
+      path: `pod-${space.sId}/greet.ts`,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    const fn = result.value;
+    expect(fn.slug).toBe("greet");
+    expect(fn.description).toBe("Greet someone.");
+    expect(fn.inputSchema).toEqual(inputSchema);
+    expect(fn.outputSchema).toEqual(outputSchema);
+
+    expect(buildSandboxFunctionOnSandbox).toHaveBeenCalledWith(auth, {
+      sandbox,
+      srcSandboxPath: `/files/pod-${space.sId}/greet.ts`,
+    });
+
+    // The source stays on the mount, so the bundle is the only FileResource.
+    const files = await FileModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+    expect(files).toHaveLength(1);
+    const bundle = files[0];
+    expect(bundle.id).toBe(fn.fileId);
+    expect(bundle.contentType).toBe(sandboxFunctionContentType);
+    expect(bundle.useCase).toBe("project_context");
+    expect(bundle.fileName).toBe("greet.ts");
+    expect(bundle.useCaseMetadata?.spaceId).toBe(space.sId);
+    expect(bundle.mountFilePath).toBe(
+      `w/${workspace.sId}/pods/${space.sId}/sandbox_functions/greet.ts`
+    );
+
+    const listed = await SandboxFunctionResource.listBySpace(auth, space);
+    expect(listed.map(({ id }) => id)).toEqual([fn.id]);
+  });
+
+  it("replaces the bundle on re-publish, keeping one row and one file", async () => {
+    const { workspace, space, auth } = await setupPod();
+    await mockReadySandbox(auth);
+
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({ bundleCode: "v1", inputSchema, outputSchema })
+    );
+    const first = await publishSandboxFunction(auth, {
+      space,
+      slug: "greet",
+      description: "v1",
+      path: `pod-${space.sId}/greet.ts`,
+    });
+    expect(first.isOk()).toBe(true);
+    if (first.isErr()) {
+      return;
+    }
+    const firstFileId = first.value.fileId;
+
+    const newOutputSchema: JSONSchema = {
+      type: "object",
+      properties: { text: { type: "string" } },
+      required: ["text"],
+    };
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({ bundleCode: "v2", inputSchema, outputSchema: newOutputSchema })
+    );
+    const second = await publishSandboxFunction(auth, {
+      space,
+      slug: "greet",
+      description: "v2",
+      path: `pod-${space.sId}/greet.ts`,
+    });
+    expect(second.isOk()).toBe(true);
+    if (second.isErr()) {
+      return;
+    }
+
+    expect(second.value.id).toBe(first.value.id);
+    expect(second.value.description).toBe("v2");
+    expect(second.value.outputSchema).toEqual(newOutputSchema);
+    expect(second.value.fileId).not.toBe(firstFileId);
+
+    const listed = await SandboxFunctionResource.listBySpace(auth, space);
+    expect(listed).toHaveLength(1);
+    const files = await FileModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+    expect(files.map((file) => file.id)).toEqual([second.value.fileId]);
+  });
+
+  it("rejects a path that escapes the pod mount", async () => {
+    const { space, auth } = await setupPod();
+
+    const result = await publishSandboxFunction(auth, {
+      space,
+      slug: "greet",
+      description: "Greet someone.",
+      path: `pod-${space.sId}/../escape.ts`,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("invalid_path");
+    expect(ensurePodSandboxReady).not.toHaveBeenCalled();
+    expect(buildSandboxFunctionOnSandbox).not.toHaveBeenCalled();
+  });
+
+  it("maps a sandbox failure to sandbox_unavailable", async () => {
+    const { space, auth } = await setupPod();
+    vi.mocked(ensurePodSandboxReady).mockResolvedValue(
+      new Err(new Error("sandbox down"))
+    );
+
+    const result = await publishSandboxFunction(auth, {
+      space,
+      slug: "greet",
+      description: "Greet someone.",
+      path: `pod-${space.sId}/greet.ts`,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("sandbox_unavailable");
+    expect(buildSandboxFunctionOnSandbox).not.toHaveBeenCalled();
+  });
+
+  it("passes a build failure through and creates no file", async () => {
+    const { workspace, space, auth } = await setupPod();
+    await mockReadySandbox(auth);
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Err(new SandboxFunctionError("build_failed", "boom"))
+    );
+
+    const result = await publishSandboxFunction(auth, {
+      space,
+      slug: "greet",
+      description: "Greet someone.",
+      path: `pod-${space.sId}/greet.ts`,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("build_failed");
+
+    const files = await FileModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+    expect(files).toHaveLength(0);
+    const listed = await SandboxFunctionResource.listBySpace(auth, space);
+    expect(listed).toHaveLength(0);
+  });
+});

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -1,5 +1,4 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
@@ -49,18 +48,8 @@ export async function publishSandboxFunction(
     );
   }
 
-  const ensureResult = await ensurePodSandboxReady(auth, space);
-  if (ensureResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError(
-        "sandbox_unavailable",
-        ensureResult.error.message
-      )
-    );
-  }
-
   const buildResult = await buildSandboxFunctionOnSandbox(auth, {
-    sandbox: ensureResult.value.sandbox,
+    space,
     srcSandboxPath: srcResult.value,
   });
   if (buildResult.isErr()) {

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -68,12 +68,8 @@ export async function publishSandboxFunction(
   }
   const { bundleCode, inputSchema, outputSchema } = buildResult.value;
 
-  const fileResult = await createBundleFile(auth, { space, slug, bundleCode });
-  if (fileResult.isErr()) {
-    return fileResult;
-  }
-  const file = fileResult.value;
-
+  // Re-publish overwrites the existing bundle in place so its mount path (<prefix>/<slug>.ts) stays
+  // stable; only a first publish creates the backing file.
   const existing = await SandboxFunctionResource.fetchBySpaceAndSlug(
     auth,
     space,
@@ -81,7 +77,7 @@ export async function publishSandboxFunction(
   );
   if (existing) {
     const updateResult = await existing.updateContent(auth, {
-      file,
+      bundleCode,
       description,
       inputSchema,
       outputSchema,
@@ -95,9 +91,14 @@ export async function publishSandboxFunction(
     return new Ok(existing);
   }
 
+  const fileResult = await createBundleFile(auth, { space, slug, bundleCode });
+  if (fileResult.isErr()) {
+    return fileResult;
+  }
+
   const created = await SandboxFunctionResource.makeNew(auth, {
     space,
-    file,
+    file: fileResult.value,
     slug,
     description,
     inputSchema,

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -1,0 +1,137 @@
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { sandboxFunctionContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+/**
+ * Publish a sandbox function: build the source the model wrote to the pod mount, then store the
+ * bundle and its extracted contract.
+ *
+ * The bundle is stored as a single `project_context` FileResource with the sandbox-function content
+ * type, which FileResource routes into the dedicated, front-only sandbox_functions prefix. The
+ * SandboxFunctionResource is upserted on (space, slug): re-publish swaps the bundle, otherwise a new
+ * row is created. Returns a domain Result, no HTTP shapes (BACK18).
+ */
+export async function publishSandboxFunction(
+  auth: Authenticator,
+  {
+    space,
+    slug,
+    description,
+    path: sourcePath,
+  }: {
+    space: SpaceResource;
+    slug: string;
+    description: string;
+    path: string;
+  }
+): Promise<Result<SandboxFunctionResource, SandboxFunctionError>> {
+  // Resolve the model-supplied scoped path (e.g. `pod-{id}/greet.ts`) to its absolute path inside
+  // the sandbox, reusing DustFileSystem's traversal and mount checks rather than rebuilding them.
+  const fsResult = await DustFileSystem.forPod(auth, space);
+  if (fsResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("invalid_path", fsResult.error.message)
+    );
+  }
+  const srcResult = fsResult.value.toSandboxPath(sourcePath);
+  if (srcResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("invalid_path", srcResult.error.message)
+    );
+  }
+
+  const ensureResult = await ensurePodSandboxReady(auth, space);
+  if (ensureResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError(
+        "sandbox_unavailable",
+        ensureResult.error.message
+      )
+    );
+  }
+
+  const buildResult = await buildSandboxFunctionOnSandbox(auth, {
+    sandbox: ensureResult.value.sandbox,
+    srcSandboxPath: srcResult.value,
+  });
+  if (buildResult.isErr()) {
+    return buildResult;
+  }
+  const { bundleCode, inputSchema, outputSchema } = buildResult.value;
+
+  const fileResult = await createBundleFile(auth, { space, slug, bundleCode });
+  if (fileResult.isErr()) {
+    return fileResult;
+  }
+  const file = fileResult.value;
+
+  const existing = await SandboxFunctionResource.fetchBySpaceAndSlug(
+    auth,
+    space,
+    slug
+  );
+  if (existing) {
+    const updateResult = await existing.updateContent(auth, {
+      file,
+      description,
+      inputSchema,
+      outputSchema,
+    });
+    if (updateResult.isErr()) {
+      return new Err(
+        new SandboxFunctionError("internal", updateResult.error.message)
+      );
+    }
+
+    return new Ok(existing);
+  }
+
+  const created = await SandboxFunctionResource.makeNew(auth, {
+    space,
+    file,
+    slug,
+    description,
+    inputSchema,
+    outputSchema,
+  });
+
+  return new Ok(created);
+}
+
+async function createBundleFile(
+  auth: Authenticator,
+  {
+    space,
+    slug,
+    bundleCode,
+  }: { space: SpaceResource; slug: string; bundleCode: string }
+): Promise<Result<FileResource, SandboxFunctionError>> {
+  try {
+    const file = await FileResource.makeNew({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      userId: auth.user()?.id ?? null,
+      contentType: sandboxFunctionContentType,
+      fileName: `${slug}.ts`,
+      fileSize: Buffer.byteLength(bundleCode, "utf8"),
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+
+    await file.uploadContent(auth, bundleCode);
+
+    return new Ok(file);
+  } catch (err) {
+    return new Err(
+      new SandboxFunctionError("internal", normalizeError(err).message)
+    );
+  }
+}

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -479,6 +479,83 @@ describe("SandboxFunctionResource", () => {
     });
   });
 
+  it("replaces the bundle and contract on re-publish", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const makeBundle = (fileName: string) =>
+      FileFactory.create(authenticator, null, {
+        contentType: sandboxFunctionContentType,
+        fileName,
+        fileSize: 100,
+        status: "created",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: space.sId },
+      });
+
+    const firstFile = await makeBundle("greet.ts");
+    const sandboxFunction = await SandboxFunctionResource.makeNew(
+      authenticator,
+      {
+        space,
+        file: firstFile,
+        slug: "greet",
+        description: "First.",
+        inputSchema,
+        outputSchema,
+      }
+    );
+
+    const newInputSchema: JSONSchema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    };
+    const newOutputSchema: JSONSchema = {
+      type: "object",
+      properties: { text: { type: "string" } },
+      required: ["text"],
+    };
+    const secondFile = await makeBundle("greet.ts");
+
+    const result = await sandboxFunction.updateContent(authenticator, {
+      file: secondFile,
+      description: "Second.",
+      inputSchema: newInputSchema,
+      outputSchema: newOutputSchema,
+    });
+    expect(result.isOk()).toBe(true);
+
+    // The same row now points at the new bundle and contract.
+    expect(sandboxFunction.fileId).toBe(secondFile.id);
+    expect(sandboxFunction.description).toBe("Second.");
+    expect(sandboxFunction.inputSchema).toEqual(newInputSchema);
+    expect(sandboxFunction.outputSchema).toEqual(newOutputSchema);
+    expect(sandboxFunction.file.id).toBe(secondFile.id);
+
+    // Exactly one row remains, and the superseded bundle was deleted.
+    const listed = await SandboxFunctionResource.listBySpace(
+      authenticator,
+      space
+    );
+    expect(listed.map(({ id }) => id)).toEqual([sandboxFunction.id]);
+    await expect(
+      FileResource.fetchById(authenticator, firstFile.sId)
+    ).resolves.toBeNull();
+    await expect(
+      FileResource.fetchById(authenticator, secondFile.sId)
+    ).resolves.not.toBeNull();
+
+    const fetched = await SandboxFunctionResource.fetchById(
+      authenticator,
+      sandboxFunction.sId
+    );
+    expect(fetched?.fileId).toBe(secondFile.id);
+    expect(fetched?.description).toBe("Second.");
+    expect(fetched?.outputSchema).toEqual(newOutputSchema);
+  });
+
   it("deletes all sandbox functions for a space", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -11,6 +11,7 @@ import {
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { sandboxFunctionContentType } from "@app/types/files";
@@ -50,6 +51,7 @@ const outputSchema: JSONSchema = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  fileStorageMock.reset();
 });
 
 describe("SandboxFunctionResource", () => {
@@ -479,22 +481,22 @@ describe("SandboxFunctionResource", () => {
     });
   });
 
-  it("replaces the bundle and contract on re-publish", async () => {
+  it("overwrites the bundle and contract in place on re-publish", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
     const space = await SpaceFactory.project(workspace);
-    const makeBundle = (fileName: string) =>
-      FileFactory.create(authenticator, null, {
-        contentType: sandboxFunctionContentType,
-        fileName,
-        fileSize: 100,
-        status: "created",
-        useCase: "project_context",
-        useCaseMetadata: { spaceId: space.sId },
-      });
 
-    const firstFile = await makeBundle("greet.ts");
+    const firstFile = await FileFactory.create(authenticator, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: "greet.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+    await firstFile.uploadContent(authenticator, "v1");
+
     const sandboxFunction = await SandboxFunctionResource.makeNew(
       authenticator,
       {
@@ -506,6 +508,7 @@ describe("SandboxFunctionResource", () => {
         outputSchema,
       }
     );
+    const firstVersion = firstFile.version;
 
     const newInputSchema: JSONSchema = {
       type: "object",
@@ -517,24 +520,25 @@ describe("SandboxFunctionResource", () => {
       properties: { text: { type: "string" } },
       required: ["text"],
     };
-    const secondFile = await makeBundle("greet.ts");
 
     const result = await sandboxFunction.updateContent(authenticator, {
-      file: secondFile,
+      bundleCode: "v2",
       description: "Second.",
       inputSchema: newInputSchema,
       outputSchema: newOutputSchema,
     });
     expect(result.isOk()).toBe(true);
 
-    // The same row now points at the new bundle and contract.
-    expect(sandboxFunction.fileId).toBe(secondFile.id);
+    // The row keeps the same bundle file and gets the refreshed contract.
+    expect(sandboxFunction.fileId).toBe(firstFile.id);
     expect(sandboxFunction.description).toBe("Second.");
     expect(sandboxFunction.inputSchema).toEqual(newInputSchema);
     expect(sandboxFunction.outputSchema).toEqual(newOutputSchema);
-    expect(sandboxFunction.file.id).toBe(secondFile.id);
+    expect(sandboxFunction.file.id).toBe(firstFile.id);
+    // Re-upload bumped the bundle's version rather than creating a new file.
+    expect(sandboxFunction.file.version).toBeGreaterThan(firstVersion);
 
-    // Exactly one row remains, and the superseded bundle was deleted.
+    // Exactly one row and one (reused) bundle file remain.
     const listed = await SandboxFunctionResource.listBySpace(
       authenticator,
       space
@@ -542,16 +546,13 @@ describe("SandboxFunctionResource", () => {
     expect(listed.map(({ id }) => id)).toEqual([sandboxFunction.id]);
     await expect(
       FileResource.fetchById(authenticator, firstFile.sId)
-    ).resolves.toBeNull();
-    await expect(
-      FileResource.fetchById(authenticator, secondFile.sId)
     ).resolves.not.toBeNull();
 
     const fetched = await SandboxFunctionResource.fetchById(
       authenticator,
       sandboxFunction.sId
     );
-    expect(fetched?.fileId).toBe(secondFile.id);
+    expect(fetched?.fileId).toBe(firstFile.id);
     expect(fetched?.description).toBe("Second.");
     expect(fetched?.outputSchema).toEqual(newOutputSchema);
   });

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -20,7 +20,6 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
-import logger from "@app/logger/logger";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   SandboxFunctionInvocationType,
@@ -173,70 +172,30 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   }
 
   /**
-   * Replace this function's bundle and contract on re-publish: point the row at the new file, refresh
-   * the schemas and description, then delete the superseded bundle. Enforces the same file invariants
-   * as makeNew. The caller checks write permission.
+   * Re-publish: overwrite this function's bundle in place and refresh its contract. uploadContent
+   * rewrites the same file (canonical original plus its mount path <prefix>/<slug>.ts) and bumps the
+   * version, so the function's storage path stays stable across re-publishes rather than drifting to
+   * a disambiguated name. The caller checks write permission.
    */
   async updateContent(
     auth: Authenticator,
     {
-      file,
+      bundleCode,
       description,
       inputSchema,
       outputSchema,
     }: {
-      file: FileResource;
+      bundleCode: string;
       description: string;
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
     }
   ): Promise<Result<undefined, Error>> {
-    assert(
-      file.workspaceId === auth.getNonNullableWorkspace().id,
-      "The file must belong to the authenticated workspace."
-    );
-    assert(
-      file.contentType === sandboxFunctionContentType,
-      `The file must use the ${sandboxFunctionContentType} content type.`
-    );
-    assert(
-      file.useCase === "project_context",
-      "The file must use the project_context use case."
-    );
-    assert(
-      file.useCaseMetadata?.spaceId === this.space.sId,
-      "The file must belong to the same pod as the sandbox function."
-    );
-
-    const previousFile = this.file;
-
     try {
-      await this.update({
-        fileId: file.id,
-        description,
-        inputSchema,
-        outputSchema,
-      });
+      await this.file.uploadContent(auth, bundleCode);
+      await this.update({ description, inputSchema, outputSchema });
     } catch (error) {
       return new Err(normalizeError(error));
-    }
-
-    this.file = file;
-
-    // The row already points at the new bundle, so a failed cleanup of the old one only orphans a
-    // file in the front-only prefix. Log it rather than failing an otherwise successful publish.
-    if (previousFile.id !== file.id) {
-      const deleteResult = await previousFile.delete(auth);
-      if (deleteResult.isErr()) {
-        logger.error(
-          {
-            err: deleteResult.error,
-            sandboxFunctionId: this.sId,
-            previousFileId: previousFile.sId,
-          },
-          "Failed to delete superseded sandbox function bundle"
-        );
-      }
     }
 
     return new Ok(undefined);

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -11,10 +11,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import {
-  isValidSandboxFunctionSlug,
-  SandboxFunctionModel,
-} from "@app/lib/resources/storage/models/sandbox_function";
+import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import {
@@ -23,10 +20,12 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import logger from "@app/logger/logger";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   SandboxFunctionInvocationType,
 } from "@app/types/api/sandbox_functions";
+import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { isDevelopment } from "@app/types/shared/env";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -171,6 +170,76 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     );
 
     return new this(this.model, sandboxFunction.get(), space, file);
+  }
+
+  /**
+   * Replace this function's bundle and contract on re-publish: point the row at the new file, refresh
+   * the schemas and description, then delete the superseded bundle. Enforces the same file invariants
+   * as makeNew. The caller checks write permission.
+   */
+  async updateContent(
+    auth: Authenticator,
+    {
+      file,
+      description,
+      inputSchema,
+      outputSchema,
+    }: {
+      file: FileResource;
+      description: string;
+      inputSchema: JSONSchema;
+      outputSchema: JSONSchema;
+    }
+  ): Promise<Result<undefined, Error>> {
+    assert(
+      file.workspaceId === auth.getNonNullableWorkspace().id,
+      "The file must belong to the authenticated workspace."
+    );
+    assert(
+      file.contentType === sandboxFunctionContentType,
+      `The file must use the ${sandboxFunctionContentType} content type.`
+    );
+    assert(
+      file.useCase === "project_context",
+      "The file must use the project_context use case."
+    );
+    assert(
+      file.useCaseMetadata?.spaceId === this.space.sId,
+      "The file must belong to the same pod as the sandbox function."
+    );
+
+    const previousFile = this.file;
+
+    try {
+      await this.update({
+        fileId: file.id,
+        description,
+        inputSchema,
+        outputSchema,
+      });
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
+
+    this.file = file;
+
+    // The row already points at the new bundle, so a failed cleanup of the old one only orphans a
+    // file in the front-only prefix. Log it rather than failing an otherwise successful publish.
+    if (previousFile.id !== file.id) {
+      const deleteResult = await previousFile.delete(auth);
+      if (deleteResult.isErr()) {
+        logger.error(
+          {
+            err: deleteResult.error,
+            sandboxFunctionId: this.sId,
+            previousFileId: previousFile.sId,
+          },
+          "Failed to delete superseded sandbox function bundle"
+        );
+      }
+    }
+
+    return new Ok(undefined);
   }
 
   private static async baseFetch(

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1039,7 +1039,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       if (err instanceof SandboxNotFoundError) {
         logger.error(
           { sandbox: this.toLogJSON() },
-          "Sandbox not found at provider during readFile — marking as deleted"
+          "Sandbox not found at provider during readFile, marking as deleted"
         );
 
         await this.updateStatus("deleted");

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -5,7 +5,10 @@ import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import type { SandboxFunctionInvocationStatus } from "@app/types/api/sandbox_functions";
-import { SANDBOX_FUNCTION_INVOCATION_STATUSES } from "@app/types/api/sandbox_functions";
+import {
+  isValidSandboxFunctionSlug,
+  SANDBOX_FUNCTION_INVOCATION_STATUSES,
+} from "@app/types/api/sandbox_functions";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 
@@ -18,13 +21,6 @@ function validateSandboxFunctionJsonSchema(value: unknown): void {
   if (!validationResult.isValid) {
     throw new Error(`Invalid JSON schema: ${validationResult.error}`);
   }
-}
-
-// Lowercase alphanumeric with single hyphen separators (e.g. `greet`, `send-slack-message`).
-export const SANDBOX_FUNCTION_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-
-export function isValidSandboxFunctionSlug(value: unknown): value is string {
-  return typeof value === "string" && SANDBOX_FUNCTION_SLUG_REGEX.test(value);
 }
 
 function validateSandboxFunctionSlug(value: unknown): void {

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -3,6 +3,13 @@ export const SANDBOX_FUNCTION_INVOCATION_STATUSES = ["created"] as const;
 export type SandboxFunctionInvocationStatus =
   (typeof SANDBOX_FUNCTION_INVOCATION_STATUSES)[number];
 
+// Lowercase alphanumeric with single hyphen separators (e.g. `greet`, `send-slack-message`).
+export const SANDBOX_FUNCTION_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export function isValidSandboxFunctionSlug(value: unknown): value is string {
+  return typeof value === "string" && SANDBOX_FUNCTION_SLUG_REGEX.test(value);
+}
+
 export type SandboxFunctionInvocationType = {
   sId: string;
   functionId: string;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds the publish half of sandbox functions: a model working in a pod writes a TypeScript source onto the pod-mounted filesystem, then publishes it by path. The source is bundled on the pod's own sandbox and its input and output JSON schemas are extracted from the function's schema export, so a published function carries a self-contained bundle plus a typed contract.

The build runs on the sandbox but never writes storage itself. The sandbox produces the bundle and schema in a non-mounted scratch directory and MCP tool reads them back, then front is the sole writer of the stored bundle. This is deliberate: if the sandbox could write bundle storage, a malicious function running on that same sandbox could forge or overwrite any bundle. The bundle is the only persisted file, stored in a dedicated prefix separate from the read-write pod files, so nothing inside a sandbox can reach or tamper with a published bundle. The source the model wrote stays on the mount and never becomes a tracked file.

Bundling executes untrusted code (extracting the schema imports the module and runs its top-level code), so it runs as the same egress-controlled, unprivileged user the invocation path already uses, rather than as root. The model-supplied path is resolved and traversal-checked through the existing file system layer rather than by rebuilding that logic. Publishing is idempotent on the function slug within a pod: re-publishing swaps the bundle and refreshes the contract in place, and a failed cleanup of the superseded bundle does not fail an otherwise successful publish.

The capability is exposed as a single MCP tool gated on pod write permission, which validates the slug and surfaces build and schema errors back to the caller so it can correct the source. This stacks on the read-file and dedicated-prefix groundwork in the prior change and depends on the bundler shipping in the sandbox image.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

No migrations to run only some refactoring around type imports.
