### PR TITLE
Mount published sandbox functions read-only into the pod sandbox

### DIFF
--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -2,6 +2,7 @@ import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandb
 import type {
   DustFileSystemError,
   FileSystemMount,
+  SandboxOnlyMount,
 } from "@app/lib/api/file_system/types";
 import type {
   FileSystemDirectoryEntry,
@@ -113,6 +114,7 @@ export interface FileSystemBackend {
    * The adapter holds all backend-specific context so callers never see storage paths.
    */
   createSandboxAdapter(
-    mounts: ReadonlyArray<FileSystemMount>
+    mounts: ReadonlyArray<FileSystemMount>,
+    sandboxOnlyMounts?: ReadonlyArray<SandboxOnlyMount>
   ): SandboxMountAdapter;
 }

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -613,7 +613,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
   private sandboxOnlyMountGCSPrefix(mount: SandboxOnlyMount): string {
     switch (mount.kind) {
       case "pod_sandbox_functions":
-        return `w/${this.workspaceId}/pods/${mount.id}/sandbox_functions`;
+        return `w/${this.workspaceId}/pods/${mount.id}/sandbox-functions`;
 
       default:
         assertNever(mount.kind);

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -1,7 +1,10 @@
 import type { GCSMountTarget } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
 import { GCSSandboxMountAdapter } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
 import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandbox_mount_adapter";
-import type { FileSystemMount } from "@app/lib/api/file_system/types";
+import type {
+  FileSystemMount,
+  SandboxOnlyMount,
+} from "@app/lib/api/file_system/types";
 import {
   DustFileSystemError,
   SCOPED_PREFIX_CONVERSATION,
@@ -585,15 +588,35 @@ export class GCSFileSystemBackend implements FileSystemBackend {
   }
 
   createSandboxAdapter(
-    mounts: ReadonlyArray<FileSystemMount>
+    mounts: ReadonlyArray<FileSystemMount>,
+    sandboxOnlyMounts: ReadonlyArray<SandboxOnlyMount> = []
   ): SandboxMountAdapter {
     const bucket = fileStorageConfig.getGcsPrivateUploadsBucket();
-    const targets: GCSMountTarget[] = mounts.map((mount) => ({
-      gcsPrefix: this.mountRootGCSPrefix(mount),
-      sandboxMountPoint: mount.sandboxMountPoint,
-      legacySandboxMountPoint: mount.legacySandboxMountPoint,
-    }));
+    const targets: GCSMountTarget[] = [
+      ...mounts.map((mount) => ({
+        gcsPrefix: this.mountRootGCSPrefix(mount),
+        sandboxMountPoint: mount.sandboxMountPoint,
+        legacySandboxMountPoint: mount.legacySandboxMountPoint,
+        readOnly: false,
+      })),
+      ...sandboxOnlyMounts.map((mount) => ({
+        gcsPrefix: this.sandboxOnlyMountGCSPrefix(mount),
+        sandboxMountPoint: mount.sandboxMountPoint,
+        legacySandboxMountPoint: null,
+        readOnly: mount.readOnly,
+      })),
+    ];
 
     return new GCSSandboxMountAdapter(bucket, targets);
+  }
+
+  private sandboxOnlyMountGCSPrefix(mount: SandboxOnlyMount): string {
+    switch (mount.kind) {
+      case "pod_sandbox_functions":
+        return `w/${this.workspaceId}/pods/${mount.id}/sandbox_functions`;
+
+      default:
+        assertNever(mount.kind);
+    }
   }
 }

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -17,7 +17,10 @@
 import config from "@app/lib/api/config";
 import type { FileSystemBackend } from "@app/lib/api/file_system/backends/file_system_backend";
 import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
-import type { FileSystemMount } from "@app/lib/api/file_system/types";
+import type {
+  FileSystemMount,
+  SandboxOnlyMount,
+} from "@app/lib/api/file_system/types";
 import {
   DustFileSystemError,
   LEGACY_PREFIX_CONVERSATION,
@@ -181,7 +184,8 @@ export class DustFileSystem {
   private constructor(
     private readonly auth: Authenticator,
     private readonly mounts: ReadonlyArray<FileSystemMount>,
-    private readonly backend: FileSystemBackend
+    private readonly backend: FileSystemBackend,
+    private readonly sandboxOnlyMounts: ReadonlyArray<SandboxOnlyMount> = []
   ) {}
 
   // --------------------------------------------------------------------------
@@ -256,7 +260,9 @@ export class DustFileSystem {
    */
   static async forPod(
     auth: Authenticator,
-    space: SpaceResource
+    space: SpaceResource,
+    // Decided by the caller that owns that concern (the file system only passes them to setup).
+    { sandboxOnlyMounts = [] }: { sandboxOnlyMounts?: SandboxOnlyMount[] } = {}
   ): Promise<Result<DustFileSystem, DustFileSystemError>> {
     if (!space.canRead(auth)) {
       return new Err(
@@ -275,7 +281,9 @@ export class DustFileSystem {
       fileStorageConfig.getGcsPrivateUploadsBucket()
     );
 
-    return new Ok(new DustFileSystem(auth, [mount], backend));
+    return new Ok(
+      new DustFileSystem(auth, [mount], backend, sandboxOnlyMounts)
+    );
   }
 
   /**
@@ -985,7 +993,10 @@ export class DustFileSystem {
     sandbox: SandboxResource,
     image: SandboxImage
   ): Promise<Result<void, Error>> {
-    const adapter = this.backend.createSandboxAdapter(this.mounts);
+    const adapter = this.backend.createSandboxAdapter(
+      this.mounts,
+      this.sandboxOnlyMounts
+    );
     return adapter.setup(this.auth, sandbox, image);
   }
 
@@ -994,7 +1005,10 @@ export class DustFileSystem {
     sandbox: SandboxResource,
     image: SandboxImage
   ): Promise<Result<void, Error>> {
-    const adapter = this.backend.createSandboxAdapter(this.mounts);
+    const adapter = this.backend.createSandboxAdapter(
+      this.mounts,
+      this.sandboxOnlyMounts
+    );
     return adapter.refreshCredential(this.auth, sandbox, image);
   }
 }

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -34,6 +34,8 @@ export type GCSMountTarget = {
    * so that old hardcoded paths (`/files/conversation`, `/files/pod`) keep working.
    */
   legacySandboxMountPoint: string | null;
+  /** When set, the mount uses `-o ro` and a read-only-scoped token (see buildAccessBoundaryRules). */
+  readOnly: boolean;
 };
 
 /**
@@ -77,8 +79,14 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       prefixes,
     });
 
-    // 1. Mint a CAB-scoped token covering every prefix.
-    const tokenResult = await mintDownscopedGcsToken({ bucket, prefixes });
+    // 1. Mint a CAB-scoped token covering every prefix, read-only where the target is.
+    const tokenResult = await mintDownscopedGcsToken({
+      bucket,
+      prefixes: targets.map((t) => ({
+        prefix: t.gcsPrefix,
+        readOnly: t.readOnly,
+      })),
+    });
     if (tokenResult.isErr()) {
       childLogger.error(
         { err: tokenResult.error },
@@ -138,6 +146,7 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
             bucket,
             prefix: target.gcsPrefix,
             mountPoint: target.sandboxMountPoint,
+            readOnly: target.readOnly,
           }),
           { timeoutMs: MOUNT_TIMEOUT_MS }
         );
@@ -212,10 +221,12 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       return new Ok(undefined);
     }
 
-    const prefixes = this.targets.map((t) => t.gcsPrefix);
     const tokenResult = await mintDownscopedGcsToken({
       bucket: this.bucket,
-      prefixes,
+      prefixes: this.targets.map((t) => ({
+        prefix: t.gcsPrefix,
+        readOnly: t.readOnly,
+      })),
     });
     if (tokenResult.isErr()) {
       return tokenResult;
@@ -233,7 +244,7 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       {
         sandboxId: sandbox.sId,
         workspaceId: auth.getNonNullableWorkspace().sId,
-        prefixes,
+        prefixes: this.targets.map((t) => t.gcsPrefix),
       },
       "GCS sandbox mount: credential refreshed"
     );
@@ -245,7 +256,7 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
   getAccessBoundaryRules() {
     return buildAccessBoundaryRules(
       this.bucket,
-      this.targets.map((t) => t.gcsPrefix)
+      this.targets.map((t) => ({ prefix: t.gcsPrefix, readOnly: t.readOnly }))
     );
   }
 }
@@ -254,11 +265,21 @@ function buildMountCommand({
   bucket,
   prefix,
   mountPoint,
+  readOnly,
 }: {
   bucket: string;
   prefix: string;
   mountPoint: string;
+  readOnly: boolean;
 }): RootCommand {
+  // allow_other lets the unprivileged sandbox user read the root-mounted fs. `ro` is only
+  // defense-in-depth: the real write protection is the read-only token scope (see
+  // buildAccessBoundaryRules), not this flag.
+  const mountOptions = ["allow_other"];
+  if (readOnly) {
+    mountOptions.push("ro");
+  }
+
   const flags = [
     "--token-url",
     TOKEN_SERVER_URL,
@@ -268,7 +289,7 @@ function buildMountCommand({
     prefix,
     "--implicit-dirs",
     "-o",
-    "allow_other",
+    mountOptions.join(","),
     "--file-mode=666",
     "--dir-mode=777",
     "--kernel-list-cache-ttl-secs=60",

--- a/front/lib/api/file_system/types.ts
+++ b/front/lib/api/file_system/types.ts
@@ -50,6 +50,24 @@ export type FileSystemMount = {
   };
 };
 
+/**
+ * A mount that exists only inside the sandbox filesystem and is never exposed through the
+ * scoped-path API (the agent's file tools never see it). Used for prefixes the sandbox must read
+ * but that are not an agent-visible namespace, e.g. published sandbox-function bundles.
+ */
+export type SandboxOnlyMountKind = "pod_sandbox_functions";
+
+export type SandboxOnlyMount = {
+  kind: SandboxOnlyMountKind;
+
+  /** sId of the pod this mount belongs to. */
+  id: string;
+
+  sandboxMountPoint: string;
+
+  readOnly: boolean;
+};
+
 export type DustFileSystemErrorCode =
   | "unauthorized"
   | "not_found"

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -59,7 +59,7 @@ describe("mount_path helpers", () => {
     it("should return a dedicated prefix separate from pod files", () => {
       expect(
         getPodSandboxFunctionsBasePath({ workspaceId: "ws1", podId: "spc1" })
-      ).toBe("w/ws1/pods/spc1/sandbox_functions/");
+      ).toBe("w/ws1/pods/spc1/sandbox-functions/");
     });
   });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -84,7 +84,7 @@ export function getPodSandboxFunctionsBasePath({
   workspaceId: string;
   podId: string;
 }): string {
-  return `${getBaseMountPathForWorkspace({ workspaceId })}pods/${podId}/sandbox_functions/`;
+  return `${getBaseMountPathForWorkspace({ workspaceId })}pods/${podId}/sandbox-functions/`;
 }
 
 /**
@@ -93,7 +93,7 @@ export function getPodSandboxFunctionsBasePath({
  * collision.
  */
 export function getPodSandboxFunctionsMountPoint(podId: string): string {
-  return `/sandbox_functions/pods/${podId}`;
+  return `/sandbox-functions/pods/${podId}`;
 }
 
 /**

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -88,6 +88,15 @@ export function getPodSandboxFunctionsBasePath({
 }
 
 /**
+ * Absolute in-sandbox path the pod's published bundles are mounted at. Pod-scoped like the
+ * `/files/pod-<id>` files mount, so one sandbox could carry several pods' functions without
+ * collision.
+ */
+export function getPodSandboxFunctionsMountPoint(podId: string): string {
+  return `/sandbox_functions/pods/${podId}`;
+}
+
+/**
  * Given a mount file path like "w/.../files/report.pdf",
  * returns "w/.../files/report.processed.pdf".
  * For files without extension: "w/.../files/Makefile" -> "w/.../files/Makefile.processed".

--- a/front/lib/api/sandbox/gcs/token.test.ts
+++ b/front/lib/api/sandbox/gcs/token.test.ts
@@ -31,7 +31,7 @@ describe.skipIf(!runManual)("GCS downscoped token CAB", () => {
     bucket = fileStorageConfig.getGcsPrivateUploadsBucket();
     const result = await mintDownscopedGcsToken({
       bucket,
-      prefixes: [PREFIX],
+      prefixes: [{ prefix: PREFIX, readOnly: false }],
     });
     expect(result.isOk()).toBe(true);
     if (result.isErr()) {
@@ -140,29 +140,56 @@ describe("buildAccessBoundaryRules", () => {
 
   it("emits one bucket-get rule + 2 rules per prefix (single prefix)", () => {
     const rules = buildAccessBoundaryRules("bucket-x", [
-      "w/ws1/conversations/c1/files",
+      { prefix: "w/ws1/conversations/c1/files", readOnly: false },
     ]);
     expect(rules).toHaveLength(3);
   });
 
   it("scales linearly with the number of prefixes", () => {
     const rules = buildAccessBoundaryRules("bucket-x", [
-      "w/ws1/conversations/c1/files",
-      "w/ws1/pods/spc1/files",
+      { prefix: "w/ws1/conversations/c1/files", readOnly: false },
+      { prefix: "w/ws1/pods/spc1/files", readOnly: false },
     ]);
     expect(rules).toHaveLength(5);
   });
 
   it("keeps the unconditional bucket-get rule first", () => {
     const rules = buildAccessBoundaryRules("bucket-x", [
-      "w/ws1/conversations/c1/files",
+      { prefix: "w/ws1/conversations/c1/files", readOnly: false },
     ]);
     expect(rules[0].availablePermissions[0]).toMatch(/sandbox_storage_mount/);
     expect("availabilityCondition" in rules[0]).toBe(false);
   });
 
+  it("grants read/write (objectUser) for a writable prefix", () => {
+    const rules = buildAccessBoundaryRules("bucket-x", [
+      { prefix: "w/ws1/pods/spc1/files", readOnly: false },
+    ]);
+    expect(
+      rules.some((r) => r.availablePermissions[0].includes("objectUser"))
+    ).toBe(true);
+    expect(
+      rules.some((r) => r.availablePermissions[0].includes("objectViewer"))
+    ).toBe(false);
+  });
+
+  it("grants read-only (objectViewer) for a read-only prefix", () => {
+    const rules = buildAccessBoundaryRules("bucket-x", [
+      { prefix: "w/ws1/pods/spc1/sandbox_functions", readOnly: true },
+    ]);
+    expect(
+      rules.some((r) => r.availablePermissions[0].includes("objectViewer"))
+    ).toBe(true);
+    expect(
+      rules.some((r) => r.availablePermissions[0].includes("objectUser"))
+    ).toBe(false);
+  });
+
   it("references every prefix in list and resource.name conditions", () => {
-    const prefixes = ["w/ws1/conversations/c1/files", "w/ws1/pods/spc1/files"];
+    const prefixes = [
+      { prefix: "w/ws1/conversations/c1/files", readOnly: false },
+      { prefix: "w/ws1/pods/spc1/files", readOnly: false },
+    ];
     const rules = buildAccessBoundaryRules("bucket-x", prefixes);
 
     const listRules = rules.filter((r) =>
@@ -174,7 +201,7 @@ describe("buildAccessBoundaryRules", () => {
     expect(listRules).toHaveLength(2);
     expect(objectRules).toHaveLength(2);
 
-    for (const prefix of prefixes) {
+    for (const { prefix } of prefixes) {
       expect(
         listRules.some(
           (r) =>

--- a/front/lib/api/sandbox/gcs/token.test.ts
+++ b/front/lib/api/sandbox/gcs/token.test.ts
@@ -175,7 +175,7 @@ describe("buildAccessBoundaryRules", () => {
 
   it("grants read-only (objectViewer) for a read-only prefix", () => {
     const rules = buildAccessBoundaryRules("bucket-x", [
-      { prefix: "w/ws1/pods/spc1/sandbox_functions", readOnly: true },
+      { prefix: "w/ws1/pods/spc1/sandbox-functions", readOnly: true },
     ]);
     expect(
       rules.some((r) => r.availablePermissions[0].includes("objectViewer"))

--- a/front/lib/api/sandbox/gcs/token.ts
+++ b/front/lib/api/sandbox/gcs/token.ts
@@ -22,6 +22,11 @@ export interface DownscopedGcsToken {
   expiresInSeconds: number;
 }
 
+export interface GcsTokenPrefix {
+  prefix: string;
+  readOnly: boolean;
+}
+
 interface StsTokenResponse {
   access_token: string;
   expires_in: number;
@@ -69,7 +74,7 @@ async function exchangeToken({
   sourceToken,
 }: {
   bucket: string;
-  prefixes: string[];
+  prefixes: GcsTokenPrefix[];
   sourceToken: string;
 }): Promise<Result<StsTokenResponse, Error>> {
   try {
@@ -107,7 +112,7 @@ export async function mintDownscopedGcsToken({
   prefixes,
 }: {
   bucket: string;
-  prefixes: string[];
+  prefixes: GcsTokenPrefix[];
 }): Promise<Result<DownscopedGcsToken, Error>> {
   if (prefixes.length === 0) {
     return new Err(new Error("mintDownscopedGcsToken requires >= 1 prefix."));
@@ -158,15 +163,20 @@ function getStorageMountRole(): string {
  *     be started with --enable-hns=false to avoid the GetStorageLayout call (which requires
  *     unrestricted objects.list and would bypass this condition).
  *
- *  3. objectUser with resource.name condition — one rule per prefix. Read/write scoped to prefix.
+ *  3. objectUser (read/write) or objectViewer (read-only) with a resource.name condition, one rule
+ *     per prefix. A read-only prefix gets no object create/delete, so a workload that extracts the
+ *     loopback-served token (gcsfuse fetches it over http) still cannot write there.
  *
  * Total rule count is `1 + 2 * prefixes.length`. CAB allows up to 10 rules, so we support up to 4
- * concurrent prefixes (today we use at most 2: conversation + project).
+ * concurrent prefixes.
  */
-export function buildAccessBoundaryRules(bucket: string, prefixes: string[]) {
+export function buildAccessBoundaryRules(
+  bucket: string,
+  prefixes: GcsTokenPrefix[]
+) {
   const bucketResource = `//storage.googleapis.com/projects/_/buckets/${bucket}`;
 
-  const perPrefixRules = prefixes.flatMap((prefix) => [
+  const perPrefixRules = prefixes.flatMap(({ prefix, readOnly }) => [
     {
       availablePermissions: ["inRole:roles/storage.legacyBucketReader"],
       availableResource: bucketResource,
@@ -175,7 +185,11 @@ export function buildAccessBoundaryRules(bucket: string, prefixes: string[]) {
       },
     },
     {
-      availablePermissions: ["inRole:roles/storage.objectUser"],
+      availablePermissions: [
+        readOnly
+          ? "inRole:roles/storage.objectViewer"
+          : "inRole:roles/storage.objectUser",
+      ],
       availableResource: bucketResource,
       availabilityCondition: {
         expression: `resource.name.startsWith('projects/_/buckets/${bucket}/objects/${prefix}/')`,

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -249,7 +249,17 @@ describe("ensureConversationSandboxReady", () => {
     expect(result.isOk()).toBe(true);
     expect(mockEnsurePodSandboxActive).toHaveBeenCalledWith(auth, pod);
     expect(mockEnsureSandboxActive).not.toHaveBeenCalled();
-    expect(mockForPod).toHaveBeenCalledWith(auth, pod);
+    // The pod's published bundles are mounted read-only under a pod-scoped path.
+    expect(mockForPod).toHaveBeenCalledWith(auth, pod, {
+      sandboxOnlyMounts: [
+        {
+          kind: "pod_sandbox_functions",
+          id: pod.sId,
+          sandboxMountPoint: `/sandbox_functions/pods/${pod.sId}`,
+          readOnly: true,
+        },
+      ],
+    });
     expect(mockForConversation).not.toHaveBeenCalled();
     expect(mockPrepareSandboxEgressBeforeMount).toHaveBeenCalledWith(
       auth,

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -255,7 +255,7 @@ describe("ensureConversationSandboxReady", () => {
         {
           kind: "pod_sandbox_functions",
           id: pod.sId,
-          sandboxMountPoint: `/sandbox_functions/pods/${pod.sId}`,
+          sandboxMountPoint: `/sandbox-functions/pods/${pod.sId}`,
           readOnly: true,
         },
       ],

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -1,4 +1,6 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import type { SandboxOnlyMount } from "@app/lib/api/file_system/types";
+import { getPodSandboxFunctionsMountPoint } from "@app/lib/api/files/mount_path";
 import {
   ensureSandboxEgressOnExec,
   prepareSandboxEgressBeforeMount,
@@ -161,13 +163,27 @@ export async function ensureConversationSandboxReady(
   });
 }
 
+// A pod's published function bundles are mounted read-only so the sandbox can execute them while
+// front stays the sole writer of bundles.
+function podSandboxFunctionsMount(pod: SpaceResource): SandboxOnlyMount {
+  return {
+    kind: "pod_sandbox_functions",
+    id: pod.sId,
+    sandboxMountPoint: getPodSandboxFunctionsMountPoint(pod.sId),
+    readOnly: true,
+  };
+}
+
 export async function ensurePodSandboxReady(
   auth: Authenticator,
   pod: SpaceResource
 ): Promise<Result<EnsureSandboxReadyResult, Error>> {
   return ensureOwnerSandboxReady(auth, {
     ensureActive: () => PodSandboxAdapter.ensureSandboxActive(auth, pod),
-    getFileSystem: () => DustFileSystem.forPod(auth, pod),
+    getFileSystem: () =>
+      DustFileSystem.forPod(auth, pod, {
+        sandboxOnlyMounts: [podSandboxFunctionsMount(pod)],
+      }),
     runtimeOwner: {
       kind: "pod",
       spaceId: pod.sId,

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -103,7 +103,7 @@ describe("publishSandboxFunction", () => {
     expect(bundle.fileName).toBe("greet.ts");
     expect(bundle.useCaseMetadata?.spaceId).toBe(space.sId);
     expect(bundle.mountFilePath).toBe(
-      `w/${workspace.sId}/pods/${space.sId}/sandbox_functions/greet.ts`
+      `w/${workspace.sId}/pods/${space.sId}/sandbox-functions/greet.ts`
     );
 
     const listed = await SandboxFunctionResource.listBySpace(auth, space);
@@ -165,7 +165,7 @@ describe("publishSandboxFunction", () => {
     });
     expect(files.map((file) => file.id)).toEqual([firstFileId]);
     expect(files[0].mountFilePath).toBe(
-      `w/${workspace.sId}/pods/${space.sId}/sandbox_functions/greet.ts`
+      `w/${workspace.sId}/pods/${space.sId}/sandbox-functions/greet.ts`
     );
     expect(files[0].version).toBeGreaterThan(firstVersion ?? 0);
   });

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -15,7 +15,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
  * bundle and its extracted contract.
  *
  * The bundle is stored as a single `project_context` FileResource with the sandbox-function content
- * type, which FileResource routes into the dedicated, front-only sandbox_functions prefix. The
+ * type, which FileResource routes into the dedicated, front-only sandbox-functions prefix. The
  * SandboxFunctionResource is upserted on (space, slug): re-publish swaps the bundle, otherwise a new
  * row is created. Returns a domain Result, no HTTP shapes (BACK18).
  */

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -1454,7 +1454,7 @@ describe("FileResource", () => {
         where: { id: bundleFile.id, workspaceId: workspace.id },
       });
       expect(row?.mountFilePath).toBe(
-        `w/${workspace.sId}/pods/${space.sId}/sandbox_functions/greet.ts`
+        `w/${workspace.sId}/pods/${space.sId}/sandbox-functions/greet.ts`
       );
     });
 

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -449,15 +449,10 @@ describe("SandboxFunctionResource", () => {
       return;
     }
     const [, command, opts] = execCall;
-    const stagedFunctionsDir = `/tmp/dust-sandbox-functions/${result.value.sId}`;
-    expect(command).toContain(
-      `cat > '${stagedFunctionsDir}/add-comment.ts' <<'DUST_SANDBOX_FUNCTION_EOF'`
-    );
-    expect(command).toContain("async fetch(_req: Request): Promise<Response>");
-    expect(command).toContain("return Response.json({ ok: true });");
-    expect(command).toContain("/opt/bin/dsbx function run 'add-comment'");
+    // The bundle is read from the read-only mount, so the command is just the run, no staging write.
+    expect(command).toBe("/opt/bin/dsbx function run 'add-comment'");
     expect(opts?.envVars).toMatchObject({
-      DUST_FUNCTIONS_DIR: stagedFunctionsDir,
+      DUST_FUNCTIONS_DIR: `/sandbox_functions/pods/${space.sId}`,
       DUST_SANDBOX_TOKEN: "sbt-function-token",
     });
     expect(opts?.user).toBe("agent-proxied");

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -452,7 +452,7 @@ describe("SandboxFunctionResource", () => {
     // The bundle is read from the read-only mount, so the command is just the run, no staging write.
     expect(command).toBe("/opt/bin/dsbx function run 'add-comment'");
     expect(opts?.envVars).toMatchObject({
-      DUST_FUNCTIONS_DIR: `/sandbox_functions/pods/${space.sId}`,
+      DUST_FUNCTIONS_DIR: `/sandbox-functions/pods/${space.sId}`,
       DUST_SANDBOX_TOKEN: "sbt-function-token",
     });
     expect(opts?.user).toBe("agent-proxied");

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
 import config from "@app/lib/api/config";
+import { getPodSandboxFunctionsMountPoint } from "@app/lib/api/files/mount_path";
 import {
   generateExecId,
   generateSandboxFunctionInvocationToken,
@@ -36,7 +36,6 @@ import type { Attributes, Transaction } from "sequelize";
 
 const SANDBOX_FUNCTION_WORKING_DIRECTORY = "/home/agent";
 const SANDBOX_FUNCTION_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
-const SANDBOX_FUNCTION_STAGING_ROOT = "/tmp/dust-sandbox-functions";
 const DSBX_BIN_PATH = "/opt/bin/dsbx";
 
 function dustAPIBaseUrlForSandbox(): string {
@@ -45,29 +44,10 @@ function dustAPIBaseUrlForSandbox(): string {
     : config.getApiBaseUrl();
 }
 
-function buildSandboxFunctionCommand({
-  stagedFunctionsDir,
-  slug,
-}: {
-  stagedFunctionsDir: string;
-  slug: string;
-}): string {
-  // dsbx resolves `function run <slug>` as `${DUST_FUNCTIONS_DIR}/<slug>.ts`.
-  const functionPath = path.posix.join(stagedFunctionsDir, `${slug}.ts`);
-
-  return [
-    "set -euo pipefail",
-    `rm -rf -- ${shellEscape(stagedFunctionsDir)}`,
-    `mkdir -p -- ${shellEscape(stagedFunctionsDir)}`,
-    `cat > ${shellEscape(functionPath)} <<'DUST_SANDBOX_FUNCTION_EOF'`,
-    "export default {",
-    "  async fetch(_req: Request): Promise<Response> {",
-    "    return Response.json({ ok: true });",
-    "  },",
-    "};",
-    "DUST_SANDBOX_FUNCTION_EOF",
-    `${DSBX_BIN_PATH} function run ${shellEscape(slug)}`,
-  ].join("\n");
+function buildSandboxFunctionRunCommand(slug: string): string {
+  // dsbx resolves `function run <slug>` as `${DUST_FUNCTIONS_DIR}/<slug>.ts`, which is the
+  // read-only mount of the pod's published bundles.
+  return `${DSBX_BIN_PATH} function run ${shellEscape(slug)}`;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -346,14 +326,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         execId,
       });
 
-      const stagedFunctionsDir = path.posix.join(
-        SANDBOX_FUNCTION_STAGING_ROOT,
-        invocation.sId
-      );
-      const command = buildSandboxFunctionCommand({
-        stagedFunctionsDir,
-        slug: this.slug,
-      });
+      const command = buildSandboxFunctionRunCommand(this.slug);
       const inputEnvelope = {
         method: "POST",
         url: `https://dust.local/sandbox-functions/${this.sId}/invocations/${invocation.sId}`,
@@ -375,7 +348,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         workingDirectory: SANDBOX_FUNCTION_WORKING_DIRECTORY,
         envVars: {
           DUST_API_URL: `${dustAPIBaseUrlForSandbox()}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
-          DUST_FUNCTIONS_DIR: stagedFunctionsDir,
+          DUST_FUNCTIONS_DIR: getPodSandboxFunctionsMountPoint(this.space.sId),
           DUST_SANDBOX_TOKEN: token,
         },
         stdin: JSON.stringify(inputEnvelope),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This makes a pod's published function bundles available inside its own sandbox so they can be executed, while keeping the backend the only writer of them.

The dedicated, backend-only storage location that holds a pod's bundles is now mounted into that pod's sandbox as a read-only filesystem, and the function runtime reads bundles directly from it instead of materializing a placeholder into a scratch directory at invocation time.

Read-only is enforced where it actually matters, which is the storage credential rather than the mount itself. The credential backing the mount is served to the filesystem over loopback and is therefore reachable by untrusted code running in the sandbox, so a write-capable credential would let a function overwrite or forge a published bundle and defeat the integrity guarantee the dedicated location exists to provide. The downscoped credential now grants only object reads for the bundle location, while the writable pod-files location keeps read-write as before. The mount also carries the operating-system read-only flag as a second layer, but the credential scope is the real protection.

The bundle mount sits under a per-pod path, mirroring how a pod's regular files are already mounted, so a single sandbox could carry more than one pod's functions without collision later on.

The generic filesystem abstraction stays generic: it only gains the notion of a mount that lives inside the sandbox but is never exposed through the agent-visible path API. The specific decision that a pod's sandbox mounts its functions read-only lives with the pod sandbox lifecycle, which already owns what gets mounted there.

<img width="841" height="557" alt="image" src="https://github.com/user-attachments/assets/609e73ac-3f8e-42c0-8dc2-9cf77cd16e4c" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
