### PR TITLE
chore(mcp): improve files tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -217,9 +217,9 @@ const FILES_TOOLS_COMMON_METADATA = {
   },
   [FILES_GREP_ACTION_NAME]: {
     description:
-      "Search a text file for lines matching a regular expression. " +
-      "Returns matching lines with their line numbers. " +
-      `Use the line numbers with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` to read surrounding context. ` +
+      "Search a text file for lines matching a regular expression pattern. " +
+      "Returns each matching line with its number, which you can pass to " +
+      `\`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` to read surrounding context. ` +
       `Results are capped at ${GREP_MATCHES_MAX} matches.`,
     schema: {
       path: z

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1227,6 +1227,48 @@ export const QUERIES: LabeledQuery[] = [
     expected: "gong.get_call_transcript",
   },
 
+  // --- files ---
+  {
+    query: "list the files in the conversation and pod file system",
+    expected: "files.list",
+  },
+  {
+    query: "resolve a fil_ file id to its scoped file system path",
+    expected: "files.resolve",
+  },
+  {
+    query: "read the contents of a file at a scoped path line by line",
+    expected: "files.cat",
+  },
+  {
+    query: "grep a file for lines matching a regular expression",
+    expected: "files.grep",
+  },
+  {
+    query: "create a new text file in the conversation file system",
+    expected: "files.create",
+  },
+  {
+    query: "download a file from a public https url into the file system",
+    expected: "files.upload_from_url",
+  },
+  {
+    query: "delete a file from the conversation or pod file system",
+    expected: "files.delete",
+  },
+  {
+    query: "extract text from a pdf or docx binary document",
+    expected: "files.extract_text",
+  },
+  {
+    query: "copy a file from one scoped path to another keeping the source",
+    expected: "files.copy",
+  },
+  {
+    query: "move a file to a different scoped path and remove the source",
+    expected: "files.move",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -20,6 +20,7 @@ import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_wareho
 import { EXTRACT_DATA_SERVER } from "@app/lib/api/actions/servers/extract_data/metadata";
 import { FATHOM_SERVER } from "@app/lib/api/actions/servers/fathom/metadata";
 import { FILE_GENERATION_SERVER } from "@app/lib/api/actions/servers/file_generation/metadata";
+import { FILES_SERVER } from "@app/lib/api/actions/servers/files/metadata";
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { GONG_SERVER } from "@app/lib/api/actions/servers/gong/metadata";
@@ -173,6 +174,7 @@ const SERVERS: ServerEntry[] = [
   { name: "luma", tools: LUMA_SERVER.tools },
   { name: "extract_data", tools: EXTRACT_DATA_SERVER.tools },
   { name: "gong", tools: GONG_SERVER.tools },
+  { name: "files", tools: FILES_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

- Tweaks the `files` MCP server tool descriptions so they rank and segregate better under the BM25 norm used by tool-search. The `grep` tool description is reworded to lead with the "regular expression pattern" intent vocabulary and to keep the line-number/`cat` cross-reference compact.
- Registers the `files` server in the BM25 testing script (`scripts/mcp_bm25/run.ts`) and adds a labeled `// --- files ---` query section (`scripts/mcp_bm25/queries.ts`) so each `files.*` tool has a representative query covered by the harness.
- No behavior change: descriptions are metadata only, and the script edits are diagnostic tooling.

## Tests

- Ran the BM25 harness locally; all 10 `files.*` queries rank 1, no `files.*` misses.

## Risk

- Low.

## Deploy Plan

- Deploy front.
