### PR TITLE
chore(mcp): improve exa tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/exa/metadata.ts
+++ b/front/lib/api/actions/servers/exa/metadata.ts
@@ -7,7 +7,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const EXA_TOOLS_METADATA = createToolsRecord({
   search_people: {
     description:
-      "Search for people by name, role, or company using Exa's people index. Use this to find LinkedIn profiles, professional backgrounds, or identify people at specific companies (e.g. 'CTO of Mistral AI', 'VP of Sales at French SaaS startups').",
+      "Find a person by name, job title, or employer using Exa's people directory. Looks up an individual's LinkedIn profile, professional background, and career history, or identifies who holds a given role at a specific company (e.g. 'CTO of Stripe', 'VP of Sales at French SaaS startups').",
     schema: {
       query: z
         .string()
@@ -42,7 +42,7 @@ export const EXA_TOOLS_METADATA = createToolsRecord({
   },
   search_companies: {
     description:
-      "Search for companies by name, industry, or criteria using Exa's company index. Use this to find company profiles, competitors, or market research (e.g. 'French AI startups', 'competitors of Notion').",
+      "Find a company, business, or startup by name, industry, or criteria using Exa's company directory. Looks up company profiles, identifies competitors, and surfaces firms matching a sector or market (e.g. 'French fintech startups', 'competitors of Notion').",
     schema: {
       query: z
         .string()

--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -1456,6 +1456,28 @@ export const QUERIES: LabeledQuery[] = [
     expected: "common_utilities.set_conversation_title",
   },
 
+  // --- exa_people_and_company ---
+  {
+    query: "find the LinkedIn profile of the CTO of Mistral AI",
+    expected: "exa_people_and_company.search_people",
+  },
+  {
+    query: "look up the professional background of a person by name and role",
+    expected: "exa_people_and_company.search_people",
+  },
+  {
+    query: "identify who runs sales at French SaaS startups",
+    expected: "exa_people_and_company.search_people",
+  },
+  {
+    query: "research French AI startups and their company profiles",
+    expected: "exa_people_and_company.search_companies",
+  },
+  {
+    query: "find competitors of Notion for market research",
+    expected: "exa_people_and_company.search_companies",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -18,6 +18,7 @@ import { COMMON_UTILITIES_SERVER } from "@app/lib/api/actions/servers/common_uti
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
 import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_warehouses/metadata";
+import { EXA_SERVER } from "@app/lib/api/actions/servers/exa/metadata";
 import { EXTRACT_DATA_SERVER } from "@app/lib/api/actions/servers/extract_data/metadata";
 import { FATHOM_SERVER } from "@app/lib/api/actions/servers/fathom/metadata";
 import { FILE_GENERATION_SERVER } from "@app/lib/api/actions/servers/file_generation/metadata";
@@ -194,6 +195,7 @@ const SERVERS: ServerEntry[] = [
     tools: HTTP_CLIENT_SERVER.tools.filter((t) => t.name === "send_request"),
   },
   { name: "common_utilities", tools: COMMON_UTILITIES_SERVER.tools },
+  { name: "exa_people_and_company", tools: EXA_SERVER.tools },
 ];
 
 function out(line: string): void {


### PR DESCRIPTION
## Description

This PR tweaks the `exa_people_and_company` tool descriptions so that the phrasing for each description ranks better to the intended tool in tool search and is better segregated with regard to the BM25 norm ([design doc](https://app.notion.com/p/dust-tt/Design-Doc-Anthropic-Token-Consumption-Cache-Efficiency-38728599d94180a2b7f8e101a776f564?source=copy_link#a7d3294f78444b25966d56efe3f3bd51), [tool-search doc](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)).

Also adds samples in the BM25 harness.

No behavior change (description wording only).

## Tests

- Tested locally with BM25 samples.

## Risk

- Low.

## Deploy Plan

- Deploy front.
