### PR TITLE
[front] chore: discourage less heavily > 4 options in ask user question

### DIFF
--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -58,7 +58,10 @@ export const UserQuestionSchema = z.object({
     .describe("The question text. Should be clear and specific."),
   options: z
     .array(UserQuestionOptionSchema)
-    .describe("The available choices (2 to 4 options)."),
+    .describe(
+      "The available choices (typically 2 to 4 options, too many options to " +
+        "choose from can be overwhelming for the user)."
+    ),
   multiSelect: z
     .boolean()
     .describe(


### PR DESCRIPTION
## Description

The current description of the `options` parameter in the `ask_user_question` tool discourages strongly having between 2 and 4 options. As reported [here](https://dust4ai.slack.com/archives/C07EEJQT0RX/p1782830155153089), sometimes you might want more, and even though possible, the current wording causes agents to usually be quite adamant that > 4 is not possible.

This PR tweaks the argument description accordingly.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
