### PR TITLE
chore(llm): log fallback to the old router with workspaceId

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -247,13 +247,16 @@ export async function getStreamLLM(
   );
 
   if (featureFlags.includes("use_new_llm_router") && streamEndpointLLM) {
-    logger.info(
-      { modelId: llmParameters.modelId },
-      `Sending request to ${llmParameters.modelId} with new router`
-    );
-
     return streamEndpointLLM;
   }
+
+  logger.info(
+    {
+      modelId: llmParameters.modelId,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    },
+    `Falling back to the old router for ${llmParameters.modelId}`
+  );
 
   const legacyLLM = await getLegacyLLM(auth, llmParameters);
 


### PR DESCRIPTION
## Description

Moves the router-selection log in `getStreamLLM` from the new-router branch to the fallback path, and tags it with `workspaceId`.

Now that everyone has the `use_new_llm_router` flag, this log is useful to catch any unexpected fallback to the old router, we shouldn't see it in practice, and if it shows up, `workspaceId` gives us a starting point for triage.

## Tests

None.

## Risk

None. Only moves and enriches a log line, no behavior change.

## Deploy Plan

Standard.