### PR TITLE
Pricing: cap per group 3: api to set the group cap as a limit on metronome

### DIFF
--- a/front/admin/audit_log_schemas/group.spend_limit_updated.json
+++ b/front/admin/audit_log_schemas/group.spend_limit_updated.json
@@ -1,0 +1,15 @@
+{
+  "action": "group.spend_limit_updated",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "group"
+    }
+  ],
+  "metadata": {
+    "kind": "string",
+    "awu_credits": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -30,6 +30,7 @@
   "dust_mcp_server.settings_updated": 1,
   "file.moved": 1,
   "frame.authorized_files_updated": 1,
+  "group.spend_limit_updated": 1,
   "invitation.revoked": 3,
   "invitation.role_updated": 3,
   "mcp_connection.created": 2,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -47,6 +47,7 @@ export const AUDIT_ACTIONS = [
   "member.bulk_invited",
   "member.bulk_revoked",
   "member.spend_limit_updated",
+  "group.spend_limit_updated",
   "membership.upgrade_request_created",
   "membership.upgrade_request_resolved",
   "membership.seat_auto_upgraded",

--- a/front/lib/api/groups/spend_limit.test.ts
+++ b/front/lib/api/groups/spend_limit.test.ts
@@ -1,0 +1,216 @@
+import * as workosAudit from "@app/lib/api/audit/workos_audit";
+import { setGroupSpendLimit } from "@app/lib/api/groups/spend_limit";
+import { Authenticator } from "@app/lib/auth";
+import * as groupCapAlert from "@app/lib/metronome/alerts/spend_limits";
+import * as planType from "@app/lib/metronome/plan_type";
+import * as seatTypes from "@app/lib/metronome/seat_types";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { Ok } from "@app/types/shared/result";
+import type { Subscription } from "@metronome/sdk/resources";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
+  const actual = await vi.importActual<typeof groupCapAlert>(
+    "@app/lib/metronome/alerts/spend_limits"
+  );
+  return {
+    ...actual,
+    upsertMetronomeGroupCapAlertForSeatType: vi.fn(),
+    upsertMetronomeGroupWarningAlertForSeatType: vi.fn(),
+    clearMetronomeGroupCapAlertForSeatType: vi.fn(),
+    clearMetronomeGroupWarningAlertForSeatType: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/api/audit/workos_audit", async () => {
+  const actual = await vi.importActual<typeof workosAudit>(
+    "@app/lib/api/audit/workos_audit"
+  );
+  return {
+    ...actual,
+    emitAuditLogEvent: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/plan_type", async () => {
+  const actual = await vi.importActual<typeof planType>(
+    "@app/lib/metronome/plan_type"
+  );
+  return {
+    ...actual,
+    getActiveContract: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<typeof seatTypes>(
+    "@app/lib/metronome/seat_types"
+  );
+  return {
+    ...actual,
+    getProductSeatTypes: vi.fn(),
+    getSeatSubscriptionsFromContract: vi.fn(),
+    getAwuAllocationForNormalizedSeatType: vi.fn(),
+  };
+});
+
+const METRONOME_CUSTOMER_ID = "cust_test_xxx";
+const AUDIT_CONTEXT = { location: "127.0.0.1" };
+
+const FAKE_CONTRACT = {
+  id: "contract_xxx",
+  customer_id: METRONOME_CUSTOMER_ID,
+  rate_card_id: "rc_xxx",
+  subscriptions: [],
+} as unknown as planType.CachedContract;
+
+const FAKE_PRODUCT_SEAT_TYPES = new Map([["prod_pro", "pro" as const]]);
+const FAKE_SEAT_SUBSCRIPTIONS = new Map<MembershipSeatType, Subscription>([
+  [
+    "pro",
+    { subscription_rate: { product: { id: "prod_pro" } } } as Subscription,
+  ],
+]);
+
+beforeEach(() => {
+  vi.mocked(
+    groupCapAlert.upsertMetronomeGroupCapAlertForSeatType
+  ).mockResolvedValue(new Ok({ alertId: "alert_group_cap_xxx" }));
+  vi.mocked(
+    groupCapAlert.upsertMetronomeGroupWarningAlertForSeatType
+  ).mockResolvedValue(new Ok({ alertId: "alert_group_warning_xxx" }));
+  vi.mocked(
+    groupCapAlert.clearMetronomeGroupCapAlertForSeatType
+  ).mockResolvedValue(new Ok(undefined));
+  vi.mocked(
+    groupCapAlert.clearMetronomeGroupWarningAlertForSeatType
+  ).mockResolvedValue(new Ok(undefined));
+  vi.mocked(workosAudit.emitAuditLogEvent).mockResolvedValue(undefined);
+
+  vi.mocked(planType.getActiveContract).mockResolvedValue(FAKE_CONTRACT);
+  vi.mocked(seatTypes.getProductSeatTypes).mockResolvedValue(
+    FAKE_PRODUCT_SEAT_TYPES
+  );
+  vi.mocked(seatTypes.getSeatSubscriptionsFromContract).mockReturnValue(
+    FAKE_SEAT_SUBSCRIPTIONS
+  );
+  vi.mocked(seatTypes.getAwuAllocationForNormalizedSeatType).mockReturnValue(
+    8000
+  );
+});
+
+describe("setGroupSpendLimit", () => {
+  it("persists the cap and upserts per-seat-type alerts with seat allowance added", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const group = await GroupResource.makeNew({
+      name: "Sales",
+      workspaceId: workspace.id,
+      kind: "regular",
+    });
+
+    const result = await setGroupSpendLimit(auth, {
+      groupId: group.sId,
+      limit: { kind: "limited", awuCredits: 25_000 },
+      auditContext: AUDIT_CONTEXT,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    // DB is the source of truth: the cap is persisted on the group.
+    const reloaded = await GroupResource.fetchById(auth, group.sId);
+    if (reloaded.isErr()) {
+      throw reloaded.error;
+    }
+    expect(reloaded.value.poolCapAwuCredits).toBe(25_000);
+
+    // Metronome threshold = 8_000 (seat) + 25_000 (group) = 33_000.
+    expect(
+      groupCapAlert.upsertMetronomeGroupCapAlertForSeatType
+    ).toHaveBeenCalledWith({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      workspaceId: workspace.sId,
+      groupId: group.sId,
+      seatType: "pro",
+      awuCredits: 33_000,
+    });
+    expect(workosAudit.emitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "group.spend_limit_updated",
+        metadata: { kind: "limited", awu_credits: "25000" },
+      })
+    );
+  });
+
+  it("clears the alerts and the cap when set to unlimited", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const group = await GroupResource.makeNew({
+      name: "Sales",
+      workspaceId: workspace.id,
+      kind: "regular",
+    });
+    await group.updatePoolCap(auth, 25_000);
+
+    const result = await setGroupSpendLimit(auth, {
+      groupId: group.sId,
+      limit: { kind: "unlimited" },
+      auditContext: AUDIT_CONTEXT,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const reloaded = await GroupResource.fetchById(auth, group.sId);
+    if (reloaded.isErr()) {
+      throw reloaded.error;
+    }
+    expect(reloaded.value.poolCapAwuCredits).toBeNull();
+
+    expect(
+      groupCapAlert.clearMetronomeGroupCapAlertForSeatType
+    ).toHaveBeenCalled();
+    expect(
+      groupCapAlert.upsertMetronomeGroupCapAlertForSeatType
+    ).not.toHaveBeenCalled();
+    expect(workosAudit.emitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "group.spend_limit_updated",
+        metadata: { kind: "unlimited", awu_credits: "unlimited" },
+      })
+    );
+  });
+
+  it("rejects out-of-bounds thresholds with invalid_threshold", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const group = await GroupResource.makeNew({
+      name: "Sales",
+      workspaceId: workspace.id,
+      kind: "regular",
+    });
+
+    for (const awuCredits of [-1, 1_000_001, 1.5]) {
+      const result = await setGroupSpendLimit(auth, {
+        groupId: group.sId,
+        limit: { kind: "limited", awuCredits },
+        auditContext: AUDIT_CONTEXT,
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.type).toBe("invalid_threshold");
+      }
+    }
+    expect(
+      groupCapAlert.upsertMetronomeGroupCapAlertForSeatType
+    ).not.toHaveBeenCalled();
+    expect(workosAudit.emitAuditLogEvent).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/groups/spend_limit.test.ts
+++ b/front/lib/api/groups/spend_limit.test.ts
@@ -110,7 +110,8 @@ describe("setGroupSpendLimit", () => {
     const group = await GroupResource.makeNew({
       name: "Sales",
       workspaceId: workspace.id,
-      kind: "regular",
+      kind: "provisioned",
+      workOSGroupId: "fake-sales",
     });
 
     const result = await setGroupSpendLimit(auth, {
@@ -154,7 +155,8 @@ describe("setGroupSpendLimit", () => {
     const group = await GroupResource.makeNew({
       name: "Sales",
       workspaceId: workspace.id,
-      kind: "regular",
+      kind: "provisioned",
+      workOSGroupId: "fake-sales",
     });
     await group.updatePoolCap(auth, 25_000);
 
@@ -194,7 +196,8 @@ describe("setGroupSpendLimit", () => {
     const group = await GroupResource.makeNew({
       name: "Sales",
       workspaceId: workspace.id,
-      kind: "regular",
+      kind: "provisioned",
+      workOSGroupId: "fake-sales",
     });
 
     for (const awuCredits of [-1, 1_000_001, 1.5]) {

--- a/front/lib/api/groups/spend_limit.ts
+++ b/front/lib/api/groups/spend_limit.ts
@@ -1,0 +1,320 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
+import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
+import type { AuditLogContext } from "@app/lib/api/workos/organization";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  clearMetronomeGroupCapAlertForSeatType,
+  clearMetronomeGroupWarningAlertForSeatType,
+  upsertMetronomeGroupCapAlertForSeatType,
+  upsertMetronomeGroupWarningAlertForSeatType,
+} from "@app/lib/metronome/alerts/spend_limits";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import {
+  getAwuAllocationForNormalizedSeatType,
+  getProductSeatTypes,
+  getSeatSubscriptionsFromContract,
+} from "@app/lib/metronome/seat_types";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import logger from "@app/logger/logger";
+import type {
+  GroupSpendLimit,
+  SetGroupSpendLimitResponse,
+} from "@app/types/api/groups/spend_limit";
+import { isCapEligibleGroupKind } from "@app/types/groups";
+import type { NormalizedPoolLimitSeatType } from "@app/types/memberships";
+import {
+  NORMALIZED_POOL_LIMIT_SEAT_TYPES,
+  normalizeToPoolLimitSeatType,
+} from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+
+export const MIN_GROUP_SPEND_LIMIT_AWU_CREDITS = 1;
+export const MAX_GROUP_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
+
+export type GroupSpendLimitErrorType =
+  | "group_not_found"
+  | "invalid_group_kind"
+  | "unauthorized"
+  | "workspace_not_metronome_billed"
+  | "invalid_threshold"
+  | "contract_not_found"
+  | "metronome_error";
+
+export class GroupSpendLimitError extends Error {
+  constructor(
+    readonly type: GroupSpendLimitErrorType,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Create/update or clear the per-(group, seat-type) Metronome cap + warning
+ * alerts from the group's intended cap. When `poolCapAwuCredits` is null the
+ * alerts are cleared for every pool-limit seat type; otherwise one cap + warning
+ * alert is upserted per seat type at (seatAllowance + groupCap). The alerts fan
+ * out over all users — the webhook decides per user whether the cap applies.
+ */
+async function syncGroupCapAlertsForGroup({
+  workspace,
+  groupId,
+  poolCapAwuCredits,
+}: {
+  workspace: LightWorkspaceType;
+  groupId: string;
+  poolCapAwuCredits: number | null;
+}): Promise<Result<void, GroupSpendLimitError>> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return new Ok(undefined);
+  }
+
+  // Clearing needs no contract lookup — just archive every seat type's alerts.
+  if (poolCapAwuCredits === null) {
+    for (const seatType of NORMALIZED_POOL_LIMIT_SEAT_TYPES) {
+      const clearResult = await clearMetronomeGroupCapAlertForSeatType({
+        metronomeCustomerId,
+        workspaceId: workspace.sId,
+        groupId,
+        seatType,
+      });
+      if (clearResult.isErr()) {
+        return new Err(
+          new GroupSpendLimitError("metronome_error", clearResult.error.message)
+        );
+      }
+      const clearWarningResult =
+        await clearMetronomeGroupWarningAlertForSeatType({
+          metronomeCustomerId,
+          workspaceId: workspace.sId,
+          groupId,
+          seatType,
+        });
+      if (clearWarningResult.isErr()) {
+        logger.warn(
+          {
+            workspaceId: workspace.sId,
+            groupId,
+            seatType,
+            err: clearWarningResult.error,
+          },
+          "[GroupSpendLimit] Failed to clear group warning alert; continuing"
+        );
+      }
+    }
+    return new Ok(undefined);
+  }
+
+  const contract = await getActiveContract(workspace.sId);
+  if (!contract) {
+    logger.error(
+      { workspaceId: workspace.sId, groupId },
+      "[GroupSpendLimit] syncGroupCapAlerts: no active contract found"
+    );
+    return new Err(
+      new GroupSpendLimitError(
+        "contract_not_found",
+        "No active contract found for this workspace."
+      )
+    );
+  }
+  const productSeatTypes = await getProductSeatTypes();
+  const seatSubscriptions = getSeatSubscriptionsFromContract(
+    contract,
+    productSeatTypes
+  );
+
+  const normalizedSeatTypes = new Set<NormalizedPoolLimitSeatType>();
+  for (const seatType of seatSubscriptions.keys()) {
+    const normalized = normalizeToPoolLimitSeatType(seatType);
+    if (normalized) {
+      normalizedSeatTypes.add(normalized);
+    }
+  }
+
+  for (const seatType of normalizedSeatTypes) {
+    const seatAllowance = getAwuAllocationForNormalizedSeatType(
+      contract,
+      seatType,
+      productSeatTypes
+    );
+    const totalThreshold = seatAllowance + poolCapAwuCredits;
+
+    const upsertResult = await upsertMetronomeGroupCapAlertForSeatType({
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+      groupId,
+      seatType,
+      awuCredits: totalThreshold,
+    });
+    if (upsertResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          groupId,
+          seatType,
+          totalThreshold,
+          err: upsertResult.error,
+        },
+        "[GroupSpendLimit] syncGroupCapAlerts: failed to upsert cap alert"
+      );
+      return new Err(
+        new GroupSpendLimitError("metronome_error", upsertResult.error.message)
+      );
+    }
+
+    const warningResult = await upsertMetronomeGroupWarningAlertForSeatType({
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+      groupId,
+      seatType,
+      capAwuCredits: totalThreshold,
+    });
+    if (warningResult.isErr()) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          groupId,
+          seatType,
+          totalThreshold,
+          err: warningResult.error,
+        },
+        "[GroupSpendLimit] syncGroupCapAlerts: failed to upsert warning alert; continuing"
+      );
+    }
+  }
+
+  return new Ok(undefined);
+}
+
+/**
+ * Set or clear a group's per-member usage spend limit.
+ *
+ * Persists the pool-only cap on the group (source of truth), then syncs the
+ * derived Metronome per-(group, seat-type) alerts and reconciles workspace
+ * credit states so members are (un)capped immediately rather than on the next
+ * webhook. `limit.kind === "unlimited"` clears the cap.
+ */
+export async function setGroupSpendLimit(
+  auth: Authenticator,
+  {
+    groupId,
+    limit,
+    auditContext,
+  }: {
+    groupId: string;
+    limit: GroupSpendLimit;
+    auditContext: AuditLogContext;
+  }
+): Promise<Result<SetGroupSpendLimitResponse, GroupSpendLimitError>> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!workspace.metronomeCustomerId) {
+    return new Err(
+      new GroupSpendLimitError(
+        "workspace_not_metronome_billed",
+        "Workspace is not on Metronome billing."
+      )
+    );
+  }
+  const { metronomeCustomerId } = workspace;
+
+  if (
+    limit.kind === "limited" &&
+    (!Number.isInteger(limit.awuCredits) ||
+      limit.awuCredits < MIN_GROUP_SPEND_LIMIT_AWU_CREDITS ||
+      limit.awuCredits > MAX_GROUP_SPEND_LIMIT_AWU_CREDITS)
+  ) {
+    return new Err(
+      new GroupSpendLimitError(
+        "invalid_threshold",
+        `awuCredits must be an integer between ${MIN_GROUP_SPEND_LIMIT_AWU_CREDITS} and ${MAX_GROUP_SPEND_LIMIT_AWU_CREDITS}.`
+      )
+    );
+  }
+
+  const groupRes = await GroupResource.fetchById(auth, groupId);
+  if (groupRes.isErr()) {
+    return new Err(
+      new GroupSpendLimitError(
+        "group_not_found",
+        "Could not find the group in this workspace."
+      )
+    );
+  }
+  const group = groupRes.value;
+
+  if (!isCapEligibleGroupKind(group.kind)) {
+    return new Err(
+      new GroupSpendLimitError(
+        "invalid_group_kind",
+        `Group of kind '${group.kind}' cannot carry a spend limit.`
+      )
+    );
+  }
+
+  const poolCapAwuCredits = limit.kind === "limited" ? limit.awuCredits : null;
+
+  // Persist the admin's intent first: the group column is the source of truth,
+  // the Metronome alerts below are derived enforcement (a failed sync can be
+  // retried and re-derives from this value).
+  const updateResult = await group.updatePoolCap(auth, poolCapAwuCredits);
+  if (updateResult.isErr()) {
+    return new Err(
+      new GroupSpendLimitError("unauthorized", updateResult.error.message)
+    );
+  }
+
+  const syncResult = await syncGroupCapAlertsForGroup({
+    workspace,
+    groupId: group.sId,
+    poolCapAwuCredits,
+  });
+  if (syncResult.isErr()) {
+    return new Err(syncResult.error);
+  }
+
+  // Reconcile workspace user credit states so members are (un)capped against the
+  // new group cap immediately rather than waiting for the next webhook.
+  const metronomeContractId = auth.subscription()?.metronomeContractId ?? null;
+  if (metronomeContractId) {
+    void reconcileWorkspaceUserCreditStates({
+      workspace,
+      metronomeCustomerId,
+      metronomeContractId,
+      planCode: auth.subscription()?.plan.code ?? "",
+    }).catch((err) => {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          groupId: group.sId,
+          err: normalizeError(err),
+        },
+        "[GroupSpendLimit] set: failed to reconcile user credit states after cap update"
+      );
+    });
+  }
+
+  void emitAuditLogEvent({
+    auth,
+    action: "group.spend_limit_updated",
+    targets: [
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("group", { sId: group.sId, name: group.name }),
+    ],
+    context: auditContext,
+    metadata: {
+      kind: limit.kind,
+      awu_credits:
+        limit.kind === "limited" ? String(limit.awuCredits) : "unlimited",
+    },
+  });
+
+  return new Ok({ limit });
+}

--- a/front/lib/metronome/alerts/spend_limits.ts
+++ b/front/lib/metronome/alerts/spend_limits.ts
@@ -678,3 +678,198 @@ export async function clearMetronomePerUserWarningAlert({
   }
   return new Ok(undefined);
 }
+
+// ============================================================================
+// Per-group cap alerts — one per (group, seat type), using the value-less
+// `user_id` fan-out like the default per-seat-type alerts. Metronome evaluates
+// the threshold (seatAllowance + groupCap) independently for every user; the
+// webhook decides whether it actually applies by comparing the fired threshold
+// to the user's effective cap (a group cap only matters for members for whom it
+// is the highest cap, and never for a user with a personal override). Membership
+// changes therefore need no alert updates — only a change to the group's cap.
+// ============================================================================
+
+function groupCapAlertUniquenessKeyForSeatType(
+  groupId: string,
+  seatType: NormalizedPoolLimitSeatType,
+  workspaceId: string
+): string {
+  return `group-cap-${groupId}-${seatType}-${workspaceId}`;
+}
+
+function groupWarningAlertUniquenessKeyForSeatType(
+  groupId: string,
+  seatType: NormalizedPoolLimitSeatType,
+  workspaceId: string
+): string {
+  return `group-warning-${groupId}-${seatType}-${workspaceId}`;
+}
+
+/**
+ * Idempotently ensure a per-(group, seat-type) cap alert exists with the given
+ * AWU threshold (seatAllowance + groupCap, computed by the caller). If an alert
+ * with a different threshold already exists, it's archived and recreated.
+ */
+export async function upsertMetronomeGroupCapAlertForSeatType({
+  metronomeCustomerId,
+  workspaceId,
+  groupId,
+  seatType,
+  awuCredits,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  groupId: string;
+  seatType: NormalizedPoolLimitSeatType;
+  awuCredits: number;
+}): Promise<Result<{ alertId: string }, Error>> {
+  const upsertResult = await upsertMetronomeAlert({
+    alert_type: "spend_threshold_reached",
+    name: `Group cap ${groupId} ${seatType} ${workspaceId} (${awuCredits} AWU)`,
+    threshold: awuCredits,
+    credit_type_id: getCreditTypeAwuId(),
+    customer_id: metronomeCustomerId,
+    group_values: [{ key: USER_ID_GROUP_KEY }],
+    uniqueness_key: groupCapAlertUniquenessKeyForSeatType(
+      groupId,
+      seatType,
+      workspaceId
+    ),
+  });
+  if (upsertResult.isErr()) {
+    return new Err(upsertResult.error);
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      groupId,
+      seatType,
+      metronomeCustomerId,
+      alertId: upsertResult.value.alertId,
+      awuCredits,
+    },
+    "[Metronome GroupCap] Synced per-group cap alert"
+  );
+  return new Ok({ alertId: upsertResult.value.alertId });
+}
+
+/**
+ * Idempotently ensure a per-(group, seat-type) 80% warning alert exists. The
+ * threshold is floor(capAwuCredits * 0.8). Skipped if the result would be zero.
+ */
+export async function upsertMetronomeGroupWarningAlertForSeatType({
+  metronomeCustomerId,
+  workspaceId,
+  groupId,
+  seatType,
+  capAwuCredits,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  groupId: string;
+  seatType: NormalizedPoolLimitSeatType;
+  capAwuCredits: number;
+}): Promise<Result<{ alertId: string } | null, Error>> {
+  const threshold = warningAwuCredits(capAwuCredits);
+  if (threshold <= 0) {
+    return new Ok(null);
+  }
+  const upsertResult = await upsertMetronomeAlert({
+    alert_type: "spend_threshold_reached",
+    name: `Group warning ${groupId} ${seatType} ${workspaceId} (${threshold} AWU / ${Math.round(USER_AWU_WARNING_PERCENTAGE * 100)}% of ${capAwuCredits})`,
+    threshold,
+    credit_type_id: getCreditTypeAwuId(),
+    customer_id: metronomeCustomerId,
+    group_values: [{ key: USER_ID_GROUP_KEY }],
+    uniqueness_key: groupWarningAlertUniquenessKeyForSeatType(
+      groupId,
+      seatType,
+      workspaceId
+    ),
+  });
+  if (upsertResult.isErr()) {
+    return new Err(upsertResult.error);
+  }
+  logger.info(
+    {
+      workspaceId,
+      groupId,
+      seatType,
+      metronomeCustomerId,
+      alertId: upsertResult.value.alertId,
+      threshold,
+      capAwuCredits,
+    },
+    "[Metronome GroupWarning] Synced per-group warning alert"
+  );
+  return new Ok({ alertId: upsertResult.value.alertId });
+}
+
+/**
+ * Archive the per-(group, seat-type) cap alert, if any. Idempotent.
+ */
+export async function clearMetronomeGroupCapAlertForSeatType({
+  metronomeCustomerId,
+  workspaceId,
+  groupId,
+  seatType,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  groupId: string;
+  seatType: NormalizedPoolLimitSeatType;
+}): Promise<Result<void, Error>> {
+  const result = await clearMetronomeAlert({
+    metronomeCustomerId,
+    uniquenessKey: groupCapAlertUniquenessKeyForSeatType(
+      groupId,
+      seatType,
+      workspaceId
+    ),
+  });
+  if (result.isErr()) {
+    return new Err(result.error);
+  }
+  if (result.value) {
+    logger.info(
+      { workspaceId, groupId, seatType, metronomeCustomerId },
+      "[Metronome GroupCap] Cleared per-group cap alert"
+    );
+  }
+  return new Ok(undefined);
+}
+
+/**
+ * Archive the per-(group, seat-type) 80% warning alert, if any. Idempotent.
+ */
+export async function clearMetronomeGroupWarningAlertForSeatType({
+  metronomeCustomerId,
+  workspaceId,
+  groupId,
+  seatType,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  groupId: string;
+  seatType: NormalizedPoolLimitSeatType;
+}): Promise<Result<void, Error>> {
+  const result = await clearMetronomeAlert({
+    metronomeCustomerId,
+    uniquenessKey: groupWarningAlertUniquenessKeyForSeatType(
+      groupId,
+      seatType,
+      workspaceId
+    ),
+  });
+  if (result.isErr()) {
+    return new Err(result.error);
+  }
+  if (result.value) {
+    logger.info(
+      { workspaceId, groupId, seatType, metronomeCustomerId },
+      "[Metronome GroupWarning] Cleared per-group warning alert"
+    );
+  }
+  return new Ok(undefined);
+}

--- a/front/types/api/groups/spend_limit.ts
+++ b/front/types/api/groups/spend_limit.ts
@@ -1,0 +1,9 @@
+export type GroupSpendLimit =
+  | { kind: "unlimited" }
+  | { kind: "limited"; awuCredits: number };
+
+export type SetGroupSpendLimitResponse = {
+  limit: GroupSpendLimit;
+};
+
+export type PutGroupSpendLimitResponseBody = SetGroupSpendLimitResponse;

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -41,6 +41,10 @@ export type GroupKind = (typeof GROUP_KINDS)[number];
 // groups.
 export const CAP_ELIGIBLE_GROUP_KINDS = ["provisioned"] as const;
 
+export function isCapEligibleGroupKind(kind: GroupKind): boolean {
+  return CAP_ELIGIBLE_GROUP_KINDS.some((k) => k === kind);
+}
+
 export function isGroupKind(value: unknown): value is GroupKind {
   return GROUP_KINDS.includes(value as GroupKind);
 }


### PR DESCRIPTION
Related to https://github.com/dust-tt/tasks/issues/9339

## Description

Add API to set a cap on a group. It updates the DB value and set the metronome limit.
The metronome limit is set for the whole workspace, it is when we receive the limit that we evaluate if the limit actually apply to the given user (by comparing it to the effective cap of the user)
This is similar to how the workspace default limit work.
We actually register 2 metronome limits per group: one alert at 80% and one at 100%

Orher considered design:
Regiser per user only, but this imply registering more limit and tracking group membership to change the limit on metronome, which is way more work.

## Tests

Added unit tests.

## Risk

low
We may receive a lot of webhooks for big workspaces with many groups but I think it will remain reasonnable.
Even a workspace with 1000 users and 50 group with limits means a maximum of 50K webhook requests

## Deploy Plan

register new audit schema
deploy front
