### PR TITLE
fix(assistant): include model in unsupported model error response

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -808,6 +808,7 @@ export async function postUserMessage(
         api_error: {
           type: "invalid_request_error",
           message: "The model is not supported.",
+          model: agentConfig.model,
         },
       });
     }


### PR DESCRIPTION
## Description

When a message is posted to an agent whose configured model is not available (feature flag / plan / region gating), `postUserMessage` returns a `400 invalid_request_error` with the message "The model is not supported." This adds the offending `model` to the error response so it's clear which model triggered the failure, making the error easier to diagnose from client logs and support tickets.

## Change

- `front/lib/api/assistant/conversation.ts`: include `model: agentConfig.model` in the `api_error` returned for the unsupported-model case.

## Testing

- `tsgo --noEmit` clean for the changed file; pre-commit typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)