### PR TITLE
chore(mcp): improve common_utilities tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/common_utilities/metadata.ts
+++ b/front/lib/api/actions/servers/common_utilities/metadata.ts
@@ -12,7 +12,7 @@ const MAX_WAIT_DURATION_MS = 3 * 60 * 1_000;
 export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
   generate_random_number: {
     description:
-      "Generate a random positive number between 1 and the provided maximum (inclusive).",
+      "Generate a random integer (whole number) between 1 and the provided maximum (inclusive). Pick a random number in a range.",
     schema: {
       max: z
         .number()
@@ -78,9 +78,12 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
     },
   },
   math_operation: {
-    description: "Perform mathematical operations.",
+    description:
+      "Calculate the result of a math expression: arithmetic, percentages, and other mathematical operations.",
     schema: {
-      expression: z.string().describe("The expression to evaluate. "),
+      expression: z
+        .string()
+        .describe("The math expression to evaluate, e.g. 15 percent of 240."),
     },
     stake: "never_ask",
     displayLabels: {

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1430,6 +1430,32 @@ export const QUERIES: LabeledQuery[] = [
     expected: "http_client.send_request",
   },
 
+  // --- common_utilities ---
+  {
+    query: "pick a random number between 1 and 100",
+    expected: "common_utilities.generate_random_number",
+  },
+  {
+    query: "give me a random decimal between 0 and 1",
+    expected: "common_utilities.generate_random_float",
+  },
+  {
+    query: "pause for 5 seconds before continuing",
+    expected: "common_utilities.wait",
+  },
+  {
+    query: "what is the current date and time right now",
+    expected: "common_utilities.get_current_time",
+  },
+  {
+    query: "calculate 15 percent of 240",
+    expected: "common_utilities.math_operation",
+  },
+  {
+    query: "rename this conversation to something descriptive",
+    expected: "common_utilities.set_conversation_title",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -14,6 +14,7 @@
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import { ASHBY_SERVER } from "@app/lib/api/actions/servers/ashby/metadata";
 import { CLARI_COPILOT_SERVER } from "@app/lib/api/actions/servers/clari_copilot/metadata";
+import { COMMON_UTILITIES_SERVER } from "@app/lib/api/actions/servers/common_utilities/metadata";
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
 import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_warehouses/metadata";
@@ -192,6 +193,7 @@ const SERVERS: ServerEntry[] = [
     name: HTTP_CLIENT_TOOL_NAME,
     tools: HTTP_CLIENT_SERVER.tools.filter((t) => t.name === "send_request"),
   },
+  { name: "common_utilities", tools: COMMON_UTILITIES_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

This PR tweaks the `common_utilities` tool descriptions so each ranks better to the intended tool in tool search and is better segregated under the BM25 norm ([design doc](https://app.notion.com/p/dust-tt/Design-Doc-Anthropic-Token-Consumption-Cache-Efficiency-38728599d94180a2b7f8e101a776f564?source=copy_link#a7d3294f78444b25966d56efe3f3bd51), [tool-search doc](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)).

- `generate_random_number`: now says "integer (whole number)" and "pick a random number in a range" so it segregates from the `generate_random_float` sibling (both previously matched the bare token "number").
- `math_operation`: was just "Perform mathematical operations.", now leads with "Calculate" and names arithmetic/percentages to match typical use cases (this tool was not showing up for "calculate 15 percent of 240").

The other four tools already ranked #1 and were left untouched. Also registers `common_utilities` in the BM25 testing script with one labeled query per tool.

Note: some of the tools here may be deprecated in a near future (e.g. you can just rush bash on a sandbox to do computations) so not spending too much time here.

No behavior change.

## Tests

- Tested locally with BM25 samples.

## Risk

- Low.

## Deploy Plan

- Deploy front.
