### PR TITLE
fix(slack): descriptive error when channel blocks bot posting

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -15,6 +15,7 @@ import {
   getUserInfo,
 } from "@connectors/connectors/slack/lib/bot_user_helpers";
 import {
+  isSlackPostingPermissionError,
   isSlackWebAPIPlatformError,
   isWebAPIRateLimitedError,
   SlackExternalUserError,
@@ -85,6 +86,10 @@ const SLACK_RATE_LIMIT_ERROR_MARKDOWN =
   "You have reached a rate limit enforced by Slack. Please try again later (or contact Slack to increase your rate limit on the <https://dust4ai.slack.com/marketplace/A09214D6XQT-dust|Dust App for Slack>).";
 const SLACK_ERROR_TEXT =
   "An unexpected error occurred while answering your message, please retry.";
+const SLACK_POSTING_PERMISSION_ERROR_MARKDOWN =
+  "Dust doesn't have permission to post in this channel. The agent answered, but " +
+  "Slack rejected the reply. Ask a workspace admin to allow the Dust app to post " +
+  "here, then retry.";
 
 // Keep aligned with front/types/files.ts MAX_FILE_SIZES for conversation uploads.
 const MAX_OTHER_FILE_SIZE_TO_UPLOAD = 50 * 1024 * 1024; // 50 MB
@@ -207,6 +212,13 @@ export async function botAnswerMessage(
           thread_ts: slackMessageTs,
           unfurl_links: false,
         });
+      } else if (isSlackPostingPermissionError(e)) {
+        await slackClient.chat.postMessage({
+          channel: slackChannel,
+          blocks: makeMarkdownBlock(SLACK_POSTING_PERMISSION_ERROR_MARKDOWN),
+          thread_ts: slackMessageTs,
+          unfurl_links: false,
+        });
       } else {
         await slackClient.chat.postMessage({
           channel: slackChannel,
@@ -280,6 +292,13 @@ export async function botReplaceMention(
         await slackClient.chat.postMessage({
           channel: slackChannel,
           blocks: makeMarkdownBlock(SLACK_RATE_LIMIT_ERROR_MARKDOWN),
+          thread_ts: slackMessageTs,
+          unfurl_links: false,
+        });
+      } else if (isSlackPostingPermissionError(e)) {
+        await slackClient.chat.postMessage({
+          channel: slackChannel,
+          blocks: makeMarkdownBlock(SLACK_POSTING_PERMISSION_ERROR_MARKDOWN),
           thread_ts: slackMessageTs,
           unfurl_links: false,
         });

--- a/connectors/src/connectors/slack/lib/errors.test.ts
+++ b/connectors/src/connectors/slack/lib/errors.test.ts
@@ -1,0 +1,44 @@
+import { ErrorCode } from "@slack/web-api";
+import { describe, expect, it } from "vitest";
+
+import { isSlackPostingPermissionError } from "./errors";
+
+function makePlatformError(error: string) {
+  return {
+    code: ErrorCode.PlatformError,
+    data: { ok: false, error },
+  };
+}
+
+describe("isSlackPostingPermissionError", () => {
+  it("returns true for channel posting restriction errors", () => {
+    for (const error of [
+      "restricted_action",
+      "restricted_action_read_only_channel",
+      "restricted_action_thread_only_channel",
+      "restricted_action_non_threadable_channel",
+      "not_in_channel",
+    ]) {
+      expect(isSlackPostingPermissionError(makePlatformError(error))).toBe(
+        true
+      );
+    }
+  });
+
+  it("returns false for unrelated platform errors", () => {
+    expect(
+      isSlackPostingPermissionError(makePlatformError("message_not_found"))
+    ).toBe(false);
+    expect(
+      isSlackPostingPermissionError(makePlatformError("rate_limited"))
+    ).toBe(false);
+  });
+
+  it("returns false for non-Slack errors", () => {
+    expect(isSlackPostingPermissionError(new Error("restricted_action"))).toBe(
+      false
+    );
+    expect(isSlackPostingPermissionError(null)).toBe(false);
+    expect(isSlackPostingPermissionError(undefined)).toBe(false);
+  });
+});

--- a/connectors/src/connectors/slack/lib/errors.ts
+++ b/connectors/src/connectors/slack/lib/errors.ts
@@ -41,6 +41,26 @@ export function isSlackWebAPIPlatformErrorBotNotFound(
   return isSlackWebAPIPlatformError(err) && err.data.error === "bot_not_found";
 }
 
+// Slack rejects the bot's posts when the channel restricts who can post (e.g.
+// "Who can post" is limited to specific members/apps, the channel is read-only,
+// or the bot was never added to the channel).
+const SLACK_POSTING_PERMISSION_ERRORS = [
+  "restricted_action",
+  "restricted_action_read_only_channel",
+  "restricted_action_thread_only_channel",
+  "restricted_action_non_threadable_channel",
+  "not_in_channel",
+];
+
+export function isSlackPostingPermissionError(
+  err: unknown
+): err is WebAPIPlatformError {
+  return (
+    isSlackWebAPIPlatformError(err) &&
+    SLACK_POSTING_PERMISSION_ERRORS.includes(err.data.error)
+  );
+}
+
 // Type guards for Slack errors
 // See https://github.com/slackapi/node-slack-sdk/blob/main/packages/web-api/src/errors.ts.
 export function isWebAPIRateLimitedError(


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9215

When a Slack channel restricts who can post, the bot's reply is rejected and users only saw the generic "An unexpected error occurred" message, giving no hint that it was a posting-permission denial.

Detect the relevant Slack platform error codes (checked relevant error codes from https://docs.slack.dev/reference/methods/chat.postMessage) and surface a descriptive message pointing admins at the channel posting permissions.

## Tests

Unit

## Risk

Low
## Deploy Plan

Connectors