### PR TITLE
Restrict access to advanced model in the agentic loop

### DIFF
--- a/front/lib/advanced_models/access.test.ts
+++ b/front/lib/advanced_models/access.test.ts
@@ -1,0 +1,158 @@
+import {
+  ADVANCED_MODEL_NOT_ENABLED_ERROR_CODE,
+  getAdvancedModelAccessErrorForAgentConfiguration,
+} from "@app/lib/advanced_models/access";
+import { Authenticator } from "@app/lib/auth";
+import { AdvancedModelResource } from "@app/lib/resources/advanced_model_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import {
+  CLAUDE_OPUS_4_6_MODEL_ID,
+  CLAUDE_OPUS_4_7_MODEL_ID,
+  CLAUDE_SONNET_4_6_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
+import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
+import { describe, expect, it } from "vitest";
+
+const opusModel = SUPPORTED_MODEL_CONFIGS.find(
+  (m) => m.modelId === CLAUDE_OPUS_4_6_MODEL_ID
+)!;
+const sonnetModel = SUPPORTED_MODEL_CONFIGS.find(
+  (m) => m.modelId === CLAUDE_SONNET_4_6_MODEL_ID
+)!;
+
+describe("getAdvancedModelAccessErrorForAgentConfiguration", () => {
+  it("returns null when models_picker is disabled", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const result = await getAdvancedModelAccessErrorForAgentConfiguration(
+      auth,
+      {
+        agentName: "Opus Agent",
+        model: opusModel,
+        featureFlags: [],
+      }
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null for non-advanced models when models_picker is enabled", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "models_picker");
+
+    const result = await getAdvancedModelAccessErrorForAgentConfiguration(
+      auth,
+      {
+        agentName: "Sonnet Agent",
+        model: sonnetModel,
+        featureFlags: ["models_picker"],
+      }
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns an error for advanced models that are not in the allowlist", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "models_picker");
+
+    const result = await getAdvancedModelAccessErrorForAgentConfiguration(
+      auth,
+      {
+        agentName: "Opus Agent",
+        model: opusModel,
+        featureFlags: ["models_picker"],
+      }
+    );
+
+    expect(result?.code).toBe(ADVANCED_MODEL_NOT_ENABLED_ERROR_CODE);
+    expect(result?.message).toContain("not enabled for you");
+    expect(result?.metadata?.errorTitle).toBe("Advanced model not enabled");
+  });
+
+  it("returns null when the advanced model is granted at workspace level", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(userAuth, "models_picker");
+
+    await AdvancedModelResource.addWorkspaceAllowedAdvancedModel(adminAuth, {
+      providerId: "anthropic",
+      modelId: CLAUDE_OPUS_4_6_MODEL_ID,
+    });
+
+    const result = await getAdvancedModelAccessErrorForAgentConfiguration(
+      userAuth,
+      {
+        agentName: "Opus Agent",
+        model: opusModel,
+        featureFlags: ["models_picker"],
+      }
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the advanced model is granted directly to the user", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(userAuth, "models_picker");
+
+    await AdvancedModelResource.addUserAllowedAdvancedModel(adminAuth, {
+      userId: user.sId,
+      providerId: "anthropic",
+      modelId: CLAUDE_OPUS_4_7_MODEL_ID,
+    });
+
+    const opus47Model = SUPPORTED_MODEL_CONFIGS.find(
+      (m) => m.modelId === CLAUDE_OPUS_4_7_MODEL_ID
+    )!;
+
+    const result = await getAdvancedModelAccessErrorForAgentConfiguration(
+      userAuth,
+      {
+        agentName: "Opus 4.7 Agent",
+        model: opus47Model,
+        featureFlags: ["models_picker"],
+      }
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/front/lib/advanced_models/access.ts
+++ b/front/lib/advanced_models/access.ts
@@ -1,0 +1,61 @@
+import { advancedModelKey } from "@app/lib/advanced_models/resolve_allowed";
+import type { Authenticator } from "@app/lib/auth";
+import { AdvancedModelResource } from "@app/lib/resources/advanced_model_resource";
+import type { GenericErrorContent } from "@app/types/assistant/agent";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+export const ADVANCED_MODEL_NOT_ENABLED_ERROR_CODE =
+  "advanced_model_not_enabled";
+
+export function buildAdvancedModelAccessDeniedError(
+  agentName: string
+): GenericErrorContent {
+  return {
+    code: ADVANCED_MODEL_NOT_ENABLED_ERROR_CODE,
+    message:
+      `Assistant ${agentName} uses an advanced model that is not enabled for you. ` +
+      `Please contact your workspace admin or use another assistant.`,
+    metadata: {
+      errorTitle: "Advanced model not enabled",
+      category: "unknown_error",
+    },
+  };
+}
+
+export async function getAdvancedModelAccessErrorForAgentConfiguration(
+  auth: Authenticator,
+  {
+    agentName,
+    model,
+    featureFlags,
+  }: {
+    agentName: string;
+    model: ModelConfigurationType;
+    featureFlags: WhitelistableFeature[];
+  }
+): Promise<GenericErrorContent | null> {
+  if (!featureFlags.includes("models_picker")) {
+    return null;
+  }
+
+  if (!AdvancedModelResource.isAdvancedModel(model)) {
+    return null;
+  }
+
+  const { models: allowedModels } =
+    await AdvancedModelResource.resolveAllowedAdvancedModels(auth, {
+      user: auth.user(),
+    });
+  const allowedModelKeys = new Set(allowedModels.map(advancedModelKey));
+  const modelKey = advancedModelKey({
+    providerId: model.providerId,
+    modelId: model.modelId,
+  });
+
+  if (allowedModelKeys.has(modelKey)) {
+    return null;
+  }
+
+  return buildAdvancedModelAccessDeniedError(agentName);
+}

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -7,6 +7,7 @@ import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { isServerSideMCPServerConfigurationWithName } from "@app/lib/actions/types/guards";
 import { computeStepContexts } from "@app/lib/actions/utils";
+import { getAdvancedModelAccessErrorForAgentConfiguration } from "@app/lib/advanced_models/access";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
@@ -222,6 +223,23 @@ export async function runModel(
     return null;
   }
 
+  const featureFlags = await getFeatureFlags(auth);
+
+  if (step === 0) {
+    const accessError = await getAdvancedModelAccessErrorForAgentConfiguration(
+      auth,
+      {
+        agentName: agentConfiguration.name,
+        model,
+        featureFlags,
+      }
+    );
+    if (accessError) {
+      await publishAgentError(accessError);
+      return null;
+    }
+  }
+
   const {
     enabledSkills,
     systemSkills,
@@ -365,7 +383,6 @@ export async function runModel(
   });
 
   const isNewFileExplorer = conversation.metadata?.useFileSystem === true;
-  const featureFlags = await getFeatureFlags(auth);
   const hasSandboxTools = isComputerFeatureEnabled(featureFlags);
   const disableFormattingPrompt = featureFlags.includes(
     "disable_formatting_prompt"


### PR DESCRIPTION
## Description

Enforces advanced model access restrictions server-side in the agentic loop, not just the UI. At `step === 0` in `runModel`, calls `getAdvancedModelAccessErrorForAgentConfiguration` — which checks `models_picker` FF, `AdvancedModelResource.isAdvancedModel`, and the user/workspace allowlist — and short-circuits with `publishAgentError` if access is denied. Extracts the check into `front/lib/advanced_models/access.ts` with `buildAdvancedModelAccessDeniedError` producing a `GenericErrorContent` with code `advanced_model_not_enabled`.

## Tests

Added Vitest integration tests in `access.test.ts` covering: FF disabled → null, non-advanced model → null, advanced model not allowlisted → error, workspace allowlist grant → null, user allowlist grant → null.

<img width="788" height="351" alt="file-5327cd53288b2169293d0176879ed1d2" src="https://github.com/user-attachments/assets/5a8a9ad3-b576-456b-9e41-610381dd4a20" />


## Risk

Low. Gated entirely on `models_picker` feature flag; no behaviour change for workspaces without it. Check runs only at `step === 0` to avoid redundant DB calls per loop step. Rollback is a deploy revert.

## Deploy Plan

Deploy front.
