### PR TITLE
feat: bubble up ask_user_question for sub-agents

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1299,7 +1299,6 @@ function AgentMessageContent({
       triggeringUser={triggeringUser}
       owner={owner}
       conversationId={conversationId}
-      messageId={sId}
       retryHandler={retryHandlerWithResetState}
     />
   ) : null;

--- a/front/components/assistant/conversation/BlockedAction.tsx
+++ b/front/components/assistant/conversation/BlockedAction.tsx
@@ -11,7 +11,6 @@ interface BlockedActionProps {
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
   conversationId: string;
-  messageId: string;
   retryHandler: (params: {
     conversationId: string;
     messageId: string;
@@ -23,7 +22,6 @@ export function BlockedAction({
   triggeringUser,
   owner,
   conversationId,
-  messageId,
   retryHandler,
 }: BlockedActionProps) {
   switch (blockedAction.status) {
@@ -72,8 +70,12 @@ export function BlockedAction({
           blockedAction={blockedAction}
           triggeringUser={triggeringUser}
           owner={owner}
-          conversationId={conversationId}
-          messageId={messageId}
+          retryHandler={() =>
+            retryHandler({
+              conversationId: blockedAction.conversationId,
+              messageId: blockedAction.messageId,
+            })
+          }
         />
       );
 

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -15,6 +15,7 @@ import { UserAnswerRequired } from "./UserAnswerRequired";
 
 const removeCompletedActionMock = vi.fn();
 const answerQuestionMock = vi.fn();
+const retryHandlerMock = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("@app/lib/auth/AuthContext", () => ({
   useAuth: () => ({
@@ -221,8 +222,7 @@ describe("UserAnswerRequired", () => {
         blockedAction={makeBlockedAction()}
         triggeringUser={null}
         owner={owner}
-        conversationId="conv_1"
-        messageId="msg_1"
+        retryHandler={retryHandlerMock}
       />
     );
 
@@ -246,8 +246,7 @@ describe("UserAnswerRequired", () => {
         blockedAction={makeBlockedAction()}
         triggeringUser={null}
         owner={owner}
-        conversationId="conv_1"
-        messageId="msg_1"
+        retryHandler={retryHandlerMock}
       />
     );
 
@@ -275,8 +274,7 @@ describe("UserAnswerRequired", () => {
         blockedAction={makeBlockedAction()}
         triggeringUser={null}
         owner={owner}
-        conversationId="conv_1"
-        messageId="msg_1"
+        retryHandler={retryHandlerMock}
       />
     );
 
@@ -302,8 +300,7 @@ describe("UserAnswerRequired", () => {
         blockedAction={makeBlockedAction()}
         triggeringUser={null}
         owner={owner}
-        conversationId="conv_1"
-        messageId="msg_1"
+        retryHandler={retryHandlerMock}
       />
     );
 
@@ -329,8 +326,7 @@ describe("UserAnswerRequired", () => {
         blockedAction={makeBlockedAction({ multiSelect: true })}
         triggeringUser={null}
         owner={owner}
-        conversationId="conv_1"
-        messageId="msg_1"
+        retryHandler={retryHandlerMock}
       />
     );
 
@@ -369,8 +365,7 @@ describe("UserAnswerRequired", () => {
         blockedAction={makeBlockedAction({ multiSelect: true })}
         triggeringUser={null}
         owner={owner}
-        conversationId="conv_1"
-        messageId="msg_1"
+        retryHandler={retryHandlerMock}
       />
     );
 
@@ -411,8 +406,7 @@ describe("UserAnswerRequired", () => {
         blockedAction={makeBlockedAction({ multiSelect: true })}
         triggeringUser={null}
         owner={owner}
-        conversationId="conv_1"
-        messageId="msg_1"
+        retryHandler={retryHandlerMock}
       />
     );
 
@@ -433,8 +427,7 @@ describe("UserAnswerRequired", () => {
         blockedAction={makeBlockedAction()}
         triggeringUser={null}
         owner={owner}
-        conversationId="conv_1"
-        messageId="msg_1"
+        retryHandler={retryHandlerMock}
       />
     );
 
@@ -461,8 +454,7 @@ describe("UserAnswerRequired", () => {
         blockedAction={makeBlockedAction({ multiSelect: true })}
         triggeringUser={null}
         owner={owner}
-        conversationId="conv_1"
-        messageId="msg_1"
+        retryHandler={retryHandlerMock}
       />
     );
 
@@ -495,8 +487,7 @@ describe("UserAnswerRequired", () => {
         blockedAction={makeBlockedAction({ multiSelect: true })}
         triggeringUser={null}
         owner={owner}
-        conversationId="conv_1"
-        messageId="msg_1"
+        retryHandler={retryHandlerMock}
       />
     );
 

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -25,8 +25,7 @@ interface UserAnswerRequiredProps {
   };
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
-  conversationId: string;
-  messageId: string;
+  retryHandler: () => Promise<void>;
 }
 
 function isPrintableKey(e: KeyboardEvent<HTMLDivElement>) {
@@ -47,8 +46,7 @@ export function UserAnswerRequired({
   blockedAction,
   triggeringUser,
   owner,
-  conversationId,
-  messageId,
+  retryHandler,
 }: UserAnswerRequiredProps) {
   const { user } = useAuth();
   const { removeCompletedAction } = useBlockedActionsContext();
@@ -93,14 +91,20 @@ export function UserAnswerRequired({
     { isSkip = false }: { isSkip?: boolean } = {}
   ) {
     setIsSkipPending(isSkip);
+    // Submit against the action's own conversation/message: for a sub-agent
+    // question these are the child's ids (the action lives in the child
+    // conversation). For a direct question they equal the current conversation.
     const result = await answerQuestion({
-      conversationId,
-      messageId,
+      conversationId: blockedAction.conversationId,
+      messageId: blockedAction.messageId,
       actionId: blockedAction.actionId,
       answer,
     });
 
     if (result.success) {
+      // Resume the agent run. For a sub-agent question this also relaunches the
+      // blocked parent run (the child retry is a no-op once the answer is in).
+      await retryHandler();
       removeCompletedAction(blockedAction.actionId);
     }
 

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -669,7 +669,8 @@ const runAgent = async (
       } else if (
         event.type === "tool_approve_execution" ||
         event.type === "tool_personal_auth_required" ||
-        event.type === "tool_file_auth_required"
+        event.type === "tool_file_auth_required" ||
+        event.type === "tool_ask_user_question"
       ) {
         // Collect blocking events until the child marks one as the last blocking event for this
         // step, then stop the parent run_agent call and return a blocked response upstream.

--- a/front/lib/api/actions/servers/run_agent/types.ts
+++ b/front/lib/api/actions/servers/run_agent/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ToolAskUserQuestionEvent,
   ToolFileAuthRequiredEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
@@ -39,7 +40,8 @@ export function isRunAgentResumeState(
 export type RunAgentBlockingEvent =
   | MCPApproveExecutionEvent
   | ToolPersonalAuthRequiredEvent
-  | ToolFileAuthRequiredEvent;
+  | ToolFileAuthRequiredEvent
+  | ToolAskUserQuestionEvent;
 
 /**
  * Make a tool blocked awaiting input response.

--- a/front/lib/api/assistant/streaming/helpers.ts
+++ b/front/lib/api/assistant/streaming/helpers.ts
@@ -47,7 +47,8 @@ export function getEventMessageChannelId(event: AgentMessageEvents) {
     event.type === "tool_approve_execution" ||
     event.type === "tool_error" ||
     event.type === "tool_personal_auth_required" ||
-    event.type === "tool_file_auth_required"
+    event.type === "tool_file_auth_required" ||
+    event.type === "tool_ask_user_question"
   ) {
     return getMessageChannelId(
       event.metadata?.pubsubMessageId ?? event.messageId

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -83,6 +83,7 @@ export async function publishDeferredEventsActivity(
       case "tool_ask_user_question":
         eventToPublish = {
           ...event,
+          isLastBlockingEventForStep: isLastEvent,
           metadata: {
             ...event.metadata,
             // Override the message id to root the event to the right channel.

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1578,6 +1578,7 @@ const ToolAskUserQuestionEventSchema = ToolExecutionMetadataSchema.extend({
   configurationId: z.string(),
   conversationId: z.string(),
   created: z.number(),
+  isLastBlockingEventForStep: z.boolean().optional(),
   messageId: z.string(),
   question: UserQuestionItemSchema,
 });


### PR DESCRIPTION
## Description

When an agent spawns a sub-agent through the `run_agent` tool, the sub-agent's blocking events (tool approvals, personal/file auth) already bubble up to the parent conversation so the user can respond there. `ask_user_question` was the one blocking event left out of that chain — a sub-agent's question never surfaced in the parent, so the user couldn't answer and the run stalled.

This makes a sub-agent's question behave like a sub-agent's file-authorization request:

- collect `tool_ask_user_question` in the `run_agent` blocking-event loop and route it to the parent channel via `pubsubMessageId` (`getEventMessageChannelId`)
- stamp `isLastBlockingEventForStep` on the deferred question event in `publish_deferred_events` — auth events already carried it, questions didn't, so the parent step never finalized
- on answer, resume both runs through the existing FE `retryHandler` (`retryHandlerWithResetState`), the same two-call path file authorization uses: the child retry is a no-op once the answer is registered (the action is no longer blocked), and the parent's `blocked_child_action_input_required` retry relaunches the parent run. No `resume_ancestor_conversations` flag on the answer endpoints.
- submit the answer to the child conversation/message ids carried by the blocked action rather than the parent props (backward compatible: in the non-bubbled case those equal the current conversation)

## Tests

- `UserAnswerRequired.test.tsx` green (10/10) with the new `retryHandler` wiring.
- Manual end-to-end via the hive app: agent A (`run_agent` → agent B with `ask_user_question`) — question renders in A's conversation, answering targets the child id, both B and A resume to completion, and the pending question survives a parent reload.
- Regression: direct (non-sub-agent) `ask_user_question` and sub-agent approvals/file-auth unaffected.

## Risk

Low. The answer endpoints' request schema is unchanged. The resume is driven by the same FE retry handler that already powers sub-agent file authorization, so no new backend coordination path is introduced. Worst case the question doesn't bubble (current behavior). Safe to rollback.

## Deploy Plan

- [ ] Deploy the SDK (`@dust-tt/client` gains the optional `isLastBlockingEventForStep` field) and front-api before/with front so the bubbled event carries the field the parent step relies on.