### PR TITLE
Ungate Frame publishing by removing the frame_publish feature flag

### DIFF
--- a/front/lib/api/actions/servers/files/tools/create.test.ts
+++ b/front/lib/api/actions/servers/files/tools/create.test.ts
@@ -3,7 +3,6 @@ import type { ToolContextType } from "@app/lib/actions/types";
 import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -79,7 +78,6 @@ describe("createHandler", () => {
 
   it("overwrites an existing frame file, preserving its content type", async () => {
     const { auth, conversation } = await setupProjectConversation();
-    await FeatureFlagFactory.basic(auth, "frame_publish");
     fileStorageMock.setFileMetadata(() => ({
       contentType: "application/vnd.dust.frame",
       size: "100",
@@ -109,29 +107,4 @@ describe("createHandler", () => {
     );
   });
 
-  it("overwrites an existing frame file without frame_publish, pointing at the file-id edit tool", async () => {
-    const { auth, conversation } = await setupProjectConversation();
-    fileStorageMock.setFileMetadata(() => ({
-      contentType: "application/vnd.dust.frame",
-      size: "100",
-    }));
-
-    const result = await createHandler(
-      {
-        path: `conversation-${conversation.sId}/interactive.tsx`,
-        content: "export default function App() { return null; }",
-        content_type: "text/plain",
-      },
-      makeExtra(auth, conversation)
-    );
-
-    assert(result.isOk());
-    expect(result.value[0]).toMatchObject({
-      type: "text",
-      text: expect.stringContaining(
-        "interactive_content__edit_interactive_content_file"
-      ),
-    });
-    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
-  });
 });

--- a/front/lib/api/actions/servers/files/tools/create.test.ts
+++ b/front/lib/api/actions/servers/files/tools/create.test.ts
@@ -106,5 +106,4 @@ describe("createHandler", () => {
       "application/vnd.dust.frame"
     );
   });
-
 });

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -11,7 +11,6 @@ import {
   scopedPathsFromArgs,
 } from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
 import { frameSourceUpdatedNotice } from "@app/lib/api/actions/servers/files/tools/utils";
-import { getFeatureFlags } from "@app/lib/auth";
 import { getFilePreviewDirectiveInstruction } from "@app/lib/markdown/file_preview";
 import {
   isAllSupportedFileContentType,
@@ -96,15 +95,10 @@ export async function createHandler(
   const verb = exists ? "Updated" : "Created";
 
   if (isFrameSourceOverwrite) {
-    const flags = await getFeatureFlags(auth);
     return new Ok([
       {
         type: "text",
-        text:
-          `Updated \`${path}\` (${sizeKb} KB). ` +
-          frameSourceUpdatedNotice({
-            hasFramePublishFF: flags.includes("frame_publish"),
-          }),
+        text: `Updated \`${path}\` (${sizeKb} KB). ${frameSourceUpdatedNotice()}`,
       },
     ]);
   }

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -3,7 +3,6 @@ import type { ToolContextType } from "@app/lib/actions/types";
 import { editHandler } from "@app/lib/api/actions/servers/files/tools/edit";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -117,9 +116,8 @@ describe("editHandler", () => {
     );
   });
 
-  it("appends a publish reminder when editing a Frame source with frame_publish enabled", async () => {
+  it("appends a publish reminder when editing a Frame source file", async () => {
     const { auth, conversation } = await setupProjectConversation();
-    await FeatureFlagFactory.basic(auth, "frame_publish");
     mockStoredFile(
       "export default function App() { return <h1>Old</h1>; }\n",
       "application/vnd.dust.frame"
@@ -145,32 +143,6 @@ describe("editHandler", () => {
     expect(fileStorageMock.saveFileCalls[0].contentType).toBe(
       "application/vnd.dust.frame"
     );
-  });
-
-  it("points at the file-id edit tool when editing a Frame source without frame_publish", async () => {
-    const { auth, conversation } = await setupProjectConversation();
-    mockStoredFile(
-      "export default function App() { return <h1>Old</h1>; }\n",
-      "application/vnd.dust.frame"
-    );
-
-    const result = await editHandler(
-      {
-        path: `conversation-${conversation.sId}/App.tsx`,
-        old_string: "Old",
-        new_string: "New",
-      },
-      makeExtra(auth, conversation)
-    );
-
-    assert(result.isOk());
-    expect(result.value[0]).toMatchObject({
-      type: "text",
-      text: expect.stringContaining(
-        "interactive_content__edit_interactive_content_file"
-      ),
-    });
-    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
   });
 
   it("returns Err when the file does not exist", async () => {

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -14,7 +14,6 @@ import {
   isReadableAsText,
 } from "@app/lib/api/actions/servers/files/tools/utils";
 import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
-import { getFeatureFlags } from "@app/lib/auth";
 import {
   isInteractiveContentType,
   stripMimeParameters,
@@ -155,10 +154,7 @@ export async function editHandler(
   let text = `Updated \`${path}\`: made ${occurrences} replacement${pluralize(occurrences)}.`;
 
   if (isFrameSource) {
-    const flags = await getFeatureFlags(auth);
-    text += ` ${frameSourceUpdatedNotice({
-      hasFramePublishFF: flags.includes("frame_publish"),
-    })}`;
+    text += ` ${frameSourceUpdatedNotice()}`;
   }
 
   return new Ok([{ type: "text", text }]);

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -166,25 +166,12 @@ export function frameFileEditRejectedError(): MCPError {
 
 /**
  * Notice appended after a write to a Frame source file on the mount. The mount write never
- * changes the rendered Frame directly: with frame_publish the model must publish to rebuild
- * it, without the flag the rendered Frame can only be updated through the file-id edit tool.
+ * changes the rendered Frame directly, the model must publish to rebuild it.
  */
-export function frameSourceUpdatedNotice({
-  hasFramePublishFF,
-}: {
-  hasFramePublishFF: boolean;
-}): string {
-  if (hasFramePublishFF) {
-    return (
-      "This updated the Frame's source only. The rendered Frame is unchanged until you " +
-      `publish it with \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\`.`
-    );
-  }
-
+export function frameSourceUpdatedNotice(): string {
   return (
-    "This updated the Frame's source only and will not appear in the rendered Frame. " +
-    `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` to get the file id, ` +
-    `then \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` to update the rendered Frame.`
+    "This updated the Frame's source only. The rendered Frame is unchanged until you " +
+    `publish it with \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\`.`
   );
 }
 

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -47,9 +47,9 @@ ${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
 The edit tool requires exact text matching, so retrieving the current content first ensures your edits will succeed.
 `;
 
-// Computer-first variant, used when frame_publish is enabled. The Frame's source is mounted in the
-// Computer, so the model edits the file in place and republishes instead of round-tripping through
-// the retrieve and edit tools.
+// Computer-first variant, used when the Computer is available. The Frame's source is mounted in
+// the Computer, so the model edits the file in place and republishes instead of round-tripping
+// through the retrieve and edit tools.
 const UPDATING_SECTION_COMPUTER_FIRST = `\
 ### Updating Existing Files (preferred: edit in the Computer):
 
@@ -260,11 +260,11 @@ ${INTERACTIVE_CONTENT_CHART_EXAMPLES_V2}
 const buildInstructions = (updatingSection: string) =>
   `${interactiveContentProseBeforeAuthoring(updatingSection)}\n${INTERACTIVE_CONTENT_AUTHORING_PROSE_V2}\n${INTERACTIVE_CONTENT_TOOLS_PROSE_AFTER_AUTHORING}`;
 
-// Default (no frame_publish): the model updates Frames through the retrieve and edit tools.
+// Default (no Computer): the model updates Frames through the retrieve and edit tools.
 export const INTERACTIVE_CONTENT_INSTRUCTIONS = buildInstructions(
   UPDATING_SECTION_LEGACY
 );
 
-// frame_publish enabled: the model edits the mounted source in the Computer and republishes.
+// Computer available: the model edits the mounted source in the Computer and republishes.
 export const INTERACTIVE_CONTENT_INSTRUCTIONS_COMPUTER_FIRST =
   buildInstructions(UPDATING_SECTION_COMPUTER_FIRST);

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -24,7 +24,6 @@ import { screenshotInteractiveContentFile } from "@app/lib/api/files/screenshot"
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
 import { publishFrame } from "@app/lib/api/viz/publish_frame";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -424,15 +423,5 @@ export async function createInteractiveContentTools(
     },
   };
 
-  const tools = buildTools(INTERACTIVE_CONTENT_TOOLS_METADATA, handlers);
-
-  // Publishing a Frame's edited source tree into the rendered bundle is gated behind frame_publish.
-  const flags = await getFeatureFlags(auth);
-  if (flags.includes("frame_publish")) {
-    return tools;
-  }
-
-  return tools.filter(
-    (tool) => tool.name !== "publish_interactive_content_file"
-  );
+  return buildTools(INTERACTIVE_CONTENT_TOOLS_METADATA, handlers);
 }

--- a/front/lib/resources/skill/code_defined/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/frames.test.ts
@@ -7,9 +7,8 @@ import { describe, expect, it } from "vitest";
 const COMPUTER_FIRST_MARKER = "preferred: edit in the Computer";
 
 describe("framesSkill.fetchInstructions", () => {
-  it("teaches the computer-first flow when frame_publish and the Computer are both enabled", async () => {
+  it("teaches the computer-first flow when the Computer is enabled", async () => {
     const { authenticator: auth } = await createResourceTest({});
-    await FeatureFlagFactory.basic(auth, "frame_publish");
 
     const instructions = await framesSkill.fetchInstructions(auth, {
       spaceIds: [],
@@ -22,20 +21,8 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("publish_interactive_content_file");
   });
 
-  it("falls back to the retrieve and edit flow when frame_publish is off", async () => {
+  it("falls back to the retrieve and edit flow when the Computer is disabled", async () => {
     const { authenticator: auth } = await createResourceTest({});
-
-    const instructions = await framesSkill.fetchInstructions(auth, {
-      spaceIds: [],
-    });
-
-    expect(instructions).not.toContain(COMPUTER_FIRST_MARKER);
-    expect(instructions).toContain("### Updating Existing Files:");
-  });
-
-  it("falls back when frame_publish is on but the Computer is disabled", async () => {
-    const { authenticator: auth } = await createResourceTest({});
-    await FeatureFlagFactory.basic(auth, "frame_publish");
     await FeatureFlagFactory.basic(auth, "disable_computer_feature");
 
     const instructions = await framesSkill.fetchInstructions(auth, {

--- a/front/lib/resources/skill/code_defined/frames.ts
+++ b/front/lib/resources/skill/code_defined/frames.ts
@@ -21,17 +21,15 @@ export const framesSkill = {
     "using when tsx or React code is shared or available in the conversation. " +
     "Frames used to a be a tool, now deprecated. Use this skill when the Frames/interactive " +
     "content tool is mentioned.",
-  // Computer-first guidance (edit the mounted source in place, then publish) is taught only when the
-  // Computer and frame_publish are both available. Otherwise the model updates Frames through the
-  // retrieve and edit tools.
+  // Computer-first guidance (edit the mounted source in place, then publish) is taught only when
+  // the Computer is available. Otherwise the model updates Frames through the retrieve and edit
+  // tools.
   fetchInstructions: async (
     auth: Authenticator,
     _params: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
   ) => {
     const flags = await getFeatureFlags(auth);
-    const computerFirst =
-      flags.includes("frame_publish") && isComputerFeatureEnabled(flags);
-    return computerFirst
+    return isComputerFeatureEnabled(flags)
       ? INTERACTIVE_CONTENT_INSTRUCTIONS_COMPUTER_FIRST
       : INTERACTIVE_CONTENT_INSTRUCTIONS;
   },

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -345,11 +345,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Whitelabel frames: customize the workspace logo, favicon and OG image shown on shared Frames.",
     stage: "on_demand",
   },
-  frame_publish: {
-    description:
-      "Publish a Frame's edited source tree into a built bundle so model and live edits become the rendered, shareable Frame.",
-    stage: "dust_only",
-  },
   models_picker: {
     description:
       "Model picker in the conversation input bar: pick a model tier (Fast, Balanced, Powerful, Frontier) or a specific model.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -789,7 +789,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "workspace_default_agent"
   | "sound_notification"
   | "whitelabel_frames"
-  | "frame_publish"
   | "workday_mcp"
 >();
 


### PR DESCRIPTION
## Description

Frame publishing has been running gated for long enough and only a single workspace carries the flag, so this removes it and makes publishing available everywhere.

The publish tool is now always registered on the interactive content server. The Frames skill teaches the computer-first flow, edit the mounted source in place and republish, whenever the Computer is available, with the retrieve and edit loop remaining the fallback when it is not. The flag itself is deleted from the feature flag registry and the SDK.

This also simplifies the files server guidance that landed with the path-keyed edit tool. Since publish now always exists, the notice after a write to a Frame source no longer branches on the flag and simply tells the model to publish for the change to reach the rendered Frame.

No cleanup migration is included, the single flag row left in the database is inert once the flag is gone from the registry and can be deleted by hand.

## Risk

Low. Publishing becomes available to all workspaces at once, behavior for the previously flagged workspace is unchanged.

## Deploy Plan