### PR TITLE
fix(front): classify Anthropic mid-stream errors like the old router

### DIFF
--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
@@ -528,7 +528,51 @@ describe("streamErrorToErrorEvent", () => {
     );
   });
 
-  it("maps a non-SDK error to unknown_error", () => {
+  // An `APIError` raised mid-stream from an SSE `error` event carries no HTTP
+  // status; like the old router we default it to 500 (server_error) instead of
+  // collapsing it to unknown_error.
+  it("maps a statusless APIError to server_error", () => {
+    const err = new APIError(
+      undefined,
+      { error: { type: "overloaded_error", message: "Overloaded" } },
+      "overloaded",
+      undefined,
+      "overloaded_error"
+    );
+    expect(streamErrorToErrorEvent(metadata, err).content.type).toBe(
+      "server_error"
+    );
+  });
+
+  // The SDK rewraps any non-APIError stream-body failure (connection drop, SSE
+  // parse failure, stream-invariant violation) into a bare `AnthropicError`.
+  // The old router substring-matched these to keep transient failures retryable;
+  // we replicate that classification (see `bareStreamErrorToErrorEvent`).
+  it.each([
+    ["terminated", "network_error"],
+    ["other side closed", "network_error"],
+    ["socket hang up, connection reset", "network_error"],
+    ["ECONNREFUSED", "network_error"],
+    ["too many requests", "rate_limit_error"],
+    ["Overloaded", "overloaded_error"],
+    ["request timed out", "timeout_error"],
+    ["stream interrupted", "stream_error"],
+    ["internal server error", "server_error"],
+  ] as const)("classifies bare AnthropicError %j as %s (old-router parity)", (message, expectedType) => {
+    const err = new AnthropicError(message);
+    expect(streamErrorToErrorEvent(metadata, err).content.type).toBe(
+      expectedType
+    );
+  });
+
+  it("maps an unclassifiable bare error to unknown_error", () => {
+    const err = new AnthropicError("something inexplicable happened");
+    expect(streamErrorToErrorEvent(metadata, err).content.type).toBe(
+      "unknown_error"
+    );
+  });
+
+  it("maps a non-SDK error with no matchable message to unknown_error", () => {
     expect(streamErrorToErrorEvent(metadata, "boom").content.type).toBe(
       "unknown_error"
     );

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -23,6 +23,7 @@ import {
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type {
   ErrorEvent,
+  ErrorType,
   ModelResponseEvent,
   NonDeltaResponseEvent,
   ProviderPassthroughEvent,
@@ -41,6 +42,7 @@ import {
   assertNever,
   assertNeverAndIgnore,
 } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isRecord } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 
@@ -401,7 +403,9 @@ function apiErrorToErrorEvent(
   metadata: EndpointMetadata,
   error: APIError
 ): ErrorEvent {
-  const status = error.status;
+  // Mid-stream SSE `error` events surface as an `APIError` with no HTTP status;
+  // the old router defaulted those to 500, so mirror that here.
+  const status = error.status ?? 500;
   switch (status) {
     case 400:
     case 422:
@@ -493,15 +497,127 @@ export function streamErrorToErrorEvent(
     case "api":
       return apiErrorToErrorEvent(metadata, classified.error);
     case "unknown":
-      return buildErrorEvent({
-        metadata,
-        type: "unknown_error",
-        message: `Unknown error from Anthropic`,
-        originalError: error,
-      });
+      return bareStreamErrorToErrorEvent(metadata, error);
     default:
       assertNever(classified);
   }
+}
+
+// Errors that are neither an `APIError` nor an `APIConnectionError` reach here —
+// most commonly a mid-stream connection drop the SDK rewraps as a bare
+// `AnthropicError`. The old router classified these by substring-matching the
+// message (its `categorizeLLMError`), which kept transient failures retryable
+// instead of collapsing them into a terminal unknown_error. We replicate that
+// here verbatim for migration parity (see CODING_RULES GEN1); revisit once the
+// old router is fully retired. The new `ErrorType` union has no
+// `terminated_error`/`context_length_exceeded`, so those map to the closest
+// retryability-equivalent type (network_error / invalid_request_error).
+function bareStreamErrorToErrorEvent(
+  metadata: EndpointMetadata,
+  error: unknown
+): ErrorEvent {
+  const message = normalizeError(error).message;
+  const lower = message.toLowerCase();
+
+  const build = (type: ErrorType, text: string): ErrorEvent =>
+    buildErrorEvent({ metadata, type, message: text, originalError: error });
+
+  if (lower.includes("terminated") || lower.includes("other side closed")) {
+    return build(
+      "network_error",
+      `Connection to Anthropic terminated: ${message}`
+    );
+  }
+  if (
+    lower.includes("rate limit") ||
+    lower.includes("quota exceeded") ||
+    lower.includes("too many requests")
+  ) {
+    return build(
+      "rate_limit_error",
+      `Rate limit exceeded for Anthropic/${metadata.modelId}: ${message}`
+    );
+  }
+  if (
+    lower.includes("overloaded") ||
+    lower.includes("capacity") ||
+    lower.includes("service unavailable")
+  ) {
+    return build("overloaded_error", `Anthropic is overloaded: ${message}`);
+  }
+  if (
+    lower.includes("context") ||
+    lower.includes("token limit") ||
+    lower.includes("context window") ||
+    lower.includes("too large")
+  ) {
+    return build(
+      "invalid_request_error",
+      `Context length exceeded for Anthropic/${metadata.modelId}: ${message}`
+    );
+  }
+  if (
+    lower.includes("unauthorized") ||
+    lower.includes("authentication") ||
+    lower.includes("api key")
+  ) {
+    return build(
+      "authentication_error",
+      `Authentication failed for Anthropic: ${message}`
+    );
+  }
+  if (lower.includes("forbidden") || lower.includes("permission")) {
+    return build(
+      "permission_error",
+      `Permission denied for Anthropic: ${message}`
+    );
+  }
+  if (lower.includes("not found")) {
+    return build(
+      "not_found_error",
+      `Resource not found for Anthropic: ${message}`
+    );
+  }
+  if (
+    lower.includes("invalid request") ||
+    lower.includes("bad request") ||
+    lower.includes("validation error")
+  ) {
+    return build(
+      "invalid_request_error",
+      `Invalid request to Anthropic: ${message}`
+    );
+  }
+  if (
+    lower.includes("network") ||
+    lower.includes("connection") ||
+    lower.includes("econnrefused") ||
+    lower.includes("enotfound") ||
+    lower.includes("etimedout")
+  ) {
+    return build(
+      "network_error",
+      `Network error connecting to Anthropic: ${message}`
+    );
+  }
+  if (lower.includes("timeout") || lower.includes("timed out")) {
+    return build("timeout_error", `Request to Anthropic timed out: ${message}`);
+  }
+  if (
+    lower.includes("stream") ||
+    lower.includes("streaming") ||
+    lower.includes("interrupted")
+  ) {
+    return build("stream_error", `Stream error from Anthropic: ${message}`);
+  }
+  if (
+    lower.includes("internal server error") ||
+    lower.includes("server error")
+  ) {
+    return build("server_error", `Server error from Anthropic: ${message}`);
+  }
+
+  return build("unknown_error", `Unknown error from Anthropic: ${message}`);
 }
 
 // -- Composite state machine: depends on the leaf converters --


### PR DESCRIPTION
## Description

Since the `use_new_llm_router` rollout, mid-stream Anthropic failures (socket reset / premature close) surface as terminal `unknown_error` ("Unknown error from Anthropic") across sonnet/opus/haiku. Zero before 2026-06-17, ~284 on 2026-06-30.

The SDK's `messages.stream()` rewraps non-`APIError` body-read failures into a bare `AnthropicError` (it's not an `APIConnectionError` — that's only built at connect time). `classifyStreamError` matched none of its cases and fell through to a non-retryable `unknown_error`. The old router (`lib/api/llm`) classified the same errors via `categorizeLLMError` and kept them retryable, so they were silently retried and never surfaced.

This restores the old router's classification:
- `apiErrorToErrorEvent`: default missing status to 500 (mirrors `categorizeAnthropicError`'s `status ?? 500`).
- New `bareStreamErrorToErrorEvent`: ports `categorizeLLMError`'s substring matching to the new `ErrorType` union.

Substring matching is a deliberate 1:1 replica of the old router for migration parity (GEN1); commented to revisit once it's retired.

## Tests

Added parity cases in `output/utils.test.ts` (bare `AnthropicError` → network/rate-limit/overloaded/timeout/stream/server, unmatched → unknown; statusless `APIError` → server_error). 86 pass; tsgo + biome clean.

## Risk

Low, confined to Anthropic stream-error classification. Worst case: a terminal error containing a matched keyword gets retried a few times before failing. Matches old-router behavior. Revert to roll back.

## Deploy Plan

Standard deploy, no migration. Watch `@errorContent.message:"Unknown error from Anthropic"` drop after rollout.