### PR TITLE
feat(skills): add Activation global skill [S1-1]

### DIFF
--- a/front/lib/resources/skill/code_defined/activation.ts
+++ b/front/lib/resources/skill/code_defined/activation.ts
@@ -1,0 +1,69 @@
+import { getFeatureFlags } from "@app/lib/auth";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+
+const ACTIVATION_INSTRUCTIONS = `
+Recommend the next best action for the user to get more value from Dust. Help them execute it in this conversation, then offer to convert it into a habit (a saved skill and a recurring schedule).
+
+Before recommending, read any available context to determine the user's intention for activation.
+
+## Recommend
+
+Surface exactly one recommendation per turn. Follow this priority order. Move to the next tier only if the current tier yields no viable recommendation. Never explain the tier system to the user.
+
+1. Pre-selected skills — Call \`list_skills\` to see what skills are pinned or available. Prioritize any that align with the user's stated goals or role.
+2. Existing agents in this workspace — Call \`list_all_published_agents\` to see what agents exist. Recommend the one whose description best fits the user's work.
+3. Curated use cases by job type — If no skills or agents are a clear fit, suggest a curated use case matched to the user's role. Keep setup steps minimal; note any required tool connections.
+4. Personalized daily task manager - Connect primary daily sources (Slack, email, calendar) and set up a daily briefing.
+
+Each recommendation includes:
+- A 1-2 sentence rationale explaining why this is worth their time.
+- An offer to execute it directly in this conversation — not just describe it.
+- If applicable, a brief, skippable inline explanation of the relevant Dust concept (skill, trigger, schedule, Frame, etc.). One sentence, easy to ignore.
+
+## After Successful Use Case Execution
+
+Follow this sequence — do not offer it as a choice, just move through each step:
+
+1. **Save as a skill** — Use the \`skill_authoring\` tools to save the workflow as a reusable skill. Confirm with the user before saving.
+2. **Make it recurring** — Use the \`schedules_management\` tools to set up a recurring trigger. End this step with:
+
+:quickReply[Set it up]{message="Yes, set this up to run on a schedule"} :quickReply[Skip]{message="No thanks, skip the schedule"}
+
+## Accept / Reject
+
+After surfacing a recommendation, always end with one-click options:
+
+:quickReply[Let's try it]{message="Yes, let's try this now"} :quickReply[Not for me]{message="This isn't relevant to my work"} :quickReply[Tell me more]{message="Tell me more before we start"}
+
+## Quality
+
+- Be concise. Every message should be actionable in under 30 seconds of reading.
+- Never block the user. If they want to skip, change direction, ask an unrelated question, or leave, let them.
+- Always end messages with at least one \`quickReply\` button.
+- If the user asks a question unrelated to recommendations, answer it helpfully, then gently steer back.
+- Present recommendations naturally. Do not explain the priority tiers, the skill-pinning mechanism, or how this works. The user should feel like they're getting personalized suggestions, not being processed through a funnel.
+`.trim();
+
+export const activationSkill = {
+  sId: "activation",
+  name: "Activation",
+  userFacingDescription:
+    "Get a recommendation for the next best action to get more value from Dust, then execute it and make it a habit.",
+  agentFacingDescription:
+    "Use when the user wants a recommendation on what to try next in Dust. " +
+    "Surfaces one action at a time from available workspace skills and agents, then helps the user " +
+    "execute it, save it as a reusable skill, and set it up as a recurring schedule.",
+  instructions: ACTIVATION_INSTRUCTIONS,
+  mcpServers: [
+    { name: "agent_router" },
+    { name: "skill_authoring" },
+    { name: "schedules_management" },
+    { name: "files" },
+  ],
+  version: 1,
+  icon: "ActionRocketIcon",
+  isRestricted: async (auth) => {
+    const flags = await getFeatureFlags(auth);
+    return !flags.includes("activation_skill");
+  },
+} as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/global_registry.ts
+++ b/front/lib/resources/skill/code_defined/global_registry.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { activationSkill } from "@app/lib/resources/skill/code_defined/activation";
 import { framesSkill } from "@app/lib/resources/skill/code_defined/frames";
 import { goDeepSkill } from "@app/lib/resources/skill/code_defined/go_deep";
 import { mentionUsersSkill } from "@app/lib/resources/skill/code_defined/mention_users";
@@ -18,6 +19,7 @@ import { serializeSkillTag } from "@app/lib/skills/format";
 
 // Registry is a simple array.
 const GLOBAL_SKILLS_ARRAY = ensureUniqueSIds([
+  activationSkill,
   framesSkill,
   goDeepSkill,
   mentionUsersSkill,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -355,6 +355,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Model picker in the conversation input bar: pick a model tier (Fast, Balanced, Powerful, Frontier) or a specific model.",
     stage: "dust_only",
   },
+  activation_skill: {
+    description: "Enable the Activation skill for agentic user activation pods",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -700,6 +700,7 @@ export type RetrievalDocumentPublicType = z.infer<
 >;
 
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
+  | "activation_skill"
   | "advanced_notion_management"
   | "agent_builder_copilot"
   | "agent_builder_copilot_builders"


### PR DESCRIPTION
## Summary
* Implements [dust-tt/tasks#9352](https://github.com/dust-tt/tasks/issues/9352).
* Consider this an initial skeleton for the activation skill (to be given a better name at a future date)
* Behind FF
* Will be iterating on this continuously in initiative

## Testing
* manually went through workflow in local

## Risk

Low, behind FF