### PR TITLE
[front] Seat mid-period new members on both current and pending contracts

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -95,6 +95,12 @@ async function resolveSeatTypeForNewMembership(
   if (!workspace.metronomeCustomerId) {
     return "none";
   }
+  // The new member's active seat is always resolved against the workspace's
+  // ACTIVE contract — the plan billing them right now. A pending contract switch
+  // (e.g. a legacy→Business migration in its window) does NOT change this: the
+  // member takes the current contract's seat now, and is separately scheduled
+  // onto the pending contract at its start by the seat sync (see
+  // `syncMetronomeSeatCountForWorkspace`).
   const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
     workspace.id
   );

--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -4,9 +4,11 @@ import {
 } from "@app/lib/api/metronome/reconcile_credit_state";
 import { syncDefaultPoolCapAlertsForWorkspace } from "@app/lib/api/workspace/default_user_spend_limit";
 import { Authenticator } from "@app/lib/auth";
+import { getMetronomeContractById } from "@app/lib/metronome/client";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   hasContractSeatSubscription,
+  remapMembershipSeatTypesForContract,
   syncSeatCount,
 } from "@app/lib/metronome/seats";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -60,37 +62,45 @@ export async function syncMetronomeSeatCountForWorkspace({
     });
   }
 
-  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
-    workspace.id
-  );
-  if (!subscription?.metronomeContractId) {
-    return new Ok({
-      status: "skipped",
-      reason: "workspace has no Metronome contract on its active subscription",
-    });
-  }
+  // When the workspace has a scheduled future contract switch (e.g. a
+  // legacy→Business migration in its window), also stage the PENDING contract:
+  // members added/changed mid-window must be seated on the contract that will
+  // bill them once it starts. The seat invoice is cut at contract start, so
+  // this is pre-provisioned now — the `contract.start` webhook would be too
+  // late. Every membership change routes through this function, so the pending
+  // contract stays correct across adds, revokes, and seat changes alike. This
+  // is independent of, and in addition to, reconciling the active contract
+  // below (whose seats a legacy shadow contract still bills / finalizes).
+  const stagedPending = await stagePendingContractSeats(workspace);
 
-  const contract = await getActiveContract(workspace.sId);
-  if (!contract) {
-    return new Ok({
-      status: "skipped",
-      reason: "no active contract found for workspace",
-    });
-  }
+  const activeSubscription =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+  const activeContract = activeSubscription?.metronomeContractId
+    ? await getActiveContract(workspace.sId)
+    : null;
 
-  if (!(await hasContractSeatSubscription(contract))) {
-    return new Ok({
-      status: "skipped",
-      reason: "active contract has no seat subscription",
-    });
+  if (
+    !activeSubscription?.metronomeContractId ||
+    !activeContract ||
+    !(await hasContractSeatSubscription(activeContract))
+  ) {
+    return new Ok(
+      stagedPending
+        ? { status: "synced" }
+        : {
+            status: "skipped",
+            reason:
+              "no active or pending contract with a seat subscription to sync",
+          }
+    );
   }
 
   const result = await syncSeatCount({
     metronomeCustomerId: workspace.metronomeCustomerId,
-    contractId: subscription.metronomeContractId,
+    contractId: activeSubscription.metronomeContractId,
     workspace,
-    planCode: subscription.getPlan().code,
-    contract,
+    planCode: activeSubscription.getPlan().code,
+    contract: activeContract,
   });
   if (result.isErr()) {
     return new Err(result.error);
@@ -131,8 +141,8 @@ export async function syncMetronomeSeatCountForWorkspace({
   await reconcileWorkspaceUserCreditStates({
     workspace,
     metronomeCustomerId: workspace.metronomeCustomerId,
-    metronomeContractId: subscription.metronomeContractId,
-    planCode: subscription.getPlan().code,
+    metronomeContractId: activeSubscription.metronomeContractId,
+    planCode: activeSubscription.getPlan().code,
   });
 
   // Ensure per-seat-type cap alerts exist with the current default pool limit.
@@ -146,4 +156,83 @@ export async function syncMetronomeSeatCountForWorkspace({
   }
 
   return new Ok({ status: "synced" });
+}
+
+/**
+ * Stage the workspace's PENDING (created_backend_only) contract, if any, so a
+ * scheduled future switch has correct seats before it starts.
+ *
+ * Schedules a future-dated seat change per member onto the pending contract
+ * (`remapMembershipSeatTypesForContract` with `swapAt: "next-hour"`), then
+ * pre-provisions the seat counts (`syncSeatCount` with the pending start).
+ * Legacy plans only carry `workspace`/`none` seats, which Business doesn't bill,
+ * so they are promoted to `pro` (the migration's target seat).
+ *
+ * Skips the live-balance credit reconcile: the contract isn't active yet, so
+ * that runs at `contract.start` (and on the next sync once it is active).
+ * Best-effort — a failure is logged and the next membership change re-runs it.
+ *
+ * Returns whether the pending contract was staged.
+ */
+async function stagePendingContractSeats(
+  workspace: LightWorkspaceType
+): Promise<boolean> {
+  if (!workspace.metronomeCustomerId) {
+    return false;
+  }
+  const pendingSubscription =
+    await SubscriptionResource.fetchPendingByWorkspaceModelId(workspace.id);
+  if (!pendingSubscription?.metronomeContractId) {
+    return false;
+  }
+  const pendingContractResult = await getMetronomeContractById({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    metronomeContractId: pendingSubscription.metronomeContractId,
+  });
+  if (
+    pendingContractResult.isErr() ||
+    !(await hasContractSeatSubscription(pendingContractResult.value))
+  ) {
+    return false;
+  }
+  const pendingContract = pendingContractResult.value;
+
+  // Schedule each member's future-dated seat change onto the pending contract.
+  // `promoteNoneSeatType: "pro"` maps legacy `workspace`/`none` members onto
+  // Business's `pro` seat (Business has no committed seats, so they'd otherwise
+  // stay `none`). Fixed to `"pro"` for the current legacy→Business migration.
+  const remapResult = await remapMembershipSeatTypesForContract({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    contractId: pendingSubscription.metronomeContractId,
+    workspace,
+    swapAt: "next-hour",
+    startingAt: new Date(pendingContract.starting_at),
+    contract: pendingContract,
+    promoteNoneSeatType: "pro",
+  });
+  if (remapResult.isErr()) {
+    logger.warn(
+      { workspaceId: workspace.sId, err: remapResult.error.message },
+      "[SeatSync] Failed to remap seats onto pending contract; continuing"
+    );
+    return false;
+  }
+
+  const syncResult = await syncSeatCount({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    contractId: pendingSubscription.metronomeContractId,
+    workspace,
+    planCode: pendingSubscription.getPlan().code,
+    contract: pendingContract,
+    startingAt: pendingContract.starting_at,
+  });
+  if (syncResult.isErr()) {
+    logger.warn(
+      { workspaceId: workspace.sId, err: syncResult.error.message },
+      "[SeatSync] Failed to pre-provision pending contract seats; continuing"
+    );
+    return false;
+  }
+
+  return true;
 }

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -319,20 +319,51 @@ const PROMOTABLE_SEAT_TYPES: ReadonlySet<MembershipSeatType> = new Set([
   "workspace_yearly",
 ]);
 
+/**
+ * Promote `none` seat types onto paid seats the contract bills.
+ *
+ * `forceSeatType` (used by a legacy contract migration) preempts the committed
+ * placement entirely: when set — and the contract bills it — EVERY `none` member
+ * is moved straight onto it. This is how a migration puts all seat-less members
+ * on a paid seat (e.g. `pro`), regardless of any committed allocation the
+ * contract might have.
+ *
+ * Without `forceSeatType`, `none` members are placed into committed paid seats
+ * (`minSeats > 0`) with spare capacity, in ascending tier order — a committed
+ * seat is billed whether or not it is assigned, so filling it adds no cost. This
+ * committed promotion is all-or-nothing: if a `none` member can't be placed, no
+ * member is promoted (the input is returned unchanged), so we never bill a
+ * partial set.
+ */
 export function promoteNoneSeatTypesForContract({
   contract,
   productSeatTypes,
   seatTypes,
   seatLimits,
+  forceSeatType,
 }: {
   contract: CachedContract;
   productSeatTypes: Map<string, MembershipSeatType>;
   seatTypes: MembershipSeatType[];
   seatLimits?: Map<MembershipSeatType, SeatLimit>;
+  // Seat type to force every `none` member onto, preempting the committed-seat
+  // placement below. Used by the legacy→Business migration to put `workspace`/
+  // `none` members on `pro`. Ignored unless the contract bills it.
+  forceSeatType?: MembershipSeatType;
 }): MembershipSeatType[] {
-  const committedPaidSeatTypes = [
-    ...getSeatSubscriptionsFromContract(contract, productSeatTypes).keys(),
-  ]
+  const onContract = new Set(
+    getSeatSubscriptionsFromContract(contract, productSeatTypes).keys()
+  );
+
+  // A forced seat preempts committed placement: move every `none` straight onto
+  // it, provided the contract bills it.
+  if (forceSeatType && onContract.has(forceSeatType)) {
+    return seatTypes.map((seatType) =>
+      seatType === "none" ? forceSeatType : seatType
+    );
+  }
+
+  const committedPaidSeatTypes = [...onContract]
     .filter(
       (seatType) =>
         PROMOTABLE_SEAT_TYPES.has(seatType) &&
@@ -397,6 +428,12 @@ export function promoteNoneSeatTypesForContract({
  * `promoteNoneSeatTypesForContract`): a committed seat is billed whether or not
  * it is assigned, so filling it with an otherwise seat-less member adds no cost.
  *
+ * When `promoteNoneSeatType` is set, every member that would otherwise stay on
+ * `none` is instead forced onto that seat type (provided the new contract bills
+ * it) — this preempts the committed-spare promotion above. It is how a legacy
+ * contract migration puts every member on a paid seat (e.g. `pro` for a monthly
+ * switch, `pro_yearly` for a yearly one).
+ *
  * No-op for memberships already on a covered seat type. A membership with no
  * resolvable `UserResource` is logged and skipped; a DB error while applying a
  * change throws (internal error → 500), so the operator knows the remap was
@@ -409,6 +446,7 @@ export async function remapMembershipSeatTypesForContract({
   swapAt,
   startingAt,
   contract,
+  promoteNoneSeatType,
 }: {
   metronomeCustomerId: string;
   contractId: string;
@@ -416,6 +454,10 @@ export async function remapMembershipSeatTypesForContract({
   swapAt: "current-hour" | "next-hour";
   startingAt: Date;
   contract?: CachedContract;
+  // Seat type that every `none` member is forced onto, preempting the
+  // committed-spare promotion (see `promoteNoneSeatTypesForContract`). Used by
+  // the legacy→Business migration to force `workspace`/`none` members onto `pro`.
+  promoteNoneSeatType?: MembershipSeatType;
 }): Promise<Result<undefined, Error>> {
   let resolvedContract: CachedContract;
   if (contract) {
@@ -522,6 +564,7 @@ export async function remapMembershipSeatTypesForContract({
     productSeatTypes,
     seatTypes: remapTargets.map((t) => t.baseTarget),
     seatLimits,
+    forceSeatType: promoteNoneSeatType,
   });
 
   for (const [


### PR DESCRIPTION
## Description

When a workspace has a scheduled future contract switch (e.g. a legacy→Business migration in its window), a member added or changed **mid-window** must be seated on **both** contracts, with the correct seat on each:

- the **current** contract with the seat they actually take now (e.g. a legacy `workspace`/`none` seat) — the current contract still bills / finalizes a proration invoice for the added seat; and
- the **pending** contract with the seat that will bill them once it starts (legacy `workspace`/`none` → `pro` on Business), so its first invoice is correct.

The seat invoice is cut at contract start, so the pending contract's seats must be staged **before** it starts — reconciling in the `contract.start` webhook is too late.

### Changes
- **`resolveSeatTypeForNewMembership`** (`membership.ts`): resolves the active seat against the **active** contract only (the plan billing the member right now). A pending switch does not change the active seat.
- **`syncMetronomeSeatCountForWorkspace`** (`seat_sync.ts`): keeps reconciling the **active** contract exactly as before, and additionally **stages the pending contract** when one exists (`stagePendingContractSeats`): schedules a future-dated seat change per member (`remapMembershipSeatTypesForContract`, `swapAt: "next-hour"`, `startingAt` = pending start) and pre-provisions its seat counts (`syncSeatCount` at the pending start). Best-effort (logged, self-heals on the next membership change); skips the live-balance credit reconcile since the contract isn't active yet. Every membership change already routes through this fn, so the pending contract stays correct across adds, revokes, and seat changes.
- **`remapMembershipSeatTypesForContract` / `promoteNoneSeatTypesForContract`** (`seats.ts`): gain a `forceSeatType` (surfaced as `promoteNoneSeatType` on the remap wrapper) that, when set and billed by the contract, forces **every** `none` member onto it — preempting the committed-spare promotion. `stagePendingContractSeats` passes `"pro"` for the current legacy→Business migration (Business has no committed seats, so behavior is unchanged there).

The scheduled future rows are provisioned to Metronome by `syncSeatCount`, which reads active + scheduled-future memberships and writes each future segment with its own `starting_at` (Metronome flips it on the date; no scheduler on our side).

## Tests

Manual: on a workspace with an active legacy contract + a pending Business contract, adding a member (including via the invitation flow) creates the active `none`/`workspace` row on the current contract **plus** a scheduled `pro` row on the pending contract, and both contracts sync (the mid-window sync runs via the debounced `syncMetronomeSeatCountWorkflow`). `lib/metronome/seats.test.ts` green; `tsgo` clean on changed files.

## Risk

Low. Additive to the seat-sync path — the active-contract reconcile is unchanged. Pending-contract staging is best-effort and idempotent, and only runs when a pending contract with a seat subscription exists.

## Deploy Plan

No migration or config change. Base is `main`; also the base of the migration PR (#28134).

