### PR TITLE
[front] enh: make soffice tools render in /files/conversation

### DIFF
--- a/front/lib/api/sandbox/image/profile/soffice/docx_inspect.py
+++ b/front/lib/api/sandbox/image/profile/soffice/docx_inspect.py
@@ -18,6 +18,7 @@ from xml.etree import ElementTree as ET
 
 import ooxml
 import render
+import render_publish
 from docx import Document
 from docx.document import Document as DocumentType
 from utils import (
@@ -35,7 +36,7 @@ DEFAULT_MAX_PARAGRAPHS = 200
 
 USAGE = (
     "docx_inspect <file> [--styles] [--paragraphs] [--text] [--tables] "
-    "[--sections] [--fields] [--media] [--render] "
+    "[--sections] [--fields] [--media] [--render] [--render-dir DIR] "
     "[--offset N] [--max N] [--page N]"
 )
 
@@ -55,8 +56,11 @@ HELP_TEXT = (
     "  --sections    Page size, margins, orientation per section.\n"
     "  --fields      Fields (TOC, REF, HYPERLINK, DATE, ...) with stale flag.\n"
     "  --media       Embedded media under word/media/ with sizes.\n"
-    "  --render      Rasterize pages to JPEG (100 dpi) via soffice + pdftoppm.\n"
-    "                Outputs to /tmp/docx_render/<doc>/page-NNN.jpg.\n"
+    "  --render      Rasterize pages to JPEG (100 dpi) via soffice + pdftoppm,\n"
+    "                published to the conversation; the scoped path of each page\n"
+    "                is printed (a files__cat-readable image).\n"
+    "  --render-dir DIR  Base dir renders are published under, as\n"
+    "                DIR/.docx_render/<doc>/ (default: /files/conversation).\n"
     "  --max N       Max paragraphs printed in --paragraphs (default 200).\n"
     "  --offset N    Skip first N paragraphs in --paragraphs (default 0).\n"
     "  --page N      Render only the given page (1-indexed) with --render.\n"
@@ -602,19 +606,30 @@ def print_media(file_path: str) -> str:
     return "\n".join(lines)
 
 
-def print_render(file_path: str, page_idx: Optional[int]) -> str:
-    out_dir, rendered = render.render_via_soffice(
+# docx renders are published onto the conversation/pod mount (where the model can
+# open them with files__cat) under this dot-prefixed subdir; the shared publish
+# machinery lives in render_publish.
+_VIEW_SUBDIR = ".docx_render"
+
+
+def print_render(
+    file_path: str,
+    page_idx: Optional[int],
+    render_dir: str = "/files/conversation",
+) -> str:
+    _, rendered = render.render_via_soffice(
         file_path,
         out_root=Path("/tmp/docx_render"),
         item_name="page",
         item_idx=page_idx,
     )
-    plural = "" if len(rendered) == 1 else "s"
-    lines = [
-        f"[Rendered: {len(rendered)} page{plural} | jpeg @ 100 dpi | {out_dir}]"
-    ]
-    for p in rendered:
-        lines.append(str(p))
+    basename = os.path.splitext(os.path.basename(file_path))[0]
+    published = render_publish.publish_renders(
+        basename, rendered, render_dir, _VIEW_SUBDIR
+    )
+    plural = "" if len(published) == 1 else "s"
+    lines = [f"[Rendered {len(published)} page{plural} @ 100 dpi:]"]
+    lines.extend(render_publish.render_view_lines(published, item_name="page"))
     return "\n".join(lines)
 
 
@@ -638,6 +653,12 @@ def main() -> int:
     parser.add_argument("--fields", action="store_true")
     parser.add_argument("--media", action="store_true")
     parser.add_argument("--render", action="store_true")
+    parser.add_argument(
+        "--render-dir",
+        dest="render_dir",
+        metavar="DIR",
+        default="/files/conversation",
+    )
     parser.add_argument("--max", type=int, default=DEFAULT_MAX_PARAGRAPHS)
     parser.add_argument("--offset", type=int, default=0)
     parser.add_argument("--page", type=int)
@@ -670,7 +691,7 @@ def main() -> int:
     if args.media:
         body = print_media(args.file)
     elif args.render:
-        body = print_render(args.file, args.page)
+        body = print_render(args.file, args.page, args.render_dir)
     else:
         doc = Document(args.file)
         with zipfile.ZipFile(args.file) as zf:

--- a/front/lib/api/sandbox/image/profile/soffice/render_publish.py
+++ b/front/lib/api/sandbox/image/profile/soffice/render_publish.py
@@ -1,0 +1,147 @@
+"""Publish soffice renders onto the conversation/pod mount so the model can see
+them.
+
+Renders are rasterized to /tmp (fast, with a reusable PDF cache) but /tmp is
+invisible to the model — only files under the conversation/pod mount are. So QA /
+preview renders are *published* onto that mount as small JPEGs the model can open
+with the files__cat tool, grouped in a dot-prefixed subdir to keep them apart
+from real deliverables. Shared by pptx_inspect and docx_inspect.
+
+NOTE: the dot-prefixed subdir keeps renders grouped but does NOT by itself hide
+them from the user's file list — the file-system backend's list() filters
+hidden-dir *contents* (see gcs_file_system_backend.ts) to do that.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from PIL import Image
+
+VIEW_MAX_PX = 2000  # downscale ceiling for published JPEGs
+VIEW_MAX_BYTES = 1_900_000  # stay safely under files__cat's 2 MB vision cap
+
+
+def mount_for_path(
+    path: str, glob_fn=glob.glob
+) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve the canonical conversation/pod mount a sandbox path lives on.
+
+    Returns ``(canonical_mount_root, scoped_prefix)`` — e.g.
+    ``("/files/conversation-abc", "conversation-abc")`` — where ``scoped_prefix``
+    is the form the files__cat tool accepts. The legacy aliases
+    ``/files/conversation`` and ``/files/pod`` share storage with their
+    canonical mount, so we resolve the unique canonical sibling. Returns
+    ``(None, None)`` when the path is not under a resolvable mount (e.g. /tmp)."""
+    parts = os.path.normpath(path).split(os.sep)
+    if len(parts) < 3 or parts[1] != "files":
+        return (None, None)
+    mount = parts[2]
+    for prefix in ("conversation-", "pod-"):
+        if mount.startswith(prefix) and len(mount) > len(prefix):
+            return ("/files/" + mount, mount)
+    legacy = {"conversation": "conversation-", "pod": "pod-"}.get(mount)
+    if legacy:
+        canon = sorted(
+            os.path.basename(p)
+            for p in glob_fn("/files/" + legacy + "*")
+            if os.path.basename(p).startswith(legacy)
+        )
+        if len(canon) == 1:
+            return ("/files/" + canon[0], canon[0])
+    return (None, None)
+
+
+def scoped_path(abs_path: str, glob_fn=glob.glob) -> Optional[str]:
+    """The files__cat scoped path for an absolute path on a conversation/pod
+    mount (`conversation-<id>/<rel>`), or None when it is not on a resolvable
+    mount."""
+    parts = os.path.normpath(abs_path).split(os.sep)
+    if len(parts) < 4 or parts[1] != "files":
+        return None
+    _, scoped_prefix = mount_for_path("/files/" + parts[2], glob_fn=glob_fn)
+    if not scoped_prefix:
+        return None
+    return scoped_prefix + "/" + "/".join(parts[3:])
+
+
+def save_viewable(src: Path, dest_root: Path) -> Path:
+    """Publish one render into ``dest_root`` as a JPEG small enough for
+    files__cat's vision cap; returns the written path. A source that PIL cannot
+    decode is copied through verbatim (keeping its real extension so the bytes
+    match the name). A destination-write failure raises OSError so the caller can
+    degrade the whole publish."""
+    try:
+        with Image.open(src) as img:
+            rgb = img.convert("RGB")
+    except (OSError, ValueError):
+        # Odd/unreadable source (rare — the box overlay already passed PIL once):
+        # copy the bytes through unchanged so files__cat still gets a valid image.
+        dest = dest_root / src.name
+        shutil.copyfile(src, dest)
+        return dest
+    if max(rgb.size) > VIEW_MAX_PX:
+        rgb.thumbnail((VIEW_MAX_PX, VIEW_MAX_PX))
+    dest = dest_root / (src.stem + ".jpg")
+    quality = 85
+    rgb.save(dest, "JPEG", quality=quality)
+    # A pathological high-entropy page could exceed the vision cap at q85; step
+    # quality down, then shrink dimensions, until it fits so files__cat never
+    # rejects the render. (Real renders are ~tens of KB and never loop.)
+    while dest.stat().st_size > VIEW_MAX_BYTES and (
+        quality > 35 or min(rgb.size) > 64
+    ):
+        if quality > 35:
+            quality -= 15
+        else:
+            rgb = rgb.resize(
+                (max(64, rgb.size[0] * 3 // 4), max(64, rgb.size[1] * 3 // 4))
+            )
+        rgb.save(dest, "JPEG", quality=quality)
+    return dest
+
+
+def publish_renders(
+    basename: str,
+    local_paths: List[Path],
+    render_dir: str,
+    subdir: str,
+) -> List[Tuple[Path, Optional[str]]]:
+    """Publish renders under ``<render_dir>/<subdir>/<basename>`` as small JPEGs
+    the model can open with files__cat, returning ``(dest_path, scoped_path)`` for
+    each in input order. ``subdir`` is the dot-prefixed folder to group them under
+    (e.g. ``.pptx_render``); ``render_dir`` defaults to the conversation mount.
+    ``scoped_path`` is None when the destination is not on a resolvable
+    conversation/pod mount. If the destination cannot be written (read-only / full
+    / missing mount), returns ``(local_path, None)`` for each so the caller's text
+    output still survives."""
+    dest_root = Path(render_dir) / subdir / basename
+    try:
+        os.makedirs(dest_root, exist_ok=True)
+        published = [save_viewable(p, dest_root) for p in local_paths]
+    except OSError:
+        return [(p, None) for p in local_paths]
+    return [(dest, scoped_path(str(dest))) for dest in published]
+
+
+def render_view_lines(
+    published: List[Tuple[Path, Optional[str]]],
+    item_name: str = "slide",
+) -> List[str]:
+    """Per-item ``<label>: <scoped render path>`` lines — data only. What to do
+    with them (open each with files__cat) is the skill's job, not the tool's. Falls
+    back to the local path when a render is not on a resolvable mount."""
+    lines: List[str] = []
+    for dest, scoped in published:
+        m = re.search(r"-(\d+)", dest.name)
+        label = f"{item_name} {int(m.group(1))}" if m else dest.name
+        if scoped:
+            lines.append(f"  {label}: {scoped}")
+        else:
+            lines.append(f"  {label}: {dest} (not on the conversation mount)")
+    return lines

--- a/front/lib/api/sandbox/image/profile/soffice/tests/test_audit.py
+++ b/front/lib/api/sandbox/image/profile/soffice/tests/test_audit.py
@@ -9,7 +9,7 @@ Run directly (`python test_audit.py`) or under pytest.
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "soffice"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from pptx import Presentation  # noqa: E402
 from pptx.util import Inches  # noqa: E402

--- a/front/lib/api/sandbox/image/profile/soffice/tests/test_geometry.py
+++ b/front/lib/api/sandbox/image/profile/soffice/tests/test_geometry.py
@@ -1,14 +1,11 @@
 """Tier-1 pure-logic tests for pptx_geometry: overlap classification, the
 text-fit estimate, and EMU conversion. No fixtures — tuples and a tiny fake
 shape. Run directly (`python test_geometry.py`) or under pytest.
-
-Lives in soffice_tests/ (sibling of soffice/), which getLocalDirContent never
-copies into the sandbox image; it adds soffice/ to sys.path to import the module.
 """
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "soffice"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import pptx_geometry as G  # noqa: E402
 

--- a/front/lib/api/sandbox/image/profile/soffice/tests/test_publish.py
+++ b/front/lib/api/sandbox/image/profile/soffice/tests/test_publish.py
@@ -1,0 +1,200 @@
+"""Tier-1 tests for render_publish: mapping sandbox paths to the files__cat scoped
+form, re-encoding renders as small JPEGs, and the data-only view lines. This is
+the plumbing (shared by pptx_inspect and docx_inspect) that makes QA / preview
+renders viewable by the model — they live under the conversation mount, not /tmp.
+
+Run directly (`python test_publish.py`) or under pytest.
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PIL import Image  # noqa: E402
+
+import render_publish as RP  # noqa: E402
+
+
+def _one_canonical(_pat):
+    return ["/files/conversation-abc123"]
+
+
+def _no_canonical(_pat):
+    return []
+
+
+def _two_canonical(_pat):
+    return ["/files/conversation-a", "/files/conversation-b"]
+
+
+# --- mount_for_path -------------------------------------------------------
+
+
+def test_mount_for_path_canonical_conversation():
+    assert RP.mount_for_path("/files/conversation-abc123/output.pptx") == (
+        "/files/conversation-abc123",
+        "conversation-abc123",
+    )
+
+
+def test_mount_for_path_canonical_pod():
+    assert RP.mount_for_path("/files/pod-xyz/deck.pptx") == (
+        "/files/pod-xyz",
+        "pod-xyz",
+    )
+
+
+def test_mount_for_path_legacy_resolves_unique_canonical():
+    assert RP.mount_for_path(
+        "/files/conversation/output.pptx", glob_fn=_one_canonical
+    ) == ("/files/conversation-abc123", "conversation-abc123")
+
+
+def test_mount_for_path_legacy_unresolvable_is_none():
+    assert RP.mount_for_path(
+        "/files/conversation/output.pptx", glob_fn=_no_canonical
+    ) == (None, None)
+    assert RP.mount_for_path(
+        "/files/conversation/output.pptx", glob_fn=_two_canonical
+    ) == (None, None)
+
+
+def test_mount_for_path_off_mount_is_none():
+    assert RP.mount_for_path("/tmp/x/slide.jpg") == (None, None)
+    assert RP.mount_for_path("/files/somethingelse/x.pptx") == (None, None)
+
+
+# --- scoped_path ----------------------------------------------------------
+
+
+def test_scoped_path_canonical():
+    assert (
+        RP.scoped_path(
+            "/files/conversation-abc123/.pptx_render/output/slide-002-boxes.jpg"
+        )
+        == "conversation-abc123/.pptx_render/output/slide-002-boxes.jpg"
+    )
+
+
+def test_scoped_path_legacy_resolves():
+    assert (
+        RP.scoped_path(
+            "/files/conversation/.pptx_render/output/slide-002-boxes.jpg",
+            glob_fn=_one_canonical,
+        )
+        == "conversation-abc123/.pptx_render/output/slide-002-boxes.jpg"
+    )
+
+
+def test_scoped_path_off_mount_is_none():
+    assert RP.scoped_path("/tmp/x/slide.jpg") is None
+
+
+# --- render_view_lines (data only — no imperative, no files__cat) ----------
+
+
+def test_render_view_lines_emits_scoped_path_only():
+    pub = [
+        (
+            Path("/files/conversation-abc/.pptx_render/output/slide-002-boxes.jpg"),
+            "conversation-abc/.pptx_render/output/slide-002-boxes.jpg",
+        )
+    ]
+    (line,) = RP.render_view_lines(pub)
+    assert (
+        line
+        == "  slide 2: conversation-abc/.pptx_render/output/slide-002-boxes.jpg"
+    )
+    assert "files__cat" not in line  # the tool prescribes nothing
+    assert "open" not in line.lower()
+
+
+def test_render_view_lines_item_name_and_off_mount():
+    pub = [(Path("/tmp/docx_render/doc/page-003.jpg"), None)]
+    (line,) = RP.render_view_lines(pub, item_name="page")
+    assert line.startswith("  page 3: /tmp/docx_render/doc/page-003.jpg")
+    assert "not on the conversation mount" in line
+
+
+# --- save_viewable --------------------------------------------------------
+
+
+def test_save_viewable_reencodes_to_jpeg():
+    with tempfile.TemporaryDirectory() as src, tempfile.TemporaryDirectory() as dst:
+        png = Path(src) / "slide-001-boxes.png"
+        Image.new("RGB", (4000, 3000), (200, 30, 30)).save(png)
+        dest = RP.save_viewable(png, Path(dst))
+        assert dest.suffix == ".jpg"
+        with Image.open(dest) as img:
+            assert img.format == "JPEG"
+            assert max(img.size) <= RP.VIEW_MAX_PX
+
+
+def test_save_viewable_enforces_byte_cap():
+    original_cap = RP.VIEW_MAX_BYTES
+    try:
+        RP.VIEW_MAX_BYTES = 50_000
+        with tempfile.TemporaryDirectory() as src, tempfile.TemporaryDirectory() as dst:
+            noisy = Path(src) / "slide-001-boxes.png"
+            # os.urandom -> incompressible, so q85 would blow the cap.
+            Image.frombytes("RGB", (1200, 1200), os.urandom(1200 * 1200 * 3)).save(
+                noisy
+            )
+            dest = RP.save_viewable(noisy, Path(dst))
+            assert dest.stat().st_size <= RP.VIEW_MAX_BYTES
+            with Image.open(dest) as img:
+                assert img.format == "JPEG"
+    finally:
+        RP.VIEW_MAX_BYTES = original_cap
+
+
+def test_save_viewable_fallback_keeps_source_extension():
+    with tempfile.TemporaryDirectory() as src, tempfile.TemporaryDirectory() as dst:
+        bogus = Path(src) / "slide-001-boxes.png"
+        bogus.write_bytes(b"this is not a real image")
+        dest = RP.save_viewable(bogus, Path(dst))
+        assert dest.name == "slide-001-boxes.png"  # extension preserved
+        assert dest.read_bytes() == b"this is not a real image"
+
+
+# --- publish_renders ------------------------------------------------------
+
+
+def test_publish_renders_writes_under_render_dir_subdir_basename():
+    with tempfile.TemporaryDirectory() as src, tempfile.TemporaryDirectory() as dst:
+        png = Path(src) / "slide-001-boxes.png"
+        Image.new("RGB", (800, 600), (10, 20, 30)).save(png)
+        out = RP.publish_renders("deck", [png], dst, ".pptx_render")
+        assert len(out) == 1
+        dest, scoped = out[0]
+        assert dest.exists()
+        assert dest.parent.name == "deck"
+        assert dest.parent.parent.name == ".pptx_render"  # DIR/.pptx_render/deck
+        assert dest.suffix == ".jpg"
+        assert scoped is None  # tmp render_dir is off any mount
+
+
+def test_publish_renders_degrades_when_dest_unwritable():
+    # render_dir is a regular FILE, so makedirs(<file>/.pptx_render/deck) raises;
+    # publishing must degrade to the unviewable-local path, never crash.
+    with tempfile.TemporaryDirectory() as src:
+        png = Path(src) / "slide-001-boxes.png"
+        Image.new("RGB", (100, 100), (0, 0, 0)).save(png)
+        not_a_dir = Path(src) / "iam-a-file"
+        not_a_dir.write_text("x")
+        out = RP.publish_renders("deck", [png], str(not_a_dir), ".pptx_render")
+        assert out == [(png, None)]
+
+
+if __name__ == "__main__":
+    tests = [
+        v
+        for k, v in sorted(globals().items())
+        if k.startswith("test_") and callable(v)
+    ]
+    for fn in tests:
+        fn()
+        print(f"ok   {fn.__name__}")
+    print(f"\n{len(tests)} publish tests passed")

--- a/front/lib/api/sandbox/image/profile/soffice/tests/test_render.py
+++ b/front/lib/api/sandbox/image/profile/soffice/tests/test_render.py
@@ -4,15 +4,15 @@ soffice for every slide. No soffice/subprocess — just temp files and mtimes.
 
 Run directly (`python test_render.py`) or under pytest.
 
-Lives in soffice_tests/ (sibling of soffice/), which getLocalDirContent never
-copies into the sandbox image; it adds soffice/ to sys.path to import the module.
+Lives in soffice/tests/, a subdir getLocalDirContent skips: it copies only the
+regular files directly in soffice/ (never recursing), so tests never ship in the image. It adds soffice/ to sys.path to import the module.
 """
 import os
 import sys
 import tempfile
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "soffice"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import render as R  # noqa: E402
 

--- a/front/lib/api/sandbox/image/profile/soffice/tests/test_render_boxes.py
+++ b/front/lib/api/sandbox/image/profile/soffice/tests/test_render_boxes.py
@@ -8,7 +8,7 @@ Run directly (`python test_render_boxes.py`) or under pytest.
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "soffice"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from PIL import Image  # noqa: E402
 from pptx.enum.shapes import MSO_SHAPE_TYPE  # noqa: E402

--- a/front/lib/api/sandbox/image/profile/soffice/tests/test_typography.py
+++ b/front/lib/api/sandbox/image/profile/soffice/tests/test_typography.py
@@ -8,7 +8,7 @@ Run directly (`python test_typography.py`) or under pytest.
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "soffice"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from pptx import Presentation  # noqa: E402
 from pptx.dml.color import RGBColor  # noqa: E402

--- a/front/lib/api/sandbox/image/profile/soffice/tests/test_utils.py
+++ b/front/lib/api/sandbox/image/profile/soffice/tests/test_utils.py
@@ -2,13 +2,13 @@
 parser shared by the inspect scripts (used by `pptx_inspect --qa`). No fixtures
 — just strings. Run directly (`python test_utils.py`) or under pytest.
 
-Lives in soffice_tests/ (sibling of soffice/), which getLocalDirContent never
-copies into the sandbox image; it adds soffice/ to sys.path to import the module.
+Lives in soffice/tests/, a subdir getLocalDirContent skips: it copies only the
+regular files directly in soffice/ (never recursing), so tests never ship in the image. It adds soffice/ to sys.path to import the module.
 """
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "soffice"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import utils as U  # noqa: E402
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -642,11 +642,11 @@ SHELLEOF`,
   .registerTool({
     name: "docx_inspect",
     description:
-      "Inspect .docx structure: sections, headings outline, paragraph and character styles with resolved typography, run formatting, tables, tracked changes, fields, embedded media. Use before editing a document to map style names so the model can apply Heading1 / Normal / Quote rather than restyling inline",
+      "Inspect .docx structure: sections, headings outline, paragraph and character styles with resolved typography, run formatting, tables, tracked changes, fields, embedded media. Use before editing a document to map style names so the model can apply Heading1 / Normal / Quote rather than restyling inline. --render rasterizes pages to JPEG, published into the conversation; the command prints each page's scoped path (a files__cat-readable image). --render-dir DIR is the base dir renders publish under, as DIR/.docx_render/<doc>/ (default /files/conversation)",
     usage:
-      "docx_inspect <file> [--styles] [--paragraphs] [--text] [--tables] [--sections] [--changes] [--fields] [--media] [--render] [--offset N] [--max N] [--page N]",
+      "docx_inspect <file> [--styles] [--paragraphs] [--text] [--tables] [--sections] [--changes] [--fields] [--media] [--render] [--render-dir DIR] [--offset N] [--max N] [--page N]",
     returns:
-      "Document overview with theme + default typography and heading outline, or one paragraph/style/section/table/change/field per line. Render mode emits one absolute jpeg path per page",
+      "Document overview with theme + default typography and heading outline, or one paragraph/style/section/table/change/field per line. Render mode publishes each page and prints its scoped path (files__cat-readable)",
     runtime: "system",
   })
   .withCapability("gcsfuse")

--- a/front/lib/resources/skill/code_defined/docx.ts
+++ b/front/lib/resources/skill/code_defined/docx.ts
@@ -97,14 +97,18 @@ Two passes. Both required — never ship after only the structural pass.
      text.", "Error! No table of contents entries found.", "Lorem
      ipsum", "xxxx").
 
-2. **Visual** — render every page and \`Read\` each image:
+2. **Visual** — render every page, then open each with \`files__cat\`:
    \`\`\`bash
    docx_inspect /files/conversation/doc.docx --render
    \`\`\`
-   Prints one absolute path per page
-   (\`/tmp/docx_render/<doc>/page-001.jpg\`, …). For **every** path
-   printed, use the \`Read\` tool to load the image into context. Do
-   not stop after one or two. On each page, check for:
+   This publishes each page's render into the conversation and prints,
+   per page, its path like
+   \`page 1: conversation-<id>/.docx_render/doc/page-001.jpg\` (with your
+   real conversation id filled in). For **every** page, call the
+   \`files__cat\` tool on the exact path it printed — that is the only
+   way to see the pixels (a bash \`cat\` of an image returns binary
+   garbage, and the \`/tmp\` path is invisible to you). Do not stop
+   after one or two. On each page, check for:
    - text overflowing into the margins or off the page,
    - headings rendered as plain body text (style not applied),
    - orphaned headings (heading at the bottom of a page with no
@@ -118,8 +122,8 @@ Two passes. Both required — never ship after only the structural pass.
    \`\`\`bash
    docx_inspect /files/conversation/doc.docx --render --page 3
    \`\`\`
-   \`Read\` just that one image, confirm the fix, move on. Do not
-   declare the doc done until every page has been \`Read\` clean.
+   Open just that one render with \`files__cat\`, confirm the fix, move
+   on. Do not declare the doc done until every page has read back clean.
 `;
 
 export const docxSkill = {
@@ -132,7 +136,7 @@ export const docxSkill = {
   instructions: DOCX_SKILL_INSTRUCTIONS,
   exposeInstructions: true,
   mcpServers: [{ name: "sandbox" }],
-  version: 1,
+  version: 2,
   icon: "ActionDocumentTextIcon",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);


### PR DESCRIPTION
## Description

Add a `render_publish` that makes the soffice tools (pptx_inspect 👀 ) render consistently in /files/conversations

fixes https://github.com/dust-tt/tasks/issues/9233

## Tests

Tested locally + unti tests

## Risk

Low

## Deploy Plan

Merge