### PR TITLE
poke: add workspace metadata JSON viewer tab

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -24,6 +24,7 @@ import {
 } from "@app/components/poke/subscriptions/table";
 import { TriggerDataTable } from "@app/components/poke/triggers/table";
 import { WebhookSourceDataTable } from "@app/components/poke/webhook_sources/table";
+import { WorkspaceMetadataTab } from "@app/components/poke/workspace/MetadataTab";
 import { WorkspaceInfoTable } from "@app/components/poke/workspace/table";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
@@ -277,6 +278,7 @@ export function WorkspacePage() {
             className="min-h-[1024px] w-full"
           >
             <TabsList>
+              <TabsTrigger value="metadata" label="Metadata" />
               <TabsTrigger value="agents" label="Agents" />
               <TabsTrigger value="apps" label="Apps" />
               <TabsTrigger value="datasources" label="Data Sources" />
@@ -295,6 +297,9 @@ export function WorkspacePage() {
               <TabsTrigger value="analytics" label="Analytics" />
             </TabsList>
 
+            <TabsContent value="metadata">
+              <WorkspaceMetadataTab owner={owner} />
+            </TabsContent>
             <TabsContent value="datasources">
               <DataSourceDataTable owner={owner} loadOnInit />
             </TabsContent>

--- a/front/components/poke/workspace/MetadataTab.tsx
+++ b/front/components/poke/workspace/MetadataTab.tsx
@@ -1,0 +1,41 @@
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Clipboard,
+  ClipboardCheck,
+  useCopyToClipboard,
+} from "@dust-tt/sparkle";
+import { JsonViewer } from "@textea/json-viewer";
+
+interface WorkspaceMetadataTabProps {
+  owner: WorkspaceType;
+}
+
+export function WorkspaceMetadataTab({ owner }: WorkspaceMetadataTabProps) {
+  const { isDark } = useTheme();
+  const [isCopied, copy] = useCopyToClipboard();
+
+  const metadata = owner.metadata ?? {};
+
+  return (
+    <div>
+      <div className="mb-4 pt-4 flex justify-end">
+        <Button
+          label={isCopied ? "Copied!" : "Copy JSON"}
+          variant="outline"
+          size="sm"
+          icon={isCopied ? ClipboardCheck : Clipboard}
+          onClick={() => copy(JSON.stringify(metadata, null, 2))}
+        />
+      </div>
+      <JsonViewer
+        theme={isDark ? "dark" : "light"}
+        value={metadata}
+        rootName="metadata"
+        defaultInspectDepth={3}
+        className="p-4"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Add a "Metadata" tab to the poke workspace page (as the first tab in the bottom tab group), showing the raw workspace `metadata` JSON blob (e.g. maintenance mode, kill switch, retention overrides) via a `JsonViewer`, mirroring the existing `RawJsonTab` pattern used for LLM traces. 

## Tests

verified the new tab renders `owner.metadata` correctly.
