### PR TITLE
chore(mcp): improve http_client tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1420,6 +1420,16 @@ export const QUERIES: LabeledQuery[] = [
     expected: "github.list_pull_requests",
   },
 
+  // --- http_client ---
+  {
+    query: "call an external REST API endpoint with an HTTP request",
+    expected: "http_client.send_request",
+  },
+  {
+    query: "send a POST request to a URL with a JSON body and custom headers",
+    expected: "http_client.send_request",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -29,6 +29,10 @@ import { GONG_SERVER } from "@app/lib/api/actions/servers/gong/metadata";
 import { GOOGLE_CALENDAR_SERVER } from "@app/lib/api/actions/servers/google_calendar/metadata";
 import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
 import { GOOGLE_SHEETS_SERVER } from "@app/lib/api/actions/servers/google_sheets/metadata";
+import {
+  HTTP_CLIENT_SERVER,
+  HTTP_CLIENT_TOOL_NAME,
+} from "@app/lib/api/actions/servers/http_client/metadata";
 import { HUBSPOT_SERVER } from "@app/lib/api/actions/servers/hubspot/metadata";
 import { IMAGE_GENERATION_SERVER } from "@app/lib/api/actions/servers/image_generation/metadata";
 import { INCLUDE_DATA_SERVER } from "@app/lib/api/actions/servers/include_data/metadata";
@@ -181,6 +185,13 @@ const SERVERS: ServerEntry[] = [
   { name: "gmail", tools: GMAIL_SERVER.tools },
   { name: "google_calendar", tools: GOOGLE_CALENDAR_SERVER.tools },
   { name: "github", tools: GITHUB_SERVER.tools },
+  {
+    // http_client re-exports the web_search_&_browse tools, which are already
+    // indexed under their own server above; only index its own send_request
+    // tool here to avoid duplicate documents.
+    name: HTTP_CLIENT_TOOL_NAME,
+    tools: HTTP_CLIENT_SERVER.tools.filter((t) => t.name === "send_request"),
+  },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

This PR registers the `http_client` server in the BM25 tool-search evaluation harness and adds labeled queries for it. The description already matches well on the sample queries, so no tool description.
No behavior change either.

## Tests

- Tested locally with BM25 samples.

## Risk

- Low.

## Deploy Plan

- Deploy front.
