### PR TITLE
Add a path-keyed edit tool to the files server and treat Frame sources as regular files

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -118,6 +118,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "copy": "never_ask",
     "create": "never_ask",
     "delete": "medium",
+    "edit": "never_ask",
     "extract_text": "never_ask",
     "grep": "never_ask",
     "list": "never_ask",

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -755,7 +755,7 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "edit the code of my frame",
     expected: "interactive_content.edit_interactive_content_file",
-    maxRank: 2, // pod_manager.edit_information collides on "edit"
+    maxRank: 3, // pod_manager.edit_information and files__edit collides on "edit"
   },
   {
     query: "change the chart colors in my dashboard",

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -3,7 +3,6 @@ import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
-  EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   INTERACTIVE_CONTENT_SERVER_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { FILE_PREVIEW_DIRECTIVE_EXAMPLE } from "@app/lib/markdown/file_preview";
@@ -17,6 +16,7 @@ export const FILES_LIST_ACTION_NAME = "list" as const;
 export const FILES_CAT_ACTION_NAME = "cat" as const;
 export const FILES_GREP_ACTION_NAME = "grep" as const;
 export const FILES_CREATE_ACTION_NAME = "create" as const;
+export const FILES_EDIT_ACTION_NAME = "edit" as const;
 export const FILES_UPLOAD_FROM_URL_ACTION_NAME = "upload_from_url" as const;
 export const FILES_DELETE_ACTION_NAME = "delete" as const;
 export const FILES_COPY_ACTION_NAME = "copy" as const;
@@ -247,9 +247,10 @@ const FILES_TOOLS_COMMON_METADATA = {
       "Accepts UTF-8 text content only. Binary files cannot be created via this tool. " +
       `Content is capped at ${CREATE_CONTENT_MAX_BYTES / 1024} KB. ` +
       "If the file already exists it is silently overwritten (shell \`>\` semantics). " +
-      `${FRAME_FILES_UNSUPPORTED}; use ` +
-      `\`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` to create or ` +
-      `\`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` to edit them. ` +
+      "A file written with a Frame content type is only a source file on the mount. To turn it " +
+      `into a shareable rendered Frame, use \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` ` +
+      "with mode='template' and this path as source. " +
+      "Overwriting an existing Frame file updates only its source, never the rendered Frame directly. " +
       "Returns whether the file was created or updated, along with its path and size.",
     schema: {
       path: z
@@ -323,6 +324,44 @@ const FILES_TOOLS_COMMON_METADATA = {
   },
 };
 
+const EDIT_TOOL = {
+  description:
+    "Edit a text file by replacing an exact string match with new content. " +
+    "`old_string` must match the file content exactly, including whitespace and indentation. " +
+    "Fails if `old_string` is not found or if the number of occurrences does not match " +
+    "`expected_replacements` (default 1); make `old_string` unique by including surrounding lines. " +
+    `Files larger than ${CREATE_CONTENT_MAX_BYTES / 1024} KB cannot be edited with this tool. ` +
+    "Editing a Frame source file updates only its source, never the rendered Frame directly. " +
+    "The tool result explains how to apply the change to the rendered Frame.",
+  schema: {
+    path: z
+      .string()
+      .describe(
+        `Scoped file path as returned by \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` (e.g. \`conversation-<id>/App.tsx\`)`
+      ),
+    old_string: z
+      .string()
+      .min(1)
+      .describe(
+        "Exact text to replace, matching the file content character for character"
+      ),
+    new_string: z.string().describe("Text to replace `old_string` with"),
+    expected_replacements: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        "Number of occurrences expected to be replaced (default 1). The edit fails if the actual count differs."
+      ),
+  },
+  stake: "never_ask" as const,
+  displayLabels: {
+    running: "Editing file",
+    done: "Edited file",
+  },
+};
+
 const EXTRACT_TEXT_TOOL = {
   description:
     "Extract text from a binary document (PDF, DOCX, DOC, PPTX, PPT, XLSX, XLS) " +
@@ -348,6 +387,7 @@ const EXTRACT_TEXT_TOOL = {
 export const FILES_TOOLS_METADATA = createToolsRecord({
   [FILES_LIST_ACTION_NAME]: LIST_TOOL,
   ...FILES_TOOLS_COMMON_METADATA,
+  [FILES_EDIT_ACTION_NAME]: EDIT_TOOL,
   [FILES_EXTRACT_TEXT_ACTION_NAME]: EXTRACT_TEXT_TOOL,
   [FILES_COPY_ACTION_NAME]: COPY_TOOL,
   [FILES_MOVE_ACTION_NAME]: MOVE_TOOL,

--- a/front/lib/api/actions/servers/files/tools/create.test.ts
+++ b/front/lib/api/actions/servers/files/tools/create.test.ts
@@ -4,6 +4,7 @@ import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
@@ -48,8 +49,16 @@ async function setupProjectConversation(): Promise<{
 }
 
 describe("createHandler", () => {
-  it("returns Err when content_type is a frame MIME type", async () => {
+  it("creates a new frame-typed file as a regular mount write", async () => {
     const { auth, conversation } = await setupProjectConversation();
+
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({
+        exists: vi.fn().mockResolvedValue([false]),
+        save: saveMock,
+      })),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
     const result = await createHandler(
       {
@@ -60,19 +69,23 @@ describe("createHandler", () => {
       makeExtra(auth, conversation)
     );
 
-    expect(result.isErr()).toBe(true);
-    if (!result.isErr()) {
-      return;
-    }
-    expect(result.error.message).toContain(
-      "interactive_content__create_interactive_content_file"
-    );
+    assert(result.isOk());
+    expect(result.value[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("Created"),
+    });
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(saveMock.mock.calls[0][1]).toMatchObject({
+      contentType: "application/vnd.dust.frame",
+    });
   });
 
-  it("returns Err when overwriting an existing frame file", async () => {
+  it("overwrites an existing frame file, preserving its content type", async () => {
     const { auth, conversation } = await setupProjectConversation();
+    await FeatureFlagFactory.basic(auth, "frame_publish");
 
-    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
       file: vi.fn(() => ({
         exists: vi.fn().mockResolvedValue([true]),
         getMetadata: vi
@@ -80,6 +93,7 @@ describe("createHandler", () => {
           .mockResolvedValue([
             { contentType: "application/vnd.dust.frame", size: "100" },
           ]),
+        save: saveMock,
       })),
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
@@ -92,13 +106,53 @@ describe("createHandler", () => {
       makeExtra(auth, conversation)
     );
 
-    expect(result.isErr()).toBe(true);
-    if (!result.isErr()) {
-      return;
-    }
-    expect(result.error.message).toContain(
-      "interactive_content__edit_interactive_content_file"
+    assert(result.isOk());
+    expect(result.value[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining(
+        "interactive_content__publish_interactive_content_file"
+      ),
+    });
+
+    // The mount object must keep the frame content type, not the incoming one.
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(saveMock.mock.calls[0][1]).toMatchObject({
+      contentType: "application/vnd.dust.frame",
+    });
+  });
+
+  it("overwrites an existing frame file without frame_publish, pointing at the file-id edit tool", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({
+        exists: vi.fn().mockResolvedValue([true]),
+        getMetadata: vi
+          .fn()
+          .mockResolvedValue([
+            { contentType: "application/vnd.dust.frame", size: "100" },
+          ]),
+        save: saveMock,
+      })),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const result = await createHandler(
+      {
+        path: `conversation-${conversation.sId}/interactive.tsx`,
+        content: "export default function App() { return null; }",
+        content_type: "text/plain",
+      },
+      makeExtra(auth, conversation)
     );
-    expect(result.error.message).toContain("files__list");
+
+    assert(result.isOk());
+    expect(result.value[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining(
+        "interactive_content__edit_interactive_content_file"
+      ),
+    });
+    expect(saveMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/front/lib/api/actions/servers/files/tools/create.test.ts
+++ b/front/lib/api/actions/servers/files/tools/create.test.ts
@@ -3,13 +3,13 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import assert from "assert";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 function makeExtra(
   auth: Authenticator,
@@ -49,16 +49,13 @@ async function setupProjectConversation(): Promise<{
 }
 
 describe("createHandler", () => {
+  beforeEach(() => {
+    fileStorageMock.reset();
+  });
+
   it("creates a new frame-typed file as a regular mount write", async () => {
     const { auth, conversation } = await setupProjectConversation();
-
-    const saveMock = vi.fn().mockResolvedValue(undefined);
-    vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      file: vi.fn(() => ({
-        exists: vi.fn().mockResolvedValue([false]),
-        save: saveMock,
-      })),
-    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+    fileStorageMock.setFileExists(() => false);
 
     const result = await createHandler(
       {
@@ -74,28 +71,19 @@ describe("createHandler", () => {
       type: "text",
       text: expect.stringContaining("Created"),
     });
-    expect(saveMock).toHaveBeenCalledTimes(1);
-    expect(saveMock.mock.calls[0][1]).toMatchObject({
-      contentType: "application/vnd.dust.frame",
-    });
+    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
+    expect(fileStorageMock.saveFileCalls[0].contentType).toBe(
+      "application/vnd.dust.frame"
+    );
   });
 
   it("overwrites an existing frame file, preserving its content type", async () => {
     const { auth, conversation } = await setupProjectConversation();
     await FeatureFlagFactory.basic(auth, "frame_publish");
-
-    const saveMock = vi.fn().mockResolvedValue(undefined);
-    vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      file: vi.fn(() => ({
-        exists: vi.fn().mockResolvedValue([true]),
-        getMetadata: vi
-          .fn()
-          .mockResolvedValue([
-            { contentType: "application/vnd.dust.frame", size: "100" },
-          ]),
-        save: saveMock,
-      })),
-    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+    fileStorageMock.setFileMetadata(() => ({
+      contentType: "application/vnd.dust.frame",
+      size: "100",
+    }));
 
     const result = await createHandler(
       {
@@ -115,27 +103,18 @@ describe("createHandler", () => {
     });
 
     // The mount object must keep the frame content type, not the incoming one.
-    expect(saveMock).toHaveBeenCalledTimes(1);
-    expect(saveMock.mock.calls[0][1]).toMatchObject({
-      contentType: "application/vnd.dust.frame",
-    });
+    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
+    expect(fileStorageMock.saveFileCalls[0].contentType).toBe(
+      "application/vnd.dust.frame"
+    );
   });
 
   it("overwrites an existing frame file without frame_publish, pointing at the file-id edit tool", async () => {
     const { auth, conversation } = await setupProjectConversation();
-
-    const saveMock = vi.fn().mockResolvedValue(undefined);
-    vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      file: vi.fn(() => ({
-        exists: vi.fn().mockResolvedValue([true]),
-        getMetadata: vi
-          .fn()
-          .mockResolvedValue([
-            { contentType: "application/vnd.dust.frame", size: "100" },
-          ]),
-        save: saveMock,
-      })),
-    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+    fileStorageMock.setFileMetadata(() => ({
+      contentType: "application/vnd.dust.frame",
+      size: "100",
+    }));
 
     const result = await createHandler(
       {
@@ -153,6 +132,6 @@ describe("createHandler", () => {
         "interactive_content__edit_interactive_content_file"
       ),
     });
-    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
   });
 });

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -10,10 +10,8 @@ import {
   requireAgentLoopConversation,
   scopedPathsFromArgs,
 } from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
-import {
-  frameFileCreateRejectedError,
-  frameFileEditRejectedError,
-} from "@app/lib/api/actions/servers/files/tools/utils";
+import { frameSourceUpdatedNotice } from "@app/lib/api/actions/servers/files/tools/utils";
+import { getFeatureFlags } from "@app/lib/auth";
 import { getFilePreviewDirectiveInstruction } from "@app/lib/markdown/file_preview";
 import {
   isAllSupportedFileContentType,
@@ -57,23 +55,23 @@ export async function createHandler(
 
   const dustFs = fsResult.value;
 
-  const incomingMimeType = stripMimeParameters(content_type);
-  if (isInteractiveContentType(incomingMimeType)) {
-    return new Err(frameFileCreateRejectedError());
-  }
-
   // Check existence before writing so we can report "Created" vs "Updated".
   const statResult = await dustFs.stat(path);
   const exists = statResult.isOk() && statResult.value !== null;
 
+  let isFrameSourceOverwrite = false;
+  let writeContentType = content_type;
+
   if (statResult.isOk() && statResult.value !== null) {
     const existingMimeType = stripMimeParameters(statResult.value.contentType);
     if (isInteractiveContentType(existingMimeType)) {
-      return new Err(frameFileEditRejectedError());
+      isFrameSourceOverwrite = true;
+      // Keep the frame content type on the mount so the file stays recognized as a Frame.
+      writeContentType = statResult.value.contentType;
     }
   }
 
-  const writeResult = await dustFs.write(path, contentBuffer, content_type);
+  const writeResult = await dustFs.write(path, contentBuffer, writeContentType);
   if (writeResult.isErr()) {
     const err = writeResult.error;
     switch (err.code) {
@@ -96,6 +94,20 @@ export async function createHandler(
   const fileName = path.split("/").pop() ?? path;
   const sizeKb = Math.ceil(contentBuffer.byteLength / 1024);
   const verb = exists ? "Updated" : "Created";
+
+  if (isFrameSourceOverwrite) {
+    const flags = await getFeatureFlags(auth);
+    return new Ok([
+      {
+        type: "text",
+        text:
+          `Updated \`${path}\` (${sizeKb} KB). ` +
+          frameSourceUpdatedNotice({
+            hasFramePublishFF: flags.includes("frame_publish"),
+          }),
+      },
+    ]);
+  }
 
   const items: Array<
     | { type: "text"; text: string }

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -3,13 +3,12 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { editHandler } from "@app/lib/api/actions/servers/files/tools/edit";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import assert from "assert";
-import { Readable } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/file_storage/config", () => ({
@@ -56,40 +55,17 @@ async function setupProjectConversation(): Promise<{
   return { auth: projectAuth, conversation };
 }
 
+function mockStoredFile(content: string, contentType: string) {
+  fileStorageMock.setFileMetadata(() => ({
+    contentType,
+    size: String(Buffer.byteLength(content, "utf8")),
+  }));
+  fileStorageMock.setFileContent(() => content);
+}
+
 describe("editHandler", () => {
-  let existsMock: ReturnType<typeof vi.fn>;
-  let getMetadataMock: ReturnType<typeof vi.fn>;
-  let createReadStreamMock: ReturnType<typeof vi.fn>;
-  let saveMock: ReturnType<typeof vi.fn>;
-  let fileMock: ReturnType<typeof vi.fn>;
-
-  function mockStoredFile(content: string, contentType: string) {
-    existsMock.mockResolvedValue([true]);
-    getMetadataMock.mockResolvedValue([
-      { contentType, size: String(Buffer.byteLength(content, "utf8")) },
-    ]);
-    createReadStreamMock.mockImplementation(() =>
-      Readable.from([Buffer.from(content, "utf8")])
-    );
-  }
-
   beforeEach(() => {
-    existsMock = vi.fn().mockResolvedValue([true]);
-    getMetadataMock = vi
-      .fn()
-      .mockResolvedValue([{ contentType: "text/plain", size: "0" }]);
-    createReadStreamMock = vi.fn(() => Readable.from([Buffer.from("")]));
-    saveMock = vi.fn().mockResolvedValue(undefined);
-    fileMock = vi.fn(() => ({
-      exists: existsMock,
-      getMetadata: getMetadataMock,
-      createReadStream: createReadStreamMock,
-      save: saveMock,
-    }));
-
-    vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      file: fileMock,
-    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+    fileStorageMock.reset();
   });
 
   it("replaces a string and writes back with the original content type", async () => {
@@ -112,11 +88,11 @@ describe("editHandler", () => {
       text: expect.stringContaining("made 1 replacement"),
     });
 
-    expect(saveMock).toHaveBeenCalledTimes(1);
-    const [savedContent, saveOpts] = saveMock.mock.calls[0];
-    expect(savedContent.toString("utf8")).toBe("const label = 'Hello Dust';\n");
-    expect(saveOpts).toMatchObject({ contentType: "text/plain" });
-    expect(fileMock).toHaveBeenCalledWith(
+    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
+    const { filePath, content, contentType } = fileStorageMock.saveFileCalls[0];
+    expect(content.toString("utf8")).toBe("const label = 'Hello Dust';\n");
+    expect(contentType).toBe("text/plain");
+    expect(filePath).toBe(
       `w/${workspaceId}/conversations/${conversation.sId}/files/notes.txt`
     );
   });
@@ -136,7 +112,9 @@ describe("editHandler", () => {
     );
 
     assert(result.isOk());
-    expect(saveMock.mock.calls[0][0].toString("utf8")).toBe("c b c b c\n");
+    expect(fileStorageMock.saveFileCalls[0].content.toString("utf8")).toBe(
+      "c b c b c\n"
+    );
   });
 
   it("appends a publish reminder when editing a Frame source with frame_publish enabled", async () => {
@@ -164,9 +142,9 @@ describe("editHandler", () => {
       ),
     });
 
-    expect(saveMock.mock.calls[0][1]).toMatchObject({
-      contentType: "application/vnd.dust.frame",
-    });
+    expect(fileStorageMock.saveFileCalls[0].contentType).toBe(
+      "application/vnd.dust.frame"
+    );
   });
 
   it("points at the file-id edit tool when editing a Frame source without frame_publish", async () => {
@@ -192,12 +170,12 @@ describe("editHandler", () => {
         "interactive_content__edit_interactive_content_file"
       ),
     });
-    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
   });
 
   it("returns Err when the file does not exist", async () => {
     const { auth, conversation } = await setupProjectConversation();
-    existsMock.mockResolvedValue([false]);
+    fileStorageMock.setFileExists(() => false);
 
     const result = await editHandler(
       {
@@ -212,7 +190,7 @@ describe("editHandler", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("not found");
     }
-    expect(saveMock).not.toHaveBeenCalled();
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
   it("returns Err when old_string is not found", async () => {
@@ -232,7 +210,7 @@ describe("editHandler", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("String not found");
     }
-    expect(saveMock).not.toHaveBeenCalled();
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
   it("returns Err when occurrences do not match expected_replacements", async () => {
@@ -254,7 +232,7 @@ describe("editHandler", () => {
         "Expected 1 replacements, but found 2 occurrences"
       );
     }
-    expect(saveMock).not.toHaveBeenCalled();
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
   it("returns Err for a binary file", async () => {
@@ -274,15 +252,15 @@ describe("editHandler", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("binary file");
     }
-    expect(saveMock).not.toHaveBeenCalled();
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
   it("returns Err when the file exceeds the size limit", async () => {
     const { auth, conversation } = await setupProjectConversation();
-    existsMock.mockResolvedValue([true]);
-    getMetadataMock.mockResolvedValue([
-      { contentType: "text/plain", size: String(51 * 1024) },
-    ]);
+    fileStorageMock.setFileMetadata(() => ({
+      contentType: "text/plain",
+      size: String(51 * 1024),
+    }));
 
     const result = await editHandler(
       {
@@ -297,6 +275,6 @@ describe("editHandler", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("KB limit");
     }
-    expect(saveMock).not.toHaveBeenCalled();
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 });

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -1,0 +1,302 @@
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { editHandler } from "@app/lib/api/actions/servers/files/tools/edit";
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import assert from "assert";
+import { Readable } from "stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/file_storage/config", () => ({
+  default: { getGcsPrivateUploadsBucket: vi.fn(() => "test-bucket") },
+}));
+vi.mock("@app/lib/api/config", () => ({
+  default: { getApiBaseUrl: vi.fn(() => "https://dust.tt") },
+}));
+
+function makeExtra(
+  auth: Authenticator,
+  conversation: ConversationType
+): ToolHandlerExtra {
+  const agentLoopContext = {
+    runContext: { conversation },
+  } as unknown as AgentLoopContextType;
+  return { auth, agentLoopContext } as unknown as ToolHandlerExtra;
+}
+
+async function setupProjectConversation(): Promise<{
+  auth: Authenticator;
+  conversation: ConversationType;
+}> {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const user = auth.getNonNullableUser();
+
+  const space = await SpaceFactory.project(workspace, user.id);
+  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
+  assert(addRes.isOk(), "Failed to add user to project space");
+
+  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
+  const conversation = await createConversation(projectAuth, {
+    title: "Test",
+    visibility: "unlisted",
+    spaceId: space.id,
+  });
+
+  return { auth: projectAuth, conversation };
+}
+
+describe("editHandler", () => {
+  let existsMock: ReturnType<typeof vi.fn>;
+  let getMetadataMock: ReturnType<typeof vi.fn>;
+  let createReadStreamMock: ReturnType<typeof vi.fn>;
+  let saveMock: ReturnType<typeof vi.fn>;
+  let fileMock: ReturnType<typeof vi.fn>;
+
+  function mockStoredFile(content: string, contentType: string) {
+    existsMock.mockResolvedValue([true]);
+    getMetadataMock.mockResolvedValue([
+      { contentType, size: String(Buffer.byteLength(content, "utf8")) },
+    ]);
+    createReadStreamMock.mockImplementation(() =>
+      Readable.from([Buffer.from(content, "utf8")])
+    );
+  }
+
+  beforeEach(() => {
+    existsMock = vi.fn().mockResolvedValue([true]);
+    getMetadataMock = vi
+      .fn()
+      .mockResolvedValue([{ contentType: "text/plain", size: "0" }]);
+    createReadStreamMock = vi.fn(() => Readable.from([Buffer.from("")]));
+    saveMock = vi.fn().mockResolvedValue(undefined);
+    fileMock = vi.fn(() => ({
+      exists: existsMock,
+      getMetadata: getMetadataMock,
+      createReadStream: createReadStreamMock,
+      save: saveMock,
+    }));
+
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: fileMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  it("replaces a string and writes back with the original content type", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+    mockStoredFile("const label = 'Hello world';\n", "text/plain");
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/notes.txt`,
+        old_string: "Hello world",
+        new_string: "Hello Dust",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    expect(result.value[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("made 1 replacement"),
+    });
+
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    const [savedContent, saveOpts] = saveMock.mock.calls[0];
+    expect(savedContent.toString("utf8")).toBe("const label = 'Hello Dust';\n");
+    expect(saveOpts).toMatchObject({ contentType: "text/plain" });
+    expect(fileMock).toHaveBeenCalledWith(
+      `w/${workspaceId}/conversations/${conversation.sId}/files/notes.txt`
+    );
+  });
+
+  it("replaces multiple occurrences when expected_replacements matches", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("a b a b a\n", "text/plain");
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/notes.txt`,
+        old_string: "a",
+        new_string: "c",
+        expected_replacements: 3,
+      },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    expect(saveMock.mock.calls[0][0].toString("utf8")).toBe("c b c b c\n");
+  });
+
+  it("appends a publish reminder when editing a Frame source with frame_publish enabled", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    await FeatureFlagFactory.basic(auth, "frame_publish");
+    mockStoredFile(
+      "export default function App() { return <h1>Old</h1>; }\n",
+      "application/vnd.dust.frame"
+    );
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/App.tsx`,
+        old_string: "Old",
+        new_string: "New",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    expect(result.value[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining(
+        "interactive_content__publish_interactive_content_file"
+      ),
+    });
+
+    expect(saveMock.mock.calls[0][1]).toMatchObject({
+      contentType: "application/vnd.dust.frame",
+    });
+  });
+
+  it("points at the file-id edit tool when editing a Frame source without frame_publish", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile(
+      "export default function App() { return <h1>Old</h1>; }\n",
+      "application/vnd.dust.frame"
+    );
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/App.tsx`,
+        old_string: "Old",
+        new_string: "New",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    expect(result.value[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining(
+        "interactive_content__edit_interactive_content_file"
+      ),
+    });
+    expect(saveMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns Err when the file does not exist", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    existsMock.mockResolvedValue([false]);
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/missing.txt`,
+        old_string: "a",
+        new_string: "b",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("not found");
+    }
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it("returns Err when old_string is not found", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("some content\n", "text/plain");
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/notes.txt`,
+        old_string: "absent",
+        new_string: "b",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("String not found");
+    }
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it("returns Err when occurrences do not match expected_replacements", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("a b a\n", "text/plain");
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/notes.txt`,
+        old_string: "a",
+        new_string: "c",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "Expected 1 replacements, but found 2 occurrences"
+      );
+    }
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it("returns Err for a binary file", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("binary", "image/png");
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/logo.png`,
+        old_string: "a",
+        new_string: "b",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("binary file");
+    }
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it("returns Err when the file exceeds the size limit", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    existsMock.mockResolvedValue([true]);
+    getMetadataMock.mockResolvedValue([
+      { contentType: "text/plain", size: String(51 * 1024) },
+    ]);
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/big.txt`,
+        old_string: "a",
+        new_string: "b",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("KB limit");
+    }
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -20,6 +20,7 @@ import {
   stripMimeParameters,
 } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 
 export async function editHandler(
   {
@@ -151,8 +152,7 @@ export async function editHandler(
     }
   }
 
-  const pluralSuffix = occurrences === 1 ? "" : "s";
-  let text = `Updated \`${path}\`: made ${occurrences} replacement${pluralSuffix}.`;
+  let text = `Updated \`${path}\`: made ${occurrences} replacement${pluralize(occurrences)}.`;
 
   if (isFrameSource) {
     const flags = await getFeatureFlags(auth);

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -1,0 +1,165 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
+import {
+  getDustFileSystemForAgentLoop,
+  requireAgentLoopConversation,
+  scopedPathsFromArgs,
+} from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
+import {
+  frameSourceUpdatedNotice,
+  isReadableAsText,
+} from "@app/lib/api/actions/servers/files/tools/utils";
+import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
+import { getFeatureFlags } from "@app/lib/auth";
+import {
+  isInteractiveContentType,
+  stripMimeParameters,
+} from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
+
+export async function editHandler(
+  {
+    path,
+    old_string,
+    new_string,
+    expected_replacements,
+  }: {
+    path: string;
+    old_string: string;
+    new_string: string;
+    expected_replacements?: number;
+  },
+  { auth, agentLoopContext }: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  if (conversationRes.isErr()) {
+    return conversationRes;
+  }
+
+  const fsResult = await getDustFileSystemForAgentLoop(
+    auth,
+    conversationRes.value,
+    scopedPathsFromArgs(path)
+  );
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+
+  const dustFs = fsResult.value;
+
+  const statResult = await dustFs.stat(path);
+  if (statResult.isErr()) {
+    return new Err(new MCPError(statResult.error.message, { tracked: false }));
+  }
+  if (statResult.value === null) {
+    return new Err(
+      new MCPError(`File not found: \`${path}\`.`, { tracked: false })
+    );
+  }
+
+  const { contentType, sizeBytes } = statResult.value;
+  const mimeType = stripMimeParameters(contentType);
+  // Frame source files carry the frame content type but hold plain TSX text.
+  const isFrameSource = isInteractiveContentType(mimeType);
+
+  if (!isFrameSource && !isReadableAsText(mimeType)) {
+    return new Err(
+      new MCPError(
+        `\`${path}\` is a binary file (${mimeType}) and cannot be edited as text.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  if (sizeBytes > CREATE_CONTENT_MAX_BYTES) {
+    return new Err(
+      new MCPError(
+        `\`${path}\` exceeds the ${CREATE_CONTENT_MAX_BYTES / 1024} KB limit and cannot be edited with this tool.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const readResult = await dustFs.readBuffer(path);
+  if (readResult.isErr()) {
+    return new Err(new MCPError(readResult.error.message, { tracked: false }));
+  }
+  if (readResult.value === null) {
+    return new Err(
+      new MCPError(`File not found: \`${path}\`.`, { tracked: false })
+    );
+  }
+
+  const currentContent = readResult.value.toString("utf8");
+
+  const { updatedContent, occurrences } = getUpdatedContentAndOccurrences({
+    oldString: old_string,
+    newString: new_string,
+    currentContent,
+  });
+
+  if (occurrences === 0) {
+    return new Err(
+      new MCPError(`String not found in file: "${old_string}"`, {
+        tracked: false,
+      })
+    );
+  }
+
+  const expectedReplacements = expected_replacements ?? 1;
+  if (occurrences !== expectedReplacements) {
+    return new Err(
+      new MCPError(
+        `Expected ${expectedReplacements} replacements, but found ${occurrences} occurrences`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const updatedBuffer = Buffer.from(updatedContent, "utf8");
+  if (updatedBuffer.byteLength > CREATE_CONTENT_MAX_BYTES) {
+    return new Err(
+      new MCPError(
+        `Edited content exceeds the ${CREATE_CONTENT_MAX_BYTES / 1024} KB limit.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  // Reusing the stored content type keeps a Frame source frame-typed on the mount.
+  const writeResult = await dustFs.write(path, updatedBuffer, contentType);
+  if (writeResult.isErr()) {
+    const err = writeResult.error;
+    switch (err.code) {
+      case "legacy_path":
+      case "unauthorized":
+        return new Err(new MCPError(err.message, { tracked: false }));
+
+      case "invalid_path":
+        return new Err(
+          new MCPError(`Invalid path: \`${path}\`.`, { tracked: false })
+        );
+
+      default:
+        return new Err(
+          new MCPError(`Failed to write file \`${path}\`: ${err.message}`)
+        );
+    }
+  }
+
+  const pluralSuffix = occurrences === 1 ? "" : "s";
+  let text = `Updated \`${path}\`: made ${occurrences} replacement${pluralSuffix}.`;
+
+  if (isFrameSource) {
+    const flags = await getFeatureFlags(auth);
+    text += ` ${frameSourceUpdatedNotice({
+      hasFramePublishFF: flags.includes("frame_publish"),
+    })}`;
+  }
+
+  return new Ok([{ type: "text", text }]);
+}

--- a/front/lib/api/actions/servers/files/tools/index.ts
+++ b/front/lib/api/actions/servers/files/tools/index.ts
@@ -4,6 +4,7 @@ import {
   FILES_COPY_ACTION_NAME,
   FILES_CREATE_ACTION_NAME,
   FILES_DELETE_ACTION_NAME,
+  FILES_EDIT_ACTION_NAME,
   FILES_EXTRACT_TEXT_ACTION_NAME,
   FILES_GREP_ACTION_NAME,
   FILES_LIST_ACTION_NAME,
@@ -16,6 +17,7 @@ import { catHandler } from "@app/lib/api/actions/servers/files/tools/cat";
 import { copyHandler } from "@app/lib/api/actions/servers/files/tools/copy";
 import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
 import { deleteHandler } from "@app/lib/api/actions/servers/files/tools/delete";
+import { editHandler } from "@app/lib/api/actions/servers/files/tools/edit";
 import { extractTextHandler } from "@app/lib/api/actions/servers/files/tools/extract_text";
 import { grepHandler } from "@app/lib/api/actions/servers/files/tools/grep";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
@@ -27,6 +29,7 @@ const HANDLERS = {
   [FILES_CAT_ACTION_NAME]: catHandler,
   [FILES_COPY_ACTION_NAME]: copyHandler,
   [FILES_CREATE_ACTION_NAME]: createHandler,
+  [FILES_EDIT_ACTION_NAME]: editHandler,
   [FILES_UPLOAD_FROM_URL_ACTION_NAME]: uploadFromUrlHandler,
   [FILES_DELETE_ACTION_NAME]: deleteHandler,
   [FILES_EXTRACT_TEXT_ACTION_NAME]: extractTextHandler,

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -9,6 +9,7 @@ import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   INTERACTIVE_CONTENT_SERVER_NAME,
+  PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
 import {
@@ -156,10 +157,34 @@ export function frameFileCreateRejectedError(): MCPError {
 
 export function frameFileEditRejectedError(): MCPError {
   return new MCPError(
-    `Frame files cannot be edited with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CREATE_ACTION_NAME)}\`. ` +
+    "Frame files cannot be edited with this tool. " +
       `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` to get the file id, ` +
       `then \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` to update it.`,
     { tracked: false }
+  );
+}
+
+/**
+ * Notice appended after a write to a Frame source file on the mount. The mount write never
+ * changes the rendered Frame directly: with frame_publish the model must publish to rebuild
+ * it, without the flag the rendered Frame can only be updated through the file-id edit tool.
+ */
+export function frameSourceUpdatedNotice({
+  hasFramePublishFF,
+}: {
+  hasFramePublishFF: boolean;
+}): string {
+  if (hasFramePublishFF) {
+    return (
+      "This updated the Frame's source only. The rendered Frame is unchanged until you " +
+      `publish it with \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\`.`
+    );
+  }
+
+  return (
+    "This updated the Frame's source only and will not appear in the rendered Frame. " +
+    `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` to get the file id, ` +
+    `then \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` to update the rendered Frame.`
   );
 }
 

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from "stream";
+import { PassThrough, Readable } from "stream";
 import { vi } from "vitest";
 
 export interface WriteStreamCall {
@@ -28,6 +28,10 @@ class FileStorageMock {
   private _saveFileCalls: SaveFileCall[] = [];
   private _existsPredicate: (filePath: string) => boolean = () => true;
   private _saveShouldFail: (filePath: string) => boolean = () => false;
+  private _metadataForPath: (
+    filePath: string
+  ) => { contentType: string; size: string } | null = () => null;
+  private _contentForPath: (filePath: string) => string | null = () => null;
 
   get writeStreamCalls(): readonly WriteStreamCall[] {
     return this._writeStreamCalls;
@@ -53,11 +57,32 @@ class FileStorageMock {
     this._saveShouldFail = predicate;
   }
 
+  /**
+   * Controls what `file(path).getMetadata()` resolves to, keyed by the GCS path.
+   * Return null to fall back to the default (`text/plain`, size 0). Reset between tests
+   * via `reset()`.
+   */
+  setFileMetadata(
+    fn: (filePath: string) => { contentType: string; size: string } | null
+  ): void {
+    this._metadataForPath = fn;
+  }
+
+  /**
+   * Controls what `file(path).createReadStream()` streams, keyed by the GCS path.
+   * Return null to fall back to the default empty stream. Reset between tests via `reset()`.
+   */
+  setFileContent(fn: (filePath: string) => string | null): void {
+    this._contentForPath = fn;
+  }
+
   reset(): void {
     this._writeStreamCalls.length = 0;
     this._saveFileCalls.length = 0;
     this._existsPredicate = () => true;
     this._saveShouldFail = () => false;
+    this._metadataForPath = () => null;
+    this._contentForPath = () => null;
   }
 
   /**
@@ -84,7 +109,13 @@ class FileStorageMock {
   private createMockGCSFile(filePath?: string) {
     return {
       copy: vi.fn().mockResolvedValue(undefined),
-      createReadStream: vi.fn().mockReturnValue(new PassThrough()),
+      createReadStream: vi.fn(() => {
+        const content = this._contentForPath(filePath ?? "");
+        if (content !== null) {
+          return Readable.from([Buffer.from(content, "utf8")]);
+        }
+        return new PassThrough();
+      }),
       createWriteStream: vi
         .fn()
         .mockImplementation((opts?: { contentType?: string }) => {
@@ -99,9 +130,14 @@ class FileStorageMock {
       exists: vi.fn(() =>
         Promise.resolve([this._existsPredicate(filePath ?? "")])
       ),
-      getMetadata: vi
-        .fn()
-        .mockResolvedValue([{ contentType: "text/plain", size: "0" }]),
+      getMetadata: vi.fn(() =>
+        Promise.resolve([
+          this._metadataForPath(filePath ?? "") ?? {
+            contentType: "text/plain",
+            size: "0",
+          },
+        ])
+      ),
       getSignedUrl: vi.fn().mockResolvedValue(["https://signed-url.test"]),
       publicUrl: vi.fn().mockReturnValue("https://public-url.test"),
       save: vi


### PR DESCRIPTION
## Description

Frames are moving to an edit-source-then-publish flow: the model edits a Frame's source files in place on the Computer mount and explicitly publishes to rebuild the rendered Frame. Until now the files server could not participate in that flow. It had no way to make a surgical change to a file, and it refused to touch anything with a Frame content type, forcing every Frame edit through the file-id based edit tool that writes the canonical file directly.

This adds an edit tool to the files server that replaces an exact string match in a text file, with the same matching and occurrence-count semantics as the existing Frame edit tool. It also removes the Frame-specific rejections from file creation: a Frame file on the mount is now handled like any other file. This matches reality, since the model can already write these files freely through the Computer, so the rejection never gated a capability, it only made the files server inconsistent with it. Creating a file with a Frame content type just writes source to the mount. An actual shareable Frame is still minted through the interactive content server, which can take that path as a template source.

Writes to a Frame source preserve its content type on the mount and never touch the rendered Frame. The tool result says how to apply the change: workspaces with frame publishing are told to publish, others are pointed at the file-id edit tool. This is the only place the feature flag is consulted, availability of the tools themselves is not gated.

Downloading remote content over a Frame source stays rejected, as does the mirrored create tool on the separate MCP server surface, both untouched by this change.

## Risk

Low. New tool plus relaxed guards on the files server, no change to how Frames render or publish. Worst case a model writes a Frame source that only lands on the mount, which is already possible through the Computer today.

## Deploy Plan

Deploy front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)