### PR TITLE
[front] metronome contracts: add displayedName + use it for free plan

### DIFF
--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -114,6 +114,7 @@ async function provisionCreditPricedFreePlan(
     swapAt: "current-hour",
     enableStripeBilling: false,
     planCode: CREDIT_PRICED_FREE_PLAN_CODE,
+    displayedName: `Free Business ${currency.toUpperCase()}`,
     // We create the subscription row ourselves right below via
     // `createSubscriptionFromCheckout`. Stamp the contract so the
     // contract.start webhook skips its own subscription swap instead of

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -774,6 +774,7 @@ export async function createMetronomeContract({
   planCode,
   additionalCustomFields,
   fromContractId,
+  displayedName,
 }: {
   metronomeCustomerId: string;
   /** Mutually exclusive with `packageId`. */
@@ -781,6 +782,11 @@ export async function createMetronomeContract({
   /** Mutually exclusive with `packageAlias` */
   packageId?: string;
   uniquenessKey?: string;
+  // Displayed in the Metronome dashboard/invoices. Metronome's create endpoint
+  // rejects `name` alongside package_alias/package_id, so this is applied via
+  // a follow-up `v2.contracts.edit` (`update_contract_name`) once the
+  // contract exists. Left unset, Metronome derives it from the package.
+  displayedName?: string;
   // Must already be on an hour boundary (Metronome requirement).
   startingAt: Date;
   enableStripeBilling: boolean;
@@ -889,6 +895,17 @@ export async function createMetronomeContract({
   });
   if (customFieldsResult.isErr()) {
     return new Err(customFieldsResult.error);
+  }
+
+  if (displayedName) {
+    const renameResult = await editMetronomeContract({
+      contract_id: contractId,
+      customer_id: metronomeCustomerId,
+      update_contract_name: displayedName,
+    });
+    if (renameResult.isErr()) {
+      return new Err(renameResult.error);
+    }
   }
 
   logger.info(

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -200,6 +200,7 @@ export async function provisionMetronomeContract({
   additionalCustomFields,
   enableSeatSync = true,
   fromContractId,
+  displayedName,
 }: {
   metronomeCustomerId: string;
   workspace: LightWorkspaceType;
@@ -212,6 +213,7 @@ export async function provisionMetronomeContract({
   additionalCustomFields?: Record<string, string>;
   enableSeatSync?: boolean;
   fromContractId?: string;
+  displayedName?: string;
 }): Promise<Result<{ metronomeContractId: string }, Error>> {
   const alignedStart = new Date(
     swapAt === "current-hour"
@@ -240,6 +242,7 @@ export async function provisionMetronomeContract({
     planCode,
     additionalCustomFields,
     fromContractId,
+    displayedName,
   });
   if (contractResult.isErr()) {
     return new Err(contractResult.error);


### PR DESCRIPTION
## Description

Add an optional displayed name when creating a new metronome contract + use if for free plans

* Add an optional displayedName param to createMetronomeContract and provisionMetronomeContract so callers can set a human-readable name on a Metronome contract.
* Metronome's contracts.create rejects name when package_alias/package_id is set (our only creation path), so displayedName is applied via a follow-up v2.contracts.edit (update_contract_name) once the contract exists, alongside the existing custom-fields/Stripe-billing post-create steps.
* Use it in provisionCreditPricedFreePlan to name free-plan contracts Free Business USD / Free Business EUR based on the workspace's billing currency, making them identifiable in the Metronome dashboard.

## Tests

Tested locally:
* creating a free plan contract uses the displayed name
* creating a contract without a displayed name works as before

## Risk

Medium, impacts free plan creation but more generally the creation of new contracts with Metronome

## Deploy Plan

Deploy front