### PR TITLE
[dsbx] Set NODE_PATH when running functions so zod resolves at invocation

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -127,17 +127,18 @@ pub(crate) async fn spawn_function(
         c.arg(&*runner).arg(subcommand).arg(&handler);
         c
     };
-    cmd.stdin(if inherit_stdin {
-        Stdio::inherit()
-    } else {
-        Stdio::null()
-    })
-    .stdout(if capture_stdout {
-        Stdio::piped()
-    } else {
-        Stdio::inherit()
-    })
-    .stderr(Stdio::inherit());
+    cmd.env("NODE_PATH", harness_node_path())
+        .stdin(if inherit_stdin {
+            Stdio::inherit()
+        } else {
+            Stdio::null()
+        })
+        .stdout(if capture_stdout {
+            Stdio::piped()
+        } else {
+            Stdio::inherit()
+        })
+        .stderr(Stdio::inherit());
     if let Some(dir) = &functions_dir {
         cmd.current_dir(dir);
     }

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.43",
+      tag: "0.8.44",
     });
   });
 
@@ -341,7 +341,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.30/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.31/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -19,8 +19,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.43";
-const DSBX_CLI_VERSION = "0.1.30";
+const DUST_BASE_IMAGE_VERSION = "0.8.44";
+const DSBX_CLI_VERSION = "0.1.31";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Testing pod function invocation I got:
```
{"eventId":"1782849201661-0","data":{"type":"sandbox_function_invocation_result","created":1782849201660,"invocationId":"sfi_nWqafL1MPG","functionId":"sfn_q03Y14OQ9a","result":{"error":{"kind":"import_failed","message":"ResolveMessage: Cannot find package 'zod' from '/sandbox-functions/pods/vlt_nWqafL1MP7oRW/list-comments.ts'","stack":"Error: ResolveMessage: Cannot find package 'zod' from '/sandbox-functions/pods/vlt_nWqafL1MP7oRW/list-comments.ts'\n at fail (/tmp/dsbx-functions-runner-CoF82j.js:14492:49)\n at async runHandler (/tmp/dsbx-functions-runner-CoF82j.js:14517:27)"},"ok":false}}}
```

Published sandbox functions keep zod and the rest of the sandbox harness as external imports rather than inlining them, so the bundle stays small and shares a single zod instance with the runner. Resolving those externals at runtime relies on `NODE_PATH` pointing at the image's global npm modules. The build path set that environment variable but the run path did not, so building a function succeeded while invoking it failed with "Cannot find package 'zod'". This was confirmed directly on a sandbox as the agent user: importing a published bundle fails with no NODE_PATH and succeeds once it points at the global modules.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
