### PR TITLE
Keep sandbox functions active for reaper

### DIFF
--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -4,6 +4,7 @@ import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
 import {
   SandboxFunctionInvocationModel,
   SandboxFunctionModel,
@@ -48,6 +49,8 @@ const outputSchema: JSONSchema = {
   },
   required: ["commentId"],
 };
+
+const ONE_HOUR_MS = 60 * 60 * 1_000;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -396,6 +399,11 @@ describe("SandboxFunctionResource", () => {
       baseImage: "dust-base",
       version: "0.0.0-test",
     });
+    const staleLastActivityAt = new Date(Date.now() - ONE_HOUR_MS);
+    await SandboxModel.update(
+      { lastActivityAt: staleLastActivityAt },
+      { where: { id: sandbox.id } }
+    );
     const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Ok({
         exitCode: 0,
@@ -431,6 +439,12 @@ describe("SandboxFunctionResource", () => {
     });
     expect(invocation).not.toBeNull();
     expect(invocation?.status).toBe("created");
+    const refreshedSandbox = await SandboxModel.findOne({
+      where: { id: sandbox.id, workspaceId: workspace.id },
+    });
+    expect(refreshedSandbox?.lastActivityAt.getTime()).toBeGreaterThan(
+      staleLastActivityAt.getTime()
+    );
     expect(ensurePodSandboxReady).toHaveBeenCalledWith(authenticator, space);
     expect(generateSandboxFunctionInvocationToken).toHaveBeenCalledWith(
       authenticator,

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -343,6 +343,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
         sandboxFunction: this,
       });
+      await ensureResult.value.sandbox.updateLastActivityAt();
+
       const execId = generateExecId();
       const token = await generateSandboxFunctionInvocationToken(auth, {
         sandbox: ensureResult.value.sandbox,


### PR DESCRIPTION
## Description

Follow up of #28123 and #28292. Function invocations now refresh `sandboxes.lastActivityAt` after pod sandbox setup, so pod sandboxes running functions stay visible to the Reaper through the existing activity signal.

> [!NOTE]
> This keeps current short function invocations visible to the Reaper through the existing `lastActivityAt` signal. It does not yet model active long-running invocations; that will need either a heartbeat or Reaper-side active invocation state once result persistence lands.

## Tests

Tested locally:
- `npx biome check --write --error-on-warnings front/lib/resources/sandbox_function_resource.ts front/lib/resources/sandbox_function_resource.test.ts`
- `NODE_ENV=test npm run test -- lib/resources/sandbox_function_resource.test.ts` from `front`
- `npm run tsgo -- --noEmit` from `front`

## Risk

Worst case, one extra `lastActivityAt` write on sandbox function invocation start. Safe to rollback.

## Deploy Plan

Standard deploy.