### PR TITLE
feat(sandbox): pod egress allowlist — data layer

### DIFF
--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -226,6 +226,13 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     await this.update({ defaultAgentId }, transaction);
   }
 
+  async updatePodNetworkAllowedDomains(
+    podNetworkAllowedDomains: string[],
+    transaction?: Transaction
+  ) {
+    await this.update({ podNetworkAllowedDomains }, transaction);
+  }
+
   async setDefaultSkills(
     auth: Authenticator,
     skills: SkillResource[],

--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -24,6 +24,12 @@ export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataMod
   /** sId of the agent pre-selected for new conversations in this pod. Null = @dust. */
   declare defaultAgentId: CreationOptional<string | null>;
   declare defaultSkillsIds: CreationOptional<string[] | null>;
+  /**
+   * Pod-level sandbox egress allowlist. Merged into the pod sandbox's egress
+   * policy at activation, on top of the workspace-level allowlist. Same domain
+   * format as `EgressPolicy.allowedDomains`.
+   */
+  declare podNetworkAllowedDomains: CreationOptional<string[]>;
 }
 
 ProjectMetadataModel.init(
@@ -74,6 +80,11 @@ ProjectMetadataModel.init(
       allowNull: true,
       defaultValue: null,
       field: "defaultSkillsIds",
+    },
+    podNetworkAllowedDomains: {
+      type: DataTypes.ARRAY(DANGEROUSLY_UNBOUNDED_TEXT),
+      allowNull: false,
+      defaultValue: [],
     },
   },
   {

--- a/front/migrations/pre-deploy/20260702120000_add_pod_network_allowed_domains.sql
+++ b/front/migrations/pre-deploy/20260702120000_add_pod_network_allowed_domains.sql
@@ -1,0 +1,2 @@
+ALTER TABLE project_metadata
+ADD COLUMN pod_network_allowed_domains TEXT[] DEFAULT '{}' NOT NULL;


### PR DESCRIPTION
> **Superseded** by the owner-keyed egress policy re-layout stack (`egress-relayout-*` branches, PRs `28652`–`28655`). Branch kept for reference.

## Pod egress allowlist — data layer

Extends the workspace-level sandbox egress allowlist down to Pod level. Each Pod (a Space with `kind = "project"`) will carry its own *additional* allowlist, merged on top of the workspace allowlist for the Pod's Shared Computer. This PR is the data layer only:

- `podNetworkAllowedDomains` (`text[]`, non-null, default `{}`) on `project_metadata` — pre-deploy migration included.
- Model field + `ProjectMetadataResource.updatePodNetworkAllowedDomains`.

Nothing reads or writes the column yet — consumers land in the rest of the stack.

### Stack

Pod-level network egress allowlist, split for review:

1. #28352 — data layer (this stack's base)
2. #28512 — egress policy backend
3. #28513 — admin API route
4. #28514 — audit logging (droppable)
5. #28515 — settings UI

> [!NOTE]
> This PR previously contained the entire feature; it was split into the stack above per review feedback. Earlier review comments refer to code that now lives in the later PRs.

### Risk

Worst case, an unused column. Safe to rollback.

### Deploy plan

- [ ] Apply the pre-deploy migration before deploying `front`