### PR TITLE
fix: correct Productboard entity search request body against API schema

### DIFF
--- a/front/lib/api/actions/servers/productboard/client.ts
+++ b/front/lib/api/actions/servers/productboard/client.ts
@@ -372,7 +372,7 @@ export class ProductboardClient {
     }
 
     const filterData: Record<string, unknown> = {
-      type: filters.type,
+      type: [filters.type],
     };
 
     if (filters.ids !== undefined && filters.ids.length > 0) {

--- a/front/lib/api/actions/servers/productboard/client.ts
+++ b/front/lib/api/actions/servers/productboard/client.ts
@@ -356,8 +356,6 @@ export class ProductboardClient {
     statusNames?: string[];
     ownerIds?: string[];
     ownerEmails?: string[];
-    timeframeStartDate?: string;
-    timeframeEndDate?: string;
     fields?: "all" | "default";
     pageCursor?: string;
   }): Promise<
@@ -379,20 +377,13 @@ export class ProductboardClient {
       filterData.id = filters.ids;
     }
 
+    // Field-level filters: name, archived, status, owner all live under filter.fields
     const fieldFilters: Record<string, unknown> = {};
     if (filters.name !== undefined) {
       fieldFilters.name = filters.name;
     }
     if (filters.archived !== undefined) {
       fieldFilters.archived = filters.archived;
-    }
-    if (Object.keys(fieldFilters).length > 0) {
-      filterData.fields = fieldFilters;
-    }
-
-    const relationshipFilters: Record<string, unknown> = {};
-    if (filters.parentId !== undefined) {
-      relationshipFilters.parent = { id: filters.parentId };
     }
     if (
       (filters.statusIds !== undefined && filters.statusIds.length > 0) ||
@@ -405,7 +396,7 @@ export class ProductboardClient {
       if (filters.statusNames) {
         statuses.push(...filters.statusNames.map((name) => ({ name })));
       }
-      relationshipFilters.statuses = statuses;
+      fieldFilters.status = statuses;
     }
     if (
       (filters.ownerIds !== undefined && filters.ownerIds.length > 0) ||
@@ -418,24 +409,19 @@ export class ProductboardClient {
       if (filters.ownerEmails) {
         owners.push(...filters.ownerEmails.map((email) => ({ email })));
       }
-      relationshipFilters.owners = owners;
+      fieldFilters.owner = owners;
+    }
+    if (Object.keys(fieldFilters).length > 0) {
+      filterData.fields = fieldFilters;
+    }
+
+    // Relationship filters: only parent (as array) and customer are supported
+    const relationshipFilters: Record<string, unknown> = {};
+    if (filters.parentId !== undefined) {
+      relationshipFilters.parent = [{ id: filters.parentId }];
     }
     if (Object.keys(relationshipFilters).length > 0) {
       filterData.relationships = relationshipFilters;
-    }
-
-    if (
-      filters.timeframeStartDate !== undefined ||
-      filters.timeframeEndDate !== undefined
-    ) {
-      const timeframe: { startDate?: string; endDate?: string } = {};
-      if (filters.timeframeStartDate !== undefined) {
-        timeframe.startDate = filters.timeframeStartDate;
-      }
-      if (filters.timeframeEndDate !== undefined) {
-        timeframe.endDate = filters.timeframeEndDate;
-      }
-      filterData.timeframe = timeframe;
     }
 
     const bodyData: Record<string, unknown> = {

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -210,16 +210,6 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
         .array(z.string().email())
         .optional()
         .describe("Filter by owner emails"),
-      timeframe_start_date: z
-        .string()
-        .optional()
-        .describe(
-          "Filter by timeframe start date (ISO date format YYYY-MM-DD)"
-        ),
-      timeframe_end_date: z
-        .string()
-        .optional()
-        .describe("Filter by timeframe end date (ISO date format YYYY-MM-DD)"),
       fields: z
         .enum(["all", "default"])
         .optional()

--- a/front/lib/api/actions/servers/productboard/tools/index.ts
+++ b/front/lib/api/actions/servers/productboard/tools/index.ts
@@ -224,8 +224,6 @@ export function createProductboardTools(): ToolDefinition[] {
         status_names,
         owner_ids,
         owner_emails,
-        timeframe_start_date,
-        timeframe_end_date,
         fields,
         page_cursor,
       },
@@ -252,8 +250,6 @@ export function createProductboardTools(): ToolDefinition[] {
         statusNames: status_names,
         ownerIds: owner_ids,
         ownerEmails: owner_emails,
-        timeframeStartDate: timeframe_start_date,
-        timeframeEndDate: timeframe_end_date,
         fields,
         pageCursor: page_cursor,
       });


### PR DESCRIPTION
## Summary

- `query_entities` was failing on every call with validation errors from the Productboard API due to multiple mismatches between what we sent and what the API actually expects (cross-referenced against the Productboard v2 docs)
- `filter.type` was sent as a bare string — API requires an array: `["release"]`
- `filter.relationships.statuses` and `filter.relationships.owners` were in the wrong location with plural keys — API expects `filter.fields.status` and `filter.fields.owner` (singular, under `fields` not `relationships`)
- `filter.relationships.parent` was sent as `{ id }` — API requires an array `[{ id }]`
- `filter.timeframe` doesn't exist in the Productboard API — removed from client, tool handler, and tool schema

## Risk

Low. All changes are to the outbound request shape for a single tool (`query_entities`). No DB changes, no auth changes. The tool was broken before (100% validation error rate), so any regression would be immediately visible.

## Testing Plan

- [ ] Run the Release Note Writer skill against Productboard and confirm `query_entities` returns results instead of a validation error
- [ ] Test with `status_names` filter to confirm `filter.fields.status` is accepted
- [ ] Test with `parent_id` filter to confirm `filter.relationships.parent` array shape is accepted