### PR TITLE
chore(mcp): improve productboard tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1073,6 +1073,16 @@ export const QUERIES: LabeledQuery[] = [
     expected: "speech_generator.text_to_dialogue",
   },
 
+  // --- productboard ---
+  {
+    query: "capture customer feedback in Productboard",
+    expected: "productboard.create_note",
+  },
+  {
+    query: "find Productboard features by status and owner",
+    expected: "productboard.query_entities",
+  },
+
   // --- statuspage ---
   {
     query: "list available status pages",

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1027,6 +1027,16 @@ export const QUERIES: LabeledQuery[] = [
     maxRank: 4,
   },
 
+  // --- workday ---
+  {
+    query: "list workers from Workday",
+    expected: "workday.get_workers",
+  },
+  {
+    query: "get employees in Workday",
+    expected: "workday.get_workers",
+  },
+
   // --- sound_studio ---
   {
     query: "generate a sound effect from a text description",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -43,6 +43,7 @@ import { VAL_TOWN_SERVER } from "@app/lib/api/actions/servers/val_town/metadata"
 import { VANTA_SERVER } from "@app/lib/api/actions/servers/vanta/metadata";
 import { WAKEUPS_SERVER } from "@app/lib/api/actions/servers/wakeups/metadata";
 import { WEB_SEARCH_BROWSE_SERVER } from "@app/lib/api/actions/servers/web_search_browse/metadata";
+import { WORKDAY_SERVER } from "@app/lib/api/actions/servers/workday/metadata";
 import { WORKSPACE_ANALYTICS_SERVER } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import { buildIndex, rank } from "@app/scripts/mcp_bm25/bm25";
@@ -124,6 +125,7 @@ const SERVERS: ServerEntry[] = [
   { name: "query_tables_v2", tools: QUERY_TABLES_V2_SERVER.tools },
   { name: "pod_manager", tools: POD_MANAGER_SERVER.tools },
   { name: "sound_studio", tools: SOUND_STUDIO_SERVER.tools },
+  { name: "workday", tools: WORKDAY_SERVER.tools },
   { name: "speech_generator", tools: SPEECH_GENERATOR_SERVER.tools },
   { name: "statuspage", tools: STATUSPAGE_SERVER.tools },
   { name: "val_town", tools: VAL_TOWN_SERVER.tools },

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -26,6 +26,7 @@ import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
 import { POD_MANAGER_SERVER } from "@app/lib/api/actions/servers/pod_manager/metadata";
+import { PRODUCTBOARD_SERVER } from "@app/lib/api/actions/servers/productboard/metadata";
 import { QUERY_TABLES_V2_SERVER } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
 import {
   getRunAgentToolDescription,
@@ -124,6 +125,7 @@ const SERVERS: ServerEntry[] = [
   { name: "data_warehouses", tools: DATA_WAREHOUSES_SERVER.tools },
   { name: "query_tables_v2", tools: QUERY_TABLES_V2_SERVER.tools },
   { name: "pod_manager", tools: POD_MANAGER_SERVER.tools },
+  { name: "productboard", tools: PRODUCTBOARD_SERVER.tools },
   { name: "sound_studio", tools: SOUND_STUDIO_SERVER.tools },
   { name: "workday", tools: WORKDAY_SERVER.tools },
   { name: "speech_generator", tools: SPEECH_GENERATOR_SERVER.tools },


### PR DESCRIPTION
## Description

Adds `productboard` to the BM25 harness with 2 labeled queries. No description changes needed — "customer feedback", "Productboard", and entity vocabulary are sufficiently unique in the corpus.

Both queries pass at rank 1.

Part of a series improving MCP tool descriptions for BM25 recall.

## Tests

Run `npx tsx scripts/mcp_bm25/run.ts` from `front/`. Both productboard queries pass at rank 1.

## Risk

Low — harness-only change (run.ts + queries.ts), no production behavior change.
