### PR TITLE
fix(llm): keep native thinking disabled for light effort without native light reasoning

### DIFF
--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -63,17 +63,22 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 
 /**
- * Maps old reasoning effort values to the new model's effort values.
+ * Maps a reasoning effort to the model constructor's effort values.
  */
 function mapReasoningEffort(
-  effort: ReasoningEffort | null
+  effort: ReasoningEffort | null,
+  useNativeLightReasoning: boolean
 ): "none" | "low" | "medium" | "high" | "maximal" {
   switch (effort) {
     case null:
     case "none":
       return "none";
     case "light":
-      return "low";
+      // Models without native light reasoning rely on the chain-of-thought meta
+      // prompt instead of native thinking. Enabling native thinking while that
+      // meta prompt is injected makes the <thinking>/<response> tags leak, so
+      // keep thinking disabled for them.
+      return useNativeLightReasoning ? "low" : "none";
     case "medium":
       return "medium";
     case "high":
@@ -576,7 +581,12 @@ abstract class BaseTransition extends LLM {
     return configSchema.parse({
       tools: specifications as ToolSpecification[],
       temperature: this.temperature ?? undefined,
-      reasoning: { effort: mapReasoningEffort(this.reasoningEffort) },
+      reasoning: {
+        effort: mapReasoningEffort(
+          this.reasoningEffort,
+          this.modelConfig.useNativeLightReasoning ?? false
+        ),
+      },
       forceTool: forceToolCall,
       outputFormat: parseResponseFormatSchema(
         this.responseFormat,


### PR DESCRIPTION
## Description

With the new LLM router (`use_new_llm_router`), `<thinking>`/`<response>` tags started leaking into agent responses, mainly on Opus. These tags did not leak with the previous router.

Root cause: the new router's `mapReasoningEffort` collapsed `light` → `low` unconditionally, enabling native thinking. Models without `useNativeLightReasoning` (Opus, Sonnet, Haiku, etc.) still get the chain-of-thought meta prompt injected in `generation.ts`, which instructs the model to wrap output in `<thinking>`/`<response>` tags. With native thinking now enabled alongside that meta prompt, the tags surfaced in the response.

The previous router disabled native thinking for `light` + `!useNativeLightReasoning` (via `toThinkingConfig` / `toAutoThinkingConfig`), so the model relied purely on the meta prompt and the content parser stripped the tags cleanly.

This threads `useNativeLightReasoning` into `mapReasoningEffort` so `light` maps to `none` (thinking disabled) for those models, restoring the previous behavior. Models with native light reasoning (only Fable 5 on Anthropic) keep `light` → `low`. Since the mapping lives in the shared transition layer, this applies uniformly across all providers and both the stream and batch surfaces.

## Tests

Type-checked the change locally (`tsgo` clean for `lib/api/llm` and `model_constructors`; remaining errors are a pre-existing unbuilt `@dust-tt/sparkle` in the local env). The fix mirrors the previous router's `light` + `!useNativeLightReasoning` → disabled-thinking behavior, which the content parser already handles for tag stripping.

## Risk

Low. Behavior-preserving parity with the previous router, scoped to how `light` reasoning effort maps to native thinking. Only affects models with `light` effort and no `useNativeLightReasoning`. Rollback is a straightforward revert; the change is also gated behind the `use_new_llm_router` flag path.

## Deploy Plan

Standard deploy. No migrations or config changes required.