### PR TITLE
Add: unify method to resolve allowed models.

### DIFF
--- a/front/lib/advanced_models/resolve_allowed.ts
+++ b/front/lib/advanced_models/resolve_allowed.ts
@@ -1,0 +1,43 @@
+import type { AllowedAdvancedModelType } from "@app/types/api/advanced_models";
+
+export function advancedModelKey(model: AllowedAdvancedModelType): string {
+  return `${model.providerId}:${model.modelId}`;
+}
+
+export type ResolvedAllowedAdvancedModels = {
+  models: AllowedAdvancedModelType[];
+  hasUserLevelOverride: boolean;
+};
+
+export function resolveAllowedAdvancedModels({
+  workspaceAllowedAdvancedModels,
+  groupAllowedAdvancedModelsList,
+  userAllowedAdvancedModels,
+}: {
+  workspaceAllowedAdvancedModels: AllowedAdvancedModelType[];
+  groupAllowedAdvancedModelsList: AllowedAdvancedModelType[][];
+  userAllowedAdvancedModels: AllowedAdvancedModelType[];
+}): ResolvedAllowedAdvancedModels {
+  const hasUserLevelOverride = userAllowedAdvancedModels.length > 0;
+
+  const modelsByKey = new Map<string, AllowedAdvancedModelType>();
+
+  const addModels = (models: AllowedAdvancedModelType[]) => {
+    for (const model of models) {
+      modelsByKey.set(advancedModelKey(model), model);
+    }
+  };
+
+  addModels(workspaceAllowedAdvancedModels);
+
+  for (const groupModels of groupAllowedAdvancedModelsList) {
+    addModels(groupModels);
+  }
+
+  addModels(userAllowedAdvancedModels);
+
+  return {
+    models: [...modelsByKey.values()],
+    hasUserLevelOverride,
+  };
+}

--- a/front/lib/client/advanced_models.ts
+++ b/front/lib/client/advanced_models.ts
@@ -1,11 +1,14 @@
+import {
+  advancedModelKey,
+  type ResolvedAllowedAdvancedModels,
+  resolveAllowedAdvancedModels,
+} from "@app/lib/advanced_models/resolve_allowed";
 import type {
   AdvancedModelType,
   AllowedAdvancedModelType,
 } from "@app/types/api/advanced_models";
 
-export function advancedModelKey(model: AllowedAdvancedModelType): string {
-  return `${model.providerId}:${model.modelId}`;
-}
+export { advancedModelKey };
 
 export function isSameAdvancedModel(
   a: AllowedAdvancedModelType,
@@ -14,10 +17,7 @@ export function isSameAdvancedModel(
   return a.providerId === b.providerId && a.modelId === b.modelId;
 }
 
-export type ResolvedAdvancedModelsForUser = {
-  models: AllowedAdvancedModelType[];
-  hasUserLevelOverride: boolean;
-};
+export type ResolvedAdvancedModelsForUser = ResolvedAllowedAdvancedModels;
 
 export function resolveAdvancedModelsForUser({
   userId,
@@ -35,31 +35,20 @@ export function resolveAdvancedModelsForUser({
   workspaceAllowedAdvancedModels: AllowedAdvancedModelType[];
 }): ResolvedAdvancedModelsForUser {
   const userModels = userAllowedAdvancedModelsByUserId[userId] ?? [];
-  const hasUserLevelOverride = userModels.length > 0;
 
-  const modelsByKey = new Map<string, AllowedAdvancedModelType>();
-
-  const addModels = (models: AllowedAdvancedModelType[]) => {
-    for (const model of models) {
-      modelsByKey.set(advancedModelKey(model), model);
-    }
-  };
-
-  addModels(workspaceAllowedAdvancedModels);
-
-  for (const groupName of groupNames) {
+  const groupAllowedAdvancedModelsList = groupNames.map((groupName) => {
     const groupId = groupNameToId.get(groupName);
-    if (groupId) {
-      addModels(groupAdvancedModelsByGroupId[groupId] ?? []);
+    if (!groupId) {
+      return [];
     }
-  }
+    return groupAdvancedModelsByGroupId[groupId] ?? [];
+  });
 
-  addModels(userModels);
-
-  return {
-    models: [...modelsByKey.values()],
-    hasUserLevelOverride,
-  };
+  return resolveAllowedAdvancedModels({
+    workspaceAllowedAdvancedModels,
+    groupAllowedAdvancedModelsList,
+    userAllowedAdvancedModels: userModels,
+  });
 }
 
 export function getAdvancedModelDisplayNames({

--- a/front/lib/resources/advanced_model_resource.test.ts
+++ b/front/lib/resources/advanced_model_resource.test.ts
@@ -381,7 +381,7 @@ describe("AdvancedModelResource.resolveAllowedAdvancedModels", () => {
     expect(withoutOverride.hasUserLevelOverride).toBe(false);
   });
 
-  it("uses explicit groupIds instead of the user's groups when provided", async () => {
+  it("uses explicit groupModelIds instead of the user's groups when provided", async () => {
     const workspace = await WorkspaceFactory.basic();
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
@@ -416,7 +416,7 @@ describe("AdvancedModelResource.resolveAllowedAdvancedModels", () => {
       userAuth,
       {
         user,
-        groupIds: [otherGroup.id],
+        groupModelIds: [otherGroup.id],
       }
     );
 

--- a/front/lib/resources/advanced_model_resource.test.ts
+++ b/front/lib/resources/advanced_model_resource.test.ts
@@ -249,3 +249,201 @@ describe("AdvancedModelResource admin management", () => {
     }
   });
 });
+
+describe("AdvancedModelResource.resolveAllowedAdvancedModels", () => {
+  const opus46 = {
+    providerId: "anthropic" as const,
+    modelId: CLAUDE_OPUS_4_6_MODEL_ID,
+  };
+  const opus47 = {
+    providerId: "anthropic" as const,
+    modelId: CLAUDE_OPUS_4_7_MODEL_ID,
+  };
+  const opus48 = {
+    providerId: "anthropic" as const,
+    modelId: CLAUDE_OPUS_4_8_MODEL_ID,
+  };
+
+  it("returns the union of workspace, group, and user models", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const group = await GroupFactory.regular(workspace, "Engineering");
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    await GroupFactory.withMembers(adminAuth, group, [user]);
+
+    await AdvancedModelResource.addWorkspaceAllowedAdvancedModel(adminAuth, {
+      ...opus47,
+    });
+    await AdvancedModelResource.addGroupAllowedAdvancedModel(adminAuth, {
+      groupId: makeSId("group", {
+        id: group.id,
+        workspaceId: workspace.id,
+      }),
+      ...opus46,
+    });
+    await AdvancedModelResource.addUserAllowedAdvancedModel(adminAuth, {
+      userId: user.sId,
+      ...opus48,
+    });
+
+    const result = await AdvancedModelResource.resolveAllowedAdvancedModels(
+      userAuth,
+      { user }
+    );
+
+    expect(result.models).toHaveLength(3);
+    expect(result.hasUserLevelOverride).toBe(true);
+  });
+
+  it("deduplicates models present in multiple scopes", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const group = await GroupFactory.regular(workspace, "Engineering");
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    await GroupFactory.withMembers(adminAuth, group, [user]);
+
+    await AdvancedModelResource.addWorkspaceAllowedAdvancedModel(adminAuth, {
+      ...opus46,
+    });
+    await AdvancedModelResource.addGroupAllowedAdvancedModel(adminAuth, {
+      groupId: makeSId("group", {
+        id: group.id,
+        workspaceId: workspace.id,
+      }),
+      ...opus46,
+    });
+    await AdvancedModelResource.addUserAllowedAdvancedModel(adminAuth, {
+      userId: user.sId,
+      ...opus46,
+    });
+
+    const result = await AdvancedModelResource.resolveAllowedAdvancedModels(
+      userAuth,
+      { user }
+    );
+
+    expect(result.models).toEqual([opus46]);
+    expect(result.hasUserLevelOverride).toBe(true);
+  });
+
+  it("marks hasUserLevelOverride when the user has direct grants", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    await AdvancedModelResource.addUserAllowedAdvancedModel(adminAuth, {
+      userId: user.sId,
+      ...opus46,
+    });
+
+    const withOverride =
+      await AdvancedModelResource.resolveAllowedAdvancedModels(userAuth, {
+        user,
+      });
+
+    await AdvancedModelResource.removeUserAllowedAdvancedModel(adminAuth, {
+      userId: user.sId,
+      ...opus46,
+    });
+    await AdvancedModelResource.addWorkspaceAllowedAdvancedModel(adminAuth, {
+      ...opus46,
+    });
+
+    const withoutOverride =
+      await AdvancedModelResource.resolveAllowedAdvancedModels(userAuth, {
+        user,
+      });
+
+    expect(withOverride.hasUserLevelOverride).toBe(true);
+    expect(withoutOverride.hasUserLevelOverride).toBe(false);
+  });
+
+  it("uses explicit groupIds instead of the user's groups when provided", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const memberGroup = await GroupFactory.regular(workspace, "Member group");
+    const otherGroup = await GroupFactory.regular(workspace, "Other group");
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    await GroupFactory.withMembers(adminAuth, memberGroup, [user]);
+
+    await AdvancedModelResource.addGroupAllowedAdvancedModel(adminAuth, {
+      groupId: makeSId("group", {
+        id: memberGroup.id,
+        workspaceId: workspace.id,
+      }),
+      ...opus46,
+    });
+    await AdvancedModelResource.addGroupAllowedAdvancedModel(adminAuth, {
+      groupId: makeSId("group", {
+        id: otherGroup.id,
+        workspaceId: workspace.id,
+      }),
+      ...opus47,
+    });
+
+    const result = await AdvancedModelResource.resolveAllowedAdvancedModels(
+      userAuth,
+      {
+        user,
+        groupIds: [otherGroup.id],
+      }
+    );
+
+    expect(result.models).toEqual([opus47]);
+    expect(result.hasUserLevelOverride).toBe(false);
+  });
+
+  it("does not require admin permissions", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    await AdvancedModelResource.addWorkspaceAllowedAdvancedModel(adminAuth, {
+      ...opus46,
+    });
+
+    const result =
+      await AdvancedModelResource.resolveAllowedAdvancedModels(userAuth);
+
+    expect(result.models).toEqual([opus46]);
+    expect(result.hasUserLevelOverride).toBe(false);
+  });
+});

--- a/front/lib/resources/advanced_model_resource.ts
+++ b/front/lib/resources/advanced_model_resource.ts
@@ -1,3 +1,7 @@
+import {
+  type ResolvedAllowedAdvancedModels,
+  resolveAllowedAdvancedModels,
+} from "@app/lib/advanced_models/resolve_allowed";
 import { isAdvancedModel as isAdvancedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -29,6 +33,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
+import { Op } from "sequelize";
 
 export class AdvancedModelResource {
   private static assertIsAdmin(auth: Authenticator): void {
@@ -396,8 +401,114 @@ export class AdvancedModelResource {
     this.assertIsAdmin(auth);
 
     const workspace = auth.getNonNullableWorkspace();
+    return this.loadWorkspaceAllowedAdvancedModels(workspace.id);
+  }
+
+  static async resolveAllowedAdvancedModels(
+    auth: Authenticator,
+    {
+      user,
+      groupIds: explicitGroupIds,
+    }: {
+      user?: UserResource | null;
+      groupIds?: ModelId[];
+    } = {}
+  ): Promise<ResolvedAllowedAdvancedModels> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    let groupIds = explicitGroupIds;
+    if (groupIds === undefined && user) {
+      groupIds = await GroupResource.dangerouslyListUserGroupsForAuth({
+        user,
+        workspace,
+      });
+    }
+    groupIds = groupIds ?? [];
+
+    const [workspaceAllowedAdvancedModels, groupModelsByGroupId, userModels] =
+      await Promise.all([
+        this.loadWorkspaceAllowedAdvancedModels(workspace.id),
+        groupIds.length > 0
+          ? this.loadGroupAllowedAdvancedModelsByGroupId({
+              workspaceId: workspace.id,
+              groupIds,
+            })
+          : Promise.resolve(new Map<ModelId, AllowedAdvancedModelType[]>()),
+        user
+          ? this.loadUserAllowedAdvancedModels({
+              workspaceId: workspace.id,
+              userId: user.id,
+            })
+          : Promise.resolve([]),
+      ]);
+
+    const groupAllowedAdvancedModelsList = groupIds.map(
+      (groupId) => groupModelsByGroupId.get(groupId) ?? []
+    );
+
+    return resolveAllowedAdvancedModels({
+      workspaceAllowedAdvancedModels,
+      groupAllowedAdvancedModelsList,
+      userAllowedAdvancedModels: userModels,
+    });
+  }
+
+  private static async loadWorkspaceAllowedAdvancedModels(
+    workspaceId: ModelId
+  ): Promise<AllowedAdvancedModelType[]> {
     const rows = await WorkspaceAllowedAdvancedModel.findAll({
-      where: { workspaceId: workspace.id },
+      where: { workspaceId },
+    });
+
+    return rows.flatMap((row) => {
+      const model = this.parseAllowedAdvancedModelRow(row);
+      return model ? [model] : [];
+    });
+  }
+
+  private static async loadGroupAllowedAdvancedModelsByGroupId({
+    workspaceId,
+    groupIds,
+  }: {
+    workspaceId: ModelId;
+    groupIds: ModelId[];
+  }): Promise<Map<ModelId, AllowedAdvancedModelType[]>> {
+    const rows = await GroupAllowedAdvancedModel.findAll({
+      where: {
+        workspaceId,
+        groupId: {
+          [Op.in]: groupIds,
+        },
+      },
+    });
+
+    const modelsByGroupId = new Map<ModelId, AllowedAdvancedModelType[]>();
+    for (const row of rows) {
+      const model = this.parseAllowedAdvancedModelRow(row);
+      if (!model) {
+        continue;
+      }
+
+      const models = modelsByGroupId.get(row.groupId) ?? [];
+      models.push(model);
+      modelsByGroupId.set(row.groupId, models);
+    }
+
+    return modelsByGroupId;
+  }
+
+  private static async loadUserAllowedAdvancedModels({
+    workspaceId,
+    userId,
+  }: {
+    workspaceId: ModelId;
+    userId: ModelId;
+  }): Promise<AllowedAdvancedModelType[]> {
+    const rows = await UserAllowedAdvancedModel.findAll({
+      where: {
+        workspaceId,
+        userId,
+      },
     });
 
     return rows.flatMap((row) => {

--- a/front/lib/resources/advanced_model_resource.ts
+++ b/front/lib/resources/advanced_model_resource.ts
@@ -408,42 +408,42 @@ export class AdvancedModelResource {
     auth: Authenticator,
     {
       user,
-      groupIds: explicitGroupIds,
+      groupModelIds: explicitGroupModelIds,
     }: {
       user?: UserResource | null;
-      groupIds?: ModelId[];
+      groupModelIds?: ModelId[];
     } = {}
   ): Promise<ResolvedAllowedAdvancedModels> {
     const workspace = auth.getNonNullableWorkspace();
 
-    let groupIds = explicitGroupIds;
-    if (groupIds === undefined && user) {
-      groupIds = await GroupResource.dangerouslyListUserGroupsForAuth({
+    let groupModelIds = explicitGroupModelIds;
+    if (groupModelIds === undefined && user) {
+      groupModelIds = await GroupResource.dangerouslyListUserGroupsForAuth({
         user,
         workspace,
       });
     }
-    groupIds = groupIds ?? [];
+    groupModelIds = groupModelIds ?? [];
 
     const [workspaceAllowedAdvancedModels, groupModelsByGroupId, userModels] =
       await Promise.all([
         this.loadWorkspaceAllowedAdvancedModels(workspace.id),
-        groupIds.length > 0
+        groupModelIds.length > 0
           ? this.loadGroupAllowedAdvancedModelsByGroupId({
               workspaceId: workspace.id,
-              groupIds,
+              groupModelIds,
             })
           : Promise.resolve(new Map<ModelId, AllowedAdvancedModelType[]>()),
         user
           ? this.loadUserAllowedAdvancedModels({
               workspaceId: workspace.id,
-              userId: user.id,
+              userModelId: user.id,
             })
           : Promise.resolve([]),
       ]);
 
-    const groupAllowedAdvancedModelsList = groupIds.map(
-      (groupId) => groupModelsByGroupId.get(groupId) ?? []
+    const groupAllowedAdvancedModelsList = groupModelIds.map(
+      (groupModelId) => groupModelsByGroupId.get(groupModelId) ?? []
     );
 
     return resolveAllowedAdvancedModels({
@@ -468,16 +468,16 @@ export class AdvancedModelResource {
 
   private static async loadGroupAllowedAdvancedModelsByGroupId({
     workspaceId,
-    groupIds,
+    groupModelIds,
   }: {
     workspaceId: ModelId;
-    groupIds: ModelId[];
+    groupModelIds: ModelId[];
   }): Promise<Map<ModelId, AllowedAdvancedModelType[]>> {
     const rows = await GroupAllowedAdvancedModel.findAll({
       where: {
         workspaceId,
         groupId: {
-          [Op.in]: groupIds,
+          [Op.in]: groupModelIds,
         },
       },
     });
@@ -499,15 +499,15 @@ export class AdvancedModelResource {
 
   private static async loadUserAllowedAdvancedModels({
     workspaceId,
-    userId,
+    userModelId,
   }: {
     workspaceId: ModelId;
-    userId: ModelId;
+    userModelId: ModelId;
   }): Promise<AllowedAdvancedModelType[]> {
     const rows = await UserAllowedAdvancedModel.findAll({
       where: {
         workspaceId,
-        userId,
+        userId: userModelId,
       },
     });
 


### PR DESCRIPTION
## Description

Extracts the allowed-models resolution logic into a shared pure function `resolveAllowedAdvancedModels` in `front/lib/advanced_models/resolve_allowed.ts`, and adds a server-side `AdvancedModelResource.resolveAllowedAdvancedModels` static method that fetches from the DB and delegates to it.

Previously the union/dedup logic lived inline in `resolveAdvancedModelsForUser` (client-side, pre-fetched maps). This PR:
- Moves `advancedModelKey` and the core resolution logic to a shared module, reusable by both client and server paths.
- Adds `AdvancedModelResource.resolveAllowedAdvancedModels(auth, { user?, groupIds? })` for single-call server-side resolution (parallel DB fetches via `Promise.all`), with private helpers `loadWorkspaceAllowedAdvancedModels`, `loadGroupAllowedAdvancedModelsByGroupId`, `loadUserAllowedAdvancedModels`.
- Makes `ResolvedAdvancedModelsForUser` a type alias for `ResolvedAllowedAdvancedModels`.

## Tests

Added integration tests in `advanced_model_resource.test.ts` covering: union across all three scopes, deduplication, `hasUserLevelOverride` flag, explicit `groupIds` override, and non-admin access.

## Risk

Low. Pure refactor — no behavior change to existing `resolveAdvancedModelsForUser`. New server-side method is additive. No DB schema changes.

## Deploy Plan

Deploy front.
