### PR TITLE
fix(llm-router): recover malformed tool-call JSON instead of failing

### DIFF
--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
@@ -189,6 +189,18 @@ function apiInvalidToolJsonError(): APIError {
   );
 }
 
+// An AnthropicError carrying a native JSON.parse SyntaxError as its `cause`,
+// with a bare parse message (no `Unable to parse tool parameter JSON` needle or
+// embedded buffer) — how the SDK surfaces malformed tool JSON.
+function bareToolJsonParseError(): AnthropicError {
+  const syntaxError = new SyntaxError(
+    "Expected ',' or '}' after property value in JSON at position 4 (line 1 column 5)"
+  );
+  const err = new AnthropicError(syntaxError.message);
+  Object.defineProperty(err, "cause", { value: syntaxError });
+  return err;
+}
+
 describe("getInvalidToolJsonMessage", () => {
   it("extracts the message from a matching APIError", () => {
     expect(getInvalidToolJsonMessage(apiInvalidToolJsonError())).toBe(
@@ -1310,6 +1322,68 @@ describe("rawOutputToEvents", () => {
     expect(success).toMatchObject({
       content: { aggregated: [{ type: "tool_call" }] },
     });
+  });
+
+  it("recovers an in-progress tool call from the accumulator on a bare JSON parse error", async () => {
+    // The error carries no embedded JSON, so the recovered arguments must come
+    // from the accumulated buffer.
+    const events = await collect(
+      rawOutputToEvents(
+        streamOf(
+          [
+            {
+              type: "content_block_start",
+              index: 0,
+              content_block: {
+                type: "tool_use",
+                id: "tu-1",
+                name: "search",
+                input: {},
+              },
+            } as RawMessageStreamEvent,
+            {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "input_json_delta", partial_json: "{bad" },
+            } as RawMessageStreamEvent,
+          ],
+          bareToolJsonParseError()
+        ),
+        metadata,
+        realConverters
+      )
+    );
+
+    const toolCall = events.find((e) => e.type === "tool_call");
+    expect(toolCall).toMatchObject({
+      content: {
+        id: "tu-1",
+        name: "search",
+        arguments: { INVALID_JSON: "{bad" },
+      },
+    });
+    expect(events.some((e) => e.type === "error")).toBe(false);
+  });
+
+  it("surfaces a bare JSON parse error as an error event when no tool_use block is open", async () => {
+    // Without an in-progress tool_use block there is nothing to recover, so it
+    // must fall through to the unified error path rather than being swallowed.
+    const events = await collect(
+      rawOutputToEvents(
+        streamOf(
+          [
+            {
+              type: "message_start",
+              message: { id: "msg_1" },
+            } as RawMessageStartEvent,
+          ],
+          bareToolJsonParseError()
+        ),
+        metadata,
+        realConverters
+      )
+    );
+    expect(events.map((e) => e.type)).toEqual(["response_id", "error"]);
   });
 
   it("omits the token_usage event when no message_delta carried usage", async () => {

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -101,6 +101,38 @@ export function getInvalidToolJsonMessage(err: unknown): string | null {
   return null;
 }
 
+// The SDK surfaces a malformed tool-call JSON as a raw `JSON.parse` SyntaxError,
+// either bare or as the `cause` of an AnthropicError. `partialParse` tolerates
+// truncation and only throws on genuinely malformed input, so this is always bad
+// model output, never a transport cut.
+function isBareToolJsonParseError(err: unknown): boolean {
+  if (err instanceof SyntaxError) {
+    return true;
+  }
+  return (
+    err instanceof AnthropicError &&
+    "cause" in err &&
+    err.cause instanceof SyntaxError
+  );
+}
+
+// The raw malformed tool JSON when a stream aborted on a tool-call parse
+// failure, or null if unrelated. When the SDK embeds it in the error message
+// (after `JSON: `) we use that; otherwise we recover from the buffer accumulated
+// so far, which is enough for the agent loop to re-sample.
+function invalidToolJsonFromStreamError(
+  err: unknown,
+  accumulator: string
+): string | null {
+  const wrapped = getInvalidToolJsonMessage(err);
+  if (wrapped !== null) {
+    return wrapped.slice(
+      wrapped.lastIndexOf(INVALID_JSON_MARKER) + INVALID_JSON_MARKER.length
+    );
+  }
+  return isBareToolJsonParseError(err) ? accumulator : null;
+}
+
 // Cursor for the content block being streamed; deltas accumulate here until
 // `content_block_stop` flushes it as an event.
 export type BlockState =
@@ -901,29 +933,27 @@ export async function* rawOutputToEvents(
     try {
       result = await stream.next();
     } catch (err) {
-      // On invalid tool JSON aborting the stream, if a tool_use block is in
-      // progress, recover by emitting a tool_call wrapping the invalid JSON so
-      // the agent loop can send it back and let the model self-correct.
-      const invalidJsonMessage = getInvalidToolJsonMessage(err);
-      if (
-        invalidJsonMessage !== null &&
-        blockState !== null &&
-        blockState.type === "tool_use"
-      ) {
-        const invalidJson = invalidJsonMessage.slice(
-          invalidJsonMessage.lastIndexOf(INVALID_JSON_MARKER) +
-            INVALID_JSON_MARKER.length
+      // Invalid tool-call JSON aborts the stream while the tool_use block is
+      // still open. Recover by emitting a tool_call wrapping the raw JSON so the
+      // agent loop can hand it back and let the model self-correct, instead of
+      // surfacing a terminal error.
+      if (blockState !== null && blockState.type === "tool_use") {
+        const invalidJson = invalidToolJsonFromStreamError(
+          err,
+          blockState.accumulator
         );
-        const ev = converters.invalidJsonToolCallToToolCallEvent(
-          metadata,
-          blockState.toolId,
-          blockState.toolName,
-          invalidJson
-        );
-        aggregated.push(ev);
-        yield ev;
-        blockState = null;
-        break;
+        if (invalidJson !== null) {
+          const ev = converters.invalidJsonToolCallToToolCallEvent(
+            metadata,
+            blockState.toolId,
+            blockState.toolName,
+            invalidJson
+          );
+          aggregated.push(ev);
+          yield ev;
+          blockState = null;
+          break;
+        }
       }
       // Everything leaving the endpoint is an event: map any other SDK error to
       // a unified error event and terminate the stream rather than throwing.


### PR DESCRIPTION
## Description

With `use_new_llm_router`, some turns fail with `unknown_error` / "Unknown error from Anthropic: Expected ',' or '}' after property value in JSON at position N" (and similar `JSON.parse` messages). These are malformed tool-call arguments: with `eager_input_streaming` the model streams tool JSON and Anthropic no longer validates it server-side.

The new router streams via the non-beta `messages.stream()` accumulator, which lets the raw `JSON.parse` `SyntaxError` escape. `getInvalidToolJsonMessage` only matches the wrapped form, so the bare error fell through to a terminal `unknown_error` and the in-progress tool-call recovery was skipped.

Now, when a `tool_use` block is open and the abort is a JSON parse failure (`partialParse` only throws on genuinely malformed input, never on truncation), we recover the raw JSON from the block's own accumulator and emit a `tool_call` wrapping it — the same self-correction path already used for the wrapped-error case — so the agent loop re-samples instead of failing the turn.

## Tests

Added coverage in `utils.test.ts`: recovery from the accumulator on a bare parse error, and the guard that a bare parse error with no open `tool_use` block still surfaces as an error event. Full suite passes (88).

## Risk

Low. Change is scoped to the stream error path; a genuine parse abort now becomes a recoverable `tool_call` instead of a terminal error. Non-parse errors are unchanged. Easy to roll back.

## Deploy Plan

Standard.