### PR TITLE
chore(mcp): improve image_generation tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1093,6 +1093,25 @@ export const QUERIES: LabeledQuery[] = [
     expected: "clari_copilot.get_call_details",
   },
 
+  // --- image_generation ---
+  {
+    query: "generate an image of a watercolor mountain landscape at sunset",
+    expected: "image_generation.generate_image",
+  },
+  {
+    query: "create a picture of a minimalist tech company logo",
+    expected: "image_generation.generate_image",
+  },
+  {
+    query: "draw an illustration of a friendly robot mascot",
+    expected: "image_generation.generate_image",
+  },
+  {
+    query:
+      "edit this photo to remove the background and replace it with a beach",
+    expected: "image_generation.generate_image",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -22,6 +22,7 @@ import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
 import { GOOGLE_SHEETS_SERVER } from "@app/lib/api/actions/servers/google_sheets/metadata";
 import { HUBSPOT_SERVER } from "@app/lib/api/actions/servers/hubspot/metadata";
+import { IMAGE_GENERATION_SERVER } from "@app/lib/api/actions/servers/image_generation/metadata";
 import { INCLUDE_DATA_SERVER } from "@app/lib/api/actions/servers/include_data/metadata";
 import { INTERACTIVE_CONTENT_SERVER } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
@@ -157,6 +158,7 @@ const SERVERS: ServerEntry[] = [
     tools: WEB_SEARCH_BROWSE_SERVER.tools,
   },
   { name: "clari_copilot", tools: CLARI_COPILOT_SERVER.tools },
+  { name: "image_generation", tools: IMAGE_GENERATION_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

Part of the series improving BM25 tool-search recall for internal MCP servers ([design doc](https://app.notion.com/p/dust-tt/Design-Doc-Anthropic-Token-Consumption-Cache-Efficiency-38728599d94180a2b7f8e101a776f564?source=copy_link), [tool-search doc](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)).

The `image_generation` server has a single tool, `generate_image`, which already ranks well in the BM25 harness, so this PR only adds samples in the BM25 harness

No behavior change.

## Tests

- Tested locally with BM25 samples.

## Risk

- Low.

## Deploy Plan

- Deploy front.
