### PR TITLE
Add function to extract advanced models.

### DIFF
--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -1,5 +1,10 @@
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
-import { filterEnabledModels, isModelAvailable } from "@app/lib/assistant";
+import {
+  filterEnabledModels,
+  getAdvancedModels,
+  isAdvancedModel,
+  isModelAvailable,
+} from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import {
   FREE_NO_PLAN_CODE,
@@ -8,6 +13,11 @@ import {
 } from "@app/lib/plans/plan_codes";
 import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import {
+  CLAUDE_OPUS_4_6_MODEL_ID,
+  CLAUDE_OPUS_4_7_MODEL_ID,
+  CLAUDE_OPUS_4_8_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { PlanType } from "@app/types/plan";
@@ -84,6 +94,64 @@ function createMockPlan(
     hasAdvancedModelAccess,
   };
 }
+
+describe("isAdvancedModel", () => {
+  it("should return true when plansWithAdvancedModels is set to true", () => {
+    const model = createMockModel({
+      availableIfOneOf: { plansWithAdvancedModels: true },
+    });
+
+    expect(isAdvancedModel(model)).toBe(true);
+  });
+
+  it("should return false when plansWithAdvancedModels is not set", () => {
+    const model = createMockModel({
+      availableIfOneOf: { featureFlag: "deepseek_feature" },
+    });
+
+    expect(isAdvancedModel(model)).toBe(false);
+  });
+
+  it("should return false when availableIfOneOf is undefined", () => {
+    const model = createMockModel({ availableIfOneOf: undefined });
+
+    expect(isAdvancedModel(model)).toBe(false);
+  });
+});
+
+describe("getAdvancedModels", () => {
+  it("should return all supported models with plansWithAdvancedModels set to true", () => {
+    const expectedAdvancedModels = SUPPORTED_MODEL_CONFIGS.filter(
+      (m) => m.availableIfOneOf?.plansWithAdvancedModels === true
+    );
+
+    expect(getAdvancedModels()).toEqual(expectedAdvancedModels);
+  });
+
+  it("should include the Claude Opus advanced models", () => {
+    const advancedModelIds = getAdvancedModels().map((m) => m.modelId);
+
+    expect(advancedModelIds).toEqual(
+      expect.arrayContaining([
+        CLAUDE_OPUS_4_6_MODEL_ID,
+        CLAUDE_OPUS_4_7_MODEL_ID,
+        CLAUDE_OPUS_4_8_MODEL_ID,
+      ])
+    );
+  });
+
+  it("should not include models gated only by feature flags", () => {
+    const featureFlagOnlyModels = SUPPORTED_MODEL_CONFIGS.filter(
+      (m) =>
+        m.availableIfOneOf?.featureFlag !== undefined &&
+        m.availableIfOneOf.plansWithAdvancedModels !== true
+    );
+
+    for (const model of featureFlagOnlyModels) {
+      expect(getAdvancedModels()).not.toContain(model);
+    }
+  });
+});
 
 describe("isModelAvailable", () => {
   const owner: WorkspaceType = LightWorkspaceFactory.build();

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,4 +1,5 @@
 import { isUpgraded } from "@app/lib/plans/plan_codes";
+import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import { isByokProviderId } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
@@ -7,6 +8,14 @@ import type {
 import type { PlanType } from "@app/types/plan";
 import type { RegionType } from "@app/types/region";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+export function isAdvancedModel(m: ModelConfigurationType): boolean {
+  return m.availableIfOneOf?.plansWithAdvancedModels === true;
+}
+
+export function getAdvancedModels(): ModelConfigurationType[] {
+  return SUPPORTED_MODEL_CONFIGS.filter(isAdvancedModel);
+}
 
 // Returns true if the model is available to the workspace for build.
 export function isModelAvailable(


### PR DESCRIPTION
## Description

Adds `isAdvancedModel(m: ModelConfigurationType)` and `getAdvancedModels()` to `front/lib/assistant.ts`. Both functions identify models gated by `availableIfOneOf.plansWithAdvancedModels === true` (e.g. Claude Opus 4.x variants). These helpers centralise the "advanced model" predicate so callers don't inline the `availableIfOneOf` check — a building block for the model tier enforcement logic.

## Tests

Added Vitest unit tests for both `isAdvancedModel` and `getAdvancedModels` in `assistant.test.ts`, covering the `plansWithAdvancedModels` flag, absent flag, undefined `availableIfOneOf`, and exclusion of feature-flag-only models.

## Risk

Low. Pure additive export — no existing behaviour changes. No consumers yet; nothing breaks if the functions are unused.

## Deploy Plan

Deploy front.
