### PR TITLE
[front] contract.start: create subscription when none active (webhook ordering)

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -80,6 +80,7 @@ import { setUserNearLimit } from "@app/lib/metronome/user_block";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
 import { notifyUserAwuCapReached } from "@app/lib/notifications/workflows/user-awu-cap-reached";
+import { FREE_NO_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
@@ -1547,17 +1548,10 @@ export async function processMetronomeWebhook({
 
       const activeSubscription =
         await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
-      if (!activeSubscription) {
-        logger.warn(
-          { contractId, customerId, workspaceId: workspace.sId },
-          "[Metronome Webhook] contract.start: no active subscription"
-        );
-        break;
-      }
 
       // Idempotency: re-deliveries land here with the active subscription
       // already pointing at the new contract.
-      if (activeSubscription.metronomeContractId === contractId) {
+      if (activeSubscription?.metronomeContractId === contractId) {
         logger.info(
           { contractId, workspaceId: workspace.sId },
           "[Metronome Webhook] contract.start: subscription already swapped, skipping"
@@ -1577,7 +1571,8 @@ export async function processMetronomeWebhook({
         pendingSubscription &&
         pendingSubscription.status === "created_backend_only"
       ) {
-        const previousPlanCode = activeSubscription.getPlan().code;
+        const previousPlanCode =
+          activeSubscription?.getPlan().code ?? FREE_NO_PLAN_CODE;
         // `activatePending` flushes the contract cache itself.
         await pendingSubscription.activatePending();
         const auth = await Authenticator.internalAdminForWorkspace(
@@ -1617,7 +1612,7 @@ export async function processMetronomeWebhook({
       // which also lack a delivery config, are not mistaken for shadows).
       const startedContractIsShadow =
         !contractResult.value.customer_billing_provider_configuration &&
-        !!activeSubscription.stripeSubscriptionId;
+        !!activeSubscription?.stripeSubscriptionId;
       if (startedContractIsShadow) {
         logger.info(
           {
@@ -1630,14 +1625,27 @@ export async function processMetronomeWebhook({
         break;
       }
 
-      // End the current subscription as `ended_backend_only` and create
-      // a new active subscription on the target plan + new contract.
-      const legacyPreviousPlanCode = activeSubscription.getPlan().code;
-      // `swapMetronomeContract` flushes the contract cache itself.
-      await activeSubscription.swapMetronomeContract({
-        metronomeContractId: contractId,
-        planCode: targetPlan.code,
-      });
+      // Swap the active subscription onto the new contract, or — when the
+      // workspace has NO active subscription (e.g. it was cancelled and the
+      // `customer.subscription.deleted` webhook already ended the sub and
+      // scheduled a scrub, and this `contract.start` is the re-registration) —
+      // create the new subscription. Either way `restoreWorkspaceAfterSubscription`
+      // below cancels any scheduled scrub.
+      const previousPlanCode =
+        activeSubscription?.getPlan().code ?? FREE_NO_PLAN_CODE;
+      if (activeSubscription) {
+        // `swapMetronomeContract` flushes the contract cache itself.
+        await activeSubscription.swapMetronomeContract({
+          metronomeContractId: contractId,
+          planCode: targetPlan.code,
+        });
+      } else {
+        await SubscriptionResource.createActiveMetronomeSubscription({
+          workspaceModelId: workspace.id,
+          planCode: targetPlan.code,
+          metronomeContractId: contractId,
+        });
+      }
 
       // Cancel any scheduled scrub workflow, unpause connectors, re-enable
       // triggers. Idempotent — safe to call regardless of prior state.
@@ -1646,7 +1654,7 @@ export async function processMetronomeWebhook({
       emitSubscriptionChangedAuditEvent({
         auth,
         planCode: targetPlan.code,
-        previousPlanCode: legacyPreviousPlanCode,
+        previousPlanCode,
         metronomeContractId: contractId,
       });
 

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1298,6 +1298,51 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   }
 
   /**
+   * Create a new active subscription on a Metronome contract + plan when the
+   * workspace currently has NO active subscription — e.g. it was cancelled
+   * (subscription ended) and is now re-subscribing as a new contract starts.
+   * Mirrors the creation half of `swapMetronomeContract` with no prior
+   * subscription to end. The new subscription is Metronome-billed (no Stripe).
+   */
+  static async createActiveMetronomeSubscription({
+    workspaceModelId,
+    planCode,
+    metronomeContractId,
+  }: {
+    workspaceModelId: ModelId;
+    planCode: string;
+    metronomeContractId: string;
+  }): Promise<SubscriptionResource> {
+    const newPlan = await SubscriptionResource.findPlanOrThrow(planCode);
+
+    const created = await withTransaction(async (t) => {
+      const subscription = await SubscriptionResource.makeNew(
+        {
+          sId: generateRandomModelSId(),
+          workspaceId: workspaceModelId,
+          planId: newPlan.id,
+          status: "active",
+          trialing: false,
+          startDate: new Date(),
+          endDate: null,
+          stripeSubscriptionId: null,
+          metronomeContractId,
+        },
+        renderPlanFromModel({ plan: newPlan }),
+        t
+      );
+      invalidateCacheAfterCommit(t, () =>
+        SubscriptionResource.invalidateContractCacheByWorkspaceModelId(
+          workspaceModelId
+        )
+      );
+      return subscription;
+    });
+    await SubscriptionResource.invalidateSubscriptionCache(workspaceModelId);
+    return created;
+  }
+
+  /**
    * Flip this pending (created_backend_only) subscription to active, while
    * ending whatever active subscription currently holds the workspace's seat.
    * Mirrors `swapMetronomeContract` but for the pre-provisioned pending-row


### PR DESCRIPTION
The stripe `customer.subscription.deleted` and metronome `contract.start`
webhooks arrive in random order. When `deleted` is processed first it ends the
active subscription (and schedules a scrub), so `contract.start` then found no
active subscription and bailed — leaving the workspace with no subscription and
a pending scrub. This is also the normal "cancel then re-register" flow.

`contract.start` now tolerates a missing active subscription: it swaps the
active sub onto the new contract when present, otherwise creates a new active
subscription (SubscriptionResource.createActiveMetronomeSubscription). Either
path then runs restoreWorkspaceAfterSubscription, which cancels the scheduled
scrub. previousPlanCode falls back to FREE_NO_PLAN_CODE for the audit event.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
