### PR TITLE
Fix invoice cleanup, add check on total to avoid double billing

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1351,34 +1351,95 @@ export async function finalizeInvoice(
 const METRONOME_INVOICE_LINES_CLEANED_FLAG = "lines_cleaned";
 
 /**
+ * Metronome represents a fully-applied commit/credit as a pair of lines on the
+ * same invoice with equal and opposite amounts: a negative line whose
+ * description is "<label> applied", and the positive usage/subscription line
+ * it offsets, whose description contains "(<label>)" (e.g. a negative
+ * "Platform Seat (Yearly) commitment: 53 seats applied" line offsetting a
+ * positive "Platform Seat (Yearly) (Platform Seat (Yearly) commitment: 53
+ * seats)" line). Neither line carries metadata identifying the pairing (there
+ * is no such thing as `metronome_commit_id` on Stripe line items — Metronome
+ * does not document or set one), so we match them by description + amount
+ * instead.
+ */
+function findCommitAppliedLineIds(
+  lines: Stripe.InvoiceLineItem[]
+): Set<string> {
+  const appliedSuffix = " applied";
+  const matchedLineIds = new Set<string>();
+
+  for (const creditLine of lines) {
+    const description = creditLine.description;
+    if (
+      creditLine.amount >= 0 ||
+      !description ||
+      !description.endsWith(appliedSuffix)
+    ) {
+      continue;
+    }
+
+    const label = description.slice(0, -appliedSuffix.length);
+    const offsetLine = lines.find(
+      (candidate) =>
+        candidate.id !== creditLine.id &&
+        !matchedLineIds.has(candidate.id) &&
+        candidate.amount === -creditLine.amount &&
+        candidate.currency === creditLine.currency &&
+        candidate.description?.includes(`(${label})`)
+    );
+
+    if (offsetLine) {
+      matchedLineIds.add(offsetLine.id);
+    }
+  }
+
+  return matchedLineIds;
+}
+
+/**
  * Removes from a Metronome-pushed Stripe draft invoice the line items that
- * should not appear on the customer-facing invoice, mirroring the filters
- * applied by the /invoice/lines API endpoint:
+ * should not appear on the customer-facing invoice:
  *
- * 1. Negative lines
- * 2. Lines with an applied commit or credit — usage/subscription lines whose
- *    cost is covered by a commit/credit (identified by `metronome_commit_id`
- *    in the Stripe line item metadata).
+ * 1. Negative lines.
+ * 2. Lines with a fully-applied commit or credit, matched via
+ *    `findCommitAppliedLineIds` (see its doc comment).
  * 3. Wrong-currency lines — non-fiat lines (e.g. AWU-priced) that Metronome may
  *    not transfer to Stripe; guard retained for safety.
  *
- * Filters 1 and 2 cancel each other out: every negative credit line is paired
- * with a positive usage line of the same absolute amount, so removing both
- * leaves the invoice total unchanged.
+ * Filters 1 and 2 cancel each other out: the negative "applied" line and the
+ * positive line it offsets have equal and opposite amounts, so removing both
+ * leaves the invoice total unchanged. As a safety net against a bad match, the
+ * invoice total before and after cleaning is returned so the caller can abort
+ * finalization if it drifted.
  */
 async function cleanMetronomeInvoiceLines(
   stripe: Stripe,
   invoice: Stripe.Invoice
-): Promise<void> {
+): Promise<{
+  totalsMatch: boolean;
+  originalTotalCents: number;
+  newTotalCents: number;
+}> {
   const invoiceCurrency = invoice.currency;
+  const originalTotalCents = invoice.total;
 
   // `invoice.lines` only holds the first page; iterate the list endpoint so we
   // see every line. The Stripe SDK list result auto-paginates when iterated.
+  // We need the full set upfront (not streamed) since matching a commit's
+  // negative line to the positive line it offsets requires looking across all
+  // of the invoice's lines.
+  const lines: Stripe.InvoiceLineItem[] = [];
   for await (const line of stripe.invoices.listLineItems(invoice.id, {
     limit: 100,
   })) {
+    lines.push(line);
+  }
+
+  const commitAppliedLineIds = findCommitAppliedLineIds(lines);
+
+  for (const line of lines) {
     const isNegative = line.amount < 1;
-    const hasAppliedCommitOrCredit = !!line.metadata?.metronome_commit_id;
+    const hasAppliedCommitOrCredit = commitAppliedLineIds.has(line.id);
     const isWrongCurrency = line.currency !== invoiceCurrency;
     const shouldRemove =
       isNegative || hasAppliedCommitOrCredit || isWrongCurrency;
@@ -1418,6 +1479,15 @@ async function cleanMetronomeInvoiceLines(
 
     await stripe.invoiceItems.del(invoiceItemId);
   }
+
+  const updatedInvoice = await stripe.invoices.retrieve(invoice.id);
+  const newTotalCents = updatedInvoice.total;
+
+  return {
+    totalsMatch: newTotalCents === originalTotalCents,
+    originalTotalCents,
+    newTotalCents,
+  };
 }
 
 /**
@@ -1438,7 +1508,10 @@ export async function cleanAndFinalizeMetronomeDraftInvoice({
   invoiceId: string;
   workspaceId: string;
 }): Promise<
-  Result<{ outcome: "cleaned" | "skipped" }, { error_message: string }>
+  Result<
+    { outcome: "cleaned" | "skipped" | "totals_mismatch" },
+    { error_message: string }
+  >
 > {
   const stripe = getStripeClient();
 
@@ -1482,7 +1555,8 @@ export async function cleanAndFinalizeMetronomeDraftInvoice({
       creditConfig?.autoInvoiceFinalizationEnabled ??
       DEFAULT_AUTO_INVOICE_FINALIZATION_ENABLED;
 
-    await cleanMetronomeInvoiceLines(stripe, invoice);
+    const { totalsMatch, originalTotalCents, newTotalCents } =
+      await cleanMetronomeInvoiceLines(stripe, invoice);
 
     await stripe.invoices.update(invoiceId, {
       metadata: {
@@ -1490,6 +1564,23 @@ export async function cleanAndFinalizeMetronomeDraftInvoice({
         [METRONOME_INVOICE_LINES_CLEANED_FLAG]: "true",
       },
     });
+
+    if (!totalsMatch) {
+      // The lines_cleaned flag is already set above, so a Temporal retry
+      // would just hit the "already cleaned" early return and no-op — this
+      // needs a human, not a retry. Report Ok rather than throwing.
+      logger.error(
+        {
+          panic: true,
+          stripeInvoiceId: invoiceId,
+          workspaceId,
+          originalTotalCents,
+          newTotalCents,
+        },
+        "[Stripe] Invoice total changed after cleaning Metronome line items, leaving as draft for manual review"
+      );
+      return new Ok({ outcome: "totals_mismatch" });
+    }
 
     if (!autoInvoiceFinalizationEnabled) {
       logger.info(


### PR DESCRIPTION
## Description

`cleanMetronomeInvoiceLines` (used to strip commit/credit-covered lines from
Metronome-pushed Stripe draft invoices before finalization) relied on a
`metronome_commit_id` Stripe line-item metadata key to detect lines whose cost
was already covered by a commit. That key does not exist — Metronome never
sets it, so the check always evaluated to `false` and those lines were never
removed.

In practice this double-billed customers: Metronome represents a fully-applied
commit as a pair of lines on the same invoice with equal and opposite amounts
— a negative line (`"<label> applied"`) and the positive usage/subscription
line it offsets (description containing `(<label>)`). Only the negative line
was ever caught (via the `isNegative` filter); the matching positive line
stayed on the invoice, so the customer was charged for it a second time on top
of the actual commitment charge.

Fix:
- Added `findCommitAppliedLineIds`, which pairs the negative `"<label>
  applied"` line with the positive line whose description contains
  `(<label>)` and whose amount/currency match exactly, and marks the positive
  line for removal too.
- As a safety net, `cleanMetronomeInvoiceLines` now returns the invoice total
  before and after cleaning. If cleaning changed the total (i.e. our matching
  didn't net out as expected), `cleanAndFinalizeMetronomeDraftInvoice` logs a
  `panic: true` error and leaves the invoice as an unfinalized draft
  (`totals_mismatch` outcome) instead of finalizing a possibly-wrong invoice.
  It returns `Ok` rather than throwing, since the `lines_cleaned` metadata
  flag is already set by that point — a Temporal retry would just no-op into
  `skipped`, not re-attempt anything useful.

Found while investigating a production invoice where a "Pro Seat (Yearly)"
commitment line was double-billed; confirmed via logs that the
`metronome_commit_id` metadata key never appears on any Stripe line item.

## Tests

Type-checked (`npx tsgo --noEmit`, clean). No functional test added — this is
a narrow fix to a Temporal-invoked billing helper with no HTTP endpoint;
verified the new pairing logic against the two real production log samples
that surfaced the bug (matching negative/positive line pairs by description +
amount).

## Risk

Billing-critical path (Stripe invoice finalization for Metronome customers).
Mitigated by the new total-invariant check: if the fix's matching logic ever
misfires, the invoice is held as a draft and alerted on (`panic: true`) rather
than finalized incorrectly, so the worst case is a delayed invoice, not a
wrong one.

Only 2 known affected invoices found in production logs so far — need a
follow-up to check whether they were already finalized/paid and require a
credit note.

## Deploy Plan

Standard deploy. No migration, no config change, no feature flag.
