### PR TITLE
[front] chore: prevent sub agents from running `ask_user_question`

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -308,12 +308,16 @@ export async function runModel(
     );
   }
 
-  // Filter out ask_user_question for origins that don't support interactive questions.
-  const filteredMcpActions = !ASK_USER_QUESTION_ALLOWED_ORIGINS.includes(
-    userMessage.context.origin
-  )
-    ? mcpActions.filter((s) => s.serverName !== "ask_user_question")
-    : mcpActions;
+  // Filter out ask_user_question when no human is available to answer: origins that don't
+  // support interactive questions, or sub-agent runs (conversation depth > 0) where the
+  // "user" is the parent agent rather than a human.
+  const supportsInteractiveQuestions =
+    ASK_USER_QUESTION_ALLOWED_ORIGINS.includes(userMessage.context.origin) &&
+    conversation.depth === 0;
+
+  const filteredMcpActions = supportsInteractiveQuestions
+    ? mcpActions
+    : mcpActions.filter((s) => s.serverName !== "ask_user_question");
 
   const isLastStep = step === agentConfiguration.maxStepsPerRun;
 


### PR DESCRIPTION
## Description

This PR temporarily prevents sub agents from asking questions using the ask user question tool, which can cause the main conversation to be stuck.
This behavior will be rolled back once we implement `user_question_required` bubbling up.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
