### PR TITLE
[front] enh: tweak slack bot tools description for user ID formatting

### DIFF
--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -17,7 +17,12 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). Do NOT use Slack-specific markup like <url|text> for links. The system converts Markdown to Slack format automatically. To mention a user, use <@USER_ID>. To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
+          "The message to post, using standard Markdown formatting " +
+            "(e.g., [text](url) for links, **bold**, *italic*). Do NOT " +
+            "use Slack-specific markup like <url|text> for links. The " +
+            "system converts Markdown to Slack format automatically. To " +
+            "mention a user, use <@USER_ID>. To reference a channel, use " +
+            "#CHANNEL or <#CHANNEL_ID>."
         ),
       threadTs: z
         .string()
@@ -63,7 +68,12 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The new message content, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). Do NOT use Slack-specific markup like <url|text> for links. The system converts Markdown to Slack format automatically. To mention a user, use <@USER_ID>. To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
+          "The new message content, using standard Markdown formatting " +
+            "(e.g., [text](url) for links, **bold**, *italic*). Do NOT " +
+            "use Slack-specific markup like <url|text> for links. The " +
+            "system converts Markdown to Slack format automatically. To " +
+            "mention a user, use <@USER_ID>. To reference a channel, use " +
+            "#CHANNEL or <#CHANNEL_ID>."
         ),
     },
     stake: "low",

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -21,7 +21,13 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
             "(e.g., [text](url) for links, **bold**, *italic*). Do NOT " +
             "use Slack-specific markup like <url|text> for links. The " +
             "system converts Markdown to Slack format automatically. To " +
-            "mention a user, use <@USER_ID>. To reference a channel, use " +
+            "mention a user, use <@USER_ID>, where USER_ID is a Slack " +
+            "user ID that always starts with 'U' and contains only " +
+            "uppercase letters and digits (e.g., <@U01234ABCD>), so " +
+            "every valid mention starts with '<@U'. Never use an ID " +
+            "from another system (e.g. a HubSpot, Notion, CRM, or " +
+            "database ID) as the Slack user ID; resolve it with the " +
+            "search_user tool if needed. To reference a channel, use " +
             "#CHANNEL or <#CHANNEL_ID>."
         ),
       threadTs: z
@@ -72,7 +78,13 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
             "(e.g., [text](url) for links, **bold**, *italic*). Do NOT " +
             "use Slack-specific markup like <url|text> for links. The " +
             "system converts Markdown to Slack format automatically. To " +
-            "mention a user, use <@USER_ID>. To reference a channel, use " +
+            "mention a user, use <@USER_ID>, where USER_ID is a Slack " +
+            "user ID that always starts with 'U' and contains only " +
+            "uppercase letters and digits (e.g., <@U01234ABCD>), so " +
+            "every valid mention starts with '<@U'. Never use an ID " +
+            "from another system (e.g. a HubSpot, Notion, CRM, or " +
+            "database ID) as the Slack user ID; resolve it with the " +
+            "search_user tool if needed. To reference a channel, use " +
             "#CHANNEL or <#CHANNEL_ID>."
         ),
     },


### PR DESCRIPTION
## Description

We have seen examples where the `slack_bot` agent sometimes fails to correctly fill in Slack user IDs in mentions and instead puts an ID from another system (e.g. a HubSpot ID), producing broken `<@...>` mentions in posted/edited messages.

This PR changes the description copy only; no behavior change. It's split into two commits, first a pure line-wrap of the existing strings (content identical), then the wording changes so the second commit's diff is just the new guidance.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
