### PR TITLE
chore(mcp): improve data_sources_file_system tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1536,6 +1536,30 @@ const QUERIES: LabeledQuery[] = [
     expected: "databricks.list_warehouses",
   },
 
+  // --- data_sources_file_system ---
+  {
+    query: "read a connected data source document by its nodeId",
+    expected: "data_sources_file_system.cat",
+  },
+  {
+    query: "browse the folders and pages inside a connected data source",
+    expected: "data_sources_file_system.list",
+  },
+  {
+    query:
+      "semantically search connected data sources for content about a topic",
+    expected: "data_sources_file_system.semantic_search",
+  },
+  {
+    query: "find a wiki page in a data source by part of its title",
+    expected: "data_sources_file_system.find",
+  },
+  {
+    query:
+      "show the breadcrumb ancestor path of a node in the data source tree",
+    expected: "data_sources_file_system.locate_in_tree",
+  },
+
   // --- cross-server (no platform named) ---
   {
     query: "create a support ticket",

--- a/front/lib/api/actions/servers/bm25_tool_search_utils.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search_utils.test.ts
@@ -5,6 +5,7 @@ import { CLARI_COPILOT_SERVER } from "@app/lib/api/actions/servers/clari_copilot
 import { COMMON_UTILITIES_SERVER } from "@app/lib/api/actions/servers/common_utilities/metadata";
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
 import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversation_files/metadata";
+import { DATA_SOURCES_FILE_SYSTEM_SERVER } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_warehouses/metadata";
 import { DATABRICKS_SERVER } from "@app/lib/api/actions/servers/databricks/metadata";
 import { EXA_SERVER } from "@app/lib/api/actions/servers/exa/metadata";
@@ -189,4 +190,8 @@ export const SERVERS: ServerEntry[] = [
   { name: "microsoft_excel", tools: MICROSOFT_EXCEL_SERVER.tools },
   { name: "openai_usage", tools: OPENAI_USAGE_SERVER.tools },
   { name: "databricks", tools: DATABRICKS_SERVER.tools },
+  {
+    name: "data_sources_file_system",
+    tools: DATA_SOURCES_FILE_SYSTEM_SERVER.tools,
+  },
 ];

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -26,8 +26,8 @@ export const FILESYSTEM_LIST_TOOL_NAME = "list";
 export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
   [FILESYSTEM_CAT_TOOL_NAME]: {
     description:
-      "Read and retrieve the text content of a document or page by its nodeId (like 'cat' in Unix). " +
-      `Use to open, view, or read a specific file after locating it via '${FILESYSTEM_FIND_TOOL_NAME}', '${FILESYSTEM_LIST_TOOL_NAME}', or '${FILESYSTEM_SEARCH_TOOL_NAME}'. ` +
+      "Read the full text content of a connected data source document or page by its nodeId (like 'cat' in Unix). " +
+      `Use to open, view, or read a specific data source file after locating it via '${FILESYSTEM_FIND_TOOL_NAME}', '${FILESYSTEM_LIST_TOOL_NAME}', or '${FILESYSTEM_SEARCH_TOOL_NAME}'. ` +
       "The nodeId is the unique identifier exposed in the output of all navigation and search tools in this server. " +
       "The output reports the document's total size. For large documents, use 'grep' to extract only the relevant " +
       "content rather than paging through the whole document by incrementing 'offset', which exhausts the context window.",
@@ -55,9 +55,9 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
   },
   [FILESYSTEM_SEARCH_TOOL_NAME]: {
     description:
-      "Search for information, documents, or content by semantic similarity within the data source. " +
+      "Search semantically for information, documents, or content by topic, concept, or meaning within a connected data source. " +
       "Use to find relevant passages, answer questions, look up knowledge, or retrieve content from " +
-      "connected spaces. Searches all children of the designated nodeIds. " +
+      "connected data sources. Searches all children of the designated nodeIds. " +
       `Prefer this over '${FILESYSTEM_FIND_TOOL_NAME}' when you know what you're looking for conceptually but not the exact document title.`,
     schema: SearchWithNodesInputSchema.shape,
     stake: "never_ask",


### PR DESCRIPTION
## Description

Part of the ongoing effort to improve BM25 tool-search recall for internal MCP servers.

This PR tweaks the `data_sources_file_system` tool descriptions so each one ranks first for its intended user intent in tool search, and is better segregated under the BM25 norm ([tool-search doc](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)).

Also added sample queries in the BM25 harness.
No behavior change.

## Tests

- Tested locally with BM25 samples.

## Risk

- Low.

## Deploy Plan

- Deploy front.
