### PR TITLE
Add: column and modal for advanced models.

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -10,12 +10,17 @@ import {
   seatTypeDisplayName,
 } from "@app/components/workspace/billing/seatTypeUtils";
 import { ChangeSeatModal } from "@app/components/workspace/ChangeSeatModal";
+import {
+  EditAdvancedModelsModal,
+  type EditAdvancedModelsTarget,
+} from "@app/components/workspace/EditAdvancedModelsModal";
 import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitModal";
 import { GroupsUsageTable } from "@app/components/workspace/GroupsUsageTable";
 import { MembersSelectionBanner } from "@app/components/workspace/MembersSelectionBanner";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
 import { UpgradeRequestsTable } from "@app/components/workspace/UpgradeRequestsTable";
+import { AdvancedModelsSettingsCard } from "@app/components/workspace/usage/AdvancedModelsSettingsCard";
 import { LockedSection } from "@app/components/workspace/usage/LockedSection";
 import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNotificationsCard";
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
@@ -27,6 +32,7 @@ import {
   useFeatureFlags,
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
+import { buildAdvancedModelDisplayNameMap } from "@app/lib/client/advanced_models";
 import { formatCredits } from "@app/lib/client/credits";
 import {
   isCreditPricedFreePlan,
@@ -35,6 +41,12 @@ import {
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
+import {
+  useAdvancedModels,
+  useGroupAllowedAdvancedModels,
+  useUserAllowedAdvancedModels,
+  useWorkspaceAllowedAdvancedModels,
+} from "@app/lib/swr/advanced_models";
 import {
   useAwuPoolSummary,
   useAwuPurchaseInfo,
@@ -212,6 +224,8 @@ export function UsagePage() {
   );
   const [editSpendLimitMember, setEditSpendLimitMember] =
     useState<MemberUsageType | null>(null);
+  const [editAdvancedModelsTarget, setEditAdvancedModelsTarget] =
+    useState<EditAdvancedModelsTarget | null>(null);
   const [
     totalAllowedUsagePendingMemberIds,
     setTotalAllowedUsagePendingMemberIds,
@@ -228,6 +242,7 @@ export function UsagePage() {
   // Admin-only Requests tab: pending member-initiated upgrade requests, resolved
   // by approving (via the seat / spend-limit modals) or denying.
   const isWorkspaceAdmin = isAdmin(owner);
+  const modelsPickerEnabled = hasFeature("models_picker") && isWorkspaceAdmin;
   const [membersTab, setMembersTab] = useState<"members" | "requests">(
     "members"
   );
@@ -281,6 +296,23 @@ export function UsagePage() {
     (member: MemberUsageType) => {
       setPendingApproveRequestId(null);
       setEditSpendLimitMember(member);
+    },
+    []
+  );
+  const handleEditAdvancedModelsFromTable = useCallback(
+    (member: MemberUsageType) => {
+      setEditAdvancedModelsTarget({
+        scope: "user",
+        userId: member.sId,
+        name: member.name,
+        image: member.image,
+      });
+    },
+    []
+  );
+  const handleEditWorkspaceAdvancedModels = useCallback(
+    (target: Extract<EditAdvancedModelsTarget, { scope: "workspace" }>) => {
+      setEditAdvancedModelsTarget(target);
     },
     []
   );
@@ -417,10 +449,75 @@ export function UsagePage() {
   const { groups } = useGroups({
     owner,
     kinds: ["provisioned"],
-    disabled: !isWorkspaceAdmin || !pricingGroupsEnabled,
+    disabled:
+      !isWorkspaceAdmin || (!pricingGroupsEnabled && !modelsPickerEnabled),
   });
   const selectedGroupName =
     groups.find((g) => g.sId === groupFilter)?.name ?? null;
+
+  const { models: advancedModelsCatalog } = useAdvancedModels({
+    owner,
+    disabled: !modelsPickerEnabled,
+  });
+  const { users: userAllowedAdvancedModels } = useUserAllowedAdvancedModels({
+    owner,
+    disabled: !modelsPickerEnabled,
+  });
+  const { groups: groupAllowedAdvancedModels } = useGroupAllowedAdvancedModels({
+    owner,
+    disabled: !modelsPickerEnabled,
+  });
+  const { models: workspaceAllowedAdvancedModels } =
+    useWorkspaceAllowedAdvancedModels({
+      owner,
+      disabled: !modelsPickerEnabled,
+    });
+  const advancedModelDisplayNameByKey = useMemo(
+    () => buildAdvancedModelDisplayNameMap(advancedModelsCatalog),
+    [advancedModelsCatalog]
+  );
+  const userAllowedAdvancedModelsByUserId = useMemo(() => {
+    const map: Record<
+      string,
+      (typeof userAllowedAdvancedModels)[number]["models"]
+    > = {};
+    for (const entry of userAllowedAdvancedModels) {
+      map[entry.userId] = entry.models;
+    }
+    return map;
+  }, [userAllowedAdvancedModels]);
+  const groupAdvancedModelsByGroupId = useMemo(() => {
+    const map: Record<
+      string,
+      (typeof groupAllowedAdvancedModels)[number]["models"]
+    > = {};
+    for (const entry of groupAllowedAdvancedModels) {
+      map[entry.groupId] = entry.models;
+    }
+    return map;
+  }, [groupAllowedAdvancedModels]);
+  const groupNameToId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const group of groups) {
+      map.set(group.name, group.sId);
+    }
+    return map;
+  }, [groups]);
+
+  const handleEditGroupAdvancedModels = useCallback(() => {
+    if (!groupFilter) {
+      return;
+    }
+    const group = groups.find((g) => g.sId === groupFilter);
+    if (!group) {
+      return;
+    }
+    setEditAdvancedModelsTarget({
+      scope: "group",
+      groupId: group.sId,
+      name: group.name,
+    });
+  }, [groupFilter, groups]);
 
   // Cross-page selection for batch actions on the members table. Resets when the
   // filter identity changes (the "all matching" set is no longer the same).
@@ -723,12 +820,19 @@ export function UsagePage() {
       isRefreshing={isMembersUsageRefreshing}
       readOnly={isReadOnly}
       showSpendLimit={!isFreePlanWorkspace}
+      showAdvancedModelsColumn={modelsPickerEnabled}
+      userAllowedAdvancedModelsByUserId={userAllowedAdvancedModelsByUserId}
+      groupAdvancedModelsByGroupId={groupAdvancedModelsByGroupId}
+      workspaceAllowedAdvancedModels={workspaceAllowedAdvancedModels}
+      groupNameToId={groupNameToId}
+      advancedModelDisplayNameByKey={advancedModelDisplayNameByKey}
       totalAllowedUsagePendingMemberIds={totalAllowedUsagePendingMemberIds}
       seatChangePendingMemberIds={seatChangePendingMemberIds}
       isSeatBased={isSeatBased}
       onChangeSeat={handleChangeSeatFromTable}
       onRemoveSeat={onRemoveSeat}
       onEditSpendLimit={handleEditSpendLimitFromTable}
+      onEditAdvancedModels={handleEditAdvancedModelsFromTable}
       pagination={pagination}
       setPagination={setPagination}
       totalRowCount={totalMembersUsage}
@@ -880,7 +984,7 @@ export function UsagePage() {
                     <ButtonsSwitchList
                       size="xs"
                       defaultValue="members"
-                      onValueChange={(v) =>
+                      onValueChange={(v: string) =>
                         setMembersTab(v === "requests" ? "requests" : "members")
                       }
                     >
@@ -899,6 +1003,15 @@ export function UsagePage() {
                     {membersTab === "members" && (
                       <div className="flex flex-row items-center gap-2">
                         {groupsFilterDropdown}
+                        {modelsPickerEnabled && groupFilter && (
+                          <Button
+                            label="Edit group advanced models"
+                            variant="outline"
+                            size="sm"
+                            disabled={isReadOnly}
+                            onClick={handleEditGroupAdvancedModels}
+                          />
+                        )}
                         {seatFilterDropdown}
                       </div>
                     )}
@@ -948,6 +1061,15 @@ export function UsagePage() {
                 readOnly={isReadOnly}
                 hasPool={hasPool}
               />
+              {modelsPickerEnabled && (
+                <AdvancedModelsSettingsCard
+                  owner={owner}
+                  readOnly={isReadOnly}
+                  onEditWorkspaceAdvancedModels={
+                    handleEditWorkspaceAdvancedModels
+                  }
+                />
+              )}
               <LockedSection
                 locked={!isAwuPoolSummaryLoading && !hasPool}
                 className="flex flex-col gap-10"
@@ -1007,6 +1129,13 @@ export function UsagePage() {
         onClose={() => setIsBulkSpendLimitOpen(false)}
         memberCount={selection.selectedCount}
         onValidate={handleBulkSpendLimitValidate}
+      />
+      <EditAdvancedModelsModal
+        isOpen={editAdvancedModelsTarget !== null}
+        onClose={() => setEditAdvancedModelsTarget(null)}
+        owner={owner}
+        target={editAdvancedModelsTarget}
+        readOnly={isReadOnly}
       />
     </>
   );

--- a/front/components/workspace/EditAdvancedModelsModal.tsx
+++ b/front/components/workspace/EditAdvancedModelsModal.tsx
@@ -1,0 +1,349 @@
+import { advancedModelKey } from "@app/lib/client/advanced_models";
+import {
+  useAdvancedModels,
+  useGroupAllowedAdvancedModelMutations,
+  useGroupAllowedAdvancedModels,
+  useUserAllowedAdvancedModelMutations,
+  useUserAllowedAdvancedModels,
+  useWorkspaceAllowedAdvancedModelMutations,
+  useWorkspaceAllowedAdvancedModels,
+} from "@app/lib/swr/advanced_models";
+import type { AllowedAdvancedModelType } from "@app/types/api/advanced_models";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  AlertCircle,
+  Avatar,
+  ContentMessage,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  SettingsList,
+  SliderToggle,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useCallback, useMemo, useState } from "react";
+
+export type EditAdvancedModelsTarget =
+  | {
+      scope: "user";
+      userId: string;
+      name: string;
+      image: string | null;
+    }
+  | {
+      scope: "group";
+      groupId: string;
+      name: string;
+    }
+  | {
+      scope: "workspace";
+    };
+
+interface EditAdvancedModelsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  owner: LightWorkspaceType;
+  target: EditAdvancedModelsTarget | null;
+  readOnly?: boolean;
+}
+
+function getDialogTitle(target: EditAdvancedModelsTarget): string {
+  switch (target.scope) {
+    case "user":
+      return `Advanced models for ${target.name}`;
+    case "group":
+      return `Advanced models for ${target.name}`;
+    case "workspace":
+      return "Workspace advanced models";
+    default:
+      return assertNever(target);
+  }
+}
+
+function getDialogDescription(target: EditAdvancedModelsTarget): string {
+  switch (target.scope) {
+    case "user":
+      return "Choose which advanced models this member can use.";
+    case "group":
+      return "Choose which advanced models members of this group can use.";
+    case "workspace":
+      return "Choose which advanced models are available to everyone in this workspace.";
+    default:
+      return assertNever(target);
+  }
+}
+
+export function EditAdvancedModelsModal({
+  isOpen,
+  onClose,
+  owner,
+  target,
+  readOnly = false,
+}: EditAdvancedModelsModalProps) {
+  const {
+    models: advancedModelsCatalog,
+    isAdvancedModelsLoading,
+    isAdvancedModelsError,
+  } = useAdvancedModels({
+    owner,
+    disabled: !isOpen,
+  });
+
+  const {
+    users: userAllowedAdvancedModels,
+    isUserAllowedAdvancedModelsLoading,
+    isUserAllowedAdvancedModelsError,
+  } = useUserAllowedAdvancedModels({
+    owner,
+    disabled: !isOpen || target?.scope !== "user",
+  });
+
+  const {
+    groups: groupAllowedAdvancedModels,
+    isGroupAllowedAdvancedModelsLoading,
+    isGroupAllowedAdvancedModelsError,
+  } = useGroupAllowedAdvancedModels({
+    owner,
+    disabled: !isOpen || target?.scope !== "group",
+  });
+
+  const {
+    models: workspaceAllowedAdvancedModels,
+    isWorkspaceAllowedAdvancedModelsLoading,
+    isWorkspaceAllowedAdvancedModelsError,
+  } = useWorkspaceAllowedAdvancedModels({
+    owner,
+    disabled: !isOpen || target?.scope !== "workspace",
+  });
+
+  const { addUserAllowedAdvancedModel, removeUserAllowedAdvancedModel } =
+    useUserAllowedAdvancedModelMutations({ owner });
+  const { addGroupAllowedAdvancedModel, removeGroupAllowedAdvancedModel } =
+    useGroupAllowedAdvancedModelMutations({ owner });
+  const {
+    addWorkspaceAllowedAdvancedModel,
+    removeWorkspaceAllowedAdvancedModel,
+  } = useWorkspaceAllowedAdvancedModelMutations({ owner });
+
+  const [pendingModelKeys, setPendingModelKeys] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
+
+  const allowedModels = useMemo((): AllowedAdvancedModelType[] => {
+    if (!target) {
+      return [];
+    }
+    switch (target.scope) {
+      case "user":
+        return (
+          userAllowedAdvancedModels.find(
+            (entry) => entry.userId === target.userId
+          )?.models ?? []
+        );
+      case "group":
+        return (
+          groupAllowedAdvancedModels.find(
+            (entry) => entry.groupId === target.groupId
+          )?.models ?? []
+        );
+      case "workspace":
+        return workspaceAllowedAdvancedModels;
+      default:
+        return assertNever(target);
+    }
+  }, [
+    target,
+    userAllowedAdvancedModels,
+    groupAllowedAdvancedModels,
+    workspaceAllowedAdvancedModels,
+  ]);
+
+  const allowedModelKeys = useMemo(
+    () => new Set(allowedModels.map(advancedModelKey)),
+    [allowedModels]
+  );
+
+  const isAllowedLoading = (() => {
+    if (!target) {
+      return false;
+    }
+    switch (target.scope) {
+      case "user":
+        return isUserAllowedAdvancedModelsLoading;
+      case "group":
+        return isGroupAllowedAdvancedModelsLoading;
+      case "workspace":
+        return isWorkspaceAllowedAdvancedModelsLoading;
+      default:
+        return assertNever(target);
+    }
+  })();
+
+  const isAllowedError = (() => {
+    if (!target) {
+      return false;
+    }
+    switch (target.scope) {
+      case "user":
+        return isUserAllowedAdvancedModelsError;
+      case "group":
+        return isGroupAllowedAdvancedModelsError;
+      case "workspace":
+        return isWorkspaceAllowedAdvancedModelsError;
+      default:
+        return assertNever(target);
+    }
+  })();
+
+  const setModelPending = useCallback(
+    (modelKey: string, isPending: boolean) => {
+      setPendingModelKeys((prev) => {
+        const next = new Set(prev);
+        next[isPending ? "add" : "delete"](modelKey);
+        return next;
+      });
+    },
+    []
+  );
+
+  const handleToggleModel = useCallback(
+    async (model: AllowedAdvancedModelType, isAllowed: boolean) => {
+      if (!target || readOnly) {
+        return;
+      }
+
+      const modelKey = advancedModelKey(model);
+      setModelPending(modelKey, true);
+      try {
+        let ok = false;
+        switch (target.scope) {
+          case "user":
+            ok = isAllowed
+              ? await addUserAllowedAdvancedModel({
+                  userId: target.userId,
+                  ...model,
+                })
+              : await removeUserAllowedAdvancedModel({
+                  userId: target.userId,
+                  ...model,
+                });
+            break;
+          case "group":
+            ok = isAllowed
+              ? await addGroupAllowedAdvancedModel({
+                  groupId: target.groupId,
+                  ...model,
+                })
+              : await removeGroupAllowedAdvancedModel({
+                  groupId: target.groupId,
+                  ...model,
+                });
+            break;
+          case "workspace":
+            ok = isAllowed
+              ? await addWorkspaceAllowedAdvancedModel(model)
+              : await removeWorkspaceAllowedAdvancedModel(model);
+            break;
+          default:
+            assertNever(target);
+        }
+        if (!ok) {
+          return;
+        }
+      } finally {
+        setModelPending(modelKey, false);
+      }
+    },
+    [
+      target,
+      readOnly,
+      addUserAllowedAdvancedModel,
+      removeUserAllowedAdvancedModel,
+      addGroupAllowedAdvancedModel,
+      removeGroupAllowedAdvancedModel,
+      addWorkspaceAllowedAdvancedModel,
+      removeWorkspaceAllowedAdvancedModel,
+      setModelPending,
+    ]
+  );
+
+  const isLoading = isAdvancedModelsLoading || isAllowedLoading;
+  const hasError = isAdvancedModelsError || isAllowedError;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="md">
+        <DialogHeader>
+          {target?.scope === "user" ? (
+            <div className="flex items-center gap-3">
+              <Avatar
+                size="sm"
+                name={target.name}
+                visual={target.image ?? undefined}
+              />
+              <DialogTitle>{getDialogTitle(target)}</DialogTitle>
+            </div>
+          ) : (
+            <DialogTitle>{target ? getDialogTitle(target) : ""}</DialogTitle>
+          )}
+        </DialogHeader>
+        <DialogContainer>
+          {target && (
+            <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+              {getDialogDescription(target)}
+            </p>
+          )}
+
+          {hasError && (
+            <ContentMessage
+              title="Failed to load advanced models"
+              icon={AlertCircle}
+              variant="warning"
+            >
+              An error occurred while loading advanced models. Please try again.
+            </ContentMessage>
+          )}
+
+          {isLoading ? (
+            <div className="flex justify-center py-8">
+              <Spinner />
+            </div>
+          ) : (
+            <SettingsList>
+              {advancedModelsCatalog.map((model) => {
+                const key = advancedModelKey(model);
+                const isAllowed = allowedModelKeys.has(key);
+                const isPending = pendingModelKeys.has(key);
+
+                return (
+                  <SettingsList.Row
+                    key={key}
+                    title={model.displayName}
+                    description={model.modelId}
+                    action={
+                      isPending ? (
+                        <Spinner size="xs" />
+                      ) : (
+                        <SliderToggle
+                          size="xs"
+                          selected={isAllowed}
+                          disabled={readOnly}
+                          onClick={() =>
+                            void handleToggleModel(model, !isAllowed)
+                          }
+                        />
+                      )
+                    }
+                  />
+                );
+              })}
+            </SettingsList>
+          )}
+        </DialogContainer>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/workspace/EditAdvancedModelsModal.tsx
+++ b/front/components/workspace/EditAdvancedModelsModal.tsx
@@ -59,7 +59,7 @@ function getDialogTitle(target: EditAdvancedModelsTarget): string {
     case "workspace":
       return "Workspace advanced models";
     default:
-      return assertNever(target);
+      assertNever(target.scope);
   }
 }
 
@@ -72,7 +72,7 @@ function getDialogDescription(target: EditAdvancedModelsTarget): string {
     case "workspace":
       return "Choose which advanced models are available to everyone in this workspace.";
     default:
-      return assertNever(target);
+      assertNever(target.scope);
   }
 }
 
@@ -152,7 +152,7 @@ export function EditAdvancedModelsModal({
       case "workspace":
         return workspaceAllowedAdvancedModels;
       default:
-        return assertNever(target);
+        assertNever(target.scope);
     }
   }, [
     target,
@@ -166,7 +166,7 @@ export function EditAdvancedModelsModal({
     [allowedModels]
   );
 
-  const isAllowedLoading = (() => {
+  const isAllowedLoading = useMemo(() => {
     if (!target) {
       return false;
     }
@@ -178,11 +178,16 @@ export function EditAdvancedModelsModal({
       case "workspace":
         return isWorkspaceAllowedAdvancedModelsLoading;
       default:
-        return assertNever(target);
+        assertNever(target.scope);
     }
-  })();
+  }, [
+    target,
+    isUserAllowedAdvancedModelsLoading,
+    isGroupAllowedAdvancedModelsLoading,
+    isWorkspaceAllowedAdvancedModelsLoading,
+  ]);
 
-  const isAllowedError = (() => {
+  const isAllowedError = useMemo(() => {
     if (!target) {
       return false;
     }
@@ -194,9 +199,14 @@ export function EditAdvancedModelsModal({
       case "workspace":
         return isWorkspaceAllowedAdvancedModelsError;
       default:
-        return assertNever(target);
+        assertNever(target.scope);
     }
-  })();
+  }, [
+    target,
+    isUserAllowedAdvancedModelsError,
+    isGroupAllowedAdvancedModelsError,
+    isWorkspaceAllowedAdvancedModelsError,
+  ]);
 
   const setModelPending = useCallback(
     (modelKey: string, isPending: boolean) => {
@@ -248,7 +258,7 @@ export function EditAdvancedModelsModal({
               : await removeWorkspaceAllowedAdvancedModel(model);
             break;
           default:
-            assertNever(target);
+            assertNever(target.scope);
         }
         if (!ok) {
           return;

--- a/front/components/workspace/EditAdvancedModelsModal.tsx
+++ b/front/components/workspace/EditAdvancedModelsModal.tsx
@@ -59,7 +59,7 @@ function getDialogTitle(target: EditAdvancedModelsTarget): string {
     case "workspace":
       return "Workspace advanced models";
     default:
-      assertNever(target.scope);
+      return assertNever(target);
   }
 }
 
@@ -72,7 +72,7 @@ function getDialogDescription(target: EditAdvancedModelsTarget): string {
     case "workspace":
       return "Choose which advanced models are available to everyone in this workspace.";
     default:
-      assertNever(target.scope);
+      return assertNever(target);
   }
 }
 
@@ -152,7 +152,7 @@ export function EditAdvancedModelsModal({
       case "workspace":
         return workspaceAllowedAdvancedModels;
       default:
-        assertNever(target.scope);
+        return assertNever(target);
     }
   }, [
     target,
@@ -178,7 +178,7 @@ export function EditAdvancedModelsModal({
       case "workspace":
         return isWorkspaceAllowedAdvancedModelsLoading;
       default:
-        assertNever(target.scope);
+        return assertNever(target);
     }
   }, [
     target,
@@ -199,7 +199,7 @@ export function EditAdvancedModelsModal({
       case "workspace":
         return isWorkspaceAllowedAdvancedModelsError;
       default:
-        assertNever(target.scope);
+        return assertNever(target);
     }
   }, [
     target,
@@ -258,7 +258,7 @@ export function EditAdvancedModelsModal({
               : await removeWorkspaceAllowedAdvancedModel(model);
             break;
           default:
-            assertNever(target.scope);
+            return assertNever(target);
         }
         if (!ok) {
           return;

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -10,8 +10,13 @@ import {
   OVERAGE_BAR_CLASSES,
 } from "@app/components/workspace/seat_styles";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import {
+  getAdvancedModelDisplayNames,
+  resolveAdvancedModelsForUser,
+} from "@app/lib/client/advanced_models";
 import { formatCredits } from "@app/lib/client/credits";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
+import type { AllowedAdvancedModelType } from "@app/types/api/advanced_models";
 import {
   type MembershipSeatType,
   SEAT_TYPE_ORDER,
@@ -37,6 +42,18 @@ import type {
 } from "@tanstack/react-table";
 import { useMemo } from "react";
 
+const EMPTY_USER_ALLOWED_ADVANCED_MODELS_BY_USER_ID: Record<
+  string,
+  AllowedAdvancedModelType[]
+> = {};
+const EMPTY_GROUP_ADVANCED_MODELS_BY_GROUP_ID: Record<
+  string,
+  AllowedAdvancedModelType[]
+> = {};
+const EMPTY_WORKSPACE_ALLOWED_ADVANCED_MODELS: AllowedAdvancedModelType[] = [];
+const EMPTY_GROUP_NAME_TO_ID = new Map<string, string>();
+const EMPTY_ADVANCED_MODEL_DISPLAY_NAME_BY_KEY = new Map<string, string>();
+
 type RowData = {
   sId: string;
   name: string;
@@ -55,6 +72,8 @@ type RowData = {
   scheduledSeatChangeAt: string | null;
   isTotalAllowedUsagePending: boolean;
   isSeatChangePending: boolean;
+  advancedModelDisplayNames: string[];
+  hasUserLevelAdvancedModelsOverride: boolean;
   menuItems: MenuItem[];
 };
 
@@ -456,6 +475,64 @@ const consumedAwuCreditsColumn: ColumnDef<RowData, string> = {
   enableSorting: true,
 };
 
+const advancedModelsColumn: ColumnDef<RowData, string> = {
+  id: "advancedModels" as const,
+  header: "Advanced models",
+  enableSorting: false,
+  accessorFn: (row) => row.advancedModelDisplayNames.join(", "),
+  cell: (info: Info) => {
+    const displayNames = info.row.original.advancedModelDisplayNames;
+    const customSuffix = info.row.original.hasUserLevelAdvancedModelsOverride
+      ? " (custom)"
+      : "";
+
+    if (displayNames.length === 0) {
+      return (
+        <DataTable.CellContent>
+          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            --
+          </span>
+        </DataTable.CellContent>
+      );
+    }
+
+    if (displayNames.length === 1) {
+      return (
+        <DataTable.CellContent>
+          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            {displayNames[0]}
+            {customSuffix}
+          </span>
+        </DataTable.CellContent>
+      );
+    }
+
+    return (
+      <DataTable.CellContent>
+        <Tooltip
+          label={
+            <div className="flex flex-col gap-0.5">
+              {displayNames.map((name, index) => (
+                <span key={`${name}-${index}`}>{name}</span>
+              ))}
+            </div>
+          }
+          tooltipTriggerAsChild
+          trigger={
+            <span className="cursor-default text-sm text-muted-foreground dark:text-muted-foreground-night">
+              {displayNames.length} models
+              {customSuffix}
+            </span>
+          }
+        />
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-48",
+  },
+};
+
 const actionsColumn: ColumnDef<RowData, string> = {
   id: "actions" as const,
   header: "",
@@ -472,14 +549,17 @@ const actionsColumn: ColumnDef<RowData, string> = {
 function buildColumns({
   enableSelection,
   showGroupsColumn,
+  showAdvancedModelsColumn,
 }: {
   enableSelection: boolean;
   showGroupsColumn: boolean;
+  showAdvancedModelsColumn: boolean;
 }): ColumnDef<RowData, string>[] {
   return [
     ...(enableSelection ? [createSelectionColumn<RowData>()] : []),
     nameColumn,
     ...(showGroupsColumn ? [groupsColumn] : []),
+    ...(showAdvancedModelsColumn ? [advancedModelsColumn] : []),
     seatTypeColumn,
     { ...consumedAwuCreditsColumn, meta: { className: "w-64" } },
     actionsColumn,
@@ -498,6 +578,16 @@ interface MembersUsageTableProps {
   onChangeSeat: (member: MemberUsageType) => void;
   onRemoveSeat: (member: MemberUsageType) => void;
   onEditSpendLimit: (member: MemberUsageType) => void;
+  onEditAdvancedModels?: (member: MemberUsageType) => void;
+  showAdvancedModelsColumn?: boolean;
+  userAllowedAdvancedModelsByUserId?: Record<
+    string,
+    AllowedAdvancedModelType[]
+  >;
+  groupAdvancedModelsByGroupId?: Record<string, AllowedAdvancedModelType[]>;
+  workspaceAllowedAdvancedModels?: AllowedAdvancedModelType[];
+  groupNameToId?: Map<string, string>;
+  advancedModelDisplayNameByKey?: Map<string, string>;
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
   totalRowCount: number;
@@ -521,6 +611,13 @@ export function MembersUsageTable({
   onChangeSeat,
   onRemoveSeat,
   onEditSpendLimit,
+  onEditAdvancedModels,
+  showAdvancedModelsColumn = false,
+  userAllowedAdvancedModelsByUserId = EMPTY_USER_ALLOWED_ADVANCED_MODELS_BY_USER_ID,
+  groupAdvancedModelsByGroupId = EMPTY_GROUP_ADVANCED_MODELS_BY_GROUP_ID,
+  workspaceAllowedAdvancedModels = EMPTY_WORKSPACE_ALLOWED_ADVANCED_MODELS,
+  groupNameToId = EMPTY_GROUP_NAME_TO_ID,
+  advancedModelDisplayNameByKey = EMPTY_ADVANCED_MODEL_DISPLAY_NAME_BY_KEY,
   pagination,
   setPagination,
   totalRowCount,
@@ -533,93 +630,136 @@ export function MembersUsageTable({
 }: MembersUsageTableProps) {
   const rows: RowData[] = useMemo(
     () =>
-      members.map((m) => ({
-        sId: m.sId,
-        name: m.name,
-        email: m.email,
-        image: m.image,
-        groups: m.groups,
-        seatType: m.seatType,
-        memberUsageLimit: m.memberUsageLimit,
-        seatBalanceAwu: m.seatBalanceAwu,
-        consumedAwuCredits: m.consumedAwuCredits,
-        consumedFromAllowanceAwuCredits: m.consumedFromAllowanceAwuCredits,
-        consumedFromPoolAwuCredits: m.consumedFromPoolAwuCredits,
-        spendLimitAwuCredits: m.spendLimitAwuCredits,
-        spendLimitSource: m.spendLimitSource,
-        scheduledSeatType: m.scheduledSeatType,
-        scheduledSeatChangeAt: m.scheduledSeatChangeAt,
-        isTotalAllowedUsagePending: totalAllowedUsagePendingMemberIds.has(
-          m.sId
-        ),
-        isSeatChangePending: seatChangePendingMemberIds.has(m.sId),
-        menuItems: [
-          ...(!m.seatType || m.seatType === "none"
-            ? [
-                {
-                  kind: "item" as const,
-                  label: "Assign seat",
-                  disabled: readOnly,
-                  onClick: () => onChangeSeat(m),
-                },
-              ]
-            : []),
-          ...(isSeatBased && m.seatType && m.seatType !== "none"
-            ? [
-                {
-                  kind: "item" as const,
-                  label: "Change seat type",
-                  disabled: readOnly,
-                  onClick: () => onChangeSeat(m),
-                },
-              ]
-            : []),
-          // Only paid, message-sending seats have a spend limit to edit. Free
-          // seats have no pool (their cap is just the fixed free allowance), and
-          // "none"/seatless members can't send anything — so the option hides.
-          ...(showSpendLimit &&
-          m.seatType &&
-          m.seatType !== "free" &&
-          m.seatType !== "none"
-            ? [
-                {
-                  kind: "item" as const,
-                  label: "Edit spend limit",
-                  disabled: readOnly,
-                  onClick: () => onEditSpendLimit(m),
-                },
-              ]
-            : []),
-          // Only members who currently hold a billable seat can have it removed.
-          ...(isSeatBased && m.seatType && m.seatType !== "none"
-            ? [
-                {
-                  kind: "item" as const,
-                  label: "Remove seat",
-                  variant: "warning" as const,
-                  disabled: readOnly,
-                  onClick: () => onRemoveSeat(m),
-                },
-              ]
-            : []),
-        ],
-      })),
+      members.map((m) => {
+        const resolvedAdvancedModels = showAdvancedModelsColumn
+          ? resolveAdvancedModelsForUser({
+              userId: m.sId,
+              groupNames: m.groups,
+              groupNameToId,
+              userAllowedAdvancedModelsByUserId,
+              groupAdvancedModelsByGroupId,
+              workspaceAllowedAdvancedModels,
+            })
+          : null;
+
+        return {
+          sId: m.sId,
+          name: m.name,
+          email: m.email,
+          image: m.image,
+          groups: m.groups,
+          seatType: m.seatType,
+          memberUsageLimit: m.memberUsageLimit,
+          seatBalanceAwu: m.seatBalanceAwu,
+          consumedAwuCredits: m.consumedAwuCredits,
+          consumedFromAllowanceAwuCredits: m.consumedFromAllowanceAwuCredits,
+          consumedFromPoolAwuCredits: m.consumedFromPoolAwuCredits,
+          spendLimitAwuCredits: m.spendLimitAwuCredits,
+          spendLimitSource: m.spendLimitSource,
+          scheduledSeatType: m.scheduledSeatType,
+          scheduledSeatChangeAt: m.scheduledSeatChangeAt,
+          isTotalAllowedUsagePending: totalAllowedUsagePendingMemberIds.has(
+            m.sId
+          ),
+          isSeatChangePending: seatChangePendingMemberIds.has(m.sId),
+          advancedModelDisplayNames: resolvedAdvancedModels
+            ? getAdvancedModelDisplayNames({
+                models: resolvedAdvancedModels.models,
+                displayNameByKey: advancedModelDisplayNameByKey,
+              })
+            : [],
+          hasUserLevelAdvancedModelsOverride:
+            resolvedAdvancedModels?.hasUserLevelOverride ?? false,
+          menuItems: [
+            ...(!m.seatType || m.seatType === "none"
+              ? [
+                  {
+                    kind: "item" as const,
+                    label: "Assign seat",
+                    disabled: readOnly,
+                    onClick: () => onChangeSeat(m),
+                  },
+                ]
+              : []),
+            ...(isSeatBased && m.seatType && m.seatType !== "none"
+              ? [
+                  {
+                    kind: "item" as const,
+                    label: "Change seat type",
+                    disabled: readOnly,
+                    onClick: () => onChangeSeat(m),
+                  },
+                ]
+              : []),
+            // Only paid, message-sending seats have a spend limit to edit. Free
+            // seats have no pool (their cap is just the fixed free allowance), and
+            // "none"/seatless members can't send anything — so the option hides.
+            ...(showSpendLimit &&
+            m.seatType &&
+            m.seatType !== "free" &&
+            m.seatType !== "none"
+              ? [
+                  {
+                    kind: "item" as const,
+                    label: "Edit spend limit",
+                    disabled: readOnly,
+                    onClick: () => onEditSpendLimit(m),
+                  },
+                ]
+              : []),
+            ...(showAdvancedModelsColumn && onEditAdvancedModels
+              ? [
+                  {
+                    kind: "item" as const,
+                    label: "Edit advanced models",
+                    disabled: readOnly,
+                    onClick: () => onEditAdvancedModels(m),
+                  },
+                ]
+              : []),
+            // Only members who currently hold a billable seat can have it removed.
+            ...(isSeatBased && m.seatType && m.seatType !== "none"
+              ? [
+                  {
+                    kind: "item" as const,
+                    label: "Remove seat",
+                    variant: "warning" as const,
+                    disabled: readOnly,
+                    onClick: () => onRemoveSeat(m),
+                  },
+                ]
+              : []),
+          ],
+        };
+      }),
     [
       members,
       totalAllowedUsagePendingMemberIds,
       seatChangePendingMemberIds,
       isSeatBased,
       showSpendLimit,
+      showAdvancedModelsColumn,
+      userAllowedAdvancedModelsByUserId,
+      groupAdvancedModelsByGroupId,
+      workspaceAllowedAdvancedModels,
+      groupNameToId,
+      advancedModelDisplayNameByKey,
       readOnly,
       onChangeSeat,
       onRemoveSeat,
       onEditSpendLimit,
+      onEditAdvancedModels,
     ]
   );
 
   const columns = useMemo(
-    () => buildColumns({ enableSelection, showGroupsColumn }),
-    [enableSelection, showGroupsColumn]
+    () =>
+      buildColumns({
+        enableSelection,
+        showGroupsColumn,
+        showAdvancedModelsColumn,
+      }),
+    [enableSelection, showGroupsColumn, showAdvancedModelsColumn]
   );
 
   if (isLoading) {

--- a/front/components/workspace/usage/AdvancedModelsSettingsCard.tsx
+++ b/front/components/workspace/usage/AdvancedModelsSettingsCard.tsx
@@ -1,0 +1,78 @@
+import type { EditAdvancedModelsTarget } from "@app/components/workspace/EditAdvancedModelsModal";
+import {
+  buildAdvancedModelDisplayNameMap,
+  formatAdvancedModelsSummary,
+} from "@app/lib/client/advanced_models";
+import {
+  useAdvancedModels,
+  useWorkspaceAllowedAdvancedModels,
+} from "@app/lib/swr/advanced_models";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Button, Page, SettingsList, Spinner } from "@dust-tt/sparkle";
+
+interface AdvancedModelsSettingsCardProps {
+  owner: LightWorkspaceType;
+  readOnly: boolean;
+  onEditWorkspaceAdvancedModels: (
+    target: Extract<EditAdvancedModelsTarget, { scope: "workspace" }>
+  ) => void;
+}
+
+export function AdvancedModelsSettingsCard({
+  owner,
+  readOnly,
+  onEditWorkspaceAdvancedModels,
+}: AdvancedModelsSettingsCardProps) {
+  const { models: advancedModelsCatalog, isAdvancedModelsLoading } =
+    useAdvancedModels({ owner });
+  const {
+    models: workspaceAllowedAdvancedModels,
+    isWorkspaceAllowedAdvancedModelsLoading,
+  } = useWorkspaceAllowedAdvancedModels({ owner });
+
+  const displayNameByKey = buildAdvancedModelDisplayNameMap(
+    advancedModelsCatalog
+  );
+  const summary = formatAdvancedModelsSummary({
+    models: workspaceAllowedAdvancedModels,
+    displayNameByKey,
+  });
+  const isLoading =
+    isAdvancedModelsLoading || isWorkspaceAllowedAdvancedModelsLoading;
+
+  return (
+    <Page.Vertical gap="sm" align="stretch">
+      <span className="heading-base text-foreground dark:text-foreground-night">
+        Advanced models
+      </span>
+      <SettingsList>
+        <SettingsList.Row
+          title="Workspace access"
+          description="Grant advanced models to all members of this workspace."
+          action={
+            isLoading ? (
+              <Spinner size="xs" />
+            ) : (
+              <Button
+                label="Edit advanced models"
+                variant="outline"
+                size="sm"
+                disabled={readOnly}
+                onClick={() =>
+                  onEditWorkspaceAdvancedModels({ scope: "workspace" })
+                }
+              />
+            )
+          }
+        />
+      </SettingsList>
+      {!isLoading && (
+        <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+          {summary === "--"
+            ? "No advanced models enabled for the workspace."
+            : `Enabled: ${summary}`}
+        </span>
+      )}
+    </Page.Vertical>
+  );
+}

--- a/front/lib/client/advanced_models.test.ts
+++ b/front/lib/client/advanced_models.test.ts
@@ -1,0 +1,102 @@
+import {
+  CLAUDE_OPUS_4_6_MODEL_ID,
+  CLAUDE_OPUS_4_7_MODEL_ID,
+  CLAUDE_SONNET_4_6_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
+import { describe, expect, it } from "vitest";
+
+import { resolveAdvancedModelsForUser } from "./advanced_models";
+
+const opus = {
+  providerId: "anthropic" as const,
+  modelId: CLAUDE_OPUS_4_6_MODEL_ID,
+};
+
+const sonnet = {
+  providerId: "anthropic" as const,
+  modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+};
+
+describe("resolveAdvancedModelsForUser", () => {
+  it("returns the union of workspace, group, and user models", () => {
+    const result = resolveAdvancedModelsForUser({
+      userId: "user1",
+      groupNames: ["Engineering"],
+      groupNameToId: new Map([["Engineering", "group1"]]),
+      userAllowedAdvancedModelsByUserId: {
+        user1: [sonnet],
+      },
+      groupAdvancedModelsByGroupId: {
+        group1: [opus],
+      },
+      workspaceAllowedAdvancedModels: [
+        {
+          providerId: "anthropic",
+          modelId: CLAUDE_OPUS_4_7_MODEL_ID,
+        },
+      ],
+    });
+
+    expect(result.models).toHaveLength(3);
+    expect(result.hasUserLevelOverride).toBe(true);
+  });
+
+  it("deduplicates models present in multiple scopes", () => {
+    const result = resolveAdvancedModelsForUser({
+      userId: "user1",
+      groupNames: ["Engineering"],
+      groupNameToId: new Map([["Engineering", "group1"]]),
+      userAllowedAdvancedModelsByUserId: {
+        user1: [opus],
+      },
+      groupAdvancedModelsByGroupId: {
+        group1: [opus],
+      },
+      workspaceAllowedAdvancedModels: [opus],
+    });
+
+    expect(result.models).toEqual([opus]);
+    expect(result.hasUserLevelOverride).toBe(true);
+  });
+
+  it("marks hasUserLevelOverride when the user has direct grants", () => {
+    const withOverride = resolveAdvancedModelsForUser({
+      userId: "user1",
+      groupNames: [],
+      groupNameToId: new Map(),
+      userAllowedAdvancedModelsByUserId: {
+        user1: [opus],
+      },
+      groupAdvancedModelsByGroupId: {},
+      workspaceAllowedAdvancedModels: [],
+    });
+
+    const withoutOverride = resolveAdvancedModelsForUser({
+      userId: "user1",
+      groupNames: [],
+      groupNameToId: new Map(),
+      userAllowedAdvancedModelsByUserId: {},
+      groupAdvancedModelsByGroupId: {},
+      workspaceAllowedAdvancedModels: [opus],
+    });
+
+    expect(withOverride.hasUserLevelOverride).toBe(true);
+    expect(withoutOverride.hasUserLevelOverride).toBe(false);
+  });
+
+  it("ignores group models when the group name cannot be resolved", () => {
+    const result = resolveAdvancedModelsForUser({
+      userId: "user1",
+      groupNames: ["Unknown group"],
+      groupNameToId: new Map(),
+      userAllowedAdvancedModelsByUserId: {},
+      groupAdvancedModelsByGroupId: {
+        group1: [opus],
+      },
+      workspaceAllowedAdvancedModels: [],
+    });
+
+    expect(result.models).toEqual([]);
+    expect(result.hasUserLevelOverride).toBe(false);
+  });
+});

--- a/front/lib/client/advanced_models.ts
+++ b/front/lib/client/advanced_models.ts
@@ -1,0 +1,102 @@
+import type {
+  AdvancedModelType,
+  AllowedAdvancedModelType,
+} from "@app/types/api/advanced_models";
+
+export function advancedModelKey(model: AllowedAdvancedModelType): string {
+  return `${model.providerId}:${model.modelId}`;
+}
+
+export function isSameAdvancedModel(
+  a: AllowedAdvancedModelType,
+  b: AllowedAdvancedModelType
+): boolean {
+  return a.providerId === b.providerId && a.modelId === b.modelId;
+}
+
+export type ResolvedAdvancedModelsForUser = {
+  models: AllowedAdvancedModelType[];
+  hasUserLevelOverride: boolean;
+};
+
+export function resolveAdvancedModelsForUser({
+  userId,
+  groupNames,
+  groupNameToId,
+  userAllowedAdvancedModelsByUserId,
+  groupAdvancedModelsByGroupId,
+  workspaceAllowedAdvancedModels,
+}: {
+  userId: string;
+  groupNames: string[];
+  groupNameToId: Map<string, string>;
+  userAllowedAdvancedModelsByUserId: Record<string, AllowedAdvancedModelType[]>;
+  groupAdvancedModelsByGroupId: Record<string, AllowedAdvancedModelType[]>;
+  workspaceAllowedAdvancedModels: AllowedAdvancedModelType[];
+}): ResolvedAdvancedModelsForUser {
+  const userModels = userAllowedAdvancedModelsByUserId[userId] ?? [];
+  const hasUserLevelOverride = userModels.length > 0;
+
+  const modelsByKey = new Map<string, AllowedAdvancedModelType>();
+
+  const addModels = (models: AllowedAdvancedModelType[]) => {
+    for (const model of models) {
+      modelsByKey.set(advancedModelKey(model), model);
+    }
+  };
+
+  addModels(workspaceAllowedAdvancedModels);
+
+  for (const groupName of groupNames) {
+    const groupId = groupNameToId.get(groupName);
+    if (groupId) {
+      addModels(groupAdvancedModelsByGroupId[groupId] ?? []);
+    }
+  }
+
+  addModels(userModels);
+
+  return {
+    models: [...modelsByKey.values()],
+    hasUserLevelOverride,
+  };
+}
+
+export function getAdvancedModelDisplayNames({
+  models,
+  displayNameByKey,
+}: {
+  models: AllowedAdvancedModelType[];
+  displayNameByKey: Map<string, string>;
+}): string[] {
+  return models.map(
+    (model) => displayNameByKey.get(advancedModelKey(model)) ?? model.modelId
+  );
+}
+
+export function formatAdvancedModelsSummary({
+  models,
+  displayNameByKey,
+}: {
+  models: AllowedAdvancedModelType[];
+  displayNameByKey: Map<string, string>;
+}): string {
+  const displayNames = getAdvancedModelDisplayNames({
+    models,
+    displayNameByKey,
+  });
+  if (displayNames.length === 0) {
+    return "--";
+  }
+  return displayNames.join(", ");
+}
+
+export function buildAdvancedModelDisplayNameMap(
+  catalog: AdvancedModelType[]
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const model of catalog) {
+    map.set(advancedModelKey(model), model.displayName);
+  }
+  return map;
+}


### PR DESCRIPTION
## Description

Wires the advanced models allowlist UI into the admin Usage page, gated on `models_picker` feature flag + admin role.

- **`MembersUsageTable`**: new `advancedModels` column showing resolved model names per member (tooltip for multi-model, `(custom)` suffix for user-level overrides via `resolveAdvancedModelsForUser`).
- **`EditAdvancedModelsModal`**: new `Dialog` with `SliderToggle` per model, scoped to `user | group | workspace`. Calls add/remove mutations from `useUser/Group/WorkspaceAllowedAdvancedModelMutations` with per-model pending state.
- **`UsagePage`**: loads catalog + allowed models from all four SWR hooks, derives `userAllowedAdvancedModelsByUserId`, `groupAdvancedModelsByGroupId`, and `groupNameToId` lookup maps, passes them to `MembersUsageTable`, renders `EditAdvancedModelsModal` for user/group/workspace targets, adds `AdvancedModelsSettingsCard` in the settings section, and exposes a group-filter button to open the group scope modal.

<img width="1199" height="472" alt="file-d26eed69087daa6ef3454ef89adface8" src="https://github.com/user-attachments/assets/65bac89e-1900-497f-8760-98da183fd986" />

<img width="1126" height="539" alt="file-8fba08f178c4c2e3bd8f3754ebad6687" src="https://github.com/user-attachments/assets/93050034-8d8a-4d05-87ff-7293364abf5f" />

<img width="489" height="399" alt="file-67485704efb0eb80656b3cc8f2ee13bc" src="https://github.com/user-attachments/assets/84b35a86-3c1d-4eb6-a42d-79ecc903b179" />

<img width="1134" height="179" alt="file-f7cb74f2638ddaa9fc19cc40dcea01cd" src="https://github.com/user-attachments/assets/29670bc6-f6c5-4acc-b70c-9d30011b0770" />

<img width="537" height="412" alt="file-fd6cdb4d0f148bce8eab50598797eb82" src="https://github.com/user-attachments/assets/888df652-8671-437c-9e71-9e403181d4ac" />

<img width="1125" height="989" alt="file-91047aa0ba46a5df43cdcab00043254d" src="https://github.com/user-attachments/assets/bc44a907-d782-4bdf-8adc-03cecefcdcff" />

Note that design wise we can def. iterate.

## Tests

Tested locally with `models_picker` feature flag enabled. Verified toggle add/remove for user, group, and workspace scopes; column display with single model, multiple models (tooltip), and empty state.

## Risk

Low. Entirely gated behind `models_picker` FF + admin check. All SWR hooks disable when the flag is off. No DB changes.

## Deploy Plan

Deploy front.
