### PR TITLE
[ci] Cancel superseded workflow runs on feature branches

### DIFF
--- a/.github/workflows/build-and-test-core.yml
+++ b/.github/workflows/build-and-test-core.yml
@@ -4,6 +4,12 @@ on:
   push:
   workflow_dispatch:
 
+# Cancel superseded runs on feature branches when a new commit is pushed; never
+# cancel on main so every mainline commit keeps a full CI record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/build-and-test-front-api.yml
+++ b/.github/workflows/build-and-test-front-api.yml
@@ -10,6 +10,12 @@ on:
       - sparkle/**
       - .github/workflows/build-and-test-front-api.yml
 
+# Cancel superseded runs on feature branches when a new commit is pushed; never
+# cancel on main so every mainline commit keeps a full CI record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -9,6 +9,12 @@ on:
       - sparkle/**
       - .github/workflows/build-and-test-front.yml
 
+# Cancel superseded runs on feature branches when a new commit is pushed; never
+# cancel on main so every mainline commit keeps a full CI record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/build-and-test-marketing.yml
+++ b/.github/workflows/build-and-test-marketing.yml
@@ -9,6 +9,12 @@ on:
       - sparkle/**
       - .github/workflows/build-and-test-marketing.yml
 
+# Cancel superseded runs on feature branches when a new commit is pushed; never
+# cancel on main so every mainline commit keeps a full CI record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/build-dust-sandbox.yml
+++ b/.github/workflows/build-dust-sandbox.yml
@@ -4,6 +4,12 @@ on:
   push:
   workflow_dispatch:
 
+# Cancel superseded runs on feature branches when a new commit is pushed; never
+# cancel on main so every mainline commit keeps a full CI record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/build-egress-proxy.yml
+++ b/.github/workflows/build-egress-proxy.yml
@@ -4,6 +4,12 @@ on:
   push:
   workflow_dispatch:
 
+# Cancel superseded runs on feature branches when a new commit is pushed; never
+# cancel on main so every mainline commit keeps a full CI record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -10,6 +10,12 @@ on:
       - extension/**
       - .github/workflows/build-extension.yml
 
+# Cancel superseded runs on feature branches when a new commit is pushed; never
+# cancel on main so every mainline commit keeps a full CI record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/build-spa.yaml
+++ b/.github/workflows/build-spa.yaml
@@ -10,6 +10,12 @@ on:
       - sdks/js/**
       - .github/workflows/build-and-test-spa.yml
 
+# Cancel superseded runs on feature branches when a new commit is pushed; never
+# cancel on main so every mainline commit keeps a full CI record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -21,6 +21,12 @@ on:
       - package-lock.json
       - .github/workflows/format-check.yml
 
+# Cancel superseded runs on feature branches when a new commit is pushed; never
+# cancel on main so every mainline commit keeps a full CI record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1782818734673559).

Our CI runs on GitHub-hosted runners, so we're capped at a fixed number of concurrent jobs. The heavy push-triggered workflows had no concurrency control, so every push to a branch started a fresh full matrix without cancelling the previous in-flight one. When several branches push repeatedly, runs stack up and queue behind the concurrent-job ceiling, which is why we periodically run short on runners.

This adds a per-branch concurrency group to those workflows so that pushing a new commit to a feature branch cancels the superseded run of the same workflow on that same branch. Cancellation is scoped strictly to the branch being pushed, so one branch never affects another.

`main` is deliberately exempt: every commit that lands on main keeps a full CI record rather than being cancelled by the next merge. The tradeoff is that main can still stack runs during merge bursts, which we accept in exchange for per-commit verification.

This is a steady-state improvement for repeated pushes to the same branch. It does not prevent spikes caused by many distinct branches being pushed at once, which remain a separate capacity question.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
