### PR TITLE
chore(mcp): improve speech_generator tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1027,6 +1027,32 @@ export const QUERIES: LabeledQuery[] = [
     maxRank: 4,
   },
 
+  // --- speech_generator ---
+  {
+    query: "transcribe an audio file to text",
+    expected: "speech_generator.speech_to_text",
+  },
+  {
+    query: "convert a video recording to text",
+    expected: "speech_generator.speech_to_text",
+  },
+  {
+    query: "generate speech audio from a text prompt",
+    expected: "speech_generator.text_to_speech",
+  },
+  {
+    query: "convert text to spoken audio with a voice",
+    expected: "speech_generator.text_to_speech",
+  },
+  {
+    query: "generate a multi-speaker dialogue audio",
+    expected: "speech_generator.text_to_dialogue",
+  },
+  {
+    query: "create audio from a script with multiple speakers",
+    expected: "speech_generator.text_to_dialogue",
+  },
+
   // --- statuspage ---
   {
     query: "list available status pages",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -36,6 +36,7 @@ import { SALESFORCE_SERVER } from "@app/lib/api/actions/servers/salesforce/metad
 import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadata";
 import { SLACK_PERSONAL_SERVER } from "@app/lib/api/actions/servers/slack_personal/metadata";
 import { SNOWFLAKE_SERVER } from "@app/lib/api/actions/servers/snowflake/metadata";
+import { SPEECH_GENERATOR_SERVER } from "@app/lib/api/actions/servers/speech_generator/metadata";
 import { STATUSPAGE_SERVER } from "@app/lib/api/actions/servers/statuspage/metadata";
 import { VAL_TOWN_SERVER } from "@app/lib/api/actions/servers/val_town/metadata";
 import { VANTA_SERVER } from "@app/lib/api/actions/servers/vanta/metadata";
@@ -121,6 +122,7 @@ const SERVERS: ServerEntry[] = [
   { name: "data_warehouses", tools: DATA_WAREHOUSES_SERVER.tools },
   { name: "query_tables_v2", tools: QUERY_TABLES_V2_SERVER.tools },
   { name: "pod_manager", tools: POD_MANAGER_SERVER.tools },
+  { name: "speech_generator", tools: SPEECH_GENERATOR_SERVER.tools },
   { name: "statuspage", tools: STATUSPAGE_SERVER.tools },
   { name: "val_town", tools: VAL_TOWN_SERVER.tools },
   { name: "vanta", tools: VANTA_SERVER.tools },


### PR DESCRIPTION
## Description

Adds `speech_generator` to the BM25 harness with 6 labeled queries (2 per tool). No description changes needed — the existing descriptions have strong discriminating vocabulary:

- `speech_to_text`: "transcribe" is unique and high-IDF, routing correctly despite the tool having a long schema (domain allowlist in `audio_url` description)
- `text_to_speech`: "voice" and "prompt" discriminate from `text_to_dialogue`
- `text_to_dialogue`: "dialogue", "speakers", "lines" are unique

All 6 queries pass at rank 1 (283/309 overall).

Part of a series improving MCP tool descriptions for BM25 recall (wakeups: #28191, vanta: #28193, val_town: #28194, statuspage: #28199).

## Tests

Run `npx tsx scripts/mcp_bm25/run.ts` from `front/`. All 6 speech_generator queries pass at rank 1.

## Risk

Low — harness-only change (run.ts + queries.ts), no production behavior change.
