### PR TITLE
feat(poke-rbac): add admin and talent roles

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/extend_trial.ts
+++ b/front/lib/api/poke/plugins/workspaces/extend_trial.ts
@@ -15,7 +15,7 @@ export const extendTrialPlugin = createPlugin({
         description: "Number of days to extend the trial period",
       },
     },
-    requiredRoles: ["billing"],
+    requiredRoles: ["billing", "talent"],
   },
   execute: async (auth, _, args) => {
     const subscription = auth.subscription();

--- a/front/lib/poke/roles.ts
+++ b/front/lib/poke/roles.ts
@@ -4,7 +4,13 @@ import { isDevelopment } from "@app/types/shared/env";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { z } from "zod";
 
-const PokeRoleSchema = z.enum(["billing", "engineering", "support"]);
+const PokeRoleSchema = z.enum([
+  "admin",
+  "billing",
+  "engineering",
+  "support",
+  "talent",
+]);
 
 export type PokeRole = z.infer<typeof PokeRoleSchema>;
 


### PR DESCRIPTION
## Description

- Add `admin` and `talent` roles
- Enable `Extend Trial` plugin for `talent` members
