### PR TITLE
fix(stt): fix leading blank line and websocket guard in live transcription compact mode

### DIFF
--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -91,7 +91,7 @@ const useEditorService = (editor: Editor | null, isMobileViewport: boolean) => {
           } else {
             editor
               .chain()
-              .insertContentAt(editor.state.doc.content.size, content, {
+              .insertContentAt(editor.state.doc.content.size - 1, content, {
                 updateSelection: false,
               })
               .run();
@@ -135,9 +135,11 @@ const useEditorService = (editor: Editor | null, isMobileViewport: boolean) => {
           } else {
             editor
               .chain()
-              .insertContentAt(editor.state.doc.content.size, committedText, {
-                updateSelection: false,
-              })
+              .insertContentAt(
+                editor.state.doc.content.size - 1,
+                committedText,
+                { updateSelection: false }
+              )
               .run();
           }
         }

--- a/front/hooks/useVoiceLiveTranscriberService.ts
+++ b/front/hooks/useVoiceLiveTranscriberService.ts
@@ -246,7 +246,7 @@ export function useVoiceLiveTranscriberService({
       const workletNode = new AudioWorkletNode(audioContext, "pcm-processor");
       workletNode.port.onmessage = (event: MessageEvent<ArrayBuffer>) => {
         const b64 = arrayBufferToBase64(event.data);
-        if (!isShuttingDownRef.current || scribeRef.current.isConnected) {
+        if (!isShuttingDownRef.current && scribeRef.current.isConnected) {
           scribeRef.current.sendAudio(b64, { sampleRate: SAMPLE_RATE_HZ });
         }
       };


### PR DESCRIPTION
## Description

Two bugs in the live speech-to-text compact mode:

**1. Leading blank line in submitted message (`useCustomEditor.tsx`)**

In the mobile-viewport path, voice partial/committed text was inserted using `insertContentAt(doc.content.size, ...)`. In ProseMirror, `doc.content.size` is the position *after* the last block node — a block boundary. Inserting an inline node there forces ProseMirror to wrap it in a new paragraph, leaving the original empty paragraph at the top. When serialized to markdown this produced a leading blank line. Fix: use `doc.content.size - 1`, which is the last valid inline position *inside* the last paragraph.

**2. `WebSocket is not connected` error on audio send (`useVoiceLiveTranscriberService.ts`)**

The guard before `sendAudio` used `||` instead of `&&`:
```
if (!isShuttingDownRef.current || scribeRef.current.isConnected)
```
During normal recording `isShuttingDownRef.current` is `false`, so `!false || anything` is always `true` — audio chunks were sent regardless of whether the WebSocket was open yet (e.g. before the connection handshake completed). Fix: `&&` so audio is only forwarded when both conditions hold.

## Tests

Tested manually in compact mode.
