### PR TITLE
Re-use the new plan field for advanced models + increase the cache version

### DIFF
--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -2,7 +2,6 @@ import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import { filterEnabledModels, isModelAvailable } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import {
-  DUST_COMPANY_PLAN_CODE,
   FREE_NO_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
   PRO_PLAN_SEAT_29_CODE,
@@ -29,7 +28,10 @@ function createMockModel(
 }
 
 // createMockPlan is only used by isModelAvailable tests (pure sync, no factory available).
-function createMockPlan(code: string): PlanType {
+function createMockPlan(
+  code: string,
+  { hasAdvancedModelAccess = false }: { hasAdvancedModelAccess?: boolean } = {}
+): PlanType {
   return {
     code,
     name: `Test Plan ${code}`,
@@ -79,7 +81,7 @@ function createMockPlan(code: string): PlanType {
     },
     isByok: false,
     isAuditLogsAllowed: false,
-    hasAdvancedModelAccess: false,
+    hasAdvancedModelAccess,
   };
 }
 
@@ -212,12 +214,14 @@ describe("isModelAvailable", () => {
     ).toBe(false);
   });
 
-  it("should return true when plansWithAdvancedModels is set and plan is an enterprise plan", () => {
+  it("should return true when plansWithAdvancedModels is set and plan has advanced model access", () => {
     const model = createMockModel({
       availableIfOneOf: { plansWithAdvancedModels: true },
       largeModel: false,
     });
-    const plan = createMockPlan(DUST_COMPANY_PLAN_CODE);
+    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE, {
+      hasAdvancedModelAccess: true,
+    });
 
     expect(
       isModelAvailable(model, {
@@ -229,12 +233,14 @@ describe("isModelAvailable", () => {
     ).toBe(true);
   });
 
-  it("should return true when plansWithAdvancedModels is set and plan has ENT_ prefix", () => {
+  it("should return false when plansWithAdvancedModels is set but plan lacks advanced model access", () => {
     const model = createMockModel({
       availableIfOneOf: { plansWithAdvancedModels: true },
       largeModel: false,
     });
-    const plan = createMockPlan("ENT_CUSTOM_PLAN");
+    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE, {
+      hasAdvancedModelAccess: false,
+    });
 
     expect(
       isModelAvailable(model, {
@@ -243,10 +249,10 @@ describe("isModelAvailable", () => {
         regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it("should return true when both plansWithAdvancedModels and featureFlag are set, with enterprise plan", () => {
+  it("should return true when both plansWithAdvancedModels and featureFlag are set, with advanced model access", () => {
     const model = createMockModel({
       availableIfOneOf: {
         plansWithAdvancedModels: true,
@@ -254,7 +260,9 @@ describe("isModelAvailable", () => {
       },
       largeModel: false,
     });
-    const plan = createMockPlan(DUST_COMPANY_PLAN_CODE);
+    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE, {
+      hasAdvancedModelAccess: true,
+    });
 
     expect(
       isModelAvailable(model, {

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,9 +1,4 @@
-import {
-  isCreditPricedPlanPrefix,
-  isDustCompanyPlan,
-  isEnterprisePlanPrefix,
-  isUpgraded,
-} from "@app/lib/plans/plan_codes";
+import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { isByokProviderId } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
@@ -12,17 +7,6 @@ import type {
 import type { PlanType } from "@app/types/plan";
 import type { RegionType } from "@app/types/region";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
-
-// TODO(fabien): replace this check with `plan.hasAdvancedModelAccess` once
-// all plans have been configured via Poke.
-export function isPlanForAdvancedModels(plan: PlanType | null): boolean {
-  return (
-    plan !== null &&
-    (isEnterprisePlanPrefix(plan.code) ||
-      isCreditPricedPlanPrefix(plan.code) ||
-      isDustCompanyPlan(plan.code))
-  );
-}
 
 // Returns true if the model is available to the workspace for build.
 export function isModelAvailable(
@@ -57,7 +41,7 @@ export function isModelAvailable(
 
   const { plansWithAdvancedModels, featureFlag } = m.availableIfOneOf;
 
-  if (plansWithAdvancedModels === true && isPlanForAdvancedModels(plan)) {
+  if (plansWithAdvancedModels === true && plan?.hasAdvancedModelAccess) {
     return true;
   }
 

--- a/front/types/shared/cache_resource_registry.ts
+++ b/front/types/shared/cache_resource_registry.ts
@@ -44,7 +44,7 @@ export function buildCacheKeyPattern(
 }
 
 export const WORKSPACE_CACHE_KEY_VERSION = 2;
-export const SUBSCRIPTION_CACHE_KEY_VERSION = 1;
+export const SUBSCRIPTION_CACHE_KEY_VERSION = 2;
 
 export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
   {

--- a/front/types/shared/cache_resource_registry.ts
+++ b/front/types/shared/cache_resource_registry.ts
@@ -43,6 +43,8 @@ export function buildCacheKeyPattern(
   return `cacheWithRedis-${resource.fnName}-${resource.resolverKeyPattern}`;
 }
 
+// Bump these versions whenever the shape or the semantics of the cached payload
+// change (e.g. a new field added).
 export const WORKSPACE_CACHE_KEY_VERSION = 2;
 export const SUBSCRIPTION_CACHE_KEY_VERSION = 2;
 


### PR DESCRIPTION
## Description

 - re-revert https://github.com/dust-tt/dust/pull/28272
 - increase the subscription cache version so we always have the new field availalbe

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests


## Risk

may break the same customers if cache was not the reason.
I will monitor

## Deploy Plan

deploy front 
