### PR TITLE
[front-api] Pool credits coupons 2/3: Coupon redeem endpoint + validate context param

### DIFF
--- a/front-api/routes/w/[wId]/coupon/index.ts
+++ b/front-api/routes/w/[wId]/coupon/index.ts
@@ -1,10 +1,12 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
+import redeem from "./redeem";
 import validate from "./validate";
 
 // Mounted under /api/w/:wId/coupon.
 const app = workspaceApp();
 
 app.route("/validate", validate);
+app.route("/redeem", redeem);
 
 export default app;

--- a/front-api/routes/w/[wId]/coupon/redeem.test.ts
+++ b/front-api/routes/w/[wId]/coupon/redeem.test.ts
@@ -1,0 +1,65 @@
+import { CouponFactory } from "@app/tests/utils/CouponFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function redeem(workspace: { sId: string }, body: unknown) {
+  return honoApp.request(`/api/w/${workspace.sId}/coupon/redeem`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/w/:wId/coupon/redeem", () => {
+  it("returns 400 when code is missing", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    const response = await redeem(workspace, {});
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 404 for an unknown coupon code", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    const response = await redeem(workspace, { code: "UNKNOWN" });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("coupon_not_found");
+  });
+
+  it("returns 400 (coupon_not_redeemable) for a seat coupon", async () => {
+    const coupon = await CouponFactory.create({ discountType: "seat" });
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    const response = await redeem(workspace, { code: coupon.code });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("coupon_not_redeemable");
+  });
+
+  it("returns 400 for a non-admin (regular member)", async () => {
+    const coupon = await CouponFactory.create({
+      discountType: "credit_pool_top_up",
+    });
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+    });
+
+    const response = await redeem(workspace, { code: coupon.code });
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/front-api/routes/w/[wId]/coupon/redeem.ts
+++ b/front-api/routes/w/[wId]/coupon/redeem.ts
@@ -1,0 +1,109 @@
+import { redeemCreditsCoupon } from "@app/lib/metronome/coupons";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
+import type { CouponType } from "@app/types/coupon";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+// `coupon` JSON-serializes to the wire (Date -> ISO string); the response type
+// mirrors `CouponType` but is what the handler actually returns via ctx.json.
+export type PostCouponRedeemResponseBody = {
+  coupon: CouponType;
+  redemptionId: string;
+};
+
+const PostCouponRedeemBodySchema = z.object({
+  code: z.string().min(1),
+});
+
+// Mounted at /api/w/:wId/coupon/redeem. Redeems a "credits" coupon, granting
+// bonus AWU credits to the workspace pool. Standalone (no payment).
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  validate("json", PostCouponRedeemBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+
+    const { code } = ctx.req.valid("json");
+
+    const coupon = await CouponResource.findByCode(code);
+    if (!coupon) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "coupon_not_found",
+          message: "Coupon not found.",
+        },
+      });
+    }
+
+    const result = await redeemCreditsCoupon(auth, { coupon });
+    if (result.isErr()) {
+      const err = result.error;
+      if (err instanceof Error) {
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to redeem coupon. Please try again.",
+          },
+        });
+      }
+      switch (err.code) {
+        case "workspace_not_on_metronome":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Credit coupons are not available for this workspace. Please contact support.",
+            },
+          });
+        case "coupon_validation_failed": {
+          const { reason } = err;
+          let message: string;
+          switch (reason.code) {
+            case "wrong_coupon_type":
+              message = "This coupon cannot be used for credit top-ups.";
+              break;
+            case "expired":
+              message = "This coupon has expired.";
+              break;
+            case "exhausted":
+              message = "This coupon has reached its redemption limit.";
+              break;
+            case "archived":
+              message = "This coupon is no longer available.";
+              break;
+            case "already_redeemed":
+              message =
+                "This coupon has already been redeemed by this workspace.";
+              break;
+            default:
+              assertNever(reason);
+          }
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: { type: "coupon_not_redeemable", message },
+          });
+        }
+        default:
+          assertNever(err);
+      }
+    }
+
+    return ctx.json({
+      coupon: coupon.toJSON(),
+      redemptionId: result.value.sId,
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/coupon/validate.test.ts
+++ b/front-api/routes/w/[wId]/coupon/validate.test.ts
@@ -100,6 +100,63 @@ describe("GET /api/w/:wId/coupon/validate", () => {
     expect((await response.json()).error.type).toBe("coupon_not_redeemable");
   });
 
+  it("returns 400 for a seat coupon when context=credits", async () => {
+    const coupon = await CouponFactory.create({
+      code: "SEATONLY",
+      discountType: "seat",
+    });
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const response = await validateCoupon(workspace, {
+      code: coupon.code,
+      context: "credits",
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("coupon_not_redeemable");
+  });
+
+  it("returns 200 for a credits coupon when context=credits", async () => {
+    const coupon = await CouponFactory.create({
+      code: "CREDITS5000",
+      discountType: "credit_pool_top_up",
+      amount: 5000,
+    });
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const response = await validateCoupon(workspace, {
+      code: coupon.code,
+      context: "credits",
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.coupon.discountType).toBe("credit_pool_top_up");
+    expect(data.coupon.amount).toBe(5000);
+  });
+
+  it("returns 400 for a credits coupon in the default (subscription) context", async () => {
+    const coupon = await CouponFactory.create({
+      code: "CREDITSONLY",
+      discountType: "credit_pool_top_up",
+    });
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const response = await validateCoupon(workspace, { code: coupon.code });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("coupon_not_redeemable");
+  });
+
   it("returns 400 when coupon already redeemed by this workspace", async () => {
     const coupon = await CouponFactory.create({ code: "ALREADYUSED" });
     const { workspace, auth } = await createPrivateApiMockRequest({

--- a/front-api/routes/w/[wId]/coupon/validate.ts
+++ b/front-api/routes/w/[wId]/coupon/validate.ts
@@ -10,6 +10,9 @@ export type { GetCouponValidateResponseBody } from "@app/lib/resources/coupon_re
 
 const GetCouponValidateQuerySchema = z.object({
   code: z.string(),
+  // Redemption context the coupon is being validated for. Defaults to
+  // "subscription" so existing callers (checkout) keep their behaviour.
+  context: z.enum(["subscription", "credits"]).optional(),
 });
 
 // Mounted at /api/w/:wId/coupon/validate.
@@ -23,7 +26,7 @@ app.get(
   async (ctx) => {
     const auth = ctx.get("auth");
 
-    const { code } = ctx.req.valid("query");
+    const { code, context = "subscription" } = ctx.req.valid("query");
 
     const coupon = await CouponResource.findByCode(code);
     if (!coupon) {
@@ -36,14 +39,20 @@ app.get(
       });
     }
 
-    const validationResult = coupon.validateRedemption();
+    const validationResult = coupon.validateRedemptionForContext(context);
     if (validationResult.isErr()) {
       const { code: errorCode } = validationResult.error;
+      const message =
+        errorCode === "wrong_coupon_type"
+          ? context === "credits"
+            ? "This coupon cannot be used for credit top-ups."
+            : "This coupon cannot be used for subscriptions."
+          : `Coupon is not redeemable: ${errorCode}.`;
       return apiError(ctx, {
         status_code: 400,
         api_error: {
           type: "coupon_not_redeemable",
-          message: `Coupon is not redeemable: ${errorCode}.`,
+          message,
         },
       });
     }

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -261,10 +261,7 @@ app.use(
 );
 app.route("/trial-message-usage", trialMessageUsage);
 
-app.use(
-  "/coupon/validate/*",
-  workspaceAuth({ doesNotRequireCanUseProduct: true })
-);
+app.use("/coupon/*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 app.route("/coupon", coupon);
 
 app.use("/trial/start/*", workspaceAuth({ doesNotRequireCanUseProduct: true }));


### PR DESCRIPTION
Related to https://github.com/dust-tt/tasks/issues/8844

Stacked PR 2/3 for the credit-pool top-up coupon feature. **Base: `fabien/pricing/coupon-1-type-validation` (PR #28238).**

## Description

 - Adds `POST /api/w/:wId/coupon/redeem` (admin-only) to redeem a `credit_pool_top_up` coupon and grant free AWU credits, plus an optional `context` query param on the validate endpoint.
 - Functional tests included

## Deploy Plan

Deploy front

## Stack
 - https://github.com/dust-tt/dust/pull/28238
 - https://github.com/dust-tt/dust/pull/28239
 - https://github.com/dust-tt/dust/pull/28240