### PR TITLE
chore(mcp): improve salesloft tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1073,6 +1073,12 @@ export const QUERIES: LabeledQuery[] = [
     expected: "speech_generator.text_to_dialogue",
   },
 
+  // --- salesloft ---
+  {
+    query: "get my due sales cadence actions in Salesloft",
+    expected: "salesloft.get_actions",
+  },
+
   // --- productboard ---
   {
     query: "capture customer feedback in Productboard",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -34,6 +34,7 @@ import {
   RUN_AGENT_TOOL_SCHEMA,
 } from "@app/lib/api/actions/servers/run_agent/metadata";
 import { SALESFORCE_SERVER } from "@app/lib/api/actions/servers/salesforce/metadata";
+import { SALESLOFT_SERVER } from "@app/lib/api/actions/servers/salesloft/metadata";
 import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadata";
 import { SLACK_PERSONAL_SERVER } from "@app/lib/api/actions/servers/slack_personal/metadata";
 import { SNOWFLAKE_SERVER } from "@app/lib/api/actions/servers/snowflake/metadata";
@@ -116,6 +117,7 @@ const SERVERS: ServerEntry[] = [
   { name: "hubspot", tools: HUBSPOT_SERVER.tools },
   { name: "include_data", tools: INCLUDE_DATA_SERVER.tools },
   { name: "salesforce", tools: SALESFORCE_SERVER.tools },
+  { name: "salesloft", tools: SALESLOFT_SERVER.tools },
   { name: "interactive_content", tools: INTERACTIVE_CONTENT_SERVER.tools },
   { name: "snowflake", tools: SNOWFLAKE_SERVER.tools },
   {


### PR DESCRIPTION
## Description

Adds `salesloft` to the BM25 harness with 1 labeled query. No description changes needed — "cadence", "Salesloft", and "due actions" vocabulary is unique in the corpus.

Query passes at rank 1.

Part of a series improving MCP tool descriptions for BM25 recall.

## Tests

Run `npx tsx scripts/mcp_bm25/run.ts` from `front/`. The salesloft query passes at rank 1.

## Risk

Low — harness-only change (run.ts + queries.ts), no production behavior change.
