### PR TITLE
Pricing: cap per group 1: add column to store cap in group model

### DIFF
--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -622,6 +622,41 @@ describe("GroupResource", () => {
     });
   });
 
+  describe("updatePoolCap", () => {
+    it("persists a cap and clears it with null", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Pool Cap Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      expect(regularGroup.poolCapAwuCredits).toBeNull();
+
+      const setResult = await regularGroup.updatePoolCap(authenticator, 5000);
+      expect(setResult.isOk()).toBe(true);
+
+      const afterSet = await GroupResource.fetchById(
+        authenticator,
+        regularGroup.sId
+      );
+      if (afterSet.isErr()) {
+        throw afterSet.error;
+      }
+      expect(afterSet.value.poolCapAwuCredits).toBe(5000);
+
+      const clearResult = await regularGroup.updatePoolCap(authenticator, null);
+      expect(clearResult.isOk()).toBe(true);
+
+      const afterClear = await GroupResource.fetchById(
+        authenticator,
+        regularGroup.sId
+      );
+      if (afterClear.isErr()) {
+        throw afterClear.error;
+      }
+      expect(afterClear.value.poolCapAwuCredits).toBeNull();
+    });
+  });
+
   describe("listWorkspaceGroupsFromKey", () => {
     it("system key: populates cache on first call and serves from cache on second", async () => {
       const key = await KeyFactory.system(systemGroup);

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -75,6 +75,7 @@ type CachedGroup = {
   kind: GroupKind;
   workspaceId: ModelId;
   workOSGroupId: string | null;
+  poolCapAwuCredits: number | null;
   createdAt: number;
   updatedAt: number;
 };
@@ -129,6 +130,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       kind: g.kind,
       workspaceId: g.workspaceId,
       workOSGroupId: g.workOSGroupId,
+      poolCapAwuCredits: g.poolCapAwuCredits,
       createdAt: g.createdAt.getTime(),
       updatedAt: g.updatedAt.getTime(),
     }));
@@ -168,6 +170,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       kind: data.kind,
       workspaceId: data.workspaceId,
       workOSGroupId: data.workOSGroupId,
+      poolCapAwuCredits: data.poolCapAwuCredits,
       createdAt: new Date(data.createdAt),
       updatedAt: new Date(data.updatedAt),
     });
@@ -2108,6 +2111,20 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new Ok(undefined);
   }
 
+  // Per-group usage spend limit (excluding seat allowance), applied per member.
+  // Pass null to clear the cap.
+  async updatePoolCap(
+    auth: Authenticator,
+    poolCapAwuCredits: number | null
+  ): Promise<Result<undefined, Error>> {
+    if (!auth.canAdministrate(this.requestedPermissions())) {
+      return new Err(new Error("Only admins can update group spend limits."));
+    }
+
+    await this.update({ poolCapAwuCredits });
+    return new Ok(undefined);
+  }
+
   // Deletion
 
   async delete(
@@ -2380,6 +2397,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       workspaceId: this.workspaceId,
       kind: this.kind,
       memberCount: 0, // Default value, use toJSONWithMemberCount for actual count
+      poolCapAwuCredits: this.poolCapAwuCredits,
     };
   }
 
@@ -2392,6 +2410,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       workspaceId: this.workspaceId,
       kind: this.kind,
       memberCount,
+      poolCapAwuCredits: this.poolCapAwuCredits,
     };
   }
 }

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -14,6 +14,10 @@ export class GroupModel extends WorkspaceAwareModel<GroupModel> {
 
   // Group ID on workOS, unique across all directories.
   declare workOSGroupId: string | null;
+
+  // Per-group usage spend limit (excluding seat allowance), applied per member.
+  // null means the group carries no cap (falls back to the workspace default).
+  declare poolCapAwuCredits: CreationOptional<number | null>;
 }
 
 GroupModel.init(
@@ -38,6 +42,10 @@ GroupModel.init(
     },
     workOSGroupId: {
       type: DataTypes.STRING,
+      allowNull: true,
+    },
+    poolCapAwuCredits: {
+      type: DataTypes.INTEGER,
       allowNull: true,
     },
   },

--- a/front/migrations/pre-deploy/20260701162321_add_pool_cap_awu_credits_to_groups.sql
+++ b/front/migrations/pre-deploy/20260701162321_add_pool_cap_awu_credits_to_groups.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."groups" ADD COLUMN "poolCapAwuCredits" integer;

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -61,6 +61,9 @@ export type GroupType = {
   kind: GroupKind;
   workspaceId: ModelId;
   memberCount: number;
+  // Per-group usage spend limit (excluding seat allowance), applied per member.
+  // null means the group carries no cap (falls back to the workspace default).
+  poolCapAwuCredits: number | null;
 };
 
 export const GroupKindCodec = z.enum([


### PR DESCRIPTION
Related to https://github.com/dust-tt/tasks/issues/9339

## Description

 - Add a new poolCapAwuCredits column to store the AWU usage cap for a given group.
 - Added migration
 - Add function to update it in resource + test 
 - It's not yet plugged to anything

## Tests

added unit test

## Risk

low

## Deploy Plan

lock front
merge
apply migration
deploy
unlock front
