### PR TITLE
[front] poke members table: show active seat + scheduled seat change

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/memberships.ts
+++ b/front-api/routes/poke/workspaces/[wId]/memberships.ts
@@ -4,8 +4,10 @@ import type {
 } from "@app/lib/api/poke/memberships";
 import { getMembers } from "@app/lib/api/workspace";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { getMembershipInvitationUrl } from "@app/lib/utils/invitation_token";
+import type { MembershipSeatType } from "@app/types/memberships";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -92,15 +94,45 @@ app.get("/", async (ctx): HandlerResult<PokeGetMemberships> => {
   const auth = ctx.get("auth");
   const owner = auth.getNonNullableWorkspace();
 
-  const [{ members }, pendingInvitations] = await Promise.all([
-    getMembers(auth),
-    MembershipInvitationResource.getPendingInvitations(auth, {
-      includeExpired: true,
-    }),
-  ]);
+  // Members are listed by their ACTIVE seat. Scheduled future seat changes
+  // (e.g. a member seated mid-migration whose seat flips at the pending contract
+  // start) live in separate future-dated rows — surface them separately so the
+  // table shows "current → scheduled (date)" rather than the not-yet-active seat.
+  const [{ members }, scheduledFutureMemberships, pendingInvitations] =
+    await Promise.all([
+      getMembers(auth, { activeOnly: true }),
+      MembershipResource.getScheduledFutureMemberships({ workspace: owner }),
+      MembershipInvitationResource.getPendingInvitations(auth, {
+        includeExpired: true,
+      }),
+    ]);
+
+  // Keep the soonest scheduled change per member.
+  const scheduledByUserId = new Map<
+    string,
+    { seatType: MembershipSeatType; at: number }
+  >();
+  for (const m of scheduledFutureMemberships) {
+    const userId = m.user?.sId;
+    if (!userId) {
+      continue;
+    }
+    const at = m.startAt.getTime();
+    const existing = scheduledByUserId.get(userId);
+    if (!existing || at < existing.at) {
+      scheduledByUserId.set(userId, { seatType: m.seatType, at });
+    }
+  }
 
   return ctx.json({
-    members,
+    members: members.map((m) => {
+      const scheduled = scheduledByUserId.get(m.sId);
+      return {
+        ...m,
+        scheduledSeatType: scheduled?.seatType ?? null,
+        scheduledSeatChangeAt: scheduled?.at ?? null,
+      };
+    }),
     pendingInvitations: pendingInvitations.map((invite) => {
       const i = invite.toJSON();
       return {

--- a/front/components/poke/members/columns.tsx
+++ b/front/components/poke/members/columns.tsx
@@ -19,6 +19,10 @@ export type MemberDisplayType = {
   sId: string;
   origin?: MembershipOriginType;
   seatType?: MembershipSeatType;
+  // Upcoming seat change scheduled for a future date (e.g. flips at a pending
+  // contract start). `seatType` above stays the active seat.
+  scheduledSeatType?: MembershipSeatType | null;
+  scheduledSeatChangeAt?: number | null;
 };
 
 export function makeColumnsForMembers({
@@ -151,30 +155,49 @@ export function makeColumnsForMembers({
     cell: ({ row }) => {
       const member = row.original;
 
+      const scheduledChange =
+        member.scheduledSeatType &&
+        member.scheduledSeatType !== member.seatType ? (
+          <span className="text-xs text-gray-500">
+            {`→ ${member.scheduledSeatType}`}
+            {member.scheduledSeatChangeAt
+              ? ` on ${formatTimestampToFriendlyDate(member.scheduledSeatChangeAt)}`
+              : ""}
+          </span>
+        ) : null;
+
       if (readonly) {
-        return <span>{member.seatType ?? "-"}</span>;
+        return (
+          <div className="flex flex-col">
+            <span>{member.seatType ?? "-"}</span>
+            {scheduledChange}
+          </div>
+        );
       }
 
       return (
-        <select
-          className="rounded-lg border border-gray-300 bg-gray-50 text-sm text-gray-900"
-          value={member.seatType ?? ""}
-          onChange={async (e) => {
-            await onUpdateMemberSeatType(
-              member,
-              e.target.value as MembershipSeatType
-            );
-          }}
-        >
-          <option value="" disabled>
-            -
-          </option>
-          {MEMBERSHIP_SEAT_TYPES.map((st) => (
-            <option key={st} value={st}>
-              {st}
+        <div className="flex flex-col gap-1">
+          <select
+            className="rounded-lg border border-gray-300 bg-gray-50 text-sm text-gray-900"
+            value={member.seatType ?? ""}
+            onChange={async (e) => {
+              await onUpdateMemberSeatType(
+                member,
+                e.target.value as MembershipSeatType
+              );
+            }}
+          >
+            <option value="" disabled>
+              -
             </option>
-          ))}
-        </select>
+            {MEMBERSHIP_SEAT_TYPES.map((st) => (
+              <option key={st} value={st}>
+                {st}
+              </option>
+            ))}
+          </select>
+          {scheduledChange}
+        </div>
       );
     },
   });

--- a/front/components/poke/members/table.tsx
+++ b/front/components/poke/members/table.tsx
@@ -1,6 +1,7 @@
 import type { MemberDisplayType } from "@app/components/poke/members/columns";
 import { makeColumnsForMembers } from "@app/components/poke/members/columns";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import type { PokeWorkspaceMember } from "@app/lib/api/poke/memberships";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import {
@@ -10,14 +11,10 @@ import {
   MEMBERSHIP_SEAT_TYPES,
   type MembershipSeatType,
 } from "@app/types/memberships";
-import type {
-  RoleType,
-  UserTypeWithWorkspaces,
-  WorkspaceType,
-} from "@app/types/user";
+import type { RoleType, WorkspaceType } from "@app/types/user";
 
 function prepareMembersForDisplay(
-  members: UserTypeWithWorkspaces[]
+  members: PokeWorkspaceMember[]
 ): MemberDisplayType[] {
   return members.map((m) => {
     return {
@@ -29,13 +26,15 @@ function prepareMembersForDisplay(
       sId: m.sId,
       origin: m.origin,
       seatType: isMembershipSeatType(m.seatType) ? m.seatType : undefined,
+      scheduledSeatType: m.scheduledSeatType,
+      scheduledSeatChangeAt: m.scheduledSeatChangeAt,
     };
   });
 }
 
 interface MembersDataTableProps {
   groupName?: string;
-  members: UserTypeWithWorkspaces[];
+  members: PokeWorkspaceMember[];
   owner: WorkspaceType;
   readonly?: boolean;
 }

--- a/front/lib/api/poke/memberships.ts
+++ b/front/lib/api/poke/memberships.ts
@@ -1,9 +1,23 @@
 import type { MembershipInvitationTypeWithLink } from "@app/types/membership_invitation";
+import type { MembershipSeatType } from "@app/types/memberships";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 import { z } from "zod";
 
+/**
+ * A workspace member as shown in the Poke members table. `seatType` is the
+ * member's ACTIVE seat right now; when a future seat change is scheduled (e.g. a
+ * member seated mid-migration whose seat flips at the pending contract start),
+ * `scheduledSeatType` / `scheduledSeatChangeAt` describe that upcoming change so
+ * the table can show "current → scheduled (date)" instead of surfacing the
+ * not-yet-active seat as the current one.
+ */
+export type PokeWorkspaceMember = UserTypeWithWorkspaces & {
+  scheduledSeatType?: MembershipSeatType | null;
+  scheduledSeatChangeAt?: number | null;
+};
+
 export type PokeGetMemberships = {
-  members: UserTypeWithWorkspaces[];
+  members: PokeWorkspaceMember[];
   pendingInvitations: MembershipInvitationTypeWithLink[];
 };
 


### PR DESCRIPTION
## Description

The Poke members list fed the table via `getMembers(auth)` (no `activeOnly`),
which uses `getLatestMemberships` — the row with the greatest `startAt` per
user, with no `startAt <= now` filter. For a member with a scheduled future
seat change (e.g. seated mid-migration, flipping to `pro` at the pending
contract start), that returned the not-yet-active future row, so the table
showed `pro` as if it were current. The seat dropdown posts changes with
`immediate: true`, so the displayed value wasn't even what a change would diff
against.

Fetch members by their ACTIVE seat (`activeOnly: true`) and surface any
scheduled future seat change separately: the endpoint reads
`getScheduledFutureMemberships`, attaches `scheduledSeatType` /
`scheduledSeatChangeAt` (soonest per member) to each member, and the table
renders the active seat with a `→ <seat> on <date>` indicator beside it.

## Tests

locally 

## Risk

low, poke

## Deploy Plan

deploy front
