### PR TITLE
Add: models to store users, groups and workspaces allowed advanced models.

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -45,6 +45,11 @@ import { WebhookRequestModel } from "@app/lib/models/agent/triggers/webhook_requ
 import { WebhookRequestTriggerModel } from "@app/lib/models/agent/triggers/webhook_request_trigger";
 import { WebhookSourceModel } from "@app/lib/models/agent/triggers/webhook_source";
 import { WebhookSourcesViewModel } from "@app/lib/models/agent/triggers/webhook_sources_view";
+import {
+  GroupAllowedAdvancedModel,
+  UserAllowedAdvancedModel,
+  WorkspaceAllowedAdvancedModel,
+} from "@app/lib/models/allowed_advanced_model";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { ExtensionConfigurationModel } from "@app/lib/models/extension";
 import { FeatureFlagModel } from "@app/lib/models/feature_flag";
@@ -198,6 +203,9 @@ export function loadAllModels() {
     PlanModel,
     SubscriptionModel,
     ProviderCredentialModel,
+    UserAllowedAdvancedModel,
+    GroupAllowedAdvancedModel,
+    WorkspaceAllowedAdvancedModel,
     TemplateModel,
     CreditModel,
     CouponModel,

--- a/front/lib/models/allowed_advanced_model.ts
+++ b/front/lib/models/allowed_advanced_model.ts
@@ -1,0 +1,164 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type {
+  ModelIdType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
+import type { CreationOptional, ForeignKey } from "sequelize";
+
+export class UserAllowedAdvancedModel extends WorkspaceAwareModel<UserAllowedAdvancedModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare userId: ForeignKey<UserModel["id"]>;
+  declare providerId: ModelProviderIdType;
+  declare modelId: ModelIdType;
+}
+
+UserAllowedAdvancedModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    userId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    providerId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    modelId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "user_allowed_advanced_models",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        unique: true,
+        name: "user_allowed_advanced_models_unique_idx",
+        fields: ["workspaceId", "userId", "providerId", "modelId"],
+      },
+      { fields: ["workspaceId", "userId"], concurrently: true },
+      { fields: ["userId"], concurrently: true },
+    ],
+  }
+);
+
+UserAllowedAdvancedModel.belongsTo(UserModel, {
+  foreignKey: { name: "userId", allowNull: false },
+  targetKey: "id",
+});
+
+export class GroupAllowedAdvancedModel extends WorkspaceAwareModel<GroupAllowedAdvancedModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare groupId: ForeignKey<GroupModel["id"]>;
+  declare providerId: ModelProviderIdType;
+  declare modelId: ModelIdType;
+}
+
+GroupAllowedAdvancedModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    groupId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    providerId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    modelId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "group_allowed_advanced_models",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        unique: true,
+        name: "group_allowed_advanced_models_unique_idx",
+        fields: ["workspaceId", "groupId", "providerId", "modelId"],
+      },
+      { fields: ["workspaceId", "groupId"], concurrently: true },
+      { fields: ["groupId"], concurrently: true },
+    ],
+  }
+);
+
+GroupAllowedAdvancedModel.belongsTo(GroupModel, {
+  foreignKey: { name: "groupId", allowNull: false },
+  targetKey: "id",
+});
+
+export class WorkspaceAllowedAdvancedModel extends WorkspaceAwareModel<WorkspaceAllowedAdvancedModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare providerId: ModelProviderIdType;
+  declare modelId: ModelIdType;
+}
+
+WorkspaceAllowedAdvancedModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    providerId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    modelId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "workspace_allowed_advanced_models",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        unique: true,
+        name: "workspace_allowed_advanced_models_unique_idx",
+        fields: ["workspaceId", "providerId", "modelId"],
+      },
+      { fields: ["workspaceId"], concurrently: true },
+    ],
+  }
+);

--- a/front/migrations/pre-deploy/20260630160031_add_user_and_group_allowed_advanced_models.sql
+++ b/front/migrations/pre-deploy/20260630160031_add_user_and_group_allowed_advanced_models.sql
@@ -1,0 +1,65 @@
+SET
+	lock_timeout = '5s';
+
+CREATE TABLE
+	"public"."group_allowed_advanced_models" (
+		"createdAt" TIMESTAMP
+		WITH
+			TIME ZONE NOT NULL DEFAULT NOW (),
+			"updatedAt" TIMESTAMP
+		WITH
+			TIME ZONE NOT NULL DEFAULT NOW (),
+			"groupId" BIGINT NOT NULL REFERENCES "public"."groups" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+			"workspaceId" BIGINT NOT NULL REFERENCES "public"."workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+			"providerId" VARCHAR(255) NOT NULL,
+			"modelId" VARCHAR(255) NOT NULL,
+			"id" BIGSERIAL,
+			PRIMARY KEY ("id")
+	);
+
+CREATE INDEX CONCURRENTLY "group_allowed_advanced_models_group_id" ON "public"."group_allowed_advanced_models" ("groupId");
+
+CREATE INDEX CONCURRENTLY "group_allowed_advanced_models_workspace_id_group_id" ON "public"."group_allowed_advanced_models" ("workspaceId", "groupId");
+
+CREATE UNIQUE INDEX CONCURRENTLY "group_allowed_advanced_models_workspace_id_group_id_provider_id" ON "public"."group_allowed_advanced_models" ("workspaceId", "groupId", "providerId", "modelId");
+
+CREATE TABLE
+	"public"."user_allowed_advanced_models" (
+		"createdAt" TIMESTAMP
+		WITH
+			TIME ZONE NOT NULL DEFAULT NOW (),
+			"updatedAt" TIMESTAMP
+		WITH
+			TIME ZONE NOT NULL DEFAULT NOW (),
+			"userId" BIGINT NOT NULL REFERENCES "public"."users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+			"workspaceId" BIGINT NOT NULL REFERENCES "public"."workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+			"providerId" VARCHAR(255) NOT NULL,
+			"modelId" VARCHAR(255) NOT NULL,
+			"id" BIGSERIAL,
+			PRIMARY KEY ("id")
+	);
+
+CREATE INDEX CONCURRENTLY "user_allowed_advanced_models_user_id" ON "public"."user_allowed_advanced_models" ("userId");
+
+CREATE INDEX CONCURRENTLY "user_allowed_advanced_models_workspace_id_user_id" ON "public"."user_allowed_advanced_models" ("workspaceId", "userId");
+
+CREATE UNIQUE INDEX CONCURRENTLY "user_allowed_advanced_models_unique_idx" ON "public"."user_allowed_advanced_models" ("workspaceId", "userId", "providerId", "modelId");
+
+CREATE TABLE
+	"public"."workspace_allowed_advanced_models" (
+		"createdAt" TIMESTAMP
+		WITH
+			TIME ZONE NOT NULL DEFAULT NOW (),
+			"updatedAt" TIMESTAMP
+		WITH
+			TIME ZONE NOT NULL DEFAULT NOW (),
+			"workspaceId" BIGINT NOT NULL REFERENCES "public"."workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+			"providerId" VARCHAR(255) NOT NULL,
+			"modelId" VARCHAR(255) NOT NULL,
+			"id" BIGSERIAL,
+			PRIMARY KEY ("id")
+	);
+
+CREATE INDEX CONCURRENTLY "workspace_allowed_advanced_models_workspace_id" ON "public"."workspace_allowed_advanced_models" ("workspaceId");
+
+CREATE UNIQUE INDEX CONCURRENTLY "group_allowed_advanced_models_unique_idx" ON "public"."workspace_allowed_advanced_models" ("workspaceId", "providerId", "modelId");


### PR DESCRIPTION
## Description

Adds three Sequelize models — `UserAllowedAdvancedModel`, `GroupAllowedAdvancedModel`, and `WorkspaceAllowedAdvancedModel` — backed by `user_allowed_advanced_models`, `group_allowed_advanced_models`, and `workspace_allowed_advanced_models` tables. Each row stores an explicit `(workspaceId, entityId, providerId, modelId)` allowlist entry, enabling fine-grained per-user, per-group, and per-workspace control over which advanced models are accessible. All three extend `WorkspaceAwareModel` with `ON DELETE RESTRICT` FKs to `users`/`groups`/`workspaces`. Unique indexes enforce no duplicate grants per entity/model pair.

## Tests

No tests — schema-only addition with no business logic in this PR.

## Risk

Low. Pre-deploy migration is purely additive: three new tables with `CREATE INDEX CONCURRENTLY`. No existing tables or data are modified. Rollback means dropping the new tables, which is safe while they're empty.

## Deploy Plan

1. Run pre-deploy SQL migration against the front DB: `20260630160031_add_user_and_group_allowed_advanced_models.sql`
2. Deploy front.
