### PR TITLE
[viz] Send functionIdOrSlug to match front callFunction RPC schema

### DIFF
--- a/viz/app/lib/data-apis/rpc-data-api.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.ts
@@ -27,7 +27,7 @@ export class RPCDataAPI implements VisualizationDataAPI {
   async callFunction(functionId: string, input?: unknown) {
     try {
       const result = await this.sendMessage("callFunction", {
-        functionId,
+        functionIdOrSlug: functionId,
         input,
       });
 

--- a/viz/app/types.ts
+++ b/viz/app/types.ts
@@ -7,7 +7,7 @@ interface GetFileParams {
 }
 
 interface CallFunctionParams {
-  functionId: string;
+  functionIdOrSlug: string;
   input?: unknown;
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The viz `callFunction` RPC posted functionId while front validates incoming RPC messages against a zod schema that requires `functionIdOrSlug` since #28258. The parent gates every `postMessage` through `isVisualizationRPCRequest`, so the mismatched param made the schema parse fail, the message got silently dropped, and `createSandboxFunctionInvocation` never ran. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
