### PR TITLE
chore(mcp): improve fathom tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/fathom/metadata.ts
+++ b/front/lib/api/actions/servers/fathom/metadata.ts
@@ -7,7 +7,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const FATHOM_TOOLS_METADATA = createToolsRecord({
   list_meetings: {
     description:
-      "List Fathom video meeting recordings with optional filters for date range, team, attendee domain, recorded-by email, and CRM data. Returns summaries, action items, and metadata.",
+      "List and browse your Fathom meeting and call recordings with optional filters for date range, team, attendee domain, recorded-by email, and CRM data. Returns each Fathom recording with its summary, action items, and metadata.",
     schema: {
       cursor: z
         .string()
@@ -38,7 +38,7 @@ export const FATHOM_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe(
-          "Filter by company domains in the calendar invitee list (exact match). Pass multiple domains to return meetings where any appear, e.g. ['acme.com', 'client.com']."
+          "Filter by company domains in the calendar invitee list (exact match), e.g. ['acme.com', 'client.com']."
         ),
       calendar_invitees_domains_type: z
         .enum(["all", "only_internal", "one_or_more_external"])
@@ -50,14 +50,12 @@ export const FATHOM_TOOLS_METADATA = createToolsRecord({
         .array(z.string().email())
         .optional()
         .describe(
-          "Filter by email addresses of users who recorded meetings. Returns meetings recorded by any of the specified users, e.g. ['ceo@acme.com', 'pm@acme.com']."
+          "Filter by email addresses of users who recorded the meeting, e.g. ['ceo@acme.com', 'pm@acme.com']."
         ),
       teams: z
         .array(z.string())
         .optional()
-        .describe(
-          "Filter by team names. Returns meetings that belong to any of the specified teams, e.g. ['Sales', 'Engineering']."
-        ),
+        .describe("Filter by team names, e.g. ['Sales', 'Engineering']."),
       include_action_items: z
         .boolean()
         .optional()
@@ -72,7 +70,7 @@ export const FATHOM_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Fetch the AI-generated summary for each meeting via the recordings API. Most useful combined with recording_id."
+          "Fetch the AI-generated summary of each Fathom recording. Most useful combined with recording_id."
         ),
     },
     stake: "never_ask",
@@ -83,14 +81,12 @@ export const FATHOM_TOOLS_METADATA = createToolsRecord({
   },
   get_transcript: {
     description:
-      "Get the full transcript of a Fathom meeting recording. Use recording_id from list_meetings. Large transcripts are saved as conversation files—use conversation_files__cat with offset/limit to read in chunks.",
+      "Get the full word-for-word transcript of a Fathom meeting. Use recording_id from list_meetings. Large transcripts are saved as conversation files—use conversation_files__cat with offset/limit to read in chunks.",
     schema: {
       recording_id: z
         .number()
         .int()
-        .describe(
-          "The numeric recording ID from list_meetings (e.g. recordingId field)."
-        ),
+        .describe("The numeric ID of the meeting to fetch the transcript for."),
     },
     stake: "never_ask",
     displayLabels: {

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1146,6 +1146,16 @@ export const QUERIES: LabeledQuery[] = [
     expected: "file_generation.get_supported_source_formats_for_output_format",
   },
 
+  // --- fathom ---
+  {
+    query: "list my fathom call recordings",
+    expected: "fathom.list_meetings",
+  },
+  {
+    query: "get the transcript of a fathom call",
+    expected: "fathom.get_transcript",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -17,6 +17,7 @@ import { CLARI_COPILOT_SERVER } from "@app/lib/api/actions/servers/clari_copilot
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
 import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_warehouses/metadata";
+import { FATHOM_SERVER } from "@app/lib/api/actions/servers/fathom/metadata";
 import { FILE_GENERATION_SERVER } from "@app/lib/api/actions/servers/file_generation/metadata";
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
@@ -165,6 +166,7 @@ const SERVERS: ServerEntry[] = [
   { name: "clari_copilot", tools: CLARI_COPILOT_SERVER.tools },
   { name: "image_generation", tools: IMAGE_GENERATION_SERVER.tools },
   { name: "file_generation", tools: FILE_GENERATION_SERVER.tools },
+  { name: "fathom", tools: FATHOM_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

Tweaks the `fathom` MCP tool descriptions (`list_meetings`, `get_transcript`) so each ranks better and is better segregated under the BM25 norm used for tool search. Also registers `fathom` in the BM25 testing script. No behavior change.

## Tests

- Tested locally with BM25 samples.

## Risk

- Low.

## Deploy Plan

- Deploy front.
