### PR TITLE
fix(tools): ensure generated tool names start with a letter or underscore

### DIFF
--- a/front/lib/actions/tool_name_utils.test.ts
+++ b/front/lib/actions/tool_name_utils.test.ts
@@ -49,4 +49,16 @@ describe("getPrefixedToolName", () => {
     const result = getPrefixedToolName(shortServerName, longToolName);
     expect(result).toBe("a".repeat(60));
   });
+
+  it("should prefix an underscore when the prefixed name starts with a digit", () => {
+    const result = getPrefixedToolName("1Password", "get item");
+    expect(result).toBe(`_1password${TOOL_NAME_SEPARATOR}get_item`);
+  });
+
+  it("should prefix an underscore when the unprefixed name starts with a digit", () => {
+    const shortServerName = "ab";
+    const longToolName = "3" + "a".repeat(59);
+    const result = getPrefixedToolName(shortServerName, longToolName);
+    expect(result).toBe("_3" + "a".repeat(59));
+  });
 });

--- a/front/lib/actions/tool_name_utils.ts
+++ b/front/lib/actions/tool_name_utils.ts
@@ -5,6 +5,15 @@ import { slugify } from "@app/types/shared/utils/string_utils";
 
 const MAX_TOOL_NAME_LENGTH = 64;
 
+// Some providers (e.g. Gemini) require function/tool names to start with a letter or an
+// underscore, while slugify can yield a leading digit (e.g. "1Password" -> "1password"). Prefix an
+// underscore in that case so the name is valid everywhere.
+function ensureValidLeadingChar(name: string): string {
+  return /^[a-zA-Z_]/.test(name)
+    ? name
+    : `_${name}`.slice(0, MAX_TOOL_NAME_LENGTH);
+}
+
 // Slugify a server name into the prefix prepended to every one of its tool names. Each part is
 // slugified separately to preserve separators (used for space disambiguation notably).
 export function getToolNamePrefix(serverName: string): string {
@@ -42,7 +51,7 @@ export function tryGetPrefixedToolName(
 
   // If we don't have enough room for a meaningful prefix, just return the original name
   if (availableSpace < minPrefixLength) {
-    return new Ok(slugifiedOriginalName);
+    return new Ok(ensureValidLeadingChar(slugifiedOriginalName));
   }
 
   // Calculate the maximum allowed length for the config name portion
@@ -50,7 +59,7 @@ export function tryGetPrefixedToolName(
   const truncatedConfigName = slugifiedConfigName.slice(0, maxConfigNameLength);
   const prefixedName = `${truncatedConfigName}${separator}${slugifiedOriginalName}`;
 
-  return new Ok(prefixedName);
+  return new Ok(ensureValidLeadingChar(prefixedName));
 }
 
 // Throwing variant for call sites passing compile-time constant names (e.g.


### PR DESCRIPTION
## Description

Tool names are generated by `tryGetPrefixedToolName` (`front/lib/actions/tool_name_utils.ts`), which slugifies `<server>__<tool>`. `slugify` produces `^[a-z0-9_]+$`, so a server/tool name beginning with a digit yields a tool name that starts with a digit (e.g. `1Password` → `1password__get_item`, `3d` → `3d__render`).

Gemini requires function declaration names to **start with a letter or an underscore**:

> Function names should start with a letter or an underscore and contain only characters a-z, A-Z, 0-9, underscores, dots or dashes, with a maximum length of 64.
[Introduction to function calling](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/tools/function-calling) / [Function calling with the Gemini API](https://ai.google.dev/gemini-api/docs/function-calling)

Older Gemini models did not enforce the leading-character rule, but `gemini-3.1-pro-preview` does, returning a 400:

```
The GenerateContentRequest proto is invalid:
  * tools[0].function_declarations[5].name: [FIELD_INVALID] Invalid function name.
    Must start with a letter or an underscore. ...
```

This fix prefixes an underscore when the generated name does not start with a letter or underscore (clamped to the 64-char max).

Both the old router (`front/lib/api/llm/clients/google/utils/conversation_to_google.ts`) and the new router (`front/lib/model_constructors/.../converters/input/utils.ts`) pass the tool name through unchanged and both consume the same upstream `AgentActionSpecification.name`. 
Fixing it at the source means the name is generated once and reused on both the request and Gemini's echoed-back `functionCall`, so request/response names stay consistent and both routers are covered with a single change. The bug was latent in the old router too. 

## Tests

Added two regression cases to `tool_name_utils.test.ts` (digit-leading name with and without a server prefix). Verified red→green: both new cases fail against current `main` and pass with the fix; the full `tool_name_utils` suite is 8/8. Type-check and format clean.

## Risk

Low. Only affects the rare case where a generated tool name would otherwise start with a digit; all other names are unchanged. Such names get a leading `_`, which changes the name the model sees (and the prompt-cache key) for those specific tools only.