### PR TITLE
[front] swapMetronomeContract: new sub is Metronome-only (no Stripe id)

### DIFF
--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1276,7 +1276,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
           trialing: false,
           startDate: new Date(),
           endDate: null,
-          stripeSubscriptionId: this.stripeSubscriptionId,
+          stripeSubscriptionId: null,
           metronomeContractId,
         },
         renderPlanFromModel({ plan: newPlan }),


### PR DESCRIPTION
`swapMetronomeContract` copied the current sub's `stripeSubscriptionId` onto
the new subscription. Since the new sub is billed by its Metronome contract,
that produced an invalid credit-priced (CP_*) subscription carrying a Stripe
subscription id — a shadow-billed state — when swapping from a shadow-billed
(Stripe + Metronome) subscription. Set it to null.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
