### PR TITLE
fix(input-bar): center "Search knowledge" empty state in its container

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -602,7 +602,9 @@ export const InputBarAttachmentsPicker = ({
         </DropdownMenuSubTrigger>
       )}
       <ContentWrapper
-        className="h-80 w-80 xs:h-96 xs:w-96"
+        // Radix ScrollArea wraps content in a content-height `display:table` div. Force it to fill
+        // the viewport so the empty-state's `h-full` centering resolves against the full height.
+        className="h-80 w-80 xs:h-96 xs:w-96 [&_[data-radix-scroll-area-viewport]>div]:h-full"
         collisionPadding={15}
         onEscapeKeyDown={() => setIsOpen(false)}
         {...(type === "subdropdown"


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9320

The empty-state block is rendered inside sparkle's DropdownMenuContent, whose Radix ScrollArea wraps children in a content-height `display:table` div. The block's `h-full` centering resolved against that collapsed height, so it rendered at the top and crowded the separator. Force the Radix scroll wrapper to fill the viewport so the existing centering resolves correctly.

<img width="417" height="398" alt="Screenshot 2026-06-30 at 15 38 19" src="https://github.com/user-attachments/assets/2edf7304-b653-4d5e-b21c-dc9aa33faa16" />


## Tests

Local

## Risk

Low

## Deploy Plan

Front