### PR TITLE
SandboxFunctions: add support for podId/slugName

### DIFF
--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -95,15 +95,17 @@ async function setupSandboxFunction({
 
 function postInvocation({
   workspaceId,
-  functionId,
+  functionIdOrSlug,
   body = {},
 }: {
   workspaceId: string;
-  functionId: string;
+  functionIdOrSlug: string;
   body?: unknown;
 }) {
+  const encodedFunctionIdOrSlug = encodeURIComponent(functionIdOrSlug);
+
   return honoApp.request(
-    `/api/w/${workspaceId}/sandbox-functions/${functionId}/invocations`,
+    `/api/w/${workspaceId}/sandbox-functions/${encodedFunctionIdOrSlug}/invocations`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -112,7 +114,7 @@ function postInvocation({
   );
 }
 
-describe("POST /api/w/:wId/sandbox-functions/:functionId/invocations", () => {
+describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () => {
   it("creates an invocation through the sandbox function resource", async () => {
     const { workspace, sandboxFunction } = await setupSandboxFunction();
     const createdAt = new Date().toISOString();
@@ -129,7 +131,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionId/invocations", () => {
 
     const response = await postInvocation({
       workspaceId: workspace.sId,
-      functionId: sandboxFunction.sId,
+      functionIdOrSlug: sandboxFunction.sId,
       body: {
         input: { message: "hello" },
         context: { frameFileId: sandboxFunction.file.sId },
@@ -165,6 +167,34 @@ describe("POST /api/w/:wId/sandbox-functions/:functionId/invocations", () => {
     );
   });
 
+  it("creates an invocation by pod id and function slug", async () => {
+    const { workspace, sandboxFunction } = await setupSandboxFunction();
+    const createdAt = new Date().toISOString();
+    const invokeSpy = vi
+      .spyOn(SandboxFunctionResource.prototype, "invoke")
+      .mockResolvedValue(
+        new Ok({
+          sId: "test-invocation-id",
+          functionId: sandboxFunction.sId,
+          status: "created",
+          createdAt,
+        })
+      );
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: `${sandboxFunction.space.sId}/${sandboxFunction.slug}`,
+      body: {
+        input: { message: "hello" },
+      },
+    });
+
+    expect(response.status).toBe(201);
+    expect(invokeSpy).toHaveBeenCalledWith(expect.anything(), {
+      input: { message: "hello" },
+    });
+  });
+
   it("returns 404 when the user cannot access the function space", async () => {
     const { workspace, sandboxFunction } = await setupSandboxFunction({
       addCallerToSpace: false,
@@ -172,7 +202,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionId/invocations", () => {
 
     const response = await postInvocation({
       workspaceId: workspace.sId,
-      functionId: sandboxFunction.sId,
+      functionIdOrSlug: sandboxFunction.sId,
     });
 
     expect(response.status).toBe(404);
@@ -194,7 +224,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionId/invocations", () => {
 
     const response = await postInvocation({
       workspaceId: workspace.sId,
-      functionId: sandboxFunction.sId,
+      functionIdOrSlug: sandboxFunction.sId,
     });
 
     expect(response.status).toBe(201);
@@ -208,7 +238,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionId/invocations", () => {
 
     const response = await postInvocation({
       workspaceId: workspace.sId,
-      functionId: sandboxFunction.sId,
+      functionIdOrSlug: sandboxFunction.sId,
     });
 
     expect(response.status).toBe(500);
@@ -227,7 +257,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionId/invocations", () => {
 
     const response = await postInvocation({
       workspaceId: workspace.sId,
-      functionId: sandboxFunction.sId,
+      functionIdOrSlug: sandboxFunction.sId,
     });
 
     expect(response.status).toBe(403);

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -11,7 +11,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
-  functionId: z.string().min(1),
+  functionIdOrSlug: z.string().min(1),
 });
 
 const PostSandboxFunctionInvocationBodySchema = z
@@ -26,7 +26,7 @@ const PostSandboxFunctionInvocationBodySchema = z
   })
   .strict();
 
-// Mounted at /api/w/:wId/sandbox-functions/:functionId/invocations.
+// Mounted at /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations.
 const app = workspaceApp();
 
 /**
@@ -79,14 +79,14 @@ app.post(
   validate("json", PostSandboxFunctionInvocationBodySchema),
   async (ctx): HandlerResult<PostSandboxFunctionInvocationResponseBody> => {
     const auth = ctx.get("auth");
-    const { functionId } = ctx.req.valid("param");
+    const { functionIdOrSlug } = ctx.req.valid("param");
 
     const body: PostSandboxFunctionInvocationRequestBody =
       ctx.req.valid("json");
 
-    const sandboxFunction = await SandboxFunctionResource.fetchById(
+    const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
       auth,
-      functionId
+      functionIdOrSlug
     );
     if (!sandboxFunction) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/sandbox-functions/index.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/index.ts
@@ -12,6 +12,6 @@ app.use(
   })
 );
 
-app.route("/:functionId", functionId);
+app.route("/:functionIdOrSlug", functionId);
 
 export default app;

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -195,7 +195,7 @@ function useVisualizationDataHandler({
   vizIframeRef,
 }: {
   createSandboxFunctionInvocation: (
-    functionId: string,
+    functionIdOrSlug: string,
     input?: unknown
   ) => Promise<Result<SandboxFunctionInvocationType, Error>>;
   getFileBlob: (fileId: string) => Promise<Blob | null>;
@@ -264,7 +264,7 @@ function useVisualizationDataHandler({
       switch (data.command) {
         case "callFunction": {
           const invocationRes = await createSandboxFunctionInvocation(
-            data.params.functionId,
+            data.params.functionIdOrSlug,
             data.params.input
           );
 
@@ -283,7 +283,7 @@ function useVisualizationDataHandler({
 
           const result = await waitForSandboxFunctionInvocationResult({
             workspaceId,
-            functionId: data.params.functionId,
+            functionId: invocationRes.value.functionId,
             invocationId: invocationRes.value.sId,
           });
 
@@ -498,7 +498,7 @@ export const VisualizationActionIframe = forwardRef<
 
   const createSandboxFunctionInvocation = useCallback(
     async (
-      functionId: string,
+      functionIdOrSlug: string,
       input?: unknown
     ): Promise<Result<SandboxFunctionInvocationType, Error>> => {
       try {
@@ -513,8 +513,9 @@ export const VisualizationActionIframe = forwardRef<
           context: frameFileId ? { frameFileId } : undefined,
         };
 
+        const encodedFunctionIdOrSlug = encodeURIComponent(functionIdOrSlug);
         const response = await clientFetch(
-          `/api/w/${workspaceId}/sandbox-functions/${functionId}/invocations`,
+          `/api/w/${workspaceId}/sandbox-functions/${encodedFunctionIdOrSlug}/invocations`,
           {
             method: "POST",
             headers: {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -282,6 +282,31 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     return sandboxFunction ?? null;
   }
 
+  static async fetchByIdOrSlug(
+    auth: Authenticator,
+    functionIdOrSlug: string
+  ): Promise<SandboxFunctionResource | null> {
+    const sandboxFunction = await this.fetchById(auth, functionIdOrSlug);
+    if (sandboxFunction) {
+      return sandboxFunction;
+    }
+
+    const [podId, slug, ...rest] = functionIdOrSlug.split("/");
+    if (!podId || !slug || rest.length > 0) {
+      return null;
+    }
+    if (!isResourceSId("space", podId) || !isValidSandboxFunctionSlug(slug)) {
+      return null;
+    }
+
+    const space = await SpaceResource.fetchById(auth, podId);
+    if (!space) {
+      return null;
+    }
+
+    return this.fetchBySpaceAndSlug(auth, space, slug);
+  }
+
   static async deleteAllForSpace(
     auth: Authenticator,
     space: SpaceResource

--- a/front/types/assistant/visualization.ts
+++ b/front/types/assistant/visualization.ts
@@ -17,7 +17,7 @@ const GetFileParamsSchema = z.object({
 type GetFileParams = z.infer<typeof GetFileParamsSchema>;
 
 const CallFunctionParamsSchema = z.object({
-  functionId: z.string(),
+  functionIdOrSlug: z.string(),
   input: z.unknown().optional(),
 });
 


### PR DESCRIPTION
## Description

Adds support for `{podId}/{sandboxFunction.slugName}` as first argument of the `callFundion` viz function.

## Tests

Tested locally

## Risk

None

## Deploy Plan

- deploy `front`