### PR TITLE
chore(mcp): improve google_calendar tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -60,7 +60,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
   },
   list_events: {
     description:
-      "List or search events from a Google Calendar. If 'q' is provided, performs a free-text search.",
+      "List, search, or browse the events and agenda on a Google Calendar for a given day, week, or date range. If 'q' is provided, performs a free-text search of events.",
     schema: {
       calendarId: z
         .string()
@@ -91,7 +91,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_event: {
-    description: "Get a single event from a Google Calendar by event ID.",
+    description:
+      "Get the full details of a single event from a Google Calendar by its event ID.",
     schema: {
       calendarId: z
         .string()
@@ -107,7 +108,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
   },
   create_event: {
     description:
-      "Create a new event in a Google Calendar. By default: (1) add the calling user as both organizer and attendee, (2) call check_availability to verify attendee availability beforehand, (3) call get_user_timezones first to determine attendee timezones for accurate scheduling.",
+      "Create a new event on a Google Calendar to schedule a meeting or appointment. By default: (1) add the calling user as both organizer and attendee, (2) call check_availability to verify attendee availability beforehand, (3) call get_user_timezones first to determine attendee timezones for accurate scheduling.",
     schema: {
       calendarId: z
         .string()
@@ -153,7 +154,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
   },
   update_event: {
-    description: "Update an existing event in a Google Calendar.",
+    description:
+      "Update or reschedule an existing event on a Google Calendar to a new time, location, or set of attendees.",
     schema: {
       calendarId: z
         .string()
@@ -196,7 +198,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
   },
   delete_event: {
-    description: "Delete an event from a Google Calendar.",
+    description: "Delete, cancel, or remove an event from a Google Calendar.",
     schema: {
       calendarId: z
         .string()
@@ -212,7 +214,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
   },
   check_availability: {
     description:
-      "Compute combined free/busy availability across multiple participants within a date range using Google Calendar.",
+      "Find free time slots when participants are all available to meet, computing combined free/busy availability across multiple attendees within a date range using Google Calendar.",
     schema: {
       participants: z
         .array(
@@ -279,7 +281,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
   },
   get_user_timezones: {
     description:
-      "Get timezone settings for multiple users from their Google Calendar configuration. Only works for calendars shared with you.",
+      "Get the timezone of attendees by looking up timezone settings for multiple users from their Google Calendar configuration. Only works for calendars shared with you.",
     schema: {
       emails: z
         .array(z.string())

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1307,6 +1307,40 @@ export const QUERIES: LabeledQuery[] = [
     expected: "gmail.get_thread",
   },
 
+  // --- google_calendar ---
+  {
+    query: "list all my google calendars",
+    expected: "google_calendar.list_calendars",
+  },
+  {
+    query: "what events are on my google calendar this week",
+    expected: "google_calendar.list_events",
+  },
+  {
+    query: "get the details of a calendar event by its id",
+    expected: "google_calendar.get_event",
+  },
+  {
+    query: "schedule a meeting on my google calendar",
+    expected: "google_calendar.create_event",
+  },
+  {
+    query: "reschedule a calendar event to a new time",
+    expected: "google_calendar.update_event",
+  },
+  {
+    query: "cancel and remove a calendar event",
+    expected: "google_calendar.delete_event",
+  },
+  {
+    query: "find a free time slot when everyone is available to meet",
+    expected: "google_calendar.check_availability",
+  },
+  {
+    query: "look up the timezone of meeting attendees",
+    expected: "google_calendar.get_user_timezones",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -25,6 +25,7 @@ import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/m
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { GMAIL_SERVER } from "@app/lib/api/actions/servers/gmail/metadata";
 import { GONG_SERVER } from "@app/lib/api/actions/servers/gong/metadata";
+import { GOOGLE_CALENDAR_SERVER } from "@app/lib/api/actions/servers/google_calendar/metadata";
 import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
 import { GOOGLE_SHEETS_SERVER } from "@app/lib/api/actions/servers/google_sheets/metadata";
 import { HUBSPOT_SERVER } from "@app/lib/api/actions/servers/hubspot/metadata";
@@ -177,6 +178,7 @@ const SERVERS: ServerEntry[] = [
   { name: "gong", tools: GONG_SERVER.tools },
   { name: "files", tools: FILES_SERVER.tools },
   { name: "gmail", tools: GMAIL_SERVER.tools },
+  { name: "google_calendar", tools: GOOGLE_CALENDAR_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

- Tweaks the `google_calendar` tool descriptions so they rank and segregate better under the BM25 norm used by tool-search: each description now carries the intent vocabulary it was missing (`schedule a meeting`, `reschedule`, `cancel/remove`, `find a free time slot when everyone is available`, `browse the agenda`, `timezone of attendees`), which lifts every tool to rank 1 for its labeled query and avoids cross-tool collisions.
- Registers `google_calendar` in the BM25 testing script (`scripts/mcp_bm25`): adds the server to `run.ts` and a labeled query section to `queries.ts`.
- No behavior change: only tool description strings and the offline diagnostic harness are touched.

## Tests

- Ran the BM25 harness locally; all `google_calendar.*` queries rank 1.

## Risk

- Low.

## Deploy Plan

- Deploy front.
