### PR TITLE
Tool search never activated on the new LLM router

### DIFF
--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -576,7 +576,8 @@ abstract class BaseTransition extends LLM {
     streamParameters: LLMStreamParameters,
     configSchema: BaseEndpointConfiguration["configSchema"]
   ): InputConfig {
-    const { specifications, forceToolCall } = streamParameters;
+    const { specifications, forceToolCall, toolSearchEnabled } =
+      streamParameters;
 
     return configSchema.parse({
       tools: specifications as ToolSpecification[],
@@ -588,6 +589,7 @@ abstract class BaseTransition extends LLM {
         ),
       },
       forceTool: forceToolCall,
+      toolSearchEnabled,
       outputFormat: parseResponseFormatSchema(
         this.responseFormat,
         this.metadata.clientId

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
@@ -97,6 +97,7 @@ export function WithAnthropicAIInputConverter<
         forceTool,
         toolSearchEnabled: toolSearchEnabled ?? false,
       });
+
       const system = this.systemMessagesToSystemParam(conversation.system);
 
       return {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The change that made tools default to deferred behind Anthropic tool search moved the defer/keep decision out of the shared tool spec and into each provider client, where it now depends on a per-request `toolSearchEnabled` signal instead of a flag precomputed upstream.

That signal was wired into the legacy Anthropic client but not into the new LLM router, whose request config is assembled through a separate path that silently dropped it. On the new router the value was therefore always false, so no tool was ever deferred and the tool search tool was never offered to the model, even with the feature flag on. Because production serves these requests through the new router, tool search stopped working entirely after that change while still appearing correct on the legacy path.

This threads toolSearchEnabled through the new router's config build so the deferral decision sees the real value, restoring parity with the legacy client. It also drops some leftover debug logging.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
