### PR TITLE
fix(agent-loop): treat already-running parent as no-op in ancestor resume

### DIFF
--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.test.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/assistant/conversation/retry_blocked_actions", () => ({
+  retryBlockedActions: vi.fn(),
+}));
+
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { resumeAncestorConversations } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
+import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Err, Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+
+async function createAgenticConversation(
+  auth: Authenticator,
+  workspace: WorkspaceType,
+  { agenticParentMessageId }: { agenticParentMessageId?: string } = {}
+): Promise<{ conversation: ConversationResource; agentMessageId: string }> {
+  const conversation = await createConversation(auth, {
+    title: "Test Conversation",
+    visibility: "unlisted",
+    spaceId: null,
+  });
+
+  const { messageRow: userMessageRow } =
+    await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: "Hello",
+      rank: 0,
+      agenticMessageType: agenticParentMessageId ? "run_agent" : undefined,
+      agenticOriginMessageId: agenticParentMessageId,
+    });
+
+  const agentMessageRow = await ConversationFactory.createAgentMessageWithRank({
+    workspace,
+    conversationId: conversation.id,
+    rank: 1,
+    agentConfigurationId: "test-agent",
+    parentId: userMessageRow.id,
+  });
+
+  const conversationResource = await ConversationResource.fetchById(
+    auth,
+    conversation.sId
+  );
+  if (!conversationResource) {
+    throw new Error("Failed to fetch conversation resource");
+  }
+
+  return {
+    conversation: conversationResource,
+    agentMessageId: agentMessageRow.sId,
+  };
+}
+
+describe("resumeAncestorConversations", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+  });
+
+  it("keeps walking up to higher ancestors when a parent loop is already running", async () => {
+    const grandParent = await createAgenticConversation(auth, workspace);
+    const parent = await createAgenticConversation(auth, workspace, {
+      agenticParentMessageId: grandParent.agentMessageId,
+    });
+    const child = await createAgenticConversation(auth, workspace, {
+      agenticParentMessageId: parent.agentMessageId,
+    });
+
+    vi.mocked(retryBlockedActions).mockResolvedValue(
+      new Err(
+        new DustError(
+          "agent_loop_already_running",
+          "Agent loop already running for this message."
+        )
+      )
+    );
+
+    const res = await resumeAncestorConversations(auth, child.conversation, {
+      agentMessageId: child.agentMessageId,
+    });
+
+    expect(res.isOk()).toBe(true);
+    // Starting the parent is a no-op (a sibling won the race), but we still walk
+    // up and attempt to resume the grandparent so it is not stranded.
+    expect(retryBlockedActions).toHaveBeenCalledTimes(2);
+    expect(retryBlockedActions).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({ sId: parent.conversation.sId }),
+      expect.objectContaining({ messageId: parent.agentMessageId })
+    );
+    expect(retryBlockedActions).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({ sId: grandParent.conversation.sId }),
+      expect.objectContaining({ messageId: grandParent.agentMessageId })
+    );
+  });
+
+  it("returns Err when retrying blocked actions fails for another reason", async () => {
+    const parent = await createAgenticConversation(auth, workspace);
+    const child = await createAgenticConversation(auth, workspace, {
+      agenticParentMessageId: parent.agentMessageId,
+    });
+
+    vi.mocked(retryBlockedActions).mockResolvedValue(
+      new Err(new Error("No blocked actions found"))
+    );
+
+    const res = await resumeAncestorConversations(auth, child.conversation, {
+      agentMessageId: child.agentMessageId,
+    });
+
+    expect(res.isErr()).toBe(true);
+  });
+
+  it("returns Ok without retrying when there is no agentic parent", async () => {
+    const root = await createAgenticConversation(auth, workspace);
+
+    const res = await resumeAncestorConversations(auth, root.conversation, {
+      agentMessageId: root.agentMessageId,
+    });
+
+    expect(res.isOk()).toBe(true);
+    expect(retryBlockedActions).not.toHaveBeenCalled();
+  });
+
+  it("walks up multiple ancestors when each resumes successfully", async () => {
+    const grandParent = await createAgenticConversation(auth, workspace);
+    const parent = await createAgenticConversation(auth, workspace, {
+      agenticParentMessageId: grandParent.agentMessageId,
+    });
+    const child = await createAgenticConversation(auth, workspace, {
+      agenticParentMessageId: parent.agentMessageId,
+    });
+
+    vi.mocked(retryBlockedActions).mockResolvedValue(new Ok(undefined));
+
+    const res = await resumeAncestorConversations(auth, child.conversation, {
+      agentMessageId: child.agentMessageId,
+    });
+
+    expect(res.isOk()).toBe(true);
+    expect(retryBlockedActions).toHaveBeenCalledTimes(2);
+  });
+});

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
@@ -54,18 +54,27 @@ export async function resumeAncestorConversations(
     );
 
     if (retryRes.isErr()) {
-      logger.error(
-        {
-          workspaceId: owner.sId,
-          parentConversationId: parentConversation.sId,
-          parentAgentMessageId: parentAgentMessage.sId,
-          err: retryRes.error,
-        },
-        "Failed to retry blocked actions on parent conversation"
-      );
-      return new Err(
-        new DustError("internal_error", "Failed to resume parent conversation")
-      );
+      const isAlreadyRunning =
+        retryRes.error instanceof DustError &&
+        retryRes.error.code === "agent_loop_already_running";
+
+      if (!isAlreadyRunning) {
+        logger.error(
+          {
+            workspaceId: owner.sId,
+            parentConversationId: parentConversation.sId,
+            parentAgentMessageId: parentAgentMessage.sId,
+            err: retryRes.error,
+          },
+          "Failed to retry blocked actions on parent conversation"
+        );
+        return new Err(
+          new DustError(
+            "internal_error",
+            "Failed to resume parent conversation"
+          )
+        );
+      }
     }
 
     cursor = {


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9115

In a parallel run_agent fan-out, sibling children completing near simultaneously each try to relaunch the parent's agent loop. Only one wins the race to start the workflow, the others get agent_loop_already_running. resumeAncestorConversations treated this as fatal and aborted the whole ancestor walk, so the losing child never resumed the chain and the parent stalled in "Thinking..." with no error surfaced to the user.

Treat agent_loop_already_running as a benign no-op for starting that one parent, but keep walking up the chain. Ancestor resumption is driven per-sibling from the request handler (validate_actions / resolve_authentication), not by the parent workflow, so each sibling must still attempt every higher ancestor. Stopping at the already-running parent could strand the grandparent if the sibling that won the race fails before reaching it. Other errors still abort as before. Scoped to the ancestor-resume path so the front-api retry endpoint keeps surfacing the error as a 400.

## Tests

Unit

## Risk

Low

## Deploy Plan

Front