### PR TITLE
chore(mcp): improve workday tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1027,6 +1027,16 @@ export const QUERIES: LabeledQuery[] = [
     maxRank: 4,
   },
 
+  // --- workday ---
+  {
+    query: "list workers from Workday",
+    expected: "workday.get_workers",
+  },
+  {
+    query: "get employees in Workday",
+    expected: "workday.get_workers",
+  },
+
   // --- sound_studio ---
   {
     query: "generate a sound effect from a text description",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -43,6 +43,7 @@ import { VAL_TOWN_SERVER } from "@app/lib/api/actions/servers/val_town/metadata"
 import { VANTA_SERVER } from "@app/lib/api/actions/servers/vanta/metadata";
 import { WAKEUPS_SERVER } from "@app/lib/api/actions/servers/wakeups/metadata";
 import { WEB_SEARCH_BROWSE_SERVER } from "@app/lib/api/actions/servers/web_search_browse/metadata";
+import { WORKDAY_SERVER } from "@app/lib/api/actions/servers/workday/metadata";
 import { WORKSPACE_ANALYTICS_SERVER } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import { buildIndex, rank } from "@app/scripts/mcp_bm25/bm25";
@@ -124,6 +125,7 @@ const SERVERS: ServerEntry[] = [
   { name: "query_tables_v2", tools: QUERY_TABLES_V2_SERVER.tools },
   { name: "pod_manager", tools: POD_MANAGER_SERVER.tools },
   { name: "sound_studio", tools: SOUND_STUDIO_SERVER.tools },
+  { name: "workday", tools: WORKDAY_SERVER.tools },
   { name: "speech_generator", tools: SPEECH_GENERATOR_SERVER.tools },
   { name: "statuspage", tools: STATUSPAGE_SERVER.tools },
   { name: "val_town", tools: VAL_TOWN_SERVER.tools },


### PR DESCRIPTION
## Description

Adds `workday` to the BM25 harness with 2 labeled queries. No description changes needed — "Workday" and "workers" vocabulary is unique in the corpus with no collision risk.

Both queries pass at rank 1.

Part of a series improving MCP tool descriptions for BM25 recall (wakeups: #28191, vanta: #28193, val_town: #28194, statuspage: #28199, speech_generator: #28201, sound_studio: #28210).

## Tests

Run `npx tsx scripts/mcp_bm25/run.ts` from `front/`. Both workday queries pass at rank 1.

## Risk

Low — harness-only change (run.ts + queries.ts), no production behavior change.
