### PR TITLE
Pricing: cap per group 4: Add UI to setcap per group

### DIFF
--- a/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
@@ -1,0 +1,279 @@
+import * as spendLimits from "@app/lib/metronome/alerts/spend_limits";
+import * as planType from "@app/lib/metronome/plan_type";
+import * as seatTypes from "@app/lib/metronome/seat_types";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import type { Subscription } from "@metronome/sdk/resources";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
+  const actual = await vi.importActual<typeof spendLimits>(
+    "@app/lib/metronome/alerts/spend_limits"
+  );
+  return {
+    ...actual,
+    upsertMetronomeGroupCapAlertForSeatType: vi.fn(),
+    upsertMetronomeGroupWarningAlertForSeatType: vi.fn(),
+    clearMetronomeGroupCapAlertForSeatType: vi.fn(),
+    clearMetronomeGroupWarningAlertForSeatType: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/plan_type", async () => {
+  const actual = await vi.importActual<typeof planType>(
+    "@app/lib/metronome/plan_type"
+  );
+  return { ...actual, getActiveContract: vi.fn() };
+});
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<typeof seatTypes>(
+    "@app/lib/metronome/seat_types"
+  );
+  return {
+    ...actual,
+    getProductSeatTypes: vi.fn(),
+    getSeatSubscriptionsFromContract: vi.fn(),
+    getAwuAllocationForNormalizedSeatType: vi.fn(),
+  };
+});
+
+const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
+const TEST_ALERT_ID = "alert_test_xxx";
+
+// Minimal fake contract with one pro seat subscription so the alert sync
+// resolves a single seat type with an 8000 AWU allowance.
+const FAKE_CONTRACT = {
+  id: "contract_xxx",
+  customer_id: TEST_METRONOME_CUSTOMER_ID,
+  rate_card_id: "rc_xxx",
+  subscriptions: [],
+} as unknown as planType.CachedContract;
+
+async function makeMetronomeWorkspaceWithCustomer(): Promise<WorkspaceType> {
+  return WorkspaceFactory.metronome({
+    metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+  });
+}
+
+async function makeProvisionedGroup(
+  workspace: WorkspaceType
+): Promise<GroupResource> {
+  return GroupResource.makeNew({
+    name: "Sales",
+    workspaceId: workspace.id,
+    kind: "provisioned",
+    workOSGroupId: "fake-sales",
+  });
+}
+
+function groupSpendLimitUrl(wId: string, groupId: string) {
+  return `/api/w/${wId}/groups/${groupId}/spend_limit`;
+}
+
+function putLimit(
+  wId: string,
+  groupId: string,
+  body: Record<string, unknown>
+) {
+  return honoApp.request(groupSpendLimitUrl(wId, groupId), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(
+    spendLimits.upsertMetronomeGroupCapAlertForSeatType
+  ).mockResolvedValue(new Ok({ alertId: TEST_ALERT_ID }));
+  vi.mocked(
+    spendLimits.upsertMetronomeGroupWarningAlertForSeatType
+  ).mockResolvedValue(new Ok({ alertId: TEST_ALERT_ID }));
+  vi.mocked(
+    spendLimits.clearMetronomeGroupCapAlertForSeatType
+  ).mockResolvedValue(new Ok(undefined));
+  vi.mocked(
+    spendLimits.clearMetronomeGroupWarningAlertForSeatType
+  ).mockResolvedValue(new Ok(undefined));
+
+  vi.mocked(planType.getActiveContract).mockResolvedValue(FAKE_CONTRACT);
+  vi.mocked(seatTypes.getProductSeatTypes).mockResolvedValue(
+    new Map([["prod_pro", "pro"]])
+  );
+  vi.mocked(seatTypes.getSeatSubscriptionsFromContract).mockReturnValue(
+    new Map<MembershipSeatType, Subscription>([
+      [
+        "pro",
+        { subscription_rate: { product: { id: "prod_pro" } } } as Subscription,
+      ],
+    ])
+  );
+  vi.mocked(seatTypes.getAwuAllocationForNormalizedSeatType).mockReturnValue(
+    8000
+  );
+});
+
+describe("/api/w/[wId]/groups/[groupId]/spend_limit", () => {
+  describe("auth", () => {
+    it("returns 403 when caller is not an admin", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const group = await makeProvisionedGroup(workspace);
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "user",
+        workspace,
+      });
+
+      const response = await putLimit(workspace.sId, group.sId, {
+        kind: "limited",
+        awuCredits: 1500,
+      });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
+    });
+
+  });
+
+  describe("input validation", () => {
+    it("returns 400 on out-of-bounds awuCredits", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const group = await makeProvisionedGroup(workspace);
+      const { auth } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      await FeatureFlagFactory.basic(auth, "pricing_groups");
+
+      for (const awuCredits of [-1, 1.5, 100_000_000]) {
+        const response = await putLimit(workspace.sId, group.sId, {
+          kind: "limited",
+          awuCredits,
+        });
+        expect(response.status).toBe(400);
+      }
+    });
+
+    it("returns 404 when the group does not exist", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { auth } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      await FeatureFlagFactory.basic(auth, "pricing_groups");
+
+      const response = await putLimit(workspace.sId, "nonexistent-group-id", {
+        kind: "limited",
+        awuCredits: 1500,
+      });
+
+      expect(response.status).toBe(404);
+      expect((await response.json()).error.type).toBe("group_not_found");
+    });
+
+    it("returns 400 on a non-provisioned group", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const regularGroup = await GroupResource.makeNew({
+        name: "Space group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      const { auth } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      await FeatureFlagFactory.basic(auth, "pricing_groups");
+
+      const response = await putLimit(workspace.sId, regularGroup.sId, {
+        kind: "limited",
+        awuCredits: 1500,
+      });
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.type).toBe("invalid_request_error");
+    });
+  });
+
+  describe("PUT", () => {
+    it("persists the cap and upserts per-seat-type alerts for limited", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const group = await makeProvisionedGroup(workspace);
+      const { auth } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      await FeatureFlagFactory.basic(auth, "pricing_groups");
+
+      const response = await putLimit(workspace.sId, group.sId, {
+        kind: "limited",
+        awuCredits: 25_000,
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        limit: { kind: "limited", awuCredits: 25_000 },
+      });
+      // Threshold = 8_000 (seat allowance) + 25_000 (group cap).
+      expect(
+        spendLimits.upsertMetronomeGroupCapAlertForSeatType
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+          workspaceId: workspace.sId,
+          groupId: group.sId,
+          seatType: "pro",
+          awuCredits: 33_000,
+        })
+      );
+
+      // The pool-only cap is persisted on the group.
+      const reloaded = await GroupResource.fetchById(auth, group.sId);
+      if (reloaded.isErr()) {
+        throw reloaded.error;
+      }
+      expect(reloaded.value.poolCapAwuCredits).toBe(25_000);
+    });
+
+    it("clears the cap and the alerts for unlimited", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const group = await makeProvisionedGroup(workspace);
+      const { auth } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      await FeatureFlagFactory.basic(auth, "pricing_groups");
+      await group.updatePoolCap(auth, 25_000);
+
+      const response = await putLimit(workspace.sId, group.sId, {
+        kind: "unlimited",
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ limit: { kind: "unlimited" } });
+      expect(
+        spendLimits.clearMetronomeGroupCapAlertForSeatType
+      ).toHaveBeenCalled();
+      expect(
+        spendLimits.upsertMetronomeGroupCapAlertForSeatType
+      ).not.toHaveBeenCalled();
+
+      const reloaded = await GroupResource.fetchById(auth, group.sId);
+      if (reloaded.isErr()) {
+        throw reloaded.error;
+      }
+      expect(reloaded.value.poolCapAwuCredits).toBeNull();
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
@@ -2,14 +2,13 @@ import * as spendLimits from "@app/lib/metronome/alerts/spend_limits";
 import * as planType from "@app/lib/metronome/plan_type";
 import * as seatTypes from "@app/lib/metronome/seat_types";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { buildCachedContractMock } from "@app/tests/utils/metronome_contracts";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import type { MembershipSeatType } from "@app/types/memberships";
 import { Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import { honoApp } from "@front-api/app";
-import type { Subscription } from "@metronome/sdk/resources";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
@@ -39,22 +38,17 @@ vi.mock("@app/lib/metronome/seat_types", async () => {
   return {
     ...actual,
     getProductSeatTypes: vi.fn(),
-    getSeatSubscriptionsFromContract: vi.fn(),
-    getAwuAllocationForNormalizedSeatType: vi.fn(),
   };
 });
 
 const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
 const TEST_ALERT_ID = "alert_test_xxx";
 
-// Minimal fake contract with one pro seat subscription so the alert sync
-// resolves a single seat type with an 8000 AWU allowance.
-const FAKE_CONTRACT = {
-  id: "contract_xxx",
-  customer_id: TEST_METRONOME_CUSTOMER_ID,
-  rate_card_id: "rc_xxx",
-  subscriptions: [],
-} as unknown as planType.CachedContract;
+// Contract with one pro seat subscription carrying an 8000 AWU allowance —
+// the seat-type resolution runs against it for real, only the contract and
+// product fetches (cache/network) are mocked.
+const { contract: FAKE_CONTRACT, productSeatTypes: FAKE_PRODUCT_SEAT_TYPES } =
+  buildCachedContractMock({ seats: [{ seatType: "pro", awu: 8000 }] });
 
 async function makeMetronomeWorkspaceWithCustomer(): Promise<WorkspaceType> {
   return WorkspaceFactory.metronome({
@@ -77,11 +71,7 @@ function groupSpendLimitUrl(wId: string, groupId: string) {
   return `/api/w/${wId}/groups/${groupId}/spend_limit`;
 }
 
-function putLimit(
-  wId: string,
-  groupId: string,
-  body: Record<string, unknown>
-) {
+function putLimit(wId: string, groupId: string, body: Record<string, unknown>) {
   return honoApp.request(groupSpendLimitUrl(wId, groupId), {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
@@ -105,18 +95,7 @@ beforeEach(() => {
 
   vi.mocked(planType.getActiveContract).mockResolvedValue(FAKE_CONTRACT);
   vi.mocked(seatTypes.getProductSeatTypes).mockResolvedValue(
-    new Map([["prod_pro", "pro"]])
-  );
-  vi.mocked(seatTypes.getSeatSubscriptionsFromContract).mockReturnValue(
-    new Map<MembershipSeatType, Subscription>([
-      [
-        "pro",
-        { subscription_rate: { product: { id: "prod_pro" } } } as Subscription,
-      ],
-    ])
-  );
-  vi.mocked(seatTypes.getAwuAllocationForNormalizedSeatType).mockReturnValue(
-    8000
+    FAKE_PRODUCT_SEAT_TYPES
   );
 });
 
@@ -139,7 +118,6 @@ describe("/api/w/[wId]/groups/[groupId]/spend_limit", () => {
       expect(response.status).toBe(403);
       expect((await response.json()).error.type).toBe("workspace_auth_error");
     });
-
   });
 
   describe("input validation", () => {

--- a/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.ts
@@ -11,8 +11,8 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
-import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
 import { validate } from "@front-api/middlewares/validator";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
 import { z } from "zod";
 
 const UpdateGroupSpendLimitBodySchema = z.discriminatedUnion("kind", [

--- a/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.ts
@@ -1,0 +1,114 @@
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
+import {
+  type GroupSpendLimitError,
+  MAX_GROUP_SPEND_LIMIT_AWU_CREDITS,
+  MIN_GROUP_SPEND_LIMIT_AWU_CREDITS,
+  setGroupSpendLimit,
+} from "@app/lib/api/groups/spend_limit";
+import type { PutGroupSpendLimitResponseBody } from "@app/types/api/groups/spend_limit";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const UpdateGroupSpendLimitBodySchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("unlimited") }),
+  z.object({
+    kind: z.literal("limited"),
+    awuCredits: z
+      .number()
+      .int()
+      .min(MIN_GROUP_SPEND_LIMIT_AWU_CREDITS)
+      .max(MAX_GROUP_SPEND_LIMIT_AWU_CREDITS),
+  }),
+]);
+
+const ParamsSchema = z.object({
+  groupId: z.string(),
+});
+
+function spendLimitErrorToApiError(
+  error: GroupSpendLimitError
+): APIErrorWithContentfulStatusCode {
+  switch (error.type) {
+    case "group_not_found":
+      return {
+        status_code: 404,
+        api_error: { type: "group_not_found", message: error.message },
+      };
+    case "invalid_group_kind":
+    case "invalid_threshold":
+      return {
+        status_code: 400,
+        api_error: { type: "invalid_request_error", message: error.message },
+      };
+    case "unauthorized":
+      return {
+        status_code: 403,
+        api_error: { type: "workspace_auth_error", message: error.message },
+      };
+    case "workspace_not_metronome_billed":
+      return {
+        status_code: 403,
+        api_error: { type: "plan_limit_error", message: error.message },
+      };
+    case "contract_not_found":
+      return {
+        status_code: 404,
+        api_error: { type: "subscription_not_found", message: error.message },
+      };
+    case "metronome_error":
+      return {
+        status_code: 502,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to update spend limit in billing system.",
+        },
+      };
+    default:
+      assertNever(error.type);
+  }
+}
+
+// Mounted at /api/w/:wId/groups/:groupId/spend_limit.
+const app = workspaceApp();
+
+app.put(
+  "/",
+  validate("param", ParamsSchema),
+  ensureIsAdmin(),
+  withFeatureFlag("pricing_groups"),
+  validate("json", UpdateGroupSpendLimitBodySchema),
+  async (ctx): HandlerResult<PutGroupSpendLimitResponseBody> => {
+    const auth = ctx.get("auth");
+
+    if (!auth.getNonNullableSubscriptionResource().isMetronomeOnlyBilled) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "plan_limit_error",
+          message:
+            "Per-group spend limits are only available on Metronome-billed workspaces.",
+        },
+      });
+    }
+
+    const { groupId } = ctx.req.valid("param");
+
+    const result = await setGroupSpendLimit(auth, {
+      groupId,
+      limit: ctx.req.valid("json"),
+      auditContext: getAuditLogContext(auth),
+    });
+    if (result.isErr()) {
+      return apiError(ctx, spendLimitErrorToApiError(result.error));
+    }
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.ts
@@ -77,6 +77,7 @@ function spendLimitErrorToApiError(
 // Mounted at /api/w/:wId/groups/:groupId/spend_limit.
 const app = workspaceApp();
 
+/** @ignoreswagger */
 app.put(
   "/",
   validate("param", ParamsSchema),

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -6,6 +6,8 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+import spendLimit from "./[groupId]/spend_limit";
+
 export type GetGroupsResponseBody = {
   groups: (GroupType & { memberCount: number })[];
 };
@@ -49,5 +51,7 @@ app.get(
     return ctx.json({ groups: groupsWithMemberCount });
   }
 );
+
+app.route("/:groupId/spend_limit", spendLimit);
 
 export default app;

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -11,6 +11,7 @@ import {
 } from "@app/components/workspace/billing/seatTypeUtils";
 import { ChangeSeatModal } from "@app/components/workspace/ChangeSeatModal";
 import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitModal";
+import { GroupsUsageTable } from "@app/components/workspace/GroupsUsageTable";
 import { MembersSelectionBanner } from "@app/components/workspace/MembersSelectionBanner";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
@@ -836,6 +837,9 @@ export function UsagePage() {
         <Tabs defaultValue="members">
           <TabsList className="mb-4">
             <TabsTrigger value="members" label="Members" />
+            {isWorkspaceAdmin && pricingGroupsEnabled && (
+              <TabsTrigger value="groups" label="Groups" />
+            )}
             <TabsTrigger value="settings" label="Settings" />
           </TabsList>
 
@@ -902,6 +906,12 @@ export function UsagePage() {
               )}
             </Page.Vertical>
           </TabsContent>
+
+          {isWorkspaceAdmin && pricingGroupsEnabled && (
+            <TabsContent value="groups">
+              <GroupsUsageTable owner={owner} readOnly={isReadOnly} />
+            </TabsContent>
+          )}
 
           <TabsContent value="settings">
             <div className="flex flex-col gap-10">

--- a/front/components/workspace/GroupsUsageTable.tsx
+++ b/front/components/workspace/GroupsUsageTable.tsx
@@ -1,0 +1,163 @@
+import { useGroups, useUpdateGroupSpendLimit } from "@app/lib/swr/groups";
+import type { GroupSpendLimit } from "@app/types/api/groups/spend_limit";
+import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
+import type { LightWorkspaceType } from "@app/types/user";
+import { DataTable, InputWithSave, Spinner, Users01 } from "@dust-tt/sparkle";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+
+interface GroupsUsageTableProps {
+  owner: LightWorkspaceType;
+  readOnly: boolean;
+}
+
+type GroupRowData = {
+  groupId: string;
+  name: string;
+  memberCount: number;
+  poolCapAwuCredits: number | null;
+  onClick?: () => void;
+};
+
+type GroupInfo = CellContext<GroupRowData, string>;
+
+interface GroupCapCellProps {
+  group: GroupRowData;
+  readOnly: boolean;
+  onSave: (group: GroupRowData, limit: GroupSpendLimit) => Promise<void>;
+}
+
+// Per-row editable cap cell. Empty input clears the cap (unlimited); a positive
+// integer sets it. Reverts to the current value when nothing is persisted.
+function GroupCapCell({ group, readOnly, onSave }: GroupCapCellProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const current = group.poolCapAwuCredits;
+
+  const handleSave = async (newValue: string) => {
+    const trimmed = newValue.trim();
+    if (trimmed === "") {
+      if (current === null) {
+        return;
+      }
+      await onSave(group, { kind: "unlimited" });
+      return;
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed === current) {
+      return;
+    }
+    await onSave(group, { kind: "limited", awuCredits: parsed });
+  };
+
+  return (
+    <div className="w-52">
+      <InputWithSave
+        inputMode="numeric"
+        pattern="[0-9]*"
+        placeholder="No limit"
+        value={current === null ? "" : current.toLocaleString()}
+        unit={current === null && !isEditing ? undefined : "credits"}
+        normalizeValue={(value) => value.replace(/[^\d]/g, "")}
+        formatValue={(value) =>
+          value ? Number(value).toLocaleString() : value
+        }
+        onSave={handleSave}
+        onFocus={() => setIsEditing(true)}
+        onBlur={() => setIsEditing(false)}
+        disabled={readOnly}
+      />
+    </div>
+  );
+}
+
+export function GroupsUsageTable({ owner, readOnly }: GroupsUsageTableProps) {
+  const { groups, isGroupsLoading } = useGroups({
+    owner,
+    kinds: [...CAP_ELIGIBLE_GROUP_KINDS],
+  });
+  const { doUpdateGroupSpendLimit } = useUpdateGroupSpendLimit({
+    workspaceId: owner.sId,
+  });
+
+  const rows: GroupRowData[] = useMemo(
+    () =>
+      groups.map((group) => ({
+        groupId: group.sId,
+        name: group.name,
+        memberCount: group.memberCount,
+        poolCapAwuCredits: group.poolCapAwuCredits,
+      })),
+    [groups]
+  );
+
+  const columns: ColumnDef<GroupRowData, string>[] = useMemo(
+    () => [
+      {
+        id: "name",
+        accessorFn: (row) => row.name,
+        header: "Group",
+        cell: (info: GroupInfo) => (
+          <DataTable.CellContent icon={Users01} className="capitalize">
+            {info.row.original.name}
+          </DataTable.CellContent>
+        ),
+        enableSorting: true,
+      },
+      {
+        id: "memberCount",
+        accessorFn: (row) => String(row.memberCount),
+        header: "Members",
+        meta: { className: "w-[120px]" },
+        cell: (info: GroupInfo) => (
+          <DataTable.BasicCellContent
+            label={`${info.row.original.memberCount}`}
+          />
+        ),
+        enableSorting: false,
+      },
+      {
+        id: "cap",
+        header: "Spend limit",
+        meta: { className: "w-64" },
+        cell: (info: GroupInfo) => (
+          <GroupCapCell
+            group={info.row.original}
+            readOnly={readOnly}
+            onSave={async (group, limit) => {
+              await doUpdateGroupSpendLimit({
+                groupId: group.groupId,
+                groupName: group.name,
+                limit,
+              });
+            }}
+          />
+        ),
+        enableSorting: false,
+      },
+    ],
+    [readOnly, doUpdateGroupSpendLimit]
+  );
+
+  if (isGroupsLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <span className="copy-sm text-muted-foreground">
+        A group's spend limit applies to each of its members. When a member
+        belongs to several groups, the highest limit is used.
+      </span>
+      <DataTable
+        filterColumn="name"
+        data={rows}
+        columns={columns}
+        columnsBreakpoints={{ name: "md" }}
+      />
+    </div>
+  );
+}

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -102,7 +102,21 @@ export function useUpdateGroupSpendLimit({
         return null;
       }
 
-      const body = PutGroupSpendLimitResponseSchema.parse(await res.json());
+      const parsed = PutGroupSpendLimitResponseSchema.safeParse(
+        await res.json()
+      );
+      if (!parsed.success) {
+        await invalidateWorkspaceGroups(workspaceId);
+        await invalidateMembersUsage(workspaceId);
+        sendNotification({
+          type: "error",
+          title: "Group spend limit status unknown",
+          description:
+            "The update was submitted but the server response could not be read. The table has been refreshed with the current state.",
+        });
+        return null;
+      }
+      const body = parsed.data;
       let description: string;
       switch (limit.kind) {
         case "unlimited":

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -1,9 +1,15 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { invalidateMembersUsage } from "@app/lib/swr/memberships";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetGroupsResponseBody } from "@app/types/api/groups";
+import type { PutGroupSpendLimitResponseBody } from "@app/types/api/groups/spend_limit";
 import type { GroupKind, GroupType } from "@app/types/groups";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useMemo } from "react";
-import type { Fetcher } from "swr";
+import { useCallback, useMemo } from "react";
+import { type Fetcher, mutate } from "swr";
+import { z } from "zod";
 
 export function useGroups({
   owner,
@@ -41,4 +47,87 @@ export function useGroups({
     isGroupsError: !!error,
     mutateGroups: mutate,
   };
+}
+
+function groupSpendLimitUrl(workspaceId: string, groupId: string): string {
+  return `/api/w/${workspaceId}/groups/${groupId}/spend_limit`;
+}
+
+const GroupSpendLimitResponseSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("unlimited") }),
+  z.object({ kind: z.literal("limited"), awuCredits: z.number() }),
+]);
+
+const PutGroupSpendLimitResponseSchema = z.object({
+  limit: GroupSpendLimitResponseSchema,
+});
+
+async function invalidateWorkspaceGroups(workspaceId: string): Promise<void> {
+  await mutate(
+    (key) =>
+      typeof key === "string" && key.startsWith(`/api/w/${workspaceId}/groups`)
+  );
+}
+
+export function useUpdateGroupSpendLimit({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const doUpdateGroupSpendLimit = useCallback(
+    async ({
+      groupId,
+      groupName,
+      limit,
+    }: {
+      groupId: string;
+      groupName: string;
+      limit: { kind: "unlimited" } | { kind: "limited"; awuCredits: number };
+    }): Promise<PutGroupSpendLimitResponseBody | null> => {
+      const res = await clientFetch(groupSpendLimitUrl(workspaceId, groupId), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(limit),
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        sendNotification({
+          type: "error",
+          title: "Failed to update group spend limit",
+          description: error?.error?.message ?? "An unexpected error occurred.",
+        });
+        return null;
+      }
+
+      const body = PutGroupSpendLimitResponseSchema.parse(await res.json());
+      let description: string;
+      switch (limit.kind) {
+        case "unlimited":
+          description = `${groupName}'s spend limit has been removed.`;
+          break;
+        case "limited":
+          description = `${groupName}'s spend limit has been set to ${limit.awuCredits.toLocaleString("en-US")} credits.`;
+          break;
+        default:
+          assertNeverAndIgnore(limit);
+          description = "";
+      }
+      sendNotification({
+        type: "success",
+        title: "Group spend limit updated",
+        description,
+      });
+
+      // The cap changes both the groups list and members' effective limits.
+      await invalidateWorkspaceGroups(workspaceId);
+      await invalidateMembersUsage(workspaceId);
+      return body;
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return { doUpdateGroupSpendLimit };
 }


### PR DESCRIPTION
Related to https://github.com/dust-tt/tasks/issues/9339

## Description

Add the UI in the "Groups" tab in the Usage page.
It displays all thje provisionned groups.
The only possible action on a group for now is to set the cap for the group.
gated behind the "pricing_group" feature flag.
Add enpoint to modify the 

<img width="2598" height="1176" alt="image" src="https://github.com/user-attachments/assets/3086d5f7-b087-4897-a8f9-341668de36da" />

## Tests

tested locally
unit tests for endpoint

## Risk

low risk, easy to revert and hidden behind feature flag

## Deploy Plan

deploy front
