### PR TITLE
feat(extension): support agentId in openSidePanel external message

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -6,6 +6,7 @@ import {
   registerForceUpdateListener,
   registerMessageListener,
 } from "@extension/shared/background";
+import { z } from "zod";
 
 const log = console.error;
 
@@ -91,6 +92,20 @@ chrome.contextMenus.onClicked.addListener(async (event, tab) => {
   }
 });
 
+const openSidePanelSchema = z
+  .object({
+    action: z.literal("openSidePanel"),
+    workspaceId: z.string().regex(/^[a-zA-Z0-9_-]{10,}$/),
+    conversationId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]{10,}$/)
+      .optional(),
+    agentId: z.string().optional(),
+  })
+  .refine((data) => data.conversationId || data.agentId, {
+    message: "Either conversationId or agentId must be provided",
+  });
+
 /**
  * Listener for messages sent from external websites that are whitelisted on the manifest.
  * It allows to open the side panel and either navigate to an existing conversation
@@ -105,24 +120,15 @@ chrome.contextMenus.onClicked.addListener(async (event, tab) => {
  * We return true to keep the message channel open for async response.
  */
 chrome.runtime.onMessageExternal.addListener((request) => {
-  if (
-    request.action !== "openSidePanel" ||
-    !request.workspaceId ||
-    !/^[a-zA-Z0-9_-]{10,}$/.test(request.workspaceId)
-  ) {
+  const parsed = openSidePanelSchema.safeParse(request);
+
+  if (!parsed.success) {
     log("[onMessageExternal] Invalid params:", request);
     return true;
   }
 
-  const hasConversationId =
-    request.conversationId &&
-    /^[a-zA-Z0-9_-]{10,}$/.test(request.conversationId);
-  const hasAgentId = request.agentId && typeof request.agentId === "string";
-
-  if (!hasConversationId && !hasAgentId) {
-    log("[onMessageExternal] Missing conversationId or agentId:", request);
-    return true;
-  }
+  const { workspaceId, conversationId, agentId } = parsed.data;
+  const hasConversationId = !!conversationId;
 
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     if (tabs[0]) {
@@ -134,7 +140,7 @@ chrome.runtime.onMessageExternal.addListener((request) => {
           chrome.storage.local.get(
             ["extensionReady", "selectedWorkspace"],
             ({ extensionReady, selectedWorkspace }) => {
-              if (request.workspaceId != selectedWorkspace) {
+              if (workspaceId != selectedWorkspace) {
                 log("[onMessageExternal] User selected another workspace.");
                 return;
               }
@@ -142,8 +148,8 @@ chrome.runtime.onMessageExternal.addListener((request) => {
               const sendMessage = () => {
                 const params = JSON.stringify(
                   hasConversationId
-                    ? { conversationId: request.conversationId }
-                    : { agentId: request.agentId }
+                    ? { conversationId }
+                    : { agentId }
                 );
                 void chrome.runtime.sendMessage({
                   type: "EXT_ROUTE_CHANGE",

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -93,19 +93,35 @@ chrome.contextMenus.onClicked.addListener(async (event, tab) => {
 
 /**
  * Listener for messages sent from external websites that are whitelisted on the manifest.
- * It allows to open the side panel and navigate to a specific conversation.
+ * It allows to open the side panel and either navigate to an existing conversation
+ * or create a new one with a pre-configured agent.
+ *
+ * Accepted payloads:
+ *   - { action: "openSidePanel", workspaceId, conversationId }
+ *     Opens an existing conversation directly.
+ *   - { action: "openSidePanel", workspaceId, agentId, spaceId? }
+ *     Creates a new conversation with the given agent (and optional Pod space)
+ *     server-side — bypassing browser CORS restrictions — then opens it.
  *
  * We return true to keep the message channel open for async response.
  */
 chrome.runtime.onMessageExternal.addListener((request) => {
   if (
     request.action !== "openSidePanel" ||
-    !request.conversationId ||
     !request.workspaceId ||
-    !/^[a-zA-Z0-9_-]{10,}$/.test(request.conversationId) ||
     !/^[a-zA-Z0-9_-]{10,}$/.test(request.workspaceId)
   ) {
     log("[onMessageExternal] Invalid params:", request);
+    return true;
+  }
+
+  const hasConversationId =
+    request.conversationId &&
+    /^[a-zA-Z0-9_-]{10,}$/.test(request.conversationId);
+  const hasAgentId = request.agentId && typeof request.agentId === "string";
+
+  if (!hasConversationId && !hasAgentId) {
+    log("[onMessageExternal] Missing conversationId or agentId:", request);
     return true;
   }
 
@@ -115,7 +131,77 @@ chrome.runtime.onMessageExternal.addListener((request) => {
         .open({
           windowId: tabs[0].windowId,
         })
-        .then(() => {
+        .then(async () => {
+          let conversationId: string = request.conversationId;
+
+          // If agentId is provided without a conversationId, create a new
+          // conversation server-side. The extension background script is not
+          // subject to CORS restrictions, so it can call the Dust API directly
+          // using the stored auth token.
+          if (!hasConversationId && hasAgentId) {
+            try {
+              const token = await platform.auth.getAccessToken();
+              const regionInfo =
+                await platform.auth.getRegionInfoFromStorage();
+
+              if (!token || !regionInfo) {
+                log(
+                  "[onMessageExternal] Missing auth token or region info."
+                );
+                return;
+              }
+
+              const body: Record<string, unknown> = {
+                title: null,
+                visibility: "unlisted",
+                message: null,
+                contentFragments: [],
+              };
+
+              if (
+                request.spaceId &&
+                typeof request.spaceId === "string"
+              ) {
+                body.spaceId = request.spaceId;
+              }
+
+              const res = await fetch(
+                `${regionInfo.url}/api/w/${request.workspaceId}/assistant/conversations`,
+                {
+                  method: "POST",
+                  headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${token}`,
+                  },
+                  credentials: "omit",
+                  body: JSON.stringify(body),
+                }
+              );
+
+              if (!res.ok) {
+                log(
+                  "[onMessageExternal] Failed to create conversation:",
+                  res.status
+                );
+                return;
+              }
+
+              const data = await res.json();
+              conversationId = data.conversation?.sId;
+
+              if (!conversationId) {
+                log(
+                  "[onMessageExternal] Invalid conversation response:",
+                  data
+                );
+                return;
+              }
+            } catch (err) {
+              log("[onMessageExternal] Error creating conversation:", err);
+              return;
+            }
+          }
+
           chrome.storage.local.get(
             ["extensionReady", "selectedWorkspace"],
             ({ extensionReady, selectedWorkspace }) => {
@@ -126,7 +212,7 @@ chrome.runtime.onMessageExternal.addListener((request) => {
 
               const sendMessage = () => {
                 const params = JSON.stringify({
-                  conversationId: request.conversationId,
+                  conversationId,
                 });
                 void chrome.runtime.sendMessage({
                   type: "EXT_ROUTE_CHANGE",

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -94,14 +94,13 @@ chrome.contextMenus.onClicked.addListener(async (event, tab) => {
 /**
  * Listener for messages sent from external websites that are whitelisted on the manifest.
  * It allows to open the side panel and either navigate to an existing conversation
- * or create a new one with a pre-configured agent.
+ * or open a new one with a pre-selected agent.
  *
  * Accepted payloads:
  *   - { action: "openSidePanel", workspaceId, conversationId }
  *     Opens an existing conversation directly.
- *   - { action: "openSidePanel", workspaceId, agentId, spaceId? }
- *     Creates a new conversation with the given agent (and optional Pod space)
- *     server-side — bypassing browser CORS restrictions — then opens it.
+ *   - { action: "openSidePanel", workspaceId, agentId }
+ *     Opens a new conversation with the given agent pre-selected in the input bar.
  *
  * We return true to keep the message channel open for async response.
  */
@@ -131,77 +130,7 @@ chrome.runtime.onMessageExternal.addListener((request) => {
         .open({
           windowId: tabs[0].windowId,
         })
-        .then(async () => {
-          let conversationId: string = request.conversationId;
-
-          // If agentId is provided without a conversationId, create a new
-          // conversation server-side. The extension background script is not
-          // subject to CORS restrictions, so it can call the Dust API directly
-          // using the stored auth token.
-          if (!hasConversationId && hasAgentId) {
-            try {
-              const token = await platform.auth.getAccessToken();
-              const regionInfo =
-                await platform.auth.getRegionInfoFromStorage();
-
-              if (!token || !regionInfo) {
-                log(
-                  "[onMessageExternal] Missing auth token or region info."
-                );
-                return;
-              }
-
-              const body: Record<string, unknown> = {
-                title: null,
-                visibility: "unlisted",
-                message: null,
-                contentFragments: [],
-              };
-
-              if (
-                request.spaceId &&
-                typeof request.spaceId === "string"
-              ) {
-                body.spaceId = request.spaceId;
-              }
-
-              const res = await fetch(
-                `${regionInfo.url}/api/w/${request.workspaceId}/assistant/conversations`,
-                {
-                  method: "POST",
-                  headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${token}`,
-                  },
-                  credentials: "omit",
-                  body: JSON.stringify(body),
-                }
-              );
-
-              if (!res.ok) {
-                log(
-                  "[onMessageExternal] Failed to create conversation:",
-                  res.status
-                );
-                return;
-              }
-
-              const data = await res.json();
-              conversationId = data.conversation?.sId;
-
-              if (!conversationId) {
-                log(
-                  "[onMessageExternal] Invalid conversation response:",
-                  data
-                );
-                return;
-              }
-            } catch (err) {
-              log("[onMessageExternal] Error creating conversation:", err);
-              return;
-            }
-          }
-
+        .then(() => {
           chrome.storage.local.get(
             ["extensionReady", "selectedWorkspace"],
             ({ extensionReady, selectedWorkspace }) => {
@@ -211,9 +140,11 @@ chrome.runtime.onMessageExternal.addListener((request) => {
               }
 
               const sendMessage = () => {
-                const params = JSON.stringify({
-                  conversationId,
-                });
+                const params = JSON.stringify(
+                  hasConversationId
+                    ? { conversationId: request.conversationId }
+                    : { agentId: request.agentId }
+                );
                 void chrome.runtime.sendMessage({
                   type: "EXT_ROUTE_CHANGE",
                   pathname: "/run",

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -147,9 +147,7 @@ chrome.runtime.onMessageExternal.addListener((request) => {
 
               const sendMessage = () => {
                 const params = JSON.stringify(
-                  hasConversationId
-                    ? { conversationId }
-                    : { agentId }
+                  hasConversationId ? { conversationId } : { agentId }
                 );
                 void chrome.runtime.sendMessage({
                   type: "EXT_ROUTE_CHANGE",

--- a/extension/ui/pages/RunPage.tsx
+++ b/extension/ui/pages/RunPage.tsx
@@ -30,6 +30,15 @@ export const RunPage = () => {
         return;
       }
 
+      // When agentId is provided, navigate to a new conversation page with the
+      // agent pre-selected in the input bar via the ?agent= query param.
+      if (params.agentId && workspace) {
+        await navigate(
+          `/w/${workspace.sId}/conversation/new?agent=${params.agentId}`
+        );
+        return;
+      }
+
       const files = await fileUploaderService.uploadContentTab({
         includeContent: params.includeContent,
         includeCapture: params.includeCapture,


### PR DESCRIPTION
## Description

Extends `onMessageExternal` in the Chrome extension to accept an `agentId` in addition to the existing `conversationId`, so external pages (e.g. Salesforce VisualForce) can open a fresh conversation with a specific agent pre-selected — without any server-side API call.

**Context:** Alan (enterprise customer) embeds the Dust extension in Salesforce via a "Ask Copilot" button. They need to open a fresh conversation with a specific agent directly from Salesforce. The client-side approach (creating the conversation via `fetch`) is blocked by CORS.

**Approach (per @matteo's suggestion):** route to `/w/{wId}/conversation/new?agent={agentId}`. The existing `AgentQueryParamHandler` in `ExtensionInputBarProvider` reads the `?agent=` param and pre-selects the agent in the input bar. No API call needed.

### New payload

```js
// Existing — unchanged
chrome.runtime.sendMessage(EXTENSION_ID, {
  action: "openSidePanel",
  workspaceId: "...",
  conversationId: "...",
});

// New
chrome.runtime.sendMessage(EXTENSION_ID, {
  action: "openSidePanel",
  workspaceId: "...",
  agentId: "...",  // sId of the agent configuration
});
```

### Changes

- **`background.ts`**: validate `onMessageExternal` params with a Zod schema (GEN13); accept `agentId` OR `conversationId`; pass `{ agentId }` in the `EXT_ROUTE_CHANGE` params when `conversationId` is absent.
- **`RunPage.tsx`**: when `params.agentId` is present, navigate to `/w/${workspace.sId}/conversation/new?agent=${params.agentId}`.

## Tests

Build locally, load unpacked, then from `https://dust.tt` DevTools console:

```js
chrome.runtime.sendMessage(
  "fnkfcndbgingjcbdhaofkcnhcjpljhdn",
  { action: "openSidePanel", workspaceId: "<wId>", agentId: "<agentSId>" },
  r => console.log(r)
)
```

Verify the extension opens on an empty conversation with the agent pre-selected in the input bar.

## Risk

Low. Additive and backward compatible — existing `conversationId` payloads are unchanged. No manifest changes, no API calls.

## Deploy Plan

Standard extension release (Chrome Web Store submission after merge).
