### PR TITLE
[front] free plan: do not rely on webhook for subscription

### DIFF
--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -15,6 +15,7 @@ import {
   CONTRACT_CREDIT_TYPE_POOL,
   getCreditTypeAwuId,
   PLAN_CODE_CUSTOM_FIELD_KEY,
+  SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import { setUserNearLimit } from "@app/lib/metronome/user_block";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
@@ -253,6 +254,39 @@ describe("processMetronomeWebhook — contract.start", () => {
         starting_at: new Date().toISOString(),
         custom_fields: {
           [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE,
+        },
+      } as never)
+    );
+
+    const result = await processMetronomeWebhook({
+      event: event as never,
+      workspace,
+    });
+    expect(result.isOk()).toBe(true);
+
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    const sub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+      refreshed!.id
+    );
+    expect(sub!.metronomeContractId).toBe(OLD_CONTRACT_ID);
+    expect(restoreWorkspaceAfterSubscription).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the contract carries SUBSCRIPTION_SWAP_HANDLED_INLINE", async () => {
+    // The caller (e.g. provisionCreditPricedFreePlan) already created the
+    // active subscription synchronously — the webhook must not also swap it,
+    // which would race with that write and leave two active subscriptions.
+    await PlanFactory.enterprise(ENT_PLAN_CODE);
+    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.start", NEW_CONTRACT_ID);
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: NEW_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: new Date().toISOString(),
+        custom_fields: {
+          [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE,
+          [SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY]: "true",
         },
       } as never)
     );

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -67,6 +67,7 @@ import {
   PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY,
   PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION,
   PLAN_CODE_CUSTOM_FIELD_KEY,
+  SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY,
   USAGE_TYPE_GROUP_KEY,
   USAGE_TYPE_PROGRAMMATIC,
 } from "@app/lib/metronome/constants";
@@ -1530,6 +1531,22 @@ export async function processMetronomeWebhook({
         logger.info(
           { contractId, workspaceId: workspace.sId },
           "[Metronome Webhook] contract.start: payment-gated activation contract, skipping — payment_gate.payment_status will activate"
+        );
+        break;
+      }
+
+      // The calling code that provisioned this contract already created the
+      // workspace's DB subscription row synchronously (e.g.
+      // provisionCreditPricedFreePlan) to avoid racing with this webhook's
+      // own swap logic below — skip it entirely.
+      if (
+        contractResult.value.custom_fields?.[
+          SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY
+        ]
+      ) {
+        logger.info(
+          { contractId, workspaceId: workspace.sId },
+          "[Metronome Webhook] contract.start: subscription swap handled inline by caller, skipping"
         );
         break;
       }

--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -3,7 +3,7 @@ import { getDataSources } from "@app/lib/api/data_sources";
 import { updateMembershipSeatAndTrack } from "@app/lib/api/membership";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
-import { floorToHourISO } from "@app/lib/metronome/client";
+import { SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
@@ -56,7 +56,7 @@ async function provisionCreditPricedFreePlan(
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
   const lightWorkspace = renderLightWorkspaceType({ workspace: owner });
-  const now = new Date(floorToHourISO(new Date()));
+  const now = new Date();
 
   const currency = getBillingCurrencyForCountry(countryCode ?? "US", true);
   const packageAlias = resolvePackageAliasForCurrency(
@@ -114,6 +114,13 @@ async function provisionCreditPricedFreePlan(
     swapAt: "current-hour",
     enableStripeBilling: false,
     planCode: CREDIT_PRICED_FREE_PLAN_CODE,
+    // We create the subscription row ourselves right below via
+    // `createSubscriptionFromCheckout`. Stamp the contract so the
+    // contract.start webhook skips its own subscription swap instead of
+    // racing with this synchronous write (see the custom field's doc comment).
+    additionalCustomFields: {
+      [SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY]: "true",
+    },
   });
   if (contractResult.isErr()) {
     throw new Error(

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -75,6 +75,17 @@ export const PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY = "DUST_PAYMENT_GATE_TYPE";
 export const PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION =
   "subscription_activation";
 
+// Custom field stamped on contracts whose corresponding DB subscription row
+// is created synchronously by the calling code right after provisioning the
+// contract (e.g. `provisionCreditPricedFreePlan`), instead of relying on this
+// webhook to do it. Without this, the synchronous write and contract.start's
+// own subscription-swap logic can both read the workspace's active
+// subscription concurrently and each end it + insert a new active row,
+// leaving the workspace with two active subscriptions. The contract.start
+// webhook checks this field and skips its subscription swap entirely when set.
+export const SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY =
+  "DUST_SUBSCRIPTION_SWAP_INLINE";
+
 // Custom field stamped on every seat-style product (Workspace / Pro / Max /
 // Free / future seat tiers). Value is the membership seat type ("workspace"
 // | "pro" | "max" | "free"). Lets runtime code identify which subscription

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -30,6 +30,7 @@ import {
   PROD_CREDIT_TYPE_AWU_ID,
   SEAT_TYPE_CUSTOM_FIELD_KEY,
   STRIPE_PRODUCT_ID_CUSTOM_FIELD_KEY,
+  SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import { invalidateProductSeatTypesCache } from "@app/lib/metronome/seat_types";
 import {
@@ -1449,6 +1450,10 @@ const CUSTOM_FIELD_KEYS: Array<{
   { entity: "contract", key: "MAU_THRESHOLD" },
   { entity: "contract", key: PLAN_CODE_CUSTOM_FIELD_KEY },
   { entity: "contract", key: PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY },
+  {
+    entity: "contract",
+    key: SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY,
+  },
   { entity: "contract", key: HUBSPOT_DEAL_ID_CUSTOM_FIELD_KEY },
   // Stamped on individual contract_credit instances to identify excess
   // recurring credits ("excess") vs. workspace-pool credits ("pool"). Lets


### PR DESCRIPTION
## Description

The race:
* `provisionCreditPricedFreePlan` provisions a Metronome contract stamped with DUST_PLAN_CODE, then synchronously calls `SubscriptionResource.createSubscriptionFromCheckout` to flip the DB subscription.
* Metronome's `contract.start` webhook can fire and be processed concurrently, and its "legacy fallback" swap path (lib/api/metronome/process_webhook.ts) independently reads the workspace's active subscription and does its own end-old/create-new. Under READ COMMITTED, both paths can read the same "current active subscription" before either commits, each end it and insert a new active row — leaving the workspace with two active subscriptions.

Fix (mirrors the existing PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY pattern used for business activation):

* Added SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY as a contract custom field
* `provisionCreditPricedFreePlan` now stamps this field via additionalCustomFields when provisioning the free-plan contract
* The `contract.start` webhook handler checks this field (right after the payment-gate check, before the subscription-swap logic) and skips the swap entirely when present — the reconciliation steps (credit-state sync, renewal carry-over) still run as before
* Registered the new key in scripts/metronome_setup.ts's CUSTOM_FIELD_KEYS.
* Added a regression test in process_webhook.test.ts asserting the webhook no-ops when the field is set.

## Tests

* Type check and the full process_webhook.test.ts suite (25 tests) pass.
* Tested locally

## Risk

Medium, impact the free plan subscription flow

## Deploy Plan

* run npx tsx scripts/metronome_setup.ts --execute
* deploy front