### PR TITLE
chore(mcp): improve outlook tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -445,6 +445,16 @@ export const QUERIES: LabeledQuery[] = [
     expected: "slack_bot.read_channel_history",
   },
 
+  // --- outlook ---
+  {
+    query: "get emails from my Outlook inbox",
+    expected: "outlook.get_messages",
+  },
+  {
+    query: "check Outlook Calendar availability for multiple people",
+    expected: "outlook_calendar.check_availability",
+  },
+
   // --- microsoft_teams ---
   {
     query: "search microsoft teams messages for the budget discussion",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -25,6 +25,8 @@ import { INTERACTIVE_CONTENT_SERVER } from "@app/lib/api/actions/servers/interac
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
+import { OUTLOOK_CALENDAR_SERVER } from "@app/lib/api/actions/servers/outlook/calendar_metadata";
+import { OUTLOOK_MAIL_SERVER } from "@app/lib/api/actions/servers/outlook/mail_metadata";
 import { POD_MANAGER_SERVER } from "@app/lib/api/actions/servers/pod_manager/metadata";
 import { PRODUCTBOARD_SERVER } from "@app/lib/api/actions/servers/productboard/metadata";
 import { QUERY_TABLES_V2_SERVER } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
@@ -114,6 +116,8 @@ const SERVERS: ServerEntry[] = [
   { name: "slack", tools: SLACK_PERSONAL_SERVER.tools },
   { name: "slack_bot", tools: SLACK_BOT_SERVER.tools },
   { name: "microsoft_teams", tools: MICROSOFT_TEAMS_SERVER.tools },
+  { name: "outlook", tools: OUTLOOK_MAIL_SERVER.tools },
+  { name: "outlook_calendar", tools: OUTLOOK_CALENDAR_SERVER.tools },
   { name: "wakeups", tools: WAKEUPS_SERVER.tools },
   { name: "confluence", tools: CONFLUENCE_SERVER.tools },
   { name: "hubspot", tools: HUBSPOT_SERVER.tools },


### PR DESCRIPTION
Adds outlook and outlook_calendar servers to the BM25 harness and adds labeled queries for email inbox retrieval and calendar availability checking.