### PR TITLE
chore(mcp): improve notion tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -449,6 +449,16 @@ export const QUERIES: LabeledQuery[] = [
     expected: "slack_bot.read_channel_history",
   },
 
+  // --- notion ---
+  {
+    query: "find a Notion page by keyword",
+    expected: "notion.search",
+  },
+  {
+    query: "insert a new row into a Notion database",
+    expected: "notion.insert_row_into_database",
+  },
+
   // --- outlook ---
   {
     query: "get emails from my Outlook inbox",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -27,6 +27,7 @@ import { INTERACTIVE_CONTENT_SERVER } from "@app/lib/api/actions/servers/interac
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
+import { NOTION_SERVER } from "@app/lib/api/actions/servers/notion/metadata";
 import { OUTLOOK_CALENDAR_SERVER } from "@app/lib/api/actions/servers/outlook/calendar_metadata";
 import { OUTLOOK_MAIL_SERVER } from "@app/lib/api/actions/servers/outlook/mail_metadata";
 import { POD_MANAGER_SERVER } from "@app/lib/api/actions/servers/pod_manager/metadata";
@@ -118,6 +119,7 @@ const SERVERS: ServerEntry[] = [
   { name: "slack", tools: SLACK_PERSONAL_SERVER.tools },
   { name: "slack_bot", tools: SLACK_BOT_SERVER.tools },
   { name: "microsoft_teams", tools: MICROSOFT_TEAMS_SERVER.tools },
+  { name: "notion", tools: NOTION_SERVER.tools },
   { name: "outlook", tools: OUTLOOK_MAIL_SERVER.tools },
   { name: "outlook_calendar", tools: OUTLOOK_CALENDAR_SERVER.tools },
   { name: "wakeups", tools: WAKEUPS_SERVER.tools },


### PR DESCRIPTION
Adds notion server to the BM25 harness and adds labeled queries for page search and database row insertion.