### PR TITLE
feat(front): add per-message requested-model columns to agent messages

### DIFF
--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -459,12 +459,9 @@ export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
   declare prunedContext: boolean | null;
   declare costCredits: number | null;
 
-  // Per-message model override from the input-bar model picker. `requestedModelTier`
-  // records the abstract tier the user picked ("efficient" | "balanced" | "powerful",
-  // null for an explicit "advanced" pick or no pick); the provider/model/effort
-  // triplet is the concrete model that tier (or advanced pick) resolved to at
-  // send time. All null when the message runs the agent's configured model.
-  declare requestedModelTier: string | null;
+  // Per-message model override from the input-bar model picker: the concrete
+  // provider/model/effort triplet the user picked at send time. All null when
+  // the message runs the agent's configured model.
   declare requestedProviderId: string | null;
   declare requestedModelId: string | null;
   declare requestedReasoningEffort: string | null;
@@ -555,11 +552,6 @@ AgentMessageModel.init(
     },
     costCredits: {
       type: DataTypes.INTEGER,
-      allowNull: true,
-      defaultValue: null,
-    },
-    requestedModelTier: {
-      type: DataTypes.STRING,
       allowNull: true,
       defaultValue: null,
     },

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -460,7 +460,7 @@ export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
   declare costCredits: number | null;
 
   // Per-message model override from the input-bar model picker. `requestedModelTier`
-  // records the abstract tier the user picked ("fast" | "balanced" | "powerful",
+  // records the abstract tier the user picked ("efficient" | "balanced" | "powerful",
   // null for an explicit "advanced" pick or no pick); the provider/model/effort
   // triplet is the concrete model that tier (or advanced pick) resolved to at
   // send time. All null when the message runs the agent's configured model.

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -458,6 +458,16 @@ export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
   declare completedAt: Date | null;
   declare prunedContext: boolean | null;
   declare costCredits: number | null;
+
+  // Per-message model override from the input-bar model picker. `requestedModelTier`
+  // records the abstract tier the user picked ("fast" | "balanced" | "powerful",
+  // null for an explicit "advanced" pick or no pick); the provider/model/effort
+  // triplet is the concrete model that tier (or advanced pick) resolved to at
+  // send time. All null when the message runs the agent's configured model.
+  declare requestedModelTier: string | null;
+  declare requestedProviderId: string | null;
+  declare requestedModelId: string | null;
+  declare requestedReasoningEffort: string | null;
 }
 
 AgentMessageModel.init(
@@ -545,6 +555,26 @@ AgentMessageModel.init(
     },
     costCredits: {
       type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    requestedModelTier: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
+    requestedProviderId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
+    requestedModelId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
+    requestedReasoningEffort: {
+      type: DataTypes.STRING,
       allowNull: true,
       defaultValue: null,
     },

--- a/front/migrations/pre-deploy/20260701165547_add_requested_model_to_agent_message.sql
+++ b/front/migrations/pre-deploy/20260701165547_add_requested_model_to_agent_message.sql
@@ -1,0 +1,27 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_messages" ADD COLUMN "requestedModelTier" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_messages" ADD COLUMN "requestedProviderId" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_messages" ADD COLUMN "requestedModelId" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_messages" ADD COLUMN "requestedReasoningEffort" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;

--- a/front/migrations/pre-deploy/20260701165547_add_requested_model_to_agent_message.sql
+++ b/front/migrations/pre-deploy/20260701165547_add_requested_model_to_agent_message.sql
@@ -3,24 +3,17 @@ Statement 0
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."agent_messages" ADD COLUMN "requestedModelTier" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;
+ALTER TABLE "public"."agent_messages" ADD COLUMN "requestedProviderId" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;
 
 /*
 Statement 1
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."agent_messages" ADD COLUMN "requestedProviderId" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;
-
-/*
-Statement 2
-*/
-SET SESSION statement_timeout = 3000;
-SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."agent_messages" ADD COLUMN "requestedModelId" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;
 
 /*
-Statement 3
+Statement 2
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -327,7 +327,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   models_picker: {
     description:
-      "Model picker in the conversation input bar: pick a model tier (Fast, Balanced, Powerful, Frontier) or a specific model.",
+      "Model picker in the conversation input bar: pick a specific model.",
     stage: "dust_only",
   },
   activation_skill: {


### PR DESCRIPTION
## Description

First PR of a stack allowing to change the model + reasoning effort level at runtime for the messages. 
This uses a model picker in the input bar. 
We also lay the groundwork necessary to have different models picked according to the message.

In this PR, we add 3 columns to AgentMessageModel
- requestedProviderId
- requestedModelId
- requestedReasoningEffort

Why is this stored? 
- front display
- allow for "same model" retry
- auditability

Why store this triplet 
- modelId: pretty logical
- providerId : needed to differentiate providers of same models to not break EU-only inference, of providers of OS models. Cost might differ. Overall, the whole code disambiguates by provider&model
- reasoningEffort : cost might greatly differ depending on the reasoning effort

Other things we can potentially store
- a reason for override: model picker or auto mode later on. We'll see when we get to auto mode if that is needed.


## Tests

Schema-only change; covered by existing model/migration tooling. Migration applied locally.

## Risk

Low. Additive, nullable columns with a pre-deploy migration — no backfill, no read/write path yet,
trivially rollback-safe.

## Deploy Plan

Pre-deploy migration: must run before the code that reads/writes these columns (#28346) is live.
Standard expand pattern; columns are nullable so no backfill is required.
