### PR TITLE
chore(mcp): improve sound_studio tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1027,6 +1027,16 @@ export const QUERIES: LabeledQuery[] = [
     maxRank: 4,
   },
 
+  // --- sound_studio ---
+  {
+    query: "generate a sound effect from a text description",
+    expected: "sound_studio.generate_sound_effects",
+  },
+  {
+    query: "create a looping background sound effect",
+    expected: "sound_studio.generate_sound_effects",
+  },
+
   // --- speech_generator ---
   {
     query: "transcribe an audio file to text",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -36,6 +36,7 @@ import { SALESFORCE_SERVER } from "@app/lib/api/actions/servers/salesforce/metad
 import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadata";
 import { SLACK_PERSONAL_SERVER } from "@app/lib/api/actions/servers/slack_personal/metadata";
 import { SNOWFLAKE_SERVER } from "@app/lib/api/actions/servers/snowflake/metadata";
+import { SOUND_STUDIO_SERVER } from "@app/lib/api/actions/servers/sound_studio/metadata";
 import { SPEECH_GENERATOR_SERVER } from "@app/lib/api/actions/servers/speech_generator/metadata";
 import { STATUSPAGE_SERVER } from "@app/lib/api/actions/servers/statuspage/metadata";
 import { VAL_TOWN_SERVER } from "@app/lib/api/actions/servers/val_town/metadata";
@@ -122,6 +123,7 @@ const SERVERS: ServerEntry[] = [
   { name: "data_warehouses", tools: DATA_WAREHOUSES_SERVER.tools },
   { name: "query_tables_v2", tools: QUERY_TABLES_V2_SERVER.tools },
   { name: "pod_manager", tools: POD_MANAGER_SERVER.tools },
+  { name: "sound_studio", tools: SOUND_STUDIO_SERVER.tools },
   { name: "speech_generator", tools: SPEECH_GENERATOR_SERVER.tools },
   { name: "statuspage", tools: STATUSPAGE_SERVER.tools },
   { name: "val_town", tools: VAL_TOWN_SERVER.tools },


### PR DESCRIPTION
## Description

Adds `sound_studio` to the BM25 harness with 2 labeled queries. No description changes needed — "sound effect" vocabulary is unique in the corpus with no collision risk.

All 2 queries pass at rank 1.

Part of a series improving MCP tool descriptions for BM25 recall (wakeups: #28191, vanta: #28193, val_town: #28194, statuspage: #28199, speech_generator: #28201).

## Tests

Run `npx tsx scripts/mcp_bm25/run.ts` from `front/`. Both sound_studio queries pass at rank 1.

## Risk

Low — harness-only change (run.ts + queries.ts), no production behavior change.
