### PR TITLE
Analytics export: return all editors of the agent in analytics

### DIFF
--- a/front-api/routes/v1/w/[wId]/analytics/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.test.ts
@@ -56,6 +56,7 @@ vi.mock("@app/lib/api/analytics/agents_export", async () => ({
     async () =>
       new Ok([{ agentId: "agent-123", name: "TestAgent", messages: 5 }])
   ),
+  toAgentExportCsvRow: (row: unknown) => row,
 }));
 
 vi.mock("@app/lib/api/analytics/users_export", async () => ({

--- a/front-api/routes/w/[wId]/analytics/agents-export.ts
+++ b/front-api/routes/w/[wId]/analytics/agents-export.ts
@@ -2,13 +2,14 @@ import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability
 import {
   AGENT_EXPORT_HEADERS,
   fetchAgentExportRows,
+  toAgentExportCsvRow,
 } from "@app/lib/api/analytics/agents_export";
+import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureHasPermission } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { stringify } from "csv-stringify/sync";
 import { z } from "zod";
 
 const QuerySchema = z.object({
@@ -46,12 +47,10 @@ app.get(
       });
     }
 
-    const csvData = result.value.map((row) =>
-      AGENT_EXPORT_HEADERS.map((h) => row[h])
+    const csv = rowsToCsv(
+      AGENT_EXPORT_HEADERS,
+      result.value.map(toAgentExportCsvRow)
     );
-    const csv = stringify([AGENT_EXPORT_HEADERS, ...csvData], {
-      header: false,
-    });
 
     ctx.header("Content-Type", "text/csv");
     ctx.header(

--- a/front/lib/api/analytics/agents_export.test.ts
+++ b/front/lib/api/analytics/agents_export.test.ts
@@ -1,8 +1,10 @@
 import type { AgentExportRow } from "@app/lib/api/analytics/agents_export";
 import {
+  AGENT_EXPORT_HEADERS,
   fetchAgentExportRows,
   toAgentExportCsvRow,
 } from "@app/lib/api/analytics/agents_export";
+import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -141,9 +143,9 @@ describe("toAgentExportCsvRow", () => {
     credits: 0,
   };
 
-  it('joins editorEmails with "; " for CSV output', () => {
+  it("joins editorEmails into a comma-separated string for CSV output", () => {
     expect(toAgentExportCsvRow(baseRow).editorEmails).toBe(
-      "a@dust.tt; b@dust.tt"
+      "a@dust.tt,b@dust.tt"
     );
   });
 
@@ -151,5 +153,10 @@ describe("toAgentExportCsvRow", () => {
     expect(
       toAgentExportCsvRow({ ...baseRow, editorEmails: [] }).editorEmails
     ).toBe("");
+  });
+
+  it("wraps the comma-separated editors in double quotes once serialized", () => {
+    const csv = rowsToCsv(AGENT_EXPORT_HEADERS, [toAgentExportCsvRow(baseRow)]);
+    expect(csv).toContain('"a@dust.tt,b@dust.tt"');
   });
 });

--- a/front/lib/api/analytics/agents_export.test.ts
+++ b/front/lib/api/analytics/agents_export.test.ts
@@ -1,0 +1,155 @@
+import type { AgentExportRow } from "@app/lib/api/analytics/agents_export";
+import {
+  fetchAgentExportRows,
+  toAgentExportCsvRow,
+} from "@app/lib/api/analytics/agents_export";
+import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Keep `bucketsToArray` (and everything else) real; only stub the Elasticsearch
+// query so the test does not depend on a live cluster.
+vi.mock("@app/lib/api/elasticsearch", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/elasticsearch")>();
+  return { ...actual, searchAnalytics: vi.fn() };
+});
+
+// The export reads from the read replica; in tests there is no replica so point
+// it at the primary test connection.
+vi.mock("@app/lib/resources/storage", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/resources/storage")>();
+  return {
+    ...actual,
+    getFrontReplicaDbConnection: () => actual.frontSequelize,
+  };
+});
+
+function mockEmptyEsMetrics() {
+  vi.mocked(searchAnalytics).mockResolvedValue(
+    new Ok({
+      took: 1,
+      timed_out: false,
+      _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      hits: { total: { value: 0, relation: "eq" }, hits: [] },
+      aggregations: {
+        by_agent: { buckets: [] },
+      },
+    })
+  );
+}
+
+describe("fetchAgentExportRows", () => {
+  beforeEach(() => {
+    mockEmptyEsMetrics();
+  });
+
+  it("returns every editor across all versions in editorEmails and the active-version author in authorEmails", async () => {
+    const {
+      authenticator: authorAAuth,
+      workspace,
+      user: authorA,
+    } = await createResourceTest({ role: "admin" });
+
+    // A second member who will edit (create a new version of) the agent.
+    const authorB = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, authorB, { role: "admin" });
+    const authorBAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      authorB.sId,
+      workspace.sId
+    );
+
+    // Version 0 authored by A, version 1 (an edit) authored by B.
+    const agent = await AgentConfigurationFactory.createTestAgent(authorAAuth, {
+      name: "Multi-author agent",
+    });
+    await AgentConfigurationFactory.updateTestAgent(authorBAuth, agent.sId);
+
+    const result = await fetchAgentExportRows(
+      {},
+      authorAAuth,
+      /* includeHiddenAgents */ false
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const row = result.value.find((r) => r.agentId === agent.sId);
+    expect(row).toBeDefined();
+
+    // editorEmails lists everyone who authored any version (A and B).
+    expect(row!.editorEmails).toHaveLength(2);
+    expect(new Set(row!.editorEmails)).toEqual(
+      new Set([authorA.email, authorB.email])
+    );
+
+    // authorEmails keeps its original behavior: the author of the active
+    // (latest) version, which is B after B's edit.
+    expect(row!.authorEmails).toBe(authorB.email);
+  });
+
+  it("returns the single author for an agent with a single version", async () => {
+    const { authenticator, user } = await createResourceTest({
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Single-author agent" }
+    );
+
+    const result = await fetchAgentExportRows(
+      {},
+      authenticator,
+      /* includeHiddenAgents */ false
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const row = result.value.find((r) => r.agentId === agent.sId);
+    expect(row).toBeDefined();
+    expect(row!.authorEmails).toBe(user.email);
+    expect(row!.editorEmails).toEqual([user.email]);
+  });
+});
+
+describe("toAgentExportCsvRow", () => {
+  const baseRow: AgentExportRow = {
+    agentId: "a1",
+    name: "Agent",
+    description: "",
+    settings: "published",
+    modelId: "gpt-4-turbo",
+    providerId: "openai",
+    authorEmails: "b@dust.tt",
+    editorEmails: ["a@dust.tt", "b@dust.tt"],
+    messages: 0,
+    distinctUsersReached: 0,
+    distinctConversations: 0,
+    lastEdit: "",
+    credits: 0,
+  };
+
+  it('joins editorEmails with "; " for CSV output', () => {
+    expect(toAgentExportCsvRow(baseRow).editorEmails).toBe(
+      "a@dust.tt; b@dust.tt"
+    );
+  });
+
+  it("renders an empty editors list as an empty string", () => {
+    expect(
+      toAgentExportCsvRow({ ...baseRow, editorEmails: [] }).editorEmails
+    ).toBe("");
+  });
+});

--- a/front/lib/api/analytics/agents_export.ts
+++ b/front/lib/api/analytics/agents_export.ts
@@ -136,7 +136,8 @@ export async function fetchAgentExportRows(
     ])
   );
 
-  const scopeFilter = includeHiddenAgents ? "" : `AND ac."scope" != 'hidden'`;
+  const scopeFilter = (alias: string) =>
+    includeHiddenAgents ? "" : `AND ${alias}."scope" != 'hidden'`;
 
   // TODO(BACK5): Migrate to AgentConfigurationResource when a suitable method exists.
   const readReplica = getFrontReplicaDbConnection();
@@ -170,11 +171,20 @@ export async function fetchAgentExportRows(
         FROM "agent_configurations" av
           JOIN "users" edt ON av."authorId" = edt."id"
         WHERE av."workspaceId" = :wId
+          -- Only aggregate versions of the agents the outer query exports;
+          -- computing editors for archived/draft agents is wasted work.
+          AND av."sId" IN (
+            SELECT act."sId"
+            FROM "agent_configurations" act
+            WHERE act."workspaceId" = :wId
+              AND act."status" = 'active'
+              ${scopeFilter("act")}
+          )
         GROUP BY av."sId"
       ) editors ON editors."sId" = ac."sId"
     WHERE ac."workspaceId" = :wId
       AND ac."status" = 'active'
-      ${scopeFilter}
+      ${scopeFilter("ac")}
     `,
     {
       type: QueryTypes.SELECT,

--- a/front/lib/api/analytics/agents_export.ts
+++ b/front/lib/api/analytics/agents_export.ts
@@ -54,13 +54,15 @@ export interface AgentExportRow {
 }
 
 // CSV projection of AgentExportRow: the CSV serializer only handles scalar
-// cells, so the array-valued editorEmails is joined into a single string.
+// cells, so the array-valued editorEmails is joined into a single
+// comma-separated string. The serializer then wraps it in double quotes
+// automatically since the cell contains commas.
 export type AgentExportCsvRow = Omit<AgentExportRow, "editorEmails"> & {
   editorEmails: string;
 };
 
 export function toAgentExportCsvRow(row: AgentExportRow): AgentExportCsvRow {
-  return { ...row, editorEmails: row.editorEmails.join("; ") };
+  return { ...row, editorEmails: row.editorEmails.join(",") };
 }
 
 export const AGENT_EXPORT_HEADERS: (keyof AgentExportRow)[] = [

--- a/front/lib/api/analytics/agents_export.ts
+++ b/front/lib/api/analytics/agents_export.ts
@@ -31,6 +31,7 @@ interface AgentMetadataRow {
   modelId: string;
   providerId: string;
   authorEmail: string | null;
+  editorEmails: string[] | null;
   lastEdit: string;
 }
 
@@ -42,11 +43,24 @@ export interface AgentExportRow {
   modelId: string;
   providerId: string;
   authorEmails: string;
+  // Emails of every user who edited any version of the agent
+  // Returned as an array in JSON; CSV renders it joined with "; "
+  editorEmails: string[];
   messages: number;
   distinctUsersReached: number;
   distinctConversations: number;
   lastEdit: string;
   credits: number;
+}
+
+// CSV projection of AgentExportRow: the CSV serializer only handles scalar
+// cells, so the array-valued editorEmails is joined into a single string.
+export type AgentExportCsvRow = Omit<AgentExportRow, "editorEmails"> & {
+  editorEmails: string;
+};
+
+export function toAgentExportCsvRow(row: AgentExportRow): AgentExportCsvRow {
+  return { ...row, editorEmails: row.editorEmails.join("; ") };
 }
 
 export const AGENT_EXPORT_HEADERS: (keyof AgentExportRow)[] = [
@@ -57,6 +71,7 @@ export const AGENT_EXPORT_HEADERS: (keyof AgentExportRow)[] = [
   "modelId",
   "providerId",
   "authorEmails",
+  "editorEmails",
   "messages",
   "distinctUsersReached",
   "distinctConversations",
@@ -137,12 +152,24 @@ export async function fetchAgentExportRows(
            ac."modelId",
            ac."providerId",
            aut."email" AS "authorEmail",
+           editors."editorEmails",
            COALESCE(
              CAST(ac."updatedAt" AS DATE),
              CAST(ac."createdAt" AS DATE)
            ) AS "lastEdit"
     FROM "agent_configurations" ac
       LEFT JOIN "users" aut ON ac."authorId" = aut."id"
+      -- Aggregate the emails of every user who authored any version of the
+      -- agent (matching how "lastAuthors" is sourced in recent_authors.ts:
+      -- distinct authorIds across all versions, not just the active one).
+      LEFT JOIN (
+        SELECT av."sId",
+               ARRAY_AGG(DISTINCT edt."email") AS "editorEmails"
+        FROM "agent_configurations" av
+          JOIN "users" edt ON av."authorId" = edt."id"
+        WHERE av."workspaceId" = :wId
+        GROUP BY av."sId"
+      ) editors ON editors."sId" = ac."sId"
     WHERE ac."workspaceId" = :wId
       AND ac."status" = 'active'
       ${scopeFilter}
@@ -163,6 +190,7 @@ export async function fetchAgentExportRows(
       modelId: agent.modelId,
       providerId: agent.providerId,
       authorEmails: agent.authorEmail ?? "",
+      editorEmails: agent.editorEmails ?? [],
       messages: metrics?.messages ?? 0,
       distinctUsersReached: metrics?.distinctUsersReached ?? 0,
       distinctConversations: metrics?.distinctConversations ?? 0,
@@ -189,6 +217,7 @@ export async function fetchAgentExportRows(
         modelId: agent.model.modelId,
         providerId: agent.model.providerId,
         authorEmails: "",
+        editorEmails: [],
         messages: metrics?.messages ?? 0,
         distinctUsersReached: metrics?.distinctUsersReached ?? 0,
         distinctConversations: metrics?.distinctConversations ?? 0,

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -2,6 +2,7 @@ import type { AgentExportRow } from "@app/lib/api/analytics/agents_export";
 import {
   AGENT_EXPORT_HEADERS,
   fetchAgentExportRows,
+  toAgentExportCsvRow,
 } from "@app/lib/api/analytics/agents_export";
 import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
 import type { FeedbackExportRow } from "@app/lib/api/analytics/feedback_export";
@@ -234,7 +235,7 @@ export function stringifyExportTableAsCsv(data: ExportTableData): string {
     case "source":
       return rowsToCsv(data.headers, data.rows);
     case "agents":
-      return rowsToCsv(data.headers, data.rows);
+      return rowsToCsv(data.headers, data.rows.map(toAgentExportCsvRow));
     case "users":
       return rowsToCsv(data.headers, data.rows);
     case "skills":


### PR DESCRIPTION
## Description

Adds an `editorEmails` field to the agents analytics export listing everyone who authored any version of an agent (sourced like lastAuthors). authorEmails is unchanged, and it should be deprecated then removed

  - JSON: editorEmails is a string array.
  - CSV: rendered as a `; `-joined cell (via `toAgentExportCsvRow`).

## Tests

added unit tests
tested locally

## Risk

low, may slow down the query but seems OK

## Deploy Plan

deploy front
