### PR TITLE
Pricing: cap per group 2: Always consider max group cap when computing effective cap

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -737,6 +737,7 @@ export async function fetchRemainingCapCreditsPercentageForUser({
   userId,
   seatType,
   poolCapOverrideAwuCredits,
+  groupCapAwuCredits,
   defaultPoolCapAwuCredits,
 }: {
   metronomeCustomerId: string | null;
@@ -744,6 +745,9 @@ export async function fetchRemainingCapCreditsPercentageForUser({
   userId: string;
   seatType: MembershipSeatType | null | undefined;
   poolCapOverrideAwuCredits: number | null;
+  // Max group cap (pool-only, excluding seat allowance) across the user's
+  // groups; null when none carry a cap.
+  groupCapAwuCredits: number | null;
   defaultPoolCapAwuCredits: number;
 }): Promise<number | null> {
   const contract = metronomeCustomerId
@@ -787,8 +791,16 @@ export async function fetchRemainingCapCreditsPercentageForUser({
           : 0)
       : null;
 
+  // Max group cap (pool-only) + seat allowance, matching override/default units.
+  // Only pool-bearing seats get a group cap.
+  const groupCapTotalAwuCredits =
+    groupCapAwuCredits !== null && normalizedSeatType !== null
+      ? groupCapAwuCredits + (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
+      : null;
+
   const spendLimitAwuCredits = resolveEffectiveSpendLimitAwuCredits({
     overrideAwuCredits,
+    groupCapAwuCredits: groupCapTotalAwuCredits,
     defaultAwuCredits,
   });
 
@@ -866,11 +878,16 @@ export async function getMemberUsage({
     return { member: null };
   }
 
-  const groupNamesByUserModelId =
-    await GroupResource.listGroupNamesByUserModelIdInWorkspace({
+  const [groupNamesByUserModelId, groupCapByUserModelId] = await Promise.all([
+    GroupResource.listGroupNamesByUserModelIdInWorkspace({
       workspace,
       userModelIds: [userResource.id],
-    });
+    }),
+    GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+      workspace,
+      userModelIds: [userResource.id],
+    }),
+  ]);
 
   const metronomeUserId =
     membership.seatType === "free" ? toFreeMetronomeUserId(userId) : userId;
@@ -935,8 +952,19 @@ export async function getMemberUsage({
   const effectiveDefaultAwuCredits =
     membership.seatType === "free" ? effectiveAllocationAwu : defaultAwuCredits;
 
+  // Max group cap (pool-only) + seat allowance, matching override/default units.
+  // Only pool-bearing seats (pro/max/workspace) get a group cap.
+  const groupPoolCapAwuCredits =
+    groupCapByUserModelId.get(userResource.id) ?? null;
+  const groupCapAwuCredits =
+    groupPoolCapAwuCredits !== null && normalizedSeatType !== null
+      ? groupPoolCapAwuCredits +
+        (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
+      : null;
+
   const spendLimitSource = resolveEffectiveSpendLimitSource({
     overrideAwuCredits,
+    groupCapAwuCredits,
     defaultAwuCredits: effectiveDefaultAwuCredits,
   });
 
@@ -962,6 +990,7 @@ export async function getMemberUsage({
       scheduledSeatChangeAt: null,
       spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
         overrideAwuCredits,
+        groupCapAwuCredits,
         defaultAwuCredits: effectiveDefaultAwuCredits,
       }),
       spendLimitSource,
@@ -1248,6 +1277,7 @@ export async function getMembersUsage({
     perUserSpendLimits,
     freeCreditAlertIdsByUserId,
     groupNamesByUserModelId,
+    groupCapByUserModelId,
   ] = await Promise.all([
     fetchConsumedAwuCreditsByUserId({
       workspace,
@@ -1296,6 +1326,10 @@ export async function getMembersUsage({
       workspace,
       userModelIds: users.map((u) => u.id),
       groupKinds: ["provisioned"],
+    }),
+    GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+      workspace,
+      userModelIds: users.map((u) => u.id),
     }),
   ]);
   const freeCreditAlertIds =
@@ -1394,8 +1428,19 @@ export async function getMembersUsage({
         ? effectiveAllocationAwu
         : defaultAwuCredits;
 
+    // Max group cap (pool-only, stored on the group) + seat allowance, to match
+    // the units of override/default above. Only pool-bearing seats
+    // (pro/max/workspace) get a group cap; free/none have no pool.
+    const groupPoolCapAwuCredits = groupCapByUserModelId.get(u.id) ?? null;
+    const groupCapAwuCredits =
+      groupPoolCapAwuCredits !== null && normalizedSeatType !== null
+        ? groupPoolCapAwuCredits +
+          (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
+        : null;
+
     const spendLimitSource = resolveEffectiveSpendLimitSource({
       overrideAwuCredits,
+      groupCapAwuCredits,
       defaultAwuCredits: effectiveDefaultAwuCredits,
     });
     const effectiveCapAlert =
@@ -1448,6 +1493,7 @@ export async function getMembersUsage({
         scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
         spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
           overrideAwuCredits,
+          groupCapAwuCredits,
           defaultAwuCredits: effectiveDefaultAwuCredits,
         }),
         spendLimitSource,

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -20,35 +20,41 @@ import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_s
 import { transitionWorkspaceCreditState } from "@app/lib/metronome/workspace_credit_state_machine";
 import { notifyAdminsProgrammaticCapReached } from "@app/lib/notifications/workflows/programmatic-cap-reached";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { resolveEffectiveSpendLimitAwuCredits } from "@app/lib/spend_limits/effective";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
-
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
 
 /**
  * Resolve the effective pool credit limit for a user.
  *
- * Priority: per-user override > workspace default. When nothing is configured,
- * defaults to 0 (no pool access). Unlimited pool is not supported.
+ * Priority: per-user override > max group cap > workspace default. When nothing
+ * is configured, defaults to 0 (no pool access). Unlimited pool is not
+ * supported. All values are pool-only (excluding seat allowance).
  *
  * Returns `number`: the pool credit limit (0 = no pool access).
  */
-async function resolvePoolLimitForUser({
+function resolvePoolLimitForUser({
   workspace,
   membership,
+  groupCapAwuCredits,
   defaultPoolCapAwuCredits,
 }: {
   workspace: WorkspaceResource;
   membership: MembershipResource;
+  groupCapAwuCredits: number | null;
   defaultPoolCapAwuCredits: number;
-}): Promise<number> {
+}): number {
   if (!workspace.metronomeCustomerId) {
     return 0;
   }
@@ -57,13 +63,33 @@ async function resolvePoolLimitForUser({
   if (membership.seatType === "free" || membership.seatType === "none") {
     return 0;
   }
-  // Per-user override takes precedence over the workspace default.
-  if (membership.poolCapOverrideAwuCredits !== null) {
-    return membership.poolCapOverrideAwuCredits;
-  }
-  // All remaining seat types (pro/max/workspace) have pool access governed by
-  // the workspace default (0 = no pool if not configured).
-  return defaultPoolCapAwuCredits;
+  // Remaining seat types (pro/max/workspace) have pool access following the
+  // shared ladder: per-user override > max group cap > workspace default.
+  return (
+    resolveEffectiveSpendLimitAwuCredits({
+      overrideAwuCredits: membership.poolCapOverrideAwuCredits,
+      groupCapAwuCredits,
+      defaultAwuCredits: defaultPoolCapAwuCredits,
+    }) ?? defaultPoolCapAwuCredits
+  );
+}
+
+// Max group cap (pool-only, excluding seat allowance) across a single user's
+// groups; null when none carry a cap. Fed into the effective-cap resolution so
+// group caps rank between the per-user override and the workspace default.
+async function fetchMaxGroupPoolCapForUser({
+  workspace,
+  userModelId,
+}: {
+  workspace: LightWorkspaceType;
+  userModelId: ModelId;
+}): Promise<number | null> {
+  const caps =
+    await GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+      workspace,
+      userModelIds: [userModelId],
+    });
+  return caps.get(userModelId) ?? null;
 }
 
 /**
@@ -111,9 +137,18 @@ export async function dispatchSeatBalanceExhausted({
   const defaultPoolCapAwuCredits =
     creditUsageConfig?.defaultPoolCapAwuCredits ?? 0;
 
-  const poolLimitAwuCredits = await resolvePoolLimitForUser({
+  // Max group cap (pool-only) across the user's groups; null when none carry a
+  // cap. Resolved once and fed to both the pool-limit and remaining-% helpers so
+  // they agree on the effective cap.
+  const groupCapAwuCredits = await fetchMaxGroupPoolCapForUser({
+    workspace: lightWorkspace,
+    userModelId: user.id,
+  });
+
+  const poolLimitAwuCredits = resolvePoolLimitForUser({
     workspace,
     membership,
+    groupCapAwuCredits,
     defaultPoolCapAwuCredits,
   });
   const remainingCapCreditsPercentage =
@@ -123,6 +158,7 @@ export async function dispatchSeatBalanceExhausted({
       userId,
       seatType: membership.seatType,
       poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+      groupCapAwuCredits,
       defaultPoolCapAwuCredits,
     });
 
@@ -208,6 +244,10 @@ export async function dispatchSeatBalanceResolved({
     userId,
     seatType: membership.seatType,
     poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    groupCapAwuCredits: await fetchMaxGroupPoolCapForUser({
+      workspace: lightWorkspace,
+      userModelId: membership.userId,
+    }),
   });
 
   const result = await transitionUserCreditState(
@@ -326,6 +366,10 @@ export async function dispatchPerUserCapResolved({
     userId,
     seatType: membership.seatType,
     poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    groupCapAwuCredits: await fetchMaxGroupPoolCapForUser({
+      workspace: lightWorkspace,
+      userModelId: membership.userId,
+    }),
   });
 
   const result = await transitionUserCreditState(
@@ -353,11 +397,13 @@ async function resolveLiveUserBalance({
   userId,
   seatType,
   poolCapOverrideAwuCredits,
+  groupCapAwuCredits,
 }: {
   workspace: WorkspaceResource;
   userId: string;
   seatType: MembershipSeatType | null;
   poolCapOverrideAwuCredits: number | null;
+  groupCapAwuCredits: number | null;
 }): Promise<LiveUserSeatBalance | undefined> {
   const { metronomeCustomerId } = workspace;
   if (!metronomeCustomerId) {
@@ -379,6 +425,7 @@ async function resolveLiveUserBalance({
     userId,
     seatType,
     poolCapOverrideAwuCredits,
+    groupCapAwuCredits,
     defaultPoolCapAwuCredits: creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
     metronomeCustomerId,
     metronomeContractId,

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -82,11 +82,16 @@ import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
 import { notifyUserAwuCapReached } from "@app/lib/notifications/workflows/user-awu-cap-reached";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import {
+  resolveEffectiveSpendLimitAwuCredits,
+  resolveEffectiveSpendLimitSource,
+} from "@app/lib/spend_limits/effective";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { launchReconcileWorkspaceUserCreditStatesWorkflow } from "@app/temporal/metronome_events_queue/client";
@@ -625,12 +630,29 @@ async function handlePerUserSpendThresholdEvent({
     await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
       workspace.id
     );
+  // Max group cap (pool-only) across the user's groups; null when none carry a
+  // cap. Priority: per-user override > max group cap > workspace default (shared
+  // ladder).
+  const groupCapAwuCredits =
+    (
+      await GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+        workspace: lightWorkspace,
+        userModelIds: [membership.userId],
+      })
+    ).get(membership.userId) ?? null;
+  const defaultPoolCapAwuCredits =
+    creditUsageConfig?.defaultPoolCapAwuCredits ?? 0;
   const poolCap =
-    membership.poolCapOverrideAwuCredits ??
-    creditUsageConfig?.defaultPoolCapAwuCredits ??
-    0;
-  const capSource =
-    membership.poolCapOverrideAwuCredits !== null ? "override" : "default";
+    resolveEffectiveSpendLimitAwuCredits({
+      overrideAwuCredits: membership.poolCapOverrideAwuCredits,
+      groupCapAwuCredits,
+      defaultAwuCredits: defaultPoolCapAwuCredits,
+    }) ?? defaultPoolCapAwuCredits;
+  const capSource = resolveEffectiveSpendLimitSource({
+    overrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    groupCapAwuCredits,
+    defaultAwuCredits: defaultPoolCapAwuCredits,
+  });
 
   let seatAllowance = 0;
   try {

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -35,10 +35,12 @@ import {
 } from "@app/lib/metronome/workspace_credit_state_machine";
 import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { resolveEffectiveSpendLimitAwuCredits } from "@app/lib/spend_limits/effective";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type {
@@ -114,7 +116,7 @@ type UserReconcileReport = {
   seatBalanceAwu: number | null;
   seatStartingBalanceAwu: number | null;
   effectiveCapAwuCredits: number | null;
-  capSource: "override" | "default" | "none";
+  capSource: "override" | "group" | "default" | "none";
   consumedAwuCredits: number | null;
 };
 
@@ -394,6 +396,14 @@ export async function reconcileUser({
   const creditUsageConfig =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
 
+  const groupCapAwuCredits =
+    (
+      await GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+        workspace: lightWorkspace,
+        userModelIds: [membership.userId],
+      })
+    ).get(membership.userId) ?? null;
+
   const liveResult = await fetchLiveUserCreditInputs({
     workspaceId: workspace.sId,
     userId,
@@ -401,6 +411,7 @@ export async function reconcileUser({
     // Pool-only values persisted in the DB; the live-inputs helper adds the
     // seat allowance back to get the total threshold.
     poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    groupCapAwuCredits,
     defaultPoolCapAwuCredits: creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
     metronomeCustomerId,
     metronomeContractId,
@@ -567,6 +578,14 @@ export async function reconcileWorkspaceUserCreditStates({
   }
   const usageByUser = usageResult.value;
 
+  // Max group cap (pool-only) per member, fetched once to avoid an N+1. Users
+  // with no capped group are absent (they fall back to the workspace default).
+  const groupCapByUserModelId =
+    await GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+      workspace,
+      userModelIds: memberships.map((m) => m.userId),
+    });
+
   // One UPDATE per drifting membership. Bounded by the workspace's seat count
   // and gated on the `continue` above, so steady-state writes are ~zero; even
   // the worst case (every seat drifting) is a small, infrequent loop on a
@@ -583,9 +602,18 @@ export async function reconcileWorkspaceUserCreditStates({
     // Cap + usage only apply to pool-limit seat types (pro/max/workspace),
     // matching fetchLiveUserCreditInputs. Free/none seats have no pool access —
     // their effective cap is null and near-limit uses the seat-balance path.
+    // Priority: per-user override > max group cap > workspace default (shared
+    // ladder).
+    const groupCapAwuCredits =
+      groupCapByUserModelId.get(membership.userId) ?? null;
+    const poolCapAwuCredits =
+      resolveEffectiveSpendLimitAwuCredits({
+        overrideAwuCredits: membership.poolCapOverrideAwuCredits,
+        groupCapAwuCredits,
+        defaultAwuCredits: defaultPoolCapAwuCredits,
+      }) ?? defaultPoolCapAwuCredits;
     const effectiveCapAwuCredits = normalizedSeatType
-      ? (membership.poolCapOverrideAwuCredits ?? defaultPoolCapAwuCredits) +
-        (seatAllowances[normalizedSeatType] ?? 0)
+      ? poolCapAwuCredits + (seatAllowances[normalizedSeatType] ?? 0)
       : null;
     // Seat balance comes from `listMetronomeSeatBalances` for pro/max; free
     // seats read their per-user credit balance instead (not a seat balance).

--- a/front/lib/metronome/live_user_credit_inputs.test.ts
+++ b/front/lib/metronome/live_user_credit_inputs.test.ts
@@ -62,6 +62,7 @@ describe("fetchLiveUserCreditInputs", () => {
       userId: USER_ID,
       seatType: "max",
       poolCapOverrideAwuCredits: null,
+      groupCapAwuCredits: null,
       defaultPoolCapAwuCredits: 0,
       metronomeCustomerId: CUSTOMER_ID,
       metronomeContractId: CONTRACT_ID,
@@ -94,6 +95,7 @@ describe("fetchLiveUserCreditInputs", () => {
       // Pool-only override from the membership; no contract resolves for
       // "ws_test" so the seat allowance is 0 and the total cap equals it.
       poolCapOverrideAwuCredits: 50000,
+      groupCapAwuCredits: null,
       defaultPoolCapAwuCredits: 0,
       metronomeCustomerId: CUSTOMER_ID,
       metronomeContractId: CONTRACT_ID,
@@ -108,6 +110,55 @@ describe("fetchLiveUserCreditInputs", () => {
     }
   });
 
+  it("uses the group cap when there is no override, ranking above the default", async () => {
+    mockListMetronomeSeatBalances.mockResolvedValue(
+      new Ok(seatBalance(0, 40000))
+    );
+
+    const result = await fetchLiveUserCreditInputs({
+      workspaceId: "ws_test",
+      userId: USER_ID,
+      seatType: "max",
+      poolCapOverrideAwuCredits: null,
+      // No override → the group cap wins over the workspace default. No contract
+      // resolves for "ws_test" so the seat allowance is 0 and the total cap
+      // equals the group cap.
+      groupCapAwuCredits: 30000,
+      defaultPoolCapAwuCredits: 10000,
+      metronomeCustomerId: CUSTOMER_ID,
+      metronomeContractId: CONTRACT_ID,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.effectiveCapAwuCredits).toBe(30000);
+      expect(result.value.capSource).toBe("group");
+    }
+  });
+
+  it("prefers the per-user override over the group cap", async () => {
+    mockListMetronomeSeatBalances.mockResolvedValue(
+      new Ok(seatBalance(0, 40000))
+    );
+
+    const result = await fetchLiveUserCreditInputs({
+      workspaceId: "ws_test",
+      userId: USER_ID,
+      seatType: "max",
+      poolCapOverrideAwuCredits: 50000,
+      groupCapAwuCredits: 30000,
+      defaultPoolCapAwuCredits: 10000,
+      metronomeCustomerId: CUSTOMER_ID,
+      metronomeContractId: CONTRACT_ID,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.effectiveCapAwuCredits).toBe(50000);
+      expect(result.value.capSource).toBe("override");
+    }
+  });
+
   it("surfaces an Err when the live seat-balance read fails", async () => {
     mockListMetronomeSeatBalances.mockResolvedValue(
       new Err(new Error("metronome down"))
@@ -118,6 +169,7 @@ describe("fetchLiveUserCreditInputs", () => {
       userId: USER_ID,
       seatType: "max",
       poolCapOverrideAwuCredits: null,
+      groupCapAwuCredits: null,
       defaultPoolCapAwuCredits: 0,
       metronomeCustomerId: CUSTOMER_ID,
       metronomeContractId: CONTRACT_ID,

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -21,6 +21,10 @@ import {
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import type { MetronomeSeatBalance } from "@app/lib/metronome/types";
+import {
+  resolveEffectiveSpendLimitAwuCredits,
+  resolveEffectiveSpendLimitSource,
+} from "@app/lib/spend_limits/effective";
 import type { MembershipSeatType } from "@app/types/memberships";
 import {
   isSeatBased,
@@ -54,7 +58,7 @@ export type LiveUserCreditInputs = {
   // Effective per-user cap = poolCap + seatAllowance. Null for seat types with
   // no pool access (free, none).
   effectiveCapAwuCredits: number | null;
-  capSource: "override" | "default" | "none";
+  capSource: "override" | "group" | "default" | "none";
   consumedAwuCredits: number | null;
 };
 
@@ -80,6 +84,7 @@ export async function fetchLiveUserCreditInputs({
   userId,
   seatType,
   poolCapOverrideAwuCredits,
+  groupCapAwuCredits,
   defaultPoolCapAwuCredits,
   metronomeCustomerId,
   metronomeContractId,
@@ -88,6 +93,9 @@ export async function fetchLiveUserCreditInputs({
   userId: string;
   seatType: MembershipSeatType | null;
   poolCapOverrideAwuCredits: number | null;
+  // Max group cap (pool-only, excluding seat allowance) across the user's
+  // groups; null when none carry a cap.
+  groupCapAwuCredits: number | null;
   defaultPoolCapAwuCredits: number;
   metronomeCustomerId: string;
   metronomeContractId: string | null;
@@ -142,9 +150,20 @@ export async function fetchLiveUserCreditInputs({
   let consumedAwuCredits: number | null = null;
 
   if (normalizedSeatType) {
+    // Priority: per-user override > max group cap > workspace default (shared
+    // ladder). The `?? defaultPoolCapAwuCredits` is unreachable — the default is
+    // always a number here — but keeps the type non-null for the arithmetic.
     const poolCapAwuCredits =
-      poolCapOverrideAwuCredits ?? defaultPoolCapAwuCredits;
-    capSource = poolCapOverrideAwuCredits !== null ? "override" : "default";
+      resolveEffectiveSpendLimitAwuCredits({
+        overrideAwuCredits: poolCapOverrideAwuCredits,
+        groupCapAwuCredits,
+        defaultAwuCredits: defaultPoolCapAwuCredits,
+      }) ?? defaultPoolCapAwuCredits;
+    capSource = resolveEffectiveSpendLimitSource({
+      overrideAwuCredits: poolCapOverrideAwuCredits,
+      groupCapAwuCredits,
+      defaultAwuCredits: defaultPoolCapAwuCredits,
+    });
 
     let seatAllowance = 0;
     try {

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -657,6 +657,54 @@ describe("GroupResource", () => {
     });
   });
 
+  describe("listMaxPoolCapAwuCreditsByUserModelIdInWorkspace", () => {
+    it("returns the highest cap across a user's groups, ignoring uncapped groups and users", async () => {
+      const user2 = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user2, { role: "user" });
+
+      const capped500 = await GroupResource.makeNew({
+        name: "Capped 500",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await capped500.updatePoolCap(authenticator, 500);
+      await capped500.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      const capped800 = await GroupResource.makeNew({
+        name: "Capped 800",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await capped800.updatePoolCap(authenticator, 800);
+      await capped800.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      // Uncapped group: user2 belongs only here, so they have no group cap.
+      const uncapped = await GroupResource.makeNew({
+        name: "Uncapped",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await uncapped.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON(), user2.toJSON()],
+      });
+
+      const result =
+        await GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+          workspace,
+          userModelIds: [user.id, user2.id],
+        });
+
+      // user is in both capped groups → the highest cap wins.
+      expect(result.get(user.id)).toBe(800);
+      // user2 is only in an uncapped group → absent (falls back to default).
+      expect(result.has(user2.id)).toBe(false);
+    });
+  });
+
   describe("listWorkspaceGroupsFromKey", () => {
     it("system key: populates cache on first call and serves from cache on second", async () => {
       const key = await KeyFactory.system(systemGroup);

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -658,39 +658,55 @@ describe("GroupResource", () => {
   });
 
   describe("listMaxPoolCapAwuCreditsByUserModelIdInWorkspace", () => {
-    it("returns the highest cap across a user's groups, ignoring uncapped groups and users", async () => {
+    it("returns the highest cap across a user's provisioned groups, ignoring uncapped and non-provisioned groups", async () => {
       const user2 = await UserFactory.basic();
       await MembershipFactory.associate(workspace, user2, { role: "user" });
 
-      const capped500 = await GroupResource.makeNew({
-        name: "Capped 500",
-        workspaceId: workspace.id,
-        kind: "regular",
-      });
+      // Provisioned groups are synced from WorkOS; members are seeded directly.
+      const capped500 = await GroupResource.makeNew(
+        {
+          name: "Capped 500",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-capped-500",
+        },
+        { memberIds: [user.id] }
+      );
       await capped500.updatePoolCap(authenticator, 500);
-      await capped500.dangerouslyAddMembers(authenticator, {
-        users: [user.toJSON()],
-      });
 
-      const capped800 = await GroupResource.makeNew({
-        name: "Capped 800",
-        workspaceId: workspace.id,
-        kind: "regular",
-      });
+      const capped800 = await GroupResource.makeNew(
+        {
+          name: "Capped 800",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-capped-800",
+        },
+        { memberIds: [user.id] }
+      );
       await capped800.updatePoolCap(authenticator, 800);
-      await capped800.dangerouslyAddMembers(authenticator, {
-        users: [user.toJSON()],
-      });
 
       // Uncapped group: user2 belongs only here, so they have no group cap.
-      const uncapped = await GroupResource.makeNew({
-        name: "Uncapped",
-        workspaceId: workspace.id,
-        kind: "regular",
-      });
-      await uncapped.dangerouslyAddMembers(authenticator, {
-        users: [user.toJSON(), user2.toJSON()],
-      });
+      await GroupResource.makeNew(
+        {
+          name: "Uncapped",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-uncapped",
+        },
+        { memberIds: [user.id, user2.id] }
+      );
+
+      // Regular (Space-backed) groups are not cap-eligible: even with a higher
+      // cap, they must not contribute to any member's group cap.
+      const regularGroup = await GroupResource.makeNew(
+        {
+          name: "Regular capped",
+          workspaceId: workspace.id,
+          kind: "regular",
+        },
+        { memberIds: [user.id, user2.id] }
+      );
+      await regularGroup.updatePoolCap(authenticator, 10_000);
 
       const result =
         await GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
@@ -698,9 +714,11 @@ describe("GroupResource", () => {
           userModelIds: [user.id, user2.id],
         });
 
-      // user is in both capped groups → the highest cap wins.
+      // user is in both capped provisioned groups → the highest cap wins; the
+      // regular group's higher cap is ignored.
       expect(result.get(user.id)).toBe(800);
-      // user2 is only in an uncapped group → absent (falls back to default).
+      // user2 is only in uncapped/non-eligible groups → absent (falls back to
+      // the workspace default).
       expect(result.has(user2.id)).toBe(false);
     });
   });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1246,17 +1246,16 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   // For each user, the highest per-group pool cap (excluding seat allowance)
-  // among the cap-eligible groups they belong to. Users with no capped group are
-  // absent from the map (the caller falls back to the workspace default). Used to
-  // resolve the "max(group caps)" term of a user's effective spend limit.
+  // among the cap-eligible (provisioned) groups they belong to. Users with no
+  // capped group are absent from the map (the caller falls back to the workspace
+  // default). Used to resolve the "max(group caps)" term of a user's effective
+  // spend limit.
   static async listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
     workspace,
     userModelIds,
-    groupKinds = [...CAP_ELIGIBLE_GROUP_KINDS],
   }: {
     workspace: LightWorkspaceType;
     userModelIds: ModelId[];
-    groupKinds?: Exclude<GroupKind, "system">[];
   }): Promise<Map<ModelId, number>> {
     const result = new Map<ModelId, number>();
     if (userModelIds.length === 0) {
@@ -1282,7 +1281,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       where: {
         id: groupModelIds,
         workspaceId: workspace.id,
-        kind: groupKinds,
+        kind: [...CAP_ELIGIBLE_GROUP_KINDS],
         poolCapAwuCredits: { [Op.ne]: null },
       },
     });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -28,6 +28,7 @@ import type {
 import type { GroupKind, GroupType } from "@app/types/groups";
 import {
   AGENT_GROUP_PREFIX,
+  CAP_ELIGIBLE_GROUP_KINDS,
   GROUP_KINDS,
   isAgentEditorGroupKind,
   isSkillEditorGroupKind,
@@ -1239,6 +1240,65 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     for (const names of result.values()) {
       names.sort((a, b) => a.localeCompare(b));
+    }
+
+    return result;
+  }
+
+  // For each user, the highest per-group pool cap (excluding seat allowance)
+  // among the cap-eligible groups they belong to. Users with no capped group are
+  // absent from the map (the caller falls back to the workspace default). Used to
+  // resolve the "max(group caps)" term of a user's effective spend limit.
+  static async listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+    workspace,
+    userModelIds,
+    groupKinds = [...CAP_ELIGIBLE_GROUP_KINDS],
+  }: {
+    workspace: LightWorkspaceType;
+    userModelIds: ModelId[];
+    groupKinds?: Exclude<GroupKind, "system">[];
+  }): Promise<Map<ModelId, number>> {
+    const result = new Map<ModelId, number>();
+    if (userModelIds.length === 0) {
+      return result;
+    }
+
+    const now = new Date();
+    const memberships = await GroupMembershipModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        userId: userModelIds,
+        status: "active",
+        startAt: { [Op.lte]: now },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+      },
+    });
+    if (memberships.length === 0) {
+      return result;
+    }
+
+    const groupModelIds = [...new Set(memberships.map((m) => m.groupId))];
+    const groups = await GroupModel.findAll({
+      where: {
+        id: groupModelIds,
+        workspaceId: workspace.id,
+        kind: groupKinds,
+        poolCapAwuCredits: { [Op.ne]: null },
+      },
+    });
+    const capByGroupId = new Map(
+      groups.map((g) => [g.id, g.poolCapAwuCredits])
+    );
+
+    for (const m of memberships) {
+      const cap = capByGroupId.get(m.groupId);
+      if (cap === undefined || cap === null) {
+        continue;
+      }
+      const existing = result.get(m.userId);
+      if (existing === undefined || cap > existing) {
+        result.set(m.userId, cap);
+      }
     }
 
     return result;

--- a/front/lib/spend_limits/effective.test.ts
+++ b/front/lib/spend_limits/effective.test.ts
@@ -1,0 +1,89 @@
+import {
+  resolveEffectiveSpendLimitAwuCredits,
+  resolveEffectiveSpendLimitSource,
+} from "@app/lib/spend_limits/effective";
+import { describe, expect, it } from "vitest";
+
+describe("resolveEffectiveSpendLimitAwuCredits", () => {
+  it("prefers the override, then the group cap, then the default", () => {
+    expect(
+      resolveEffectiveSpendLimitAwuCredits({
+        overrideAwuCredits: 100,
+        groupCapAwuCredits: 200,
+        defaultAwuCredits: 300,
+      })
+    ).toBe(100);
+
+    expect(
+      resolveEffectiveSpendLimitAwuCredits({
+        overrideAwuCredits: null,
+        groupCapAwuCredits: 200,
+        defaultAwuCredits: 300,
+      })
+    ).toBe(200);
+
+    expect(
+      resolveEffectiveSpendLimitAwuCredits({
+        overrideAwuCredits: null,
+        groupCapAwuCredits: null,
+        defaultAwuCredits: 300,
+      })
+    ).toBe(300);
+  });
+
+  it("returns null when nothing is configured", () => {
+    expect(
+      resolveEffectiveSpendLimitAwuCredits({
+        overrideAwuCredits: null,
+        groupCapAwuCredits: null,
+        defaultAwuCredits: null,
+      })
+    ).toBeNull();
+  });
+
+  it("treats a 0 group cap as a real cap, not as unset", () => {
+    expect(
+      resolveEffectiveSpendLimitAwuCredits({
+        overrideAwuCredits: null,
+        groupCapAwuCredits: 0,
+        defaultAwuCredits: 300,
+      })
+    ).toBe(0);
+  });
+});
+
+describe("resolveEffectiveSpendLimitSource", () => {
+  it("reports the winning source following override > group > default > none", () => {
+    expect(
+      resolveEffectiveSpendLimitSource({
+        overrideAwuCredits: 100,
+        groupCapAwuCredits: 200,
+        defaultAwuCredits: 300,
+      })
+    ).toBe("override");
+
+    expect(
+      resolveEffectiveSpendLimitSource({
+        overrideAwuCredits: null,
+        groupCapAwuCredits: 200,
+        defaultAwuCredits: 300,
+      })
+    ).toBe("group");
+
+    expect(
+      resolveEffectiveSpendLimitSource({
+        overrideAwuCredits: null,
+        groupCapAwuCredits: null,
+        defaultAwuCredits: 300,
+      })
+    ).toBe("default");
+
+    expect(
+      resolveEffectiveSpendLimitSource({
+        overrideAwuCredits: null,
+        groupCapAwuCredits: null,
+        defaultAwuCredits: null,
+      })
+    ).toBe("none");
+  });
+});

--- a/front/lib/spend_limits/effective.ts
+++ b/front/lib/spend_limits/effective.ts
@@ -1,33 +1,52 @@
 import type { CustomerAlert } from "@metronome/sdk/resources/v1/customers";
 
-export type EffectiveSpendLimitSource = "override" | "default" | "none";
+export type EffectiveSpendLimitSource =
+  | "override"
+  | "group"
+  | "default"
+  | "none";
 
 export type SpendLimitAlertState = CustomerAlert["customer_status"];
 
+// Priority: per-user `override` > the highest of the user's `group` caps >
+// seat-type `default`. `groupCapAwuCredits` is the max cap across the groups the
+// user belongs to (null when none of them carry a cap). All three values must be
+// expressed in the same unit (all pool-only, or all pool + seat allowance).
 export function resolveEffectiveSpendLimitAwuCredits({
   overrideAwuCredits,
+  groupCapAwuCredits,
   defaultAwuCredits,
 }: {
   overrideAwuCredits: number | null;
+  groupCapAwuCredits: number | null;
   defaultAwuCredits: number | null;
 }): number | null {
   if (overrideAwuCredits !== null) {
     return overrideAwuCredits;
   }
+  if (groupCapAwuCredits !== null) {
+    return groupCapAwuCredits;
+  }
   return defaultAwuCredits;
 }
 
-// Where the effective spend limit comes from: a user-specific `override`, the
-// seat-type `default`, or `none` when neither is configured (unlimited).
+// Where the effective spend limit comes from: a user-specific `override`, a
+// `group` cap, the seat-type `default`, or `none` when nothing is configured
+// (unlimited).
 export function resolveEffectiveSpendLimitSource({
   overrideAwuCredits,
+  groupCapAwuCredits,
   defaultAwuCredits,
 }: {
   overrideAwuCredits: number | null;
+  groupCapAwuCredits: number | null;
   defaultAwuCredits: number | null;
 }): EffectiveSpendLimitSource {
   if (overrideAwuCredits !== null) {
     return "override";
+  }
+  if (groupCapAwuCredits !== null) {
+    return "group";
   }
   if (defaultAwuCredits !== null) {
     return "default";

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -37,10 +37,9 @@ export const GROUP_KINDS = [
 export type GroupKind = (typeof GROUP_KINDS)[number];
 
 // Group kinds that can carry a per-group usage spend limit and be surfaced in
-// the Usage > Groups admin table. Real user-facing groups only: "global" is the
-// whole workspace (that's the default), "system" is internal, and the
-// agent/skill/space editor groups are per-resource, not membership groups.
-export const CAP_ELIGIBLE_GROUP_KINDS = ["regular", "provisioned"] as const;
+// the Usage > Groups admin table. Only "provisioned" (SSO/SCIM directory)
+// groups.
+export const CAP_ELIGIBLE_GROUP_KINDS = ["provisioned"] as const;
 
 export function isGroupKind(value: unknown): value is GroupKind {
   return GROUP_KINDS.includes(value as GroupKind);

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -36,6 +36,12 @@ export const GROUP_KINDS = [
 ] as const;
 export type GroupKind = (typeof GROUP_KINDS)[number];
 
+// Group kinds that can carry a per-group usage spend limit and be surfaced in
+// the Usage > Groups admin table. Real user-facing groups only: "global" is the
+// whole workspace (that's the default), "system" is internal, and the
+// agent/skill/space editor groups are per-resource, not membership groups.
+export const CAP_ELIGIBLE_GROUP_KINDS = ["regular", "provisioned"] as const;
+
 export function isGroupKind(value: unknown): value is GroupKind {
   return GROUP_KINDS.includes(value as GroupKind);
 }


### PR DESCRIPTION
Related to https://github.com/dust-tt/tasks/issues/9339

## Description

Effective cap now account for the max group cap everywhere it is computed.
Note that there is no way to currently set the cap so far so nothing will change for now.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front
