### PR TITLE
chore(mcp): improve slab tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/slab/metadata.ts
+++ b/front/lib/api/actions/servers/slab/metadata.ts
@@ -80,7 +80,7 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
   },
   get_topics: {
     description:
-      "Retrieve all topics for navigation and organization understanding.",
+      "Retrieve all Slab topics for navigation and organization understanding.",
     schema: {},
     stake: "never_ask",
     displayLabels: {

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1073,6 +1073,16 @@ export const QUERIES: LabeledQuery[] = [
     expected: "speech_generator.text_to_dialogue",
   },
 
+  // --- slab ---
+  {
+    query: "search Slab posts by keyword",
+    expected: "slab.search_posts",
+  },
+  {
+    query: "list all topics in Slab",
+    expected: "slab.get_topics",
+  },
+
   // --- salesloft ---
   {
     query: "get my due sales cadence actions in Salesloft",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -35,6 +35,7 @@ import {
 } from "@app/lib/api/actions/servers/run_agent/metadata";
 import { SALESFORCE_SERVER } from "@app/lib/api/actions/servers/salesforce/metadata";
 import { SALESLOFT_SERVER } from "@app/lib/api/actions/servers/salesloft/metadata";
+import { SLAB_SERVER } from "@app/lib/api/actions/servers/slab/metadata";
 import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadata";
 import { SLACK_PERSONAL_SERVER } from "@app/lib/api/actions/servers/slack_personal/metadata";
 import { SNOWFLAKE_SERVER } from "@app/lib/api/actions/servers/snowflake/metadata";
@@ -118,6 +119,7 @@ const SERVERS: ServerEntry[] = [
   { name: "include_data", tools: INCLUDE_DATA_SERVER.tools },
   { name: "salesforce", tools: SALESFORCE_SERVER.tools },
   { name: "salesloft", tools: SALESLOFT_SERVER.tools },
+  { name: "slab", tools: SLAB_SERVER.tools },
   { name: "interactive_content", tools: INTERACTIVE_CONTENT_SERVER.tools },
   { name: "snowflake", tools: SNOWFLAKE_SERVER.tools },
   {


### PR DESCRIPTION
## Description

Adds `slab` to the BM25 harness with 2 labeled queries. Adds "Slab" to the `get_topics` description so that the topics query can discriminate against `search_posts` (which already contained "Slab workspace" in its description).

Both queries pass at rank 1.

Part of a series improving MCP tool descriptions for BM25 recall.

## Tests

Run `npx tsx scripts/mcp_bm25/run.ts` from `front/`. Both slab queries pass at rank 1.

## Risk

Low — one-word description addition to `get_topics`, no behavioral change.
