### PR TITLE
Rename listPrivateConversationsForUserPaginatedFromDB and add script to clean up ES.

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -204,14 +204,11 @@ app.get("/", async (ctx): HandlerResult<GetConversationsResponseBody> => {
   const pagination = paginationRes.value;
 
   const result =
-    await ConversationResource.listPrivateConversationsForUserPaginatedFromDB(
-      auth,
-      {
-        limit: pagination.limit,
-        lastValue: pagination.lastValue,
-        orderDirection: pagination.orderDirection,
-      }
-    );
+    await ConversationResource.listPrivateConversationsForUserPaginated(auth, {
+      limit: pagination.limit,
+      lastValue: pagination.lastValue,
+      orderDirection: pagination.orderDirection,
+    });
 
   return ctx.json({
     conversations: result.conversations,

--- a/front/lib/api/mcp_server/tools/conversations/list.ts
+++ b/front/lib/api/mcp_server/tools/conversations/list.ts
@@ -100,7 +100,7 @@ export function registerConversationsListTool(server: McpServer) {
       }
 
       const result =
-        await ConversationResource.listPrivateConversationsForUserPaginatedFromDB(
+        await ConversationResource.listPrivateConversationsForUserPaginated(
           auth,
           {
             limit: LIST_CONVERSATIONS_PAGE_SIZE,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -2742,7 +2742,7 @@ describe("listPrivateConversationsForUser", () => {
     assert(scheduledWakeUpResult.isOk(), "Failed to create scheduled wake-up.");
 
     const result =
-      await ConversationResource.listPrivateConversationsForUserPaginatedFromDB(
+      await ConversationResource.listPrivateConversationsForUserPaginated(
         userAuth,
         { limit: 100 }
       );
@@ -2805,7 +2805,7 @@ describe("listPrivateConversationsForUser", () => {
     });
 
     const result =
-      await ConversationResource.listPrivateConversationsForUserPaginatedFromDB(
+      await ConversationResource.listPrivateConversationsForUserPaginated(
         userAuth,
         { limit: 100 }
       );

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1840,29 +1840,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       orderDirection?: "asc" | "desc";
     }
   ): Promise<{
-    conversations: ConversationResource[];
-    hasMore: boolean;
-    lastValue: string | null;
-  }> {
-    return this.fetchPrivateConversationsPaginated(auth, { pagination });
-  }
-
-  static async listPrivateConversationsForUserPaginatedFromDB(
-    auth: Authenticator,
-    pagination: {
-      limit: number;
-      lastValue?: string;
-      orderDirection?: "asc" | "desc";
-    }
-  ): Promise<{
     conversations: ConversationListItemType[];
     hasMore: boolean;
     lastValue: string | null;
   }> {
-    const result = await this.listPrivateConversationsForUserPaginated(
-      auth,
-      pagination
-    );
+    const result = await this.fetchPrivateConversationsPaginated(auth, {
+      pagination,
+    });
     const nextWakeupAtByConversationId =
       await this.fetchNextWakeupAtByConversationId(
         auth,

--- a/front/scripts/delete_conversation_search_es.ts
+++ b/front/scripts/delete_conversation_search_es.ts
@@ -1,0 +1,141 @@
+import {
+  CONVERSATION_SEARCH_ALIAS_NAME,
+  getClient,
+} from "@app/lib/api/elasticsearch";
+import { makeScript } from "@app/scripts/helpers";
+import { errors as esErrors } from "@elastic/elasticsearch";
+import * as readline from "readline";
+
+const INDEX_PATTERN = `${CONVERSATION_SEARCH_ALIAS_NAME}*`;
+
+async function listConversationSearchIndices(): Promise<string[]> {
+  const client = await getClient();
+  const indices = new Set<string>();
+
+  try {
+    const aliasResponse = await client.indices.getAlias({
+      name: CONVERSATION_SEARCH_ALIAS_NAME,
+    });
+    for (const index of Object.keys(aliasResponse)) {
+      indices.add(index);
+    }
+  } catch (err) {
+    if (!(err instanceof esErrors.ResponseError && err.statusCode === 404)) {
+      throw err;
+    }
+  }
+
+  try {
+    const indicesResponse = await client.indices.get({
+      index: INDEX_PATTERN,
+      ignore_unavailable: true,
+    });
+    for (const index of Object.keys(indicesResponse)) {
+      indices.add(index);
+    }
+  } catch (err) {
+    if (!(err instanceof esErrors.ResponseError && err.statusCode === 404)) {
+      throw err;
+    }
+  }
+
+  return [...indices].sort();
+}
+
+/**
+ * Deletes the conversation search Elasticsearch index and alias.
+ *
+ * Follow-up cleanup for https://github.com/dust-tt/dust/pull/28208, which
+ * removed the application read/write paths for `front.conversation_search`.
+ *
+ * Usage:
+ * tsx front/scripts/delete_conversation_search_es.ts
+ * tsx front/scripts/delete_conversation_search_es.ts --execute
+ * tsx front/scripts/delete_conversation_search_es.ts --execute --skipConfirmation
+ */
+makeScript(
+  {
+    skipConfirmation: {
+      type: "boolean",
+      describe: "Skip interactive confirmation when using --execute",
+      default: false,
+    },
+  },
+  async ({ execute, skipConfirmation }, logger) => {
+    const indices = await listConversationSearchIndices();
+
+    if (indices.length === 0) {
+      logger.info(
+        {
+          alias: CONVERSATION_SEARCH_ALIAS_NAME,
+          indexPattern: INDEX_PATTERN,
+        },
+        "No conversation search indices found in Elasticsearch."
+      );
+      return;
+    }
+
+    const client = await getClient();
+    const stats = await client.indices.stats({
+      index: indices.join(","),
+    });
+
+    const documentCounts = indices.map((index) => ({
+      index,
+      documentCount: stats.indices?.[index]?.total?.docs?.count ?? 0,
+    }));
+
+    logger.info(
+      {
+        alias: CONVERSATION_SEARCH_ALIAS_NAME,
+        indices: documentCounts,
+      },
+      execute
+        ? "Will delete conversation search indices."
+        : "[DRY RUN] Would delete conversation search indices."
+    );
+
+    if (!execute) {
+      return;
+    }
+
+    if (!skipConfirmation) {
+      logger.info(
+        `CHECK: Delete conversation search indices ${indices.join(", ")}? (y to confirm)`
+      );
+
+      const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+
+      const answer = await new Promise<string>((resolve) => {
+        rl.question("", (input) => {
+          rl.close();
+          resolve(input.trim());
+        });
+      });
+
+      if (answer !== "y") {
+        throw new Error("Aborted");
+      }
+    }
+
+    for (const index of indices) {
+      logger.info({ index }, "Deleting index...");
+      await client.indices.delete({
+        index,
+        ignore_unavailable: true,
+      });
+      logger.info({ index }, "Deleted index.");
+    }
+
+    logger.info(
+      {
+        alias: CONVERSATION_SEARCH_ALIAS_NAME,
+        deletedIndices: indices,
+      },
+      "Conversation search Elasticsearch cleanup complete."
+    );
+  }
+);


### PR DESCRIPTION
## Description

Two follow-up cleanup items after #28208 removed the ES conversation search read/write paths:

- Renamed `listPrivateConversationsForUserPaginatedFromDB` → `listPrivateConversationsForUserPaginated` in `ConversationResource`. The `FromDB` suffix was meaningful only while the ES path existed; the intermediate wrapper returning `ConversationResource[]` is also removed, collapsing the call chain to go directly to `fetchPrivateConversationsPaginated`.
- Added `front/scripts/delete_conversation_search_es.ts` to physically delete the `front.conversation_search` ES indices and alias. The script supports dry-run (default), `--execute`, and `--execute --skipConfirmation` modes, and logs document counts before deleting.

## Tests

- Existing unit tests in `conversation_resource.test.ts` updated to call the renamed method — no behavioural change.
- Script tested locally in dry-run mode against a dev ES cluster.

## Risk

Low. The rename is a pure refactor with no logic change. The ES cleanup script is destructive but gated behind `--execute` with an interactive confirmation prompt; the index has had no application traffic since #28208 merged.

## Deploy Plan

1. Deploy front.
2. Run the ES cleanup script when ready: `tsx front/scripts/delete_conversation_search_es.ts --execute`
