### PR TITLE
fix(docker): copy front migration SQL files into front-api runtime image for pre-deploy checks

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -250,6 +250,8 @@ COPY --from=base-deps /app/scripts/db /app/scripts/db
 
 # front-api workspace (server.ts, app.ts, routes/, middleware/).
 COPY --from=front-api-build /app/front-api ./front-api
+# Copy migration SQL files (migrations live in front/ but the pre-deploy hook runs from /app/front-api).
+COPY --from=base-deps /app/front/migrations ./front-api/migrations
 
 # Sibling workspaces resolved via @app aliases or transitive imports.
 COPY --from=base-deps /app/sdks/js ./sdks/js


### PR DESCRIPTION
## Description

Fixes the helm pre-deploy hook for `front-sse` (which runs in the `front-api` image): the migration SQL files were missing from the right path.

The `front-api` image already had `dist/migrate.js` compiled (the esbuild shared config includes a "migrate" target alongside "server"), so the check script itself was present. The problem is that `migration-runner.ts` globs `migrations/{phase}/*.sql` relative to the process working directory, which is `/app/front-api` when the helm hook runs. The SQL files only existed under `/app/front/migrations/`, so the glob found nothing.

Fix: add an explicit `COPY` of `front/migrations` into `front-api/migrations` in the `front-api` runtime stage.

**connectors** and **front-workers** are not affected — connectors by the earlier PR (#28179), connectors via `COPY /connectors/ .` which already includes its migrations.

## Tests

Traced the full migration check path for the front-api image:
- `dist/migrate.js` at `/app/front-api/dist/migrate.js` ✓ (built by esbuild.shared.ts "migrate" target)
- `scripts/db/run-migrate.cjs` at `/app/scripts/db/` ✓
- `migrations/pre-deploy/*.sql` at `/app/front-api/migrations/` now ✓

## Risk

Low — two lines added to the Dockerfile, no code or runtime behaviour change. Only affects the pre-deploy hook job.
