### PR TITLE
[front] enh: hide dot-folders in files pane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ thoughts/*
 # Storybook static build output
 **/storybook-static/
 
+# Local pptx test decks dropped at the repo root during pptx tooling work
+/*.pptx
+
+# Sandbox provider build scratch dirs
+/front/lib/api/sandbox/providers/sandbox-build-*/
+

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
@@ -113,6 +113,62 @@ describe("GCSFileSystemBackend.list", () => {
     expect(paths).not.toContain(`conversation-${CONV_ID}/photo.processed.jpg`);
   });
 
+  it("hides files inside a hidden (dot-prefixed) directory, except .tool_outputs", async () => {
+    const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        gcsFile({
+          name: `${prefix}report.pdf`,
+          contentType: "application/pdf",
+        }),
+        gcsFile({
+          name: `${prefix}.pptx_render/deck/slide-001-boxes.jpg`,
+          contentType: "image/jpeg",
+        }),
+        gcsFile({
+          name: `${prefix}.tool_outputs/1700000000000_note.md`,
+          contentType: "text/markdown",
+        }),
+      ],
+      pageFetchCount: 1,
+    });
+
+    const result = await makeBackend().list(`conversation-${CONV_ID}/`);
+    assert(result.isOk());
+    const paths = result.value.filter((e) => !e.isDirectory).map((e) => e.path);
+    expect(paths).toContain(`conversation-${CONV_ID}/report.pdf`);
+    // .tool_outputs stays visible (the one exempt hidden dir).
+    expect(paths).toContain(
+      `conversation-${CONV_ID}/.tool_outputs/1700000000000_note.md`
+    );
+    // QA renders under a hidden dir are not surfaced to the user.
+    expect(paths).not.toContain(
+      `conversation-${CONV_ID}/.pptx_render/deck/slide-001-boxes.jpg`
+    );
+  });
+
+  it("shows hidden-directory contents when that directory is listed directly", async () => {
+    const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/.pptx_render/deck/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        gcsFile({
+          name: `${prefix}slide-001-boxes.jpg`,
+          contentType: "image/jpeg",
+        }),
+      ],
+      pageFetchCount: 1,
+    });
+
+    const result = await makeBackend().list(
+      `conversation-${CONV_ID}/.pptx_render/deck/`
+    );
+    assert(result.isOk());
+    const paths = result.value.filter((e) => !e.isDirectory).map((e) => e.path);
+    expect(paths).toContain(
+      `conversation-${CONV_ID}/.pptx_render/deck/slide-001-boxes.jpg`
+    );
+  });
+
   it("includes .processed. siblings when includeProcessed is true", async () => {
     const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
     getAllFilesByPrefixMock.mockResolvedValue({

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -197,6 +197,21 @@ export class GCSFileSystemBackend implements FileSystemBackend {
         return false;
       }
 
+      // Hide files inside a hidden ("."-prefixed, non-tool-outputs) directory
+      // below the listed prefix. Listing is recursive, so the folder filter
+      // below (which only hides the dot-directory *entry*) is not enough on its
+      // own — without this, e.g. pptx/docx QA renders under .pptx_render/ /
+      // .docx_render/ would still surface. Computed relative to the listed
+      // prefix, so listing a hidden directory directly still returns its files.
+      const relDirs = f.name.slice(gcsPrefix.length).split("/").slice(0, -1);
+      if (
+        relDirs.some(
+          (seg) => seg.startsWith(".") && seg !== TOOL_OUTPUTS_FOLDER_NAME
+        )
+      ) {
+        return false;
+      }
+
       if (includeProcessed) {
         return true;
       }


### PR DESCRIPTION
## Description

Currently, dot-folders (e.g `/files/conversation/.cache`) are visible in the file pane

In this stack (https://github.com/dust-tt/dust/pull/28363) we make it so that pptx_inspect computer tool renders consistently in /files/conversation, but in a .pptx_renders folder, the intent being not flooding the files user view with useless renders.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

Deploy front