### PR TITLE
fix(conversation): stop duplicated inline activity steps on Temporal retries

### DIFF
--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -249,9 +249,14 @@ describe("appendThinkingStep", () => {
   it("appends a thinking step when none exists", () => {
     const steps: InlineActivityStep[] = [];
     expect(
-      appendThinkingStep(steps, "Enable the toolset", "thinking-1")
+      appendThinkingStep(steps, "Enable the toolset", "thinking-1", 0)
     ).toEqual([
-      { type: "thinking", content: "Enable the toolset", id: "thinking-1" },
+      {
+        type: "thinking",
+        content: "Enable the toolset",
+        id: "thinking-1",
+        step: 0,
+      },
     ]);
   });
 
@@ -259,18 +264,25 @@ describe("appendThinkingStep", () => {
     const steps: InlineActivityStep[] = [
       { type: "thinking", content: "Enable the toolset", id: "thinking-1" },
     ];
-    expect(appendThinkingStep(steps, "Enable the toolset", "thinking-2")).toBe(
-      steps
-    );
+    expect(
+      appendThinkingStep(steps, "Enable the toolset", "thinking-2", 0)
+    ).toBe(steps);
   });
 
   it("appends a new step when the content differs from the last thinking step", () => {
     const steps: InlineActivityStep[] = [
       { type: "thinking", content: "First attempt", id: "thinking-1" },
     ];
-    expect(appendThinkingStep(steps, "Second attempt", "thinking-2")).toEqual([
+    expect(
+      appendThinkingStep(steps, "Second attempt", "thinking-2", 1)
+    ).toEqual([
       { type: "thinking", content: "First attempt", id: "thinking-1" },
-      { type: "thinking", content: "Second attempt", id: "thinking-2" },
+      {
+        type: "thinking",
+        content: "Second attempt",
+        id: "thinking-2",
+        step: 1,
+      },
     ]);
   });
 });
@@ -457,6 +469,7 @@ describe("useAgentMessageStream", () => {
         content:
           "The user wants recent world events. Let me search the web for this.",
         id: expect.stringContaining("thinking-toolparams-"),
+        step: 0,
       },
       {
         type: "action",
@@ -465,6 +478,7 @@ describe("useAgentMessageStream", () => {
         actionId: action.sId,
         internalMCPServerName: action.internalMCPServerName,
         toolName: action.toolName ?? null,
+        step: 0,
       },
     ]);
     expect(currentMessage.chainOfThought).toBe("");
@@ -667,7 +681,7 @@ describe("useAgentMessageStream", () => {
     ]);
   });
 
-  it("discards stale tokens from prior Temporal retries at tool_params", () => {
+  it("collapses same-step Temporal retries to the final attempt", () => {
     let currentMessage = makeInitialMessageStreamState(
       makeLightAgentMessage({ content: null, chainOfThought: null })
     );
@@ -707,7 +721,8 @@ describe("useAgentMessageStream", () => {
     const action = makeStreamAction();
 
     act(() => {
-      // Retry 1: CoT → tokens → retry fails (traceId=attempt-1)
+      // Retry 1: CoT → tokens → retry fails (traceId=attempt-1). The CoT is
+      // flushed as a thinking step at the CoT→tokens transition.
       onEventCallback!(
         JSON.stringify({
           eventId: "1-0",
@@ -719,6 +734,7 @@ describe("useAgentMessageStream", () => {
             text: "I need to enable the toolset first.",
             classification: "chain_of_thought",
             traceId: "attempt-1",
+            step: 0,
           },
         })
       );
@@ -732,12 +748,13 @@ describe("useAgentMessageStream", () => {
             messageId: currentMessage.sId,
             text: "Enabling now.",
             classification: "tokens",
+            step: 0,
           },
         })
       );
-      // Retry 2: different CoT → tokens → retry fails (traceId=attempt-2)
-      // The new traceId resets both accumulators before the tokens→CoT transition
-      // fires, so "Enabling now." is never flushed as a stale content step.
+      // Retry 2: same step re-runs with a fresh traceId. The already-flushed
+      // step-0 thinking step is dropped, and stale tokens ("Enabling now.") are
+      // discarded before they can become a content step.
       onEventCallback!(
         JSON.stringify({
           eventId: "3-0",
@@ -749,6 +766,7 @@ describe("useAgentMessageStream", () => {
             text: "I should enable the Create Files toolset.",
             classification: "chain_of_thought",
             traceId: "attempt-2",
+            step: 0,
           },
         })
       );
@@ -762,10 +780,12 @@ describe("useAgentMessageStream", () => {
             messageId: currentMessage.sId,
             text: "Let me enable it.",
             classification: "tokens",
+            step: 0,
           },
         })
       );
-      // Retry 3: final CoT → tool_params succeeds (traceId=attempt-3)
+      // Retry 3: final CoT → tool_params succeeds (traceId=attempt-3). Drops the
+      // step-0 thinking step from retry 2 and rebuilds it from this attempt.
       onEventCallback!(
         JSON.stringify({
           eventId: "5-0",
@@ -777,6 +797,7 @@ describe("useAgentMessageStream", () => {
             text: "I need to enable the Create Files toolset first.",
             classification: "chain_of_thought",
             traceId: "attempt-3",
+            step: 0,
           },
         })
       );
@@ -796,24 +817,186 @@ describe("useAgentMessageStream", () => {
       );
     });
 
-    // Each retry produced different CoT, so each appears as its own thinking
-    // step. Stale tokens ("Enabling now.", "Let me enable it.") were discarded
-    // by the traceId-based reset before they could be flushed as content steps.
+    // All three attempts are the SAME step (Temporal retries), so only the final
+    // attempt's thinking step survives — the earlier ones are dropped instead of
+    // flooding the timeline with duplicates (the ticket-9287 bug).
     expect(currentMessage.streaming.inlineActivitySteps).toEqual([
-      {
-        type: "thinking",
-        content: "I need to enable the toolset first.",
-        id: expect.stringContaining("thinking-pre-"),
-      },
-      {
-        type: "thinking",
-        content: "I should enable the Create Files toolset.",
-        id: expect.stringContaining("thinking-pre-"),
-      },
       {
         type: "thinking",
         content: "I need to enable the Create Files toolset first.",
         id: expect.stringContaining("thinking-toolparams-"),
+        step: 0,
+      },
+    ]);
+  });
+
+  it("keeps earlier completed steps when a later step is retried", () => {
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({ content: null, chainOfThought: null })
+    );
+    let onEventCallback: ((event: string) => void) | null = null;
+
+    mockUseVirtuosoMethods.mockReturnValue(
+      makeVirtuosoMethodsMock(
+        (
+          updater: (message: typeof currentMessage) => typeof currentMessage
+        ) => {
+          currentMessage = updater(currentMessage);
+          return [currentMessage];
+        }
+      )
+    );
+
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+
+    renderHook(() =>
+      useAgentMessageStream({
+        agentMessage: currentMessage,
+        conversationId: "conv_123",
+        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        owner: mockOwner,
+        streamId: "stream_123",
+      })
+    );
+
+    const action0 = makeStreamAction({ id: 20, sId: "act_0" });
+
+    act(() => {
+      // Step 0: CoT → tool_params → action success. Fully committed.
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "1-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "First I search the web.",
+            classification: "chain_of_thought",
+            traceId: "step0-trace",
+            step: 0,
+          },
+        })
+      );
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "2-0",
+          data: {
+            type: "tool_params",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            action: action0,
+            runIds: ["llm_trace_0"],
+            step: 0,
+          },
+        })
+      );
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "3-0",
+          data: {
+            type: "agent_action_success",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            action: { ...action0, status: "succeeded", executionDurationMs: 1 },
+            step: 0,
+          },
+        })
+      );
+      // Step 1 attempt 1: CoT flushed, then the activity retries.
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "4-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "Stale step-1 reasoning.",
+            classification: "chain_of_thought",
+            traceId: "step1-attempt-1",
+            step: 1,
+          },
+        })
+      );
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "5-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "writing",
+            classification: "tokens",
+            step: 1,
+          },
+        })
+      );
+      // Step 1 attempt 2: fresh traceId, same step → drop only step-1 work.
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "6-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "Final step-1 reasoning.",
+            classification: "chain_of_thought",
+            traceId: "step1-attempt-2",
+            step: 1,
+          },
+        })
+      );
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "7-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "done writing",
+            classification: "tokens",
+            step: 1,
+          },
+        })
+      );
+    });
+
+    // Step 0's thinking + action survive; only step 1's final attempt remains.
+    expect(currentMessage.streaming.inlineActivitySteps).toEqual([
+      {
+        type: "thinking",
+        content: "First I search the web.",
+        id: expect.stringContaining("thinking-toolparams-"),
+        step: 0,
+      },
+      {
+        type: "action",
+        label: "Search",
+        id: `action-${action0.id}`,
+        actionId: action0.sId,
+        internalMCPServerName: action0.internalMCPServerName,
+        toolName: action0.toolName ?? null,
+        step: 0,
+      },
+      {
+        type: "thinking",
+        content: "Final step-1 reasoning.",
+        id: expect.stringContaining("thinking-pre-"),
+        step: 1,
       },
     ]);
   });
@@ -875,6 +1058,7 @@ describe("useAgentMessageStream", () => {
             text: "I need to search the web.",
             classification: "chain_of_thought",
             traceId: "attempt-1",
+            step: 0,
           },
         })
       );
@@ -891,6 +1075,7 @@ describe("useAgentMessageStream", () => {
             text: "I need to search the web.",
             classification: "chain_of_thought",
             traceId: "attempt-2",
+            step: 0,
           },
         })
       );

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -208,7 +208,8 @@ export function updateProgress(
 export function appendThinkingStep(
   steps: InlineActivityStep[],
   cotContent: string,
-  id: string
+  id: string,
+  stepIndex: number
 ): InlineActivityStep[] {
   for (let i = steps.length - 1; i >= 0; i--) {
     const step = steps[i];
@@ -219,15 +220,22 @@ export function appendThinkingStep(
       break;
     }
   }
-  return [...steps, { type: "thinking", content: cotContent, id }];
+  return [
+    ...steps,
+    { type: "thinking", content: cotContent, id, step: stepIndex },
+  ];
 }
 
 function appendContentStep(
   steps: InlineActivityStep[],
   textContent: string,
-  id: string
+  id: string,
+  stepIndex: number
 ): InlineActivityStep[] {
-  return [...steps, { type: "content", content: textContent, id }];
+  return [
+    ...steps,
+    { type: "content", content: textContent, id, step: stepIndex },
+  ];
 }
 
 /**
@@ -244,6 +252,7 @@ function flushPendingSegment({
   content,
   steps,
   suffix,
+  stepIndex,
   retryCoTBuffer,
 }: {
   lastClassification: { current: "tokens" | "chain_of_thought" | null };
@@ -251,6 +260,7 @@ function flushPendingSegment({
   content: { current: string };
   steps: InlineActivityStep[];
   suffix: string;
+  stepIndex: number;
   retryCoTBuffer?: { current: string | null };
 }): { steps: InlineActivityStep[]; contentCleared: boolean } {
   const cls = lastClassification.current;
@@ -261,7 +271,12 @@ function flushPendingSegment({
       retryCoTBuffer.current = null;
     }
     return {
-      steps: appendThinkingStep(steps, cotToFlush, `thinking-${suffix}`),
+      steps: appendThinkingStep(
+        steps,
+        cotToFlush,
+        `thinking-${suffix}`,
+        stepIndex
+      ),
       contentCleared: false,
     };
   }
@@ -269,7 +284,12 @@ function flushPendingSegment({
     const textToFlush = content.current;
     content.current = "";
     return {
-      steps: appendContentStep(steps, textToFlush, `content-${suffix}`),
+      steps: appendContentStep(
+        steps,
+        textToFlush,
+        `content-${suffix}`,
+        stepIndex
+      ),
       contentCleared: true,
     };
   }
@@ -369,6 +389,11 @@ export function useAgentMessageStream({
   const lastClassification = useRef<"tokens" | "chain_of_thought" | null>(null);
   // Tracks the traceId of the last CoT event to detect Temporal retry boundaries.
   const lastCoTTraceId = useRef<string | null>(null);
+  // Tracks the agent-loop step of the last generation event. Combined with a
+  // traceId change, an unchanged step number means the SAME step was re-run
+  // (Temporal activity retry) rather than the loop advancing to a new step. It is
+  // the signal we use to drop and rebuild that step's committed inline steps.
+  const currentStep = useRef<number | null>(null);
   // Shadow buffer for retry CoT suppression. When a new traceId arrives, CoT
   // tokens are accumulated here instead of directly into chainOfThought.current.
   // As long as the buffer is a prefix of the existing CoT, display is unchanged
@@ -433,6 +458,7 @@ export function useAgentMessageStream({
             chainOfThought.current = "";
             lastCoTTraceId.current = null;
             retryCoTBuffer.current = null;
+            currentStep.current = null;
             mapMessagesWithAutoScroll((m) => {
               if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
                 return m;
@@ -449,6 +475,7 @@ export function useAgentMessageStream({
 
           const generationTokens = eventPayload.data;
           const classification = generationTokens.classification;
+          const eventStep = generationTokens.step;
 
           if (
             classification === "tokens" ||
@@ -469,11 +496,33 @@ export function useAgentMessageStream({
               ) {
                 content.current = "";
                 retryCoTBuffer.current = "";
+                if (
+                  currentStep.current !== null &&
+                  eventStep === currentStep.current
+                ) {
+                  mapMessagesWithAutoScroll((m) => {
+                    if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
+                      return m;
+                    }
+                    return {
+                      ...m,
+                      streaming: {
+                        ...m.streaming,
+                        inlineActivitySteps:
+                          m.streaming.inlineActivitySteps.filter(
+                            (s) => s.step !== eventStep
+                          ),
+                      },
+                    };
+                  });
+                }
               }
               if (newTraceId) {
                 lastCoTTraceId.current = newTraceId;
               }
             }
+
+            currentStep.current = eventStep;
 
             // Detect classification transitions and flush completed segments.
             if (
@@ -493,6 +542,7 @@ export function useAgentMessageStream({
                   content,
                   steps: m.streaming.inlineActivitySteps,
                   suffix: `pre-${Date.now()}`,
+                  stepIndex: eventStep,
                   retryCoTBuffer,
                 });
                 return {
@@ -555,6 +605,7 @@ export function useAgentMessageStream({
 
         case "agent_action_success":
           const action = eventPayload.data.action;
+          const actionStep = eventPayload.data.step;
           mapMessagesWithAutoScroll((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
               return m;
@@ -574,6 +625,7 @@ export function useAgentMessageStream({
                     actionId: action.sId,
                     internalMCPServerName: action.internalMCPServerName,
                     toolName: action.toolName ?? null,
+                    step: actionStep,
                   },
                 ];
             return {
@@ -612,6 +664,7 @@ export function useAgentMessageStream({
               content,
               steps: m.streaming.inlineActivitySteps,
               suffix: `toolparams-${Date.now()}`,
+              stepIndex: toolParams.step,
               retryCoTBuffer,
             });
             return {
@@ -682,6 +735,7 @@ export function useAgentMessageStream({
               content,
               steps: m.streaming.inlineActivitySteps,
               suffix: `error-${Date.now()}`,
+              stepIndex: currentStep.current ?? 0,
               retryCoTBuffer,
             });
             return {
@@ -727,6 +781,7 @@ export function useAgentMessageStream({
               content,
               steps: m.streaming.inlineActivitySteps,
               suffix: `cancel-${Date.now()}`,
+              stepIndex: cancelData.step,
               retryCoTBuffer,
             });
             return {

--- a/front/hooks/useChildAgentStream.ts
+++ b/front/hooks/useChildAgentStream.ts
@@ -41,6 +41,10 @@ const initialState: ChildAgentStreamReducerState = {
   pendingToolCalls: [],
 };
 
+// TODO(tasks#9287): unlike useAgentMessageStream, this reducer does not dedupe
+// Temporal activity retries (no per-step traceId tracking / step-scoped drop,
+// no seenEventIds replay guard), so a retried sub-agent step can duplicate
+// inline steps mid-stream. It self-heals at completion via contentView.
 function childAgentStreamReducer(
   state: ChildAgentStreamReducerState,
   event: ChildAgentStreamEvent

--- a/front/lib/api/assistant/activity_steps.test.ts
+++ b/front/lib/api/assistant/activity_steps.test.ts
@@ -78,7 +78,12 @@ describe("renderAgentMessageContentView", () => {
       content: "The answer",
       chainOfThought: "Let me think",
       activitySteps: [
-        { type: "thinking", content: "Let me think", id: "reasoning-0-0" },
+        {
+          type: "thinking",
+          content: "Let me think",
+          id: "reasoning-0-0",
+          step: 0,
+        },
       ],
     });
   });
@@ -98,7 +103,7 @@ describe("renderAgentMessageContentView", () => {
       content: "Answer",
       chainOfThought: "pondering\n",
       activitySteps: [
-        { type: "thinking", content: "pondering\n", id: "cot-0-0" },
+        { type: "thinking", content: "pondering\n", id: "cot-0-0", step: 0 },
       ],
     });
   });
@@ -112,7 +117,9 @@ describe("renderAgentMessageContentView", () => {
     ).toEqual({
       content: "first\nsecond",
       chainOfThought: null,
-      activitySteps: [{ type: "content", content: "first", id: "content-0-0" }],
+      activitySteps: [
+        { type: "content", content: "first", id: "content-0-0", step: 0 },
+      ],
     });
   });
 });

--- a/front/lib/api/assistant/activity_steps.ts
+++ b/front/lib/api/assistant/activity_steps.ts
@@ -103,6 +103,7 @@ export async function renderAgentMessageContentView(
           type: "thinking",
           content: reasoning,
           id: `reasoning-${c.step}-${index}`,
+          step: c.step,
         });
       }
       continue;
@@ -123,6 +124,7 @@ export async function renderAgentMessageContentView(
           type: "thinking",
           content: parsedContent.chainOfThought,
           id: `cot-${c.step}-${index}`,
+          step: c.step,
         });
       }
 
@@ -133,6 +135,7 @@ export async function renderAgentMessageContentView(
           type: "content",
           content: parsedContent.content,
           id: `content-${c.step}-${index}`,
+          step: c.step,
         });
       }
       continue;
@@ -150,6 +153,7 @@ export async function renderAgentMessageContentView(
           actionId: matchingAction.sId,
           internalMCPServerName: matchingAction.internalMCPServerName,
           toolName: matchingAction.toolName ?? null,
+          step: c.step,
         });
       }
     }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -325,9 +325,14 @@ export type BaseAgentMessageType = {
   subAgentCostCredits?: number | null;
 };
 
+// `step` is the agent-loop step a given activity step was produced in. It lets
+// the streaming client discard the steps it built for a step that Temporal
+// re-ran (activity retry re-emits the step's events with a fresh traceId),
+// rebuilding it instead of appending duplicates. Optional: absent on the
+// server-rendered terminal view, which is already canonical.
 export type InlineActivityStep =
-  | { type: "thinking"; content: string; id: string }
-  | { type: "content"; content: string; id: string }
+  | { type: "thinking"; content: string; id: string; step?: number }
+  | { type: "content"; content: string; id: string; step?: number }
   | {
       type: "action";
       label: string;
@@ -335,6 +340,7 @@ export type InlineActivityStep =
       actionId: string;
       internalMCPServerName: InternalMCPServerNameType | null;
       toolName: string | null;
+      step?: number;
     };
 
 export type ParsedContentItem =


### PR DESCRIPTION
## Description

### Context
In a streaming agent turn, the inline "Thinking / activity" steps could be rendered dozens of times within a single turn, flooding the conversation view ([tasks#9287](https://github.com/dust-tt/tasks/issues/9287), [tasks#8022](https://github.com/dust-tt/tasks/issues/8022)). The duplication only appeared while the turn was streaming and disappeared once it completed. A hard refresh mid-stream did not help.

An agent turn runs as a Temporal loop of steps (`agentLoopWorkflow`). Each step is one `runModelAndCreateActionsActivity` (the LLM call, emitting `generation_tokens` for chain-of-thought/text and `tool_params` for tool calls) followed by `runToolActivity`. The model activity is configured with `maximumAttempts: 5`, so on failure, Temporal re-runs the whole step's model call.

Every emitted event takes two paths:
  - Redis stream (`stream:message-<sId>`): append-only log, tagged with its `step`, replayed to the client over SSE. Retried attempts are appended as brand-new entries.
  - DB step content (`AgentStepContentResource.createNewVersion`): versioned per (step, index), latest-wins. A retry overwrites the previous version.

While streaming, the client (`useAgentMessageStream`) rebuilds the timeline by reducing the Redis event stream into `inlineActivitySteps` (append-based). Once the turn ends, it replaces that array wholesale with the server-rendered `contentView`, which is computed from the collapsed DB step content, which is why the bug self-healed at "Done" and why reload was always clean.

The client reducer could not absorb a retry's re-emitted events:
  - `seenEventIds` only drops exact stream-id replays. Retried events have new ids.
  - `appendThinkingStep` deduped only against the most-recent thinking step `appendContentStep` did not dedupe at all
  - `retryCoTBuffer` only suppressed an *in-progress* (unflushed) CoT. Once a segment had been flushed into the timeline (because a tool call followed), the retry re-appended it.

So each of the up-to-5 attempts piled its steps on top of the previous ones, and a fresh mount mid-stream replayed the same log and rebuilt the same duplicates.

### Fix
Mirror the server's per-step, latest-wins semantics in the live reducer:

  - Tag every inline activity step with the agent-loop `step` that produced it (`InlineActivityStep.step`, set both client-side and in the server builder).
  - Track `currentStep` (advanced only by `generation_tokens`, the only events that fill the CoT/text buffer).
  - When a `generation_tokens` CoT event arrives with a fresh `traceId` on the same step (a new step also gets a fresh traceId, but its step number advances), treat it as a Temporal retry: drop the inline steps already committed for that step and rebuild them from the retry's events. This generalizes the old `retryCoTBuffer` beyond the unflushed case. The buffer is kept only to de-flicker the active CoT.

Note: it looks like `useChildAgentStream` has the same Temporal-retry duplication, but is out of scope for this PR. Will be done in a follow-up PR. Added a TODO comment about it.

## Tests

Locally, by injecting code in the temporal worker to force retries:

### Before the fix, see duplicated attempts
<img width="847" height="553" alt="Screenshot 2026-07-01 at 21 56 40" src="https://github.com/user-attachments/assets/6d6faa2a-9e17-4d88-991a-7b57b88efce9" />

### After the fix, only latest attempt is displayed
<img width="891" height="378" alt="Screenshot 2026-07-01 at 21 54 53" src="https://github.com/user-attachments/assets/211daf2c-2613-4beb-a278-e742b1dd425d" />


## Risk

Low

## Deploy Plan

Front
