### PR TITLE
chore(mcp): improve github tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -6,7 +6,9 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const GITHUB_TOOLS_METADATA = createToolsRecord({
   create_issue: {
-    description: "Create a new issue on a specified GitHub repository.",
+    description:
+      "Create or file a brand new issue (a bug report or feature request) on" +
+      " a specified GitHub repository, optionally with assignees and labels.",
     schema: {
       owner: z
         .string()
@@ -113,7 +115,7 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
   },
   create_pull_request_review: {
     description:
-      "Create a review on a pull request with optional line comments.",
+      "Approve, request changes on, or submit a review verdict for a pull request, with optional inline line comments.",
     schema: {
       owner: z
         .string()
@@ -233,7 +235,7 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
   },
   list_discussion_categories: {
     description:
-      "List the discussion categories available in a GitHub repository. Use this to get the category ID required when creating a discussion.",
+      "List the available discussion categories in a GitHub repository. Use this to get the category ID required to create one.",
     schema: {
       owner: z
         .string()
@@ -257,7 +259,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_discussion: {
-    description: "Create a new discussion in a GitHub repository.",
+    description:
+      "Create and start a brand new single GitHub discussion thread under a chosen category.",
     schema: {
       owner: z
         .string()
@@ -328,7 +331,7 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
   },
   get_discussion_comments: {
     description:
-      "Retrieve comments from a specified GitHub discussion with pagination.",
+      "Retrieve, fetch, and list the comments posted on a specified GitHub discussion, with pagination.",
     schema: {
       owner: z
         .string()
@@ -354,7 +357,7 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
   },
   list_discussions: {
     description:
-      "List discussions from a specified GitHub repository with optional filtering.",
+      "List discussions in a GitHub repository: browse and enumerate the repository's discussions, returning many discussions with optional filtering.",
     schema: {
       owner: z
         .string()
@@ -373,19 +376,19 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       sort: z
         .enum(["CREATED_AT", "UPDATED_AT"])
         .optional()
-        .describe("What to sort results by. Defaults to UPDATED_AT."),
+        .describe("Sort field. Defaults to UPDATED_AT."),
       direction: z
         .enum(["ASC", "DESC"])
         .optional()
-        .describe("The direction of the sort. Defaults to DESC."),
+        .describe("Sort direction. Defaults to DESC."),
       perPage: z
         .number()
         .min(1)
         .max(100)
         .optional()
         .describe("Results per page. Defaults to 50, max 100."),
-      after: z.string().optional().describe("The cursor to start after."),
-      before: z.string().optional().describe("The cursor to start before."),
+      after: z.string().optional().describe("Pagination cursor."),
+      before: z.string().optional().describe("Pagination cursor."),
     },
     stake: "never_ask",
     displayLabels: {
@@ -395,7 +398,7 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
   },
   get_issue: {
     description:
-      "Retrieve an issue from a specified GitHub repository including its description, comments, and labels.",
+      "Retrieve and read the full details of a single issue from a specified GitHub repository, including its description, comments, and labels.",
     schema: {
       owner: z
         .string()
@@ -478,20 +481,16 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
   },
   search_advanced: {
     description:
-      "Search issues and pull requests using GitHub's advanced search syntax with AND/OR operators and nested searches. " +
-      "Supports advanced query syntax like 'is:issue AND assignee:@me AND (label:support OR comments:>5)' or 'is:pr AND assignee:@me'. " +
-      "Use 'is:issue' to search for issues, 'is:pr' to search for pull requests, or omit to search both. " +
-      "Note that `@me` behavior depends on the connection type: " +
-      "with a personal connection, `@me` resolves to the user's GitHub account (example: `is:issue AND assignee:@me`); " +
-      "with a workspace (shared) connection, `@me` resolves to the Dust GitHub App bot, NOT the user, " +
-      "use the user's actual GitHub username instead (example: `is:issue AND assignee:username`).",
+      "Search GitHub issues and pull requests using GitHub's advanced search syntax with AND/OR operators and nested filters. " +
+      "Use 'is:issue' for issues, 'is:pr' for pull requests, or omit to search both. " +
+      "The `@me` qualifier resolves to the authenticated account on a personal connection, but on a workspace (shared) connection it resolves to the Dust GitHub App bot, so pass the GitHub username explicitly there.",
     schema: {
       query: z
         .string()
         .describe(
-          "The advanced search query string. Supports AND/OR operators and nested searches. " +
-            "Examples: 'is:issue AND assignee:username AND (label:bug OR comments:>5)', 'is:pr AND assignee:@me', or 'assignee:username' to search both. " +
-            "Note: Spaces between multiple repo/org/user filters are treated as AND operators."
+          "The advanced search query string. Supports AND/OR operators and nested filters. " +
+            "Examples: 'is:issue AND assignee:username AND (label:bug OR comments:>5)', 'is:pr AND assignee:@me'. " +
+            "Spaces between repo/org/user filters are treated as AND operators."
         ),
       first: z
         .number()

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1341,6 +1341,85 @@ export const QUERIES: LabeledQuery[] = [
     expected: "google_calendar.get_user_timezones",
   },
 
+  // --- github ---
+  {
+    query: "open a new github issue for this bug",
+    expected: "github.create_issue",
+  },
+  {
+    query: "close a github issue and update its labels",
+    expected: "github.update_issue",
+  },
+  {
+    query: "show me the diff and reviews of a github pull request",
+    expected: "github.get_pull_request",
+  },
+  {
+    query: "approve a github pull request with review comments",
+    expected: "github.create_pull_request_review",
+  },
+  {
+    query: "list the open project boards in my github organization",
+    expected: "github.list_organization_projects",
+  },
+  {
+    query: "add a github issue to a project board",
+    expected: "github.add_issue_to_project",
+  },
+  {
+    query: "leave a comment on a github issue",
+    expected: "github.comment_on_issue",
+  },
+  {
+    query: "what discussion categories are available in this github repo",
+    expected: "github.list_discussion_categories",
+  },
+  {
+    query: "start a new github discussion in the repo",
+    expected: "github.create_discussion",
+  },
+  {
+    query: "reply to a github discussion thread",
+    expected: "github.comment_on_discussion",
+  },
+  {
+    query: "read a github discussion and its category",
+    expected: "github.get_discussion",
+  },
+  {
+    query: "fetch the comments on a github discussion",
+    expected: "github.get_discussion_comments",
+  },
+  {
+    query: "list the discussions in a github repository",
+    expected: "github.list_discussions",
+    // create_discussion is a much shorter sibling sharing the same
+    // github/discussion/repository tokens, so BM25 length normalization keeps
+    // it just above this longer, filter-heavy list tool; the user's "list"
+    // verb cannot fully overcome the short-document advantage.
+    maxRank: 2,
+  },
+  {
+    query: "get the details and comments of a github issue",
+    expected: "github.get_issue",
+  },
+  {
+    query: "read the project custom field values on a github issue",
+    expected: "github.get_issue_custom_fields",
+  },
+  {
+    query: "list the open issues in a github repository",
+    expected: "github.list_issues",
+  },
+  {
+    query: "search github issues and pull requests assigned to me",
+    expected: "github.search_advanced",
+  },
+  {
+    query: "list the open pull requests in a github repository",
+    expected: "github.list_pull_requests",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -23,6 +23,7 @@ import { FILE_GENERATION_SERVER } from "@app/lib/api/actions/servers/file_genera
 import { FILES_SERVER } from "@app/lib/api/actions/servers/files/metadata";
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
+import { GITHUB_SERVER } from "@app/lib/api/actions/servers/github/metadata";
 import { GMAIL_SERVER } from "@app/lib/api/actions/servers/gmail/metadata";
 import { GONG_SERVER } from "@app/lib/api/actions/servers/gong/metadata";
 import { GOOGLE_CALENDAR_SERVER } from "@app/lib/api/actions/servers/google_calendar/metadata";
@@ -179,6 +180,7 @@ const SERVERS: ServerEntry[] = [
   { name: "files", tools: FILES_SERVER.tools },
   { name: "gmail", tools: GMAIL_SERVER.tools },
   { name: "google_calendar", tools: GOOGLE_CALENDAR_SERVER.tools },
+  { name: "github", tools: GITHUB_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

- Tweaks the `github` MCP server tool descriptions so the tools rank and segregate better under the BM25 norm used by tool-search.
- Also adds sample queries in the BM25 testing script and tweaks the max queries for some existing ones

## Tests

- Ran the BM25 retrieval harness locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
