### PR TITLE
Create hooks for advanced models.

### DIFF
--- a/front-api/routes/w/[wId]/advanced_models/allowed/groups.ts
+++ b/front-api/routes/w/[wId]/advanced_models/allowed/groups.ts
@@ -1,0 +1,71 @@
+import { AdvancedModelResource } from "@app/lib/resources/advanced_model_resource";
+import type { GetGroupAllowedAdvancedModelsResponseBody } from "@app/types/api/advanced_models";
+import { GroupAllowedAdvancedModelBodySchema } from "@app/types/api/advanced_models";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { advancedModelErrorToApiError } from "../errors";
+
+// Mounted at /api/w/:wId/advanced_models/allowed/groups.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetGroupAllowedAdvancedModelsResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const groups =
+      await AdvancedModelResource.listGroupAllowedAdvancedModels(auth);
+
+    return ctx.json({ groups });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  validate("json", GroupAllowedAdvancedModelBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result = await AdvancedModelResource.addGroupAllowedAdvancedModel(
+      auth,
+      body
+    );
+
+    if (result.isErr()) {
+      return apiError(ctx, advancedModelErrorToApiError(result.error));
+    }
+
+    return ctx.body(null, 201);
+  }
+);
+
+/** @ignoreswagger */
+app.delete(
+  "/",
+  ensureIsAdmin(),
+  validate("json", GroupAllowedAdvancedModelBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result = await AdvancedModelResource.removeGroupAllowedAdvancedModel(
+      auth,
+      body
+    );
+
+    if (result.isErr()) {
+      return apiError(ctx, advancedModelErrorToApiError(result.error));
+    }
+
+    return ctx.body(null, 204);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/advanced_models/allowed/index.ts
+++ b/front-api/routes/w/[wId]/advanced_models/allowed/index.ts
@@ -1,0 +1,13 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import groups from "./groups";
+import users from "./users";
+import workspace from "./workspace";
+
+// Mounted at /api/w/:wId/advanced_models/allowed.
+const app = workspaceApp();
+
+app.route("/users", users);
+app.route("/groups", groups);
+app.route("/workspace", workspace);
+
+export default app;

--- a/front-api/routes/w/[wId]/advanced_models/allowed/users.ts
+++ b/front-api/routes/w/[wId]/advanced_models/allowed/users.ts
@@ -1,0 +1,72 @@
+import { AdvancedModelResource } from "@app/lib/resources/advanced_model_resource";
+import type { GetUserAllowedAdvancedModelsResponseBody } from "@app/types/api/advanced_models";
+import { UserAllowedAdvancedModelBodySchema } from "@app/types/api/advanced_models";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+import { advancedModelErrorToApiError } from "../errors";
+
+// Mounted at /api/w/:wId/advanced_models/allowed/users.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetUserAllowedAdvancedModelsResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const users =
+      await AdvancedModelResource.listUserAllowedAdvancedModels(auth);
+
+    return ctx.json({ users });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  validate("json", UserAllowedAdvancedModelBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result = await AdvancedModelResource.addUserAllowedAdvancedModel(
+      auth,
+      body
+    );
+
+    if (result.isErr()) {
+      return apiError(ctx, advancedModelErrorToApiError(result.error));
+    }
+
+    return ctx.body(null, 201);
+  }
+);
+
+/** @ignoreswagger */
+app.delete(
+  "/",
+  ensureIsAdmin(),
+  validate("json", UserAllowedAdvancedModelBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result = await AdvancedModelResource.removeUserAllowedAdvancedModel(
+      auth,
+      body
+    );
+
+    if (result.isErr()) {
+      return apiError(ctx, advancedModelErrorToApiError(result.error));
+    }
+
+    return ctx.body(null, 204);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/advanced_models/allowed/workspace.ts
+++ b/front-api/routes/w/[wId]/advanced_models/allowed/workspace.ts
@@ -1,0 +1,72 @@
+import { AdvancedModelResource } from "@app/lib/resources/advanced_model_resource";
+import type { GetWorkspaceAllowedAdvancedModelsResponseBody } from "@app/types/api/advanced_models";
+import { AllowedAdvancedModelBodySchema } from "@app/types/api/advanced_models";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { advancedModelErrorToApiError } from "../errors";
+
+// Mounted at /api/w/:wId/advanced_models/allowed/workspace.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetWorkspaceAllowedAdvancedModelsResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const models =
+      await AdvancedModelResource.listWorkspaceAllowedAdvancedModels(auth);
+
+    return ctx.json({ models });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  validate("json", AllowedAdvancedModelBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result = await AdvancedModelResource.addWorkspaceAllowedAdvancedModel(
+      auth,
+      body
+    );
+
+    if (result.isErr()) {
+      return apiError(ctx, advancedModelErrorToApiError(result.error));
+    }
+
+    return ctx.body(null, 201);
+  }
+);
+
+/** @ignoreswagger */
+app.delete(
+  "/",
+  ensureIsAdmin(),
+  validate("json", AllowedAdvancedModelBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result =
+      await AdvancedModelResource.removeWorkspaceAllowedAdvancedModel(
+        auth,
+        body
+      );
+
+    if (result.isErr()) {
+      return apiError(ctx, advancedModelErrorToApiError(result.error));
+    }
+
+    return ctx.body(null, 204);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/advanced_models/errors.ts
+++ b/front-api/routes/w/[wId]/advanced_models/errors.ts
@@ -1,0 +1,51 @@
+import type { DustError } from "@app/lib/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+
+export function advancedModelErrorToApiError(
+  error: DustError
+): APIErrorWithContentfulStatusCode {
+  switch (error.code) {
+    case "invalid_request_error":
+      return {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: error.message,
+        },
+      };
+    case "user_not_found":
+    case "user_not_member":
+      return {
+        status_code: 404,
+        api_error: {
+          type: "workspace_user_not_found",
+          message: error.message,
+        },
+      };
+    case "group_not_found":
+    case "invalid_id":
+      return {
+        status_code: 404,
+        api_error: {
+          type: "group_not_found",
+          message: error.message,
+        },
+      };
+    case "unauthorized":
+      return {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: error.message,
+        },
+      };
+    default:
+      return {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: error.message,
+        },
+      };
+  }
+}

--- a/front-api/routes/w/[wId]/advanced_models/index.test.ts
+++ b/front-api/routes/w/[wId]/advanced_models/index.test.ts
@@ -1,0 +1,224 @@
+import { AdvancedModelResource } from "@app/lib/resources/advanced_model_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import {
+  GetAdvancedModelsResponseBodySchema,
+  GetGroupAllowedAdvancedModelsResponseBodySchema,
+  GetUserAllowedAdvancedModelsResponseBodySchema,
+  GetWorkspaceAllowedAdvancedModelsResponseBodySchema,
+} from "@app/types/api/advanced_models";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+describe("GET /api/w/:wId/advanced_models", () => {
+  it("returns 403 when caller is not an admin", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/advanced_models`
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns the advanced model catalog for admins", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/advanced_models`
+    );
+
+    expect(response.status).toBe(200);
+    const data = GetAdvancedModelsResponseBodySchema.parse(
+      await response.json()
+    );
+
+    expect(data.models).toEqual(
+      AdvancedModelResource.getAdvancedModels().map((model) => ({
+        providerId: model.providerId,
+        modelId: model.modelId,
+        displayName: model.displayName,
+      }))
+    );
+  });
+});
+
+describe("POST/DELETE /api/w/:wId/advanced_models/allowed/workspace", () => {
+  const advancedModel = AdvancedModelResource.getAdvancedModels()[0];
+
+  it("allows admins to add, list, and remove workspace allowed models", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+
+    const addResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/advanced_models/allowed/workspace`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          providerId: advancedModel.providerId,
+          modelId: advancedModel.modelId,
+        }),
+      }
+    );
+    expect(addResponse.status).toBe(201);
+
+    const listResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/advanced_models/allowed/workspace`
+    );
+    expect(listResponse.status).toBe(200);
+    expect(
+      GetWorkspaceAllowedAdvancedModelsResponseBodySchema.parse(
+        await listResponse.json()
+      )
+    ).toEqual({
+      models: [
+        {
+          providerId: advancedModel.providerId,
+          modelId: advancedModel.modelId,
+        },
+      ],
+    });
+
+    const deleteResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/advanced_models/allowed/workspace`,
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          providerId: advancedModel.providerId,
+          modelId: advancedModel.modelId,
+        }),
+      }
+    );
+    expect(deleteResponse.status).toBe(204);
+  });
+});
+
+describe("POST/DELETE /api/w/:wId/advanced_models/allowed/users", () => {
+  const advancedModel = AdvancedModelResource.getAdvancedModels()[0];
+
+  it("allows admins to add, list, and remove user allowed models", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const addResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/advanced_models/allowed/users`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          userId: user.sId,
+          providerId: advancedModel.providerId,
+          modelId: advancedModel.modelId,
+        }),
+      }
+    );
+    expect(addResponse.status).toBe(201);
+
+    const listResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/advanced_models/allowed/users`
+    );
+    expect(listResponse.status).toBe(200);
+    expect(
+      GetUserAllowedAdvancedModelsResponseBodySchema.parse(
+        await listResponse.json()
+      )
+    ).toEqual({
+      users: [
+        {
+          userId: user.sId,
+          models: [
+            {
+              providerId: advancedModel.providerId,
+              modelId: advancedModel.modelId,
+            },
+          ],
+        },
+      ],
+    });
+
+    const deleteResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/advanced_models/allowed/users`,
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          userId: user.sId,
+          providerId: advancedModel.providerId,
+          modelId: advancedModel.modelId,
+        }),
+      }
+    );
+    expect(deleteResponse.status).toBe(204);
+  });
+});
+
+describe("POST/DELETE /api/w/:wId/advanced_models/allowed/groups", () => {
+  const advancedModel = AdvancedModelResource.getAdvancedModels()[0];
+
+  it("allows admins to add, list, and remove group allowed models", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+    const group = await GroupFactory.regular(
+      workspace,
+      "Advanced models group"
+    );
+    const groupId = makeSId("group", {
+      id: group.id,
+      workspaceId: workspace.id,
+    });
+
+    const addResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/advanced_models/allowed/groups`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          groupId,
+          providerId: advancedModel.providerId,
+          modelId: advancedModel.modelId,
+        }),
+      }
+    );
+    expect(addResponse.status).toBe(201);
+
+    const listResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/advanced_models/allowed/groups`
+    );
+    expect(listResponse.status).toBe(200);
+    expect(
+      GetGroupAllowedAdvancedModelsResponseBodySchema.parse(
+        await listResponse.json()
+      )
+    ).toEqual({
+      groups: [
+        {
+          groupId,
+          models: [
+            {
+              providerId: advancedModel.providerId,
+              modelId: advancedModel.modelId,
+            },
+          ],
+        },
+      ],
+    });
+
+    const deleteResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/advanced_models/allowed/groups`,
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          groupId,
+          providerId: advancedModel.providerId,
+          modelId: advancedModel.modelId,
+        }),
+      }
+    );
+    expect(deleteResponse.status).toBe(204);
+  });
+});

--- a/front-api/routes/w/[wId]/advanced_models/index.ts
+++ b/front-api/routes/w/[wId]/advanced_models/index.ts
@@ -1,0 +1,29 @@
+import { AdvancedModelResource } from "@app/lib/resources/advanced_model_resource";
+import type { GetAdvancedModelsResponseBody } from "@app/types/api/advanced_models";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+
+import allowed from "./allowed";
+
+// Mounted at /api/w/:wId/advanced_models.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetAdvancedModelsResponseBody> => {
+    const models = AdvancedModelResource.getAdvancedModels().map((model) => ({
+      providerId: model.providerId,
+      modelId: model.modelId,
+      displayName: model.displayName,
+    }));
+
+    return ctx.json({ models });
+  }
+);
+
+app.route("/allowed", allowed);
+
+export default app;

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -25,6 +25,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { workspaceAuth } from "@front-api/middlewares/workspace_auth";
 import { escape } from "html-escaper";
 import { z } from "zod";
+import advancedModels from "./advanced_models";
 import analytics from "./analytics";
 import assistant from "./assistant";
 import auditLogs from "./audit-logs";
@@ -749,6 +750,7 @@ app.post(
 // Sub-apps using the catch-all default + the partial-subtree exception
 // targets declared above.
 app.route("/analytics", analytics);
+app.route("/advanced_models", advancedModels);
 app.route("/assistant", assistant);
 app.route("/audit-logs", auditLogs);
 app.route("/billing", billing);

--- a/front/lib/resources/advanced_model_resource.ts
+++ b/front/lib/resources/advanced_model_resource.ts
@@ -11,6 +11,11 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
+import type {
+  AllowedAdvancedModelType,
+  GroupAllowedAdvancedModelsType,
+  UserAllowedAdvancedModelsType,
+} from "@app/types/api/advanced_models";
 import {
   isModelId,
   SUPPORTED_MODEL_CONFIGS,
@@ -24,18 +29,6 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
-
-export type AllowedAdvancedModelType = SupportedModel;
-
-export type UserAllowedAdvancedModelsType = {
-  userId: string;
-  models: AllowedAdvancedModelType[];
-};
-
-export type GroupAllowedAdvancedModelsType = {
-  groupId: string;
-  models: AllowedAdvancedModelType[];
-};
 
 export class AdvancedModelResource {
   private static assertIsAdmin(auth: Authenticator): void {

--- a/front/lib/swr/advanced_models.ts
+++ b/front/lib/swr/advanced_models.ts
@@ -1,0 +1,426 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  emptyArray,
+  getErrorFromResponse,
+  useFetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
+import type {
+  AllowedAdvancedModelType,
+  GetAdvancedModelsResponseBody,
+  GetGroupAllowedAdvancedModelsResponseBody,
+  GetUserAllowedAdvancedModelsResponseBody,
+  GetWorkspaceAllowedAdvancedModelsResponseBody,
+  GroupAllowedAdvancedModelBody,
+  GroupAllowedAdvancedModelsType,
+  UserAllowedAdvancedModelBody,
+  UserAllowedAdvancedModelsType,
+} from "@app/types/api/advanced_models";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useState } from "react";
+import type { Fetcher } from "swr";
+
+export const advancedModelsUrl = (workspaceId: string) =>
+  `/api/w/${workspaceId}/advanced_models`;
+
+export const userAllowedAdvancedModelsUrl = (workspaceId: string) =>
+  `${advancedModelsUrl(workspaceId)}/allowed/users`;
+
+export const groupAllowedAdvancedModelsUrl = (workspaceId: string) =>
+  `${advancedModelsUrl(workspaceId)}/allowed/groups`;
+
+export const workspaceAllowedAdvancedModelsUrl = (workspaceId: string) =>
+  `${advancedModelsUrl(workspaceId)}/allowed/workspace`;
+
+export function useAdvancedModels({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const advancedModelsFetcher: Fetcher<GetAdvancedModelsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    advancedModelsUrl(owner.sId),
+    advancedModelsFetcher,
+    { disabled }
+  );
+
+  return {
+    models: data?.models ?? emptyArray(),
+    isAdvancedModelsLoading: !error && !data && !disabled,
+    isAdvancedModelsError: !!error,
+    mutateAdvancedModels: mutate,
+  };
+}
+
+export function useUserAllowedAdvancedModels({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const userAllowedAdvancedModelsFetcher: Fetcher<GetUserAllowedAdvancedModelsResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    userAllowedAdvancedModelsUrl(owner.sId),
+    userAllowedAdvancedModelsFetcher,
+    { disabled }
+  );
+
+  return {
+    users: data?.users ?? emptyArray<UserAllowedAdvancedModelsType>(),
+    isUserAllowedAdvancedModelsLoading: !error && !data && !disabled,
+    isUserAllowedAdvancedModelsError: !!error,
+    mutateUserAllowedAdvancedModels: mutate,
+  };
+}
+
+export function useGroupAllowedAdvancedModels({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const groupAllowedAdvancedModelsFetcher: Fetcher<GetGroupAllowedAdvancedModelsResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    groupAllowedAdvancedModelsUrl(owner.sId),
+    groupAllowedAdvancedModelsFetcher,
+    { disabled }
+  );
+
+  return {
+    groups: data?.groups ?? emptyArray<GroupAllowedAdvancedModelsType>(),
+    isGroupAllowedAdvancedModelsLoading: !error && !data && !disabled,
+    isGroupAllowedAdvancedModelsError: !!error,
+    mutateGroupAllowedAdvancedModels: mutate,
+  };
+}
+
+export function useWorkspaceAllowedAdvancedModels({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const workspaceAllowedAdvancedModelsFetcher: Fetcher<GetWorkspaceAllowedAdvancedModelsResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    workspaceAllowedAdvancedModelsUrl(owner.sId),
+    workspaceAllowedAdvancedModelsFetcher,
+    { disabled }
+  );
+
+  return {
+    models: data?.models ?? emptyArray<AllowedAdvancedModelType>(),
+    isWorkspaceAllowedAdvancedModelsLoading: !error && !data && !disabled,
+    isWorkspaceAllowedAdvancedModelsError: !!error,
+    mutateWorkspaceAllowedAdvancedModels: mutate,
+  };
+}
+
+export function useUserAllowedAdvancedModelMutations({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateUserAllowedAdvancedModels } = useUserAllowedAdvancedModels({
+    owner,
+    disabled: true,
+  });
+  const [isMutating, setIsMutating] = useState(false);
+
+  const addUserAllowedAdvancedModel = useCallback(
+    async (body: UserAllowedAdvancedModelBody): Promise<boolean> => {
+      setIsMutating(true);
+      try {
+        const response = await clientFetch(
+          userAllowedAdvancedModelsUrl(owner.sId),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to allow advanced model for user",
+            description: error.message,
+          });
+          return false;
+        }
+
+        await mutateUserAllowedAdvancedModels();
+        return true;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to allow advanced model for user",
+          description: normalizeError(e).message,
+        });
+        return false;
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [owner.sId, mutateUserAllowedAdvancedModels, sendNotification]
+  );
+
+  const removeUserAllowedAdvancedModel = useCallback(
+    async (body: UserAllowedAdvancedModelBody): Promise<boolean> => {
+      setIsMutating(true);
+      try {
+        const response = await clientFetch(
+          userAllowedAdvancedModelsUrl(owner.sId),
+          {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to remove advanced model for user",
+            description: error.message,
+          });
+          return false;
+        }
+
+        await mutateUserAllowedAdvancedModels();
+        return true;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to remove advanced model for user",
+          description: normalizeError(e).message,
+        });
+        return false;
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [owner.sId, mutateUserAllowedAdvancedModels, sendNotification]
+  );
+
+  return {
+    addUserAllowedAdvancedModel,
+    removeUserAllowedAdvancedModel,
+    isUserAllowedAdvancedModelMutating: isMutating,
+  };
+}
+
+export function useGroupAllowedAdvancedModelMutations({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateGroupAllowedAdvancedModels } = useGroupAllowedAdvancedModels({
+    owner,
+    disabled: true,
+  });
+  const [isMutating, setIsMutating] = useState(false);
+
+  const addGroupAllowedAdvancedModel = useCallback(
+    async (body: GroupAllowedAdvancedModelBody): Promise<boolean> => {
+      setIsMutating(true);
+      try {
+        const response = await clientFetch(
+          groupAllowedAdvancedModelsUrl(owner.sId),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to allow advanced model for group",
+            description: error.message,
+          });
+          return false;
+        }
+
+        await mutateGroupAllowedAdvancedModels();
+        return true;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to allow advanced model for group",
+          description: normalizeError(e).message,
+        });
+        return false;
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [owner.sId, mutateGroupAllowedAdvancedModels, sendNotification]
+  );
+
+  const removeGroupAllowedAdvancedModel = useCallback(
+    async (body: GroupAllowedAdvancedModelBody): Promise<boolean> => {
+      setIsMutating(true);
+      try {
+        const response = await clientFetch(
+          groupAllowedAdvancedModelsUrl(owner.sId),
+          {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to remove advanced model for group",
+            description: error.message,
+          });
+          return false;
+        }
+
+        await mutateGroupAllowedAdvancedModels();
+        return true;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to remove advanced model for group",
+          description: normalizeError(e).message,
+        });
+        return false;
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [owner.sId, mutateGroupAllowedAdvancedModels, sendNotification]
+  );
+
+  return {
+    addGroupAllowedAdvancedModel,
+    removeGroupAllowedAdvancedModel,
+    isGroupAllowedAdvancedModelMutating: isMutating,
+  };
+}
+
+export function useWorkspaceAllowedAdvancedModelMutations({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateWorkspaceAllowedAdvancedModels } =
+    useWorkspaceAllowedAdvancedModels({
+      owner,
+      disabled: true,
+    });
+  const [isMutating, setIsMutating] = useState(false);
+
+  const addWorkspaceAllowedAdvancedModel = useCallback(
+    async (body: AllowedAdvancedModelType): Promise<boolean> => {
+      setIsMutating(true);
+      try {
+        const response = await clientFetch(
+          workspaceAllowedAdvancedModelsUrl(owner.sId),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to allow advanced model for workspace",
+            description: error.message,
+          });
+          return false;
+        }
+
+        await mutateWorkspaceAllowedAdvancedModels();
+        return true;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to allow advanced model for workspace",
+          description: normalizeError(e).message,
+        });
+        return false;
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [owner.sId, mutateWorkspaceAllowedAdvancedModels, sendNotification]
+  );
+
+  const removeWorkspaceAllowedAdvancedModel = useCallback(
+    async (body: AllowedAdvancedModelType): Promise<boolean> => {
+      setIsMutating(true);
+      try {
+        const response = await clientFetch(
+          workspaceAllowedAdvancedModelsUrl(owner.sId),
+          {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to remove advanced model for workspace",
+            description: error.message,
+          });
+          return false;
+        }
+
+        await mutateWorkspaceAllowedAdvancedModels();
+        return true;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to remove advanced model for workspace",
+          description: normalizeError(e).message,
+        });
+        return false;
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [owner.sId, mutateWorkspaceAllowedAdvancedModels, sendNotification]
+  );
+
+  return {
+    addWorkspaceAllowedAdvancedModel,
+    removeWorkspaceAllowedAdvancedModel,
+    isWorkspaceAllowedAdvancedModelMutating: isMutating,
+  };
+}

--- a/front/types/api/advanced_models.ts
+++ b/front/types/api/advanced_models.ts
@@ -1,0 +1,80 @@
+// Shared contract types and schemas for the advanced models API,
+// imported by the advanced models API routes.
+import { ModelIdSchema } from "@app/types/assistant/models/models";
+import { ModelProviderIdSchema } from "@app/types/assistant/models/providers";
+import { z } from "zod";
+
+export const AllowedAdvancedModelSchema = z.object({
+  providerId: ModelProviderIdSchema,
+  modelId: ModelIdSchema,
+});
+export type AllowedAdvancedModelType = z.infer<
+  typeof AllowedAdvancedModelSchema
+>;
+
+export const AdvancedModelSchema = AllowedAdvancedModelSchema.extend({
+  displayName: z.string(),
+});
+export type AdvancedModelType = z.infer<typeof AdvancedModelSchema>;
+
+export const UserAllowedAdvancedModelsSchema = z.object({
+  userId: z.string(),
+  models: z.array(AllowedAdvancedModelSchema),
+});
+export type UserAllowedAdvancedModelsType = z.infer<
+  typeof UserAllowedAdvancedModelsSchema
+>;
+
+export const GroupAllowedAdvancedModelsSchema = z.object({
+  groupId: z.string(),
+  models: z.array(AllowedAdvancedModelSchema),
+});
+export type GroupAllowedAdvancedModelsType = z.infer<
+  typeof GroupAllowedAdvancedModelsSchema
+>;
+
+export const GetAdvancedModelsResponseBodySchema = z.object({
+  models: z.array(AdvancedModelSchema),
+});
+export type GetAdvancedModelsResponseBody = z.infer<
+  typeof GetAdvancedModelsResponseBodySchema
+>;
+
+export const GetUserAllowedAdvancedModelsResponseBodySchema = z.object({
+  users: z.array(UserAllowedAdvancedModelsSchema),
+});
+export type GetUserAllowedAdvancedModelsResponseBody = z.infer<
+  typeof GetUserAllowedAdvancedModelsResponseBodySchema
+>;
+
+export const GetGroupAllowedAdvancedModelsResponseBodySchema = z.object({
+  groups: z.array(GroupAllowedAdvancedModelsSchema),
+});
+export type GetGroupAllowedAdvancedModelsResponseBody = z.infer<
+  typeof GetGroupAllowedAdvancedModelsResponseBodySchema
+>;
+
+export const GetWorkspaceAllowedAdvancedModelsResponseBodySchema = z.object({
+  models: z.array(AllowedAdvancedModelSchema),
+});
+export type GetWorkspaceAllowedAdvancedModelsResponseBody = z.infer<
+  typeof GetWorkspaceAllowedAdvancedModelsResponseBodySchema
+>;
+
+export const AllowedAdvancedModelBodySchema = AllowedAdvancedModelSchema;
+
+export const UserAllowedAdvancedModelBodySchema =
+  AllowedAdvancedModelBodySchema.extend({
+    userId: z.string(),
+  });
+export type UserAllowedAdvancedModelBody = z.infer<
+  typeof UserAllowedAdvancedModelBodySchema
+>;
+
+export const GroupAllowedAdvancedModelBodySchema =
+  AllowedAdvancedModelBodySchema.extend({
+    groupId: z.string(),
+  });
+export type GroupAllowedAdvancedModelBody = z.infer<
+  typeof GroupAllowedAdvancedModelBodySchema
+>;


### PR DESCRIPTION
## Description

Adds SWR hooks in `front/lib/swr/advanced_models.ts` for the advanced models REST endpoints introduced in #28279. Four read hooks — `useAdvancedModels`, `useUserAllowedAdvancedModels`, `useGroupAllowedAdvancedModels`, `useWorkspaceAllowedAdvancedModels` — and three mutation hook pairs — `useUserAllowedAdvancedModelMutations`, `useGroupAllowedAdvancedModelMutations`, `useWorkspaceAllowedAdvancedModelMutations` — covering POST/DELETE for each scope. All mutation hooks follow the standard `clientFetch` + `isMutating` + `sendNotification` + SWR invalidation pattern used elsewhere in the codebase.

## Tests

Tested locally against the advanced models API endpoints.

## Risk

Low. Front-only, no new API routes, no DB changes. Hooks are not yet wired to any UI component.

## Deploy Plan

Deploy front.
