### PR TITLE
feat(analytics): add data export panel to the analytics page

### DIFF
--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -1,5 +1,6 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { AnalyticsExportPanel } from "@app/components/workspace/analytics/AnalyticsExportPanel";
 import type { AnalyticsFilter } from "@app/components/workspace/analytics/analyticsFilter";
 import { toggleScopeEntity } from "@app/components/workspace/analytics/analyticsFilter";
 import { WorkspaceAgentCreditsTable } from "@app/components/workspace/analytics/WorkspaceAgentCreditsTable";
@@ -130,6 +131,7 @@ export function AnalyticsPage() {
         <SafeSuspense fallback={<ChartFallback />}>
           <WorkspaceSkillUsageChart workspaceId={owner.sId} period={period} />
         </SafeSuspense>
+        <AnalyticsExportPanel workspaceId={owner.sId} />
       </div>
     </Page.Vertical>
   );

--- a/front/components/workspace/analytics/AnalyticsExportPanel.tsx
+++ b/front/components/workspace/analytics/AnalyticsExportPanel.tsx
@@ -1,0 +1,109 @@
+import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
+import { WorkspaceAnalyticsTimeRangeSelector } from "@app/components/workspace/analytics/WorkspaceAnalyticsTimeRangeSelector";
+import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+type ExportTable =
+  | "usage_metrics"
+  | "active_users"
+  | "source"
+  | "agents"
+  | "users"
+  | "skills"
+  | "skill_usage"
+  | "tool_usage"
+  | "messages"
+  | "feedback";
+
+const EXPORT_TABLES: { value: ExportTable; label: string }[] = [
+  { value: "usage_metrics", label: "Usage metrics" },
+  { value: "active_users", label: "Active users" },
+  { value: "source", label: "Message source" },
+  { value: "agents", label: "Agents" },
+  { value: "users", label: "Users" },
+  { value: "skills", label: "Skills" },
+  { value: "skill_usage", label: "Skill usage" },
+  { value: "tool_usage", label: "Tool usage" },
+  { value: "messages", label: "Messages" },
+  { value: "feedback", label: "Feedback" },
+];
+
+function toDateString(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+interface AnalyticsExportPanelProps {
+  workspaceId: string;
+}
+
+export function AnalyticsExportPanel({
+  workspaceId,
+}: AnalyticsExportPanelProps) {
+  // Dedicated period, independent from the page-level time range selector.
+  const [period, setPeriod] =
+    useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
+  const [table, setTable] = useState<ExportTable>("usage_metrics");
+
+  const endDate = new Date();
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - period);
+
+  const start = toDateString(startDate);
+  const end = toDateString(endDate);
+
+  const csvDownload = useDownloadCsv({
+    url: `/api/w/${workspaceId}/analytics/export?table=${table}&startDate=${start}&endDate=${end}`,
+    filename: `dust_${table}_${start}_${end}.csv`,
+  });
+
+  const selectedLabel =
+    EXPORT_TABLES.find((t) => t.value === table)?.label ?? table;
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h3 className="text-base font-medium text-foreground">Export data</h3>
+          <p className="text-xs text-muted-foreground">
+            Download analytics for the selected period as a CSV file.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <WorkspaceAnalyticsTimeRangeSelector
+            period={period}
+            onPeriodChange={setPeriod}
+          />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                label={selectedLabel}
+                size="xs"
+                variant="outline"
+                isSelect
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {EXPORT_TABLES.map((t) => (
+                <DropdownMenuItem
+                  key={t.value}
+                  label={t.label}
+                  onClick={() => setTable(t.value)}
+                />
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <CsvDownloadButton {...csvDownload} />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Add an export panel at the bottom of the analytics page that lets admins download any of the analytics tables (usage metrics, active users, source, agents, users, skills, skill/tool usage, messages, feedback) as CSV. It calls the new session-authed /api/w/{wId}/analytics/export route via the shared useDownloadCsv hook, restoring the export capability lost when the legacy analytics page was removed.

The panel has its own dedicated period selector, independent from the page-level time range selector, so changing one does not affect the other.


https://github.com/user-attachments/assets/d90e7e1b-ab31-48db-b614-b4e3ade82be9



## Tests

Local

## Risk

Low
## Deploy Plan

Front