### PR TITLE
fix(conversations): let pod members read agent messages from other spaces

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -1,8 +1,11 @@
+import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
@@ -43,6 +46,12 @@ function postMessage(
 function getTools(workspace: { sId: string }, conversationId: string) {
   return honoApp.request(
     `/api/w/${workspace.sId}/assistant/conversations/${conversationId}/tools`
+  );
+}
+
+function getMessages(workspace: { sId: string }, conversationId: string) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/conversations/${conversationId}/messages`
   );
 }
 
@@ -108,5 +117,118 @@ describe("POST /api/w/:wId/assistant/conversations/:cId/messages", () => {
     });
 
     expect(response.status).toBe(404);
+  });
+});
+
+describe("GET /api/w/:wId/assistant/conversations/:cId/messages", () => {
+  it("renders an agent message for a pod member even when the agent is restricted to a different space", async () => {
+    const {
+      workspace,
+      auth: creatorAuth,
+      user: creator,
+    } = await createPrivateApiMockRequest({ role: "admin" });
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    // A restricted space that only the conversation creator belongs to.
+    const privateSpace = await SpaceFactory.regular(workspace);
+    const privateSpaceGroup = privateSpace.groups.find(
+      (g) => g.kind === "regular"
+    );
+    assert(privateSpaceGroup, "Private space group not found");
+    const addCreatorToPrivateSpaceRes =
+      await privateSpaceGroup.dangerouslyAddMember(internalAdminAuth, {
+        user: creator.toJSON(),
+      });
+    assert(addCreatorToPrivateSpaceRes.isOk());
+
+    // A Pod (project space) that the creator and a second, unrelated pod member
+    // both belong to.
+    const podSpace = await SpaceFactory.project(workspace, creator.id);
+    const podSpaceGroup = podSpace.groups.find((g) => g.kind === "regular");
+    assert(podSpaceGroup, "Pod space group not found");
+    const addCreatorToPodRes = await podSpaceGroup.dangerouslyAddMember(
+      internalAdminAuth,
+      { user: creator.toJSON() }
+    );
+    assert(addCreatorToPodRes.isOk());
+    await creatorAuth.refresh();
+
+    // An agent restricted to the private space, used in the conversation.
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+      creatorAuth,
+      { requestedSpaceIds: [privateSpace.id] }
+    );
+
+    // A conversation living in the Pod (the state after being moved there),
+    // whose history includes a message from the private-space agent.
+    const conversation = await ConversationFactory.create(creatorAuth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+      spaceId: podSpace.id,
+    });
+
+    // A second pod member who is NOT a member of the private space.
+    const { user: podMember } = await createPrivateApiMockRequest({
+      workspace,
+      role: "user",
+    });
+    const addPodMemberRes = await podSpaceGroup.dangerouslyAddMember(
+      internalAdminAuth,
+      { user: podMember.toJSON() }
+    );
+    assert(addPodMemberRes.isOk());
+
+    // The conversation record itself is readable (this part already worked).
+    const conversationResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/assistant/conversations/${conversation.sId}`
+    );
+    expect(conversationResponse.status).toBe(200);
+
+    // The bug: reading the message history 403'd because the agent's own
+    // `requestedSpaceIds` still pointed at the private space.
+    const messagesResponse = await getMessages(workspace, conversation.sId);
+    expect(messagesResponse.status).toBe(200);
+
+    const body = await messagesResponse.json();
+    const agentMessage = body.messages.find(
+      (m: { type: string }) => m.type === "agent_message"
+    );
+    assert(agentMessage, "Agent message missing from response");
+    expect(agentMessage.configuration.sId).toBe(agentConfig.sId);
+  });
+
+  it("still denies message access to a user with no access to the pod at all", async () => {
+    const {
+      workspace,
+      auth: creatorAuth,
+      user: creator,
+    } = await createPrivateApiMockRequest({ role: "admin" });
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    const podSpace = await SpaceFactory.project(workspace, creator.id);
+    const podSpaceGroup = podSpace.groups.find((g) => g.kind === "regular");
+    assert(podSpaceGroup, "Pod space group not found");
+    const addCreatorToPodRes = await podSpaceGroup.dangerouslyAddMember(
+      internalAdminAuth,
+      { user: creator.toJSON() }
+    );
+    assert(addCreatorToPodRes.isOk());
+    await creatorAuth.refresh();
+
+    const conversation = await ConversationFactory.create(creatorAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+      spaceId: podSpace.id,
+    });
+
+    // A workspace member who was never added to the Pod.
+    await createPrivateApiMockRequest({ workspace, role: "user" });
+
+    const messagesResponse = await getMessages(workspace, conversation.sId);
+    expect(messagesResponse.status).toBe(404);
   });
 });

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -299,10 +299,14 @@ export async function getAgentConfigurations<V extends AgentFetchVariant>(
     agentIds,
     variant,
     globalAgentContext,
+    dangerouslySkipSpacePermissionCheck = false,
   }: {
     agentIds: string[];
     variant: V;
     globalAgentContext?: GlobalAgentContext;
+    // Used in pods: Pod conversations are, by design, readable by anyone with read access to the pod's
+    // space (see front/lib/api/assistant/conversation/permissions.ts).
+    dangerouslySkipSpacePermissionCheck?: boolean;
   }
 ): Promise<
   V extends "full" ? AgentConfigurationType[] : LightAgentConfigurationType[]
@@ -336,7 +340,8 @@ export async function getAgentConfigurations<V extends AgentFetchVariant>(
 
       const allowedAgentModels = await filterAgentsByRequestedSpaces(
         auth,
-        agentModels
+        agentModels,
+        { dangerouslySkipSpacePermissionCheck }
       );
       workspaceAgents = await enrichAgentConfigurations(
         auth,
@@ -1927,14 +1932,18 @@ async function disableTriggersForNonEditors(
 
 export async function filterAgentsByRequestedSpaces(
   auth: Authenticator,
-  agents: AgentConfigurationModel[]
+  agents: AgentConfigurationModel[],
+  {
+    // Used in pods: Pod conversations are, by design, readable by anyone with read access to the pod's
+    // space (see front/lib/api/assistant/conversation/permissions.ts).
+    dangerouslySkipSpacePermissionCheck = false,
+  }: { dangerouslySkipSpacePermissionCheck?: boolean } = {}
 ) {
   const uniqSpaceIds = Array.from(
     new Set(agents.flatMap((agent) => agent.requestedSpaceIds))
   );
 
   const spaces = await SpaceResource.fetchByModelIds(auth, uniqSpaceIds);
-  const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
 
   // Filter out agents that reference missing/deleted spaces.
   // When a space is deleted, mcp actions are removed, and requestedSpaceIds are updated.
@@ -1942,6 +1951,16 @@ export async function filterAgentsByRequestedSpaces(
   const validAgents = agents.filter((c) =>
     c.requestedSpaceIds.every((id) => foundSpaceIds.has(id))
   );
+
+  // Pod conversations are, by design, readable by anyone with read access to the pod's
+  // space (see front/lib/api/assistant/conversation/permissions.ts). Callers rendering
+  // messages that are already part of such a conversation's history can opt out of the
+  // per-agent space check: pod-level access already vouches for that history.
+  if (dangerouslySkipSpacePermissionCheck) {
+    return validAgents;
+  }
+
+  const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
 
   const allowedBySpaceIds = validAgents.filter((agent) =>
     auth.canRead(

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -226,7 +226,10 @@ function renderUserMessage(
 async function batchRenderUserMessages(
   auth: Authenticator,
   messages: MessageModel[],
-  mentionsByMessageId?: Map<ModelId, MentionModel[]>
+  mentionsByMessageId: Map<ModelId, MentionModel[]> | undefined,
+  // Used in pods: Pod conversations are, by design, readable by anyone with read access to the pod's
+  // space (see front/lib/api/assistant/conversation/permissions.ts).
+  bypassAgentSpacePermissionCheck: boolean
 ): Promise<UserMessageType[]> {
   const userMessages = messages.filter(
     (m) => m.userMessage !== null && m.userMessage !== undefined
@@ -267,6 +270,7 @@ async function batchRenderUserMessages(
       ? await getAgentConfigurations(auth, {
           agentIds: agentConfigurationIds,
           variant: "extra_light",
+          dangerouslySkipSpacePermissionCheck: bypassAgentSpacePermissionCheck,
         })
       : [];
   const reactionsByMessageId = await getMessagesReactions(auth, {
@@ -345,7 +349,10 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
   messages: MessageModel[],
   viewType: V,
   messagesWithToolOutputContent: Set<ModelId> | null = null,
-  mentionsByMessageId: Map<ModelId, MentionModel[]>
+  mentionsByMessageId: Map<ModelId, MentionModel[]>,
+  // Used in pods: Pod conversations are, by design, readable by anyone with read access to the pod's
+  // space (see front/lib/api/assistant/conversation/permissions.ts).
+  bypassAgentSpacePermissionCheck: boolean = false
 ): Promise<
   Result<
     V extends "full" ? AgentMessageType[] : LightAgentMessageType[],
@@ -397,6 +404,8 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         ? getAgentConfigurations(auth, {
             agentIds: [...agentConfigurationIds],
             variant: "extra_light",
+            dangerouslySkipSpacePermissionCheck:
+              bypassAgentSpacePermissionCheck,
           })
         : [],
   ];
@@ -906,17 +915,26 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
     }
   }
 
+  // Pod conversations are, by design, readable by anyone with read access to the pod's
+  // space (see front/lib/api/assistant/conversation/permissions.ts). `conversation` here
+  // was already fetched through a permission-checked path, so pod-level access to it also
+  // vouches for the agents mentioned in its history, even if those agents' own
+  // `requestedSpaceIds` still point at a different (e.g. private) space.
+  const bypassAgentSpacePermissionCheck = !!conversation.spaceId;
+
   const userMessages = await batchRenderUserMessages(
     auth,
     messages,
-    mentionsByMessageId
+    mentionsByMessageId,
+    bypassAgentSpacePermissionCheck // batchRenderUserMessages gets the agent configuration for agent mentions
   );
   const agentMessagesRes = await batchRenderAgentMessages(
     auth,
     messages,
     viewType,
     messagesWithToolOutputContent,
-    mentionsByMessageId
+    mentionsByMessageId,
+    bypassAgentSpacePermissionCheck
   );
 
   if (agentMessagesRes.isErr()) {

--- a/front/lib/api/cancel.ts
+++ b/front/lib/api/cancel.ts
@@ -72,7 +72,8 @@ export async function terminateMessageGeneration(
     messageRows,
     "full",
     null,
-    new Map()
+    new Map(),
+    !!conversation.spaceId
   );
 
   if (agentMessagesRes.isErr()) {


### PR DESCRIPTION
## Description

Moving a conversation into a Pod is supposed to make it readable by every Pod member, but when the conversation includes a message from an agent scoped to a different (e.g. private) space, that promise breaks: `GET .../conversations/{cId}` returns 200, while `GET .../conversations/{cId}/messages` 403s with `conversation_with_unavailable_agent` for any Pod member who isn't also a member of the agent's original space.

**The bug:** moving a conversation into a Pod (`moveConversationToProject`) rewrites the *conversation's* `requestedSpaceIds` to just the Pod's space, so the conversation record itself becomes readable Pod-wide. It never touches the *agent's* own `requestedSpaceIds`, which keeps pointing at wherever the agent originally lived. Rendering the message history resolves each agent message's configuration via `getAgentConfigurations`, which filters agents by the agent's own space permissions — so for a Pod member outside that original space, the agent config comes back missing and rendering fails.

**The fix:** when rendering messages that are already part of a Pod conversation's history, skip the per-agent space check — Pod-level read access (already verified before we get here) is sufficient to vouch for that history, consistent with how Pod conversations are designed to work elsewhere in the codebase. This is implemented as an explicit opt-in flag (`dangerouslySkipSpacePermissionCheck`) threaded through `getAgentConfigurations`, so every other caller (agent pickers, mention suggestions, etc.) is unaffected.

Fixes dust-tt/tasks#9344.

## Tests

Added a functional test reproducing the exact scenario (agent restricted to a private space, conversation moved into a Pod, a Pod member outside that private space) — verified it fails with 403 against the pre-fix code and passes with the fix. Added a second test confirming a user with no access to the Pod at all is still correctly denied, to guard against the bypass being too broad.
