### PR TITLE
chore(mcp): improve databricks tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1478,6 +1478,12 @@ export const QUERIES: LabeledQuery[] = [
     expected: "exa_people_and_company.search_companies",
   },
 
+  // --- databricks ---
+  {
+    query: "list the SQL warehouses in my Databricks workspace",
+    expected: "databricks.list_warehouses",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -18,6 +18,7 @@ import { COMMON_UTILITIES_SERVER } from "@app/lib/api/actions/servers/common_uti
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
 import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_warehouses/metadata";
+import { DATABRICKS_SERVER } from "@app/lib/api/actions/servers/databricks/metadata";
 import { EXA_SERVER } from "@app/lib/api/actions/servers/exa/metadata";
 import { EXTRACT_DATA_SERVER } from "@app/lib/api/actions/servers/extract_data/metadata";
 import { FATHOM_SERVER } from "@app/lib/api/actions/servers/fathom/metadata";
@@ -196,6 +197,7 @@ const SERVERS: ServerEntry[] = [
   },
   { name: "common_utilities", tools: COMMON_UTILITIES_SERVER.tools },
   { name: "exa_people_and_company", tools: EXA_SERVER.tools },
+  { name: "databricks", tools: DATABRICKS_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

Adds samples for the `databricks` internal MCP server in the offline BM25 tool-search testing script.
No change required in the tool description: it already has a good precision and recall on the sampled queries.

## Tests

- Tested locally with BM25 samples.

## Risk

- Low.

## Deploy Plan

- Deploy front.
