### PR TITLE
[front] contract.start: swap based on shadow-contract, not current sub billing

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1606,21 +1606,26 @@ export async function processMetronomeWebhook({
         break;
       }
 
-      // Legacy fallback: no pending row was staged. Only swap when the
-      // workspace is Metronome-only billed, or not billed at all. Shadow
-      // billed subscriptions (Stripe + Metronome) follow Stripe's signal,
-      // and pure Stripe subs have no Metronome contract at all.
-      if (
-        !activeSubscription.isMetronomeOnlyBilled &&
-        activeSubscription.isBilled
-      ) {
+      // No pending row was staged (e.g. an immediate switch). Swap the active
+      // subscription onto the new contract regardless of its current billing
+      // rail — switchContract is used this way routinely. The ONLY contract we
+      // must NOT swap onto is a shadow contract: a Metronome contract that runs
+      // in parallel to a Stripe subscription with no billing-provider delivery
+      // (Stripe owns billing). That is a property of the contract itself — it has
+      // no `customer_billing_provider_configuration` — and only applies while the
+      // workspace is still Stripe-billed (so free / Metronome-only contracts,
+      // which also lack a delivery config, are not mistaken for shadows).
+      const startedContractIsShadow =
+        !contractResult.value.customer_billing_provider_configuration &&
+        !!activeSubscription.stripeSubscriptionId;
+      if (startedContractIsShadow) {
         logger.info(
           {
             contractId,
             targetPlanCode,
             workspaceId: workspace.sId,
           },
-          "[Metronome Webhook] contract.start: subscription is not Metronome-only billed, leaving subscription alone"
+          "[Metronome Webhook] contract.start: shadow contract started, leaving subscription alone (Stripe drives billing)"
         );
         break;
       }


### PR DESCRIPTION
The contract.start fallback (no pending subscription staged, e.g. an immediate
switch) refused to swap whenever the current subscription wasn't Metronome-only
billed. That blocked legitimate switches of shadow-billed (Stripe + Metronome)
workspaces onto a new contract.

Decide from the STARTED contract instead: only skip when it is a shadow
contract — no `customer_billing_provider_configuration` (Stripe owns billing)
and the workspace is still Stripe-billed. Any contract that delivers its own
invoices takes over the subscription, whatever the current sub's rail. The
Stripe-billed guard keeps free / Metronome-only contracts (which also lack a
delivery config) from being mistaken for shadows.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
