### PR TITLE
fix(model_constructors): drop temperature for Claude Sonnet 5

### DIFF
--- a/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_five.ts
@@ -24,12 +24,11 @@ const configSchema = z.union([
       })
       .default({ effort: DEFAULT_REASONING_EFFORT }),
     forceTool: z.undefined(),
-    // Reasoning requires temperature=1.
-    temperature: temperatureSchema.optional().transform(() => 1 as const),
+    temperature: temperatureSchema.optional().transform(() => undefined),
   }),
   baseConfig.extend({
     reasoning: z.object({ effort: z.literal("none") }),
-    temperature: temperatureSchema.optional().default(1),
+    temperature: temperatureSchema.optional().transform(() => undefined),
   }),
 ]);
 


### PR DESCRIPTION
## Description

Claude Sonnet 5 rejects the `temperature` sampling parameter and returns a 400 (`temperature is deprecated for this model`). Our Sonnet 5 config forced `temperature` to `1` in both config branches, and the shared Anthropic input converter passes `temperature` straight into the request body.

This transforms `temperature` to `undefined` in both branches so it is never sent, matching the pattern already used for the OpenAI GPT-5 reasoning models (`providers/openai/models/gpt_five*.ts`). Since `JSON.stringify` drops `undefined`, the parameter never reaches the wire; no change to the shared converter is needed.

[Anthropic model migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide) the "Migrating to Claude Sonnet 5" section documents that the sampling parameters (`temperature`/`top_p`/`top_k`) are removed and return a 400.

## Tests

Type-checks clean for `model_constructors`.

## Risk

Low.

## Deploy Plan

Standard deploy.