### PR TITLE
fix(input-bar): preserve text selection on drag-release in padding

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -190,6 +190,19 @@ export interface InputBarContainerProps {
   user: UserType | null;
 }
 
+function hasActiveSelectionInEditor(
+  editorDom: HTMLElement | undefined
+): boolean {
+  const selection = window.getSelection();
+  return Boolean(
+    selection &&
+      !selection.isCollapsed &&
+      editorDom &&
+      selection.anchorNode &&
+      editorDom.contains(selection.anchorNode)
+  );
+}
+
 const InputBarContainer = ({
   allAgents,
   onEnterKeyDown,
@@ -1428,6 +1441,9 @@ const InputBarContainer = ({
         )}
         aria-hidden={isCompact}
         onClick={(e) => {
+          if (hasActiveSelectionInEditor(editorRef.current?.view.dom)) {
+            return;
+          }
           // If e.target is not a child of a div with class "tiptap", then focus on the editor
           if (
             !(e.target instanceof HTMLElement && e.target.closest(".tiptap"))


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9319

A drag-select released in the editor padding margin fired the container's onClick (target not in .tiptap), calling focusEnd() and collapsing the selection. Skip the focus steal when a non-collapsed selection exists.


https://github.com/user-attachments/assets/b4058320-3c3c-4162-a57f-6c50da12fbe1

## Tests

Local
## Risk

Low
## Deploy Plan

Front