### PR TITLE
scripts: fix bash 3.2 compatibility in run-migrations.sh

### DIFF
--- a/scripts/run-migrations.sh
+++ b/scripts/run-migrations.sh
@@ -50,7 +50,7 @@ if [[ "$COMMAND" == "post-deploy" ]]; then
   echo "     • front-sse"
   echo ""
   read -r -p "   Have you deployed front and front-sse? [y/N] " confirm
-  if [[ "${confirm,,}" != "y" ]]; then
+  if [[ "$(printf '%s' "$confirm" | tr '[:upper:]' '[:lower:]')" != "y" ]]; then
     echo "❌ Aborted. Deploy front and front-sse first." >&2
     exit 1
   fi


### PR DESCRIPTION
## Description

`run-migrations.sh` failed on macOS with `${confirm,,}: bad substitution` when confirming the post-deploy prompt. That syntax is Bash's lowercase-expansion operator, introduced in Bash 4.0. macOS ships Bash 3.2 as `/bin/bash` (Apple has kept it frozen since Bash 4+ moved to the GPLv3 license), so any script invoked directly (`./scripts/run-migrations.sh`) runs under 3.2 and chokes on the 4.0-only syntax.

Replaced it with a portable lowercase conversion using `tr '[:upper:]' '[:lower:]'`, which works identically on Bash 3.2 and 4+ (Linux CI runners, prodbox, etc.).

## Tests

Manually re-ran the post-deploy confirmation prompt locally under macOS's `/bin/bash` (3.2) to confirm the `y`/`Y` check now works instead of throwing `bad substitution`.
