### PR TITLE
[front] fix: allow null `authorId` in Ashby `opening.list` response

### DIFF
--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -282,7 +282,7 @@ export const AshbyOpeningLatestVersionSchema = z
     id: z.string(),
     identifier: z.string().optional(),
     description: z.string().nullish(),
-    authorId: z.string().optional(),
+    authorId: z.string().nullish(),
     createdAt: z.string().optional(),
     teamId: z.string().nullish(),
     jobIds: z.array(z.string()).optional(),


### PR DESCRIPTION
## Description

Fixes error seen [here](https://app.datadoghq.eu/logs?query=%22%5BAshby%5D%20Invalid%20API%20response%20format%22&additional_filters=%5B%5D&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=200152&storage=hot&stream_sort=desc&viz=stream&from_ts=1782217002385&to_ts=1782821802385&live=true).
This PR fixes the expected type from Ashby's `opening.list` endpoint.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
