### PR TITLE
[front] chore: fix DangerJS on Temporal workflow changes

### DIFF
--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -31,6 +31,7 @@ jobs:
           MONITORED_PATHS=(
             'front/lib/'
             'front/types/assistant/models/'
+            'front/temporal/'
             'front-api/'
             'connectors/src/lib/models/'
             'connectors/src/resources/storage/models/'

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -367,18 +367,9 @@ function warnTemporalWorkflowChanges(files: string[]) {
     `Temporal workflow/activity files have been modified:
 ${files.map((f) => `    - \`${f}\``).join("\n")}
 
-    **IMPORTANT**: Renaming activity functions or changing workflow logic can cause non-deterministic errors in Temporal workflows.
+    **IMPORTANT**: Risk of non-deterministic errors. Workflows replay their history on resume, so changing workflow logic or renaming/reordering activities can crash in-flight workflows.
 
-    Running workflows replay their history on resume, so they may still reference the old activity names or expect the old control flow, which will cause failures when they execute.
-
-    Best practices:
-    - **DO NOT** rename existing activity functions
-    - **DO** create new activities with new names if you need different behavior
-    - **DO** use activity versioning patterns if you must change activity signatures
-    - **DO** use Temporal patching/versioning for unavoidable workflow logic changes
-    - **DO** ensure all running workflows complete before removing old activities
-
-    If you're only adding new workflows/activities or fixing bugs within existing ones, this warning can be ignored.`
+    Use Temporal patching/versioning for workflow logic changes, and add new activities instead of renaming existing ones. Adding new workflows/activities or fixing bugs within them is safe.`
   );
 }
 

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -367,9 +367,17 @@ function warnTemporalWorkflowChanges(files: string[]) {
     `Temporal workflow/activity files have been modified:
 ${files.map((f) => `    - \`${f}\``).join("\n")}
 
-    **IMPORTANT**: Risk of non-deterministic errors. Workflows replay their history on resume, so changing workflow logic or renaming/reordering activities can crash in-flight workflows.
+    **IMPORTANT**: Renaming activity functions can cause non-deterministic errors in Temporal workflows.
 
-    Use Temporal patching/versioning for workflow logic changes, and add new activities instead of renaming existing ones. Adding new workflows/activities or fixing bugs within them is safe.`
+    Running workflows may still reference the old activity names, which will cause failures when they try to execute.
+
+    Best practices:
+    - **DO NOT** rename existing activity functions
+    - **DO** create new activities with new names if you need different behavior
+    - **DO** use activity versioning patterns if you must change activity signatures
+    - **DO** ensure all running workflows complete before removing old activities
+
+    If you're only adding new activities or fixing bugs within existing ones, this warning can be ignored.`
   );
 }
 

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -354,11 +354,39 @@ function checkSandboxImageLabel() {
 }
 
 /**
+ * Warn about changes to any Temporal workflow or activity file.
+ *
+ * Workflow code must stay deterministic: Temporal replays workflow history on
+ * every resume, so changing control flow, renaming or reordering activities, or
+ * altering activity signatures can cause non-deterministic errors that crash
+ * in-flight workflows. Activities referenced by running workflows must also keep
+ * their names until those workflows have drained.
+ */
+function warnTemporalWorkflowChanges(files: string[]) {
+  warn(
+    "Temporal workflow/activity files have been modified:\n" +
+      files.map((f) => `- \`${f}\``).join("\n") +
+      "\n\n**IMPORTANT**: Workflow code must stay deterministic. Temporal " +
+      "replays workflow history on resume, so changing control flow, renaming " +
+      "or reordering activities, or altering activity signatures can cause " +
+      "non-deterministic errors that crash in-flight workflows.\n\n" +
+      "Best practices:\n" +
+      "- **DO NOT** rename or reorder existing activities referenced by running workflows\n" +
+      "- **DO NOT** change activity signatures in a backward-incompatible way\n" +
+      "- **DO** add new workflows/activities instead of mutating existing ones when behavior must change\n" +
+      "- **DO** use Temporal patching/versioning for unavoidable workflow logic changes\n" +
+      "- **DO** ensure running workflows drain before removing old activities\n\n" +
+      "If you're only adding new workflows/activities or fixing bugs within " +
+      "existing ones, this warning can be ignored."
+  );
+}
+
+/**
  * Triggers related checks based on modified files
  */
 function warnTriggersWorkflowChanges() {
   warn(
-    `Files in \`front/temporal/agent_schedules/\` have been modified.
+    `Files in \`front/temporal/triggers/\` have been modified.
     Be careful modifying workflows/activities signatures.
     This may break running schedules. If so, soft reset them from prodbox.`
   );
@@ -616,11 +644,29 @@ async function checkDiffFiles() {
     await checkSparkleVersionConsistency();
   }
 
-  // Triggers workflow files
-  const modifiedWorkflowFiles = diffFiles.filter((path) => {
-    return path.startsWith("front/temporal/agent_schedules/");
+  // Temporal workflow/activity files — changes risk non-deterministic errors
+  // in running workflows on replay, plus activity rename/signature breakage.
+  // Test files don't run in workflows, so they're excluded.
+  const modifiedTemporalFiles = diffFiles.filter((path) => {
+    if (path.endsWith(".test.ts")) {
+      return false;
+    }
+    return (
+      /^front\/temporal\/.+\/workflows\.ts$/.test(path) ||
+      /^front\/temporal\/.+\/activities\.ts$/.test(path) ||
+      /^front\/temporal\/.+\/activities\/.+\.ts$/.test(path)
+    );
   });
-  if (modifiedWorkflowFiles.length > 0) {
+  if (modifiedTemporalFiles.length > 0) {
+    warnTemporalWorkflowChanges(modifiedTemporalFiles);
+  }
+
+  // Triggers (agent schedules) workflow files — carry specific soft-reset
+  // guidance on top of the generic determinism warning above.
+  const modifiedTriggersFiles = diffFiles.filter((path) => {
+    return path.startsWith("front/temporal/triggers/");
+  });
+  if (modifiedTriggersFiles.length > 0) {
     warnTriggersWorkflowChanges();
   }
 

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -364,20 +364,21 @@ function checkSandboxImageLabel() {
  */
 function warnTemporalWorkflowChanges(files: string[]) {
   warn(
-    "Temporal workflow/activity files have been modified:\n" +
-      files.map((f) => `- \`${f}\``).join("\n") +
-      "\n\n**IMPORTANT**: Workflow code must stay deterministic. Temporal " +
-      "replays workflow history on resume, so changing control flow, renaming " +
-      "or reordering activities, or altering activity signatures can cause " +
-      "non-deterministic errors that crash in-flight workflows.\n\n" +
-      "Best practices:\n" +
-      "- **DO NOT** rename or reorder existing activities referenced by running workflows\n" +
-      "- **DO NOT** change activity signatures in a backward-incompatible way\n" +
-      "- **DO** add new workflows/activities instead of mutating existing ones when behavior must change\n" +
-      "- **DO** use Temporal patching/versioning for unavoidable workflow logic changes\n" +
-      "- **DO** ensure running workflows drain before removing old activities\n\n" +
-      "If you're only adding new workflows/activities or fixing bugs within " +
-      "existing ones, this warning can be ignored."
+    `Temporal workflow/activity files have been modified:
+${files.map((f) => `    - \`${f}\``).join("\n")}
+
+    **IMPORTANT**: Renaming activity functions or changing workflow logic can cause non-deterministic errors in Temporal workflows.
+
+    Running workflows replay their history on resume, so they may still reference the old activity names or expect the old control flow, which will cause failures when they execute.
+
+    Best practices:
+    - **DO NOT** rename existing activity functions
+    - **DO** create new activities with new names if you need different behavior
+    - **DO** use activity versioning patterns if you must change activity signatures
+    - **DO** use Temporal patching/versioning for unavoidable workflow logic changes
+    - **DO** ensure all running workflows complete before removing old activities
+
+    If you're only adding new workflows/activities or fixing bugs within existing ones, this warning can be ignored.`
   );
 }
 


### PR DESCRIPTION
## Description

This PR fixes the DangerJS rule on non-determinism errors for Temporal changes on workflows to trigger on changes in  `front/temporal/agent_loop/workflows.ts` (among others).

Adds a more generic rule and fixes the paths where temporal workflow files are expected.

## Tests

- Checked against https://github.com/dust-tt/dust/pull/27683.

## Risk

- Low.

## Deploy Plan

- No deploy.
