### PR TITLE
feat(agents): add dust-light global agent

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -597,6 +597,18 @@ export function _getDustHaikuGlobalAgent(
   });
 }
 
+export function _getDustLightGlobalAgent(
+  auth: Authenticator,
+  args: DustLikeGlobalAgentArgs
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_LIGHT,
+    name: "dust-light",
+    preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredReasoningEffort: "light",
+  });
+}
+
 export function _getDustLionelGlobalAgent(
   auth: Authenticator,
   args: DustLikeGlobalAgentArgs

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -599,6 +599,13 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         description: "Same as dust but running Claude 4.5 Haiku.",
         pictureUrl: DUST_AVATAR_URL,
       };
+    case GLOBAL_AGENTS_SID.DUST_LIGHT:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_LIGHT,
+        name: "dust-light",
+        description: "Same as dust but running Claude Sonnet 4.6.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
     case GLOBAL_AGENTS_SID.DUST_KIMI:
       return {
         sId: GLOBAL_AGENTS_SID.DUST_KIMI,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -43,6 +43,7 @@ import {
   _getDustKimiGlobalAgent,
   _getDustKimiHighGlobalAgent,
   _getDustKimiMediumGlobalAgent,
+  _getDustLightGlobalAgent,
   _getDustLionelGlobalAgent,
   _getDustLionelHighGlobalAgent,
   _getDustLionelMediumGlobalAgent,
@@ -291,6 +292,12 @@ const GLOBAL_AGENT_FLAGS: Record<
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_HAIKU]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_LIGHT]: {
     injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
@@ -1092,6 +1099,15 @@ function getGlobalAgent({
         featureFlags,
       });
       break;
+    case GLOBAL_AGENTS_SID.DUST_LIGHT:
+      agentConfiguration = _getDustLightGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        mcpServerViews,
+        hasDeepDive,
+        featureFlags,
+      });
+      break;
     case GLOBAL_AGENTS_SID.DUST_KIMI:
       agentConfiguration = _getDustKimiGlobalAgent(auth, {
         settings,
@@ -1634,6 +1650,7 @@ export async function getGlobalAgents(
     GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED,
     GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE,
     GLOBAL_AGENTS_SID.DUST_HAIKU,
+    GLOBAL_AGENTS_SID.DUST_LIGHT,
     GLOBAL_AGENTS_SID.DUST_EDGE,
     GLOBAL_AGENTS_SID.DUST_KIMI,
     GLOBAL_AGENTS_SID.DUST_KIMI_MEDIUM,

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -98,6 +98,7 @@ export enum GLOBAL_AGENTS_SID {
   DUST_ANT_HIGH_OMITTED = "dust-ant-high-omitted",
   DUST_ANT_SONNET_EDGE = "dust-ant-sonnet-edge",
   DUST_HAIKU = "dust-haiku",
+  DUST_LIGHT = "dust-light",
   DUST_KIMI = "dust-kimi",
   DUST_KIMI_MEDIUM = "dust-kimi-medium",
   DUST_KIMI_HIGH = "dust-kimi-high",


### PR DESCRIPTION
## Description

Adds a new `dust-light` internal global agent backed by `CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG` with `light` reasoning effort, mirroring the existing `dust-haiku` variant. Like the other model-specific `dust-*` variants, it is gated behind the `dust_internal_global_agents` feature flag.

Wired up across the usual sites:
- `DUST_LIGHT` added to the `GLOBAL_AGENTS_SID` enum
- `_getDustLightGlobalAgent` factory in `dust.ts`
- Metadata entry (name/description/avatar) in `global_agent_metadata.ts`
- Import, injects-config map, dispatch `switch` case, and `DUST_INTERNAL_AGENTS` list in `global_agents.ts`

## Tests

Type-check passes for the touched files (remaining `tsgo` errors are pre-existing and unrelated to this change). The agent follows the exact pattern of the other internal `dust-*` variants and requires no new runtime behavior.
