### PR TITLE
fix(capabilities): align skill and tool avatar sizes in capabilities picker

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -351,11 +351,13 @@ export function CapabilitiesPicker({
           continue;
         }
 
+        const SkillAvatar = getSkillAvatarIcon(skill);
+
         items.push({
           kind: "skill",
           skill,
           id: `skills-picker-${skill.sId}`,
-          icon: getSkillAvatarIcon(skill),
+          icon: <SkillAvatar size="xs" />,
           label: skill.name,
           sortName: skill.name.toLowerCase(),
           description,
@@ -382,7 +384,7 @@ export function CapabilitiesPicker({
           kind: "tool",
           serverView,
           id: `capabilities-picker-${serverView.sId}`,
-          icon: () => getAvatar(serverView.server),
+          icon: getAvatar(serverView.server, "xs"),
           label,
           sortName: label.toLowerCase(),
           description,
@@ -415,7 +417,7 @@ export function CapabilitiesPicker({
           kind: "uninstalled_tool",
           server,
           id: `tools-to-install-${server.sId}`,
-          icon: () => getAvatar(server),
+          icon: getAvatar(server, "xs"),
           label,
           sortName: label.toLowerCase(),
           description,


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9346

Skill icons were rendered as components, so DropdownMenuItem's renderIcon wrapped them in <Icon size="sm"> and forced h-5 w-5 (20px) onto the avatar, while tool icons were passed as already-rendered elements that ignored the injected className and stayed at 36px. Render both as elements at a consistent xs size so they align.

<img width="466" height="332" alt="Screenshot 2026-07-01 at 15 06 08" src="https://github.com/user-attachments/assets/df08c9e1-3b29-4da5-ba74-4e4d0d232c63" />

## Tests

Local

## Risk

Low
## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
