### PR TITLE
feat(front): resolve per-message model override at send and apply at run

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -7701,7 +7701,7 @@
                           "tier": {
                             "type": "string",
                             "enum": [
-                              "fast",
+                              "efficient",
                               "balanced",
                               "powerful"
                             ]
@@ -10598,7 +10598,7 @@
                 "type": "string",
                 "nullable": true,
                 "enum": [
-                  "fast",
+                  "efficient",
                   "balanced",
                   "powerful"
                 ],

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -7680,6 +7680,60 @@
                   },
                   "skipToolsValidation": {
                     "type": "boolean"
+                  },
+                  "modelSelection": {
+                    "type": "object",
+                    "description": "Optional per-message model override from the input-bar model picker. Either a tier or an explicit model pick.",
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "tier"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "tier"
+                            ]
+                          },
+                          "tier": {
+                            "type": "string",
+                            "enum": [
+                              "fast",
+                              "balanced",
+                              "powerful"
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "providerId",
+                          "modelId"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "model"
+                            ]
+                          },
+                          "providerId": {
+                            "type": "string"
+                          },
+                          "modelId": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -10534,6 +10588,32 @@
             "type": "number",
             "nullable": true,
             "description": "Aggregated credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise."
+          },
+          "requestedModel": {
+            "type": "object",
+            "nullable": true,
+            "description": "Per-message model override from the input-bar model picker. Null when the agent ran its configured model.",
+            "properties": {
+              "tier": {
+                "type": "string",
+                "nullable": true,
+                "enum": [
+                  "fast",
+                  "balanced",
+                  "powerful"
+                ],
+                "description": "The abstract tier the user picked, or null for an explicit (\"advanced\") model pick."
+              },
+              "providerId": {
+                "type": "string"
+              },
+              "modelId": {
+                "type": "string"
+              },
+              "reasoningEffort": {
+                "type": "string"
+              }
+            }
           }
         }
       },

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -7685,17 +7685,10 @@
                     "type": "object",
                     "description": "Optional per-message model override from the input-bar model picker (an explicit model pick).",
                     "required": [
-                      "type",
                       "providerId",
                       "modelId"
                     ],
                     "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "model"
-                        ]
-                      },
                       "providerId": {
                         "type": "string"
                       },

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -7683,57 +7683,29 @@
                   },
                   "modelSelection": {
                     "type": "object",
-                    "description": "Optional per-message model override from the input-bar model picker. Either a tier or an explicit model pick.",
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "type",
-                          "tier"
-                        ],
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "enum": [
-                              "tier"
-                            ]
-                          },
-                          "tier": {
-                            "type": "string",
-                            "enum": [
-                              "efficient",
-                              "balanced",
-                              "powerful"
-                            ]
-                          }
-                        }
+                    "description": "Optional per-message model override from the input-bar model picker (an explicit model pick).",
+                    "required": [
+                      "type",
+                      "providerId",
+                      "modelId"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "model"
+                        ]
                       },
-                      {
-                        "type": "object",
-                        "required": [
-                          "type",
-                          "providerId",
-                          "modelId"
-                        ],
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "enum": [
-                              "model"
-                            ]
-                          },
-                          "providerId": {
-                            "type": "string"
-                          },
-                          "modelId": {
-                            "type": "string"
-                          },
-                          "reasoningEffort": {
-                            "type": "string"
-                          }
-                        }
+                      "providerId": {
+                        "type": "string"
+                      },
+                      "modelId": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string"
                       }
-                    ]
+                    }
                   }
                 }
               }
@@ -10594,16 +10566,6 @@
             "nullable": true,
             "description": "Per-message model override from the input-bar model picker. Null when the agent ran its configured model.",
             "properties": {
-              "tier": {
-                "type": "string",
-                "nullable": true,
-                "enum": [
-                  "efficient",
-                  "balanced",
-                  "powerful"
-                ],
-                "description": "The abstract tier the user picked, or null for an explicit (\"advanced\") model pick."
-              },
               "providerId": {
                 "type": "string"
               },

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -413,11 +413,6 @@
  *           nullable: true
  *           description: Per-message model override from the input-bar model picker. Null when the agent ran its configured model.
  *           properties:
- *             tier:
- *               type: string
- *               nullable: true
- *               enum: [efficient, balanced, powerful]
- *               description: The abstract tier the user picked, or null for an explicit ("advanced") model pick.
  *             providerId:
  *               type: string
  *             modelId:

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -408,6 +408,22 @@
  *           type: number
  *           nullable: true
  *           description: Aggregated credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise.
+ *         requestedModel:
+ *           type: object
+ *           nullable: true
+ *           description: Per-message model override from the input-bar model picker. Null when the agent ran its configured model.
+ *           properties:
+ *             tier:
+ *               type: string
+ *               nullable: true
+ *               enum: [fast, balanced, powerful]
+ *               description: The abstract tier the user picked, or null for an explicit ("advanced") model pick.
+ *             providerId:
+ *               type: string
+ *             modelId:
+ *               type: string
+ *             reasoningEffort:
+ *               type: string
  *     PrivateLightAgentMessage:
  *       type: object
  *       description: A lighter agent message used in paginated message list responses.

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -416,7 +416,7 @@
  *             tier:
  *               type: string
  *               nullable: true
- *               enum: [fast, balanced, powerful]
+ *               enum: [efficient, balanced, powerful]
  *               description: The abstract tier the user picked, or null for an explicit ("advanced") model pick.
  *             providerId:
  *               type: string

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -155,11 +155,8 @@ const app = workspaceApp();
  *               modelSelection:
  *                 type: object
  *                 description: Optional per-message model override from the input-bar model picker (an explicit model pick).
- *                 required: [type, providerId, modelId]
+ *                 required: [providerId, modelId]
  *                 properties:
- *                   type:
- *                     type: string
- *                     enum: [model]
  *                   providerId:
  *                     type: string
  *                   modelId:

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -154,29 +154,18 @@ const app = workspaceApp();
  *                 type: boolean
  *               modelSelection:
  *                 type: object
- *                 description: Optional per-message model override from the input-bar model picker. Either a tier or an explicit model pick.
- *                 oneOf:
- *                   - type: object
- *                     required: [type, tier]
- *                     properties:
- *                       type:
- *                         type: string
- *                         enum: [tier]
- *                       tier:
- *                         type: string
- *                         enum: [efficient, balanced, powerful]
- *                   - type: object
- *                     required: [type, providerId, modelId]
- *                     properties:
- *                       type:
- *                         type: string
- *                         enum: [model]
- *                       providerId:
- *                         type: string
- *                       modelId:
- *                         type: string
- *                       reasoningEffort:
- *                         type: string
+ *                 description: Optional per-message model override from the input-bar model picker (an explicit model pick).
+ *                 required: [type, providerId, modelId]
+ *                 properties:
+ *                   type:
+ *                     type: string
+ *                     enum: [model]
+ *                   providerId:
+ *                     type: string
+ *                   modelId:
+ *                     type: string
+ *                   reasoningEffort:
+ *                     type: string
  *     responses:
  *       200:
  *         description: Successfully posted message

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -152,6 +152,31 @@ const app = workspaceApp();
  *                       type: string
  *               skipToolsValidation:
  *                 type: boolean
+ *               modelSelection:
+ *                 type: object
+ *                 description: Optional per-message model override from the input-bar model picker. Either a tier or an explicit model pick.
+ *                 oneOf:
+ *                   - type: object
+ *                     required: [type, tier]
+ *                     properties:
+ *                       type:
+ *                         type: string
+ *                         enum: [tier]
+ *                       tier:
+ *                         type: string
+ *                         enum: [fast, balanced, powerful]
+ *                   - type: object
+ *                     required: [type, providerId, modelId]
+ *                     properties:
+ *                       type:
+ *                         type: string
+ *                         enum: [model]
+ *                       providerId:
+ *                         type: string
+ *                       modelId:
+ *                         type: string
+ *                       reasoningEffort:
+ *                         type: string
  *     responses:
  *       200:
  *         description: Successfully posted message
@@ -253,7 +278,7 @@ app.post(
     const user = auth.getNonNullableUser();
     const { cId: conversationId } = ctx.req.valid("param");
 
-    const { content, context, mentions, skipToolsValidation } =
+    const { content, context, mentions, skipToolsValidation, modelSelection } =
       ctx.req.valid("json");
 
     if (context.clientSideMCPServerIds) {
@@ -384,6 +409,7 @@ app.post(
         clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
       },
       skipToolsValidation: skipToolsValidation ?? false,
+      modelSelection,
     });
 
     if (messageRes.isErr()) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -164,7 +164,7 @@ const app = workspaceApp();
  *                         enum: [tier]
  *                       tier:
  *                         type: string
- *                         enum: [fast, balanced, powerful]
+ *                         enum: [efficient, balanced, powerful]
  *                   - type: object
  *                     required: [type, providerId, modelId]
  *                     properties:

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -403,6 +403,7 @@ app.post(
           clientSideMCPServerIds: message.context.clientSideMCPServerIds ?? [],
         },
         skipToolsValidation: skipToolsValidation ?? false,
+        modelSelection: message.modelSelection,
       });
       if (messageRes.isErr()) {
         return apiError(ctx, messageRes.error);

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -161,7 +161,7 @@ import {
 } from "@app/types/assistant/mentions";
 import type {
   ModelSelectionType,
-  RequestedAgentModel,
+  ResolvedRequestedModel,
 } from "@app/types/assistant/models/types";
 import type {
   ContentFragmentContextType,
@@ -600,14 +600,8 @@ export async function postUserMessage(
   // Resolve the picker selection to a concrete model for this workspace. If it
   // cannot be honored (unknown/disabled model), we leave `requestedModel` null
   // and the agent's configured model is used.
-  const resolvedRequestedModel = modelSelection
+  const requestedModel: ResolvedRequestedModel | null = modelSelection
     ? resolveModelSelection(auth, modelSelection, { featureFlags })
-    : null;
-  const requestedModel: RequestedAgentModel | null = resolvedRequestedModel
-    ? {
-        ...resolvedRequestedModel,
-        tier: modelSelection?.type === "tier" ? modelSelection.tier : null,
-      }
     : null;
 
   const isPartOfPod = isPodConversation(conversation);

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -27,7 +27,10 @@ import {
   batchRenderMessages,
   batchRenderUserMessagesWithoutMentions,
 } from "@app/lib/api/assistant/messages";
-import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
+import {
+  isProviderWhitelisted,
+  resolveModelSelection,
+} from "@app/lib/api/assistant/models";
 import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import {
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR,
@@ -156,6 +159,10 @@ import {
   isUserMention,
   toMentionType,
 } from "@app/types/assistant/mentions";
+import type {
+  ModelSelectionType,
+  RequestedAgentModel,
+} from "@app/types/assistant/models/types";
 import type {
   ContentFragmentContextType,
   ContentFragmentType,
@@ -552,6 +559,7 @@ export async function postUserMessage(
     skipToolsValidation,
     skipDustAutoMention,
     doNotAssociateUser,
+    modelSelection,
   }: {
     conversation: ConversationType;
     content: string;
@@ -561,6 +569,10 @@ export async function postUserMessage(
     skipToolsValidation: boolean;
     doNotAssociateUser?: boolean;
     skipDustAutoMention?: boolean;
+    // Optional per-message model override from the input-bar model picker,
+    // resolved to a concrete model below and applied to every agent message
+    // created for this user message.
+    modelSelection?: ModelSelectionType;
   }
 ): Promise<
   Result<
@@ -587,6 +599,20 @@ export async function postUserMessage(
   }
 
   const featureFlags = await getFeatureFlags(auth);
+
+  // Resolve the picker selection to a concrete model for this workspace. If it
+  // cannot be honored (unknown/disabled model), we leave `requestedModel` null
+  // and the agent's configured model is used.
+  const resolvedRequestedModel = modelSelection
+    ? resolveModelSelection(auth, modelSelection, { featureFlags })
+    : null;
+  const requestedModel: RequestedAgentModel | null = resolvedRequestedModel
+    ? {
+        ...resolvedRequestedModel,
+        tier: modelSelection?.type === "tier" ? modelSelection.tier : null,
+      }
+    : null;
+
   const isPartOfPod = isPodConversation(conversation);
 
   if (isPartOfPod) {
@@ -1028,6 +1054,7 @@ export async function postUserMessage(
             skipToolsValidation,
             nextMessageRank,
             userMessage: userMessageWithoutMentions,
+            requestedModel,
           },
           transaction: t,
         });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -569,9 +569,6 @@ export async function postUserMessage(
     skipToolsValidation: boolean;
     doNotAssociateUser?: boolean;
     skipDustAutoMention?: boolean;
-    // Optional per-message model override from the input-bar model picker,
-    // resolved to a concrete model below and applied to every agent message
-    // created for this user message.
     modelSelection?: ModelSelectionType;
   }
 ): Promise<

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -4,6 +4,7 @@ import {
   updateConversationRequirements,
 } from "@app/lib/api/assistant/conversation/permissions";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
+import { requestedAgentModelFromColumns } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
@@ -35,6 +36,7 @@ import type {
 import { isPodConversation } from "@app/types/assistant/conversation";
 import type { MentionType } from "@app/types/assistant/mentions";
 import { isAgentMention } from "@app/types/assistant/mentions";
+import type { RequestedAgentModel } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -263,6 +265,10 @@ export const createAgentMessages = async (
           skipToolsValidation: boolean;
           nextMessageRank: number;
           userMessage: UserMessageTypeWithoutMentions;
+          // Per-message model override (input-bar picker), already resolved to a
+          // concrete model. Applied to every agent message created here. Null
+          // when the agents run their configured models.
+          requestedModel?: RequestedAgentModel | null;
         };
     transaction?: Transaction;
   }
@@ -286,6 +292,9 @@ export const createAgentMessages = async (
     case "retry":
       {
         const agentConfiguration = metadata.agentMessage.configuration;
+        // Preserve the per-message model override so a retry re-runs on the same
+        // picked model rather than falling back to the agent's configured one.
+        const retriedModel = metadata.agentMessage.requestedModel;
         const agentMessageRow = await AgentMessageModel.create(
           {
             status: "created",
@@ -293,6 +302,10 @@ export const createAgentMessages = async (
             agentConfigurationVersion: agentConfiguration.version,
             workspaceId: owner.id,
             skipToolsValidation: metadata.agentMessage.skipToolsValidation,
+            requestedModelTier: retriedModel?.tier ?? null,
+            requestedProviderId: retriedModel?.providerId ?? null,
+            requestedModelId: retriedModel?.modelId ?? null,
+            requestedReasoningEffort: retriedModel?.reasoningEffort ?? null,
           },
           { transaction }
         );
@@ -453,6 +466,12 @@ export const createAgentMessages = async (
                 agentConfigurationVersion: configuration.version,
                 workspaceId: owner.id,
                 skipToolsValidation: metadata.skipToolsValidation,
+                requestedModelTier: metadata.requestedModel?.tier ?? null,
+                requestedProviderId:
+                  metadata.requestedModel?.providerId ?? null,
+                requestedModelId: metadata.requestedModel?.modelId ?? null,
+                requestedReasoningEffort:
+                  metadata.requestedModel?.reasoningEffort ?? null,
               },
               { transaction }
             );
@@ -553,6 +572,7 @@ export const createAgentMessages = async (
             richMentions: [],
             reactions: [],
             costCredits: null,
+            requestedModel: requestedAgentModelFromColumns(agentMessageRow),
           };
         }
       }

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -265,9 +265,6 @@ export const createAgentMessages = async (
           skipToolsValidation: boolean;
           nextMessageRank: number;
           userMessage: UserMessageTypeWithoutMentions;
-          // Per-message model override (input-bar picker), already resolved to a
-          // concrete model. Applied to every agent message created here. Null
-          // when the agents run their configured models.
           requestedModel?: ResolvedRequestedModel | null;
         };
     transaction?: Transaction;

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -4,8 +4,11 @@ import {
   updateConversationRequirements,
 } from "@app/lib/api/assistant/conversation/permissions";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
-import { requestedAgentModelFromColumns } from "@app/lib/api/assistant/models";
-import type { Authenticator } from "@app/lib/auth";
+import {
+  requestedAgentModelFromColumns,
+  resolveModelSelection,
+} from "@app/lib/api/assistant/models";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import {
   AgentMessageModel,
   CompactionMessageModel,
@@ -289,9 +292,15 @@ export const createAgentMessages = async (
     case "retry":
       {
         const agentConfiguration = metadata.agentMessage.configuration;
-        // Preserve the per-message model override so a retry re-runs on the same
-        // picked model rather than falling back to the agent's configured one.
+        // Preserve the per-message model override, but re-validate it: a model
+        // enabled at first send may have since been disabled for the workspace,
+        // in which case the retry falls back to the agent's configured model.
         const retriedModel = metadata.agentMessage.requestedModel;
+        const revalidatedModel = retriedModel
+          ? resolveModelSelection(auth, retriedModel, {
+              featureFlags: await getFeatureFlags(auth),
+            })
+          : null;
         const agentMessageRow = await AgentMessageModel.create(
           {
             status: "created",
@@ -299,9 +308,9 @@ export const createAgentMessages = async (
             agentConfigurationVersion: agentConfiguration.version,
             workspaceId: owner.id,
             skipToolsValidation: metadata.agentMessage.skipToolsValidation,
-            requestedProviderId: retriedModel?.providerId ?? null,
-            requestedModelId: retriedModel?.modelId ?? null,
-            requestedReasoningEffort: retriedModel?.reasoningEffort ?? null,
+            requestedProviderId: revalidatedModel?.providerId ?? null,
+            requestedModelId: revalidatedModel?.modelId ?? null,
+            requestedReasoningEffort: revalidatedModel?.reasoningEffort ?? null,
           },
           { transaction }
         );

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -36,7 +36,7 @@ import type {
 import { isPodConversation } from "@app/types/assistant/conversation";
 import type { MentionType } from "@app/types/assistant/mentions";
 import { isAgentMention } from "@app/types/assistant/mentions";
-import type { RequestedAgentModel } from "@app/types/assistant/models/types";
+import type { ResolvedRequestedModel } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -268,7 +268,7 @@ export const createAgentMessages = async (
           // Per-message model override (input-bar picker), already resolved to a
           // concrete model. Applied to every agent message created here. Null
           // when the agents run their configured models.
-          requestedModel?: RequestedAgentModel | null;
+          requestedModel?: ResolvedRequestedModel | null;
         };
     transaction?: Transaction;
   }
@@ -302,7 +302,6 @@ export const createAgentMessages = async (
             agentConfigurationVersion: agentConfiguration.version,
             workspaceId: owner.id,
             skipToolsValidation: metadata.agentMessage.skipToolsValidation,
-            requestedModelTier: retriedModel?.tier ?? null,
             requestedProviderId: retriedModel?.providerId ?? null,
             requestedModelId: retriedModel?.modelId ?? null,
             requestedReasoningEffort: retriedModel?.reasoningEffort ?? null,
@@ -466,7 +465,6 @@ export const createAgentMessages = async (
                 agentConfigurationVersion: configuration.version,
                 workspaceId: owner.id,
                 skipToolsValidation: metadata.skipToolsValidation,
-                requestedModelTier: metadata.requestedModel?.tier ?? null,
                 requestedProviderId:
                   metadata.requestedModel?.providerId ?? null,
                 requestedModelId: metadata.requestedModel?.modelId ?? null,

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -1,6 +1,7 @@
 import { renderAgentMessageContentView } from "@app/lib/api/assistant/activity_steps";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { requestedAgentModelFromColumns } from "@app/lib/api/assistant/models";
 import { getMessagesReactions } from "@app/lib/api/assistant/reaction";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -823,6 +824,7 @@ async function renderSingleAgentMessage(
     // Aggregated only when rendering a single agent message (see
     // batchRenderAgentMessages), so it is `null` for bulk conversation rendering.
     subAgentCostCredits,
+    requestedModel: requestedAgentModelFromColumns(agentMessage),
   } satisfies AgentMessageType;
 
   if (viewType === "full") {

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -15,16 +15,25 @@ import {
   MISTRAL_SMALL_MODEL_CONFIG,
 } from "@app/types/assistant/models/mistral";
 import {
+  isModelId,
+  SUPPORTED_MODEL_CONFIGS,
+} from "@app/types/assistant/models/models";
+import {
   GPT_5_5_MODEL_CONFIG,
   GPT_5_MINI_MODEL_CONFIG,
 } from "@app/types/assistant/models/openai";
 import {
   BYOK_MODEL_PROVIDER_IDS,
+  isModelProviderId,
   MODEL_PROVIDER_IDS,
 } from "@app/types/assistant/models/providers";
+import { isReasoningEffort } from "@app/types/assistant/models/reasoning";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
+  ModelSelectionType,
+  ReasoningEffort,
+  ResolvedRequestedModel,
 } from "@app/types/assistant/models/types";
 import {
   GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG,
@@ -198,4 +207,75 @@ function _getLargeWhitelistedModel(
         isModelEnabled(m, context) && (!hasBatch || m.supportsBatchProcessing)
     ) ?? null
   );
+}
+
+// ---------------------------------------------------------------------------
+// Per-message model picker.
+//
+// A picker selection is an explicit provider/model pick. It is validated against
+// the workspace's enabled models via the same isModelEnabled predicate enforced
+// everywhere else, so the resolved model can never be rejected later. Most picks
+// use the model's own defaultReasoningEffort; the pick may pin an explicit one.
+// ---------------------------------------------------------------------------
+
+function toResolvedModel(
+  config: ModelConfigurationType,
+  reasoningEffort?: ReasoningEffort
+): ResolvedRequestedModel {
+  return {
+    providerId: config.providerId,
+    modelId: config.modelId,
+    reasoningEffort: reasoningEffort ?? config.defaultReasoningEffort,
+  };
+}
+
+// Resolves a raw picker selection to a concrete model, or null when it cannot be
+// honored for this workspace (unknown or disabled model), in which case the
+// caller falls back to the agent's configured model.
+export function resolveModelSelection(
+  auth: Authenticator,
+  selection: ModelSelectionType,
+  { featureFlags }: { featureFlags: WhitelistableFeature[] }
+): ResolvedRequestedModel | null {
+  const config = SUPPORTED_MODEL_CONFIGS.find(
+    (m) =>
+      m.providerId === selection.providerId && m.modelId === selection.modelId
+  );
+  if (!config) {
+    return null;
+  }
+  const enabled = selectEnabledModel(auth, [config], { featureFlags });
+  if (!enabled) {
+    return null;
+  }
+  return toResolvedModel(enabled, selection.reasoningEffort);
+}
+
+// Rebuilds a `ResolvedRequestedModel` from the raw agent-message columns, or null
+// when no override was stored (or the stored values fail validation). Values are
+// written by the resolver above, so validation is defensive.
+export function requestedAgentModelFromColumns(row: {
+  requestedProviderId: string | null;
+  requestedModelId: string | null;
+  requestedReasoningEffort: string | null;
+}): ResolvedRequestedModel | null {
+  const { requestedProviderId, requestedModelId, requestedReasoningEffort } =
+    row;
+
+  if (
+    !requestedProviderId ||
+    !requestedModelId ||
+    !requestedReasoningEffort ||
+    !isModelProviderId(requestedProviderId) ||
+    !isModelId(requestedModelId) ||
+    !isReasoningEffort(requestedReasoningEffort)
+  ) {
+    return null;
+  }
+
+  return {
+    providerId: requestedProviderId,
+    modelId: requestedModelId,
+    reasoningEffort: requestedReasoningEffort,
+  };
 }

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -248,7 +248,31 @@ export function resolveModelSelection(
   if (!enabled) {
     return null;
   }
-  return toResolvedModel(enabled, selection.reasoningEffort);
+  // Honor an explicit effort only if the model supports it; otherwise fall back
+  // to its default (raw API clients can send an unsupported effort).
+  const effort =
+    selection.reasoningEffort &&
+    enabled.supportedReasoningEfforts[selection.reasoningEffort]
+      ? selection.reasoningEffort
+      : undefined;
+  return toResolvedModel(enabled, effort);
+}
+
+// Drops agent model settings the picked override can't honor: a structured-output
+// responseFormat inherited onto a model with `supportsResponseFormat: false` makes
+// the run error or silently ignore the schema.
+export function reconcileModelSettings<T extends { responseFormat?: string }>(
+  requested: ResolvedRequestedModel,
+  settings: T
+): T {
+  const config = SUPPORTED_MODEL_CONFIGS.find(
+    (m) =>
+      m.providerId === requested.providerId && m.modelId === requested.modelId
+  );
+  if (config?.supportsResponseFormat) {
+    return settings;
+  }
+  return { ...settings, responseFormat: undefined };
 }
 
 // Rebuilds a `ResolvedRequestedModel` from the raw agent-message columns, or null

--- a/front/types/api/assistant.ts
+++ b/front/types/api/assistant.ts
@@ -33,9 +33,9 @@ export const MessageBaseSchema = z.object({
     originMessageId: z.string().optional(),
     origin: UserMessageOriginSchema.optional(),
   }),
-  // Optional per-message model override from the input-bar model picker (a tier
-  // or an explicit model pick). Resolved to a concrete model server-side at send
-  // time; omitted means the agent runs its configured model.
+  // Optional per-message model override from the input-bar model picker (an
+  // explicit model pick). Resolved to a concrete model server-side at send time;
+  // omitted means the agent runs its configured model.
   modelSelection: ModelSelectionSchema.optional(),
 });
 

--- a/front/types/api/assistant.ts
+++ b/front/types/api/assistant.ts
@@ -1,7 +1,7 @@
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { INTERNAL_MIME_TYPES_VALUES } from "@dust-tt/client";
 import { z } from "zod";
-
+import { ModelSelectionSchema } from "../assistant/models/types";
 import type { SupportedNonImageContentType } from "../files";
 import { getSupportedNonImageMimeTypes } from "../files";
 
@@ -33,6 +33,10 @@ export const MessageBaseSchema = z.object({
     originMessageId: z.string().optional(),
     origin: UserMessageOriginSchema.optional(),
   }),
+  // Optional per-message model override from the input-bar model picker (a tier
+  // or an explicit model pick). Resolved to a concrete model server-side at send
+  // time; omitted means the agent runs its configured model.
+  modelSelection: ModelSelectionSchema.optional(),
 });
 
 export const InternalPostMessagesRequestBodySchema = MessageBaseSchema.extend({

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -4,6 +4,7 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
+import { reconcileModelSettings } from "@app/lib/api/assistant/models";
 import { getStaticReplyForUserMessage } from "@app/lib/api/assistant/static_reply";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
@@ -329,16 +330,16 @@ export async function getAgentLoopDataWithAuth(
 
   // Apply the per-message model override from the input-bar picker, if any. This
   // is the single choke point every downstream consumer reads for the run model
-  // (run_model, prompt commands, ...). Temperature and other model settings are
-  // inherited from the agent's configuration; only provider/model/effort change.
+  // (run_model, prompt commands, ...). Settings are inherited from the agent's
+  // configuration, then reconciled against the picked model's capabilities.
   const { requestedModel } = agentMessage;
   const agentModel = requestedModel
-    ? {
+    ? reconcileModelSettings(requestedModel, {
         ...agentConfigModel,
         providerId: requestedModel.providerId,
         modelId: requestedModel.modelId,
         reasoningEffort: requestedModel.reasoningEffort,
-      }
+      })
     : agentConfigModel;
 
   const model = getSupportedModelConfig(agentModel);

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -324,8 +324,22 @@ export async function getAgentLoopDataWithAuth(
     return new Err(new Error(`Agent configuration not found ${agentId}`));
   }
 
-  const { model: agentModel, ...agentConfigurationWithoutModel } =
+  const { model: agentConfigModel, ...agentConfigurationWithoutModel } =
     agentConfiguration;
+
+  // Apply the per-message model override from the input-bar picker, if any. This
+  // is the single choke point every downstream consumer reads for the run model
+  // (run_model, prompt commands, ...). Temperature and other model settings are
+  // inherited from the agent's configuration; only provider/model/effort change.
+  const { requestedModel } = agentMessage;
+  const agentModel = requestedModel
+    ? {
+        ...agentConfigModel,
+        providerId: requestedModel.providerId,
+        modelId: requestedModel.modelId,
+        reasoningEffort: requestedModel.reasoningEffort,
+      }
+    : agentConfigModel;
 
   const model = getSupportedModelConfig(agentModel);
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -17,6 +17,7 @@ import type {
   LightAgentConfigurationType,
 } from "./agent";
 import type { MentionType, RichMention } from "./mentions";
+import type { RequestedAgentModel } from "./models/types";
 
 export type MessageVisibility = "visible" | "deleted" | "pending";
 
@@ -362,6 +363,10 @@ export type AgentMessageType = BaseAgentMessageType & {
   actions: AgentMCPActionWithOutputType[];
   contents: Array<{ step: number; content: AgentContentItemType }>;
   modelInteractionDurationMs: number | null;
+  // Per-message model override from the input-bar model picker: the resolved
+  // model plus the tier it came from. Null/undefined when the agent ran its own
+  // configured model. Optional during rollout. See [BACK12].
+  requestedModel?: RequestedAgentModel | null;
 };
 
 export type AgentMessageTypeWithoutMentions = Omit<

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -17,7 +17,7 @@ import type {
   LightAgentConfigurationType,
 } from "./agent";
 import type { MentionType, RichMention } from "./mentions";
-import type { RequestedAgentModel } from "./models/types";
+import type { ResolvedRequestedModel } from "./models/types";
 
 export type MessageVisibility = "visible" | "deleted" | "pending";
 
@@ -364,9 +364,9 @@ export type AgentMessageType = BaseAgentMessageType & {
   contents: Array<{ step: number; content: AgentContentItemType }>;
   modelInteractionDurationMs: number | null;
   // Per-message model override from the input-bar model picker: the resolved
-  // model plus the tier it came from. Null/undefined when the agent ran its own
-  // configured model. Optional during rollout. See [BACK12].
-  requestedModel?: RequestedAgentModel | null;
+  // model. Null/undefined when the agent ran its own configured model. Optional
+  // during rollout. See [BACK12].
+  requestedModel?: ResolvedRequestedModel | null;
 };
 
 export type AgentMessageTypeWithoutMentions = Omit<

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -8,7 +8,8 @@ import type { ExtractSpecificKeys } from "../../shared/typescipt_utils";
 import type { TokenizerConfig } from "../../tokenizer";
 import type { EMBEDDING_PROVIDER_IDS } from "./embedding";
 import type { MODEL_IDS, SUPPORTED_MODEL_CONFIGS } from "./models";
-import type { BYOK_MODEL_PROVIDER_IDS, MODEL_PROVIDER_IDS } from "./providers";
+import type { BYOK_MODEL_PROVIDER_IDS } from "./providers";
+import { MODEL_PROVIDER_IDS } from "./providers";
 import { ORDERED_REASONING_EFFORTS } from "./reasoning";
 
 export type ModelIdType = (typeof MODEL_IDS)[number];
@@ -17,6 +18,23 @@ export type ByokModelProviderIdType = (typeof BYOK_MODEL_PROVIDER_IDS)[number];
 
 export const CUSTOM_THINKING_TYPES = ["auto", "enabled"] as const;
 export type CustomThinkingType = (typeof CUSTOM_THINKING_TYPES)[number];
+
+// Raw model selection coming from the input-bar model picker: an explicit
+// provider/model pick, with an optional reasoning-effort override.
+export const ModelSelectionSchema = z.object({
+  type: z.literal("model"),
+  providerId: z.enum(MODEL_PROVIDER_IDS),
+  modelId: z.string(),
+  reasoningEffort: z.enum(ORDERED_REASONING_EFFORTS).optional(),
+});
+export type ModelSelectionType = z.infer<typeof ModelSelectionSchema>;
+
+// A concrete model resolved from a picker selection at message-send time.
+export type ResolvedRequestedModel = {
+  providerId: ModelProviderIdType;
+  modelId: ModelIdType;
+  reasoningEffort: ReasoningEffort;
+};
 
 // z.object (not z.record) so every reasoning effort key is required.
 const ReasoningEffortSupportSchema = z.object({

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -22,7 +22,6 @@ export type CustomThinkingType = (typeof CUSTOM_THINKING_TYPES)[number];
 // Raw model selection coming from the input-bar model picker: an explicit
 // provider/model pick, with an optional reasoning-effort override.
 export const ModelSelectionSchema = z.object({
-  type: z.literal("model"),
   providerId: z.enum(MODEL_PROVIDER_IDS),
   modelId: z.string(),
   reasoningEffort: z.enum(ORDERED_REASONING_EFFORTS).optional(),


### PR DESCRIPTION
## Description

Backend for the input-bar model picker (on top of the #28344 migration that adds the `requested*`
columns). Wires a per-message model override end-to-end while staying a no-op until a client sends
`modelSelection` (the picker UI lands in #28049).

- Adds an optional `modelSelection` (`providerId` / `modelId` / optional `reasoningEffort`) to the
  message-post request schema — covering both the create-message and create-conversation paths — and
  documents it in swagger.
- `resolveModelSelection` (new, in `lib/api/assistant/models.ts`) turns a raw picker selection into a
  concrete model at send time, validating it against the workspace's enabled models via the same
  enablement gate used everywhere else. Unknown or disabled models resolve to `null`, so the agent
  falls back to its configured model.
- `postUserMessage` resolves the selection, then `createAgentMessages` persists the resolved
  provider/model/effort on the agent message. The override is preserved on retry so a retried message
  re-runs the same picked model.
- `requestedAgentModelFromColumns` rebuilds the resolved model from the stored columns (defensive
  validation) and serializes it onto `AgentMessageType.requestedModel`.
- `getAgentLoopDataWithAuth` is the single choke point that applies the override: it overrides
  `agentConfiguration.model` (provider/model/effort only; temperature and other settings are
  inherited) so every downstream consumer runs the picked model.

When no selection is sent, the agent runs its configured model exactly as before.

## Tests

Exercised by the existing conversation message-post endpoint tests, which pass unchanged (default
no-op path). Resolution is guarded by the workspace enablement gate, and column deserialization
validates provider/model/effort defensively.

## Risk

Low. Behavior only changes for requests that carry `modelSelection`, and no client sends it until
#28049 ships. An override can never select a model the workspace can't run (reuses the enablement
gate). Rollback-safe.

## Deploy Plan

Depends on the #28344 migration being deployed first — this PR reads and writes the `requested*`
columns on agent messages.
