### PR TITLE
Add call tool to the sandbox_functions MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -578,6 +578,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "describe_toolset": "never_ask",
   },
   "sandbox_functions": {
+    "call": "low",
     "get": "never_ask",
     "list": "never_ask",
     "publish": "low",

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -72,6 +72,31 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
       done: "Published sandbox function",
     },
   },
+  call: {
+    description:
+      "Call a sandbox function published in the current pod by its slug, passing its input " +
+      "payload, and get back the function's output. Use the get tool first to see the function's " +
+      "input schema. Input is validated inside the sandbox.",
+    schema: {
+      slug: z
+        .string()
+        .min(1)
+        .describe(
+          "The slug of the sandbox function to call, as shown by the list tool."
+        ),
+      input: z
+        .record(z.unknown())
+        .optional()
+        .describe(
+          "The function's input payload as a JSON object, matching its input schema (see the get tool)."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Calling sandbox function...",
+      done: "Called sandbox function",
+    },
+  },
 });
 
 export const SANDBOX_FUNCTIONS_SERVER = {

--- a/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
@@ -1,0 +1,60 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getPod } from "@app/lib/api/actions/servers/pod_manager/helpers";
+import { callSandboxFunction } from "@app/lib/api/sandbox_functions/call_sandbox_function";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { Err, Ok } from "@app/types/shared/result";
+
+export async function callHandler(
+  { slug, input }: { slug: string; input?: Record<string, unknown> },
+  { auth, agentLoopContext }: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const podResult = await getPod(auth, { agentLoopContext });
+  if (podResult.isErr()) {
+    return new Err(podResult.error);
+  }
+
+  const sandboxFunction = await SandboxFunctionResource.fetchBySpaceAndSlug(
+    auth,
+    podResult.value.pod,
+    slug
+  );
+  if (!sandboxFunction) {
+    return new Err(
+      new MCPError(`No sandbox function with slug "${slug}" in this pod.`, {
+        tracked: false,
+      })
+    );
+  }
+
+  const result = await callSandboxFunction(auth, sandboxFunction, input);
+  if (result.isErr()) {
+    return new Err(new MCPError(result.error.message));
+  }
+
+  const outcome = result.value;
+  if (!outcome.ok) {
+    // The function ran but returned an error: model- or builder-correctable, not internal.
+    return new Err(
+      new MCPError(
+        `Sandbox function "${slug}" returned an error (${outcome.errorKind}): ${outcome.message}`,
+        { tracked: false }
+      )
+    );
+  }
+
+  return new Ok([
+    {
+      type: "text",
+      text: [
+        `HTTP ${outcome.status}`,
+        "",
+        "Response Body:",
+        outcome.output,
+      ].join("\n"),
+    },
+  ]);
+}

--- a/front/lib/api/actions/servers/sandbox_functions/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/index.ts
@@ -1,5 +1,6 @@
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { SANDBOX_FUNCTIONS_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
+import { callHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/call";
 import { getHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/get";
 import { listHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/list";
 import { publishHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/publish";
@@ -8,6 +9,7 @@ const HANDLERS = {
   list: listHandler,
   get: getHandler,
   publish: publishHandler,
+  call: callHandler,
 };
 
 export const TOOLS = buildTools(SANDBOX_FUNCTIONS_TOOLS_METADATA, HANDLERS);

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -1,0 +1,287 @@
+import { callSandboxFunction } from "@app/lib/api/sandbox_functions/call_sandbox_function";
+import type { SandboxFunctionInvocationStreamEvent } from "@app/lib/api/sandbox_functions/events";
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { SandboxFunctionInvocationEvent } from "@app/types/api/sandbox_functions";
+import { sandboxFunctionContentType } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/events")
+    >();
+  return { ...actual, getSandboxFunctionInvocationEvents: vi.fn() };
+});
+
+import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
+
+const inputSchema: JSONSchema = {
+  type: "object",
+  properties: { name: { type: "string" } },
+  required: ["name"],
+};
+const outputSchema: JSONSchema = {
+  type: "object",
+  properties: { greeting: { type: "string" } },
+  required: ["greeting"],
+};
+
+function eventStream(
+  ...events: SandboxFunctionInvocationEvent[]
+): AsyncGenerator<SandboxFunctionInvocationStreamEvent, void> {
+  async function* gen() {
+    for (const [index, data] of events.entries()) {
+      yield { eventId: `${index}`, data };
+    }
+  }
+  return gen();
+}
+
+function mockResult(result: unknown, invocationId: string): void {
+  vi.mocked(getSandboxFunctionInvocationEvents).mockReturnValue(
+    eventStream({
+      type: "sandbox_function_invocation_result",
+      created: 0,
+      invocationId,
+      functionId: "sfn_x",
+      result,
+    })
+  );
+}
+
+async function makeFunction(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<SandboxFunctionResource> {
+  const file = await FileFactory.create(auth, null, {
+    contentType: sandboxFunctionContentType,
+    fileName: "greet.ts",
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: space.sId },
+  });
+  return SandboxFunctionResource.makeNew(auth, {
+    space,
+    file,
+    slug: "greet",
+    description: "Greet a user by name.",
+    inputSchema,
+    outputSchema,
+  });
+}
+
+async function setup(): Promise<{
+  auth: Authenticator;
+  fn: SandboxFunctionResource;
+  invocationId: string;
+}> {
+  const { authenticator, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const space = await SpaceFactory.project(workspace);
+  const fn = await makeFunction(authenticator, space);
+  const invocationId = "sfi_test";
+  vi.spyOn(fn, "invoke").mockResolvedValue(
+    new Ok({
+      sId: invocationId,
+      functionId: fn.sId,
+      status: "created",
+      createdAt: new Date(0).toISOString(),
+    })
+  );
+  return { auth: authenticator, fn, invocationId };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("callSandboxFunction", () => {
+  it("returns the decoded body on a successful result", async () => {
+    const { auth, fn, invocationId } = await setup();
+    mockResult(
+      {
+        ok: true,
+        response: {
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ greeting: "Hi, Soupinou" }),
+          encoding: "utf8",
+        },
+      },
+      invocationId
+    );
+
+    const result = await callSandboxFunction(auth, fn, { name: "Soupinou" });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value).toEqual({
+      ok: true,
+      status: 200,
+      output: JSON.stringify({ greeting: "Hi, Soupinou" }),
+    });
+  });
+
+  it("decodes a base64-encoded body", async () => {
+    const { auth, fn, invocationId } = await setup();
+    mockResult(
+      {
+        ok: true,
+        response: {
+          status: 200,
+          headers: {},
+          body: Buffer.from("plain text", "utf8").toString("base64"),
+          encoding: "base64",
+        },
+      },
+      invocationId
+    );
+
+    const result = await callSandboxFunction(auth, fn, undefined);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value).toEqual({
+      ok: true,
+      status: 200,
+      output: "plain text",
+    });
+  });
+
+  it("surfaces a function error envelope as ok: false", async () => {
+    const { auth, fn, invocationId } = await setup();
+    mockResult(
+      { ok: false, error: { kind: "threw", message: "boom" } },
+      invocationId
+    );
+
+    const result = await callSandboxFunction(auth, fn, { name: "x" });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value).toEqual({
+      ok: false,
+      errorKind: "threw",
+      message: "boom",
+    });
+  });
+
+  it("errors on an unexpected result envelope", async () => {
+    const { auth, fn, invocationId } = await setup();
+    mockResult({ not: "an envelope" }, invocationId);
+
+    const result = await callSandboxFunction(auth, fn, { name: "x" });
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("errors when no result event arrives", async () => {
+    const { auth, fn } = await setup();
+    vi.mocked(getSandboxFunctionInvocationEvents).mockReturnValue(
+      eventStream()
+    );
+
+    const result = await callSandboxFunction(auth, fn, { name: "x" });
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("returns a non-2xx response as ok with its status", async () => {
+    const { auth, fn, invocationId } = await setup();
+    mockResult(
+      {
+        ok: true,
+        response: {
+          status: 400,
+          headers: {},
+          body: JSON.stringify({ error: "invalid input" }),
+          encoding: "utf8",
+        },
+      },
+      invocationId
+    );
+
+    const result = await callSandboxFunction(auth, fn, { name: "x" });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value).toEqual({
+      ok: true,
+      status: 400,
+      output: JSON.stringify({ error: "invalid input" }),
+    });
+  });
+
+  it("skips non-result events and returns the result", async () => {
+    const { auth, fn, invocationId } = await setup();
+    vi.mocked(getSandboxFunctionInvocationEvents).mockReturnValue(
+      eventStream(
+        {
+          type: "sandbox_function_invocation_created",
+          created: 0,
+          invocation: {
+            sId: invocationId,
+            functionId: "sfn_x",
+            status: "created",
+            createdAt: new Date(0).toISOString(),
+          },
+        },
+        {
+          type: "sandbox_function_invocation_result",
+          created: 1,
+          invocationId,
+          functionId: "sfn_x",
+          result: {
+            ok: true,
+            response: {
+              status: 200,
+              headers: {},
+              body: JSON.stringify({ greeting: "Hi" }),
+              encoding: "utf8",
+            },
+          },
+        }
+      )
+    );
+
+    const result = await callSandboxFunction(auth, fn, { name: "x" });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value).toEqual({
+      ok: true,
+      status: 200,
+      output: JSON.stringify({ greeting: "Hi" }),
+    });
+  });
+
+  it("propagates an Err from invoke()", async () => {
+    const { auth, fn } = await setup();
+    vi.spyOn(fn, "invoke").mockResolvedValue(
+      new Err(new Error("sandbox unavailable"))
+    );
+
+    const result = await callSandboxFunction(auth, fn, { name: "x" });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -1,0 +1,102 @@
+import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+
+// The runner Output envelope dsbx POSTs back as the result event. Mirrors Output in
+// cli/dust-sandbox/functions-runner/protocol.ts.
+const responseOutputSchema = z.object({
+  status: z.number(),
+  headers: z.record(z.string()),
+  body: z.string().nullable(),
+  encoding: z.enum(["utf8", "base64"]),
+});
+const resultEnvelopeSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), response: responseOutputSchema }),
+  z.object({
+    ok: z.literal(false),
+    error: z.object({
+      kind: z.string(),
+      message: z.string(),
+      stack: z.string().optional(),
+    }),
+  }),
+]);
+
+// Safety ceiling on waiting for the result event (delivered over the stream, not invoke()'s
+// return). Under blocking exec it is already in history when we subscribe, so this rarely bites.
+const CALL_RESULT_WAIT_TIMEOUT_MS = 2 * 60 * 1_000;
+
+export type SandboxFunctionCallOutcome =
+  | { ok: true; status: number; output: string }
+  | { ok: false; errorKind: string; message: string };
+
+function decodeResponseBody(
+  body: string | null,
+  encoding: "utf8" | "base64"
+): string {
+  if (body === null) {
+    return "";
+  }
+  return encoding === "base64"
+    ? Buffer.from(body, "base64").toString("utf8")
+    : body;
+}
+
+/**
+ * Invoke a sandbox function and wait for its result.
+ *
+ * Returns Err for infra failures (sandbox unavailable, exec failure, missing/unparseable result),
+ * and Ok with `ok: false` when the function ran but returned an error envelope, so the caller can
+ * surface that as a correctable tool error. Input is validated by the runner, not here.
+ */
+export async function callSandboxFunction(
+  auth: Authenticator,
+  sandboxFunction: SandboxFunctionResource,
+  input: unknown
+): Promise<Result<SandboxFunctionCallOutcome, Error>> {
+  const invocationResult = await sandboxFunction.invoke(auth, { input });
+  if (invocationResult.isErr()) {
+    return invocationResult;
+  }
+  const { sId: invocationId } = invocationResult.value;
+
+  for await (const { data } of getSandboxFunctionInvocationEvents({
+    invocationId,
+    lastEventId: null,
+    signal: AbortSignal.timeout(CALL_RESULT_WAIT_TIMEOUT_MS),
+  })) {
+    if (data.type !== "sandbox_function_invocation_result") {
+      continue;
+    }
+
+    const parsed = resultEnvelopeSchema.safeParse(data.result);
+    if (!parsed.success) {
+      return new Err(
+        new Error("Sandbox function returned an unexpected result envelope.")
+      );
+    }
+    if (!parsed.data.ok) {
+      return new Ok({
+        ok: false,
+        errorKind: parsed.data.error.kind,
+        message: parsed.data.error.message,
+      });
+    }
+
+    // A non-2xx (e.g. the runner's 400 on invalid input) is a valid response, not a tool error;
+    // the handler surfaces the status so the model can react.
+    const { response } = parsed.data;
+    return new Ok({
+      ok: true,
+      status: response.status,
+      output: decodeResponseBody(response.body, response.encoding),
+    });
+  }
+
+  return new Err(
+    new Error("Sandbox function did not return a result in time.")
+  );
+}


### PR DESCRIPTION
## Description

Pod functions can be published to a Pod, but an agent had no native way to call one. S9 fixes that: `call` is a 4th tool on the existing `sandbox_functions` server (`list` / `get` / `publish` / `call`), so any agent in a Pod can invoke a published function and get a typed result back in the loop.

Design doc: [S9: Endpoint Discoverability by Agents](https://app.notion.com/p/dust-tt/S9-Endpoint-Discoverability-by-Agents-38b28599d9418088a984c4cb0d0cdc90). 

## What this PR does

1. Adds the `call` tool (`metadata.ts` + `tools/call.ts` + `tools/index.ts`): takes `slug` + `input`, returns the function's output.
2. Adds `callSandboxFunction` (sibling to `publish_sandbox_function.ts`): calls `SandboxFunctionResource.invoke()`, then consumes the existing invocation event stream for the result.

## Worth knowing

- **Delivery is reused, not rebuilt.** The result callback -> Redis pub/sub -> SSE path already exists on main; `callSandboxFunction` just subscribes with `lastEventId: null`, so history replay returns the result even though `invoke()` publishes it mid-exec. No polling.
- A function's response is relayed with its HTTP status. dsbx exits 0 regardless, so we read the envelope's ok, not the exit code. A non-2xx comes back as a normal result (HTTP <status> + body, like http_client); only a runner failure (import error, thrown handler, bad return) is surfaced as a tool error.
- **`input` is typed as an object (`z.record`), not `z.unknown()`.** `z.unknown()` compiles to `{}`, which the model sends as a string that double-encodes into a `req.json()` failure.

## Risk

Worst case, `call` times out or returns a structured tool error and the loop continues. No persisted state touched. Additive, behind the existing `sandbox_functions` FF. Safe to roll back.

## Deploy plan

Deploy front.
