### PR TITLE
[front] Pool credits coupons 1/3: credit_pool_top_up coupon type + context-aware validation

### DIFF
--- a/front/components/poke/coupons/CreateCouponForm.tsx
+++ b/front/components/poke/coupons/CreateCouponForm.tsx
@@ -179,19 +179,30 @@ export function CreateCouponForm({
               set("discountType", value as CouponDiscountType)
             }
           >
-            <RadioGroupItem value="seat" label="Seat" />
+            <RadioGroupItem value="seat" label="Seat (subscription discount)" />
+            <RadioGroupItem
+              value="credit_pool_top_up"
+              label="Credit pool top-up (bonus AWU)"
+            />
           </RadioGroup>
         </div>
 
         <div className="flex flex-col gap-1">
           <label className="text-sm font-medium">
-            Amount <span className="text-red-500">*</span>
+            {form.discountType === "credit_pool_top_up"
+              ? "Bonus AWU credits"
+              : "Amount (currency units, e.g. $)"}{" "}
+            <span className="text-red-500">*</span>
           </label>
           <Input
             type="number"
             value={form.amount}
             onChange={(e) => set("amount", e.target.value)}
-            placeholder="e.g. 50"
+            placeholder={
+              form.discountType === "credit_pool_top_up"
+                ? "e.g. 5000"
+                : "e.g. 50"
+            }
             min={0.5}
             step={0.5}
           />

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -213,7 +213,7 @@ export async function createPaymentGatedBusinessActivation({
     if (!found) {
       return new Err({ type: "invalid_coupon" });
     }
-    const validation = found.validateRedemption();
+    const validation = found.validateRedemptionForContext("subscription");
     if (validation.isErr()) {
       return new Err({ type: "invalid_coupon" });
     }

--- a/front/lib/api/poke/plugins/workspaces/apply_coupon.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_coupon.ts
@@ -84,6 +84,12 @@ export const applyCouponPlugin = createPlugin({
                   `Coupon "${couponCode}" has already been redeemed by this workspace.`
                 )
               );
+            case "wrong_coupon_type":
+              return new Err(
+                new Error(
+                  `Coupon "${couponCode}" cannot be applied as a subscription discount.`
+                )
+              );
             default:
               return assertNever(err.reason);
           }

--- a/front/lib/metronome/coupons.test.ts
+++ b/front/lib/metronome/coupons.test.ts
@@ -9,6 +9,7 @@ import {
   getCreditTypeFromContract,
   getCreditTypeFromPackage,
   redeemCoupon,
+  redeemCreditsCoupon,
   revokeCouponRedemption,
 } from "@app/lib/metronome/coupons";
 import { SEAT_TAG } from "@app/lib/metronome/setup_common";
@@ -765,5 +766,114 @@ describe("revokeCouponRedemption", () => {
 
     expect(revokeResult.isErr()).toBe(true);
     expect(redemption.status).toBe("active");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redeemCreditsCoupon
+// ---------------------------------------------------------------------------
+
+describe("redeemCreditsCoupon", () => {
+  it("happy path: grants AWU free credit, active redemption, count incremented, audit emitted", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create({
+      discountType: "credit_pool_top_up",
+      amount: 5000,
+    });
+    mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "awu-credit-1" }));
+
+    const result = await redeemCreditsCoupon(auth, { coupon });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.status).toBe("active");
+    expect(result.value.metronomeCreditIds).toEqual(["awu-credit-1"]);
+
+    // Granted directly as AWU credits (no currency conversion).
+    expect(mockCreateMetronomeCredit).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 5000 })
+    );
+    // Does not resolve a contract — granted at the customer level.
+    expect(mockGetActiveContract).not.toHaveBeenCalled();
+
+    const updated = await CouponResourceClass.fetchByCouponId(coupon.sId);
+    expect(updated?.redemptionCount).toBe(1);
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "coupon.redeemed" })
+    );
+  });
+
+  it("rejects a seat coupon with wrong_coupon_type, no credit created", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create({ discountType: "seat" });
+
+    const result = await redeemCreditsCoupon(auth, { coupon });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      return;
+    }
+    expect(result.error).toMatchObject({
+      code: "coupon_validation_failed",
+      reason: expect.objectContaining({ code: "wrong_coupon_type" }),
+    });
+    expect(mockCreateMetronomeCredit).not.toHaveBeenCalled();
+  });
+
+  it("workspace without metronomeCustomerId → workspace_not_on_metronome", async () => {
+    const { auth } = await makeWorkspaceWithUserAuthNoMetronome();
+    const coupon = await CouponFactory.create({
+      discountType: "credit_pool_top_up",
+    });
+
+    const result = await redeemCreditsCoupon(auth, { coupon });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      return;
+    }
+    expect(result.error).toMatchObject({ code: "workspace_not_on_metronome" });
+  });
+
+  it("Metronome failure → redemption rolled back to failed, count decremented", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create({
+      discountType: "credit_pool_top_up",
+    });
+    mockCreateMetronomeCredit.mockResolvedValue(
+      new Err(new Error("metronome down"))
+    );
+
+    const result = await redeemCreditsCoupon(auth, { coupon });
+    expect(result.isErr()).toBe(true);
+
+    const redemptions = await CouponRedemptionResource.listAllByCoupon(coupon);
+    expect(redemptions).toHaveLength(1);
+    expect(redemptions[0].status).toBe("failed");
+    const updated = await CouponResourceClass.fetchByCouponId(coupon.sId);
+    expect(updated?.redemptionCount).toBe(0);
+  });
+
+  it("re-redeeming an active credits coupon for the same workspace → Err", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create({
+      discountType: "credit_pool_top_up",
+    });
+    mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "awu-credit-2" }));
+
+    const first = await redeemCreditsCoupon(auth, { coupon });
+    expect(first.isOk()).toBe(true);
+
+    const second = await redeemCreditsCoupon(auth, { coupon });
+    expect(second.isErr()).toBe(true);
+    if (!second.isErr()) {
+      return;
+    }
+    expect(second.error).toMatchObject({
+      code: "coupon_validation_failed",
+      reason: expect.objectContaining({ code: "already_redeemed" }),
+    });
   });
 });

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -14,13 +14,16 @@ import {
   updateMetronomeCreditEndDate,
 } from "@app/lib/metronome/client";
 import {
+  AWU_PRIORITY_PURCHASED_COMMIT,
   CURRENCY_TO_CREDIT_TYPE_ID,
+  getCreditTypeAwuId,
+  getProductFreeCreditId,
   getProductSeatSubscriptionCreditsId,
   SEAT_PRIORITY_COUPON_CREDIT,
 } from "@app/lib/metronome/constants";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
-import { SEAT_TAG } from "@app/lib/metronome/setup_common";
+import { SEAT_TAG, USAGE_TAG } from "@app/lib/metronome/setup_common";
 import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
 import type {
   CouponResource,
@@ -100,6 +103,8 @@ function getApplicableProductTagsForDiscountType(
   switch (discountType) {
     case "seat":
       return [SEAT_TAG];
+    case "credit_pool_top_up":
+      return [USAGE_TAG];
     default:
       return assertNever(discountType);
   }
@@ -161,6 +166,146 @@ export async function createCouponCredit({
   return new Ok(result.value !== null ? [result.value.id] : []);
 }
 
+// Default access window for a bonus AWU credit grant when the coupon does not
+// specify a duration. Mirrors the one-year access of a purchased Top-Up commit.
+const CREDITS_COUPON_DEFAULT_DURATION_MONTHS = 12;
+
+// Grant the bonus AWU credits of a "credit_pool_top_up" coupon as a free credit
+// on the workspace's Metronome customer. Mirrors the free-credit grant path of
+// the `grant-awu-credits` poke plugin: AWU credit type, "usage" tag,
+// purchased-commit priority. For "credit_pool_top_up" coupons, `coupon.amount`
+// is the number of AWU credits to grant directly (AWU is currency-independent).
+async function createCreditsCouponCredit({
+  metronomeCustomerId,
+  coupon,
+  redemptionId,
+  redeemedAt,
+}: {
+  metronomeCustomerId: string;
+  coupon: CouponResource;
+  redemptionId: string;
+  redeemedAt: Date;
+}): Promise<Result<string[], Error>> {
+  const durationMonths =
+    coupon.durationMonths ?? CREDITS_COUPON_DEFAULT_DURATION_MONTHS;
+
+  const result = await createMetronomeCredit({
+    metronomeCustomerId,
+    productId: getProductFreeCreditId(),
+    creditTypeId: getCreditTypeAwuId(),
+    amount: coupon.amount,
+    startingAt: floorToHourISO(redeemedAt),
+    endingBefore: ceilToHourISO(addMonths(redeemedAt, durationMonths)),
+    name: `Coupon: ${coupon.code}`,
+    idempotencyKey: `coupon-credits-${redemptionId}-0`,
+    priority: AWU_PRIORITY_PURCHASED_COMMIT,
+    applicableProductTags:
+      getApplicableProductTagsForDiscountType("credit_pool_top_up"),
+  });
+
+  if (result.isErr()) {
+    return new Err(result.error);
+  }
+
+  return new Ok(result.value !== null ? [result.value.id] : []);
+}
+
+export type RedeemCreditsCouponError =
+  | { code: "workspace_not_on_metronome" }
+  | { code: "coupon_validation_failed"; reason: CouponValidationError };
+
+// Redeem a "credit_pool_top_up" coupon as a standalone, synchronous action (the "Use
+// coupon" Top-Up tab): no payment is involved, the coupon simply grants free
+// AWU credits to the workspace pool. Mirrors `redeemCoupon` (the subscription
+// path) end-to-end: validate → check for an existing redemption → create the
+// pending redemption (incrementing the count) → grant the credit → mark active.
+// On a Metronome failure the pending redemption is rolled back so the count is
+// released (safe here because, unlike a payment-gated flow, nothing has been
+// charged).
+export async function redeemCreditsCoupon(
+  auth: Authenticator,
+  { coupon }: { coupon: CouponResource }
+): Promise<Result<CouponRedemptionResource, RedeemCreditsCouponError | Error>> {
+  const validation = coupon.validateRedemptionForContext("credits");
+  if (validation.isErr()) {
+    return new Err({
+      code: "coupon_validation_failed",
+      reason: validation.error,
+    });
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return new Err({ code: "workspace_not_on_metronome" });
+  }
+
+  const existingRedemption =
+    await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
+      auth,
+      { coupon }
+    );
+  if (existingRedemption) {
+    return new Err({
+      code: "coupon_validation_failed",
+      reason: { code: "already_redeemed" },
+    });
+  }
+
+  const pendingResult = await CouponRedemptionResource.createPending(auth, {
+    coupon,
+  });
+  if (pendingResult.isErr()) {
+    return new Err(pendingResult.error);
+  }
+  const redemption = pendingResult.value;
+
+  const creditResult = await createCreditsCouponCredit({
+    metronomeCustomerId,
+    coupon,
+    redemptionId: redemption.sId,
+    redeemedAt: redemption.redeemedAt,
+  });
+
+  if (creditResult.isErr()) {
+    logger.error(
+      {
+        err: creditResult.error,
+        couponId: coupon.sId,
+        workspaceId: workspace.sId,
+      },
+      "[Metronome] Failed to create credits coupon credit — rolling back redemption"
+    );
+    const rollbackResult = await redemption.rollback(coupon);
+    if (rollbackResult.isErr()) {
+      logger.error(
+        {
+          err: rollbackResult.error,
+          couponId: coupon.sId,
+          workspaceId: workspace.sId,
+        },
+        "[Metronome] Failed to create credits coupon credit - failed to rollback coupon redemption"
+      );
+    }
+    return new Err(creditResult.error);
+  }
+
+  await redemption.markActive(creditResult.value);
+
+  void emitAuditLogEvent({
+    auth,
+    action: "coupon.redeemed",
+    targets: [buildAuditLogTarget("workspace", workspace)],
+    metadata: {
+      code: coupon.code,
+      redemption_id: redemption.sId,
+      amount: String(coupon.amount),
+    },
+  });
+
+  return new Ok(redemption);
+}
+
 export async function endCouponCredit({
   metronomeCustomerId,
   metronomeCreditIds,
@@ -200,7 +345,7 @@ export async function redeemCoupon(
     metronomePackageAlias?: string;
   }
 ): Promise<Result<CouponRedemptionResource, RedeemCouponError | Error>> {
-  const validation = coupon.validateRedemption();
+  const validation = coupon.validateRedemptionForContext("subscription");
   if (validation.isErr()) {
     return new Err({
       code: "coupon_validation_failed",

--- a/front/lib/resources/coupon_resource.test.ts
+++ b/front/lib/resources/coupon_resource.test.ts
@@ -46,3 +46,51 @@ describe("CouponResource.validateRedemption", () => {
     }
   });
 });
+
+describe("CouponResource.validateRedemptionForContext", () => {
+  it("accepts a seat coupon in the subscription context", async () => {
+    const coupon = await CouponFactory.create({ discountType: "seat" });
+    expect(coupon.validateRedemptionForContext("subscription").isOk()).toBe(
+      true
+    );
+  });
+
+  it("accepts a credits coupon in the credits context", async () => {
+    const coupon = await CouponFactory.create({
+      discountType: "credit_pool_top_up",
+    });
+    expect(coupon.validateRedemptionForContext("credits").isOk()).toBe(true);
+  });
+
+  it("rejects a seat coupon in the credits context with 'wrong_coupon_type'", async () => {
+    const coupon = await CouponFactory.create({ discountType: "seat" });
+    const result = coupon.validateRedemptionForContext("credits");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("wrong_coupon_type");
+    }
+  });
+
+  it("rejects a credits coupon in the subscription context with 'wrong_coupon_type'", async () => {
+    const coupon = await CouponFactory.create({
+      discountType: "credit_pool_top_up",
+    });
+    const result = coupon.validateRedemptionForContext("subscription");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("wrong_coupon_type");
+    }
+  });
+
+  it("still applies base validation (expired) within a matching context", async () => {
+    const coupon = await CouponFactory.create({
+      discountType: "credit_pool_top_up",
+      expirationDate: new Date(Date.now() - 1000),
+    });
+    const result = coupon.validateRedemptionForContext("credits");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("expired");
+    }
+  });
+});

--- a/front/lib/resources/coupon_resource.ts
+++ b/front/lib/resources/coupon_resource.ts
@@ -7,7 +7,11 @@ import {
   getResourceIdFromSId,
   makeSId,
 } from "@app/lib/resources/string_ids";
-import type { CouponType, CreateCouponBody } from "@app/types/coupon";
+import type {
+  CouponRedemptionContext,
+  CouponType,
+  CreateCouponBody,
+} from "@app/types/coupon";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -23,7 +27,17 @@ export type CouponValidationError =
   | { code: "expired"; expirationDate: Date }
   | { code: "exhausted"; maxRedemptions: number }
   | { code: "archived" }
-  | { code: "already_redeemed" };
+  | { code: "already_redeemed" }
+  | { code: "wrong_coupon_type"; expected: CouponRedemptionContext };
+
+// A coupon's `discountType` only applies in a single redemption context.
+const DISCOUNT_TYPE_TO_CONTEXT: Record<
+  CouponType["discountType"],
+  CouponRedemptionContext
+> = {
+  seat: "subscription",
+  credit_pool_top_up: "credits",
+};
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface CouponResource extends ReadonlyAttributesType<CouponModel> {}
@@ -56,7 +70,6 @@ export class CouponResource extends BaseResource<CouponModel> {
       const coupon = await CouponModel.create(
         {
           ...body,
-          discountType: "seat",
           createdByUserId: user.id,
         },
         { transaction }
@@ -126,6 +139,19 @@ export class CouponResource extends BaseResource<CouponModel> {
     }
 
     return new Ok(undefined);
+  }
+
+  // Same as `validateRedemption`, plus a check that the coupon's discount type
+  // is usable in the given redemption context (subscription checkout vs. credit
+  // Top-Up). Subscription coupons cannot be redeemed in the Top-Up flow and
+  // vice-versa.
+  validateRedemptionForContext(
+    context: CouponRedemptionContext
+  ): Result<void, CouponValidationError> {
+    if (DISCOUNT_TYPE_TO_CONTEXT[this.discountType] !== context) {
+      return new Err({ code: "wrong_coupon_type", expected: context });
+    }
+    return this.validateRedemption();
   }
 
   async incrementRedemptionCount({

--- a/front/lib/resources/storage/models/coupons.ts
+++ b/front/lib/resources/storage/models/coupons.ts
@@ -2,6 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
+import type { CouponDiscountType } from "@app/types/coupon";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 
 export class CouponModel extends BaseModel<CouponModel> {
@@ -10,7 +11,7 @@ export class CouponModel extends BaseModel<CouponModel> {
 
   declare code: string;
   declare description: string | null;
-  declare discountType: "seat";
+  declare discountType: CouponDiscountType;
   declare amount: number;
   declare durationMonths: number | null;
   declare maxRedemptions: number | null;

--- a/front/tests/utils/CouponFactory.ts
+++ b/front/tests/utils/CouponFactory.ts
@@ -1,9 +1,11 @@
 import { CouponResource } from "@app/lib/resources/coupon_resource";
 import { CouponModel } from "@app/lib/resources/storage/models/coupons";
+import type { CouponDiscountType } from "@app/types/coupon";
 import { faker } from "@faker-js/faker";
 
 interface CouponOverrides {
   code?: string;
+  discountType?: CouponDiscountType;
   amount?: number;
   maxRedemptions?: number | null;
   redemptionCount?: number;
@@ -20,7 +22,7 @@ export class CouponFactory {
     const row = await CouponModel.create({
       code: overrides.code ?? faker.string.alphanumeric(8).toUpperCase(),
       description: overrides.description ?? null,
-      discountType: "seat",
+      discountType: overrides.discountType ?? "seat",
       amount: overrides.amount ?? 10.0,
       durationMonths: overrides.durationMonths ?? null,
       maxRedemptions: overrides.maxRedemptions ?? null,

--- a/front/types/coupon.ts
+++ b/front/types/coupon.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
 
-export type CouponDiscountType = "seat";
+// "seat" — discounts the monthly seat subscription price at checkout.
+// "credit_pool_top_up" — grants bonus AWU credits to the workspace credit pool.
+// For a "credit_pool_top_up" coupon, `amount` is expressed directly in AWU
+// credits (not in currency / cents), because AWU is a currency-independent unit.
+export type CouponDiscountType = "seat" | "credit_pool_top_up";
+
+// Context in which a coupon is being redeemed. Maps 1:1 to `CouponDiscountType`
+// ("seat" coupons apply to the "subscription" context, "credit_pool_top_up"
+// coupons to the "credits" / Top-Up context) but is named after the redemption
+// flow rather than the discount mechanic.
+export type CouponRedemptionContext = "subscription" | "credits";
 
 export type CouponRedemptionStatus =
   | "pending"
@@ -31,7 +41,7 @@ export interface CouponRedemptionType {
   status: CouponRedemptionStatus;
 }
 
-export const CouponDiscountTypeSchema = z.enum(["seat"]);
+export const CouponDiscountTypeSchema = z.enum(["seat", "credit_pool_top_up"]);
 
 export const CreateCouponBodySchema = z.object({
   code: z.string().min(1).max(64),


### PR DESCRIPTION
Related to https://github.com/dust-tt/tasks/issues/8844

Stacked PR 1/3 for the credit-pool top-up coupon feature.

## Description

 - Adds the `credit_pool_top_up` coupon discount type 
 - Adds`validateRedemptionForContext` to isolate subscription vs. credit-pool coupons.
 - Includes the standalone `redeemCreditsCoupon` orchestrator (grants free AWU credits)
 - Update the Poke coupon-form option.

No user-facing surface yet (endpoints land in 2/3, UI in 3/3).

## Stack
 - https://github.com/dust-tt/dust/pull/28238
 - https://github.com/dust-tt/dust/pull/28239
 - https://github.com/dust-tt/dust/pull/28240
 
 ## Deploy Plan

Deploy front
No need for migration: we are allowing more values in the string column for discountType but no DB change