### PR TITLE
feat(seats): only auto-assign seats on credit-priced contracts

### DIFF
--- a/front/lib/api/membership.test.ts
+++ b/front/lib/api/membership.test.ts
@@ -164,4 +164,29 @@ describe("createAndTrackMembership", () => {
 
     expect(membership.seatType).toBe("pro");
   });
+
+  it("assigns none on a non-CP shadow contract despite committed paid seats", async () => {
+    setupEntitledSeats(["free", "pro"]);
+
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: "cus_test_shadow",
+    });
+    const upsertResult = await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 3,
+      maxSeats: null,
+    });
+    expect(upsertResult.isOk()).toBe(true);
+
+    const user = await UserFactory.basic();
+    const membership = await createAndTrackMembership({
+      user,
+      workspace,
+      role: "user",
+      origin: "invited",
+    });
+
+    expect(membership.seatType).toBe("none");
+  });
 });

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -22,7 +22,10 @@ import {
   classifySeatChange,
   hasContractSeatSubscription,
 } from "@app/lib/metronome/seats";
-import { isFreePlan } from "@app/lib/plans/plan_codes";
+import {
+  isCreditPricedPlanPrefix,
+  isFreePlan,
+} from "@app/lib/plans/plan_codes";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -96,6 +99,10 @@ async function resolveSeatTypeForNewMembership(
     workspace.id
   );
   if (!subscription?.metronomeContractId) {
+    return "none";
+  }
+
+  if (!isCreditPricedPlanPrefix(subscription.getPlan().code)) {
     return "none";
   }
   const contract = await getActiveContract(workspace.sId);


### PR DESCRIPTION
## Description

Follow up from https://github.com/dust-tt/dust/pull/28336#pullrequestreview-4610910622  
Gate resolveSeatTypeForNewMembership to return "none" on non-CP shadow contracts.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
