### PR TITLE
chore(mcp): improve file_generation tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/file_generation/metadata.ts
+++ b/front/lib/api/actions/servers/file_generation/metadata.ts
@@ -40,7 +40,7 @@ export const BINARY_FORMATS: OutputFormatType[] = [
 export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
   get_supported_source_formats_for_output_format: {
     description:
-      "Get a list of source formats supported for a target output format.",
+      "List which input source formats can be converted into a given target output format.",
     schema: {
       output_format: z.enum(OUTPUT_FORMATS).describe("The format to check."),
     },
@@ -51,7 +51,8 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
     },
   },
   convert_file_format: {
-    description: "Convert a file from one format to another.",
+    description:
+      "Convert an existing conversation file into another format, for example turn a document into a PDF.",
     schema: {
       file_name: z
         .string()
@@ -79,7 +80,8 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
     },
   },
   generate_file: {
-    description: "Generate a file with some content.",
+    description:
+      "Generate a new file by writing provided text or content out as a document.",
     schema: {
       file_name: z
         .string()

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1132,6 +1132,20 @@ export const QUERIES: LabeledQuery[] = [
     expected: "image_generation.generate_image",
   },
 
+  // --- file_generation ---
+  {
+    query: "turn this conversation file into a PDF",
+    expected: "file_generation.convert_file_format",
+  },
+  {
+    query: "write my report text out as a Word document",
+    expected: "file_generation.generate_file",
+  },
+  {
+    query: "which input formats can I turn into an xlsx spreadsheet",
+    expected: "file_generation.get_supported_source_formats_for_output_format",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -17,6 +17,7 @@ import { CLARI_COPILOT_SERVER } from "@app/lib/api/actions/servers/clari_copilot
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
 import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_warehouses/metadata";
+import { FILE_GENERATION_SERVER } from "@app/lib/api/actions/servers/file_generation/metadata";
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
@@ -163,6 +164,7 @@ const SERVERS: ServerEntry[] = [
   },
   { name: "clari_copilot", tools: CLARI_COPILOT_SERVER.tools },
   { name: "image_generation", tools: IMAGE_GENERATION_SERVER.tools },
+  { name: "file_generation", tools: FILE_GENERATION_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

- Tweaks the `file_generation` tool descriptions (`get_supported_source_formats_for_output_format`, `convert_file_format`, `generate_file`) so they rank and segregate better under the BM25 tool-search norm.
- Registers `file_generation` in the BM25 testing script (`queries.ts` + `run.ts`) with sample queries.
- No behavior change.

## Tests

- Tested locally with BM25 samples.

## Risk

- Low.

## Deploy Plan

- Deploy front.
