### PR TITLE
chore(mcp): improve gmail tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -8,7 +8,8 @@ export const GMAIL_TOOL_NAME = "gmail" as const;
 
 export const GMAIL_TOOLS_METADATA = createToolsRecord({
   get_drafts: {
-    description: "Get all drafts from Gmail.",
+    description:
+      "Get and list saved, unsent email drafts from Gmail. Returns existing drafts only.",
     schema: {
       q: z
         .string()
@@ -137,7 +138,7 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
   },
   get_attachment: {
     description:
-      "Get the content of a specific attachment from a Gmail message. The attachment will be uploaded and made available in the conversation.",
+      "Download an attached file from a Gmail email message. Fetches the content of a specific attachment, which is then uploaded and made available in the conversation.",
     schema: {
       messageId: z
         .string()
@@ -183,7 +184,7 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     },
   },
   set_message_labels: {
-    description: `Modify the labels of a message. System label IDs can be used directly (INBOX, SPAM, TRASH, UNREAD, STARRED, IMPORTANT, ...). User labels should be retrieved first via get_labels to get their IDs.`,
+    description: `Modify the labels on a Gmail message to mark it read or unread, star it, archive it, or move it into or out of the inbox. Adds and removes label IDs on the message. System label IDs can be used directly (INBOX, SPAM, TRASH, UNREAD, STARRED, IMPORTANT, ...). User labels should be retrieved first via get_labels to get their IDs.`,
     schema: {
       messageId: z.string().describe("The ID of the message to modify."),
       addLabelIds: z.array(z.string()).optional().describe("Label IDs to add."),

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1269,6 +1269,44 @@ export const QUERIES: LabeledQuery[] = [
     expected: "files.move",
   },
 
+  // --- gmail ---
+  {
+    query: "show my saved gmail drafts",
+    expected: "gmail.get_drafts",
+  },
+  {
+    query: "draft a reply email in gmail to send later",
+    expected: "gmail.create_draft",
+  },
+  {
+    query: "delete a draft email from gmail",
+    expected: "gmail.delete_draft",
+  },
+  {
+    query: "search my gmail inbox for emails from a coworker",
+    expected: "gmail.get_messages",
+  },
+  {
+    query: "download the file attached to a gmail email",
+    expected: "gmail.get_attachment",
+  },
+  {
+    query: "list all my gmail labels and folders",
+    expected: "gmail.get_labels",
+  },
+  {
+    query: "mark a gmail message as read and move it out of the inbox",
+    expected: "gmail.set_message_labels",
+  },
+  {
+    query: "send an email right now through gmail",
+    expected: "gmail.send_mail",
+  },
+  {
+    query: "read the whole gmail conversation thread",
+    expected: "gmail.get_thread",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -23,6 +23,7 @@ import { FILE_GENERATION_SERVER } from "@app/lib/api/actions/servers/file_genera
 import { FILES_SERVER } from "@app/lib/api/actions/servers/files/metadata";
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
+import { GMAIL_SERVER } from "@app/lib/api/actions/servers/gmail/metadata";
 import { GONG_SERVER } from "@app/lib/api/actions/servers/gong/metadata";
 import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
 import { GOOGLE_SHEETS_SERVER } from "@app/lib/api/actions/servers/google_sheets/metadata";
@@ -175,6 +176,7 @@ const SERVERS: ServerEntry[] = [
   { name: "extract_data", tools: EXTRACT_DATA_SERVER.tools },
   { name: "gong", tools: GONG_SERVER.tools },
   { name: "files", tools: FILES_SERVER.tools },
+  { name: "gmail", tools: GMAIL_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

- Tweaks the `gmail` tool descriptions so they rank and segregate better under the BM25 norm used by tool search. `get_drafts`, `get_attachment`, and `set_message_labels` now spell out their distinguishing actions (saved/unsent drafts, downloading an attached file, marking read/unread/starred/archived/inbox) so queries land on the right tool instead of a neighbor.
- Registers `gmail` in the BM25 testing script (`run.ts` import + `SERVERS` entry) and adds a `// --- gmail ---` query section in `queries.ts` to lock in recall for the nine gmail tools.
- No behavior change: only tool description strings and the offline BM25 harness.

## Tests

- Ran the BM25 harness locally; all nine `gmail.*` queries rank 1.

## Risk

- Low.

## Deploy Plan

- Deploy front.
