### PR TITLE
[front] Extract BuyCreditsTab component from the Top-Up dialog

### DIFF
--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -357,7 +357,7 @@ export function CheckoutPage() {
   };
 
   const handleApplyCoupon = handleCouponSubmit(async ({ couponCode }) => {
-    const result = await validateCoupon(couponCode.trim());
+    const result = await validateCoupon(couponCode.trim(), "subscription");
     if (!result.ok) {
       setCouponError("couponCode", { message: result.message });
       return;

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -21,7 +21,10 @@ import {
 import { useValidateCoupon } from "@app/lib/swr/workspaces";
 import type { CouponType } from "@app/types/coupon";
 import { CURRENCY_SYMBOLS } from "@app/types/currency";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import {
+  assertNever,
+  assertNeverAndIgnore,
+} from "@app/types/shared/utils/assert_never";
 import {
   Button,
   CheckCircle,
@@ -105,6 +108,269 @@ function SummaryRow({ label, value, dimmed = false }: SummaryRowProps) {
   );
 }
 
+interface UseCouponTabProps {
+  workspaceId: string;
+  currentTotalPoolCredits?: number;
+  // Closes the whole dialog.
+  onClose: () => void;
+  // Notifies the parent (e.g. to refresh the pool) once credits are granted.
+  onSuccess?: () => void;
+}
+
+// The "Use coupon" tab: a standalone, synchronous flow — enter a code, Check it
+// to preview the bonus, then Apply to grant the free credits. Owns its own
+// state, independent of the "Buy credits" payment flow.
+function UseCouponTab({
+  workspaceId,
+  currentTotalPoolCredits,
+  onClose,
+  onSuccess,
+}: UseCouponTabProps) {
+  const [couponInput, setCouponInput] = useState<string>("");
+  const [checkedCoupon, setCheckedCoupon] = useState<CouponType | null>(null);
+  const [couponState, setCouponState] = useState<CouponState>("idle");
+  const [couponError, setCouponError] = useState<string>("");
+  const [isCheckingCoupon, setIsCheckingCoupon] = useState(false);
+  const { validateCoupon } = useValidateCoupon({ workspaceId });
+  const { redeemCreditsCoupon } = useRedeemCreditsCoupon({ workspaceId });
+
+  // For a "credits" coupon, `amount` is the number of bonus AWU credits granted.
+  const bonusCredits = checkedCoupon?.amount ?? 0;
+
+  // "Check" button: validate the code as a "credits" coupon and surface the
+  // bonus it would grant before the user commits.
+  const handleCheckCoupon = useCallback(async () => {
+    const code = couponInput.trim();
+    if (!code) {
+      return;
+    }
+    setCouponError("");
+    setIsCheckingCoupon(true);
+    try {
+      const result = await validateCoupon(code, "credits");
+      if (!result.ok) {
+        setCheckedCoupon(null);
+        setCouponState("idle");
+        setCouponError(result.message);
+        return;
+      }
+      setCheckedCoupon(result.coupon);
+      setCouponState("checked");
+    } finally {
+      setIsCheckingCoupon(false);
+    }
+  }, [couponInput, validateCoupon]);
+
+  // "Apply" button: actually redeem the checked coupon and grant the credits.
+  const handleRedeemCoupon = useCallback(async () => {
+    if (!checkedCoupon) {
+      return;
+    }
+    setCouponState("redeeming");
+    const result = await redeemCreditsCoupon(checkedCoupon.code);
+    switch (result.status) {
+      case "success":
+        setCouponState("success");
+        onSuccess?.();
+        break;
+      case "error":
+        setCouponError(result.message);
+        setCouponState("error");
+        break;
+      default:
+        assertNeverAndIgnore(result);
+    }
+  }, [checkedCoupon, redeemCreditsCoupon, onSuccess]);
+
+  const resetCouponInput = useCallback(() => {
+    setCheckedCoupon(null);
+    setCouponState("idle");
+    setCouponInput("");
+    setCouponError("");
+  }, []);
+
+  switch (couponState) {
+    case "redeeming":
+      return (
+        <>
+          <DialogContainer>
+            <div className="flex flex-col items-center justify-center gap-4 py-8">
+              <Spinner size="lg" />
+              <p className="text-sm text-muted-foreground">
+                Applying coupon...
+              </p>
+            </div>
+          </DialogContainer>
+          <DialogFooter
+            rightButtonProps={{
+              label: "Applying...",
+              variant: "primary",
+              disabled: true,
+            }}
+          />
+        </>
+      );
+    case "success":
+      return (
+        <>
+          <DialogContainer>
+            <div className="flex flex-col items-center justify-center gap-4 py-8">
+              <Icon
+                visual={CheckCircle}
+                size="lg"
+                className="text-success-500"
+              />
+              <div className="text-center">
+                <p className="text-lg font-medium text-foreground">
+                  Coupon applied!
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  <span className="font-semibold">
+                    {formatCredits(bonusCredits)} credits
+                  </span>{" "}
+                  have been added to your pool.
+                </p>
+              </div>
+            </div>
+          </DialogContainer>
+          <DialogFooter
+            rightButtonProps={{
+              label: "Close",
+              variant: "primary",
+              onClick: onClose,
+            }}
+          />
+        </>
+      );
+    case "error":
+      return (
+        <>
+          <DialogContainer>
+            <div className="flex flex-col items-center justify-center gap-4 py-8">
+              <Icon visual={XCircle} size="lg" className="text-warning-500" />
+              <div className="text-center">
+                <p className="text-lg font-medium text-foreground">
+                  Couldn't apply coupon
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {couponError}
+                </p>
+              </div>
+            </div>
+          </DialogContainer>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Close",
+              variant: "outline",
+              onClick: onClose,
+            }}
+            rightButtonProps={{
+              label: "Try again",
+              variant: "primary",
+              onClick: resetCouponInput,
+            }}
+          />
+        </>
+      );
+    case "idle":
+    case "checked":
+      return (
+        <>
+          <DialogContainer>
+            <div className="flex flex-col gap-4">
+              <p className="text-sm text-muted-foreground">
+                Have a coupon code? Enter it below to add free credits to your
+                Workspace Credits Pool.
+              </p>
+              <div className="flex flex-col gap-2">
+                <label
+                  htmlFor="couponCode"
+                  className="text-sm font-medium text-foreground"
+                >
+                  Coupon code
+                </label>
+                <div className="flex items-start gap-2">
+                  <div className="flex flex-col gap-1">
+                    <Input
+                      id="couponCode"
+                      placeholder="Enter code"
+                      value={couponInput}
+                      onChange={(e) => {
+                        setCouponInput(e.target.value);
+                        setCouponError("");
+                        setCheckedCoupon(null);
+                        setCouponState("idle");
+                      }}
+                      isError={!!couponError}
+                      className="w-48"
+                    />
+                    {couponError && (
+                      <span className="text-xs text-warning-500">
+                        {couponError}
+                      </span>
+                    )}
+                  </div>
+                  <Button
+                    label="Check"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleCheckCoupon}
+                    disabled={!couponInput.trim() || isCheckingCoupon}
+                    isLoading={isCheckingCoupon}
+                  />
+                </div>
+              </div>
+
+              {couponState === "checked" && checkedCoupon && (
+                <div className="flex flex-col gap-2 rounded-xl bg-muted-background p-4">
+                  <SummaryRow
+                    label="Coupon"
+                    value={checkedCoupon.code}
+                    dimmed
+                  />
+                  {currentTotalPoolCredits !== undefined && (
+                    <SummaryRow
+                      label="Current Credits Pool"
+                      value={<CreditValue credits={currentTotalPoolCredits} />}
+                      dimmed
+                    />
+                  )}
+                  <SummaryRow
+                    label="Bonus Credits"
+                    value={<CreditValue credits={bonusCredits} />}
+                    dimmed
+                  />
+                  <div className="py-1" />
+                  {currentTotalPoolCredits !== undefined && (
+                    <SummaryRow
+                      label="New Credits Pool"
+                      value={
+                        <CreditValue
+                          credits={currentTotalPoolCredits + bonusCredits}
+                        />
+                      }
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+          </DialogContainer>
+          <DialogFooter>
+            <Button label="Cancel" variant="outline" onClick={onClose} />
+            <Button
+              label="Apply coupon"
+              variant="primary"
+              onClick={handleRedeemCoupon}
+              disabled={couponState !== "checked"}
+            />
+          </DialogFooter>
+        </>
+      );
+    default:
+      return assertNever(couponState);
+  }
+}
+
 interface BuyAwuCreditsDialogProps {
   isOpen: boolean;
   onClose: () => void;
@@ -134,18 +400,7 @@ export function BuyAwuCreditsDialog({
   const [purchaseStartedAtMs, setPurchaseStartedAtMs] = useState<number | null>(
     null
   );
-  // "Use coupon" tab state (independent of the "Buy credits" tab).
-  const [couponInput, setCouponInput] = useState<string>("");
-  const [checkedCoupon, setCheckedCoupon] = useState<CouponType | null>(null);
-  const [couponState, setCouponState] = useState<CouponState>("idle");
-  const [couponError, setCouponError] = useState<string>("");
-  const [isCheckingCoupon, setIsCheckingCoupon] = useState(false);
   const { purchaseAwuCredits } = useAwuPurchase({ workspaceId });
-  const { validateCoupon } = useValidateCoupon({ workspaceId });
-  const { redeemCreditsCoupon } = useRedeemCreditsCoupon({ workspaceId });
-
-  // For a "credits" coupon, `amount` is the number of bonus AWU credits granted.
-  const bonusCredits = checkedCoupon?.amount ?? 0;
 
   // Poll the payment-gated commit status only while waiting on the webhook
   // outcome. The Metronome -> Stripe payment is async, so the dialog can't
@@ -186,64 +441,8 @@ export function BuyAwuCreditsDialog({
     setPurchaseState("idle");
     setErrorMessage("");
     setPurchaseStartedAtMs(null);
-    setCouponInput("");
-    setCheckedCoupon(null);
-    setCouponState("idle");
-    setCouponError("");
     onClose();
   }, [onClose]);
-
-  // "Check" button: validate the code as a "credits" coupon and surface the
-  // bonus it would grant before the user commits.
-  const handleCheckCoupon = useCallback(async () => {
-    const code = couponInput.trim();
-    if (!code) {
-      return;
-    }
-    setCouponError("");
-    setIsCheckingCoupon(true);
-    try {
-      const result = await validateCoupon(code, "credits");
-      if (!result.ok) {
-        setCheckedCoupon(null);
-        setCouponState("idle");
-        setCouponError(result.message);
-        return;
-      }
-      setCheckedCoupon(result.coupon);
-      setCouponState("checked");
-    } finally {
-      setIsCheckingCoupon(false);
-    }
-  }, [couponInput, validateCoupon]);
-
-  // "Apply" button: actually redeem the checked coupon and grant the credits.
-  const handleRedeemCoupon = useCallback(async () => {
-    if (!checkedCoupon) {
-      return;
-    }
-    setCouponState("redeeming");
-    const result = await redeemCreditsCoupon(checkedCoupon.code);
-    switch (result.status) {
-      case "success":
-        setCouponState("success");
-        onPurchaseSuccess?.();
-        break;
-      case "error":
-        setCouponError(result.message);
-        setCouponState("error");
-        break;
-      default:
-        assertNeverAndIgnore(result);
-    }
-  }, [checkedCoupon, redeemCreditsCoupon, onPurchaseSuccess]);
-
-  const resetCouponInput = useCallback(() => {
-    setCheckedCoupon(null);
-    setCouponState("idle");
-    setCouponInput("");
-    setCouponError("");
-  }, []);
 
   const currency = awuPurchaseInfo?.canPurchase
     ? awuPurchaseInfo.currency
@@ -564,183 +763,6 @@ export function BuyAwuCreditsDialog({
     }
   };
 
-  const renderCouponContent = () => {
-    switch (couponState) {
-      case "redeeming":
-        return (
-          <div className="flex flex-col items-center justify-center gap-4 py-8">
-            <Spinner size="lg" />
-            <p className="text-sm text-muted-foreground">
-              Applying coupon...
-            </p>
-          </div>
-        );
-      case "success":
-        return (
-          <div className="flex flex-col items-center justify-center gap-4 py-8">
-            <Icon visual={CheckCircle} size="lg" className="text-success-500" />
-            <div className="text-center">
-              <p className="text-lg font-medium text-foreground">
-                Coupon applied!
-              </p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                <span className="font-semibold">
-                  {formatCredits(bonusCredits)} credits
-                </span>{" "}
-                have been added to your pool.
-              </p>
-            </div>
-          </div>
-        );
-      case "error":
-        return (
-          <div className="flex flex-col items-center justify-center gap-4 py-8">
-            <Icon visual={XCircle} size="lg" className="text-warning-500" />
-            <div className="text-center">
-              <p className="text-lg font-medium text-foreground">
-                Couldn't apply coupon
-              </p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                {couponError}
-              </p>
-            </div>
-          </div>
-        );
-      default:
-        return (
-          <div className="flex flex-col gap-4">
-            <p className="text-sm text-muted-foreground">
-              Have a coupon code? Enter it below to add free credits to your
-              Workspace Credits Pool.
-            </p>
-            <div className="flex flex-col gap-2">
-              <label
-                htmlFor="couponCode"
-                className="text-sm font-medium text-foreground"
-              >
-                Coupon code
-              </label>
-              <div className="flex items-start gap-2">
-                <div className="flex flex-col gap-1">
-                  <Input
-                    id="couponCode"
-                    placeholder="Enter code"
-                    value={couponInput}
-                    onChange={(e) => {
-                      setCouponInput(e.target.value);
-                      setCouponError("");
-                      setCheckedCoupon(null);
-                      setCouponState("idle");
-                    }}
-                    isError={!!couponError}
-                    className="w-48"
-                  />
-                  {couponError && (
-                    <span className="text-xs text-warning-500">
-                      {couponError}
-                    </span>
-                  )}
-                </div>
-                <Button
-                  label="Check"
-                  variant="outline"
-                  size="sm"
-                  onClick={handleCheckCoupon}
-                  disabled={!couponInput.trim() || isCheckingCoupon}
-                  isLoading={isCheckingCoupon}
-                />
-              </div>
-            </div>
-
-            {couponState === "checked" && checkedCoupon && (
-              <div className="flex flex-col gap-2 rounded-xl bg-muted-background p-4">
-                <SummaryRow label="Coupon" value={checkedCoupon.code} dimmed />
-                {currentTotalPoolCredits !== undefined && (
-                  <SummaryRow
-                    label="Current Credits Pool"
-                    value={<CreditValue credits={currentTotalPoolCredits} />}
-                    dimmed
-                  />
-                )}
-                <SummaryRow
-                  label="Bonus Credits"
-                  value={<CreditValue credits={bonusCredits} />}
-                  dimmed
-                />
-                <div className="py-1" />
-                {currentTotalPoolCredits !== undefined && (
-                  <SummaryRow
-                    label="New Credits Pool"
-                    value={
-                      <CreditValue
-                        credits={currentTotalPoolCredits + bonusCredits}
-                      />
-                    }
-                  />
-                )}
-              </div>
-            )}
-          </div>
-        );
-    }
-  };
-
-  const renderCouponFooter = () => {
-    switch (couponState) {
-      case "redeeming":
-        return (
-          <DialogFooter
-            rightButtonProps={{
-              label: "Applying...",
-              variant: "primary",
-              disabled: true,
-            }}
-          />
-        );
-      case "success":
-        return (
-          <DialogFooter
-            rightButtonProps={{
-              label: "Close",
-              variant: "primary",
-              onClick: resetModalStateAndClose,
-            }}
-          />
-        );
-      case "error":
-        return (
-          <DialogFooter
-            leftButtonProps={{
-              label: "Close",
-              variant: "outline",
-              onClick: resetModalStateAndClose,
-            }}
-            rightButtonProps={{
-              label: "Try again",
-              variant: "primary",
-              onClick: resetCouponInput,
-            }}
-          />
-        );
-      default:
-        return (
-          <DialogFooter>
-            <Button
-              label="Cancel"
-              variant="outline"
-              onClick={resetModalStateAndClose}
-            />
-            <Button
-              label="Apply coupon"
-              variant="primary"
-              onClick={handleRedeemCoupon}
-              disabled={couponState !== "checked"}
-            />
-          </DialogFooter>
-        );
-    }
-  };
-
   if (isAwuPurchaseInfoLoading) {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -989,8 +1011,12 @@ export function BuyAwuCreditsDialog({
               {renderBuyTabFooter()}
             </TabsContent>
             <TabsContent value="coupon">
-              <DialogContainer>{renderCouponContent()}</DialogContainer>
-              {renderCouponFooter()}
+              <UseCouponTab
+                workspaceId={workspaceId}
+                currentTotalPoolCredits={currentTotalPoolCredits}
+                onClose={resetModalStateAndClose}
+                onSuccess={onPurchaseSuccess}
+              />
             </TabsContent>
           </Tabs>
         )}

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -371,27 +371,29 @@ function UseCouponTab({
   }
 }
 
-interface BuyAwuCreditsDialogProps {
+interface BuyCreditsTabProps {
+  workspaceId: string;
+  awuPurchaseInfo: AwuPurchaseInfo | null;
+  currentTotalPoolCredits?: number;
   isOpen: boolean;
   onClose: () => void;
   onPurchaseSuccess?: () => void;
-  workspaceId: string;
-  awuPurchaseInfo: AwuPurchaseInfo | null;
-  isAwuPurchaseInfoLoading: boolean;
-  isAwuPurchaseInfoError: boolean;
-  currentTotalPoolCredits?: number;
+  // Reports whether a purchase is in flight so the parent can lock the tabs.
+  onInFlightChange: (inFlight: boolean) => void;
 }
 
-export function BuyAwuCreditsDialog({
+// The "Buy credits" tab: the payment-gated Top-Up flow. Owns its own purchase
+// state and status polling; renders its content + footer based on
+// `purchaseState` (plus the pending/exhausted buy-blocking states).
+function BuyCreditsTab({
+  workspaceId,
+  awuPurchaseInfo,
+  currentTotalPoolCredits,
   isOpen,
   onClose,
   onPurchaseSuccess,
-  workspaceId,
-  awuPurchaseInfo,
-  isAwuPurchaseInfoLoading,
-  isAwuPurchaseInfoError,
-  currentTotalPoolCredits,
-}: BuyAwuCreditsDialogProps) {
+  onInFlightChange,
+}: BuyCreditsTabProps) {
   const [amountInput, setAmountInput] = useState<string>("");
   const [purchaseState, setPurchaseState] = useState<PurchaseState>("idle");
   const [errorMessage, setErrorMessage] = useState<string>("");
@@ -403,8 +405,8 @@ export function BuyAwuCreditsDialog({
   const { purchaseAwuCredits } = useAwuPurchase({ workspaceId });
 
   // Poll the payment-gated commit status only while waiting on the webhook
-  // outcome. The Metronome -> Stripe payment is async, so the dialog can't
-  // know success/failure from the POST response alone.
+  // outcome. The Metronome -> Stripe payment is async, so the tab can't know
+  // success/failure from the POST response alone.
   const { attempt, mutateAwuPurchaseStatus } = useAwuPurchaseStatus({
     workspaceId,
     disabled: !isOpen || purchaseState !== "processing",
@@ -436,13 +438,10 @@ export function BuyAwuCreditsDialog({
     }
   }, [attempt, purchaseState, purchaseStartedAtMs, onPurchaseSuccess]);
 
-  const resetModalStateAndClose = useCallback(() => {
-    setAmountInput("");
-    setPurchaseState("idle");
-    setErrorMessage("");
-    setPurchaseStartedAtMs(null);
-    onClose();
-  }, [onClose]);
+  // Let the parent lock the tab bar while a purchase is in flight.
+  useEffect(() => {
+    onInFlightChange(purchaseState !== "idle");
+  }, [purchaseState, onInFlightChange]);
 
   const currency = awuPurchaseInfo?.canPurchase
     ? awuPurchaseInfo.currency
@@ -495,6 +494,16 @@ export function BuyAwuCreditsDialog({
 
   const canPurchase = isValidAmount && !amountExceedsMax;
 
+  // Buy-only blocking states — they prevent buying but not coupon redemption,
+  // so they render inside this tab rather than replacing the whole dialog.
+  const buyPendingBlock =
+    !!awuPurchaseInfo &&
+    !awuPurchaseInfo.canPurchase &&
+    awuPurchaseInfo.reason === "pending_purchase";
+  const buyExhaustedBlock =
+    !!awuPurchaseInfo?.canPurchase &&
+    awuPurchaseInfo.remainingCycleCredits < MIN_AWU_PURCHASE_CREDITS;
+
   const handlePurchase = async () => {
     setPurchaseStartedAtMs(Date.now());
     setPurchaseState("processing");
@@ -516,194 +525,83 @@ export function BuyAwuCreditsDialog({
     }
   };
 
-  const renderContent = () => {
-    switch (purchaseState) {
-      case "processing":
-        return (
-          <div className="flex flex-col items-center justify-center gap-4 py-8">
-            <Spinner size="lg" />
-            <p className="text-sm text-muted-foreground">
-              Processing payment...
-            </p>
-            <p className="text-xs text-muted-foreground">
-              This may take a few seconds.
-            </p>
-          </div>
-        );
+  if (purchaseState === "idle" && buyPendingBlock) {
+    return (
+      <>
+        <DialogContainer>
+          <p className="text-sm text-muted-foreground">
+            You have pending credit purchases awaiting payment. Please complete
+            your pending payment before making a new purchase or{" "}
+            <a
+              href={`mailto:${supportEmail}?subject=Cancel%20pending%20credit%20purchase`}
+              className="text-action-500 hover:underline"
+            >
+              contact support
+            </a>{" "}
+            to cancel your pending payments.
+          </p>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Close",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Manage invoices",
+            variant: "primary",
+            onClick: () => {
+              window.open(`/w/${workspaceId}/subscription/manage`, "_blank");
+            },
+          }}
+        />
+      </>
+    );
+  }
 
-      case "success":
-        return (
-          <div className="flex flex-col items-center justify-center gap-4 py-8">
-            <Icon visual={CheckCircle} size="lg" className="text-success-500" />
-            <div className="text-center">
-              <p className="text-lg font-medium text-foreground">
-                Credits purchased successfully!
+  if (purchaseState === "idle" && buyExhaustedBlock) {
+    return (
+      <>
+        <DialogContainer>
+          <p className="text-sm text-muted-foreground">
+            You've reached your credit limit for this billing cycle. It resets
+            at the start of your next billing cycle. If you need additional
+            credits before then, please{" "}
+            <a
+              href={`mailto:${supportEmail}?subject=Credit%20purchase%20limit%20reached`}
+              className="text-action-500 hover:underline"
+            >
+              contact support
+            </a>
+            .
+          </p>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Close",
+            variant: "outline",
+            onClick: onClose,
+          }}
+        />
+      </>
+    );
+  }
+
+  switch (purchaseState) {
+    case "processing":
+      return (
+        <>
+          <DialogContainer>
+            <div className="flex flex-col items-center justify-center gap-4 py-8">
+              <Spinner size="lg" />
+              <p className="text-sm text-muted-foreground">
+                Processing payment...
               </p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Your credits are now available.
-              </p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                <span className="font-semibold">
-                  Invoice has been sent by email.
-                </span>
+              <p className="text-xs text-muted-foreground">
+                This may take a few seconds.
               </p>
             </div>
-          </div>
-        );
-
-      case "error":
-        return (
-          <div className="flex flex-col items-center justify-center gap-4 py-8">
-            <Icon visual={XCircle} size="lg" className="text-warning-500" />
-            <div className="text-center">
-              <p className="text-lg font-medium text-foreground">
-                Something went wrong
-              </p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                {errorMessage}
-              </p>
-              <p className="mt-2 text-xs text-muted-foreground">
-                Please contact support if the issue persists.
-              </p>
-            </div>
-          </div>
-        );
-
-      default: {
-        return (
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-col gap-2">
-                <label
-                  htmlFor="amount"
-                  className="text-sm font-medium text-foreground"
-                >
-                  Amount
-                </label>
-                <div className="flex items-center gap-3">
-                  <div className="relative">
-                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
-                      {currencySymbol}
-                    </span>
-                    <Input
-                      id="amount"
-                      type="number"
-                      placeholder="0"
-                      value={amountInput}
-                      onChange={(e) => {
-                        setAmountInput(e.target.value);
-                      }}
-                      min="0"
-                      step="1"
-                      isError={amountExceedsMax && !!maxAmountFormatted}
-                      className="w-32 pl-7 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                    />
-                  </div>
-                  {isValidAmount && (
-                    <span className="flex items-center gap-1 text-sm text-muted-foreground">
-                      {formatCredits(addedCredits)} credits
-                    </span>
-                  )}
-                  <div className="ml-auto flex gap-2">
-                    {QUICK_SELECT_AMOUNTS.map((amount) => (
-                      <Button
-                        key={amount}
-                        label={`${currencySymbol}${amount}`}
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setAmountWithClamp(amount)}
-                      />
-                    ))}
-                  </div>
-                </div>
-                {amountExceedsMax && maxAmountFormatted && (
-                  <p className="text-xs text-warning-500">
-                    Amount exceeds the {maxAmountFormatted} limit. Please{" "}
-                    <a
-                      href={`mailto:${supportEmail}?subject=Higher%20credit%20limit%20request`}
-                      className="underline"
-                    >
-                      contact support
-                    </a>
-                    .
-                  </p>
-                )}
-              </div>
-
-              {isValidAmount && !amountExceedsMax && (
-                <div className="flex flex-col gap-2 rounded-xl bg-muted-background p-4">
-                  <p className="font-semibold text-foreground">Summary</p>
-                  {currentTotalPoolCredits !== undefined && (
-                    <SummaryRow
-                      label="Current Credits Pool"
-                      value={<CreditValue credits={currentTotalPoolCredits} />}
-                      dimmed
-                    />
-                  )}
-                  <SummaryRow
-                    label="Added Credits"
-                    value={<CreditValue credits={addedCredits} />}
-                    dimmed
-                  />
-                  <div className="py-1" />
-                  {currentTotalPoolCredits !== undefined && (
-                    <SummaryRow
-                      label="New Credits Pool"
-                      value={
-                        <CreditValue
-                          credits={currentTotalPoolCredits + addedCredits}
-                        />
-                      }
-                    />
-                  )}
-                  <SummaryRow
-                    label="Cost (excl. tax)"
-                    value={`${currencySymbol}${formatCost(parsedAmount)}`}
-                  />
-                </div>
-              )}
-
-              {awuPurchaseInfo?.canPurchase &&
-                awuPurchaseInfo.paymentMethod && (
-                  <div className="flex flex-col gap-2">
-                    <p className="text-sm font-medium text-foreground">
-                      Payment method
-                    </p>
-                    <div className="flex w-full items-center justify-between rounded-lg border border-separator bg-muted px-4 py-3">
-                      <div className="flex items-center gap-3">
-                        {awuPurchaseInfo.paymentMethod.type === "card" ? (
-                          <CardBrandIcon
-                            brand={awuPurchaseInfo.paymentMethod.brand}
-                            width={38}
-                            height={24}
-                          />
-                        ) : null}
-                        <span className="text-sm font-medium">
-                          {formatPaymentMethodLabel(
-                            awuPurchaseInfo.paymentMethod
-                          )}
-                        </span>
-                      </div>
-                      <Button
-                        label="Change"
-                        variant="ghost"
-                        size="sm"
-                        href={`/w/${workspaceId}/subscription/manage`}
-                      />
-                    </div>
-                  </div>
-                )}
-            </div>
-          </div>
-        );
-      }
-    }
-  };
-
-  const renderFooter = () => {
-    switch (purchaseState) {
-      case "processing":
-        return (
+          </DialogContainer>
           <DialogFooter
             leftButtonProps={{
               label: "Cancel",
@@ -716,24 +614,66 @@ export function BuyAwuCreditsDialog({
               disabled: true,
             }}
           />
-        );
-      case "success":
-        return (
+        </>
+      );
+    case "success":
+      return (
+        <>
+          <DialogContainer>
+            <div className="flex flex-col items-center justify-center gap-4 py-8">
+              <Icon
+                visual={CheckCircle}
+                size="lg"
+                className="text-success-500"
+              />
+              <div className="text-center">
+                <p className="text-lg font-medium text-foreground">
+                  Credits purchased successfully!
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Your credits are now available.
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  <span className="font-semibold">
+                    Invoice has been sent by email.
+                  </span>
+                </p>
+              </div>
+            </div>
+          </DialogContainer>
           <DialogFooter
             rightButtonProps={{
               label: "Close",
               variant: "primary",
-              onClick: resetModalStateAndClose,
+              onClick: onClose,
             }}
           />
-        );
-      case "error":
-        return (
+        </>
+      );
+    case "error":
+      return (
+        <>
+          <DialogContainer>
+            <div className="flex flex-col items-center justify-center gap-4 py-8">
+              <Icon visual={XCircle} size="lg" className="text-warning-500" />
+              <div className="text-center">
+                <p className="text-lg font-medium text-foreground">
+                  Something went wrong
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {errorMessage}
+                </p>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Please contact support if the issue persists.
+                </p>
+              </div>
+            </div>
+          </DialogContainer>
           <DialogFooter
             leftButtonProps={{
               label: "Close",
               variant: "outline",
-              onClick: resetModalStateAndClose,
+              onClick: onClose,
             }}
             rightButtonProps={{
               label: "Manage invoices",
@@ -743,15 +683,141 @@ export function BuyAwuCreditsDialog({
               },
             }}
           />
-        );
-      default:
-        return (
+        </>
+      );
+    case "idle":
+      return (
+        <>
+          <DialogContainer>
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-2">
+                  <label
+                    htmlFor="amount"
+                    className="text-sm font-medium text-foreground"
+                  >
+                    Amount
+                  </label>
+                  <div className="flex items-center gap-3">
+                    <div className="relative">
+                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+                        {currencySymbol}
+                      </span>
+                      <Input
+                        id="amount"
+                        type="number"
+                        placeholder="0"
+                        value={amountInput}
+                        onChange={(e) => {
+                          setAmountInput(e.target.value);
+                        }}
+                        min="0"
+                        step="1"
+                        isError={amountExceedsMax && !!maxAmountFormatted}
+                        className="w-32 pl-7 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                      />
+                    </div>
+                    {isValidAmount && (
+                      <span className="flex items-center gap-1 text-sm text-muted-foreground">
+                        {formatCredits(addedCredits)} credits
+                      </span>
+                    )}
+                    <div className="ml-auto flex gap-2">
+                      {QUICK_SELECT_AMOUNTS.map((amount) => (
+                        <Button
+                          key={amount}
+                          label={`${currencySymbol}${amount}`}
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setAmountWithClamp(amount)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                  {amountExceedsMax && maxAmountFormatted && (
+                    <p className="text-xs text-warning-500">
+                      Amount exceeds the {maxAmountFormatted} limit. Please{" "}
+                      <a
+                        href={`mailto:${supportEmail}?subject=Higher%20credit%20limit%20request`}
+                        className="underline"
+                      >
+                        contact support
+                      </a>
+                      .
+                    </p>
+                  )}
+                </div>
+
+                {isValidAmount && !amountExceedsMax && (
+                  <div className="flex flex-col gap-2 rounded-xl bg-muted-background p-4">
+                    <p className="font-semibold text-foreground">Summary</p>
+                    {currentTotalPoolCredits !== undefined && (
+                      <SummaryRow
+                        label="Current Credits Pool"
+                        value={
+                          <CreditValue credits={currentTotalPoolCredits} />
+                        }
+                        dimmed
+                      />
+                    )}
+                    <SummaryRow
+                      label="Added Credits"
+                      value={<CreditValue credits={addedCredits} />}
+                      dimmed
+                    />
+                    <div className="py-1" />
+                    {currentTotalPoolCredits !== undefined && (
+                      <SummaryRow
+                        label="New Credits Pool"
+                        value={
+                          <CreditValue
+                            credits={currentTotalPoolCredits + addedCredits}
+                          />
+                        }
+                      />
+                    )}
+                    <SummaryRow
+                      label="Cost (excl. tax)"
+                      value={`${currencySymbol}${formatCost(parsedAmount)}`}
+                    />
+                  </div>
+                )}
+
+                {awuPurchaseInfo?.canPurchase &&
+                  awuPurchaseInfo.paymentMethod && (
+                    <div className="flex flex-col gap-2">
+                      <p className="text-sm font-medium text-foreground">
+                        Payment method
+                      </p>
+                      <div className="flex w-full items-center justify-between rounded-lg border border-separator bg-muted px-4 py-3">
+                        <div className="flex items-center gap-3">
+                          {awuPurchaseInfo.paymentMethod.type === "card" ? (
+                            <CardBrandIcon
+                              brand={awuPurchaseInfo.paymentMethod.brand}
+                              width={38}
+                              height={24}
+                            />
+                          ) : null}
+                          <span className="text-sm font-medium">
+                            {formatPaymentMethodLabel(
+                              awuPurchaseInfo.paymentMethod
+                            )}
+                          </span>
+                        </div>
+                        <Button
+                          label="Change"
+                          variant="ghost"
+                          size="sm"
+                          href={`/w/${workspaceId}/subscription/manage`}
+                        />
+                      </div>
+                    </div>
+                  )}
+              </div>
+            </div>
+          </DialogContainer>
           <DialogFooter>
-            <Button
-              label="Cancel"
-              variant="outline"
-              onClick={resetModalStateAndClose}
-            />
+            <Button label="Cancel" variant="outline" onClick={onClose} />
             <Button
               label={`Add ${formatCredits(addedCredits)} credits`}
               variant="primary"
@@ -759,9 +825,45 @@ export function BuyAwuCreditsDialog({
               disabled={!canPurchase}
             />
           </DialogFooter>
-        );
-    }
-  };
+        </>
+      );
+    default:
+      return assertNever(purchaseState);
+  }
+}
+
+interface BuyAwuCreditsDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onPurchaseSuccess?: () => void;
+  workspaceId: string;
+  awuPurchaseInfo: AwuPurchaseInfo | null;
+  isAwuPurchaseInfoLoading: boolean;
+  isAwuPurchaseInfoError: boolean;
+  currentTotalPoolCredits?: number;
+}
+
+export function BuyAwuCreditsDialog({
+  isOpen,
+  onClose,
+  onPurchaseSuccess,
+  workspaceId,
+  awuPurchaseInfo,
+  isAwuPurchaseInfoLoading,
+  isAwuPurchaseInfoError,
+  currentTotalPoolCredits,
+}: BuyAwuCreditsDialogProps) {
+  // Set by the "Buy credits" tab while a purchase is in flight
+  // (processing/success/error). Used to hide the tab bar so the user can't
+  // switch away mid-payment, and to ignore refreshed awuPurchaseInfo — the
+  // just-created Metronome commit would otherwise flip it to `pending_purchase`
+  // and bump the user off the success screen.
+  const [buyInFlight, setBuyInFlight] = useState(false);
+
+  const handleClose = useCallback(() => {
+    setBuyInFlight(false);
+    onClose();
+  }, [onClose]);
 
   if (isAwuPurchaseInfoLoading) {
     return (
@@ -780,13 +882,7 @@ export function BuyAwuCreditsDialog({
     );
   }
 
-  // Once a purchase is in flight (processing / success / error), drive the
-  // dialog from local state and ignore the refreshed awuPurchaseInfo — the
-  // just-created Metronome commit would otherwise flip it to
-  // `pending_purchase` and bump the user off the success screen.
-  const isPurchaseInFlight = purchaseState !== "idle";
-
-  if (!isPurchaseInFlight && isAwuPurchaseInfoError) {
+  if (!buyInFlight && isAwuPurchaseInfoError) {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent size="md">
@@ -826,7 +922,7 @@ export function BuyAwuCreditsDialog({
 
   // Cannot purchase: legacy plan.
   if (
-    !isPurchaseInFlight &&
+    !buyInFlight &&
     awuPurchaseInfo &&
     !awuPurchaseInfo.canPurchase &&
     awuPurchaseInfo.reason === "legacy_plan"
@@ -866,7 +962,7 @@ export function BuyAwuCreditsDialog({
 
   // Cannot purchase: no Stripe customer.
   if (
-    !isPurchaseInFlight &&
+    !buyInFlight &&
     awuPurchaseInfo &&
     !awuPurchaseInfo.canPurchase &&
     awuPurchaseInfo.reason === "no_stripe_customer"
@@ -904,122 +1000,41 @@ export function BuyAwuCreditsDialog({
     );
   }
 
-  // Buy-credits states that only block buying (not coupon redemption). These
-  // render inside the "Buy credits" tab so the "Use coupon" tab stays usable.
-  const buyPendingBlock =
-    !isPurchaseInFlight &&
-    !!awuPurchaseInfo &&
-    !awuPurchaseInfo.canPurchase &&
-    awuPurchaseInfo.reason === "pending_purchase";
-  const buyExhaustedBlock =
-    !isPurchaseInFlight &&
-    !!awuPurchaseInfo?.canPurchase &&
-    awuPurchaseInfo.remainingCycleCredits < MIN_AWU_PURCHASE_CREDITS;
-
-  const renderBuyTabBody = () => {
-    if (purchaseState === "idle" && buyPendingBlock) {
-      return (
-        <p className="text-sm text-muted-foreground">
-          You have pending credit purchases awaiting payment. Please complete
-          your pending payment before making a new purchase or{" "}
-          <a
-            href={`mailto:${supportEmail}?subject=Cancel%20pending%20credit%20purchase`}
-            className="text-action-500 hover:underline"
-          >
-            contact support
-          </a>{" "}
-          to cancel your pending payments.
-        </p>
-      );
-    }
-    if (purchaseState === "idle" && buyExhaustedBlock) {
-      return (
-        <p className="text-sm text-muted-foreground">
-          You've reached your credit limit for this billing cycle. It resets at
-          the start of your next billing cycle. If you need additional credits
-          before then, please{" "}
-          <a
-            href={`mailto:${supportEmail}?subject=Credit%20purchase%20limit%20reached`}
-            className="text-action-500 hover:underline"
-          >
-            contact support
-          </a>
-          .
-        </p>
-      );
-    }
-    return renderContent();
-  };
-
-  const renderBuyTabFooter = () => {
-    if (purchaseState === "idle" && buyPendingBlock) {
-      return (
-        <DialogFooter
-          leftButtonProps={{
-            label: "Close",
-            variant: "outline",
-            onClick: resetModalStateAndClose,
-          }}
-          rightButtonProps={{
-            label: "Manage invoices",
-            variant: "primary",
-            onClick: () => {
-              window.open(`/w/${workspaceId}/subscription/manage`, "_blank");
-            },
-          }}
-        />
-      );
-    }
-    if (purchaseState === "idle" && buyExhaustedBlock) {
-      return (
-        <DialogFooter
-          leftButtonProps={{
-            label: "Close",
-            variant: "outline",
-            onClick: resetModalStateAndClose,
-          }}
-        />
-      );
-    }
-    return renderFooter();
-  };
-
-  // Buy or use a coupon. While a buy is in flight (processing/success/error) the
-  // tabs are hidden so the user can't switch away mid-payment.
+  // Buy or use a coupon. While a buy is in flight, the tab bar is hidden so the
+  // user can't switch away mid-payment (the active "buy" tab stays mounted).
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => !open && resetModalStateAndClose()}
-    >
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
       <DialogContent size="md">
         <DialogHeader>
           <DialogTitle>Top-up</DialogTitle>
         </DialogHeader>
-        {isPurchaseInFlight ? (
-          <>
-            <DialogContainer>{renderContent()}</DialogContainer>
-            {renderFooter()}
-          </>
-        ) : (
-          <Tabs defaultValue="buy">
+        <Tabs defaultValue="buy">
+          {!buyInFlight && (
             <TabsList>
               <TabsTrigger value="buy" label="Buy credits" />
               <TabsTrigger value="coupon" label="Use coupon" />
             </TabsList>
-            <TabsContent value="buy">
-              <DialogContainer>{renderBuyTabBody()}</DialogContainer>
-              {renderBuyTabFooter()}
-            </TabsContent>
-            <TabsContent value="coupon">
-              <UseCouponTab
-                workspaceId={workspaceId}
-                currentTotalPoolCredits={currentTotalPoolCredits}
-                onClose={resetModalStateAndClose}
-                onSuccess={onPurchaseSuccess}
-              />
-            </TabsContent>
-          </Tabs>
-        )}
+          )}
+          <TabsContent value="buy">
+            <BuyCreditsTab
+              workspaceId={workspaceId}
+              awuPurchaseInfo={awuPurchaseInfo}
+              currentTotalPoolCredits={currentTotalPoolCredits}
+              isOpen={isOpen}
+              onClose={handleClose}
+              onPurchaseSuccess={onPurchaseSuccess}
+              onInFlightChange={setBuyInFlight}
+            />
+          </TabsContent>
+          <TabsContent value="coupon">
+            <UseCouponTab
+              workspaceId={workspaceId}
+              currentTotalPoolCredits={currentTotalPoolCredits}
+              onClose={handleClose}
+              onSuccess={onPurchaseSuccess}
+            />
+          </TabsContent>
+        </Tabs>
       </DialogContent>
     </Dialog>
   );

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -570,7 +570,7 @@ export function BuyAwuCreditsDialog({
         return (
           <div className="flex flex-col items-center justify-center gap-4 py-8">
             <Spinner size="lg" />
-            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            <p className="text-sm text-muted-foreground">
               Applying coupon...
             </p>
           </div>
@@ -580,10 +580,10 @@ export function BuyAwuCreditsDialog({
           <div className="flex flex-col items-center justify-center gap-4 py-8">
             <Icon visual={CheckCircle} size="lg" className="text-success-500" />
             <div className="text-center">
-              <p className="text-lg font-medium text-foreground dark:text-foreground-night">
+              <p className="text-lg font-medium text-foreground">
                 Coupon applied!
               </p>
-              <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+              <p className="mt-1 text-sm text-muted-foreground">
                 <span className="font-semibold">
                   {formatCredits(bonusCredits)} credits
                 </span>{" "}
@@ -597,10 +597,10 @@ export function BuyAwuCreditsDialog({
           <div className="flex flex-col items-center justify-center gap-4 py-8">
             <Icon visual={XCircle} size="lg" className="text-warning-500" />
             <div className="text-center">
-              <p className="text-lg font-medium text-foreground dark:text-foreground-night">
+              <p className="text-lg font-medium text-foreground">
                 Couldn't apply coupon
               </p>
-              <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+              <p className="mt-1 text-sm text-muted-foreground">
                 {couponError}
               </p>
             </div>
@@ -609,14 +609,14 @@ export function BuyAwuCreditsDialog({
       default:
         return (
           <div className="flex flex-col gap-4">
-            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            <p className="text-sm text-muted-foreground">
               Have a coupon code? Enter it below to add free credits to your
               Workspace Credits Pool.
             </p>
             <div className="flex flex-col gap-2">
               <label
                 htmlFor="couponCode"
-                className="text-sm font-medium text-foreground dark:text-foreground-night"
+                className="text-sm font-medium text-foreground"
               >
                 Coupon code
               </label>
@@ -636,7 +636,7 @@ export function BuyAwuCreditsDialog({
                     className="w-48"
                   />
                   {couponError && (
-                    <span className="text-xs text-warning-500 dark:text-warning-500-night">
+                    <span className="text-xs text-warning-500">
                       {couponError}
                     </span>
                   )}
@@ -653,7 +653,7 @@ export function BuyAwuCreditsDialog({
             </div>
 
             {couponState === "checked" && checkedCoupon && (
-              <div className="flex flex-col gap-2 rounded-xl bg-muted-background p-4 dark:bg-muted-background-night">
+              <div className="flex flex-col gap-2 rounded-xl bg-muted-background p-4">
                 <SummaryRow label="Coupon" value={checkedCoupon.code} dimmed />
                 {currentTotalPoolCredits !== undefined && (
                   <SummaryRow
@@ -897,7 +897,7 @@ export function BuyAwuCreditsDialog({
   const renderBuyTabBody = () => {
     if (purchaseState === "idle" && buyPendingBlock) {
       return (
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        <p className="text-sm text-muted-foreground">
           You have pending credit purchases awaiting payment. Please complete
           your pending payment before making a new purchase or{" "}
           <a
@@ -912,7 +912,7 @@ export function BuyAwuCreditsDialog({
     }
     if (purchaseState === "idle" && buyExhaustedBlock) {
       return (
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        <p className="text-sm text-muted-foreground">
           You've reached your credit limit for this billing cycle. It resets at
           the start of your next billing cycle. If you need additional credits
           before then, please{" "}

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -14,7 +14,12 @@ import {
   awuCreditsToCurrency,
   currencyToAwuCredits,
 } from "@app/lib/metronome/amounts";
-import { useAwuPurchaseStatus } from "@app/lib/swr/credits";
+import {
+  useAwuPurchaseStatus,
+  useRedeemCreditsCoupon,
+} from "@app/lib/swr/credits";
+import { useValidateCoupon } from "@app/lib/swr/workspaces";
+import type { CouponType } from "@app/types/coupon";
 import { CURRENCY_SYMBOLS } from "@app/types/currency";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
@@ -30,11 +35,19 @@ import {
   Icon,
   Input,
   Spinner,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
   XCircle,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 type PurchaseState = "idle" | "processing" | "success" | "error";
+
+// Coupon redemption is synchronous (no payment): idle → checked (after the
+// "Check" button validates) → success/error (after "Apply").
+type CouponState = "idle" | "checked" | "redeeming" | "success" | "error";
 
 const QUICK_SELECT_AMOUNTS = [50, 100, 200] as const;
 
@@ -121,7 +134,18 @@ export function BuyAwuCreditsDialog({
   const [purchaseStartedAtMs, setPurchaseStartedAtMs] = useState<number | null>(
     null
   );
+  // "Use coupon" tab state (independent of the "Buy credits" tab).
+  const [couponInput, setCouponInput] = useState<string>("");
+  const [checkedCoupon, setCheckedCoupon] = useState<CouponType | null>(null);
+  const [couponState, setCouponState] = useState<CouponState>("idle");
+  const [couponError, setCouponError] = useState<string>("");
+  const [isCheckingCoupon, setIsCheckingCoupon] = useState(false);
   const { purchaseAwuCredits } = useAwuPurchase({ workspaceId });
+  const { validateCoupon } = useValidateCoupon({ workspaceId });
+  const { redeemCreditsCoupon } = useRedeemCreditsCoupon({ workspaceId });
+
+  // For a "credits" coupon, `amount` is the number of bonus AWU credits granted.
+  const bonusCredits = checkedCoupon?.amount ?? 0;
 
   // Poll the payment-gated commit status only while waiting on the webhook
   // outcome. The Metronome -> Stripe payment is async, so the dialog can't
@@ -162,8 +186,64 @@ export function BuyAwuCreditsDialog({
     setPurchaseState("idle");
     setErrorMessage("");
     setPurchaseStartedAtMs(null);
+    setCouponInput("");
+    setCheckedCoupon(null);
+    setCouponState("idle");
+    setCouponError("");
     onClose();
   }, [onClose]);
+
+  // "Check" button: validate the code as a "credits" coupon and surface the
+  // bonus it would grant before the user commits.
+  const handleCheckCoupon = useCallback(async () => {
+    const code = couponInput.trim();
+    if (!code) {
+      return;
+    }
+    setCouponError("");
+    setIsCheckingCoupon(true);
+    try {
+      const result = await validateCoupon(code, "credits");
+      if (!result.ok) {
+        setCheckedCoupon(null);
+        setCouponState("idle");
+        setCouponError(result.message);
+        return;
+      }
+      setCheckedCoupon(result.coupon);
+      setCouponState("checked");
+    } finally {
+      setIsCheckingCoupon(false);
+    }
+  }, [couponInput, validateCoupon]);
+
+  // "Apply" button: actually redeem the checked coupon and grant the credits.
+  const handleRedeemCoupon = useCallback(async () => {
+    if (!checkedCoupon) {
+      return;
+    }
+    setCouponState("redeeming");
+    const result = await redeemCreditsCoupon(checkedCoupon.code);
+    switch (result.status) {
+      case "success":
+        setCouponState("success");
+        onPurchaseSuccess?.();
+        break;
+      case "error":
+        setCouponError(result.message);
+        setCouponState("error");
+        break;
+      default:
+        assertNeverAndIgnore(result);
+    }
+  }, [checkedCoupon, redeemCreditsCoupon, onPurchaseSuccess]);
+
+  const resetCouponInput = useCallback(() => {
+    setCheckedCoupon(null);
+    setCouponState("idle");
+    setCouponInput("");
+    setCouponError("");
+  }, []);
 
   const currency = awuPurchaseInfo?.canPurchase
     ? awuPurchaseInfo.currency
@@ -484,6 +564,183 @@ export function BuyAwuCreditsDialog({
     }
   };
 
+  const renderCouponContent = () => {
+    switch (couponState) {
+      case "redeeming":
+        return (
+          <div className="flex flex-col items-center justify-center gap-4 py-8">
+            <Spinner size="lg" />
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Applying coupon...
+            </p>
+          </div>
+        );
+      case "success":
+        return (
+          <div className="flex flex-col items-center justify-center gap-4 py-8">
+            <Icon visual={CheckCircle} size="lg" className="text-success-500" />
+            <div className="text-center">
+              <p className="text-lg font-medium text-foreground dark:text-foreground-night">
+                Coupon applied!
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                <span className="font-semibold">
+                  {formatCredits(bonusCredits)} credits
+                </span>{" "}
+                have been added to your pool.
+              </p>
+            </div>
+          </div>
+        );
+      case "error":
+        return (
+          <div className="flex flex-col items-center justify-center gap-4 py-8">
+            <Icon visual={XCircle} size="lg" className="text-warning-500" />
+            <div className="text-center">
+              <p className="text-lg font-medium text-foreground dark:text-foreground-night">
+                Couldn't apply coupon
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                {couponError}
+              </p>
+            </div>
+          </div>
+        );
+      default:
+        return (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Have a coupon code? Enter it below to add free credits to your
+              Workspace Credits Pool.
+            </p>
+            <div className="flex flex-col gap-2">
+              <label
+                htmlFor="couponCode"
+                className="text-sm font-medium text-foreground dark:text-foreground-night"
+              >
+                Coupon code
+              </label>
+              <div className="flex items-start gap-2">
+                <div className="flex flex-col gap-1">
+                  <Input
+                    id="couponCode"
+                    placeholder="Enter code"
+                    value={couponInput}
+                    onChange={(e) => {
+                      setCouponInput(e.target.value);
+                      setCouponError("");
+                      setCheckedCoupon(null);
+                      setCouponState("idle");
+                    }}
+                    isError={!!couponError}
+                    className="w-48"
+                  />
+                  {couponError && (
+                    <span className="text-xs text-warning-500 dark:text-warning-500-night">
+                      {couponError}
+                    </span>
+                  )}
+                </div>
+                <Button
+                  label="Check"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleCheckCoupon}
+                  disabled={!couponInput.trim() || isCheckingCoupon}
+                  isLoading={isCheckingCoupon}
+                />
+              </div>
+            </div>
+
+            {couponState === "checked" && checkedCoupon && (
+              <div className="flex flex-col gap-2 rounded-xl bg-muted-background p-4 dark:bg-muted-background-night">
+                <SummaryRow label="Coupon" value={checkedCoupon.code} dimmed />
+                {currentTotalPoolCredits !== undefined && (
+                  <SummaryRow
+                    label="Current Credits Pool"
+                    value={<CreditValue credits={currentTotalPoolCredits} />}
+                    dimmed
+                  />
+                )}
+                <SummaryRow
+                  label="Bonus Credits"
+                  value={<CreditValue credits={bonusCredits} />}
+                  dimmed
+                />
+                <div className="py-1" />
+                {currentTotalPoolCredits !== undefined && (
+                  <SummaryRow
+                    label="New Credits Pool"
+                    value={
+                      <CreditValue
+                        credits={currentTotalPoolCredits + bonusCredits}
+                      />
+                    }
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        );
+    }
+  };
+
+  const renderCouponFooter = () => {
+    switch (couponState) {
+      case "redeeming":
+        return (
+          <DialogFooter
+            rightButtonProps={{
+              label: "Applying...",
+              variant: "primary",
+              disabled: true,
+            }}
+          />
+        );
+      case "success":
+        return (
+          <DialogFooter
+            rightButtonProps={{
+              label: "Close",
+              variant: "primary",
+              onClick: resetModalStateAndClose,
+            }}
+          />
+        );
+      case "error":
+        return (
+          <DialogFooter
+            leftButtonProps={{
+              label: "Close",
+              variant: "outline",
+              onClick: resetModalStateAndClose,
+            }}
+            rightButtonProps={{
+              label: "Try again",
+              variant: "primary",
+              onClick: resetCouponInput,
+            }}
+          />
+        );
+      default:
+        return (
+          <DialogFooter>
+            <Button
+              label="Cancel"
+              variant="outline"
+              onClick={resetModalStateAndClose}
+            />
+            <Button
+              label="Apply coupon"
+              variant="primary"
+              onClick={handleRedeemCoupon}
+              disabled={couponState !== "checked"}
+            />
+          </DialogFooter>
+        );
+    }
+  };
+
   if (isAwuPurchaseInfoLoading) {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -625,95 +882,88 @@ export function BuyAwuCreditsDialog({
     );
   }
 
-  // Cannot purchase: pending payment.
-  if (
+  // Buy-credits states that only block buying (not coupon redemption). These
+  // render inside the "Buy credits" tab so the "Use coupon" tab stays usable.
+  const buyPendingBlock =
     !isPurchaseInFlight &&
-    awuPurchaseInfo &&
+    !!awuPurchaseInfo &&
     !awuPurchaseInfo.canPurchase &&
-    awuPurchaseInfo.reason === "pending_purchase"
-  ) {
-    return (
-      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-        <DialogContent size="md">
-          <DialogHeader>
-            <DialogTitle>Top-up</DialogTitle>
-            <DialogDescription>
-              You have pending credit purchases awaiting payment.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogContainer>
-            <p className="text-sm text-muted-foreground">
-              Please complete your pending payment before making a new purchase
-              or{" "}
-              <a
-                href={`mailto:${supportEmail}?subject=Cancel%20pending%20credit%20purchase`}
-                className="text-action-500 hover:underline"
-              >
-                contact support
-              </a>{" "}
-              to cancel your pending payments.
-            </p>
-          </DialogContainer>
-          <DialogFooter
-            leftButtonProps={{
-              label: "Close",
-              variant: "outline",
-              onClick: onClose,
-            }}
-            rightButtonProps={{
-              label: "Manage invoices",
-              variant: "primary",
-              onClick: () => {
-                window.open(`/w/${workspaceId}/subscription/manage`, "_blank");
-              },
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
-  // Limit exhausted for this billing cycle.
-  if (
+    awuPurchaseInfo.reason === "pending_purchase";
+  const buyExhaustedBlock =
     !isPurchaseInFlight &&
-    awuPurchaseInfo?.canPurchase &&
-    awuPurchaseInfo.remainingCycleCredits < MIN_AWU_PURCHASE_CREDITS
-  ) {
-    return (
-      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-        <DialogContent size="md">
-          <DialogHeader>
-            <DialogTitle>Top-up</DialogTitle>
-            <DialogDescription>
-              You've reached your credit limit for this billing cycle.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogContainer>
-            <p className="text-sm text-muted-foreground">
-              Your credit purchase limit resets at the start of your next
-              billing cycle. If you need additional credits before then, please{" "}
-              <a
-                href={`mailto:${supportEmail}?subject=Credit%20purchase%20limit%20reached`}
-                className="text-action-500 hover:underline"
-              >
-                contact support
-              </a>
-              .
-            </p>
-          </DialogContainer>
-          <DialogFooter
-            leftButtonProps={{
-              label: "Close",
-              variant: "outline",
-              onClick: onClose,
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-    );
-  }
+    !!awuPurchaseInfo?.canPurchase &&
+    awuPurchaseInfo.remainingCycleCredits < MIN_AWU_PURCHASE_CREDITS;
 
-  // Can purchase.
+  const renderBuyTabBody = () => {
+    if (purchaseState === "idle" && buyPendingBlock) {
+      return (
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          You have pending credit purchases awaiting payment. Please complete
+          your pending payment before making a new purchase or{" "}
+          <a
+            href={`mailto:${supportEmail}?subject=Cancel%20pending%20credit%20purchase`}
+            className="text-action-500 hover:underline"
+          >
+            contact support
+          </a>{" "}
+          to cancel your pending payments.
+        </p>
+      );
+    }
+    if (purchaseState === "idle" && buyExhaustedBlock) {
+      return (
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          You've reached your credit limit for this billing cycle. It resets at
+          the start of your next billing cycle. If you need additional credits
+          before then, please{" "}
+          <a
+            href={`mailto:${supportEmail}?subject=Credit%20purchase%20limit%20reached`}
+            className="text-action-500 hover:underline"
+          >
+            contact support
+          </a>
+          .
+        </p>
+      );
+    }
+    return renderContent();
+  };
+
+  const renderBuyTabFooter = () => {
+    if (purchaseState === "idle" && buyPendingBlock) {
+      return (
+        <DialogFooter
+          leftButtonProps={{
+            label: "Close",
+            variant: "outline",
+            onClick: resetModalStateAndClose,
+          }}
+          rightButtonProps={{
+            label: "Manage invoices",
+            variant: "primary",
+            onClick: () => {
+              window.open(`/w/${workspaceId}/subscription/manage`, "_blank");
+            },
+          }}
+        />
+      );
+    }
+    if (purchaseState === "idle" && buyExhaustedBlock) {
+      return (
+        <DialogFooter
+          leftButtonProps={{
+            label: "Close",
+            variant: "outline",
+            onClick: resetModalStateAndClose,
+          }}
+        />
+      );
+    }
+    return renderFooter();
+  };
+
+  // Buy or use a coupon. While a buy is in flight (processing/success/error) the
+  // tabs are hidden so the user can't switch away mid-payment.
   return (
     <Dialog
       open={isOpen}
@@ -722,12 +972,28 @@ export function BuyAwuCreditsDialog({
       <DialogContent size="md">
         <DialogHeader>
           <DialogTitle>Top-up</DialogTitle>
-          <DialogDescription>
-            Add credits to your Workspace Credits Pool.
-          </DialogDescription>
         </DialogHeader>
-        <DialogContainer>{renderContent()}</DialogContainer>
-        {renderFooter()}
+        {isPurchaseInFlight ? (
+          <>
+            <DialogContainer>{renderContent()}</DialogContainer>
+            {renderFooter()}
+          </>
+        ) : (
+          <Tabs defaultValue="buy">
+            <TabsList>
+              <TabsTrigger value="buy" label="Buy credits" />
+              <TabsTrigger value="coupon" label="Use coupon" />
+            </TabsList>
+            <TabsContent value="buy">
+              <DialogContainer>{renderBuyTabBody()}</DialogContainer>
+              {renderBuyTabFooter()}
+            </TabsContent>
+            <TabsContent value="coupon">
+              <DialogContainer>{renderCouponContent()}</DialogContainer>
+              {renderCouponFooter()}
+            </TabsContent>
+          </Tabs>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -320,6 +320,58 @@ export function useAwuPurchaseInfo({
   };
 }
 
+export type RedeemCreditsCouponOutcome =
+  | { status: "success" }
+  | { status: "error"; message: string };
+
+// Redeems a "credits" coupon (the "Use coupon" Top-Up tab). Grants free AWU
+// credits synchronously — no payment involved. Refreshes the pool summary on
+// success.
+export function useRedeemCreditsCoupon({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const { mutateAwuPoolSummary } = useAwuPoolSummary({
+    workspaceId,
+    disabled: true,
+  });
+
+  const redeemCreditsCoupon = useCallback(
+    async (code: string): Promise<RedeemCreditsCouponOutcome> => {
+      try {
+        const response = await clientFetch(
+          `/api/w/${workspaceId}/coupon/redeem`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ code }),
+          }
+        );
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => null);
+          const message =
+            errorData?.error?.message ?? "Failed to redeem coupon.";
+          return { status: "error", message };
+        }
+
+        resetAwuPostPurchaseRefreshCount(workspaceId);
+        void mutateAwuPoolSummary();
+
+        return { status: "success" };
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to redeem coupon.";
+        return { status: "error", message };
+      }
+    },
+    [workspaceId, mutateAwuPoolSummary]
+  );
+
+  return { redeemCreditsCoupon };
+}
+
 export function useMyUsage({
   workspaceId,
   disabled,

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -1413,13 +1413,14 @@ export function usePreparePayment({
 export function useValidateCoupon({ workspaceId }: { workspaceId: string }) {
   const validateCoupon = useCallback(
     async (
-      code: string
+      code: string,
+      context: "subscription" | "credits"
     ): Promise<
       | { ok: true; coupon: GetCouponValidateResponseBody["coupon"] }
       | { ok: false; message: string }
     > => {
       const res = await clientFetch(
-        `/api/w/${workspaceId}/coupon/validate?code=${encodeURIComponent(code)}`
+        `/api/w/${workspaceId}/coupon/validate?code=${encodeURIComponent(code)}&context=${encodeURIComponent(context)}`
       );
       if (!res.ok) {
         const body = await res.json().catch(() => null);


### PR DESCRIPTION
Stacked on `fabien/pricing/coupon-3-topup-ui` (PR #28240).

Extracts the "Buy credits" tab into a top-level `BuyCreditsTab` component, removing the last `render*` helpers (`renderContent`, `renderFooter`, `renderBuyTabBody`, `renderBuyTabFooter`) — this clears the remaining react-doctor `no-render-in-render` warnings on the buy tab. 
