### PR TITLE
feat(agents): add dust-ant-sonnet-edge-light global agent

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -585,6 +585,18 @@ export function _getDustAntSonnetEdgeGlobalAgent(
   });
 }
 
+export function _getDustAntSonnetEdgeLightGlobalAgent(
+  auth: Authenticator,
+  args: DustLikeGlobalAgentArgs
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE_LIGHT,
+    name: "dust-ant-sonnet-edge-light",
+    preferredModelConfiguration: CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
+    preferredReasoningEffort: "light",
+  });
+}
+
 export function _getDustHaikuGlobalAgent(
   auth: Authenticator,
   args: DustLikeGlobalAgentArgs

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -592,6 +592,14 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
           "Same as dust but running Claude Sonnet 5 to experiment internally.",
         pictureUrl: DUST_AVATAR_URL,
       };
+    case GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE_LIGHT:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE_LIGHT,
+        name: "dust-ant-sonnet-edge-light",
+        description:
+          "Same as dust-ant-sonnet-edge but with light reasoning effort.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
     case GLOBAL_AGENTS_SID.DUST_HAIKU:
       return {
         sId: GLOBAL_AGENTS_SID.DUST_HAIKU,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -24,6 +24,7 @@ import {
   _getDustAntMediumGlobalAgent,
   _getDustAntMediumOmittedGlobalAgent,
   _getDustAntSonnetEdgeGlobalAgent,
+  _getDustAntSonnetEdgeLightGlobalAgent,
   _getDustDeepseekGlobalAgent,
   _getDustEdgeGlobalAgent,
   _getDustGlmGlobalAgent,
@@ -286,6 +287,12 @@ const GLOBAL_AGENT_FLAGS: Record<
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE_LIGHT]: {
     injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
@@ -1090,6 +1097,15 @@ function getGlobalAgent({
         featureFlags,
       });
       break;
+    case GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE_LIGHT:
+      agentConfiguration = _getDustAntSonnetEdgeLightGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        mcpServerViews,
+        hasDeepDive,
+        featureFlags,
+      });
+      break;
     case GLOBAL_AGENTS_SID.DUST_HAIKU:
       agentConfiguration = _getDustHaikuGlobalAgent(auth, {
         settings,
@@ -1649,6 +1665,7 @@ export async function getGlobalAgents(
     GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM_OMITTED,
     GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED,
     GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE,
+    GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE_LIGHT,
     GLOBAL_AGENTS_SID.DUST_HAIKU,
     GLOBAL_AGENTS_SID.DUST_LIGHT,
     GLOBAL_AGENTS_SID.DUST_EDGE,

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -97,6 +97,7 @@ export enum GLOBAL_AGENTS_SID {
   DUST_ANT_MEDIUM_OMITTED = "dust-ant-medium-omitted",
   DUST_ANT_HIGH_OMITTED = "dust-ant-high-omitted",
   DUST_ANT_SONNET_EDGE = "dust-ant-sonnet-edge",
+  DUST_ANT_SONNET_EDGE_LIGHT = "dust-ant-sonnet-edge-light",
   DUST_HAIKU = "dust-haiku",
   DUST_LIGHT = "dust-light",
   DUST_KIMI = "dust-kimi",


### PR DESCRIPTION
## Description

Adds a new internal global agent `dust-ant-sonnet-edge-light`, mirroring `dust-ant-sonnet-edge` (Claude Sonnet 5) but running with `light` reasoning effort. Wired through the standard four integration points: the `GLOBAL_AGENTS_SID` enum, the agent constructor, the metadata/description mapping, the injection-config map, the constructor switch, and the `DUST_INTERNAL_AGENTS` list.

## Tests

No automated tests — internal experimentation agent following the existing `dust-ant-*` / `dust-light` pattern. Verified `tsgo` reports no new type errors in the touched files.
