### PR TITLE
feat(triggers): let a trigger run its conversation inside a Pod

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.test.ts
@@ -1,0 +1,266 @@
+import { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { faker } from "@faker-js/faker";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function getTriggers(workspace: { sId: string }, aId: string) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/agent_configurations/${aId}/triggers`
+  );
+}
+
+function postTriggers(workspace: { sId: string }, aId: string, body: unknown) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/agent_configurations/${aId}/triggers`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function patchTriggers(workspace: { sId: string }, aId: string, body: unknown) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/agent_configurations/${aId}/triggers`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function scheduleTriggerBody(spaceId: string | null | undefined) {
+  return {
+    triggers: [
+      {
+        name: `trigger-${faker.string.alphanumeric(8)}`,
+        kind: "schedule" as const,
+        customPrompt: "",
+        naturalLanguageDescription: null,
+        status: "disabled" as const,
+        configuration: {
+          type: "cron" as const,
+          cron: "0 9 * * *",
+          timezone: "UTC",
+        },
+        spaceId,
+      },
+    ],
+  };
+}
+
+async function createScheduleTrigger(
+  workspace: { sId: string },
+  aId: string,
+  spaceId: string | null | undefined
+) {
+  const createRes = await postTriggers(
+    workspace,
+    aId,
+    scheduleTriggerBody(spaceId)
+  );
+  expect(createRes.status).toBe(204);
+
+  const listRes = await getTriggers(workspace, aId);
+  const { triggers } = await listRes.json();
+  return triggers[triggers.length - 1];
+}
+
+describe("POST /api/w/:wId/assistant/agent_configurations/:aId/triggers (spaceId)", () => {
+  it("creates a trigger scoped to an open pod", async () => {
+    const { workspace, user, globalGroup } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const openPod = await SpaceResource.makeNew(
+      {
+        name: `open-pod-${faker.string.alphanumeric(8)}`,
+        kind: "project",
+        workspaceId: workspace.id,
+      },
+      { members: [globalGroup] }
+    );
+
+    const response = await postTriggers(
+      workspace,
+      agent.sId,
+      scheduleTriggerBody(openPod.sId)
+    );
+
+    expect(response.status).toBe(204);
+  });
+
+  it("creates a trigger scoped to a restricted pod the user is a member of", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const memberPod = await SpaceFactory.project(workspace, user.id);
+
+    const response = await postTriggers(
+      workspace,
+      agent.sId,
+      scheduleTriggerBody(memberPod.sId)
+    );
+
+    expect(response.status).toBe(204);
+  });
+
+  it("rejects a restricted pod the user is not a member of", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const otherUser = await UserFactory.basic();
+    const restrictedPod = await SpaceFactory.project(workspace, otherUser.id);
+
+    const response = await postTriggers(
+      workspace,
+      agent.sId,
+      scheduleTriggerBody(restrictedPod.sId)
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.type).toBe("invalid_request_error");
+  });
+
+  it("rejects a space that is not a Pod", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const regularSpace = await SpaceFactory.regular(workspace);
+
+    const response = await postTriggers(
+      workspace,
+      agent.sId,
+      scheduleTriggerBody(regularSpace.sId)
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("creates a trigger with no pod (backward compatible default)", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const response = await postTriggers(
+      workspace,
+      agent.sId,
+      scheduleTriggerBody(null)
+    );
+
+    expect(response.status).toBe(204);
+  });
+
+  it("rejects a Pod that does not exist", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const response = await postTriggers(
+      workspace,
+      agent.sId,
+      scheduleTriggerBody("space_does_not_exist")
+    );
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/triggers (spaceId)", () => {
+  it("updates an existing trigger to run inside a Pod", async () => {
+    const { workspace, user, globalGroup } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createScheduleTrigger(workspace, agent.sId, null);
+    const openPod = await SpaceResource.makeNew(
+      {
+        name: `open-pod-${faker.string.alphanumeric(8)}`,
+        kind: "project",
+        workspaceId: workspace.id,
+      },
+      { members: [globalGroup] }
+    );
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [{ ...trigger, sId: trigger.sId, spaceId: openPod.sId }],
+    });
+
+    expect(response.status).toBe(204);
+    const listRes = await getTriggers(workspace, agent.sId);
+    const { triggers } = await listRes.json();
+    const updated = triggers.find(
+      (t: { sId: string }) => t.sId === trigger.sId
+    );
+    expect(updated.spaceId).toBe(openPod.sId);
+  });
+
+  it("rejects updating a trigger to a Pod the user is not a member of", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createScheduleTrigger(workspace, agent.sId, null);
+    const otherUser = await UserFactory.basic();
+    const restrictedPod = await SpaceFactory.project(workspace, otherUser.id);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [{ ...trigger, sId: trigger.sId, spaceId: restrictedPod.sId }],
+    });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -1,6 +1,9 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import {
+  resolveTriggerSpaceId,
+  TriggerResource,
+} from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { GetTriggersResponseBody } from "@app/types/api/assistant/configuration/triggers";
@@ -223,6 +226,20 @@ app.patch(
         ? getResourceIdFromSId(validatedTrigger.webhookSourceViewId)
         : null;
 
+      const spaceIdRes = await resolveTriggerSpaceId(
+        auth,
+        validatedTrigger.spaceId
+      );
+      if (spaceIdRes.isErr()) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: spaceIdRes.error,
+          },
+        });
+      }
+
       const updatedTrigger = await TriggerResource.update(
         auth,
         triggerData.sId,
@@ -230,6 +247,7 @@ app.patch(
           ...validatedTrigger,
           status: validatedTrigger.status ?? "enabled",
           webhookSourceViewId,
+          spaceId: spaceIdRes.value,
         }
       );
 
@@ -308,6 +326,20 @@ app.post(
         ? validatedTrigger.executionPerDayLimitOverride
         : null;
 
+      const spaceIdRes = await resolveTriggerSpaceId(
+        auth,
+        validatedTrigger.spaceId
+      );
+      if (spaceIdRes.isErr()) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: spaceIdRes.error,
+          },
+        });
+      }
+
       const newTrigger = await TriggerResource.makeNew(auth, {
         workspaceId: workspace.id,
         agentConfigurationId: aId,
@@ -322,6 +354,7 @@ app.post(
         executionPerDayLimitOverride: executionPerDay,
         executionMode: validatedTrigger.kind === "webhook" ? "fair_use" : null,
         origin: "user",
+        spaceId: spaceIdRes.value,
       });
 
       if (newTrigger.isErr()) {

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -81,6 +81,7 @@ const webhookTriggerSchema = z.object({
   editorName: z.string().optional(),
   executionPerDayLimitOverride: z.number().nullable(),
   executionMode: z.enum(["fair_use", "programmatic"]).nullable(),
+  spaceId: z.string().nullable().optional(),
 });
 
 const scheduleTriggerSchema = z.object({
@@ -93,6 +94,7 @@ const scheduleTriggerSchema = z.object({
   configuration: scheduleConfigSchema,
   editor: z.number().nullable(),
   editorName: z.string().optional(),
+  spaceId: z.string().nullable().optional(),
 });
 
 const triggerSchema = z.discriminatedUnion("kind", [

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -224,6 +224,7 @@ function serializeTrigger(
         kind: trigger.kind,
         executionPerDayLimitOverride: trigger.executionPerDayLimitOverride,
         webhookSourceViewId: trigger.webhookSourceViewId,
+        spaceId: trigger.spaceId ?? null,
       };
     }
     case "schedule":
@@ -234,6 +235,7 @@ function serializeTrigger(
         naturalLanguageDescription: trigger.naturalLanguageDescription,
         configuration: trigger.configuration,
         kind: trigger.kind,
+        spaceId: trigger.spaceId ?? null,
       };
     default:
       assertNever(trigger);

--- a/front/components/agent_builder/triggers/TriggerPodSelector.tsx
+++ b/front/components/agent_builder/triggers/TriggerPodSelector.tsx
@@ -1,0 +1,128 @@
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { getSpaceIcon } from "@app/lib/spaces";
+import { useSpaces } from "@app/lib/swr/spaces";
+import type { PodType } from "@app/types/space";
+import { isProjectType } from "@app/types/space";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import { useCallback, useMemo, useState } from "react";
+
+interface TriggerPodSelectorProps {
+  value: string | null | undefined;
+  onChange: (spaceId: string | null) => void;
+  disabled?: boolean;
+}
+
+export function TriggerPodSelector({
+  value,
+  onChange,
+  disabled,
+}: TriggerPodSelectorProps) {
+  const { owner } = useAgentBuilderContext();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  const { spaces, isSpacesLoading } = useSpaces({
+    workspaceId: owner.sId,
+    kinds: ["project"],
+  });
+
+  const allPods = useMemo(
+    () =>
+      spaces
+        .filter((s) => isProjectType(s))
+        .filter((s) => s.archivedAt === null),
+    [spaces]
+  );
+
+  const selectedPod = useMemo(
+    () => (value ? allPods.find((pod) => pod.sId === value) : undefined),
+    [value, allPods]
+  );
+
+  const filteredPods = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return allPods;
+    }
+    const query = searchQuery.toLowerCase();
+    return allPods.filter(
+      (pod) =>
+        pod.name.toLowerCase().includes(query) ||
+        pod.description?.toLowerCase().includes(query)
+    );
+  }, [allPods, searchQuery]);
+
+  const handleSelectPod = useCallback(
+    (pod: PodType | null) => {
+      onChange(pod ? pod.sId : null);
+      setSearchOpen(false);
+      setSearchQuery("");
+    },
+    [onChange]
+  );
+
+  return (
+    <div className="inline-flex">
+      <DropdownMenu open={searchOpen} onOpenChange={setSearchOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            label={selectedPod?.name ?? "My conversations (default)"}
+            icon={selectedPod ? getSpaceIcon(selectedPod) : undefined}
+            variant="outline"
+            size="xs"
+            isSelect
+            disabled={disabled}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          dropdownHeaders={
+            <DropdownMenuSearchbar
+              name="pod-search"
+              placeholder="Search..."
+              value={searchQuery}
+              onChange={setSearchQuery}
+              autoFocus
+            />
+          }
+        >
+          <DropdownMenuItem
+            label="My conversations (default)"
+            description="Run in my conversations."
+            onClick={() => handleSelectPod(null)}
+          />
+          {isSpacesLoading ? (
+            <div className="px-3 py-4 text-center text-xs italic text-muted-foreground">
+              Loading...
+            </div>
+          ) : filteredPods.length > 0 ? (
+            filteredPods.map((pod) => (
+              <DropdownMenuItem
+                key={pod.sId}
+                onClick={() => handleSelectPod(pod)}
+                label={pod.name}
+                description={
+                  pod.description
+                    ? pod.description.length > 50
+                      ? `${pod.description.substring(0, 50)}...`
+                      : pod.description
+                    : "No description available."
+                }
+                icon={getSpaceIcon(pod)}
+              />
+            ))
+          ) : (
+            <div className="px-3 py-4 text-center text-xs italic text-muted-foreground">
+              {searchQuery ? "No matches" : "No Pods"}
+            </div>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionSheet.tsx
@@ -1,5 +1,6 @@
 import type { AgentBuilderScheduleTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { ScheduleEditionScheduler } from "@app/components/agent_builder/triggers/schedule/ScheduleEditionScheduler";
+import { TriggerPodSelector } from "@app/components/agent_builder/triggers/TriggerPodSelector";
 import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -97,6 +98,31 @@ function ScheduleEditionMessageInput({
   );
 }
 
+interface ScheduleEditionPodSelectorProps {
+  isEditor: boolean;
+}
+
+function ScheduleEditionPodSelector({
+  isEditor,
+}: ScheduleEditionPodSelectorProps) {
+  const { control } = useFormContext<TriggerViewsSheetFormValues>();
+  const { field } = useController({ control, name: "schedule.spaceId" });
+
+  return (
+    <div className="space-y-1">
+      <Label>Where to create this conversation? (optional) </Label>
+      <p className="text-sm text-muted-foreground">
+        Run this trigger's conversation inside a Pod instead.
+      </p>
+      <TriggerPodSelector
+        value={field.value}
+        onChange={field.onChange}
+        disabled={!isEditor}
+      />
+    </div>
+  );
+}
+
 interface ScheduleEditionSheetContentProps {
   owner: LightWorkspaceType;
   trigger: AgentBuilderScheduleTriggerType | null;
@@ -128,6 +154,8 @@ export function ScheduleEditionSheetContent({
         <ScheduleEditionScheduler isEditor={isEditor} owner={owner} />
         <Separator />
         <ScheduleEditionMessageInput isEditor={isEditor} />
+        <Separator />
+        <ScheduleEditionPodSelector isEditor={isEditor} />
       </div>
     </>
   );

--- a/front/components/agent_builder/triggers/schedule/scheduleEditionFormSchema.ts
+++ b/front/components/agent_builder/triggers/schedule/scheduleEditionFormSchema.ts
@@ -21,6 +21,7 @@ const commonFields = {
   naturalLanguageDescription: z.string().optional(),
   customPrompt: z.string(),
   timezone: z.string().min(1, "Timezone is required"),
+  spaceId: z.string().nullable(),
 };
 
 const cronScheduleSchema = z.object({
@@ -55,6 +56,7 @@ export function getScheduleFormDefaultValues(
     status: trigger?.status ?? "enabled",
     naturalLanguageDescription: trigger?.naturalLanguageDescription ?? "",
     customPrompt: trigger?.customPrompt ?? "",
+    spaceId: trigger?.spaceId ?? null,
   };
 
   if (!config) {
@@ -134,5 +136,6 @@ export function formValuesToScheduleTriggerData({
       editTrigger?.kind === "schedule"
         ? editTrigger.editorName
         : (user.fullName ?? undefined),
+    spaceId: schedule.spaceId,
   };
 }

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
@@ -1,5 +1,6 @@
 import type { AgentBuilderWebhookTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { RecentWebhookRequests } from "@app/components/agent_builder/triggers/RecentWebhookRequests";
+import { TriggerPodSelector } from "@app/components/agent_builder/triggers/TriggerPodSelector";
 import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
 import { WebhookEditionFilters } from "@app/components/agent_builder/triggers/webhook/WebhookEditionFilters";
 import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
@@ -242,6 +243,31 @@ function WebhookEditionMessageInput({
   );
 }
 
+interface WebhookEditionPodSelectorProps {
+  isEditor: boolean;
+}
+
+function WebhookEditionPodSelector({
+  isEditor,
+}: WebhookEditionPodSelectorProps) {
+  const { control } = useFormContext<TriggerViewsSheetFormValues>();
+  const { field } = useController({ control, name: "webhook.spaceId" });
+
+  return (
+    <div className="space-y-1">
+      <Label>Where to create this conversation? (optional)</Label>
+      <p className="text-sm text-muted-foreground">
+        Run this trigger's conversation inside a Pod instead.
+      </p>
+      <TriggerPodSelector
+        value={field.value}
+        onChange={field.onChange}
+        disabled={!isEditor}
+      />
+    </div>
+  );
+}
+
 interface WebhookEditionSheetContentProps {
   owner: LightWorkspaceType;
   trigger: AgentBuilderWebhookTriggerType | null;
@@ -317,6 +343,11 @@ export function WebhookEditionSheetContent({
         <WebhookEditionExecutionLimit
           executionMode={trigger?.executionMode ?? "fair_use"}
         />
+
+        <Separator />
+
+        <WebhookEditionPodSelector isEditor={isEditor} />
+
         {trigger && (
           <div className="space-y-1">
             <RecentWebhookRequests

--- a/front/components/agent_builder/triggers/webhook/webhookEditionFormSchema.ts
+++ b/front/components/agent_builder/triggers/webhook/webhookEditionFormSchema.ts
@@ -23,6 +23,7 @@ export const WebhookFormSchema = z.object({
   naturalDescription: z.string().optional(),
   executionPerDayLimitOverride: z.number(),
   executionMode: z.enum(["fair_use", "programmatic"]).default("fair_use"),
+  spaceId: z.string().nullable(),
 });
 
 export type WebhookFormValues = z.infer<typeof WebhookFormSchema>;
@@ -54,6 +55,7 @@ export function getWebhookFormDefaultValues({
       trigger?.executionPerDayLimitOverride ??
       DEFAULT_SINGLE_TRIGGER_EXECUTION_PER_DAY_LIMIT,
     executionMode: trigger?.executionMode ?? "fair_use",
+    spaceId: trigger?.spaceId ?? null,
   };
 }
 
@@ -92,5 +94,6 @@ export function formValuesToWebhookTriggerData({
         : (user.fullName ?? undefined),
     executionPerDayLimitOverride: webhook.executionPerDayLimitOverride,
     executionMode: webhook.executionMode,
+    spaceId: webhook.spaceId,
   };
 }

--- a/front/lib/models/agent/triggers/triggers.ts
+++ b/front/lib/models/agent/triggers/triggers.ts
@@ -5,6 +5,7 @@ import {
   DANGEROUSLY_UNBOUNDED_TEXT,
   DataTypes,
 } from "@app/lib/resources/storage/data_types";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -46,6 +47,12 @@ export class TriggerModel extends WorkspaceAwareModel<TriggerModel> {
    */
   declare agentConfigurationId: ForeignKey<AgentConfigurationModel["sId"]>;
   declare editor: ForeignKey<UserModel["id"]>;
+
+  /**
+   * Pod (Project Space) the trigger's conversation is created in. Null means the
+   * conversation is created in the default space, matching legacy behavior.
+   */
+  declare spaceId: ForeignKey<SpaceModel["id"]> | null;
 }
 
 TriggerModel.init(
@@ -107,6 +114,10 @@ TriggerModel.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
+    spaceId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
   },
   {
     modelName: "trigger",
@@ -127,6 +138,7 @@ TriggerModel.init(
     indexes: [
       { fields: ["workspaceId", "agentConfigurationId", "name"] },
       { fields: ["workspaceId", "webhookSourceViewId"] },
+      { fields: ["spaceId"], concurrently: true },
     ],
   }
 );
@@ -139,4 +151,10 @@ TriggerModel.belongsTo(WebhookSourcesViewModel, {
   foreignKey: { name: "webhookSourceViewId", allowNull: true },
   onDelete: "RESTRICT",
   onUpdate: "CASCADE",
+});
+
+TriggerModel.belongsTo(SpaceModel, {
+  as: "space",
+  foreignKey: { name: "spaceId", allowNull: true },
+  onDelete: "RESTRICT",
 });

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1753,6 +1753,7 @@ const KNOWN_SPACE_RELATED_MODELS = [
   "project_todo_version",
   "takeaways",
   "takeaways_version",
+  "trigger",
   "webhook_sources_view",
   "user_project_preferences",
 ];

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -9,6 +9,7 @@ import { WebhookRequestModel } from "@app/lib/models/agent/triggers/webhook_requ
 import { WebhookRequestTriggerModel } from "@app/lib/models/agent/triggers/webhook_request_trigger";
 import { WebhookSourcesViewModel } from "@app/lib/models/agent/triggers/webhook_sources_view";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
@@ -41,6 +42,25 @@ import type {
   Transaction,
 } from "sequelize";
 import { Op } from "sequelize";
+
+// A trigger's Pod may be any open Pod in the workspace, or a restricted Pod the
+// caller is a member of. This is intentionally broader than the member-only check
+// used by the conversations/create MCP tool.
+export async function resolveTriggerSpaceId(
+  auth: Authenticator,
+  spaceId: string | null | undefined
+): Promise<Result<ModelId | null, string>> {
+  if (!spaceId) {
+    return new Ok(null);
+  }
+
+  const pod = await SpaceResource.fetchById(auth, spaceId);
+  if (!pod || !pod.isProject() || !pod.canRead(auth)) {
+    return new Err("Pod not found or not accessible.");
+  }
+
+  return new Ok(pod.id);
+}
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -482,6 +502,28 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(undefined);
   }
 
+  /**
+   * Detaches all triggers from a Pod (space) by nulling out their `spaceId`.
+   * Used when a space is scrubbed: the FK is `onDelete: "RESTRICT"`, so
+   * references must be cleared before the space is hard-deleted. Triggers keep
+   * running and fall back to the default (my conversations) target — see
+   * `temporal/triggers/activities.ts`.
+   */
+  static async detachAllFromSpace(
+    auth: Authenticator,
+    spaceModelId: ModelId
+  ): Promise<void> {
+    await this.model.update(
+      { spaceId: null },
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          spaceId: spaceModelId,
+        },
+      }
+    );
+  }
+
   static async disableAllForWorkspace(
     auth: Authenticator,
     targetStatus: Exclude<TriggerStatus, "enabled">
@@ -854,6 +896,12 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       naturalLanguageDescription: this.naturalLanguageDescription,
       createdAt: this.createdAt.getTime(),
       origin: this.origin,
+      spaceId: this.spaceId
+        ? SpaceResource.modelIdToSId({
+            id: this.spaceId,
+            workspaceId: this.workspaceId,
+          })
+        : null,
     };
 
     if (this.kind === "webhook") {

--- a/front/migrations/pre-deploy/20260702092329_add_space_id_to_triggers.sql
+++ b/front/migrations/pre-deploy/20260702092329_add_space_id_to_triggers.sql
@@ -1,0 +1,28 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."triggers" ADD COLUMN "spaceId" bigint;
+
+/*
+Statement 1
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY triggers_space_id ON public.triggers USING btree ("spaceId");
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."triggers" ADD CONSTRAINT "triggers_spaceId_fkey" FOREIGN KEY ("spaceId") REFERENCES vaults(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."triggers" VALIDATE CONSTRAINT "triggers_spaceId_fkey";

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -234,6 +234,11 @@ export async function scrubSpaceActivity({
     await UserProjectPreferencesResource.deleteAllBySpace(auth, space.id);
   }
 
+  // Detach triggers from this Pod before hard-deleting the space. The trigger
+  // FK is `onDelete: "RESTRICT"`, so references must be cleared first; the
+  // triggers keep running and fall back to the default target.
+  await TriggerResource.detachAllFromSpace(auth, space.id);
+
   hardDeleteLogger.info({ space: space.sId, workspaceId }, "Deleting space");
 
   await hardDeleteSpace(auth, space);

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -13,6 +13,7 @@ import {
 import { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
@@ -28,6 +29,7 @@ import {
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -48,11 +50,24 @@ async function createConversationForAgentConfiguration({
   lastRunAt: Date | null;
   webhookRequest: WebhookRequestResource | null;
 }): Promise<Result<ConversationType, APIErrorWithContentfulStatusCode>> {
+  let spaceModelId: ModelId | null = null;
+  if (trigger.spaceId) {
+    const pod = await SpaceResource.fetchById(auth, trigger.spaceId);
+    if (pod && pod.isProject() && (pod.isOpen() || pod.isMember(auth))) {
+      spaceModelId = pod.id;
+    } else {
+      logger.warn(
+        { triggerId: trigger.sId, spaceId: trigger.spaceId },
+        "Trigger's pod is no longer accessible; falling back to default (my conversations)."
+      );
+    }
+  }
+
   const newConversation = await createConversation(auth, {
     title: null,
     visibility: "unlisted",
     triggerId: trigger.id,
-    spaceId: null,
+    spaceId: spaceModelId,
   });
 
   const baseContext = {

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -120,6 +120,7 @@ export const TriggerSchema = z.discriminatedUnion("kind", [
     configuration: ScheduleConfigSchema,
     editor: z.number().optional(),
     status: TriggerStatusSchema.optional(),
+    spaceId: z.string().nullable().optional(),
   }),
   z.object({
     name: z.string(),
@@ -131,6 +132,7 @@ export const TriggerSchema = z.discriminatedUnion("kind", [
     executionPerDayLimitOverride: z.number(),
     editor: z.number().optional(),
     status: TriggerStatusSchema.optional(),
+    spaceId: z.string().nullable().optional(),
   }),
 ]);
 
@@ -145,6 +147,7 @@ const TriggerBaseSchema = z.object({
   createdAt: z.number(),
   naturalLanguageDescription: z.string().nullable(),
   origin: z.enum(["user", "agent"]),
+  spaceId: z.string().nullable(),
 });
 
 export const FullTriggerSchema = z.discriminatedUnion("kind", [

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -200,6 +200,7 @@ vi.mock("@app/lib/temporal", () => ({
     schedule: {
       getHandle: vi.fn().mockReturnValue({
         update: vi.fn(),
+        delete: vi.fn(),
       }),
     },
   }),


### PR DESCRIPTION
##  Description

  Adds an optional Pod selector to triggers (schedule and webhook) so the agent loop can run inside a specific Pod instead of the current default. In the trigger create/edit UI, users can pick from open Pods and Pods they're a member
  of; when set, the conversation created at fire time is created with spaceId pointing to that Pod. Unset (null) keeps today's behavior unchanged.

  - TriggerModel/TriggerResource gain a nullable spaceId column (indexed FK to spaces).
  - The trigger create/update API (front-api) validates the selected Pod is either open or one the caller is a member of before persisting it.
  - The Temporal trigger-fire path re-validates Pod access at run time and falls back to the default space if access was revoked since creation, rather than failing the run.
  - New TriggerPodSelector dropdown, wired into both the schedule and webhook edition sheets.

##  Tests

  Added functional tests for the trigger POST endpoint covering: open Pod, member-of-restricted Pod, rejection of a restricted Pod the caller isn't a member of, rejection of a non-Pod space, and the no-Pod default. Existing trigger
  resource, Temporal activity, and sibling route test suites pass unchanged.

##  Risk

  Low — the new column is nullable and every schema layer defaults to null, so existing triggers and API clients are unaffected. Pod access is re-checked at fire time, so revoking someone's Pod membership after they set up a trigger
  degrades gracefully to the default space instead of breaking the run.
