### PR TITLE
chore(mcp): improve gong tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/gong/metadata.ts
+++ b/front/lib/api/actions/servers/gong/metadata.ts
@@ -36,8 +36,8 @@ export const GONG_TOOLS_METADATA = createToolsRecord({
   },
   get_call: {
     description:
-      "Retrieve detailed information about a specific call by its ID. Returns comprehensive call data including " +
-      "participants, topics discussed, key points, action items, call summary, and interaction statistics.",
+      "Retrieve the details and summary of a specific Gong call by its ID. Returns comprehensive call data including " +
+      "participants, topics discussed, key points, action items, the call summary, and interaction statistics.",
     schema: {
       callId: z
         .string()

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1109,7 +1109,8 @@ export const QUERIES: LabeledQuery[] = [
     expected: "clari_copilot.get_call_details",
   },
   {
-    query: "show the transcript and competitor mentions of a clari copilot call",
+    query:
+      "show the transcript and competitor mentions of a clari copilot call",
     expected: "clari_copilot.get_call_details",
   },
 
@@ -1210,6 +1211,20 @@ export const QUERIES: LabeledQuery[] = [
   {
     query: "extract structured data from documents into a json schema",
     expected: "extract_data.extract_information_from_documents",
+  },
+
+  // --- gong ---
+  {
+    query: "list my recent Gong calls from last week",
+    expected: "gong.list_calls",
+  },
+  {
+    query: "get the details and summary of this Gong call",
+    expected: "gong.get_call",
+  },
+  {
+    query: "show me the transcript of this Gong call",
+    expected: "gong.get_call_transcript",
   },
 
   // --- cross-server (no platform named) ---

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -22,6 +22,7 @@ import { FATHOM_SERVER } from "@app/lib/api/actions/servers/fathom/metadata";
 import { FILE_GENERATION_SERVER } from "@app/lib/api/actions/servers/file_generation/metadata";
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
+import { GONG_SERVER } from "@app/lib/api/actions/servers/gong/metadata";
 import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
 import { GOOGLE_SHEETS_SERVER } from "@app/lib/api/actions/servers/google_sheets/metadata";
 import { HUBSPOT_SERVER } from "@app/lib/api/actions/servers/hubspot/metadata";
@@ -171,6 +172,7 @@ const SERVERS: ServerEntry[] = [
   { name: "fathom", tools: FATHOM_SERVER.tools },
   { name: "luma", tools: LUMA_SERVER.tools },
   { name: "extract_data", tools: EXTRACT_DATA_SERVER.tools },
+  { name: "gong", tools: GONG_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

- Adds the `gong` server to the BM25 tool-search testing script (`scripts/mcp_bm25/run.ts` import + `SERVERS` entry) with one labeled query per tool in `scripts/mcp_bm25/queries.ts` (`list_calls`, `get_call`, `get_call_transcript`).
- Tweaks the `gong.get_call` description to "Retrieve the details and summary of a specific Gong call ..." (adding "details", "summary", and the platform name "Gong"). Without this, tools from `clari_copilot` could match for the "get the details and summary of this Gong call" query.
- No behavior change.

## Tests

- Tested locally with the BM25 harness.

## Risk

- Low.

## Deploy Plan

- Deploy front.
