### PR TITLE
fix(google-calendar): normalize UTC-offset timezones in list_events

### DIFF
--- a/front/lib/api/actions/servers/google_calendar/helpers.test.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.test.ts
@@ -1,5 +1,12 @@
-import type { EnrichedGoogleCalendarEvent } from "@app/lib/api/actions/servers/google_calendar/helpers";
-import { formatEventAsText } from "@app/lib/api/actions/servers/google_calendar/helpers";
+import type {
+  EnrichedGoogleCalendarEvent,
+  GoogleCalendarEvent,
+} from "@app/lib/api/actions/servers/google_calendar/helpers";
+import {
+  enrichEventWithDayOfWeek,
+  formatEventAsText,
+  normalizeTimezone,
+} from "@app/lib/api/actions/servers/google_calendar/helpers";
 import { describe, expect, it } from "vitest";
 
 describe("formatEventAsText - attachments", () => {
@@ -58,5 +65,47 @@ describe("formatEventAsText - attachments", () => {
     const text = formatEventAsText(event);
 
     expect(text).not.toContain("Attachments:");
+  });
+});
+
+describe("normalizeTimezone", () => {
+  it("keeps valid IANA timezone names", () => {
+    expect(normalizeTimezone("Europe/Paris")).toBe("Europe/Paris");
+    expect(normalizeTimezone("America/New_York")).toBe("America/New_York");
+    expect(normalizeTimezone("UTC")).toBe("UTC");
+  });
+
+  it("converts GMT/UTC offset strings to Intl-compatible offsets", () => {
+    expect(normalizeTimezone("GMT+02:00")).toBe("+02:00");
+    expect(normalizeTimezone("GMT-05:00")).toBe("-05:00");
+    expect(normalizeTimezone("UTC+1")).toBe("+01:00");
+    expect(normalizeTimezone("GMT+05:30")).toBe("+05:30");
+  });
+
+  it("returns null for empty or unparseable values", () => {
+    expect(normalizeTimezone(null)).toBeNull();
+    expect(normalizeTimezone(undefined)).toBeNull();
+    expect(normalizeTimezone("")).toBeNull();
+    expect(normalizeTimezone("Not/AZone")).toBeNull();
+  });
+});
+
+describe("enrichEventWithDayOfWeek - timezone handling", () => {
+  it("does not throw on UTC offset timezones once normalized", () => {
+    const event: GoogleCalendarEvent = {
+      summary: "Timed meeting",
+      start: { dateTime: "2026-06-30T10:00:00Z" },
+      end: { dateTime: "2026-06-30T11:00:00Z" },
+    };
+
+    expect(() =>
+      enrichEventWithDayOfWeek(event, normalizeTimezone("GMT+02:00"))
+    ).not.toThrow();
+
+    const enriched = enrichEventWithDayOfWeek(
+      event,
+      normalizeTimezone("GMT+02:00")
+    );
+    expect(enriched.start?.eventDayOfWeek).toBe("Tuesday");
   });
 });

--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -138,6 +138,40 @@ export async function getCalendarClient(authInfo?: AuthInfo) {
   });
 }
 
+function isValidTimeZone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function normalizeTimezone(
+  timezone: string | null | undefined
+): string | null {
+  if (!timezone) {
+    return null;
+  }
+
+  if (isValidTimeZone(timezone)) {
+    return timezone;
+  }
+
+  const offsetMatch = timezone
+    .trim()
+    .match(/^(?:GMT|UTC)\s*([+-])(\d{1,2})(?::?(\d{2}))?$/i);
+  if (offsetMatch) {
+    const [, sign, hours, minutes = "00"] = offsetMatch;
+    const candidate = `${sign}${hours.padStart(2, "0")}:${minutes}`;
+    if (isValidTimeZone(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
 export function getUserTimezone(
   agentLoopContext?: AgentLoopContextType
 ): string | null {
@@ -162,7 +196,7 @@ export function getUserTimezone(
         userMessage.context &&
         "timezone" in userMessage.context
       ) {
-        return userMessage.context.timezone;
+        return normalizeTimezone(userMessage.context.timezone);
       }
     }
   }


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9230

The conversation context timezone is sometimes a UTC offset string (e.g. "GMT+02:00") rather than an IANA name. Intl.DateTimeFormat only accepts IANA names or "±HH:MM" offsets, so formatting timed events crashed with "Invalid time zone specified: GMT+02:00".

Normalize the timezone in getUserTimezone: keep valid values, convert "GMT/UTC±HH:MM" offsets to the Intl-compatible "±HH:MM" form, and fall back to null when unparseable.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
