### PR TITLE
feat(global-agents): add dust-ant-sonnet-edge internal agent on Claude Sonnet 5

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -582,7 +582,6 @@ export function _getDustAntSonnetEdgeGlobalAgent(
     agentId: GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE,
     name: "dust-ant-sonnet-edge",
     preferredModelConfiguration: CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
-    preferredReasoningEffort: "medium",
   });
 }
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -48,6 +48,7 @@ import {
   CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import {
@@ -570,6 +571,18 @@ export function _getDustAntHighGlobalAgent(
     name: "dust-ant-high",
     preferredModelConfiguration: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
     preferredReasoningEffort: "high",
+  });
+}
+
+export function _getDustAntSonnetEdgeGlobalAgent(
+  auth: Authenticator,
+  args: DustLikeGlobalAgentArgs
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE,
+    name: "dust-ant-sonnet-edge",
+    preferredModelConfiguration: CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
+    preferredReasoningEffort: "medium",
   });
 }
 

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -584,6 +584,14 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
           "Same as dust-ant-high but with omitted reasoning summaries.",
         pictureUrl: DUST_AVATAR_URL,
       };
+    case GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE,
+        name: "dust-ant-sonnet-edge",
+        description:
+          "Same as dust but running Claude Sonnet 5 to experiment internally.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
     case GLOBAL_AGENTS_SID.DUST_HAIKU:
       return {
         sId: GLOBAL_AGENTS_SID.DUST_HAIKU,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -23,6 +23,7 @@ import {
   _getDustAntHighOmittedGlobalAgent,
   _getDustAntMediumGlobalAgent,
   _getDustAntMediumOmittedGlobalAgent,
+  _getDustAntSonnetEdgeGlobalAgent,
   _getDustDeepseekGlobalAgent,
   _getDustEdgeGlobalAgent,
   _getDustGlmGlobalAgent,
@@ -278,6 +279,12 @@ const GLOBAL_AGENT_FLAGS: Record<
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE]: {
     injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
@@ -1067,6 +1074,15 @@ function getGlobalAgent({
         featureFlags,
       });
       break;
+    case GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE:
+      agentConfiguration = _getDustAntSonnetEdgeGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        mcpServerViews,
+        hasDeepDive,
+        featureFlags,
+      });
+      break;
     case GLOBAL_AGENTS_SID.DUST_HAIKU:
       agentConfiguration = _getDustHaikuGlobalAgent(auth, {
         settings,
@@ -1616,6 +1632,7 @@ export async function getGlobalAgents(
     GLOBAL_AGENTS_SID.DUST_ANT_HIGH,
     GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM_OMITTED,
     GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED,
+    GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE,
     GLOBAL_AGENTS_SID.DUST_HAIKU,
     GLOBAL_AGENTS_SID.DUST_EDGE,
     GLOBAL_AGENTS_SID.DUST_KIMI,

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -96,6 +96,7 @@ export enum GLOBAL_AGENTS_SID {
   DUST_ANT_HIGH = "dust-ant-high",
   DUST_ANT_MEDIUM_OMITTED = "dust-ant-medium-omitted",
   DUST_ANT_HIGH_OMITTED = "dust-ant-high-omitted",
+  DUST_ANT_SONNET_EDGE = "dust-ant-sonnet-edge",
   DUST_HAIKU = "dust-haiku",
   DUST_KIMI = "dust-kimi",
   DUST_KIMI_MEDIUM = "dust-kimi-medium",


### PR DESCRIPTION
## Description

Adds a new internal global agent `dust-ant-sonnet-edge` that behaves like `dust` but runs on Claude Sonnet 5 (medium reasoning effort), so we can experiment with the model internally.

The agent reuses the existing `_getDustLikeGlobalAgent` builder and wiring, mirroring the other `dust-ant-*` variants:
- New `DUST_ANT_SONNET_EDGE` entry in the `GLOBAL_AGENTS_SID` enum.
- Metadata (name, description, avatar) in `getGlobalAgentMetadata`.
- Config builder `_getDustAntSonnetEdgeGlobalAgent` using `CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG`.
- Feature flags, dispatch case, and inclusion in the global agents list.

## Tests

No automated tests — additive change following the existing `dust-ant-high` pattern. Can be verified by listing global agents and confirming `dust-ant-sonnet-edge` is available and responds using Claude Sonnet 5.

## Risk

Low. Internal-only experimental agent; no changes to existing agents or shared behavior.
