### PR TITLE
feat: remove role permission check in frontend

### DIFF
--- a/front-spa/src/app/layouts/RequireRoleLayout.tsx
+++ b/front-spa/src/app/layouts/RequireRoleLayout.tsx
@@ -5,7 +5,7 @@ import {
   isAdmin,
   isBusinessAdmin,
   type RoleType,
-} from "@dust-tt/front/types/user.js";
+} from "@dust-tt/front/types/user";
 import { Outlet } from "react-router-dom";
 
 interface RequireRoleProps {

--- a/front-spa/src/app/layouts/RequireRoleLayout.tsx
+++ b/front-spa/src/app/layouts/RequireRoleLayout.tsx
@@ -2,21 +2,23 @@ import { AdminLayout } from "@dust-tt/front/components/layouts/AdminLayout";
 import Custom404 from "@dust-tt/front/components/pages/Custom404";
 import { useAuth } from "@dust-tt/front/lib/auth/AuthContext";
 import {
-  hasPermission,
-  type Permission,
-} from "@dust-tt/front/types/permissions";
+  isAdmin,
+  isBusinessAdmin,
+  type RoleType,
+} from "@dust-tt/front/types/user.js";
 import { Outlet } from "react-router-dom";
 
-interface RequirePermissionProps {
-  permission: Permission;
+interface RequireRoleProps {
+  role: Extract<RoleType, "admin" | "business_admin">;
 }
 
-export function RequirePermissionLayout({
-  permission,
-}: RequirePermissionProps) {
+export function RequireRoleLayout({ role }: RequireRoleProps) {
   const { workspace } = useAuth();
 
-  if (!hasPermission(workspace.role, permission)) {
+  const hasRequiredRole =
+    role === "admin" ? isAdmin(workspace) : isBusinessAdmin(workspace);
+
+  if (!hasRequiredRole) {
     return <Custom404 />;
   }
 

--- a/front-spa/src/app/layouts/RequireRoleLayout.tsx
+++ b/front-spa/src/app/layouts/RequireRoleLayout.tsx
@@ -9,14 +9,14 @@ import {
 import { Outlet } from "react-router-dom";
 
 interface RequireRoleProps {
-  role: Extract<RoleType, "admin" | "business_admin">;
+  requiredRole: Extract<RoleType, "admin" | "business_admin">;
 }
 
-export function RequireRoleLayout({ role }: RequireRoleProps) {
+export function RequireRoleLayout({ requiredRole }: RequireRoleProps) {
   const { workspace } = useAuth();
 
   const hasRequiredRole =
-    role === "admin" ? isAdmin(workspace) : isBusinessAdmin(workspace);
+    requiredRole === "admin" ? isAdmin(workspace) : isBusinessAdmin(workspace);
 
   if (!hasRequiredRole) {
     return <Custom404 />;

--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -1,4 +1,4 @@
-import { RequirePermissionLayout } from "@spa/app/layouts/RequirePermissionLayout";
+import { RequireRoleLayout } from "@spa/app/layouts/RequireRoleLayout";
 import { withSuspense } from "@spa/app/routes/withSuspense";
 import type { RouteObject } from "react-router-dom";
 
@@ -95,17 +95,16 @@ const BillingPage = withSuspense(
 
 export const adminRoutes: RouteObject[] = [
   {
-    // People page: accessible to admins and business admins.
-    element: <RequirePermissionLayout permission="workspace:manage_members" />,
-    children: [{ path: "members", element: <MembersPage /> }],
-  },
-  {
-    element: <RequirePermissionLayout permission="workspace:view_analytics" />,
-    children: [{ path: "analytics", element: <AnalyticsPage /> }],
+    // Accessible to admins and business admins.
+    element: <RequireRoleLayout role="business_admin" />,
+    children: [
+      { path: "members", element: <MembersPage /> },
+      { path: "analytics", element: <AnalyticsPage /> },
+    ],
   },
   {
     // Admin-only areas.
-    element: <RequirePermissionLayout permission="workspace:admin" />,
+    element: <RequireRoleLayout role="admin" />,
     children: [
       {
         path: "identity-and-provisioning",

--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -96,7 +96,7 @@ const BillingPage = withSuspense(
 export const adminRoutes: RouteObject[] = [
   {
     // Accessible to admins and business admins.
-    element: <RequireRoleLayout role="business_admin" />,
+    element: <RequireRoleLayout requiredRole="business_admin" />,
     children: [
       { path: "members", element: <MembersPage /> },
       { path: "analytics", element: <AnalyticsPage /> },
@@ -104,7 +104,7 @@ export const adminRoutes: RouteObject[] = [
   },
   {
     // Admin-only areas.
-    element: <RequireRoleLayout role="admin" />,
+    element: <RequireRoleLayout requiredRole="admin" />,
     children: [
       {
         path: "identity-and-provisioning",

--- a/front/components/members/RolesDropDown.tsx
+++ b/front/components/members/RolesDropDown.tsx
@@ -1,8 +1,7 @@
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
-import { hasPermission } from "@app/types/permissions";
 import type { ActiveRoleType } from "@app/types/user";
-import { ACTIVE_ROLES } from "@app/types/user";
+import { ACTIVE_ROLES, isAdmin } from "@app/types/user";
 import {
   Button,
   ChevronDown,
@@ -26,10 +25,7 @@ export function RoleDropDown({
 }: RoleDropDownProps) {
   const { hasFeature } = useFeatureFlags();
   const workspace = useWorkspace();
-  const canManageAdminRole = hasPermission(
-    workspace.role,
-    "workspace:manage_admin_role"
-  );
+  const canManageAdminRole = isAdmin(workspace);
 
   const availableRoles = ACTIVE_ROLES.filter((role) => {
     // `business_admin` can only be assigned when the workspace has the

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -264,8 +264,8 @@ export const subNavigationAdmin = ({
   const isCurrent = (id: SubNavigationAdminId): boolean =>
     matchesRoutePattern(currentRoute, ADMIN_ROUTE_PATTERNS[id]);
 
-  const isAdminRole = isAdmin(owner);
-  const isBusinessAdminRole = isBusinessAdmin(owner);
+  const hasAdminRole = isAdmin(owner);
+  const hasBusinessAdminRole = isBusinessAdmin(owner);
 
   nav.push({
     id: "workspace",
@@ -277,7 +277,7 @@ export const subNavigationAdmin = ({
         icon: Users01,
         href: `/w/${owner.sId}/members`,
         current: isCurrent("members"),
-        disabled: !isBusinessAdminRole,
+        disabled: !hasBusinessAdminRole,
       },
       {
         id: "identity_and_provisioning",
@@ -285,7 +285,7 @@ export const subNavigationAdmin = ({
         icon: Fingerprint04,
         href: `/w/${owner.sId}/identity-and-provisioning`,
         current: isCurrent("identity_and_provisioning"),
-        disabled: !isAdminRole,
+        disabled: !hasAdminRole,
       },
       {
         id: "workspace",
@@ -293,7 +293,7 @@ export const subNavigationAdmin = ({
         icon: Building04,
         href: `/w/${owner.sId}/workspace`,
         current: isCurrent("workspace"),
-        disabled: !isAdminRole,
+        disabled: !hasAdminRole,
       },
       ...(featureFlags.includes("whitelabel_frames")
         ? [
@@ -303,7 +303,7 @@ export const subNavigationAdmin = ({
               icon: Palette,
               href: `/w/${owner.sId}/branding`,
               current: isCurrent("workspace_branding"),
-              disabled: !isAdminRole,
+              disabled: !hasAdminRole,
             },
           ]
         : []),
@@ -316,7 +316,7 @@ export const subNavigationAdmin = ({
               icon: PieChart01,
               href: `/w/${owner.sId}/usage`,
               current: isCurrent("usage"),
-              disabled: !isAdminRole,
+              disabled: !hasAdminRole,
             },
           ]
         : []),
@@ -326,7 +326,7 @@ export const subNavigationAdmin = ({
         icon: Brain,
         href: `/w/${owner.sId}/model-providers`,
         current: isCurrent("model_providers"),
-        disabled: !isAdminRole,
+        disabled: !hasAdminRole,
       },
       {
         id: "analytics",
@@ -334,7 +334,7 @@ export const subNavigationAdmin = ({
         icon: BarChart01,
         href: `/w/${owner.sId}/analytics`,
         current: isCurrent("analytics"),
-        disabled: !isBusinessAdminRole,
+        disabled: !hasBusinessAdminRole,
       },
       isCreditPricedPlan(subscription.plan)
         ? {
@@ -343,7 +343,7 @@ export const subNavigationAdmin = ({
             icon: CreditCard01,
             href: `/w/${owner.sId}/billing`,
             current: isCurrent("billing"),
-            disabled: !isAdminRole,
+            disabled: !hasAdminRole,
           }
         : {
             id: "subscription",
@@ -351,7 +351,7 @@ export const subNavigationAdmin = ({
             icon: CreditCard01,
             href: `/w/${owner.sId}/subscription`,
             current: isCurrent("subscription"),
-            disabled: !isAdminRole,
+            disabled: !hasAdminRole,
           },
     ],
   });
@@ -366,7 +366,7 @@ export const subNavigationAdmin = ({
         icon: Lock01,
         href: `/w/${owner.sId}/developers/api-keys`,
         current: isCurrent("api_keys"),
-        disabled: !isAdminRole,
+        disabled: !hasAdminRole,
       },
       ...(isCreditPricedPlan(subscription.plan)
         ? []
@@ -377,7 +377,7 @@ export const subNavigationAdmin = ({
               icon: Zap,
               href: `/w/${owner.sId}/developers/credits-usage`,
               current: isCurrent("credits_usage"),
-              disabled: !isAdminRole,
+              disabled: !hasAdminRole,
             },
           ]),
     ],
@@ -394,7 +394,7 @@ export const subNavigationAdmin = ({
         href: `/w/${owner.sId}/developers/providers`,
         current: isCurrent("providers"),
         featureFlag: "legacy_dust_apps",
-        disabled: !isAdminRole,
+        disabled: !hasAdminRole,
       },
       {
         id: "dev_secrets",
@@ -402,7 +402,7 @@ export const subNavigationAdmin = ({
         icon: Brackets,
         href: `/w/${owner.sId}/developers/dev-secrets`,
         current: isCurrent("dev_secrets"),
-        disabled: !isAdminRole,
+        disabled: !hasAdminRole,
       },
       {
         id: "sandbox",
@@ -410,7 +410,7 @@ export const subNavigationAdmin = ({
         icon: Globe01,
         href: `/w/${owner.sId}/developers/sandbox`,
         current: isCurrent("sandbox"),
-        disabled: !isAdminRole || !isComputerFeatureEnabled(featureFlags),
+        disabled: !hasAdminRole || !isComputerFeatureEnabled(featureFlags),
       },
       ...(computeIsSelfImprovementAvailable({
         owner,
@@ -424,7 +424,7 @@ export const subNavigationAdmin = ({
               icon: Stars02,
               href: `/w/${owner.sId}/developers/self-improving-skills`,
               current: isCurrent("self_improving_skills"),
-              disabled: !isAdminRole,
+              disabled: !hasAdminRole,
             },
           ]
         : []),

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -1,14 +1,18 @@
 import { computeIsSelfImprovementAvailable } from "@app/lib/client/self_improvement";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { AppType } from "@app/types/app";
-import { hasPermission } from "@app/types/permissions";
 import { isCreditPricedPlan, type SubscriptionType } from "@app/types/plan";
 import {
   isComputerFeatureEnabled,
   type WhitelistableFeature,
 } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
-import { isAdmin, isBuilder, isOnlyBusinessAdmin } from "@app/types/user";
+import {
+  isAdmin,
+  isBuilder,
+  isBusinessAdmin,
+  isOnlyBusinessAdmin,
+} from "@app/types/user";
 import {
   BarChart01,
   Brackets,
@@ -260,10 +264,8 @@ export const subNavigationAdmin = ({
   const isCurrent = (id: SubNavigationAdminId): boolean =>
     matchesRoutePattern(currentRoute, ADMIN_ROUTE_PATTERNS[id]);
 
-  const hasWorkspaceAdminPermission = hasPermission(
-    owner.role,
-    "workspace:admin"
-  );
+  const isAdminRole = isAdmin(owner);
+  const isBusinessAdminRole = isBusinessAdmin(owner);
 
   nav.push({
     id: "workspace",
@@ -275,7 +277,7 @@ export const subNavigationAdmin = ({
         icon: Users01,
         href: `/w/${owner.sId}/members`,
         current: isCurrent("members"),
-        disabled: !hasPermission(owner.role, "workspace:manage_members"),
+        disabled: !isBusinessAdminRole,
       },
       {
         id: "identity_and_provisioning",
@@ -283,7 +285,7 @@ export const subNavigationAdmin = ({
         icon: Fingerprint04,
         href: `/w/${owner.sId}/identity-and-provisioning`,
         current: isCurrent("identity_and_provisioning"),
-        disabled: !hasWorkspaceAdminPermission,
+        disabled: !isAdminRole,
       },
       {
         id: "workspace",
@@ -291,7 +293,7 @@ export const subNavigationAdmin = ({
         icon: Building04,
         href: `/w/${owner.sId}/workspace`,
         current: isCurrent("workspace"),
-        disabled: !hasWorkspaceAdminPermission,
+        disabled: !isAdminRole,
       },
       ...(featureFlags.includes("whitelabel_frames")
         ? [
@@ -301,7 +303,7 @@ export const subNavigationAdmin = ({
               icon: Palette,
               href: `/w/${owner.sId}/branding`,
               current: isCurrent("workspace_branding"),
-              disabled: !hasWorkspaceAdminPermission,
+              disabled: !isAdminRole,
             },
           ]
         : []),
@@ -314,7 +316,7 @@ export const subNavigationAdmin = ({
               icon: PieChart01,
               href: `/w/${owner.sId}/usage`,
               current: isCurrent("usage"),
-              disabled: !hasWorkspaceAdminPermission,
+              disabled: !isAdminRole,
             },
           ]
         : []),
@@ -324,7 +326,7 @@ export const subNavigationAdmin = ({
         icon: Brain,
         href: `/w/${owner.sId}/model-providers`,
         current: isCurrent("model_providers"),
-        disabled: !hasWorkspaceAdminPermission,
+        disabled: !isAdminRole,
       },
       {
         id: "analytics",
@@ -332,7 +334,7 @@ export const subNavigationAdmin = ({
         icon: BarChart01,
         href: `/w/${owner.sId}/analytics`,
         current: isCurrent("analytics"),
-        disabled: !hasPermission(owner.role, "workspace:view_analytics"),
+        disabled: !isBusinessAdminRole,
       },
       isCreditPricedPlan(subscription.plan)
         ? {
@@ -341,7 +343,7 @@ export const subNavigationAdmin = ({
             icon: CreditCard01,
             href: `/w/${owner.sId}/billing`,
             current: isCurrent("billing"),
-            disabled: !hasWorkspaceAdminPermission,
+            disabled: !isAdminRole,
           }
         : {
             id: "subscription",
@@ -349,7 +351,7 @@ export const subNavigationAdmin = ({
             icon: CreditCard01,
             href: `/w/${owner.sId}/subscription`,
             current: isCurrent("subscription"),
-            disabled: !hasWorkspaceAdminPermission,
+            disabled: !isAdminRole,
           },
     ],
   });
@@ -364,7 +366,7 @@ export const subNavigationAdmin = ({
         icon: Lock01,
         href: `/w/${owner.sId}/developers/api-keys`,
         current: isCurrent("api_keys"),
-        disabled: !hasWorkspaceAdminPermission,
+        disabled: !isAdminRole,
       },
       ...(isCreditPricedPlan(subscription.plan)
         ? []
@@ -375,7 +377,7 @@ export const subNavigationAdmin = ({
               icon: Zap,
               href: `/w/${owner.sId}/developers/credits-usage`,
               current: isCurrent("credits_usage"),
-              disabled: !hasWorkspaceAdminPermission,
+              disabled: !isAdminRole,
             },
           ]),
     ],
@@ -392,7 +394,7 @@ export const subNavigationAdmin = ({
         href: `/w/${owner.sId}/developers/providers`,
         current: isCurrent("providers"),
         featureFlag: "legacy_dust_apps",
-        disabled: !hasWorkspaceAdminPermission,
+        disabled: !isAdminRole,
       },
       {
         id: "dev_secrets",
@@ -400,7 +402,7 @@ export const subNavigationAdmin = ({
         icon: Brackets,
         href: `/w/${owner.sId}/developers/dev-secrets`,
         current: isCurrent("dev_secrets"),
-        disabled: !hasWorkspaceAdminPermission,
+        disabled: !isAdminRole,
       },
       {
         id: "sandbox",
@@ -408,9 +410,7 @@ export const subNavigationAdmin = ({
         icon: Globe01,
         href: `/w/${owner.sId}/developers/sandbox`,
         current: isCurrent("sandbox"),
-        disabled:
-          !hasWorkspaceAdminPermission ||
-          !isComputerFeatureEnabled(featureFlags),
+        disabled: !isAdminRole || !isComputerFeatureEnabled(featureFlags),
       },
       ...(computeIsSelfImprovementAvailable({
         owner,
@@ -424,7 +424,7 @@ export const subNavigationAdmin = ({
               icon: Stars02,
               href: `/w/${owner.sId}/developers/self-improving-skills`,
               current: isCurrent("self_improving_skills"),
-              disabled: !hasWorkspaceAdminPermission,
+              disabled: !isAdminRole,
             },
           ]
         : []),

--- a/front/components/workspace/ChangeMemberModal.tsx
+++ b/front/components/workspace/ChangeMemberModal.tsx
@@ -4,13 +4,12 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import type { SearchMembersAdminResponseBody } from "@app/lib/api/workspace";
 import { handleMembersRoleChange } from "@app/lib/client/members";
 import { useProvisioningStatus } from "@app/lib/swr/workos";
-import { hasPermission } from "@app/types/permissions";
 import type {
   ActiveRoleType,
   LightWorkspaceType,
   UserTypeWithWorkspace,
 } from "@app/types/user";
-import { isActiveRoleType } from "@app/types/user";
+import { isActiveRoleType, isAdmin } from "@app/types/user";
 import {
   Avatar,
   Button,
@@ -63,10 +62,8 @@ export function ChangeMemberModal({
     );
   };
 
-  // Revoking an admin requires the manage_admin_role permission
-  const canRevokeMember =
-    role !== "admin" ||
-    hasPermission(workspace.role, "workspace:manage_admin_role");
+  // Revoking an admin requires to be an admin
+  const canRevokeMember = role !== "admin" || isAdmin(workspace);
 
   const handleSave = async () => {
     if (!selectedRole) {

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -251,7 +251,7 @@ export function isAdmin(
 
 export function isBusinessAdmin(
   owner: WorkspaceType | null
-): owner is WorkspaceType & { role: "admin" } {
+): owner is WorkspaceType & { role: "business_admin" | "admin" } {
   if (!owner) {
     return false;
   }
@@ -270,7 +270,7 @@ export function isBusinessAdmin(
 
 export function isBuilder(
   owner: WorkspaceType | null
-): owner is WorkspaceType & { role: "builder" | "admin" } {
+): owner is WorkspaceType & { role: "builder" | "business_admin" | "admin" } {
   if (!owner) {
     return false;
   }
@@ -287,9 +287,9 @@ export function isBuilder(
   }
 }
 
-export function isUser(
-  owner: WorkspaceType | null
-): owner is WorkspaceType & { role: "user" | "builder" | "admin" } {
+export function isUser(owner: WorkspaceType | null): owner is WorkspaceType & {
+  role: "user" | "builder" | "business_admin" | "admin";
+} {
   if (!owner) {
     return false;
   }

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -249,6 +249,25 @@ export function isAdmin(
   }
 }
 
+export function isBusinessAdmin(
+  owner: WorkspaceType | null
+): owner is WorkspaceType & { role: "admin" } {
+  if (!owner) {
+    return false;
+  }
+  switch (owner.role) {
+    case "admin":
+    case "business_admin":
+      return true;
+    case "builder":
+    case "user":
+    case "none":
+      return false;
+    default:
+      assertNever(owner.role);
+  }
+}
+
 export function isBuilder(
   owner: WorkspaceType | null
 ): owner is WorkspaceType & { role: "builder" | "admin" } {


### PR DESCRIPTION
## Description

This PR replaces frontend permission checks based on `hasPermission()` with direct role-checking helper functions.

- In `RolesDropDown.tsx` and `ChangeMemberModal.tsx`, replaces `hasPermission(workspace.role, "workspace:manage_admin_role")` with `isAdmin(workspace)`.
- In `navigation/config.ts`, replaces all `hasPermission(owner.role, "workspace:admin")` calls with `isAdmin(owner)`, and replaces `hasPermission(owner.role, "workspace:manage_members")` / `hasPermission(owner.role, "workspace:view_analytics")` with `isBusinessAdmin(owner)`.
- Adds a new `isBusinessAdmin` helper to `front/types/user.ts` and removes the `hasPermission` import from the affected files.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard frontend deployment.
