### PR TITLE
chore(mcp): improve luma tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/luma/metadata.ts
+++ b/front/lib/api/actions/servers/luma/metadata.ts
@@ -23,7 +23,7 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
   },
   get_event: {
     description:
-      "Get detailed information about a specific Luma event by its ID.",
+      "Get the full details of a specific Luma event by its event ID.",
     schema: {
       event_api_id: z.string().describe("The API ID of the event to retrieve."),
     },
@@ -101,8 +101,9 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
   },
   update_event: {
     description:
-      "Update an existing Luma event. " +
-      "Only the fields you provide will be updated. " +
+      "Update an existing Luma event: edit or reschedule its name, start time, " +
+      "capacity, or visibility. " +
+      "Only the fields you provide will be changed. " +
       "Set suppress_notifications to true to avoid emailing guests about minor changes.",
     schema: {
       event_api_id: z.string().describe("The API ID of the event to update."),
@@ -190,7 +191,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_guest: {
-    description: "Get detailed information about a specific guest of an event.",
+    description:
+      "Get the registration record of a single guest who signed up for a Luma event.",
     schema: {
       event_api_id: z.string().describe("The API ID of the event."),
       guest_api_id: z.string().describe("The API ID of the guest."),
@@ -203,9 +205,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
   },
   update_guest_status: {
     description:
-      "Update the approval status of a single guest. " +
-      "Can approve or decline a guest. " +
-      "Use should_refund when declining guests with paid tickets.",
+      "Approve or decline a single guest on a Luma event, including pending guests. " +
+      "Use should_refund when declining guests who paid for registration.",
     schema: {
       event_api_id: z.string().describe("The API ID of the event."),
       guest_api_id_or_email: z
@@ -218,7 +219,7 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether to refund the guest when declining (for paid tickets)."
+          "Whether to refund the guest when declining (for paid registrations)."
         ),
     },
     stake: "medium",
@@ -270,9 +271,9 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
   },
   search_guests: {
     description:
-      "Search for a guest by name or email across all registrations of an event. " +
+      "Find a specific attendee by name or email across all registrations of a Luma event. " +
       "Fetches all guests internally and filters by the query string (case-insensitive partial match). " +
-      "Use this when you need to find a specific person. May take a moment for large events.",
+      "Use this to locate one person. May take a moment for large events.",
     schema: {
       event_api_id: z
         .string()

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1156,6 +1156,56 @@ export const QUERIES: LabeledQuery[] = [
     expected: "fathom.get_transcript",
   },
 
+  // --- luma ---
+  {
+    query: "which Luma account is the api key configured for",
+    expected: "luma.get_authenticated_user",
+  },
+  {
+    query: "get the details of a Luma event by id",
+    expected: "luma.get_event",
+  },
+  {
+    query: "list upcoming events on my Luma calendar",
+    expected: "luma.list_events",
+  },
+  {
+    query: "create a new event on Luma",
+    expected: "luma.create_event",
+  },
+  {
+    query: "edit the start time of a Luma event",
+    expected: "luma.update_event",
+  },
+  {
+    query: "list the guests registered for a Luma event",
+    expected: "luma.list_guests",
+  },
+  {
+    query: "get the registration details of one Luma guest",
+    expected: "luma.get_guest",
+  },
+  {
+    query: "approve a pending guest on a Luma event",
+    expected: "luma.update_guest_status",
+  },
+  {
+    query: "add guests to a Luma event by email",
+    expected: "luma.add_guests",
+  },
+  {
+    query: "send email invitations for a Luma event",
+    expected: "luma.send_invites",
+  },
+  {
+    query: "find a specific attendee by name in a Luma event",
+    expected: "luma.search_guests",
+  },
+  {
+    query: "show registration counts and check-in rate for a Luma event",
+    expected: "luma.get_event_insights",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -28,6 +28,7 @@ import { IMAGE_GENERATION_SERVER } from "@app/lib/api/actions/servers/image_gene
 import { INCLUDE_DATA_SERVER } from "@app/lib/api/actions/servers/include_data/metadata";
 import { INTERACTIVE_CONTENT_SERVER } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
+import { LUMA_SERVER } from "@app/lib/api/actions/servers/luma/metadata";
 import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
 import { MONDAY_SERVER } from "@app/lib/api/actions/servers/monday/metadata";
@@ -167,6 +168,7 @@ const SERVERS: ServerEntry[] = [
   { name: "image_generation", tools: IMAGE_GENERATION_SERVER.tools },
   { name: "file_generation", tools: FILE_GENERATION_SERVER.tools },
   { name: "fathom", tools: FATHOM_SERVER.tools },
+  { name: "luma", tools: LUMA_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

- Tweaks the `luma` MCP server tool descriptions so they rank and segregate better under the BM25 norm used by tool-search. Reworded descriptions for `get_event`, `update_event`, `get_guest`, `update_guest_status`, and `search_guests` to avoid a vague phrasing that can collide across tools.
- Registers `luma` in the BM25 testing script.
- No behavior change: only tool description/schema text and test-harness wiring.

## Tests

- Ran the BM25 harness locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
