### PR TITLE
Add: resource for advanced models.

### DIFF
--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -1,10 +1,5 @@
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
-import {
-  filterEnabledModels,
-  getAdvancedModels,
-  isAdvancedModel,
-  isModelAvailable,
-} from "@app/lib/assistant";
+import { filterEnabledModels, isModelAvailable } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import {
   FREE_NO_PLAN_CODE,
@@ -13,11 +8,6 @@ import {
 } from "@app/lib/plans/plan_codes";
 import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import {
-  CLAUDE_OPUS_4_6_MODEL_ID,
-  CLAUDE_OPUS_4_7_MODEL_ID,
-  CLAUDE_OPUS_4_8_MODEL_ID,
-} from "@app/types/assistant/models/anthropic";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { PlanType } from "@app/types/plan";
@@ -94,64 +84,6 @@ function createMockPlan(
     hasAdvancedModelAccess,
   };
 }
-
-describe("isAdvancedModel", () => {
-  it("should return true when plansWithAdvancedModels is set to true", () => {
-    const model = createMockModel({
-      availableIfOneOf: { plansWithAdvancedModels: true },
-    });
-
-    expect(isAdvancedModel(model)).toBe(true);
-  });
-
-  it("should return false when plansWithAdvancedModels is not set", () => {
-    const model = createMockModel({
-      availableIfOneOf: { featureFlag: "deepseek_feature" },
-    });
-
-    expect(isAdvancedModel(model)).toBe(false);
-  });
-
-  it("should return false when availableIfOneOf is undefined", () => {
-    const model = createMockModel({ availableIfOneOf: undefined });
-
-    expect(isAdvancedModel(model)).toBe(false);
-  });
-});
-
-describe("getAdvancedModels", () => {
-  it("should return all supported models with plansWithAdvancedModels set to true", () => {
-    const expectedAdvancedModels = SUPPORTED_MODEL_CONFIGS.filter(
-      (m) => m.availableIfOneOf?.plansWithAdvancedModels === true
-    );
-
-    expect(getAdvancedModels()).toEqual(expectedAdvancedModels);
-  });
-
-  it("should include the Claude Opus advanced models", () => {
-    const advancedModelIds = getAdvancedModels().map((m) => m.modelId);
-
-    expect(advancedModelIds).toEqual(
-      expect.arrayContaining([
-        CLAUDE_OPUS_4_6_MODEL_ID,
-        CLAUDE_OPUS_4_7_MODEL_ID,
-        CLAUDE_OPUS_4_8_MODEL_ID,
-      ])
-    );
-  });
-
-  it("should not include models gated only by feature flags", () => {
-    const featureFlagOnlyModels = SUPPORTED_MODEL_CONFIGS.filter(
-      (m) =>
-        m.availableIfOneOf?.featureFlag !== undefined &&
-        m.availableIfOneOf.plansWithAdvancedModels !== true
-    );
-
-    for (const model of featureFlagOnlyModels) {
-      expect(getAdvancedModels()).not.toContain(model);
-    }
-  });
-});
 
 describe("isModelAvailable", () => {
   const owner: WorkspaceType = LightWorkspaceFactory.build();

--- a/front/lib/resources/advanced_model_resource.test.ts
+++ b/front/lib/resources/advanced_model_resource.test.ts
@@ -1,0 +1,251 @@
+import { isAdvancedModel } from "@app/lib/assistant";
+import { Authenticator } from "@app/lib/auth";
+import { AdvancedModelResource } from "@app/lib/resources/advanced_model_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import {
+  CLAUDE_OPUS_4_6_MODEL_ID,
+  CLAUDE_OPUS_4_7_MODEL_ID,
+  CLAUDE_OPUS_4_8_MODEL_ID,
+  CLAUDE_SONNET_4_6_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
+import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import { describe, expect, it } from "vitest";
+
+function createMockModel(
+  overrides: Partial<ModelConfigurationType>
+): ModelConfigurationType {
+  const baseModel = SUPPORTED_MODEL_CONFIGS[0];
+  return {
+    ...baseModel,
+    ...overrides,
+  };
+}
+
+describe("AdvancedModelResource.getAdvancedModels", () => {
+  it("should return all supported models with plansWithAdvancedModels set to true", () => {
+    const expectedAdvancedModels =
+      SUPPORTED_MODEL_CONFIGS.filter(isAdvancedModel);
+
+    expect(AdvancedModelResource.getAdvancedModels()).toEqual(
+      expectedAdvancedModels
+    );
+    expect(
+      AdvancedModelResource.getAdvancedModels().map((m) => m.modelId)
+    ).toEqual(
+      expect.arrayContaining([
+        CLAUDE_OPUS_4_6_MODEL_ID,
+        CLAUDE_OPUS_4_7_MODEL_ID,
+        CLAUDE_OPUS_4_8_MODEL_ID,
+      ])
+    );
+  });
+});
+
+describe("AdvancedModelResource.isAdvancedModel", () => {
+  it("should return true when plansWithAdvancedModels is set to true", () => {
+    const model = createMockModel({
+      availableIfOneOf: { plansWithAdvancedModels: true },
+    });
+
+    expect(AdvancedModelResource.isAdvancedModel(model)).toBe(
+      isAdvancedModel(model)
+    );
+  });
+
+  it("should return false when plansWithAdvancedModels is not set", () => {
+    const model = createMockModel({
+      availableIfOneOf: { featureFlag: "deepseek_feature" },
+    });
+
+    expect(AdvancedModelResource.isAdvancedModel(model)).toBe(
+      isAdvancedModel(model)
+    );
+  });
+});
+
+describe("AdvancedModelResource admin management", () => {
+  const advancedModel = AdvancedModelResource.getAdvancedModels()[0];
+
+  it("should reject non-admin callers", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalBuilderForWorkspace(workspace.sId);
+
+    await expect(
+      AdvancedModelResource.listWorkspaceAllowedAdvancedModels(auth)
+    ).rejects.toThrow("Only admins can manage allowed advanced models.");
+  });
+
+  it("should add, list, and remove workspace allowed advanced models", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const addRes = await AdvancedModelResource.addWorkspaceAllowedAdvancedModel(
+      auth,
+      {
+        providerId: advancedModel.providerId,
+        modelId: advancedModel.modelId,
+      }
+    );
+    expect(addRes.isOk()).toBe(true);
+
+    expect(
+      await AdvancedModelResource.listWorkspaceAllowedAdvancedModels(auth)
+    ).toEqual([
+      {
+        providerId: advancedModel.providerId,
+        modelId: advancedModel.modelId,
+      },
+    ]);
+
+    const removeRes =
+      await AdvancedModelResource.removeWorkspaceAllowedAdvancedModel(auth, {
+        providerId: advancedModel.providerId,
+        modelId: advancedModel.modelId,
+      });
+    expect(removeRes.isOk()).toBe(true);
+
+    expect(
+      await AdvancedModelResource.listWorkspaceAllowedAdvancedModels(auth)
+    ).toEqual([]);
+  });
+
+  it("should add, list, and remove user allowed advanced models", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const addRes = await AdvancedModelResource.addUserAllowedAdvancedModel(
+      auth,
+      {
+        userId: user.sId,
+        providerId: advancedModel.providerId,
+        modelId: advancedModel.modelId,
+      }
+    );
+    expect(addRes.isOk()).toBe(true);
+
+    expect(
+      await AdvancedModelResource.listUserAllowedAdvancedModels(auth)
+    ).toEqual([
+      {
+        userId: user.sId,
+        models: [
+          {
+            providerId: advancedModel.providerId,
+            modelId: advancedModel.modelId,
+          },
+        ],
+      },
+    ]);
+
+    const removeRes =
+      await AdvancedModelResource.removeUserAllowedAdvancedModel(auth, {
+        userId: user.sId,
+        providerId: advancedModel.providerId,
+        modelId: advancedModel.modelId,
+      });
+    expect(removeRes.isOk()).toBe(true);
+
+    expect(
+      await AdvancedModelResource.listUserAllowedAdvancedModels(auth)
+    ).toEqual([]);
+  });
+
+  it("should add, list, and remove group allowed advanced models", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const group = await GroupFactory.regular(
+      workspace,
+      "Advanced models group"
+    );
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const addRes = await AdvancedModelResource.addGroupAllowedAdvancedModel(
+      auth,
+      {
+        groupId: makeSId("group", {
+          id: group.id,
+          workspaceId: workspace.id,
+        }),
+        providerId: advancedModel.providerId,
+        modelId: advancedModel.modelId,
+      }
+    );
+    expect(addRes.isOk()).toBe(true);
+
+    expect(
+      await AdvancedModelResource.listGroupAllowedAdvancedModels(auth)
+    ).toEqual([
+      {
+        groupId: makeSId("group", {
+          id: group.id,
+          workspaceId: workspace.id,
+        }),
+        models: [
+          {
+            providerId: advancedModel.providerId,
+            modelId: advancedModel.modelId,
+          },
+        ],
+      },
+    ]);
+
+    const removeRes =
+      await AdvancedModelResource.removeGroupAllowedAdvancedModel(auth, {
+        groupId: makeSId("group", {
+          id: group.id,
+          workspaceId: workspace.id,
+        }),
+        providerId: advancedModel.providerId,
+        modelId: advancedModel.modelId,
+      });
+    expect(removeRes.isOk()).toBe(true);
+
+    expect(
+      await AdvancedModelResource.listGroupAllowedAdvancedModels(auth)
+    ).toEqual([]);
+  });
+
+  it("should reject non-advanced models", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await AdvancedModelResource.addWorkspaceAllowedAdvancedModel(
+      auth,
+      {
+        providerId: "anthropic",
+        modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_request_error");
+    }
+  });
+
+  it("should reject users that are not workspace members", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await AdvancedModelResource.addUserAllowedAdvancedModel(
+      auth,
+      {
+        userId: user.sId,
+        providerId: advancedModel.providerId,
+        modelId: advancedModel.modelId,
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("user_not_member");
+    }
+  });
+});

--- a/front/lib/resources/advanced_model_resource.ts
+++ b/front/lib/resources/advanced_model_resource.ts
@@ -1,5 +1,5 @@
-import type { Authenticator } from "@app/lib/auth";
 import { isAdvancedModel as isAdvancedModelConfig } from "@app/lib/assistant";
+import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import {

--- a/front/lib/resources/advanced_model_resource.ts
+++ b/front/lib/resources/advanced_model_resource.ts
@@ -1,0 +1,415 @@
+import type { Authenticator } from "@app/lib/auth";
+import { isAdvancedModel as isAdvancedModelConfig } from "@app/lib/assistant";
+import { DustError } from "@app/lib/error";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import {
+  GroupAllowedAdvancedModel,
+  UserAllowedAdvancedModel,
+  WorkspaceAllowedAdvancedModel,
+} from "@app/lib/models/allowed_advanced_model";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { UserResource } from "@app/lib/resources/user_resource";
+import {
+  isModelId,
+  SUPPORTED_MODEL_CONFIGS,
+} from "@app/types/assistant/models/models";
+import { isModelProviderId } from "@app/types/assistant/models/providers";
+import type {
+  ModelConfigurationType,
+  SupportedModel,
+} from "@app/types/assistant/models/types";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
+
+export type AllowedAdvancedModelType = SupportedModel;
+
+export type UserAllowedAdvancedModelsType = {
+  userId: string;
+  models: AllowedAdvancedModelType[];
+};
+
+export type GroupAllowedAdvancedModelsType = {
+  groupId: string;
+  models: AllowedAdvancedModelType[];
+};
+
+export class AdvancedModelResource {
+  private static assertIsAdmin(auth: Authenticator): void {
+    assert(auth.isAdmin(), "Only admins can manage allowed advanced models.");
+  }
+
+  static isAdvancedModel(m: ModelConfigurationType): boolean {
+    return isAdvancedModelConfig(m);
+  }
+
+  static getAdvancedModels(): ModelConfigurationType[] {
+    return SUPPORTED_MODEL_CONFIGS.filter(isAdvancedModelConfig);
+  }
+
+  private static validateAdvancedModel({
+    providerId,
+    modelId,
+  }: SupportedModel): Result<
+    ModelConfigurationType,
+    DustError<"invalid_request_error">
+  > {
+    const modelConfig = getSupportedModelConfig({ providerId, modelId });
+    if (!modelConfig || !this.isAdvancedModel(modelConfig)) {
+      return new Err(
+        new DustError(
+          "invalid_request_error",
+          "Model is not an advanced model."
+        )
+      );
+    }
+
+    return new Ok(modelConfig);
+  }
+
+  private static parseAllowedAdvancedModelRow({
+    providerId,
+    modelId,
+  }: {
+    providerId: string;
+    modelId: string;
+  }): AllowedAdvancedModelType | null {
+    if (!isModelProviderId(providerId) || !isModelId(modelId)) {
+      return null;
+    }
+
+    return { providerId, modelId };
+  }
+
+  static async addUserAllowedAdvancedModel(
+    auth: Authenticator,
+    { userId, providerId, modelId }: SupportedModel & { userId: string }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<"invalid_request_error" | "user_not_found" | "user_not_member">
+    >
+  > {
+    this.assertIsAdmin(auth);
+
+    const modelRes = this.validateAdvancedModel({ providerId, modelId });
+    if (modelRes.isErr()) {
+      return modelRes;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const user = await UserResource.fetchById(userId);
+    if (!user) {
+      return new Err(new DustError("user_not_found", "User not found."));
+    }
+
+    const membership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace,
+      });
+    if (!membership) {
+      return new Err(
+        new DustError(
+          "user_not_member",
+          "User is not an active member of the workspace."
+        )
+      );
+    }
+
+    await UserAllowedAdvancedModel.findOrCreate({
+      where: {
+        workspaceId: workspace.id,
+        userId: user.id,
+        providerId: modelRes.value.providerId,
+        modelId: modelRes.value.modelId,
+      },
+    });
+
+    return new Ok(undefined);
+  }
+
+  static async removeUserAllowedAdvancedModel(
+    auth: Authenticator,
+    { userId, providerId, modelId }: SupportedModel & { userId: string }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<"invalid_request_error" | "user_not_found" | "user_not_member">
+    >
+  > {
+    this.assertIsAdmin(auth);
+
+    const modelRes = this.validateAdvancedModel({ providerId, modelId });
+    if (modelRes.isErr()) {
+      return modelRes;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const user = await UserResource.fetchById(userId);
+    if (!user) {
+      return new Err(new DustError("user_not_found", "User not found."));
+    }
+
+    const membership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace,
+      });
+    if (!membership) {
+      return new Err(
+        new DustError(
+          "user_not_member",
+          "User is not an active member of the workspace."
+        )
+      );
+    }
+
+    await UserAllowedAdvancedModel.destroy({
+      where: {
+        workspaceId: workspace.id,
+        userId: user.id,
+        providerId: modelRes.value.providerId,
+        modelId: modelRes.value.modelId,
+      },
+    });
+
+    return new Ok(undefined);
+  }
+
+  static async addGroupAllowedAdvancedModel(
+    auth: Authenticator,
+    { groupId, providerId, modelId }: SupportedModel & { groupId: string }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "invalid_request_error"
+        | "group_not_found"
+        | "invalid_id"
+        | "unauthorized"
+      >
+    >
+  > {
+    this.assertIsAdmin(auth);
+
+    const modelRes = this.validateAdvancedModel({ providerId, modelId });
+    if (modelRes.isErr()) {
+      return modelRes;
+    }
+
+    const groupRes = await GroupResource.fetchById(auth, groupId);
+    if (groupRes.isErr()) {
+      return groupRes;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    await GroupAllowedAdvancedModel.findOrCreate({
+      where: {
+        workspaceId: workspace.id,
+        groupId: groupRes.value.id,
+        providerId: modelRes.value.providerId,
+        modelId: modelRes.value.modelId,
+      },
+    });
+
+    return new Ok(undefined);
+  }
+
+  static async removeGroupAllowedAdvancedModel(
+    auth: Authenticator,
+    { groupId, providerId, modelId }: SupportedModel & { groupId: string }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "invalid_request_error"
+        | "group_not_found"
+        | "invalid_id"
+        | "unauthorized"
+      >
+    >
+  > {
+    this.assertIsAdmin(auth);
+
+    const modelRes = this.validateAdvancedModel({ providerId, modelId });
+    if (modelRes.isErr()) {
+      return modelRes;
+    }
+
+    const groupRes = await GroupResource.fetchById(auth, groupId);
+    if (groupRes.isErr()) {
+      return groupRes;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    await GroupAllowedAdvancedModel.destroy({
+      where: {
+        workspaceId: workspace.id,
+        groupId: groupRes.value.id,
+        providerId: modelRes.value.providerId,
+        modelId: modelRes.value.modelId,
+      },
+    });
+
+    return new Ok(undefined);
+  }
+
+  static async addWorkspaceAllowedAdvancedModel(
+    auth: Authenticator,
+    { providerId, modelId }: SupportedModel
+  ): Promise<Result<undefined, DustError<"invalid_request_error">>> {
+    this.assertIsAdmin(auth);
+
+    const modelRes = this.validateAdvancedModel({ providerId, modelId });
+    if (modelRes.isErr()) {
+      return modelRes;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    await WorkspaceAllowedAdvancedModel.findOrCreate({
+      where: {
+        workspaceId: workspace.id,
+        providerId: modelRes.value.providerId,
+        modelId: modelRes.value.modelId,
+      },
+    });
+
+    return new Ok(undefined);
+  }
+
+  static async removeWorkspaceAllowedAdvancedModel(
+    auth: Authenticator,
+    { providerId, modelId }: SupportedModel
+  ): Promise<Result<undefined, DustError<"invalid_request_error">>> {
+    this.assertIsAdmin(auth);
+
+    const modelRes = this.validateAdvancedModel({ providerId, modelId });
+    if (modelRes.isErr()) {
+      return modelRes;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    await WorkspaceAllowedAdvancedModel.destroy({
+      where: {
+        workspaceId: workspace.id,
+        providerId: modelRes.value.providerId,
+        modelId: modelRes.value.modelId,
+      },
+    });
+
+    return new Ok(undefined);
+  }
+
+  static async listUserAllowedAdvancedModels(
+    auth: Authenticator
+  ): Promise<UserAllowedAdvancedModelsType[]> {
+    this.assertIsAdmin(auth);
+
+    const workspace = auth.getNonNullableWorkspace();
+    const rows = await UserAllowedAdvancedModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const userIds = [...new Set(rows.map((row) => row.userId))];
+    const users = await UserResource.fetchByModelIds(userIds);
+    const userById = new Map(users.map((user) => [user.id, user]));
+
+    const modelsByUserId = new Map<ModelId, AllowedAdvancedModelType[]>();
+    for (const row of rows) {
+      const model = this.parseAllowedAdvancedModelRow(row);
+      if (!model) {
+        continue;
+      }
+
+      const models = modelsByUserId.get(row.userId) ?? [];
+      models.push(model);
+      modelsByUserId.set(row.userId, models);
+    }
+
+    return userIds.flatMap((userModelId) => {
+      const user = userById.get(userModelId);
+      if (!user) {
+        return [];
+      }
+
+      return [
+        {
+          userId: user.sId,
+          models: modelsByUserId.get(userModelId) ?? [],
+        },
+      ];
+    });
+  }
+
+  static async listGroupAllowedAdvancedModels(
+    auth: Authenticator
+  ): Promise<GroupAllowedAdvancedModelsType[]> {
+    this.assertIsAdmin(auth);
+
+    const workspace = auth.getNonNullableWorkspace();
+    const rows = await GroupAllowedAdvancedModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const groupIds = [...new Set(rows.map((row) => row.groupId))];
+    const groups = await GroupResource.fetchByModelIds(auth, groupIds);
+    const groupById = new Map(groups.map((group) => [group.id, group]));
+
+    const modelsByGroupId = new Map<ModelId, AllowedAdvancedModelType[]>();
+    for (const row of rows) {
+      const model = this.parseAllowedAdvancedModelRow(row);
+      if (!model) {
+        continue;
+      }
+
+      const models = modelsByGroupId.get(row.groupId) ?? [];
+      models.push(model);
+      modelsByGroupId.set(row.groupId, models);
+    }
+
+    return groupIds.flatMap((groupModelId) => {
+      const group = groupById.get(groupModelId);
+      if (!group) {
+        return [];
+      }
+
+      return [
+        {
+          groupId: makeSId("group", {
+            id: group.id,
+            workspaceId: workspace.id,
+          }),
+          models: modelsByGroupId.get(groupModelId) ?? [],
+        },
+      ];
+    });
+  }
+
+  static async listWorkspaceAllowedAdvancedModels(
+    auth: Authenticator
+  ): Promise<AllowedAdvancedModelType[]> {
+    this.assertIsAdmin(auth);
+
+    const workspace = auth.getNonNullableWorkspace();
+    const rows = await WorkspaceAllowedAdvancedModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+
+    return rows.flatMap((row) => {
+      const model = this.parseAllowedAdvancedModelRow(row);
+      return model ? [model] : [];
+    });
+  }
+}


### PR DESCRIPTION
## Description

Introduces `AdvancedModelResource` in `front/lib/resources/advanced_model_resource.ts` as the canonical layer for managing per-workspace, per-user, and per-group advanced model allowlists. Moves `isAdvancedModel` and `getAdvancedModels` from free functions in `assistant.ts` into static methods on the resource class, and adds admin-only CRUD — `addWorkspaceAllowedAdvancedModel`, `addUserAllowedAdvancedModel`, `addGroupAllowedAdvancedModel` and their `remove`/`list` counterparts. All mutations validate the target is an actual advanced model (`plansWithAdvancedModels === true`), enforce `auth.isAdmin()`, and return `Result<T, DustError<...>>`. Uses `findOrCreate` for idempotent adds.

## Tests

Full Vitest coverage in `advanced_model_resource.test.ts`: `isAdvancedModel`, `getAdvancedModels`, add/list/remove for workspace, user, and group; guard tests for non-admin callers, non-advanced models, and non-member users.

## Risk

Low. No new API routes. No schema changes in this PR — the `WorkspaceAllowedAdvancedModel`, `UserAllowedAdvancedModel`, and `GroupAllowedAdvancedModel` Sequelize models are consumed but not introduced here. If the backing tables (`workspace_allowed_advanced_models`, `user_allowed_advanced_models`, `group_allowed_advanced_models`) haven't been migrated yet, that migration must land before this PR is deployed.

## Deploy Plan

Ensure the `allowed_advanced_model` DB migration is applied first (if not already), then deploy front.
