### PR TITLE
fix(poke): resolve connector redirect across all regions

### DIFF
--- a/front/components/poke/pages/ConnectorRedirectPage.tsx
+++ b/front/components/poke/pages/ConnectorRedirectPage.tsx
@@ -1,29 +1,43 @@
+import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
-import { useFetcher } from "@app/lib/swr/swr";
+import { usePokeRegion } from "@app/lib/swr/poke";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
+import { usePokeConnectorRedirectAllRegions } from "@app/poke/swr/search";
 import { Spinner } from "@dust-tt/sparkle";
 import { useEffect } from "react";
-import useSWR from "swr";
 
 export function ConnectorRedirectPage() {
   usePokePageMetadata({ name: "Connector Redirect" });
 
   const connectorId = useRequiredPathParam("connectorId");
   const router = useAppRouter();
-  const { fetcher } = useFetcher();
+  const { regionInfo, setRegionInfo } = useRegionContext();
+  const { regionData } = usePokeRegion();
+  const regionUrls = regionData?.regionUrls ?? null;
 
-  const { data, error } = useSWR<{ redirectUrl: string }>(
-    `/api/poke/connectors/${connectorId}/redirect`,
-    fetcher
-  );
+  const { redirect, isError } = usePokeConnectorRedirectAllRegions({
+    connectorId,
+    regionUrls,
+  });
 
   useEffect(() => {
-    if (data?.redirectUrl) {
-      void router.replace(data.redirectUrl);
+    if (!redirect) {
+      return;
     }
-  }, [data, router]);
 
-  if (error) {
+    // Switch region if the connector lives in a different region before
+    // navigating, so the destination page fetches from the correct region.
+    if (redirect.region !== regionInfo.name && regionUrls) {
+      setRegionInfo({
+        name: redirect.region,
+        url: regionUrls[redirect.region],
+      });
+    }
+
+    void router.replace(redirect.redirectUrl);
+  }, [redirect, regionInfo.name, regionUrls, setRegionInfo, router]);
+
+  if (isError) {
     return (
       <div className="flex h-64 items-center justify-center">
         <p>Connector not found.</p>

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -253,3 +253,78 @@ export function usePokeWorkspacesAllRegions({
     isWorkspacesError: isError,
   };
 }
+
+export interface PokeConnectorRedirect {
+  redirectUrl: string;
+  region: RegionType;
+}
+
+/**
+ * Resolve a connector redirect across all regions in parallel. A connector ID
+ * is only known to its own region's connectors service, so we query every
+ * region and keep the first successful match, tagged with its source region.
+ * This lets a `/connectors/:id` link resolve regardless of which region the SPA
+ * currently points at.
+ */
+export function usePokeConnectorRedirectAllRegions({
+  connectorId,
+  regionUrls,
+}: {
+  connectorId: string;
+  regionUrls: Record<RegionType, string> | null;
+}) {
+  const [redirect, setRedirect] = useState<PokeConnectorRedirect | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    if (!regionUrls) {
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setIsError(false);
+    setRedirect(null);
+
+    const run = async () => {
+      const regionPromises = getUniqueRegions(regionUrls).map(
+        async (region) => {
+          const baseUrl = regionUrls[region];
+          const url = `${baseUrl}/api/poke/connectors/${connectorId}/redirect`;
+
+          const response = await clientFetch(url, { credentials: "include" });
+          if (!response.ok) {
+            throw new Error(`Connector not found in ${region}`);
+          }
+
+          const data: { redirectUrl: string } = await response.json();
+          return { redirectUrl: data.redirectUrl, region };
+        }
+      );
+
+      const settledResults = await Promise.allSettled(regionPromises);
+      if (cancelled) {
+        return;
+      }
+
+      const found = settledResults.find(
+        (result) => result.status === "fulfilled"
+      );
+      if (found && found.status === "fulfilled") {
+        setRedirect(found.value);
+      } else {
+        setIsError(true);
+      }
+      setIsLoading(false);
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [connectorId, regionUrls]);
+
+  return { redirect, isLoading, isError };
+}


### PR DESCRIPTION
## Problem

Poke links like `https://poke.dust.tt/connectors/274877912128` worked when the connector was in the US region but not the EU region. Poke's Cmd-K search worked either way.

## Root cause

`ConnectorRedirectPage` fetched `/api/poke/connectors/:id/redirect` through the normal fetcher, which `clientFetch` prefixes with the **current region's** base URL only. That endpoint queries only that region's connectors service, so a connector living in another region returned 404 → "Connector not found."

Cmd-K works cross-region because `usePokeSearchAllRegions` queries **every** region in parallel (using absolute `regionUrls[region]` URLs) and switches region on selection.

## Fix

Mirror the Cmd-K pattern for the redirect page:

- Add `usePokeConnectorRedirectAllRegions` in `front/poke/swr/search.ts` (next to the existing all-regions hooks, reusing the file's `getUniqueRegions` helper). It queries each region's redirect endpoint in parallel and keeps the first successful match, tagged with its region.
- `ConnectorRedirectPage` switches region via `setRegionInfo` if the connector lives elsewhere, then navigates to the returned relative path so the destination page fetches from the correct region.

The redirect endpoint itself is unchanged (still returns `{ redirectUrl }`), so no API/test changes are needed.

## Notes

Reusing `usePokeSearchAllRegions` directly was considered but rejected: poke search resolves a numeric ID against multiple resource types (a connector ID could also match a workspace modelId) and returns absolute cross-domain links, which would change navigation behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)