### PR TITLE
add date selection for business plan, clean up dead code

### DIFF
--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -6,15 +6,12 @@ import {
 import { clientFetch } from "@app/lib/egress/client";
 import { isEnterprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
-import { usePokeMetronomePackages, usePokePlans } from "@app/lib/swr/poke";
+import { usePokePlans } from "@app/lib/swr/poke";
 import type {
   EnterpriseUpgradeFormType,
   SubscriptionType,
 } from "@app/types/plan";
-import {
-  EnterpriseUpgradeFormSchema,
-  isSubscriptionMetronomeBilled,
-} from "@app/types/plan";
+import { EnterpriseUpgradeFormSchema } from "@app/types/plan";
 import type { ProgrammaticUsageConfigurationType } from "@app/types/programmatic_usage";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { WorkspaceType } from "@app/types/user";
@@ -33,36 +30,21 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 const MICRO_USD_PER_DOLLAR = 1_000_000;
-
-function snapDatetimeLocalToHour(value: string): string {
-  if (
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value) &&
-    value.slice(14, 16) !== "00"
-  ) {
-    return value.slice(0, 14) + "00";
-  }
-
-  return value;
-}
 
 interface EnterpriseUpgradeDialogProps {
   owner: WorkspaceType;
   subscription: SubscriptionType;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
-  hasMetronomeBillingFeature: boolean;
-  stripeCustomerId: string | null;
 }
 
 export default function EnterpriseUpgradeDialog({
   owner,
   subscription,
   programmaticUsageConfig,
-  hasMetronomeBillingFeature,
-  stripeCustomerId,
 }: EnterpriseUpgradeDialogProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -77,46 +59,8 @@ export default function EnterpriseUpgradeDialog({
     }
   }, []);
 
-  const useMetronomePath =
-    isSubscriptionMetronomeBilled(subscription) || hasMetronomeBillingFeature;
   const { plans } = usePokePlans();
-  const {
-    packages: metronomePackages,
-    isPackagesLoading,
-    packagesError,
-  } = usePokeMetronomePackages({
-    disabled: !useMetronomePath || !open,
-  });
   const router = useAppRouter();
-
-  // Min datetime for the startingAt picker — at least one hour in the future
-  // and rounded up to the next local hour boundary, since Metronome contracts
-  // must start on the hour and the picker is restricted to whole hours.
-  const minStartingAtLocal = useMemo(() => {
-    const d = new Date(Date.now() + 60 * 60 * 1000);
-    if (d.getMinutes() > 0 || d.getSeconds() > 0 || d.getMilliseconds() > 0) {
-      d.setHours(d.getHours() + 1);
-    }
-    d.setMinutes(0, 0, 0);
-    const pad = (n: number) => String(n).padStart(2, "0");
-    return (
-      `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
-      `T${pad(d.getHours())}:00`
-    );
-  }, []);
-
-  const enterprisePackageOptions = useMemo(
-    () =>
-      metronomePackages
-        .filter((p) => p.name.toLowerCase().includes("enterprise"))
-        .map((p) => ({ value: p.id, display: p.name })),
-    [metronomePackages]
-  );
-  const isEnterprisePackageSelectionDisabled =
-    useMetronomePath &&
-    (isPackagesLoading ||
-      !!packagesError ||
-      enterprisePackageOptions.length === 0);
 
   const freeCreditMicroUsd =
     programmaticUsageConfig?.freeCreditMicroUsd ?? null;
@@ -125,12 +69,7 @@ export default function EnterpriseUpgradeDialog({
   const form = useForm<EnterpriseUpgradeFormType>({
     resolver: zodResolver(EnterpriseUpgradeFormSchema),
     defaultValues: {
-      stripeSubscriptionId: !useMetronomePath
-        ? (subscription.stripeSubscriptionId ?? "")
-        : undefined,
-      metronomePackageId: useMetronomePath ? "" : undefined,
-      startingAt: useMetronomePath ? minStartingAtLocal : undefined,
-      stripeCustomerId: useMetronomePath ? (stripeCustomerId ?? "") : undefined,
+      stripeSubscriptionId: subscription.stripeSubscriptionId ?? "",
       planCode: "",
       freeCreditsOverrideEnabled: freeCreditMicroUsd !== null,
       freeCreditsDollars:
@@ -167,14 +106,6 @@ export default function EnterpriseUpgradeDialog({
           })
         )
       );
-
-      // datetime-local inputs return a local-time string with no timezone.
-      // Convert to ISO so the server's Date.parse is unambiguous.
-      if (typeof cleanedValues.startingAt === "string") {
-        cleanedValues.startingAt = new Date(
-          cleanedValues.startingAt
-        ).toISOString();
-      }
 
       const submit = async () => {
         setIsSubmitting(true);
@@ -221,11 +152,8 @@ export default function EnterpriseUpgradeDialog({
         <DialogHeader>
           <DialogTitle>Upgrade {owner.name} to Enterprise.</DialogTitle>
           <DialogDescription>
-            Select the enterprise plan and provide the{" "}
-            {useMetronomePath
-              ? "Metronome package and contract start time"
-              : "Stripe subscription Id"}{" "}
-            of the customer.
+            Select the enterprise plan and provide the Stripe subscription Id of
+            the customer.
           </DialogDescription>
         </DialogHeader>
         <DialogContainer>
@@ -256,69 +184,14 @@ export default function EnterpriseUpgradeDialog({
                         }))}
                     />
                   </div>
-                  {useMetronomePath ? (
-                    <>
-                      {isPackagesLoading && (
-                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                          <Spinner size="sm" />
-                          <span>Loading Metronome packages...</span>
-                        </div>
-                      )}
-                      {!isPackagesLoading && packagesError && (
-                        <div className="text-warning text-sm">
-                          Failed to load Metronome packages:{" "}
-                          {packagesError.message}
-                        </div>
-                      )}
-                      {!isPackagesLoading &&
-                        !packagesError &&
-                        enterprisePackageOptions.length === 0 && (
-                          <div className="text-warning text-sm">
-                            No enterprise Metronome package is available.
-                          </div>
-                        )}
-                      {!isPackagesLoading && !packagesError && (
-                        <div className="grid-cols grid items-center gap-4">
-                          <SelectField
-                            control={form.control}
-                            name="metronomePackageId"
-                            title="Metronome Enterprise Package"
-                            mountPortalContainer={portalContainer}
-                            options={enterprisePackageOptions}
-                          />
-                        </div>
-                      )}
-                      <div className="grid-cols grid items-center gap-4">
-                        <InputField
-                          control={form.control}
-                          name="startingAt"
-                          title="Starts At (local time, ≥ 1h from now, on the hour)"
-                          type="datetime-local"
-                          min={minStartingAtLocal}
-                          step={3600}
-                          transformValue={snapDatetimeLocalToHour}
-                        />
-                      </div>
-                      <div className="grid-cols grid items-center gap-4">
-                        <InputField
-                          control={form.control}
-                          name="stripeCustomerId"
-                          title="Stripe Customer Id"
-                          placeholder="cus_1234567890"
-                          readOnly={stripeCustomerId !== null}
-                        />
-                      </div>
-                    </>
-                  ) : (
-                    <div className="grid-cols grid items-center gap-4">
-                      <InputField
-                        control={form.control}
-                        name="stripeSubscriptionId"
-                        title="Stripe Subscription id"
-                        placeholder="sub_1234567890"
-                      />
-                    </div>
-                  )}
+                  <div className="grid-cols grid items-center gap-4">
+                    <InputField
+                      control={form.control}
+                      name="stripeSubscriptionId"
+                      title="Stripe Subscription id"
+                      placeholder="sub_1234567890"
+                    />
+                  </div>
 
                   <div className="border-t pt-4">
                     <h4 className="mb-4 font-medium">
@@ -382,12 +255,7 @@ export default function EnterpriseUpgradeDialog({
                   </div>
                 </div>
                 <DialogFooter>
-                  <Button
-                    type="submit"
-                    variant="warning"
-                    label="Upgrade"
-                    disabled={isEnterprisePackageSelectionDisabled}
-                  />
+                  <Button type="submit" variant="warning" label="Upgrade" />
                 </DialogFooter>
               </form>
             </PokeForm>

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -9,10 +9,7 @@ import { amountCents } from "@app/lib/metronome/amounts";
 import { isPaygEligibleTier } from "@app/lib/metronome/types";
 import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
-  CREDIT_PRICED_FREE_PLAN_CODE,
   isEnterprisePlanPrefix,
-  PRO_PLAN_SEAT_29_CODE,
-  PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import {
@@ -20,7 +17,6 @@ import {
   usePokePlans,
   usePokeStripeCustomerCurrency,
 } from "@app/lib/swr/poke";
-import assert from "@app/lib/utils/assert";
 import { usePokePluginAsyncArgs } from "@app/poke/swr/plugins";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { CreditUsageConfigurationSchema } from "@app/types/poke/credit_usage_configuration";
@@ -327,18 +323,13 @@ export default function SwitchContractDialog({
 
   // Split packages into Current vs Legacy sections (name contains "legacy",
   // case-insensitive). Each section preserves the lib-side sort order.
-  // Free-tier packages are currency-agnostic (price is 0) and surface
-  // regardless of the resolved Stripe currency.
   const packageGroups = useMemo(() => {
     const visible = metronomePackages.filter(
-      (p) => p.tier === "free" || p.currency === resolvedCurrency
+      (p) => p.currency === resolvedCurrency
     );
     const toOption = (p: (typeof visible)[number]) => ({
       value: p.id,
-      display:
-        p.tier === "free"
-          ? `${p.name} (${p.tier})`
-          : `${p.name} (${p.tier}, ${p.currency.toUpperCase()})`,
+      display: `${p.name} (${p.tier}, ${p.currency.toUpperCase()})`,
     });
     return [
       {
@@ -361,7 +352,6 @@ export default function SwitchContractDialog({
     [metronomePackages, selectedPackageId]
   );
   const selectedTier = selectedPackage?.tier ?? null;
-  const selectedName = selectedPackage?.name ?? null;
   const selectedSeats = useMemo(
     () => selectedPackage?.seats ?? [],
     [selectedPackage]
@@ -400,54 +390,39 @@ export default function SwitchContractDialog({
   }, [selectedSeats, form, resolvedCurrency]);
 
   // Clear a stale package selection when the resolved currency changes so a
-  // previously-picked package can't survive a currency switch silently. Free
-  // packages are currency-agnostic and exempt from this check.
+  // previously-picked package can't survive a currency switch silently.
   useEffect(() => {
     if (
       resolvedCurrency &&
       selectedPackage &&
-      selectedPackage.tier !== "free" &&
       selectedPackage.currency !== resolvedCurrency
     ) {
       form.setValue("metronomePackageId", "");
     }
   }, [resolvedCurrency, selectedPackage, form]);
 
-  // When the operator picks a package, derive (Pro/Business) or reset
+  // When the operator picks a package, derive (Business) or reset
   // (Enterprise) the plan code. The full list of ENT_* plans is offered for
-  // enterprise; pro/business map to a single plan code. PAYG is force-disabled
-  // for tiers that don't support it (currently: pro).
+  // enterprise; business maps to a single plan code. Both tiers use the same
+  // operator-chosen start moment.
   useEffect(() => {
-    if (selectedTier === "pro") {
-      if (isLegacyPackageName(selectedName ?? "")) {
-        form.setValue("planCode", PRO_PLAN_SEAT_29_CODE);
-      } else {
-        assert("There is no non-legacy pro plan");
-      }
-      form.setValue("startingAt", "");
-      form.setValue("startMode", "select");
-    } else if (selectedTier === "business") {
-      if (isLegacyPackageName(selectedName ?? "")) {
-        form.setValue("planCode", PRO_PLAN_SEAT_39_CODE);
-      } else {
-        form.setValue("planCode", CREDIT_PRICED_BUSINESS_PLAN_CODE);
-      }
-      form.setValue("startingAt", "");
-      form.setValue("startMode", "select");
+    if (selectedTier === "business") {
+      form.setValue("planCode", CREDIT_PRICED_BUSINESS_PLAN_CODE);
+      // Pay-as-you-go and top-up are not offered for business in this dialog.
+      form.setValue("paygEnabled", false);
+      form.setValue("topUpEnabled", false);
     } else if (selectedTier === "enterprise") {
       form.setValue("planCode", "");
+    }
+    if (selectedTier) {
       form.setValue("startingAt", defaultStartingAtUTC);
-      form.setValue("startMode", "select");
-    } else if (selectedTier === "free") {
-      form.setValue("planCode", CREDIT_PRICED_FREE_PLAN_CODE);
-      form.setValue("startingAt", "");
       form.setValue("startMode", "select");
     }
     if (selectedTier && !isPaygEligibleTier(selectedTier)) {
       form.setValue("paygEnabled", false);
       form.setValue("usageCapCredits", undefined);
     }
-  }, [selectedTier, selectedName, form, defaultStartingAtUTC]);
+  }, [selectedTier, form, defaultStartingAtUTC]);
 
   const startMode = form.watch("startMode");
   const startingAt = form.watch("startingAt");
@@ -566,9 +541,9 @@ export default function SwitchContractDialog({
           ? { hubspotDealId: trimmedHubspotDealId }
           : {}),
       };
-      // For free-tier switches, the operator can omit the Stripe customer —
-      // the resulting Metronome contract has no Stripe billing link. The
-      // collection method only matters when a Stripe customer is wired in.
+      // The operator can omit the Stripe customer — the resulting Metronome
+      // contract has no Stripe billing link. The collection method only
+      // matters when a Stripe customer is wired in.
       if (trimmedStripe) {
         cleaned.stripeCustomerId = trimmedStripe;
         cleaned.stripeCollectionMethod = values.stripeCollectionMethod;
@@ -633,17 +608,13 @@ export default function SwitchContractDialog({
           },
         };
       }
-      // Resolve the start moment for enterprise. "immediately" leaves
-      // `startingAt` unset so the server swaps at the current hour.
-      if (selectedTier === "enterprise") {
-        if (values.startMode === "retroactive_first_of_month") {
-          cleaned.startingAt = retroactiveFirstOfMonthISO;
-        } else if (values.startMode === "select" && values.startingAt) {
-          // datetime-local has no timezone — append Z to interpret as UTC.
-          cleaned.startingAt = new Date(
-            values.startingAt + ":00Z"
-          ).toISOString();
-        }
+      // Resolve the start moment. "immediately" leaves `startingAt` unset so
+      // the server swaps at the current hour.
+      if (values.startMode === "retroactive_first_of_month") {
+        cleaned.startingAt = retroactiveFirstOfMonthISO;
+      } else if (values.startMode === "select" && values.startingAt) {
+        // datetime-local has no timezone — append Z to interpret as UTC.
+        cleaned.startingAt = new Date(values.startingAt + ":00Z").toISOString();
       }
       // Seats: every seat the package knows about, each carrying its `selected`
       // state, so the server can entitle checked seats and disable unchecked
@@ -735,14 +706,7 @@ export default function SwitchContractDialog({
       };
       void submit();
     },
-    [
-      form,
-      owner.sId,
-      router,
-      selectedTier,
-      selectedSeats,
-      retroactiveFirstOfMonthISO,
-    ]
+    [form, owner.sId, router, selectedSeats, retroactiveFirstOfMonthISO]
   );
 
   return (
@@ -754,9 +718,8 @@ export default function SwitchContractDialog({
         <DialogHeader>
           <DialogTitle>Switch contract for {owner.name}</DialogTitle>
           <DialogDescription>
-            Pick the Metronome package and target plan. Enterprise packages
-            require a start time at least one hour in the future; Pro and
-            Business packages swap at the current hour.
+            Pick the Metronome package and target plan. Enterprise and Business
+            packages let you choose a start time.
           </DialogDescription>
         </DialogHeader>
         {isSubmitting ? (
@@ -888,6 +851,11 @@ export default function SwitchContractDialog({
                         mountPortalContainer={portalContainer}
                         options={enterprisePlanOptions}
                       />
+                    </>
+                  )}
+                  {(selectedTier === "enterprise" ||
+                    selectedTier === "business") && (
+                    <>
                       <Label className="text-sm">Start</Label>
                       <SelectField
                         control={form.control}
@@ -918,26 +886,22 @@ export default function SwitchContractDialog({
                       )}
                     </>
                   )}
-                  {(selectedTier === "pro" ||
-                    selectedTier === "business" ||
-                    selectedTier === "free") && (
+                  {selectedTier === "business" && (
                     <div className="col-span-2 text-sm text-muted-foreground">
                       Target plan:{" "}
                       <span className="font-mono">
                         {form.watch("planCode")}
-                      </span>{" "}
-                      — swap at the current hour, subscription flips
-                      synchronously.
+                      </span>
                     </div>
                   )}
                 </div>
-                {selectedTier && selectedTier !== "free" && (
+                {selectedTier && (
                   <div className="border-t pt-4">
                     <Label className="mb-3 block text-sm font-medium">
                       Credit configuration
                     </Label>
                     <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
-                      {paygEligible && (
+                      {paygEligible && selectedTier === "enterprise" && (
                         <>
                           <Label className="text-sm">Pay-as-you-go</Label>
                           <SliderToggle
@@ -1002,13 +966,17 @@ export default function SwitchContractDialog({
                           )
                         }
                       />
-                      <Label className="text-sm">Top-up (Enterprise)</Label>
-                      <SliderToggle
-                        selected={topUpEnabled}
-                        onClick={() =>
-                          form.setValue("topUpEnabled", !topUpEnabled)
-                        }
-                      />
+                      {selectedTier === "enterprise" && (
+                        <>
+                          <Label className="text-sm">Top-up (Enterprise)</Label>
+                          <SliderToggle
+                            selected={topUpEnabled}
+                            onClick={() =>
+                              form.setValue("topUpEnabled", !topUpEnabled)
+                            }
+                          />
+                        </>
+                      )}
                       <Label className="text-sm">
                         Auto invoice finalization
                       </Label>
@@ -1250,10 +1218,7 @@ export default function SwitchContractDialog({
                   type="submit"
                   variant="warning"
                   label="Switch"
-                  disabled={
-                    !selectedTier ||
-                    (selectedTier !== "free" && !resolvedCurrency)
-                  }
+                  disabled={!selectedTier || !resolvedCurrency}
                 />
               </DialogFooter>
             </form>

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -386,8 +386,6 @@ export function ActiveSubscriptionTable({
                 owner={owner}
                 subscription={subscription}
                 programmaticUsageConfig={programmaticUsageConfig}
-                hasMetronomeBillingFeature={hasMetronomeBillingFeature}
-                stripeCustomerId={stripeCustomerId}
               />
             )}
           </div>
@@ -591,16 +589,12 @@ interface UpgradeDowngradeModalProps {
   owner: WorkspaceType;
   subscription: SubscriptionType;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
-  hasMetronomeBillingFeature: boolean;
-  stripeCustomerId: string | null;
 }
 
 function UpgradeDowngradeModal({
   owner,
   subscription,
   programmaticUsageConfig,
-  hasMetronomeBillingFeature,
-  stripeCustomerId,
 }: UpgradeDowngradeModalProps) {
   const router = useAppRouter();
   const { plans } = usePokePlans();
@@ -688,8 +682,6 @@ function UpgradeDowngradeModal({
                 owner={owner}
                 subscription={subscription}
                 programmaticUsageConfig={programmaticUsageConfig}
-                hasMetronomeBillingFeature={hasMetronomeBillingFeature}
-                stripeCustomerId={stripeCustomerId}
               />
             </div>
             {isProPlanPrefix(subscription.plan.code) && (


### PR DESCRIPTION
## Description

In `SwitchContractDialog`, extend the enterprise-only "Start" time picker (immediately / retroactive to 1st of month / select) to business switches too, defaulting to "Select start time" — the server (`resolveSwapTiming`) already supported an arbitrary `startingAt` for any tier, only the client restricted it to enterprise.

Also cleaned up dead code surfaced along the way, now that only business/enterprise Metronome packages exist:
- Removed the unreachable `pro`/`free` tier branches from `SwitchContractDialog` (package filtering, plan-code resolution, credit-config visibility, submit gating) and the legacy-package-name check for business (already excluded from the package list).
- Hid the "Pay-as-you-go" and "Top-up (Enterprise)" toggles for business.
- Removed the Metronome branch from `EnterpriseUpgradeDialog` (and the now-unused `hasMetronomeBillingFeature`/`stripeCustomerId` props threaded through `UpgradeDowngradeModal`): that dialog only mounts when the workspace is *not* Metronome-billed, so the branch was provably dead.

## Tests

Manual: type-checked (`tsgo --noEmit`) and linted (`biome check`) the changed files.

## Risk

Low — admin-only (`poke`) UI, no API contract changes.

## Deploy Plan

Standard deploy.
