### PR TITLE
Drop legacy agent_step_contents type check constraint

### DIFF
--- a/front/migrations/pre-deploy/20260701133528_drop_agent_step_contents_type_check.sql
+++ b/front/migrations/pre-deploy/20260701133528_drop_agent_step_contents_type_check.sql
@@ -1,0 +1,15 @@
+/*
+Drop the legacy CHECK constraint on agent_step_contents.type.
+
+The constraint only allowed ('text_content','reasoning','function_call','error')
+and was never updated when 'provider_passthrough' was added (PR #28129), causing
+inserts of provider_passthrough rows to fail. Allowed values are enforced in code
+via the Sequelize `isIn` validate on AgentStepContentModel, so the DB-level check
+is redundant. This constraint is not generated from the model, hence this
+hand-written migration rather than a pg-schema-diff one.
+
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_step_contents" DROP CONSTRAINT IF EXISTS "agent_step_contents_type_check";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The database has a stale check constraint on the type column of agent step contents that only permits `text_content`, `reasoning`, `function_call`, and `error`. When `provider_passthrough` was later introduced, no migration updated this constraint, so any attempt to persist a `provider_passthrough` step content fails at insert time with a check constraint violation. The constraint exists in both EU and US.

This drops the constraint entirely rather than extending it. It's extremely confusing as this constraint does not live anywhere in the code. 

The migration is hand-written and idempotent because the constraint was never expressed in the model and is therefore not something the schema diff tooling manages.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
