### PR TITLE
fix(sparkle): remove bullet marker on markdown task list items

### DIFF
--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -64,8 +64,17 @@ export const LiBlock = memo(
   ({ children, className }: LiBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     const textSize = forcedTextSize ?? markdownParagraphSize;
+    const isTaskListItem = className?.includes("task-list-item");
     return (
-      <li className={cn(liBlockVariants(), textColor, textSize, className)}>
+      <li
+        className={cn(
+          liBlockVariants(),
+          isTaskListItem && "list-none",
+          textColor,
+          textSize,
+          className
+        )}
+      >
         {children}
       </li>
     );


### PR DESCRIPTION
## Description
 
Fixes a rendering bug in the Sparkle markdown renderer where task lists displayed **both** a bullet point and a checkbox.

`remark-gfm` renders task items as `<li class="task-list-item">` containing a checkbox, but `UlBlock` applies `list-disc` to every `<ul>`, so the browser drew its default bullet on top of the checkbox. The fix detects the `task-list-item` class in `LiBlock` and applies `list-none` to those items only, suppressing the bullet while leaving regular bulleted/numbered lists untouched.

   **Before**

   - • ☐ to do
   - • ☑ done

   **After**

   - ☐ to do
   - ☑ done

## Tests

Verified manually in Storybook 
<img width="410" height="241" alt="Screenshot 2026-07-01 at 14 04 30" src="https://github.com/user-attachments/assets/61549757-0cb8-4f95-84d0-604709478891" />
--> no longer see the bullet points in front

## Risk

 Very low, modifies just `List.tsx`

## Deploy Plan