### PR TITLE
chore(mcp): improve extract_data tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1206,6 +1206,12 @@ export const QUERIES: LabeledQuery[] = [
     expected: "luma.get_event_insights",
   },
 
+  // --- extract_data ---
+  {
+    query: "extract structured data from documents into a json schema",
+    expected: "extract_data.extract_information_from_documents",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -17,6 +17,7 @@ import { CLARI_COPILOT_SERVER } from "@app/lib/api/actions/servers/clari_copilot
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
 import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_warehouses/metadata";
+import { EXTRACT_DATA_SERVER } from "@app/lib/api/actions/servers/extract_data/metadata";
 import { FATHOM_SERVER } from "@app/lib/api/actions/servers/fathom/metadata";
 import { FILE_GENERATION_SERVER } from "@app/lib/api/actions/servers/file_generation/metadata";
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
@@ -169,6 +170,7 @@ const SERVERS: ServerEntry[] = [
   { name: "file_generation", tools: FILE_GENERATION_SERVER.tools },
   { name: "fathom", tools: FATHOM_SERVER.tools },
   { name: "luma", tools: LUMA_SERVER.tools },
+  { name: "extract_data", tools: EXTRACT_DATA_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

This PR extends the BM25 tool-search diagnostic to cover the `extract_data` server ([design doc](https://app.notion.com/p/dust-tt/Design-Doc-Anthropic-Token-Consumption-Cache-Efficiency-38728599d94180a2b7f8e101a776f564?source=copy_link#a7d3294f78444b25966d56efe3f3bd51), [tool-search doc](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)).

The server exposes a single tool, `extract_information_from_documents`, whose description already ranks well for the intended intent. "structured information" and "JSON schema" segregates it well from `include_data` and the search/retrieval tool. So this PR only adds query samples in the BM25 harness.

## Tests

- Tested locally with BM25 samples.

## Risk

- Low.

## Deploy Plan

- Deploy front.
