### PR TITLE
No seat plan for non-cp workspaces

### DIFF
--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -11,7 +11,9 @@ import {
   isMauContract,
   type SeatAwuCreditsPeriod,
 } from "@app/lib/metronome/seat_types";
+import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
@@ -89,6 +91,16 @@ export async function getSeatPlan(
 
   if (!contract || !contract.rate_card_id) {
     return new Err(new SeatPlanError("not_configured"));
+  }
+
+  // Non-CP plans (legacy shadow contracts) don't use per-seat billing in the
+  // invite flow — return empty so the UI skips the seat selector and invites
+  // always use "none", consistent with SCIM/auto-join.
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  if (!subscription || !isCreditPricedPlanPrefix(subscription.getPlan().code)) {
+    return new Ok({});
   }
 
   const creditTypeResult = await getCreditTypeFromContract(contract);


### PR DESCRIPTION
## Description

`getSeatPlan` now returns an empty seat plan for non-credit-priced workspaces (plans not prefixed with `CP_`), even when a legacy shadow contract exists on Metronome.

**Problem:** The invite modal's seat selector was driven by `useSeatPlan`, which reads entitled seat subscriptions directly from the Metronome contract. Legacy shadow contracts have a `workspace` seat subscription, so the invite modal was showing a seat type picker and inviting members as `workspace` — while SCIM and auto-join go through `resolveSeatTypeForNewMembership` and fall through to `none` (no committed/free seats). This inconsistency meant invited members and SCIM-provisioned members had different seat types for the same workspace.

**Fix:** Return `{}` early in `getSeatPlan` when the active subscription is not on a CP plan. This makes `hasSeatSelection = false` in the invite modal, so the invite always sends no explicit seat type → same `none` resolution path as SCIM.

**Side effects:**
- `BillingSeatsOverview` (billing settings page): the workspace seat pricing card no longer appears for legacy workspaces — correct since those aren't on per-seat CP billing.
- Poke workspace info: seat commitments section goes empty for non-CP workspaces.
- `ChangeSeatModal` / `UpgradeRequestsTable`: no functional change (`isSeatBased` was already `false` for single-seat-type legacy contracts).

## Tests

Manual: verify invite modal shows no seat selector on a non-CP workspace.

## Risk

Low — legacy workspaces are unaffected by Metronome seat sync; `none` is already handled as a workspace seat in `syncSeatCount` via the legacy fallback. The only visible user-facing change is the seat card disappearing from the billing page for legacy workspaces.

## Deploy Plan

Deploy — no migration needed.