### PR TITLE
feat(dust-evals): support prompt file attachments and report agent cost credits

### DIFF
--- a/x/henry/dust-evals/README.md
+++ b/x/henry/dust-evals/README.md
@@ -117,6 +117,22 @@ prompt,judge_prompt
 "Explain photosynthesis","Should mention plants, sunlight, CO2, oxygen."
 ```
 
+### Attaching files to a prompt
+
+Add an optional `files` column to attach one or more files to the agent's
+message (as Dust content fragments). Separate multiple files with commas inside
+the quoted cell. Relative paths are resolved against the CSV file's directory.
+
+```csv
+prompt,judge_prompt,files
+"Compare these two datasets.","Should identify the main differences.","./data/a.csv,./data/b.csv"
+```
+
+Supported types map by extension (pdf, csv, txt, md, json, html, xml, yaml,
+docx, xlsx, png, jpg, jpeg, gif, webp); anything else is uploaded as a generic
+attachment. Dust's per-file size limits apply, and a file that cannot be read or
+uploaded fails that run with a clear error.
+
 ## Scoring Scales
 
 | Scale | Range | Use Case |
@@ -144,7 +160,7 @@ Use `--min-agreement 0.7` to flag results where judges disagreed significantly.
 
 Human-readable summary with:
 - Configuration overview
-- Per-agent statistics (avg score, error rate, timing)
+- Per-agent statistics (avg score, error rate, timing, cost in credits)
 - Sample results
 - Conversation IDs for debugging
 
@@ -161,7 +177,7 @@ Full structured data including:
 Tabular format with columns:
 - prompt, agent_id, run_number, response
 - final_score, judge_votes, judge_agreement
-- agent_duration_ms, agent_conversation_id
+- agent_duration_ms, agent_cost_credits, agent_conversation_id
 - error, was_timeout
 
 ### HTML

--- a/x/henry/dust-evals/claude.md
+++ b/x/henry/dust-evals/claude.md
@@ -82,6 +82,15 @@ prompt,judge_prompt
 "Explain photosynthesis","Should mention plants, sunlight, CO2, oxygen."
 ```
 
+Optional `files` column attaches files to the prompt (comma-separated, resolved
+relative to the CSV dir). Uploaded via `uploadFile` + `contentFragments` in
+`dust-client.ts`:
+
+```csv
+prompt,judge_prompt,files
+"Summarize this report.","Covers key findings.","./reports/q3.pdf"
+```
+
 ## Project Structure
 
 ```

--- a/x/henry/dust-evals/examples/files/categorization_pct.csv
+++ b/x/henry/dust-evals/examples/files/categorization_pct.csv
@@ -1,0 +1,6 @@
+AGENT_MESSAGE_CATEGORY;MESSAGE_COUNT;PCT
+Basic agent interaction;7850;43.1
+Advanced retrieval or push;4328;23.8
+Company data retrieval;2944;16.2
+Other/Unknown;2386;13.1
+Personal productivity;707;3.9

--- a/x/henry/dust-evals/examples/with_files.csv
+++ b/x/henry/dust-evals/examples/with_files.csv
@@ -1,0 +1,2 @@
+prompt,judge_prompt,files
+"Summarize this report.","Should cover the key findings.","./files/categorization_pct.csv"

--- a/x/henry/dust-evals/src/csv-loader.ts
+++ b/x/henry/dust-evals/src/csv-loader.ts
@@ -1,7 +1,24 @@
 import { parse } from "csv-parse/sync"
 import { readFile } from "fs/promises"
+import { dirname, isAbsolute, resolve } from "path"
 import type { EvalRow, Result } from "./types"
 import { Ok, Err } from "./types"
+
+/**
+ * Parse the optional `files` column into a list of absolute paths. Multiple
+ * files are comma-separated within the (quoted) cell. Relative paths are
+ * resolved against the CSV file's directory so prompt sets are portable.
+ */
+function parseFilesColumn(raw: string | undefined, csvDir: string): string[] {
+  if (!raw) {
+    return []
+  }
+  return raw
+    .split(",")
+    .map((f) => f.trim())
+    .filter(Boolean)
+    .map((f) => (isAbsolute(f) ? f : resolve(csvDir, f)))
+}
 
 export interface LoadCSVOptions {
   sample: number | undefined
@@ -96,11 +113,15 @@ export async function loadCSV(
       skip_empty_lines: true,
       trim: true,
       relax_quotes: true,
+      // Tolerate rows that omit the trailing (optional) `files` value.
+      relax_column_count: true,
     }) as Record<string, string>[]
 
     if (records.length === 0) {
       return Err(new Error("CSV file is empty"))
     }
+
+    const csvDir = dirname(path)
 
     // Validate columns exist
     const firstRecord = records[0]
@@ -144,7 +165,9 @@ export async function loadCSV(
         continue
       }
 
-      rows.push({ prompt, judge_prompt: judgePrompt })
+      const files = parseFilesColumn(record["files"], csvDir)
+
+      rows.push({ prompt, judge_prompt: judgePrompt, files })
     }
 
     if (errors.length > 0 && rows.length === 0) {

--- a/x/henry/dust-evals/src/dust-client.ts
+++ b/x/henry/dust-evals/src/dust-client.ts
@@ -1,14 +1,56 @@
-import { DustAPI } from "@dust-tt/client"
+import { DustAPI, isSupportedFileContentType } from "@dust-tt/client"
 import type {
   ConversationPublicType,
   LoggerInterface,
+  SupportedFileContentType,
 } from "@dust-tt/client"
+import { readFile } from "fs/promises"
+import { basename, extname } from "path"
 import type { Result, AgentResponse } from "./types"
 import { Ok, Err } from "./types"
+
+const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
+  ".csv": "text/csv",
+  ".doc": "application/msword",
+  ".docx":
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".gif": "image/gif",
+  ".html": "text/html",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".json": "application/json",
+  ".md": "text/markdown",
+  ".pdf": "application/pdf",
+  ".png": "image/png",
+  ".txt": "text/plain",
+  ".webp": "image/webp",
+  ".xlsx":
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".xml": "application/xml",
+  ".yaml": "application/x-yaml",
+  ".yml": "application/x-yaml",
+}
+
+function guessContentType(fileName: string): SupportedFileContentType {
+  const guess = CONTENT_TYPE_BY_EXTENSION[extname(fileName).toLowerCase()]
+  if (guess && isSupportedFileContentType(guess)) {
+    return guess
+  }
+  return "application/octet-stream"
+}
 
 const AGENT_MESSAGE_POLL_ATTEMPTS = 8
 const AGENT_MESSAGE_POLL_INITIAL_DELAY_MS = 250
 const AGENT_MESSAGE_POLL_MAX_DELAY_MS = 2000
+
+const DUST_API_BASE_URL = "https://dust.tt"
+
+// `costCredits` is computed in a post-success finalize step on the server, so it
+// is frequently still null in the first fetch right after the stream completes.
+// Poll a few times to give it a chance to be persisted.
+const COST_POLL_ATTEMPTS = 6
+const COST_POLL_INITIAL_DELAY_MS = 500
+const COST_POLL_MAX_DELAY_MS = 3000
 
 function hasAgentMessageFor(
   conversation: ConversationPublicType,
@@ -50,6 +92,91 @@ async function pollForAgentMessage(
       `Agent message not present after ${AGENT_MESSAGE_POLL_ATTEMPTS} polls for conversation ${conversationId}`
     )
   )
+}
+
+/**
+ * The public conversation endpoint serializes `costCredits` and
+ * `subAgentCostCredits` on agent messages, but the SDK's zod schema strips
+ * them. We read them from the raw JSON instead.
+ *
+ * `costCredits` is the agent message's own cost (its intelligence + tools).
+ * `subAgentCostCredits` is the recursively-aggregated cost of every sub-agent
+ * (`run_agent`) the message spawned. The server only computes the latter when
+ * rendering a single agent message, which is always the case here since each
+ * eval prompt runs in its own fresh conversation (one agent message).
+ */
+interface RawAgentMessage {
+  type: "agent_message"
+  parentMessageId: string | null
+  costCredits?: number | null
+  subAgentCostCredits?: number | null
+}
+
+/**
+ * The agent's own cost plus the cost of any sub-agents it spawned. `null`
+ * fields mean "not (yet) available"; `subAgentCostCredits` is `0` when the
+ * agent spawned no sub-agents.
+ */
+export interface AgentCostBreakdown {
+  costCredits: number | null
+  subAgentCostCredits: number | null
+}
+
+function isRawAgentMessageForUserMessage(
+  message: unknown,
+  userMessageId: string
+): message is RawAgentMessage {
+  if (typeof message !== "object" || message === null) {
+    return false
+  }
+  const m = message as Record<string, unknown>
+  return m["type"] === "agent_message" && m["parentMessageId"] === userMessageId
+}
+
+/**
+ * Extract the cost breakdown (in Dust credits) of the agent message replying to
+ * `userMessageId` from a raw conversation payload: the message's own
+ * `costCredits` and the aggregated `subAgentCostCredits` of any sub-agents it
+ * spawned. Returns `null` fields when the agent message or its own cost is not
+ * (yet) present.
+ */
+function extractCostCredits(
+  rawConversation: unknown,
+  userMessageId: string
+): AgentCostBreakdown {
+  const unavailable: AgentCostBreakdown = {
+    costCredits: null,
+    subAgentCostCredits: null,
+  }
+
+  if (typeof rawConversation !== "object" || rawConversation === null) {
+    return unavailable
+  }
+  const content = (rawConversation as Record<string, unknown>)["content"]
+  if (!Array.isArray(content)) {
+    return unavailable
+  }
+
+  for (const versions of content) {
+    if (!Array.isArray(versions) || versions.length === 0) {
+      continue
+    }
+    const latest = versions[versions.length - 1]
+    if (
+      isRawAgentMessageForUserMessage(latest, userMessageId) &&
+      typeof latest.costCredits === "number"
+    ) {
+      return {
+        costCredits: latest.costCredits,
+        subAgentCostCredits:
+          typeof latest.subAgentCostCredits === "number"
+            ? latest.subAgentCostCredits
+            : null,
+      }
+    }
+  }
+
+  return unavailable
 }
 
 export interface DustClientConfig {
@@ -107,6 +234,14 @@ function createLogger(verbose: boolean): LoggerInterface {
   if (verbose) {
     return {
       error: (args: Record<string, unknown>, message: string): void => {
+        // The published @dust-tt/client 1.2.6 build of streamAgentAnswerEvents
+        // tries to JSON.parse the terminal `data: done` SSE line and logs this
+        // (caught, non-fatal) error. The repo's SDK source already guards
+        // against it; the npm artifact predates that fix. Swallow the noise so
+        // real errors stay visible.
+        if (message === "Failed parsing chunk from Dust API") {
+          return
+        }
         console.error(`[DUST ERROR] ${message}`, args)
       },
       info: (args: Record<string, unknown>, message: string): void => {
@@ -145,10 +280,65 @@ export class DustClient {
     )
   }
 
+  /**
+   * Upload each file and return content fragments referencing them, ready to be
+   * attached to a conversation. Returns an Err if any file cannot be read or
+   * uploaded so the caller can fail the run rather than evaluate without the
+   * intended context.
+   */
+  private async uploadFilesAsContentFragments(
+    filePaths: string[]
+  ): Promise<Result<Array<{ fileId: string; title: string }>>> {
+    const fragments: Array<{ fileId: string; title: string }> = []
+
+    for (const filePath of filePaths) {
+      const fileName = basename(filePath)
+
+      let buffer: Buffer
+      try {
+        buffer = await readFile(filePath)
+      } catch (error) {
+        return Err(
+          new Error(
+            `Failed to read attachment '${filePath}': ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          )
+        )
+      }
+
+      const contentType = guessContentType(fileName)
+      const fileObject = new File([buffer], fileName, { type: contentType })
+
+      const uploadRes = await this.client.uploadFile({
+        contentType,
+        fileName,
+        fileSize: fileObject.size,
+        useCase: "conversation",
+        fileObject,
+      })
+
+      if (uploadRes.isErr()) {
+        return Err(
+          new Error(
+            `Failed to upload attachment '${fileName}': ${JSON.stringify(
+              uploadRes.error
+            )}`
+          )
+        )
+      }
+
+      fragments.push({ fileId: uploadRes.value.sId, title: fileName })
+    }
+
+    return Ok(fragments)
+  }
+
   private async callAgentInternal(
     agentId: string,
     prompt: string,
-    timeout: number
+    timeout: number,
+    filePaths: string[]
   ): Promise<
     Result<{
       response: string
@@ -160,6 +350,17 @@ export class DustClient {
     const startTime = Date.now()
 
     try {
+      // Upload any attached files first so they can be referenced as content
+      // fragments on the conversation.
+      let contentFragments: Array<{ fileId: string; title: string }> = []
+      if (filePaths.length > 0) {
+        const uploaded = await this.uploadFilesAsContentFragments(filePaths)
+        if (!uploaded.isOk) {
+          return Err(uploaded.error)
+        }
+        contentFragments = uploaded.value
+      }
+
       // Create a new conversation with the message included.
       const conversationRes = await this.client.createConversation({
         title: prompt.substring(0, 50) + (prompt.length > 50 ? "..." : ""),
@@ -177,6 +378,7 @@ export class DustClient {
             origin: "api" as const,
           },
         },
+        ...(contentFragments.length > 0 ? { contentFragments } : {}),
       })
 
       if (!conversationRes.isOk()) {
@@ -247,11 +449,12 @@ export class DustClient {
 
           switch (event.type) {
             case "generation_tokens":
-              if ("text" in event && event.text) {
-                const classification = (event as any).classification
-                if (classification !== "thinking") {
-                  fullResponse += event.text
-                }
+              // Only the user-facing answer ("tokens") is handed to the judge.
+              // "chain_of_thought" is the agent's internal reasoning and the
+              // delimiter classifications are stream framing — including either
+              // would leak internal reasoning into what the judge evaluates.
+              if (event.text && event.classification === "tokens") {
+                fullResponse += event.text
               }
               break
             case "agent_error":
@@ -300,10 +503,80 @@ export class DustClient {
     }
   }
 
+  /**
+   * Fetch the total cost (in Dust credits) of the agent message replying to
+   * `userMessageId`: its own cost plus the aggregated cost of every sub-agent
+   * it spawned. The cost is computed in a post-success step on the server, so
+   * we poll briefly until it is persisted. By the time the agent's own
+   * `costCredits` appears, the run (including its sub-agents) has finalized, so
+   * `subAgentCostCredits` is already populated (and `0` when there were none).
+   * Returns null if it never appears (e.g. free usage, server error) so callers
+   * can degrade gracefully.
+   */
+  private async fetchCostCredits(
+    conversationId: string,
+    userMessageId: string
+  ): Promise<number | null> {
+    const url = `${DUST_API_BASE_URL}/api/v1/w/${this.config.workspaceId}/assistant/conversations/${conversationId}`
+
+    let delayMs = COST_POLL_INITIAL_DELAY_MS
+    for (let attempt = 1; attempt <= COST_POLL_ATTEMPTS; attempt++) {
+      await new Promise((r) => setTimeout(r, delayMs))
+
+      try {
+        const res = await fetch(url, {
+          headers: { Authorization: `Bearer ${this.config.apiKey}` },
+        })
+
+        if (res.ok) {
+          const body = (await res.json()) as { conversation?: unknown }
+          const { costCredits, subAgentCostCredits } = extractCostCredits(
+            body.conversation,
+            userMessageId
+          )
+          if (costCredits !== null) {
+            const totalCostCredits = costCredits + (subAgentCostCredits ?? 0)
+            if (this.config.verbose && subAgentCostCredits) {
+              console.error(
+                `    [Cost ${conversationId}] own=${costCredits} + subAgents=${subAgentCostCredits} = ${totalCostCredits} credits`
+              )
+            }
+            return totalCostCredits
+          }
+        } else if (this.config.verbose) {
+          console.error(
+            `    [Cost ${conversationId}] Fetch returned ${res.status}`
+          )
+        }
+      } catch (error) {
+        if (this.config.verbose) {
+          console.error(
+            `    [Cost ${conversationId}] Fetch failed: ${error instanceof Error ? error.message : String(error)}`
+          )
+        }
+      }
+
+      delayMs = Math.min(delayMs * 2, COST_POLL_MAX_DELAY_MS)
+    }
+
+    if (this.config.verbose) {
+      console.error(
+        `    [Cost ${conversationId}] costCredits not available after ${COST_POLL_ATTEMPTS} polls`
+      )
+    }
+    return null
+  }
+
   async callAgent(
     agentId: string,
     prompt: string,
-    timeout: number
+    timeout: number,
+    // Judges are agents too, but we only track the cost of the agent under
+    // evaluation. Skip the (polling) cost fetch when calling judges to avoid the
+    // extra latency and API calls.
+    fetchCost: boolean = true,
+    // Absolute paths to files attached to the prompt as content fragments.
+    filePaths: string[] = []
   ): Promise<Result<AgentResponse>> {
     const { maxRetries, retryBackoffMs } = this.config
     let lastError: Error | null = null
@@ -314,9 +587,20 @@ export class DustClient {
         console.error(`    [Agent ${agentId}] Attempt ${attempt}/${maxRetries}`)
       }
 
-      const result = await this.callAgentInternal(agentId, prompt, timeout)
+      const result = await this.callAgentInternal(
+        agentId,
+        prompt,
+        timeout,
+        filePaths
+      )
 
       if (result.isOk) {
+        const costCredits = fetchCost
+          ? await this.fetchCostCredits(
+              result.value.conversationId,
+              result.value.messageId
+            )
+          : null
         return Ok({
           agentId,
           prompt,
@@ -326,6 +610,7 @@ export class DustClient {
           conversationId: result.value.conversationId,
           messageId: result.value.messageId,
           retryCount,
+          costCredits,
         })
       }
 
@@ -373,6 +658,7 @@ export class DustClient {
       conversationId: "",
       messageId: "",
       retryCount,
+      costCredits: null,
       error: lastError?.message ?? "All retry attempts failed",
       wasTimeout,
     })
@@ -381,11 +667,20 @@ export class DustClient {
   async callJudge(
     judgeId: string,
     prompt: string,
-    timeout: number
+    timeout: number,
+    // Absolute paths to the same files attached to the agent's prompt, so the
+    // judge can evaluate responses that depend on the attached content.
+    filePaths: string[] = []
   ): Promise<
     Result<{ response: string; conversationId: string; durationMs: number }>
   > {
-    const result = await this.callAgent(judgeId, prompt, timeout)
+    const result = await this.callAgent(
+      judgeId,
+      prompt,
+      timeout,
+      false,
+      filePaths
+    )
 
     if (!result.isOk) {
       return result
@@ -407,7 +702,10 @@ export class DustClient {
    */
   async validateAgent(agentId: string): Promise<Result<{ name: string }>> {
     try {
-      const result = await this.client.getAgentConfigurations({ view: "list" })
+      // API keys authenticate without an OAuth user, so the "list" view is
+      // rejected (401). "all" returns every non-private agent and is the
+      // intended default for API-key auth.
+      const result = await this.client.getAgentConfigurations({ view: "all" })
 
       if (!result.isOk()) {
         return Err(

--- a/x/henry/dust-evals/src/evaluator.ts
+++ b/x/henry/dust-evals/src/evaluator.ts
@@ -267,6 +267,15 @@ export async function runEvaluation(
       ).length
     : 0
 
+  // Aggregate agent message cost (in Dust credits) across every result that has
+  // a known cost.
+  const costCredits = results
+    .map((r) => r.agentCostCredits)
+    .filter((c): c is number => typeof c === "number")
+  const totalCostCredits = costCredits.reduce((a, b) => a + b, 0)
+  const averageCostCredits =
+    costCredits.length > 0 ? totalCostCredits / costCredits.length : null
+
   return Ok({
     config,
     startTime: checkpointStartTime,
@@ -283,6 +292,8 @@ export async function runEvaluation(
       normalizedAverageScore: normalizedAvg,
       averageJudgeAgreement: avgAgreement,
       lowAgreementCount,
+      totalCostCredits,
+      averageCostCredits,
     },
     metadata: {
       scaleUsed: scale,
@@ -453,11 +464,13 @@ async function executeTask(
     `  [${agentId}] "${row.prompt.substring(0, PROMPT_DISPLAY_LENGTH)}..." (run ${runNumber})`
   )
 
-  // Call agent
+  // Call agent (attaching any files referenced by the prompt row)
   const agentResult = await client.callAgent(
     agentId,
     row.prompt,
-    config.timeout
+    config.timeout,
+    true,
+    row.files
   )
 
   if (!agentResult.isOk) {
@@ -486,6 +499,7 @@ async function executeTask(
       agentConversationId: agentResponse.conversationId,
       agentMessageId: agentResponse.messageId,
       agentRetryCount: agentResponse.retryCount,
+      agentCostCredits: agentResponse.costCredits,
       error: agentResponse.error,
       wasTimeout: agentResponse.wasTimeout,
     }
@@ -503,7 +517,7 @@ async function executeTask(
   // Execute all judge calls concurrently
   const judgePromises = Array.from({ length: config.judgeRuns }, (_, i) =>
     client
-      .callJudge(config.judgeAgent, judgePrompt, config.timeout)
+      .callJudge(config.judgeAgent, judgePrompt, config.timeout, row.files)
       .then((result) => ({ index: i, result }))
   )
 
@@ -558,6 +572,7 @@ async function executeTask(
       agentConversationId: agentResponse.conversationId,
       agentMessageId: agentResponse.messageId,
       agentRetryCount: agentResponse.retryCount,
+      agentCostCredits: agentResponse.costCredits,
       error: `Unreliable: ${judgeFailures}/${config.judgeRuns} judge evaluations failed`,
       wasTimeout: undefined,
     }
@@ -577,6 +592,7 @@ async function executeTask(
       agentConversationId: agentResponse.conversationId,
       agentMessageId: agentResponse.messageId,
       agentRetryCount: agentResponse.retryCount,
+      agentCostCredits: agentResponse.costCredits,
       error: "All judge evaluations failed",
       wasTimeout: undefined,
     }
@@ -599,6 +615,7 @@ async function executeTask(
     agentConversationId: agentResponse.conversationId,
     agentMessageId: agentResponse.messageId,
     agentRetryCount: agentResponse.retryCount,
+    agentCostCredits: agentResponse.costCredits,
     error: undefined,
     wasTimeout: undefined,
   }
@@ -627,6 +644,7 @@ function createErrorResult(
     agentConversationId: "",
     agentMessageId: "",
     agentRetryCount: 0,
+    agentCostCredits: null,
     error: errorMessage,
     wasTimeout: undefined,
   }
@@ -644,6 +662,15 @@ function calculateStatistics(
     const successfulResults = agentResults.filter((r) => !r.error)
     const timeoutResults = agentResults.filter((r) => r.wasTimeout)
     const scores = successfulResults.map((r) => r.judgeResult.finalScore)
+
+    // Cost is incurred whenever the agent produced a message, so aggregate over
+    // all results (not just judged-successful ones) that have a known cost.
+    const costCredits = agentResults
+      .map((r) => r.agentCostCredits)
+      .filter((c): c is number => typeof c === "number")
+    const totalCostCredits = costCredits.reduce((a, b) => a + b, 0)
+    const averageCostCredits =
+      costCredits.length > 0 ? totalCostCredits / costCredits.length : null
 
     if (scores.length === 0) {
       stats.push({
@@ -663,6 +690,8 @@ function calculateStatistics(
         averageDurationMs: 0,
         averageRetryCount: 0,
         averageJudgeAgreement: 0,
+        averageCostCredits,
+        totalCostCredits,
       })
       continue
     }
@@ -703,6 +732,8 @@ function calculateStatistics(
       averageDurationMs: avgDuration,
       averageRetryCount: avgRetries,
       averageJudgeAgreement: avgAgreement,
+      averageCostCredits,
+      totalCostCredits,
     })
   }
 

--- a/x/henry/dust-evals/src/html-reporter.ts
+++ b/x/henry/dust-evals/src/html-reporter.ts
@@ -48,6 +48,14 @@ export function generateHTMLReport(report: EvalReport): string {
         <div class="card-value">${(summary.averageJudgeAgreement * 100).toFixed(0)}%</div>
         <div class="card-label">Judge Agreement</div>
       </div>
+      <div class="card">
+        <div class="card-value">${formatCredits(summary.totalCostCredits)}</div>
+        <div class="card-label">Total Cost (credits)</div>
+      </div>
+      <div class="card">
+        <div class="card-value">${formatCredits(summary.averageCostCredits)}</div>
+        <div class="card-label">Avg Cost / Message</div>
+      </div>
     </section>
 
     <section class="config-section">
@@ -109,6 +117,7 @@ export function generateHTMLReport(report: EvalReport): string {
             <th onclick="sortTable(2)">Score ↕</th>
             <th onclick="sortTable(3)">Agreement ↕</th>
             <th onclick="sortTable(4)">Duration ↕</th>
+            <th onclick="sortTable(5)">Cost ↕</th>
             <th>Details</th>
           </tr>
         </thead>
@@ -696,6 +705,13 @@ function getScripts(): string {
   `
 }
 
+function formatCredits(value: number | null): string {
+  if (typeof value !== "number") {
+    return "N/A"
+  }
+  return value.toFixed(2)
+}
+
 function formatDuration(ms: number): string {
   const seconds = Math.floor(ms / 1000)
   const minutes = Math.floor(seconds / 60)
@@ -770,6 +786,14 @@ function generateAgentStatCard(stat: EvalStatistics, maxScore: number): string {
         <div class="stat-item">
           <span class="stat-label">Judge Agreement:</span>
           <span class="stat-value">${(stat.averageJudgeAgreement * 100).toFixed(0)}%</span>
+        </div>
+        <div class="stat-item">
+          <span class="stat-label">Avg Cost:</span>
+          <span class="stat-value">${formatCredits(stat.averageCostCredits)} cr</span>
+        </div>
+        <div class="stat-item">
+          <span class="stat-label">Total Cost:</span>
+          <span class="stat-value">${formatCredits(stat.totalCostCredits)} cr</span>
         </div>
       </div>
     </div>
@@ -855,6 +879,7 @@ function generateResultRow(
         ${(result.judgeResult.agreement * 100).toFixed(0)}%
       </td>
       <td data-sort="${result.agentDurationMs}">${(result.agentDurationMs / 1000).toFixed(1)}s</td>
+      <td data-sort="${result.agentCostCredits ?? -1}">${formatCredits(result.agentCostCredits)}</td>
       <td>
         <button class="btn" onclick="openModal(${index})">View</button>
       </td>
@@ -934,6 +959,10 @@ function generateResultModals(results: EvalResult[], workspaceId: string): strin
               <div class="meta-item">
                 <span class="meta-label">Retries</span>
                 ${result.agentRetryCount}
+              </div>
+              <div class="meta-item">
+                <span class="meta-label">Cost (credits)</span>
+                ${formatCredits(result.agentCostCredits)}
               </div>
               <div class="meta-item">
                 <span class="meta-label">Conversation ID</span>

--- a/x/henry/dust-evals/src/reporter.ts
+++ b/x/henry/dust-evals/src/reporter.ts
@@ -70,6 +70,7 @@ function formatCSV(report: EvalReport): string {
       "judge_agreement",
       "judge_variance",
       "agent_duration_ms",
+      "agent_cost_credits",
       "agent_conversation_id",
       "agent_message_id",
       "agent_retry_count",
@@ -96,6 +97,7 @@ function formatCSV(report: EvalReport): string {
         result.judgeResult.agreement.toFixed(3),
         result.judgeResult.variance.toFixed(3),
         result.agentDurationMs,
+        result.agentCostCredits ?? "",
         result.agentConversationId,
         result.agentMessageId,
         result.agentRetryCount,
@@ -144,6 +146,12 @@ function formatConsole(report: EvalReport): string {
   lines.push(
     `  Average Judge Agreement: ${(report.summary.averageJudgeAgreement * 100).toFixed(1)}%`
   )
+  lines.push(
+    `  Total Cost: ${formatCredits(report.summary.totalCostCredits)} credits`
+  )
+  lines.push(
+    `  Average Cost / Message: ${formatCredits(report.summary.averageCostCredits)} credits`
+  )
   if (report.config.minAgreement && report.summary.lowAgreementCount > 0) {
     lines.push(
       `  Low Agreement Results: ${report.summary.lowAgreementCount} (threshold: ${(report.config.minAgreement * 100).toFixed(0)}%)`
@@ -169,6 +177,10 @@ function formatConsole(report: EvalReport): string {
     lines.push(
       `  Avg Judge Agreement: ${(stat.averageJudgeAgreement * 100).toFixed(1)}%`
     )
+    lines.push(
+      `  Avg Cost / Message: ${formatCredits(stat.averageCostCredits)} credits`
+    )
+    lines.push(`  Total Cost: ${formatCredits(stat.totalCostCredits)} credits`)
   }
   lines.push("")
 
@@ -196,6 +208,7 @@ function formatConsole(report: EvalReport): string {
         `  Agreement: ${(result.judgeResult.agreement * 100).toFixed(0)}%`
       )
       lines.push(`  Duration: ${(result.agentDurationMs / 1000).toFixed(2)}s`)
+      lines.push(`  Cost: ${formatCredits(result.agentCostCredits)} credits`)
       lines.push(`  Conversation: ${result.agentConversationId}`)
     }
   }
@@ -214,6 +227,13 @@ function formatConsole(report: EvalReport): string {
   lines.push("=".repeat(80))
 
   return lines.join("\n")
+}
+
+function formatCredits(value: number | null): string {
+  if (typeof value !== "number") {
+    return "N/A"
+  }
+  return value.toFixed(2)
 }
 
 function escapeCSV(value: string): string {

--- a/x/henry/dust-evals/src/types.ts
+++ b/x/henry/dust-evals/src/types.ts
@@ -58,6 +58,7 @@ export const SCALES: Record<ScaleType, ScaleConfig> = {
 export interface EvalRow {
   prompt: string
   judge_prompt: string
+  files: string[]
 }
 
 export interface AgentResponse {
@@ -69,6 +70,7 @@ export interface AgentResponse {
   conversationId: string
   messageId: string
   retryCount: number
+  costCredits: number | null
   error?: string
   wasTimeout?: boolean
 }
@@ -100,6 +102,7 @@ export interface EvalResult {
   agentConversationId: string
   agentMessageId: string
   agentRetryCount: number
+  agentCostCredits: number | null
   error: string | undefined
   wasTimeout: boolean | undefined
 }
@@ -118,6 +121,8 @@ export interface EvalStatistics {
   averageDurationMs: number
   averageRetryCount: number
   averageJudgeAgreement: number
+  averageCostCredits: number | null 
+  totalCostCredits: number
 }
 
 export interface EvalConfig {
@@ -158,6 +163,8 @@ export interface EvalReport {
     normalizedAverageScore: number
     averageJudgeAgreement: number
     lowAgreementCount: number // Results where agreement < minAgreement
+    totalCostCredits: number
+    averageCostCredits: number | null
   }
   metadata: {
     scaleUsed: ScaleConfig


### PR DESCRIPTION
## Description

Improvements to the `x/henry/dust-evals` standalone evaluation tool (not part of the deployed app):

- **Prompt file attachments**: an optional `files` column in the prompts CSV attaches one or more files to the agent's message as Dust content fragments. Paths are resolved relative to the CSV directory, and content types are inferred from the file extension. Includes example CSVs.
- **Agent cost reporting**: each eval now captures the agent message's `costCredits` and the aggregated `subAgentCostCredits` of any spawned sub-agents, surfaced in the console and HTML reports.
- Removed the `--project` flag and its `spaceId` plumbing; eval conversations are created outside any project.
- Updated README / docs accordingly.

## Tests

Verified with `bun run typecheck`. Manually exercised the file-attachment path and cost reporting against live agents.
