### PR TITLE
[front] fix: match Anthropic tool search query and results in logs

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -46,6 +46,11 @@ const MAX_EAGER_VALIDATION_INPUT_LENGTH = 5_000;
 const INVALID_JSON_MARKER = "JSON: ";
 const INVALID_TOOL_JSON_NEEDLE = "Unable to parse tool parameter JSON";
 
+type StreamStateContainer = {
+  state: StreamState;
+  toolSearchQueriesByToolUseId: Map<string, string | undefined>;
+};
+
 // Extract the prompt-cache diagnostics reason from a message_start, when the
 // request opted into diagnostics (beta header + `diagnostics.previous_message_id`).
 // `diagnostics` is null when there was nothing to compare or no divergence.
@@ -69,7 +74,10 @@ export async function* streamLLMEvents(
   messageStreamEvents: AsyncIterable<BetaRawMessageStreamEvent>,
   metadata: LLMClientMetadata
 ): AsyncGenerator<LLMEvent> {
-  const stateContainer: { state: StreamState } = { state: null };
+  const stateContainer: StreamStateContainer = {
+    state: null,
+    toolSearchQueriesByToolUseId: new Map<string, string | undefined>(),
+  };
   // Aggregate output items to build a SuccessCompletionEvent at the end of a turn.
   const aggregate = new SuccessAggregate();
   // Accumulate token usage to return later
@@ -145,7 +153,7 @@ export async function* streamLLMEvents(
 
 function* handleMessageStreamEvent(
   messageStreamEvent: BetaRawMessageStreamEvent,
-  stateContainer: { state: StreamState },
+  stateContainer: StreamStateContainer,
   metadata: LLMClientMetadata,
   tokenUsageAccumulator: Required<TokenUsage>
 ): Generator<LLMEvent> {
@@ -215,7 +223,7 @@ function* handleMessageStreamEvent(
 
 function* handleContentBlockStart(
   event: Extract<BetaRawMessageStreamEvent, { type: "content_block_start" }>,
-  stateContainer: { state: StreamState },
+  stateContainer: StreamStateContainer,
   metadata: LLMClientMetadata
 ): Generator<LLMEvent> {
   assert(
@@ -271,11 +279,19 @@ function* handleContentBlockStart(
       };
       return;
 
-    case "tool_search_tool_result":
+    case "tool_search_tool_result": {
       // Emit a passthrough so the block replays verbatim, and log the discovered
-      // references. State stays null, so the matching stop is a no-op.
+      // references with the matching query. State stays null, so the matching
+      // stop is a no-op.
+      const query = stateContainer.toolSearchQueriesByToolUseId.get(
+        event.content_block.tool_use_id
+      );
+      stateContainer.toolSearchQueriesByToolUseId.delete(
+        event.content_block.tool_use_id
+      );
       logToolSearchResult({
         content: event.content_block.content,
+        query,
         logFields: metadata,
       });
       yield providerPassthrough(
@@ -287,6 +303,7 @@ function* handleContentBlockStart(
         metadata
       );
       return;
+    }
 
     case "web_search_tool_result":
     case "web_fetch_tool_result":
@@ -316,7 +333,7 @@ function* handleContentBlockStart(
 
 function* handleContentBlockDelta(
   event: Extract<BetaRawMessageStreamEvent, { type: "content_block_delta" }>,
-  stateContainer: { state: StreamState },
+  stateContainer: StreamStateContainer,
   metadata: LLMClientMetadata
 ): Generator<LLMEvent> {
   validateContentBlockIndex(stateContainer.state, event);
@@ -361,7 +378,7 @@ function* handleContentBlockDelta(
 
 function* handleContentBlockStop(
   event: Extract<MessageStreamEvent, { type: "content_block_stop" }>,
-  stateContainer: { state: StreamState },
+  stateContainer: StreamStateContainer,
   metadata: LLMClientMetadata
 ): Generator<LLMEvent> {
   // A null state here means the block's content_block_start was ignored (e.g.
@@ -422,12 +439,16 @@ function* handleContentBlockStop(
     }
 
     case "tool_search": {
-      logToolSearchQuery({
+      const query = logToolSearchQuery({
         rawInput: stateContainer.state.accumulator,
         toolName: stateContainer.state.toolName,
         tags: toolSearchTags(metadata),
         logFields: metadata,
       });
+      stateContainer.toolSearchQueriesByToolUseId.set(
+        stateContainer.state.toolId,
+        query
+      );
       // Replay the server_tool_use block verbatim so interleaved thinking
       // signatures stay valid, falling back to an empty input if the query
       // failed to parse.

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/tool_search_logging.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/tool_search_logging.ts
@@ -32,7 +32,7 @@ export function logToolSearchQuery({
   toolName: string;
   tags: string[];
   logFields: Record<string, unknown>;
-}): void {
+}): string | undefined {
   let query: string | undefined;
   const parsed = safeParseJSON(rawInput);
   if (
@@ -59,23 +59,28 @@ export function logToolSearchQuery({
     `tool_name:${toolName}`,
     ...tags,
   ]);
+
+  return query;
 }
 
 // Logs the tools surfaced by a tool search, or the error code when the search
 // failed (e.g. too_many_requests, unavailable).
 export function logToolSearchResult({
   content,
+  query,
   logFields,
 }: {
   content: ToolSearchResultContent;
+  query: string | undefined;
   logFields: Record<string, unknown>;
 }): void {
   if (content.type === "tool_search_tool_result_error") {
     logger.warn(
       {
+        ...logFields,
+        query,
         errorCode: content.error_code,
         errorMessage: content.error_message,
-        ...logFields,
       },
       "Anthropic tool search returned an error"
     );
@@ -84,7 +89,12 @@ export function logToolSearchResult({
 
   const toolReferences = content.tool_references.map((ref) => ref.tool_name);
   logger.info(
-    { toolReferences, resultCount: toolReferences.length, ...logFields },
+    {
+      ...logFields,
+      query,
+      toolReferences,
+      resultCount: toolReferences.length,
+    },
     "Anthropic tool search results"
   );
 }

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -512,7 +512,8 @@ export function contentBlockStartToEvents(
   event: RawContentBlockStartEvent,
   state: BlockState | null,
   metadata: EndpointMetadata,
-  converters: OutputEventConverters
+  converters: OutputEventConverters,
+  toolSearchQuery?: string
 ): [ModelResponseEvent[], BlockState | null] {
   const block = event.content_block;
   switch (block.type) {
@@ -558,6 +559,7 @@ export function contentBlockStartToEvents(
       // verbatim replay and log them. State stays null, so the stop is a no-op.
       logToolSearchResult({
         content: block.content,
+        query: toolSearchQuery,
         logFields: toolSearchLogFields(metadata),
       });
       return [
@@ -707,16 +709,6 @@ export function contentBlockStopToEvents(
     }
 
     case "tool_search": {
-      logToolSearchQuery({
-        rawInput: block.accumulator,
-        toolName: block.toolName,
-        tags: [
-          `provider_id:${metadata.providerId}`,
-          `api:${metadata.api}`,
-          `model_id:${metadata.modelId}`,
-        ],
-        logFields: toolSearchLogFields(metadata),
-      });
       // Replay the server_tool_use block verbatim so interleaved thinking
       // signatures stay valid, falling back to an empty input if the query
       // failed to parse.
@@ -776,6 +768,7 @@ export async function* rawOutputToEvents(
   const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
   let blockState: BlockState | null = null;
   let tokenUsage: MessageDeltaUsage | null = null;
+  const toolSearchQueriesByToolUseId = new Map<string, string | undefined>();
   // The per-TTL cache-creation breakdown is only emitted on `message_start`;
   // capture it so the trailing `message_delta` usage can be split by TTL.
   let cacheCreation: CacheCreation | null = null;
@@ -832,12 +825,20 @@ export async function* rawOutputToEvents(
         outputEvents = [];
         break;
       case "content_block_start": {
+        const toolSearchQuery =
+          event.content_block.type === "tool_search_tool_result"
+            ? toolSearchQueriesByToolUseId.get(event.content_block.tool_use_id)
+            : undefined;
         const [events, nextState] = contentBlockStartToEvents(
           event,
           blockState,
           metadata,
-          converters
+          converters,
+          toolSearchQuery
         );
+        if (event.content_block.type === "tool_search_tool_result") {
+          toolSearchQueriesByToolUseId.delete(event.content_block.tool_use_id);
+        }
         outputEvents = events;
         blockState = nextState;
         break;
@@ -854,6 +855,19 @@ export async function* rawOutputToEvents(
         break;
       }
       case "content_block_stop": {
+        if (blockState?.type === "tool_search") {
+          const query = logToolSearchQuery({
+            rawInput: blockState.accumulator,
+            toolName: blockState.toolName,
+            tags: [
+              `provider_id:${metadata.providerId}`,
+              `api:${metadata.api}`,
+              `model_id:${metadata.modelId}`,
+            ],
+            logFields: toolSearchLogFields(metadata),
+          });
+          toolSearchQueriesByToolUseId.set(blockState.toolId, query);
+        }
         const [events, nextState] = contentBlockStopToEvents(
           event,
           blockState,


### PR DESCRIPTION
## Description

The query and the results in tool search were separately (reported in [this notebook](https://app.datadoghq.eu/notebook/320610/anthropic-cache?refresh_mode=sliding&from_ts=1782133633008&to_ts=1782738433008)), which made it hard to analyze whether we got useful tools for a given query.

This PR keeps the parsed query from the `server_tool_use` block by `tool_use_id` and attaches it to the matching `tool_search_tool_result` log in both Anthropic clients.

## Tests

- Tested locally.

## Risk

- Low. Logging-only change for Anthropic tool-search instrumentation.

## Deploy Plan

- Deploy front.
- Update dd notebook.
