### PR TITLE
chore(mcp): improve microsoft_excel tool descriptions for BM25 tool-search recall

### DIFF
--- a/front/scripts/mcp_bm25/queries.ts
+++ b/front/scripts/mcp_bm25/queries.ts
@@ -163,6 +163,16 @@ export const QUERIES: LabeledQuery[] = [
     expected: "microsoft_drive.list_drive_items",
   },
 
+  // --- microsoft_excel ---
+  {
+    query: "find Excel files in OneDrive",
+    expected: "microsoft_excel.list_excel_files",
+  },
+  {
+    query: "read cell values from an Excel worksheet",
+    expected: "microsoft_excel.read_worksheet",
+  },
+
   // --- jira ---
   { query: "create a new issue in jira", expected: "jira.create_issue" },
   {

--- a/front/scripts/mcp_bm25/run.ts
+++ b/front/scripts/mcp_bm25/run.ts
@@ -36,6 +36,7 @@ import { INTERACTIVE_CONTENT_SERVER } from "@app/lib/api/actions/servers/interac
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { LUMA_SERVER } from "@app/lib/api/actions/servers/luma/metadata";
 import { MICROSOFT_DRIVE_SERVER } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
+import { MICROSOFT_EXCEL_SERVER } from "@app/lib/api/actions/servers/microsoft_excel/metadata";
 import { MICROSOFT_TEAMS_SERVER } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
 import { MONDAY_SERVER } from "@app/lib/api/actions/servers/monday/metadata";
 import { NOTION_SERVER } from "@app/lib/api/actions/servers/notion/metadata";
@@ -123,6 +124,7 @@ const SERVERS: ServerEntry[] = [
   { name: "google_drive", tools: GOOGLE_DRIVE_SERVER.tools },
   { name: "google_sheets", tools: GOOGLE_SHEETS_SERVER.tools },
   { name: "microsoft_drive", tools: MICROSOFT_DRIVE_SERVER.tools },
+  { name: "microsoft_excel", tools: MICROSOFT_EXCEL_SERVER.tools },
   { name: "jira", tools: JIRA_SERVER.tools },
   { name: "zendesk", tools: ZENDESK_SERVER.tools },
   { name: "front", tools: FRONT_SERVER.tools },


### PR DESCRIPTION
Adds microsoft_excel server to the BM25 harness with labeled queries for listing Excel files and reading worksheet data. Also fixes two pre-existing microsoft_drive query collisions introduced by adding the excel server.