### PR TITLE
chore(mcp): improve ashby tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -24,7 +24,7 @@ const CandidateSearchSchema = {
 export const ASHBY_TOOLS_METADATA = createToolsRecord({
   search_candidates: {
     description:
-      "Search for candidates by name and/or email. " +
+      "Find, search, and look up candidates in Ashby by name and/or email. " +
       `Returns up to ${DEFAULT_SEARCH_LIMIT} matching candidates by default.`,
     schema: CandidateSearchSchema,
     stake: "never_ask",
@@ -62,8 +62,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
   },
   get_candidate_notes: {
     description:
-      "Retrieve all notes for a candidate. " +
-      "This tool will search for the candidate by name or email and return all notes on their profile.",
+      "Retrieve and read all existing notes recorded on a candidate's profile in Ashby. " +
+      "Searches for the candidate by name or email and returns every note already on their profile.",
     schema: CandidateSearchSchema,
     stake: "never_ask",
     displayLabels: {
@@ -102,7 +102,7 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
   },
   create_candidate_note: {
     description:
-      "Create a note on a candidate's profile in Ashby. " +
+      "Create and add a new note to a candidate's profile in Ashby. " +
       "The note content can include basic HTML formatting (supported tags: h1-h6, p, b, i, u, a, ul, ol, li, code, pre).",
     schema: {
       ...CandidateSearchSchema,

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -985,6 +985,52 @@ export const QUERIES: LabeledQuery[] = [
     expected: "workspace_analytics.get_usage_timeseries",
   },
 
+  // --- ashby ---
+  {
+    query: "find a candidate in ashby by email",
+    expected: "ashby.search_candidates",
+  },
+  {
+    query: "download an ashby report as a csv file",
+    expected: "ashby.get_report_data",
+  },
+  {
+    query: "show the interview feedback for a candidate in ashby",
+    expected: "ashby.get_interview_feedback",
+  },
+  {
+    query: "read all the notes on a candidate in ashby",
+    expected: "ashby.get_candidate_notes",
+  },
+  {
+    query: "add a note to a candidate's profile in ashby",
+    expected: "ashby.create_candidate_note",
+  },
+  {
+    query: "list the job openings in ashby",
+    expected: "ashby.list_openings",
+  },
+  {
+    query: "list the published job postings in ashby",
+    expected: "ashby.list_job_postings",
+  },
+  {
+    query: "update the description of a job posting in ashby",
+    expected: "ashby.update_job_posting",
+  },
+  {
+    query: "show the referral form fields in ashby",
+    expected: "ashby.get_referral_form",
+  },
+  {
+    query: "create a referral for a candidate in ashby",
+    expected: "ashby.create_referral",
+  },
+  {
+    query: "get the offer and hire details for a hired candidate in ashby",
+    expected: "ashby.get_hire_data",
+  },
+
   // --- web_search_&_browse ---
   {
     query: "search the web for the latest AI research papers",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -12,6 +12,7 @@
 // Usage: npx tsx scripts/mcp_bm25/run.ts   (from the front/ directory)
 
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
+import { ASHBY_SERVER } from "@app/lib/api/actions/servers/ashby/metadata";
 import { CLARI_COPILOT_SERVER } from "@app/lib/api/actions/servers/clari_copilot/metadata";
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
 import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversation_files/metadata";
@@ -146,6 +147,7 @@ const SERVERS: ServerEntry[] = [
     name: "workspace_analytics",
     tools: WORKSPACE_ANALYTICS_SERVER.tools,
   },
+  { name: "ashby", tools: ASHBY_SERVER.tools },
   {
     name: "web_search_&_browse",
     tools: WEB_SEARCH_BROWSE_SERVER.tools,


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9167.

This PR tweaks the `ashby` tool descriptions so each ranks better to the intended tool in tool search and is better segregated under the BM25 norm ([design doc](https://app.notion.com/p/dust-tt/Design-Doc-Anthropic-Token-Consumption-Cache-Efficiency-38728599d94180a2b7f8e101a776f564?source=copy_link#a7d3294f78444b25966d56efe3f3bd51), [tool-search doc](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)).

The main fix makes `search_candidates`, `get_candidate_notes`, and `create_candidate_note` each carry a distinctive vocabulary (find/look up vs. read existing notes vs. add a new note) to avoid confusing them.

Also registers `ashby` in the BM25 testing script and adds one labeled query per tool.

## Tests

- Tested locally with the BM25 harness.

## Risk

- Low.

## Deploy Plan

- Deploy front.
