### PR TITLE
[front] feat: sync coupons cross-region on creation

### DIFF
--- a/front-api/routes/lookup/coupons.ts
+++ b/front-api/routes/lookup/coupons.ts
@@ -6,7 +6,14 @@ import { createHono } from "@front-api/lib/hono";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 
-export type SyncCouponResponseBody = { coupon: CouponType };
+// `expirationDate` and `archivedAt` are `Date | null` in CouponType but
+// JSON-serialize to ISO strings on the wire.
+type CouponWireShape = Omit<CouponType, "expirationDate" | "archivedAt"> & {
+  expirationDate: string | null;
+  archivedAt: string | null;
+};
+
+export type SyncCouponResponseBody = { coupon: CouponWireShape };
 
 // Mounted at /api/lookup/coupons. Uses the REGION_RESOLVER_SECRET Bearer-token
 // auth — same as all other /api/lookup/* endpoints. No session required

--- a/front-api/routes/lookup/coupons.ts
+++ b/front-api/routes/lookup/coupons.ts
@@ -45,7 +45,7 @@ app.post("/sync", async (ctx): HandlerResult<SyncCouponResponseBody> => {
 
   const body: CouponType = await ctx.req.json();
 
-  const result = await CouponResource.upsertBySId(body);
+  const result = await CouponResource.upsertById(body);
   if (result.isErr()) {
     return apiError(ctx, {
       status_code: 500,

--- a/front-api/routes/lookup/coupons.ts
+++ b/front-api/routes/lookup/coupons.ts
@@ -1,0 +1,55 @@
+import config from "@app/lib/api/config";
+import { getBearerToken } from "@app/lib/auth";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
+import type { CouponType } from "@app/types/coupon";
+import { createHono } from "@front-api/lib/hono";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+
+export type SyncCouponResponseBody = { coupon: CouponType };
+
+// Mounted at /api/lookup/coupons. Uses the REGION_RESOLVER_SECRET Bearer-token
+// auth — same as all other /api/lookup/* endpoints. No session required
+// (server-to-server call).
+const app = createHono();
+
+/** @ignoreswagger */
+app.post("/sync", async (ctx): HandlerResult<SyncCouponResponseBody> => {
+  const bearerTokenRes = await getBearerToken(ctx.req.header("authorization"));
+  if (bearerTokenRes.isErr()) {
+    return apiError(ctx, {
+      status_code: 401,
+      api_error: {
+        type: "not_authenticated",
+        message: "The request does not have valid authentication credentials",
+      },
+    });
+  }
+
+  if (bearerTokenRes.value !== config.getRegionResolverSecret()) {
+    return apiError(ctx, {
+      status_code: 401,
+      api_error: {
+        type: "invalid_basic_authorization_error",
+        message: "Invalid token",
+      },
+    });
+  }
+
+  const body: CouponType = await ctx.req.json();
+
+  const result = await CouponResource.upsertBySId(body);
+  if (result.isErr()) {
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to sync coupon: ${result.error.message}`,
+      },
+    });
+  }
+
+  return ctx.json({ coupon: result.value.toJSON() }, 200);
+});
+
+export default app;

--- a/front-api/routes/lookup/index.ts
+++ b/front-api/routes/lookup/index.ts
@@ -1,8 +1,9 @@
 import { createHono } from "@front-api/lib/hono";
-
 import resource from "./[resource]";
+import coupons from "./coupons";
 
 const app = createHono();
+app.route("/coupons", coupons);
 app.route("/:resource", resource);
 
 export default app;

--- a/front-api/routes/poke/coupons/index.test.ts
+++ b/front-api/routes/poke/coupons/index.test.ts
@@ -1,0 +1,147 @@
+import { pushCouponToOtherRegion } from "@app/lib/api/poke/coupons";
+import { config } from "@app/lib/api/regions/config";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
+import { CouponFactory } from "@app/tests/utils/CouponFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Err, Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/regions/config", async (importActual) => {
+  const mod =
+    await importActual<typeof import("@app/lib/api/regions/config")>();
+  return {
+    ...mod,
+    config: { ...mod.config, isMainRegion: vi.fn() },
+  };
+});
+
+vi.mock("@app/lib/api/poke/coupons", () => ({
+  pushCouponToOtherRegion: vi.fn(),
+}));
+
+const VALID_BODY = {
+  code: "TESTCODE",
+  description: null,
+  discountType: "seat",
+  amount: 10,
+  durationMonths: null,
+  maxRedemptions: null,
+  expirationDate: null,
+};
+
+function postCoupon(body: object) {
+  return honoApp.request("/api/poke/coupons", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/poke/coupons", { sequential: true }, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(config.isMainRegion).mockReturnValue(true);
+    vi.mocked(pushCouponToOtherRegion).mockResolvedValue(new Ok(undefined));
+  });
+
+  it("returns 401 when the user is not a super user", async () => {
+    await createPrivateApiMockRequest({ isSuperUser: false });
+
+    const response = await postCoupon(VALID_BODY);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when called from a non-main region (EU)", async () => {
+    vi.mocked(config.isMainRegion).mockReturnValue(false);
+    await createPrivateApiMockRequest({ isSuperUser: true });
+
+    const response = await postCoupon(VALID_BODY);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+    expect(pushCouponToOtherRegion).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when a coupon with the same code already exists", async () => {
+    await CouponFactory.create({ code: VALID_BODY.code });
+    await createPrivateApiMockRequest({ isSuperUser: true });
+
+    const response = await postCoupon(VALID_BODY);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: {
+        type: "invalid_request_error",
+        message: expect.stringContaining("already exists"),
+      },
+    });
+  });
+
+  it("creates coupon, pushes to other region, and returns 201", async () => {
+    await createPrivateApiMockRequest({ isSuperUser: true });
+
+    const response = await postCoupon({ ...VALID_BODY, code: "NEWCODE" });
+
+    expect(response.status).toBe(201);
+    const { coupon } = await response.json();
+    expect(coupon.code).toBe("NEWCODE");
+    expect(pushCouponToOtherRegion).toHaveBeenCalledOnce();
+    expect(pushCouponToOtherRegion).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "NEWCODE" })
+    );
+  });
+
+  it("deletes the coupon and returns 500 when the push to other region fails", async () => {
+    vi.mocked(pushCouponToOtherRegion).mockResolvedValue(
+      new Err("other_region_push_failed")
+    );
+    await createPrivateApiMockRequest({ isSuperUser: true });
+
+    const response = await postCoupon({ ...VALID_BODY, code: "FAILCODE" });
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      error: { type: "internal_server_error" },
+    });
+    const coupon = await CouponResource.findByCode("FAILCODE");
+    expect(coupon).toBeNull();
+  });
+});
+
+describe("pushCouponToOtherRegion — dev vs prod", { sequential: true }, () => {
+  // The module is mocked at the file level for the handler tests above, so we
+  // need importActual to get the real implementation here.
+  let realPushCouponToOtherRegion: typeof pushCouponToOtherRegion;
+  const mockFetch = vi.fn();
+
+  beforeAll(async () => {
+    const mod = await vi.importActual<
+      typeof import("@app/lib/api/poke/coupons")
+    >("@app/lib/api/poke/coupons");
+    realPushCouponToOtherRegion = mod.pushCouponToOtherRegion;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+  });
+
+  it("skips the fetch in development (isDevelopment=true)", async () => {
+    const envModule = await vi.importActual<
+      typeof import("@app/types/shared/env")
+    >("@app/types/shared/env");
+    const spy = vi.spyOn(envModule, "isDevelopment").mockReturnValue(true);
+
+    const coupon = await CouponFactory.create();
+    const result = await realPushCouponToOtherRegion(coupon.toJSON());
+
+    spy.mockRestore();
+
+    expect(result.isOk()).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/poke/coupons/index.test.ts
+++ b/front-api/routes/poke/coupons/index.test.ts
@@ -1,22 +1,17 @@
-import { pushCouponToOtherRegion } from "@app/lib/api/poke/coupons";
-import { config } from "@app/lib/api/regions/config";
-import { CouponResource } from "@app/lib/resources/coupon_resource";
+import {
+  canCreateCoupon,
+  createCouponAndPushToOtherRegion,
+  type pushCouponToOtherRegion,
+} from "@app/lib/api/poke/coupons";
 import { CouponFactory } from "@app/tests/utils/CouponFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-vi.mock("@app/lib/api/regions/config", async (importActual) => {
-  const mod =
-    await importActual<typeof import("@app/lib/api/regions/config")>();
-  return {
-    ...mod,
-    config: { ...mod.config, isMainRegion: vi.fn() },
-  };
-});
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/poke/coupons", () => ({
+  canCreateCoupon: vi.fn(),
+  createCouponAndPushToOtherRegion: vi.fn(),
   pushCouponToOtherRegion: vi.fn(),
 }));
 
@@ -30,6 +25,19 @@ const VALID_BODY = {
   expirationDate: null,
 };
 
+const mockCouponJSON = {
+  sId: "cou_fake",
+  code: "TESTCODE",
+  description: null,
+  discountType: "seat",
+  amount: 10,
+  durationMonths: null,
+  maxRedemptions: null,
+  redemptionCount: 0,
+  expirationDate: null,
+  archivedAt: null,
+};
+
 function postCoupon(body: object) {
   return honoApp.request("/api/poke/coupons", {
     method: "POST",
@@ -41,8 +49,10 @@ function postCoupon(body: object) {
 describe("POST /api/poke/coupons", { sequential: true }, () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(config.isMainRegion).mockReturnValue(true);
-    vi.mocked(pushCouponToOtherRegion).mockResolvedValue(new Ok(undefined));
+    vi.mocked(canCreateCoupon).mockReturnValue(true);
+    vi.mocked(createCouponAndPushToOtherRegion).mockResolvedValue(
+      new Ok({ toJSON: () => ({ ...mockCouponJSON }) } as any)
+    );
   });
 
   it("returns 401 when the user is not a super user", async () => {
@@ -54,7 +64,7 @@ describe("POST /api/poke/coupons", { sequential: true }, () => {
   });
 
   it("returns 400 when called from a non-main region (EU)", async () => {
-    vi.mocked(config.isMainRegion).mockReturnValue(false);
+    vi.mocked(canCreateCoupon).mockReturnValue(false);
     await createPrivateApiMockRequest({ isSuperUser: true });
 
     const response = await postCoupon(VALID_BODY);
@@ -63,11 +73,13 @@ describe("POST /api/poke/coupons", { sequential: true }, () => {
     expect(await response.json()).toMatchObject({
       error: { type: "invalid_request_error" },
     });
-    expect(pushCouponToOtherRegion).not.toHaveBeenCalled();
+    expect(createCouponAndPushToOtherRegion).not.toHaveBeenCalled();
   });
 
   it("returns 400 when a coupon with the same code already exists", async () => {
-    await CouponFactory.create({ code: VALID_BODY.code });
+    vi.mocked(createCouponAndPushToOtherRegion).mockResolvedValue(
+      new Err({ type: "coupon_already_exists" })
+    );
     await createPrivateApiMockRequest({ isSuperUser: true });
 
     const response = await postCoupon(VALID_BODY);
@@ -81,7 +93,10 @@ describe("POST /api/poke/coupons", { sequential: true }, () => {
     });
   });
 
-  it("creates coupon, pushes to other region, and returns 201", async () => {
+  it("calls createCouponAndPushToOtherRegion and returns 201", async () => {
+    vi.mocked(createCouponAndPushToOtherRegion).mockResolvedValue(
+      new Ok({ toJSON: () => ({ ...mockCouponJSON, code: "NEWCODE" }) } as any)
+    );
     await createPrivateApiMockRequest({ isSuperUser: true });
 
     const response = await postCoupon({ ...VALID_BODY, code: "NEWCODE" });
@@ -89,15 +104,16 @@ describe("POST /api/poke/coupons", { sequential: true }, () => {
     expect(response.status).toBe(201);
     const { coupon } = await response.json();
     expect(coupon.code).toBe("NEWCODE");
-    expect(pushCouponToOtherRegion).toHaveBeenCalledOnce();
-    expect(pushCouponToOtherRegion).toHaveBeenCalledWith(
+    expect(createCouponAndPushToOtherRegion).toHaveBeenCalledOnce();
+    expect(createCouponAndPushToOtherRegion).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({ code: "NEWCODE" })
     );
   });
 
-  it("deletes the coupon and returns 500 when the push to other region fails", async () => {
-    vi.mocked(pushCouponToOtherRegion).mockResolvedValue(
-      new Err("other_region_push_failed")
+  it("returns 500 when sync to other region fails", async () => {
+    vi.mocked(createCouponAndPushToOtherRegion).mockResolvedValue(
+      new Err({ type: "sync_failed" })
     );
     await createPrivateApiMockRequest({ isSuperUser: true });
 
@@ -107,8 +123,6 @@ describe("POST /api/poke/coupons", { sequential: true }, () => {
     expect(await response.json()).toMatchObject({
       error: { type: "internal_server_error" },
     });
-    const coupon = await CouponResource.findByCode("FAILCODE");
-    expect(coupon).toBeNull();
   });
 });
 

--- a/front-api/routes/poke/coupons/index.ts
+++ b/front-api/routes/poke/coupons/index.ts
@@ -1,6 +1,11 @@
+import {
+  canCreateCoupon,
+  createCouponAndPushToOtherRegion,
+} from "@app/lib/api/poke/coupons";
 import { CouponResource } from "@app/lib/resources/coupon_resource";
 import type { CouponDiscountType } from "@app/types/coupon";
 import { CreateCouponBodySchema } from "@app/types/coupon";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -43,6 +48,7 @@ app.get("/", async (ctx): HandlerResult<GetPokeCouponsResponseBody> => {
   const coupons = await CouponResource.listAll({ includeArchived: true });
   return ctx.json({
     coupons: coupons.map((coupon) => coupon.toJSON()),
+    canCreateCoupon: canCreateCoupon(),
   });
 });
 
@@ -53,26 +59,50 @@ app.post(
     const auth = ctx.get("auth");
     const body = ctx.req.valid("json");
 
-    const existing = await CouponResource.findByCode(body.code);
-    if (existing) {
+    if (!canCreateCoupon()) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: "A coupon with this code already exists.",
+          message:
+            "Coupons can only be created from the main region (US). " +
+            "Switch the Poke region to US and retry.",
         },
       });
     }
 
-    const result = await CouponResource.makeNew(auth, body);
+    const result = await createCouponAndPushToOtherRegion(auth, body);
     if (result.isErr()) {
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to create coupon: ${result.error.message}`,
-        },
-      });
+      switch (result.error.type) {
+        case "coupon_already_exists":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "A coupon with this code already exists.",
+            },
+          });
+        case "creation_failed":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: `Failed to create coupon: ${result.error.message}`,
+            },
+          });
+        case "sync_failed":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message:
+                "Coupon was created but failed to sync to the other region. " +
+                "The coupon has been deleted. Please try again.",
+            },
+          });
+        default:
+          assertNever(result.error);
+      }
     }
 
     return ctx.json({ coupon: result.value.toJSON() }, 201);

--- a/front/components/poke/pages/CouponsPage.tsx
+++ b/front/components/poke/pages/CouponsPage.tsx
@@ -278,7 +278,8 @@ function CouponRedemptionsPanel({ coupon }: CouponRedemptionsPanelProps) {
 export function CouponsPage() {
   usePokePageMetadata({ name: "Coupons" });
 
-  const { coupons, isCouponsLoading, mutate } = usePokeCoupons();
+  const { coupons, canCreateCoupon, isCouponsLoading, mutate } =
+    usePokeCoupons();
   const archiveCoupon = usePokeArchiveCoupon();
 
   const [expandedCouponId, setExpandedCouponId] = useState<string | null>(null);
@@ -327,27 +328,37 @@ export function CouponsPage() {
     <div className="flex h-full flex-col items-center">
       <div className="py-8 text-2xl font-bold">Coupons</div>
 
-      {showCreateForm && (
-        <div className="mb-6 w-full max-w-3xl">
-          <CreateCouponForm
-            onCreated={async () => {
-              await mutate();
-              setShowCreateForm(false);
-            }}
-            onCancel={() => setShowCreateForm(false)}
-          />
+      {canCreateCoupon ? (
+        <>
+          {showCreateForm && (
+            <div className="mb-6 w-full max-w-3xl">
+              <CreateCouponForm
+                onCreated={async () => {
+                  await mutate();
+                  setShowCreateForm(false);
+                }}
+                onCancel={() => setShowCreateForm(false)}
+              />
+            </div>
+          )}
+          <div className="mb-4 flex w-full justify-end">
+            <Button
+              icon={Plus}
+              label="Create coupon"
+              variant="outline"
+              disabled={showCreateForm}
+              onClick={() => setShowCreateForm(true)}
+            />
+          </div>
+        </>
+      ) : (
+        <div className="mb-4 w-full rounded-lg border border-warning-200 bg-warning-50 px-4 py-3 text-sm text-warning-800 dark:border-warning-800 dark:bg-warning-950 dark:text-warning-200">
+          Coupons can only be created from the{" "}
+          <span className="font-semibold">US region</span>. Use the region
+          switcher in the top-right corner to switch to US, then create the
+          coupon — it will be automatically synced to EU.
         </div>
       )}
-
-      <div className="mb-4 flex w-full justify-end">
-        <Button
-          icon={Plus}
-          label="Create coupon"
-          variant="outline"
-          disabled={showCreateForm}
-          onClick={() => setShowCreateForm(true)}
-        />
-      </div>
 
       <div className="w-full pb-24">
         <DataTable

--- a/front/lib/api/poke/coupons.ts
+++ b/front/lib/api/poke/coupons.ts
@@ -1,0 +1,79 @@
+import { config } from "@app/lib/api/regions/config";
+import type { Authenticator } from "@app/lib/auth";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
+import logger from "@app/logger/logger";
+import type { CouponType, CreateCouponBody } from "@app/types/coupon";
+import { isDevelopment } from "@app/types/shared/env";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export function canCreateCoupon(): boolean {
+  return config.isMainRegion() || isDevelopment();
+}
+
+export type CreateCouponError =
+  | { type: "coupon_already_exists" }
+  | { type: "creation_failed"; message: string }
+  | { type: "sync_failed" };
+
+export async function createCouponAndPushToOtherRegion(
+  auth: Authenticator,
+  body: CreateCouponBody
+): Promise<Result<CouponResource, CreateCouponError>> {
+  const existing = await CouponResource.findByCode(body.code);
+  if (existing) {
+    return new Err({ type: "coupon_already_exists" });
+  }
+
+  const result = await CouponResource.makeNew(auth, body);
+  if (result.isErr()) {
+    return new Err({ type: "creation_failed", message: result.error.message });
+  }
+
+  const coupon = result.value;
+
+  const pushResult = await pushCouponToOtherRegion(coupon.toJSON());
+  if (pushResult.isErr()) {
+    logger.error(
+      { couponId: coupon.sId },
+      "[CouponSync] Failed to sync coupon to other region — rolling back local creation"
+    );
+    await coupon.delete(auth);
+    return new Err({ type: "sync_failed" });
+  }
+
+  return new Ok(coupon);
+}
+
+export type PushCouponError = "other_region_push_failed";
+
+export async function pushCouponToOtherRegion(
+  coupon: CouponType
+): Promise<Result<void, PushCouponError>> {
+  if (isDevelopment()) {
+    return new Ok(undefined);
+  }
+
+  const { url } = config.getOtherRegionInfo();
+  const secret = config.getLookupApiSecret();
+
+  // eslint-disable-next-line no-restricted-globals
+  const response = await fetch(`${url}/api/lookup/coupons/sync`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${secret}`,
+    },
+    body: JSON.stringify(coupon),
+  });
+
+  if (!response.ok) {
+    logger.error(
+      { status: response.status, couponId: coupon.sId },
+      "[CouponSync] Failed to push coupon to other region"
+    );
+    return new Err("other_region_push_failed");
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/regions/config.ts
+++ b/front/lib/api/regions/config.ts
@@ -26,6 +26,9 @@ export const config = {
       ? EnvironmentConfig.getEnvVariable("DUST_EU_URL")
       : EnvironmentConfig.getEnvVariable("DUST_US_URL");
   },
+  isMainRegion(): boolean {
+    return this.getCurrentRegion() === "us-central1";
+  },
   getOtherRegionInfo(): RegionInfo {
     const currentRegion = this.getCurrentRegion();
     const otherRegion =

--- a/front/lib/resources/coupon_resource.ts
+++ b/front/lib/resources/coupon_resource.ts
@@ -167,7 +167,14 @@ export class CouponResource extends BaseResource<CouponModel> {
     };
   }
 
-  static async upsertBySId(
+  // Used exclusively for cross-region coupon sync. When a coupon is created in
+  // the main region (US) and pushed to the secondary region (EU), the EU row
+  // must share the exact same numeric primary key as the US row. This is
+  // required because CouponRedemptionModel.couponId is a numeric FK: if a
+  // workspace relocates cross-region, its redemptions must still resolve to the
+  // correct coupon row. INSERT ... ON CONFLICT (id) DO UPDATE preserves the PK
+  // without advancing the EU sequence, keeping both regions in sync.
+  static async upsertById(
     coupon: CouponType
   ): Promise<Result<CouponResource, Error>> {
     try {

--- a/front/lib/resources/coupon_resource.ts
+++ b/front/lib/resources/coupon_resource.ts
@@ -167,6 +167,35 @@ export class CouponResource extends BaseResource<CouponModel> {
     };
   }
 
+  static async upsertBySId(
+    coupon: CouponType
+  ): Promise<Result<CouponResource, Error>> {
+    try {
+      const id = getResourceIdFromSId(coupon.sId);
+      if (!id) {
+        return new Err(new Error(`Invalid coupon sId: ${coupon.sId}`));
+      }
+
+      const [row] = await CouponModel.upsert({
+        id,
+        code: coupon.code,
+        description: coupon.description,
+        discountType: coupon.discountType,
+        amount: coupon.amount,
+        durationMonths: coupon.durationMonths,
+        maxRedemptions: coupon.maxRedemptions,
+        redemptionCount: coupon.redemptionCount,
+        expirationDate: coupon.expirationDate ?? null,
+        archivedAt: coupon.archivedAt ?? null,
+        createdByUserId: null,
+      });
+
+      return new Ok(new this(this.model, row.get()));
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -103,6 +103,7 @@ export function usePokeCoupons() {
 
   return {
     coupons: data?.coupons ?? emptyArray(),
+    canCreateCoupon: data?.canCreateCoupon ?? false,
     isCouponsLoading: !error && !data,
     isCouponsError: error,
     mutate,

--- a/front/types/api/poke/coupons.ts
+++ b/front/types/api/poke/coupons.ts
@@ -4,6 +4,7 @@ import type { CouponRedemptionType, CouponType } from "@app/types/coupon";
 
 export type GetPokeCouponsResponseBody = {
   coupons: CouponType[];
+  canCreateCoupon: boolean;
 };
 
 export type CreatePokeCouponResponseBody = {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8912

CouponRedemptionModel.couponId is a numeric FK. When a workspace is relocated (US → EU), the coupon must exist in the destination DB with the same numeric id — otherwise the FK is broken. Today coupons are created manually per-region, which has already caused incidents.

What this PR does:
* When a coupon is created in Poke (US), it is synchronously pushed to EU via a new POST /api/lookup/coupons/sync endpoint using the existing REGION_RESOLVER_SECRET auth pattern. The push uses CouponModel.upsert with the explicit numeric id to guarantee both regions share the same row id.
* If the push fails, the local coupon is deleted and the caller gets a 500 — a coupon that exists in only one region is never allowed.
* In development, the push is skipped.
* Creating a coupon from EU is blocked at the API level (400). The Poke UI hides the create button in EU and shows an informational banner instead (driven by a canCreateCoupon field returned by GET /api/poke/coupons).
* No DB migration needed — reuses existing CouponModel columns and REGION_RESOLVER_SECRET.

## Tests

* Tested locally for display in page
* Added endpoint tests in front-api/routes/poke/coupons/index.test.ts

Will need to be testes in prod to make sure the mechanism works as expected from US to EUR region

## Risk

Low, impacts only coupon creation in Poke

## Deploy Plan

Deploy front