### PR TITLE
AgentLoopContextType -> ToolContextType

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -94,14 +94,14 @@ vi.mock(
       withToolResultProcessing: spy,
       registerTool: (
         auth: Parameters<typeof actual.registerTool>[0],
-        agentLoopContext: Parameters<typeof actual.registerTool>[1],
+        toolContext: Parameters<typeof actual.registerTool>[1],
         server: Parameters<typeof actual.registerTool>[2],
         tool: Parameters<typeof actual.registerTool>[3],
         opts: Parameters<typeof actual.registerTool>[4]
       ) => {
         actual.registerTool(
           auth,
-          agentLoopContext,
+          toolContext,
           server,
           {
             ...tool,
@@ -140,8 +140,7 @@ vi.mock("@app/lib/api/actions/servers/search/tools", async () => {
       mockSearchFunction({
         ...(params as object),
         auth: (extra as { auth?: unknown }).auth,
-        agentLoopContext: (extra as { agentLoopContext?: unknown })
-          .agentLoopContext,
+        toolContext: (extra as { toolContext?: unknown }).toolContext,
       }),
   };
   const handlersWithTags = {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -435,7 +435,7 @@ export async function* tryCallMCPTool(
       );
       const connectionResult = await connectToMCPServer(auth, {
         params: connectionParams,
-        agentLoopContext: { runContext: agentLoopRunContext },
+        toolContext: { runContext: agentLoopRunContext },
       });
       if (connectionResult.isErr()) {
         if (
@@ -755,7 +755,7 @@ async function connectServerSideMCP(
   const connectionParams = makeServerSideMCPConnectionParams(mcpServerView);
   const connectionResult = await connectToMCPServer(auth, {
     params: connectionParams,
-    agentLoopContext: { runContext: agentLoopRunContext },
+    toolContext: { runContext: agentLoopRunContext },
   });
 
   if (connectionResult.isErr()) {
@@ -1370,7 +1370,7 @@ async function listMCPServerToolsAndServerInstructions(
     // Connect to the MCP server.
     const r = await connectToMCPServer(auth, {
       params: connectionParams,
-      agentLoopContext: { listToolsContext: agentLoopListToolsContext },
+      toolContext: { listToolsContext: agentLoopListToolsContext },
     });
     if (r.isErr()) {
       // When the workspace connection is broken (admin token revoked/expired) or hit the rate limit,

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -2,7 +2,7 @@ import { MCPServerNotFoundError } from "@app/lib/actions/mcp_errors";
 import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import { getInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/servers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -10,7 +10,7 @@ export const connectToInternalMCPServer = async (
   mcpServerId: string,
   transport: InMemoryWithAuthTransport,
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<McpServer> => {
   const res = getInternalMCPServerNameAndWorkspaceId(mcpServerId);
   if (res.isErr()) {
@@ -24,7 +24,7 @@ export const connectToInternalMCPServer = async (
       internalMCPServerName: res.value.name,
       mcpServerId,
     },
-    agentLoopContext
+    toolContext
   );
 
   await server.connect(transport);

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -1,6 +1,6 @@
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { ADVANCED_SEARCH_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
@@ -90,21 +90,21 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
  * Check if we are in advanced search mode,
  * relying on a magic value stored in the additionalConfiguration.
  */
-function isAdvancedSearchMode(agentLoopContext?: AgentLoopContextType) {
+function isAdvancedSearchMode(toolContext?: ToolContextType) {
   return (
-    (agentLoopContext?.runContext &&
+    (toolContext?.runContext &&
       isLightServerSideMCPToolConfiguration(
-        agentLoopContext.runContext.toolConfiguration
+        toolContext.runContext.toolConfiguration
       ) &&
-      agentLoopContext.runContext.toolConfiguration.additionalConfiguration[
+      toolContext.runContext.toolConfiguration.additionalConfiguration[
         ADVANCED_SEARCH_SWITCH
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ] === true) ||
-    (agentLoopContext?.listToolsContext &&
+    (toolContext?.listToolsContext &&
       isServerSideMCPServerConfiguration(
-        agentLoopContext.listToolsContext.agentActionConfiguration
+        toolContext.listToolsContext.agentActionConfiguration
       ) &&
-      agentLoopContext.listToolsContext.agentActionConfiguration
+      toolContext.listToolsContext.agentActionConfiguration
         .additionalConfiguration[ADVANCED_SEARCH_SWITCH] === true)
   );
 }
@@ -118,167 +118,167 @@ export async function getInternalMCPServer(
     internalMCPServerName: InternalMCPServerNameType;
     mcpServerId: string;
   },
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<McpServer> {
   switch (internalMCPServerName) {
     case "github":
-      return githubServer(auth, agentLoopContext);
+      return githubServer(auth, toolContext);
     case "ashby":
-      return ashbyServer(auth, agentLoopContext);
+      return ashbyServer(auth, toolContext);
     case "clari_copilot":
-      return clariCopilotServer(auth, agentLoopContext);
+      return clariCopilotServer(auth, toolContext);
     case "hubspot":
-      return hubspotServer(auth, agentLoopContext);
+      return hubspotServer(auth, toolContext);
     case "image_generation":
-      return imageGenerationServer(auth, agentLoopContext);
+      return imageGenerationServer(auth, toolContext);
     case "speech_generator":
-      return speechGenerator(auth, agentLoopContext);
+      return speechGenerator(auth, toolContext);
     case "sound_studio":
-      return soundStudio(auth, agentLoopContext);
+      return soundStudio(auth, toolContext);
     case "file_generation":
-      return fileGenerationServer(auth, agentLoopContext);
+      return fileGenerationServer(auth, toolContext);
     case "interactive_content":
-      return interactiveContentServer(auth, agentLoopContext);
+      return interactiveContentServer(auth, toolContext);
     case "query_tables_v2":
-      return tablesQueryServerV2(auth, agentLoopContext);
+      return tablesQueryServerV2(auth, toolContext);
     case "primitive_types_debugger":
-      return primitiveTypesDebuggerServer(auth, agentLoopContext);
+      return primitiveTypesDebuggerServer(auth, toolContext);
     case "jit_testing":
-      return jitTestingServer(auth, agentLoopContext);
+      return jitTestingServer(auth, toolContext);
     case "common_utilities":
-      return commonUtilitiesServer(auth, agentLoopContext);
+      return commonUtilitiesServer(auth, toolContext);
     case "web_search_&_browse":
-      return webSearchBrowseServer(auth, agentLoopContext);
+      return webSearchBrowseServer(auth, toolContext);
     case "search":
       // If we are in advanced search mode, we use the data_sources_file_system server instead.
-      if (isAdvancedSearchMode(agentLoopContext)) {
-        return dataSourcesFileSystemServer(auth, agentLoopContext);
+      if (isAdvancedSearchMode(toolContext)) {
+        return dataSourcesFileSystemServer(auth, toolContext);
       }
-      return searchServer(auth, agentLoopContext);
+      return searchServer(auth, toolContext);
     case "missing_action_catcher":
-      return missingActionCatcherServer(auth, agentLoopContext);
+      return missingActionCatcherServer(auth, toolContext);
     case "notion":
-      return notionServer(auth, agentLoopContext);
+      return notionServer(auth, toolContext);
     case "openai_usage":
-      return openaiUsageServer(auth, agentLoopContext);
+      return openaiUsageServer(auth, toolContext);
     case "include_data":
-      return includeDataServer(auth, agentLoopContext);
+      return includeDataServer(auth, toolContext);
     case "run_agent":
-      return runAgentServer(auth, agentLoopContext);
+      return runAgentServer(auth, toolContext);
     case "run_dust_app":
-      return dustAppServer(auth, agentLoopContext);
+      return dustAppServer(auth, toolContext);
     case "agent_router":
-      return agentRouterServer(auth, agentLoopContext);
+      return agentRouterServer(auth, toolContext);
     case "extract_data":
-      return extractDataServer(auth, agentLoopContext);
+      return extractDataServer(auth, toolContext);
     case "salesforce":
-      return salesforceServer(auth, agentLoopContext);
+      return salesforceServer(auth, toolContext);
     case "salesloft":
-      return salesloftServer(auth, agentLoopContext);
+      return salesloftServer(auth, toolContext);
     case "slab":
-      return slabServer(auth, agentLoopContext);
+      return slabServer(auth, toolContext);
     case "snowflake":
-      return snowflakeServer(auth, agentLoopContext);
+      return snowflakeServer(auth, toolContext);
     case "gmail":
-      return gmailServer(auth, agentLoopContext);
+      return gmailServer(auth, toolContext);
     case "gong":
-      return gongServer(auth, agentLoopContext);
+      return gongServer(auth, toolContext);
     case "google_calendar":
-      return calendarServer(auth, agentLoopContext);
+      return calendarServer(auth, toolContext);
     case "google_drive":
-      return driveServer(auth, agentLoopContext);
+      return driveServer(auth, toolContext);
     case "google_sheets":
-      return sheetsServer(auth, agentLoopContext);
+      return sheetsServer(auth, toolContext);
     case "data_sources_file_system":
-      return dataSourcesFileSystemServer(auth, agentLoopContext);
+      return dataSourcesFileSystemServer(auth, toolContext);
     case "conversation_files":
-      return conversationFilesServer(auth, agentLoopContext);
+      return conversationFilesServer(auth, toolContext);
     case "files":
-      return filesServer(auth, agentLoopContext);
+      return filesServer(auth, toolContext);
     case "databricks":
-      return databricksServer(auth, agentLoopContext);
+      return databricksServer(auth, toolContext);
     case "jira":
-      return jiraServer(auth, agentLoopContext);
+      return jiraServer(auth, toolContext);
     case "luma":
-      return lumaServer(auth, agentLoopContext);
+      return lumaServer(auth, toolContext);
     case "microsoft_drive":
-      return microsoftDriveServer(auth, agentLoopContext);
+      return microsoftDriveServer(auth, toolContext);
     case "microsoft_excel":
-      return microsoftExcelServer(auth, agentLoopContext);
+      return microsoftExcelServer(auth, toolContext);
     case "microsoft_teams":
-      return microsoftTeamsServer(auth, agentLoopContext);
+      return microsoftTeamsServer(auth, toolContext);
     case "monday":
-      return mondayServer(auth, agentLoopContext);
+      return mondayServer(auth, toolContext);
     case "slack":
-      return slackServer(auth, mcpServerId, agentLoopContext);
+      return slackServer(auth, mcpServerId, toolContext);
     case "slack_bot":
-      return slackBotServer(auth, mcpServerId, agentLoopContext);
+      return slackBotServer(auth, mcpServerId, toolContext);
     case "agent_memory":
-      return agentMemoryServer(auth, agentLoopContext);
+      return agentMemoryServer(auth, toolContext);
     case "confluence":
-      return confluenceServer(auth, agentLoopContext);
+      return confluenceServer(auth, toolContext);
     case "outlook":
-      return outlookMailServer(auth, agentLoopContext);
+      return outlookMailServer(auth, toolContext);
     case "outlook_calendar":
-      return outlookCalendarServer(auth, agentLoopContext);
+      return outlookCalendarServer(auth, toolContext);
     case "agent_sidekick_agent_state":
-      return agentSidekickAgentStateServer(auth, agentLoopContext);
+      return agentSidekickAgentStateServer(auth, toolContext);
     case "agent_sidekick_context":
-      return agentSidekickContextServer(auth, agentLoopContext);
+      return agentSidekickContextServer(auth, toolContext);
     case "exa_people_and_company":
-      return exaServer(auth, agentLoopContext);
+      return exaServer(auth, toolContext);
     case "fathom":
-      return fathomServer(auth, agentLoopContext);
+      return fathomServer(auth, toolContext);
     case "freshservice":
-      return freshserviceServer(auth, agentLoopContext);
+      return freshserviceServer(auth, toolContext);
     case "data_warehouses":
-      return dataWarehousesServer(auth, agentLoopContext);
+      return dataWarehousesServer(auth, toolContext);
     case "toolsets":
-      return toolsetsServer(auth, agentLoopContext);
+      return toolsetsServer(auth, toolContext);
     case "val_town":
-      return valtownServer(auth, agentLoopContext);
+      return valtownServer(auth, toolContext);
     case "vanta":
-      return vantaServer(auth, agentLoopContext);
+      return vantaServer(auth, toolContext);
     case "http_client":
-      return httpClientServer(auth, agentLoopContext);
+      return httpClientServer(auth, toolContext);
     case "front":
-      return frontServer(auth, agentLoopContext);
+      return frontServer(auth, toolContext);
     case "zendesk":
-      return zendeskServer(auth, agentLoopContext);
+      return zendeskServer(auth, toolContext);
     case "workspace_analytics":
-      return workspaceAnalyticsServer(auth, agentLoopContext);
+      return workspaceAnalyticsServer(auth, toolContext);
     case "skill_management":
-      return skillManagementServer(auth, agentLoopContext);
+      return skillManagementServer(auth, toolContext);
     case "skill_authoring":
-      return skillAuthoringServer(auth, agentLoopContext);
+      return skillAuthoringServer(auth, toolContext);
     case "schedules_management":
-      return schedulesManagementServer(auth, agentLoopContext);
+      return schedulesManagementServer(auth, toolContext);
     case "productboard":
-      return productboardServer(auth, agentLoopContext);
+      return productboardServer(auth, toolContext);
     case "pod_manager":
-      return podManagerServer(auth, agentLoopContext);
+      return podManagerServer(auth, toolContext);
     case "pod_tasks":
-      return podTasksServer(auth, agentLoopContext);
+      return podTasksServer(auth, toolContext);
     case "poke":
-      return pokeServer(auth, agentLoopContext);
+      return pokeServer(auth, toolContext);
     case "ask_user_question":
-      return askUserQuestionServer(auth, agentLoopContext);
+      return askUserQuestionServer(auth, toolContext);
     case "ukg_ready":
-      return ukgReadyServer(auth, agentLoopContext);
+      return ukgReadyServer(auth, toolContext);
     case "user_mentions":
-      return userMentionsServer(auth, agentLoopContext);
+      return userMentionsServer(auth, toolContext);
     case "statuspage":
-      return statuspageServer(auth, agentLoopContext);
+      return statuspageServer(auth, toolContext);
     case "sandbox":
-      return sandboxServer(auth, agentLoopContext);
+      return sandboxServer(auth, toolContext);
     case "sandbox_functions":
-      return sandboxFunctionsServer(auth, agentLoopContext);
+      return sandboxFunctionsServer(auth, toolContext);
     case "wakeups":
-      return wakeupsServer(auth, agentLoopContext);
+      return wakeupsServer(auth, toolContext);
     case "plan_mode":
-      return planModeServer(auth, agentLoopContext);
+      return planModeServer(auth, toolContext);
     case "workday":
-      return workdayServer(auth, agentLoopContext);
+      return workdayServer(auth, toolContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -1,6 +1,6 @@
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPError } from "@app/lib/actions/mcp_errors";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import type {
   InternalMCPServerDefinitionType,
   MCPToolType,
@@ -21,7 +21,7 @@ export type ToolHandlerExtra = RequestHandlerExtra<
   ServerNotification
 > & {
   auth: Authenticator;
-  agentLoopContext?: AgentLoopContextType;
+  toolContext?: ToolContextType;
 };
 
 export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;

--- a/front/lib/actions/mcp_internal_actions/tools/tags/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/tags/utils.ts
@@ -1,4 +1,4 @@
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
@@ -12,10 +12,8 @@ function hasTagAutoMode(dataSourceConfigurations: DataSourceConfiguration[]) {
   );
 }
 
-export function shouldAutoGenerateTags(
-  agentLoopContext: AgentLoopContextType
-): boolean {
-  const { listToolsContext, runContext } = agentLoopContext;
+export function shouldAutoGenerateTags(toolContext: ToolContextType): boolean {
+  const { listToolsContext, runContext } = toolContext;
   if (
     !!listToolsContext?.agentActionConfiguration &&
     isServerSideMCPServerConfiguration(

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -1,4 +1,4 @@
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -46,12 +46,10 @@ vi.mock("@app/lib/api/file_system", async (importOriginal) => {
   };
 });
 
-function makeAgentLoopContext(
-  conversation: ConversationType
-): AgentLoopContextType {
+function makeToolContext(conversation: ConversationType): ToolContextType {
   return {
     runContext: { conversation },
-  } as unknown as AgentLoopContextType;
+  } as unknown as ToolContextType;
 }
 
 function makeReadableStream(content: string): Readable {
@@ -99,7 +97,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         canonicalPath,
-        makeAgentLoopContext({ ...conversation, content: [] })
+        makeToolContext({ ...conversation, content: [] })
       );
 
       expect(result.isOk()).toBe(true);
@@ -132,7 +130,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         `conversation-${conversation.sId}/missing.pdf`,
-        makeAgentLoopContext({ ...conversation, content: [] })
+        makeToolContext({ ...conversation, content: [] })
       );
 
       expect(result.isErr()).toBe(true);
@@ -160,7 +158,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         `conversation-${conversation.sId}/file.txt`,
-        makeAgentLoopContext({ ...conversation, content: [] })
+        makeToolContext({ ...conversation, content: [] })
       );
 
       expect(result.isErr()).toBe(true);
@@ -213,7 +211,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         file.sId,
-        makeAgentLoopContext(fullConversation)
+        makeToolContext(fullConversation)
       );
 
       expect(result.isOk()).toBe(true);
@@ -245,7 +243,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         "fil_notfound",
-        makeAgentLoopContext(conversationResult.value)
+        makeToolContext(conversationResult.value)
       );
 
       expect(result.isErr()).toBe(true);
@@ -280,7 +278,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         "conversation/notes.txt",
-        makeAgentLoopContext({ ...conversation, content: [] })
+        makeToolContext({ ...conversation, content: [] })
       );
 
       expect(result.isOk()).toBe(true);
@@ -310,7 +308,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         "conversation/missing.pdf",
-        makeAgentLoopContext({ ...conversation, content: [] })
+        makeToolContext({ ...conversation, content: [] })
       );
 
       expect(result.isErr()).toBe(true);
@@ -359,7 +357,7 @@ describe("resolveConversationFileRef", () => {
       const result = await resolveConversationFileRef(
         auth,
         canonicalPath,
-        undefined // canonical paths do not need agentLoopContext
+        undefined // canonical paths do not need toolContext
       );
 
       expect(result.isOk()).toBe(true);
@@ -372,7 +370,7 @@ describe("resolveConversationFileRef", () => {
       expect(await result.value.getSignedUrl()).toBe(signedUrl);
     });
 
-    it("does not require agentLoopContext", async () => {
+    it("does not require toolContext", async () => {
       const { authenticator: auth } = await createResourceTest({
         role: "admin",
       });
@@ -438,7 +436,7 @@ describe("resolveConversationFileRef", () => {
     });
   });
 
-  it("returns Err when agentLoopContext has no runContext", async () => {
+  it("returns Err when toolContext has no runContext", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
 
     const result = await resolveConversationFileRef(
@@ -477,7 +475,7 @@ describe("resolveConversationFileRef", () => {
     const result = await resolveConversationFileRef(
       auth,
       file.sId,
-      makeAgentLoopContext({ ...conversation, content: [] })
+      makeToolContext({ ...conversation, content: [] })
     );
 
     expect(result.isOk()).toBe(true);
@@ -516,11 +514,11 @@ describe("resolveConversationFileRef", () => {
       useCaseMetadata: { conversationId: conversationA.sId },
     });
 
-    // But agentLoopContext points to conversation B.
+    // But toolContext points to conversation B.
     const result = await resolveConversationFileRef(
       auth,
       file.sId,
-      makeAgentLoopContext({ ...conversationB, content: [] })
+      makeToolContext({ ...conversationB, content: [] })
     );
 
     expect(result.isErr()).toBe(true);

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -1,4 +1,4 @@
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { resolveFile } from "@app/lib/api/actions/servers/files/tools/utils";
 import {
   conversationAttachmentId,
@@ -49,7 +49,7 @@ export type ConversationFileRef = {
 export async function resolveConversationFileRef(
   auth: Authenticator,
   fileId: string,
-  agentLoopContext: AgentLoopContextType | undefined
+  toolContext: ToolContextType | undefined
 ): Promise<Result<ConversationFileRef, string>> {
   // Canonical scoped paths (conversation-{id}/..., pod-{id}/...) produced by the new
   // DustFileSystem layer. Resolved directly — no conversation context needed.
@@ -100,13 +100,13 @@ export async function resolveConversationFileRef(
     });
   }
 
-  if (!agentLoopContext?.runContext) {
+  if (!toolContext?.runContext) {
     return new Err("No conversation context available");
   }
 
   const parsed = parseScopedFilePath(fileId);
   if (parsed) {
-    const conversation = agentLoopContext.runContext.conversation;
+    const conversation = toolContext.runContext.conversation;
     const resolvedRes = await resolveFile(auth, conversation, fileId);
     if (resolvedRes.isErr()) {
       return new Err(resolvedRes.error.message);
@@ -121,7 +121,7 @@ export async function resolveConversationFileRef(
     });
   }
 
-  const conversation = agentLoopContext.runContext.conversation;
+  const conversation = toolContext.runContext.conversation;
   const fileResource = await FileResource.fetchById(auth, fileId);
   if (!fileResource) {
     return new Err(`File resource not found for fileId ${fileId}`);
@@ -156,7 +156,7 @@ export async function resolveConversationFileRef(
 export async function getFileFromConversationAttachment(
   auth: Authenticator,
   fileId: string,
-  agentLoopContext: AgentLoopContextType
+  toolContext: ToolContextType
 ): Promise<
   Result<
     {
@@ -167,7 +167,7 @@ export async function getFileFromConversationAttachment(
     string
   >
 > {
-  if (!agentLoopContext?.runContext) {
+  if (!toolContext?.runContext) {
     return new Err("No conversation context available");
   }
 
@@ -211,7 +211,7 @@ export async function getFileFromConversationAttachment(
   // Scoped paths resolve through mount path.
   const parsed = parseScopedFilePath(fileId);
   if (parsed) {
-    const conversation = agentLoopContext.runContext.conversation;
+    const conversation = toolContext.runContext.conversation;
     const resolvedRes = await resolveFile(auth, conversation, fileId);
     if (resolvedRes.isErr()) {
       return new Err(resolvedRes.error.message);
@@ -231,7 +231,7 @@ export async function getFileFromConversationAttachment(
   }
 
   // Legacy fileId path: scan the conversation to find the attachment.
-  const conversation = agentLoopContext.runContext.conversation;
+  const conversation = toolContext.runContext.conversation;
   let attachment: ConversationAttachmentType | null = null;
 
   for (const versions of conversation.content) {

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -3,7 +3,7 @@ import type {
   ToolDefinition,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
@@ -21,7 +21,7 @@ import type {
 
 export function registerTool(
   auth: Authenticator,
-  agentLoopContext: AgentLoopContextType | undefined,
+  toolContext: ToolContextType | undefined,
   server: McpServer,
   tool: ToolDefinition,
   { monitoringName }: { monitoringName: string }
@@ -43,12 +43,12 @@ export function registerTool(
       auth,
       {
         toolNameForMonitoring: monitoringName,
-        agentLoopContext,
+        toolContext,
         enableAlerting: tool.enableAlerting,
       },
       (params, extra) =>
         withToolResultProcessing(
-          tool.handler(params, { ...extra, agentLoopContext, auth })
+          tool.handler(params, { ...extra, toolContext, auth })
         )
     )
   );
@@ -103,11 +103,11 @@ function withToolLogging<T>(
   auth: Authenticator,
   {
     toolNameForMonitoring,
-    agentLoopContext,
+    toolContext,
     enableAlerting = false,
   }: {
     toolNameForMonitoring: string;
-    agentLoopContext: AgentLoopContextType | undefined;
+    toolContext: ToolContextType | undefined;
     enableAlerting?: boolean;
   },
   toolCallback: (
@@ -136,13 +136,13 @@ function withToolLogging<T>(
     };
 
     // Adding agent loop context if available.
-    if (agentLoopContext?.runContext) {
+    if (toolContext?.runContext) {
       const {
         agentConfiguration,
         toolConfiguration,
         conversation,
         agentMessage,
-      } = agentLoopContext.runContext;
+      } = toolContext.runContext;
       loggerArgs = {
         ...loggerArgs,
         actionConfigurationId: toolConfiguration.sId,

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -32,7 +32,7 @@ import {
   MCPOAuthProvider,
   MCPOAuthProviderError,
 } from "@app/lib/actions/mcp_oauth_provider";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_client_side";
 import type {
   MCPServerType,
@@ -356,10 +356,10 @@ export async function connectToMCPServer(
   auth: Authenticator,
   {
     params,
-    agentLoopContext,
+    toolContext,
   }: {
     params: MCPConnectionParams;
-    agentLoopContext?: AgentLoopContextType;
+    toolContext?: ToolContextType;
   }
 ): Promise<
   Result<Client, Error | MCPServerPersonalAuthenticationRequiredError>
@@ -386,13 +386,13 @@ export async function connectToMCPServer(
             params.mcpServerId,
             server,
             auth,
-            agentLoopContext
+            toolContext
           );
 
           await mcpClient.connect(client);
 
           // For internal servers, to avoid any unnecessary work, we only try to fetch the token if we are trying to run a tool.
-          if (agentLoopContext?.runContext) {
+          if (toolContext?.runContext) {
             const bearerTokenCredentials =
               await InternalMCPServerInMemoryResource.fetchDecryptedCredentials(
                 auth,
@@ -565,7 +565,7 @@ export async function connectToMCPServer(
             mcpServerId: params.mcpServerId,
             oAuthUseCase: params.oAuthUseCase,
             remoteMCPServer,
-            isToolExecution: !!agentLoopContext?.runContext,
+            isToolExecution: !!toolContext?.runContext,
           });
           if (tokenRes.isErr()) {
             return tokenRes;

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -163,7 +163,7 @@ export type AgentLoopListToolsContextType = {
   agentMessage: AgentMessageType;
 };
 
-export type AgentLoopContextType =
+export type ToolContextType =
   | {
       runContext: AgentLoopRunContextType;
       listToolsContext?: never;

--- a/front/lib/api/actions/servers/agent_memory/index.ts
+++ b/front/lib/api/actions/servers/agent_memory/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/agent_memory/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(AGENT_MEMORY_SERVER_NAME);
 
@@ -40,7 +40,7 @@ function createServer(
   }
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: AGENT_MEMORY_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/agent_memory/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_memory/tools/index.ts
@@ -36,7 +36,7 @@ const renderMemory = (
 };
 
 const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
-  [AGENT_MEMORY_RETRIEVE_TOOL_NAME]: async (_, { auth, agentLoopContext }) => {
+  [AGENT_MEMORY_RETRIEVE_TOOL_NAME]: async (_, { auth, toolContext }) => {
     const user = auth.user();
     if (!user) {
       return new Err(
@@ -47,10 +47,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      agentLoopContext?.runContext,
+      toolContext?.runContext,
       "agentLoopContext is required to run the memory retrieve tool"
     );
-    const { agentConfiguration } = agentLoopContext.runContext;
+    const { agentConfiguration } = toolContext.runContext;
 
     const memory = await AgentMemoryResource.retrieveMemory(auth, {
       agentConfiguration,
@@ -61,7 +61,7 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
 
   [AGENT_MEMORY_RECORD_TOOL_NAME]: async (
     { entries },
-    { auth, agentLoopContext }
+    { auth, toolContext }
   ) => {
     const user = auth.user();
     if (!user) {
@@ -73,10 +73,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      agentLoopContext?.runContext,
+      toolContext?.runContext,
       "agentLoopContext is required to run the memory record_entries tool"
     );
-    const { agentConfiguration } = agentLoopContext.runContext;
+    const { agentConfiguration } = toolContext.runContext;
 
     const result = await AgentMemoryResource.recordEntries(auth, {
       agentConfiguration,
@@ -93,7 +93,7 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
 
   [AGENT_MEMORY_ERASE_TOOL_NAME]: async (
     { indexes },
-    { auth, agentLoopContext }
+    { auth, toolContext }
   ) => {
     const user = auth.user();
     if (!user) {
@@ -105,10 +105,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      agentLoopContext?.runContext,
+      toolContext?.runContext,
       "agentLoopContext is required to run the memory erase_entries tool"
     );
-    const { agentConfiguration } = agentLoopContext.runContext;
+    const { agentConfiguration } = toolContext.runContext;
 
     const memory = await AgentMemoryResource.eraseEntries(auth, {
       agentConfiguration,
@@ -118,10 +118,7 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     return renderMemory(memory);
   },
 
-  [AGENT_MEMORY_EDIT_TOOL_NAME]: async (
-    { edits },
-    { auth, agentLoopContext }
-  ) => {
+  [AGENT_MEMORY_EDIT_TOOL_NAME]: async ({ edits }, { auth, toolContext }) => {
     const user = auth.user();
     if (!user) {
       return new Err(
@@ -132,10 +129,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      agentLoopContext?.runContext,
+      toolContext?.runContext,
       "agentLoopContext is required to run the memory edit_entries tool"
     );
-    const { agentConfiguration } = agentLoopContext.runContext;
+    const { agentConfiguration } = toolContext.runContext;
 
     const result = await AgentMemoryResource.editEntries(auth, {
       agentConfiguration,
@@ -152,7 +149,7 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
 
   [AGENT_MEMORY_COMPACT_TOOL_NAME]: async (
     { edits },
-    { auth, agentLoopContext }
+    { auth, toolContext }
   ) => {
     const user = auth.user();
     if (!user) {
@@ -164,10 +161,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      agentLoopContext?.runContext,
+      toolContext?.runContext,
       "agentLoopContext is required to run the memory compact_memory tool"
     );
-    const { agentConfiguration } = agentLoopContext.runContext;
+    const { agentConfiguration } = toolContext.runContext;
 
     const result = await AgentMemoryResource.editEntries(auth, {
       agentConfiguration,

--- a/front/lib/api/actions/servers/agent_router/index.ts
+++ b/front/lib/api/actions/servers/agent_router/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { AGENT_ROUTER_SERVER_NAME } from "@app/lib/api/actions/servers/agent_router/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/agent_router/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(AGENT_ROUTER_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: AGENT_ROUTER_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/agent_sidekick_agent_state.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/agent_sidekick_agent_state.test.ts
@@ -25,11 +25,11 @@ function getToolByName(name: string) {
 }
 
 // Create a minimal extra object for testing.
-function createTestExtra(auth: Authenticator, agentLoopContext?: unknown) {
+function createTestExtra(auth: Authenticator, toolContext?: unknown) {
   return {
     signal: new AbortController().signal,
     auth,
-    agentLoopContext,
+    toolContext,
   } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
 }
 

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/agent_sidekick_agent_state/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("agent_sidekick_agent_state");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "agent_sidekick_agent_state",
     });
   }

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/tools/index.ts
@@ -12,9 +12,9 @@ import { Err, Ok } from "@app/types/shared/result";
 
 const handlers: ToolHandlers<typeof AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA> =
   {
-    get_agent_info: async (_, { auth, agentLoopContext }) => {
+    get_agent_info: async (_, { auth, toolContext }) => {
       const agentConfigurationId =
-        getAgentConfigurationIdFromContext(agentLoopContext);
+        getAgentConfigurationIdFromContext(toolContext);
 
       if (!agentConfigurationId) {
         return new Err(
@@ -25,8 +25,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA> =
         );
       }
 
-      const agentVersion =
-        getAgentConfigurationVersionFromContext(agentLoopContext);
+      const agentVersion = getAgentConfigurationVersionFromContext(toolContext);
 
       // Fetch the agent configuration with full details to get the actions.
       const agentConfiguration = await getAgentConfiguration(auth, {

--- a/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
@@ -76,11 +76,11 @@ function getToolByName(name: string) {
 }
 
 // Create a minimal extra object for testing.
-function createTestExtra(auth: Authenticator, agentLoopContext?: unknown) {
+function createTestExtra(auth: Authenticator, toolContext?: unknown) {
   return {
     signal: new AbortController().signal,
     auth,
-    agentLoopContext,
+    toolContext,
   } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
 }
 

--- a/front/lib/api/actions/servers/agent_sidekick_context/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { AGENT_SIDEKICK_CONTEXT_TOOL_NAME } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/agent_sidekick_context/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("agent_sidekick_context");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: AGENT_SIDEKICK_CONTEXT_TOOL_NAME,
     });
   }

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -682,10 +682,10 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
 
   get_agent_feedback: async (
     { limit, filter, latestVersionOnly },
-    { auth, agentLoopContext }
+    { auth, toolContext }
   ) => {
     const agentConfigurationId =
-      getAgentConfigurationIdFromContext(agentLoopContext);
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -784,9 +784,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_agent_insights: async ({ days }, { auth, agentLoopContext }) => {
+  get_agent_insights: async ({ days }, { auth, toolContext }) => {
     const agentConfigurationId =
-      getAgentConfigurationIdFromContext(agentLoopContext);
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -860,9 +860,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
   },
 
   // Suggestion handlers
-  suggest_prompt_edits: async (params, { auth, agentLoopContext }) => {
+  suggest_prompt_edits: async (params, { auth, toolContext }) => {
     const agentConfigurationId =
-      getAgentConfigurationIdFromContext(agentLoopContext);
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -904,9 +904,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  suggest_tools: async (params, { auth, agentLoopContext }) => {
+  suggest_tools: async (params, { auth, toolContext }) => {
     const agentConfigurationId =
-      getAgentConfigurationIdFromContext(agentLoopContext);
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -948,9 +948,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  suggest_sub_agent: async (params, { auth, agentLoopContext }) => {
+  suggest_sub_agent: async (params, { auth, toolContext }) => {
     const agentConfigurationId =
-      getAgentConfigurationIdFromContext(agentLoopContext);
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -1069,9 +1069,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  suggest_skills: async (params, { auth, agentLoopContext }) => {
+  suggest_skills: async (params, { auth, toolContext }) => {
     const agentConfigurationId =
-      getAgentConfigurationIdFromContext(agentLoopContext);
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -1113,7 +1113,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  suggest_model: async (params, { auth, agentLoopContext }) => {
+  suggest_model: async (params, { auth, toolContext }) => {
     const availableModels = await getAvailableModelsForWorkspace(auth);
     const availableModelIds = availableModels.map((m) => m.modelId);
 
@@ -1128,7 +1128,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
 
     const agentConfigurationId =
-      getAgentConfigurationIdFromContext(agentLoopContext);
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -1303,9 +1303,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  suggest_knowledge: async (params, { auth, agentLoopContext }) => {
+  suggest_knowledge: async (params, { auth, toolContext }) => {
     const agentConfigurationId =
-      getAgentConfigurationIdFromContext(agentLoopContext);
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -1408,9 +1408,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  list_suggestions: async (params, { auth, agentLoopContext }) => {
+  list_suggestions: async (params, { auth, toolContext }) => {
     const agentConfigurationId =
-      getAgentConfigurationIdFromContext(agentLoopContext);
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(

--- a/front/lib/api/actions/servers/agent_sidekick_helpers.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_helpers.ts
@@ -1,20 +1,20 @@
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { getSidekickMetadataFromContext } from "@app/lib/api/actions/servers/helpers";
 
 export function getAgentConfigurationIdFromContext(
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): string | null {
   return (
-    getSidekickMetadataFromContext(agentLoopContext)
+    getSidekickMetadataFromContext(toolContext)
       ?.sidekickTargetAgentConfigurationId ?? null
   );
 }
 
 export function getAgentConfigurationVersionFromContext(
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): number | null {
   return (
-    getSidekickMetadataFromContext(agentLoopContext)
+    getSidekickMetadataFromContext(toolContext)
       ?.sidekickTargetAgentConfigurationVersion ?? null
   );
 }

--- a/front/lib/api/actions/servers/ashby/index.ts
+++ b/front/lib/api/actions/servers/ashby/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { ASHBY_SERVER } from "@app/lib/api/actions/servers/ashby/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/ashby/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("ashby");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       // Putting all the tools under the same name, will reconsider if we need more granularity.
       monitoringName: "ashby",
     });

--- a/front/lib/api/actions/servers/ask_user_question/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/ask_user_question/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("ask_user_question");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "ask_user_question",
     });
   }

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -13,9 +13,9 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
   ask_user_question: async (
     { question, options, multiSelect },
-    { agentLoopContext }
+    { toolContext }
   ) => {
-    const resumeState = agentLoopContext?.runContext?.stepContext?.resumeState;
+    const resumeState = toolContext?.runContext?.stepContext?.resumeState;
     if (isUserQuestionResumeState(resumeState) && resumeState.answer) {
       const { answer } = resumeState;
       const selections = getUserQuestionSelections(

--- a/front/lib/api/actions/servers/clari_copilot/index.ts
+++ b/front/lib/api/actions/servers/clari_copilot/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { CLARI_COPILOT_SERVER } from "@app/lib/api/actions/servers/clari_copilot/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/clari_copilot/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("clari_copilot");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "clari_copilot",
     });
   }

--- a/front/lib/api/actions/servers/common_utilities/index.ts
+++ b/front/lib/api/actions/servers/common_utilities/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { COMMON_UTILITIES_SERVER_NAME } from "@app/lib/api/actions/servers/common_utilities/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/common_utilities/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(COMMON_UTILITIES_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: COMMON_UTILITIES_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/common_utilities/tools/index.ts
+++ b/front/lib/api/actions/servers/common_utilities/tools/index.ts
@@ -95,10 +95,10 @@ const handlers: ToolHandlers<typeof COMMON_UTILITIES_TOOLS_METADATA> = {
     }
   },
 
-  set_conversation_title: async ({ title }, { auth, agentLoopContext }) => {
+  set_conversation_title: async ({ title }, { auth, toolContext }) => {
     const conversation =
-      agentLoopContext?.runContext?.conversation ??
-      agentLoopContext?.listToolsContext?.conversation;
+      toolContext?.runContext?.conversation ??
+      toolContext?.listToolsContext?.conversation;
 
     if (!conversation) {
       return new Err(

--- a/front/lib/api/actions/servers/confluence/index.ts
+++ b/front/lib/api/actions/servers/confluence/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { CONFLUENCE_TOOL_NAME } from "@app/lib/api/actions/servers/confluence/metadata";
 import { createConfluenceTools } from "@app/lib/api/actions/servers/confluence/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,13 +8,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("confluence");
 
   const tools = createConfluenceTools();
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: CONFLUENCE_TOOL_NAME,
     });
   }

--- a/front/lib/api/actions/servers/conversation_files/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { CONVERSATION_FILES_SERVER_NAME } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import {
   TOOLS,
@@ -11,17 +11,17 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 async function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("conversation_files");
 
   const conversation =
-    agentLoopContext?.runContext?.conversation ??
-    agentLoopContext?.listToolsContext?.conversation;
+    toolContext?.runContext?.conversation ??
+    toolContext?.listToolsContext?.conversation;
   const useFileSystem = conversation?.metadata?.useFileSystem === true;
 
   for (const tool of useFileSystem ? TOOLS_WITH_FILESYSTEM : TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: CONVERSATION_FILES_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -89,13 +89,13 @@ const listAttachmentsHandler: ToolHandlers<
   typeof CONVERSATION_FILES_TOOLS_METADATA
 >[typeof CONVERSATION_LIST_FILES_ACTION_NAME] = async (
   _,
-  { auth, agentLoopContext }
+  { auth, toolContext }
 ) => {
-  if (!agentLoopContext?.runContext) {
+  if (!toolContext?.runContext) {
     return new Err(new MCPError("No conversation context available"));
   }
 
-  const conversation = agentLoopContext.runContext.conversation;
+  const conversation = toolContext.runContext.conversation;
   const allAttachments = await listAttachments(auth, { conversation });
 
   // When the conversation uses the new file system, regular files are surfaced via the
@@ -135,15 +135,15 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
 
   [CONVERSATION_CAT_FILE_ACTION_NAME]: async (
     { fileId, offset, limit, grep },
-    { auth, agentLoopContext }
+    { auth, toolContext }
   ) => {
-    if (!agentLoopContext?.runContext) {
+    if (!toolContext?.runContext) {
       return new Err(new MCPError("No conversation context available"));
     }
 
-    const conversation = agentLoopContext.runContext.conversation;
+    const conversation = toolContext.runContext.conversation;
     const model = getSupportedModelConfig(
-      agentLoopContext.runContext.agentConfiguration.model
+      toolContext.runContext.agentConfiguration.model
     );
     if (!model) {
       return new Err(new MCPError("Model configuration not found"));
@@ -271,13 +271,13 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
 
   [CONVERSATION_SEARCH_FILES_ACTION_NAME]: async (
     { query },
-    { auth, agentLoopContext }
+    { auth, toolContext }
   ) => {
-    if (!agentLoopContext?.runContext) {
+    if (!toolContext?.runContext) {
       return new Err(new MCPError("No conversation context available"));
     }
 
-    const conversation = agentLoopContext.runContext.conversation;
+    const conversation = toolContext.runContext.conversation;
     const attachments = await listAttachments(auth, { conversation });
     const filesUsableAsRetrievalQuery = attachments.filter(
       (f) => f.isSearchable
@@ -341,7 +341,7 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
         uri: getDataSourceURI(dataSource),
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       })),
-      agentLoopContext,
+      toolContext,
     });
 
     return searchResults;

--- a/front/lib/api/actions/servers/data_sources_file_system/index.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/index.ts
@@ -1,7 +1,7 @@
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   TOOLS_WITH_TAGS,
   TOOLS_WITHOUT_TAGS,
@@ -11,16 +11,16 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("data_sources_file_system");
 
-  const areTagsDynamic = agentLoopContext
-    ? shouldAutoGenerateTags(agentLoopContext)
+  const areTagsDynamic = toolContext
+    ? shouldAutoGenerateTags(toolContext)
     : false;
 
   for (const tool of areTagsDynamic ? TOOLS_WITH_TAGS : TOOLS_WITHOUT_TAGS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: tool.name,
     });
   }

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
@@ -6,7 +6,7 @@ import {
   getAgentDataSourceConfigurations,
   makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -73,12 +73,9 @@ export async function cat(
     limit?: number;
     grep?: string;
   },
-  {
-    auth,
-    agentLoopContext,
-  }: { auth: Authenticator; agentLoopContext?: AgentLoopContextType }
+  { auth, toolContext }: { auth: Authenticator; toolContext?: ToolContextType }
 ) {
-  if (!agentLoopContext?.runContext) {
+  if (!toolContext?.runContext) {
     return new Err(new MCPError("No conversation context available"));
   }
 
@@ -169,7 +166,7 @@ export async function cat(
     );
   }
 
-  const { citationsOffset } = agentLoopContext.runContext.stepContext;
+  const { citationsOffset } = toolContext.runContext.stepContext;
 
   if (citationsOffset >= getRefs().length) {
     return new Err(

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -12,7 +12,7 @@ import type {
   SearchWithNodesInputType,
   TagsInputType,
 } from "@app/lib/actions/mcp_internal_actions/types";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
@@ -40,23 +40,19 @@ export async function search(
     tagsIn,
     tagsNot,
   }: SearchWithNodesInputType & TagsInputType,
-  {
-    auth,
-    agentLoopContext,
-  }: { auth: Authenticator; agentLoopContext?: AgentLoopContextType }
+  { auth, toolContext }: { auth: Authenticator; toolContext?: ToolContextType }
 ): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const credentials = await getLlmCredentials(auth);
   const timeFrame = parseTimeFrame(relativeTimeFrame ?? "all");
 
-  if (!agentLoopContext?.runContext) {
+  if (!toolContext?.runContext) {
     throw new Error(
       "agentLoopRunContext is required where the tool is called."
     );
   }
 
-  const { retrievalTopK, citationsOffset } =
-    agentLoopContext.runContext.stepContext;
+  const { retrievalTopK, citationsOffset } = toolContext.runContext.stepContext;
 
   const agentDataSourceConfigurationsResult =
     await getAgentDataSourceConfigurations(auth, dataSources);

--- a/front/lib/api/actions/servers/data_warehouses/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/data_warehouses/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("data_warehouses");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "data_warehouses",
     });
   }

--- a/front/lib/api/actions/servers/data_warehouses/tools/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/tools/index.ts
@@ -203,15 +203,15 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
 
   query: async (
     { dataSources, tableIds, query, fileName },
-    { auth, agentLoopContext }
+    { auth, toolContext }
   ) => {
-    if (!agentLoopContext?.runContext) {
+    if (!toolContext?.runContext) {
       return new Err(
         new MCPError("Missing agentLoopContext for file generation")
       );
     }
 
-    const agentLoopRunContext = agentLoopContext.runContext;
+    const agentLoopRunContext = toolContext.runContext;
 
     const dataSourceConfigurationsResult =
       await getAgentDataSourceConfigurations(

--- a/front/lib/api/actions/servers/databricks/index.ts
+++ b/front/lib/api/actions/servers/databricks/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/databricks/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("databricks");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "databricks",
     });
   }

--- a/front/lib/api/actions/servers/exa/index.ts
+++ b/front/lib/api/actions/servers/exa/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/exa/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("exa_people_and_company");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "exa_people_and_company",
     });
   }

--- a/front/lib/api/actions/servers/extract_data/index.ts
+++ b/front/lib/api/actions/servers/extract_data/index.ts
@@ -1,19 +1,19 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createExtractDataTools } from "@app/lib/api/actions/servers/extract_data/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("extract_data");
 
-  const tools = createExtractDataTools(auth, agentLoopContext);
+  const tools = createExtractDataTools(auth, toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "extract_data",
     });
   }

--- a/front/lib/api/actions/servers/extract_data/tools/index.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.ts
@@ -4,7 +4,7 @@ import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_inte
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import type { ProcessActionOutputsType } from "@app/lib/api/actions/servers/extract_data/helpers";
 import {
   generateProcessToolOutput,
@@ -27,10 +27,10 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 // Create tools with access to auth via closure
 export function createExtractDataTools(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ) {
-  const areTagsDynamic = agentLoopContext
-    ? shouldAutoGenerateTags(agentLoopContext)
+  const areTagsDynamic = toolContext
+    ? shouldAutoGenerateTags(toolContext)
     : false;
 
   async function extractFunction({
@@ -50,10 +50,10 @@ export function createExtractDataTools(
   }) {
     // Unwrap and prepare variables.
     assert(
-      agentLoopContext?.runContext,
+      toolContext?.runContext,
       "agentLoopContext is required to run the extract_data tool"
     );
-    const { agentConfiguration, conversation } = agentLoopContext.runContext;
+    const { agentConfiguration, conversation } = toolContext.runContext;
     const { model } = agentConfiguration;
 
     // Defensive handling: parse jsonSchema if it arrives as a JSON string.

--- a/front/lib/api/actions/servers/fathom/index.ts
+++ b/front/lib/api/actions/servers/fathom/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/fathom/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("fathom");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "fathom",
     });
   }

--- a/front/lib/api/actions/servers/file_generation/index.ts
+++ b/front/lib/api/actions/servers/file_generation/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { FILE_GENERATION_TOOL_NAME } from "@app/lib/api/actions/servers/file_generation/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/file_generation/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("file_generation");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: FILE_GENERATION_TOOL_NAME,
     });
   }

--- a/front/lib/api/actions/servers/files/index.ts
+++ b/front/lib/api/actions/servers/files/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/files/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(FILES_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: FILES_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/files/tools/agent_loop_fs.ts
+++ b/front/lib/api/actions/servers/files/tools/agent_loop_fs.ts
@@ -7,12 +7,12 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-type AgentLoopConversationExtra = Pick<ToolHandlerExtra, "agentLoopContext">;
+type ToolConversationExtra = Pick<ToolHandlerExtra, "toolContext">;
 
 export function requireAgentLoopConversation(
-  extra: AgentLoopConversationExtra
+  extra: ToolConversationExtra
 ): Result<ConversationWithoutContentType, MCPError> {
-  const conversation = extra.agentLoopContext?.runContext?.conversation;
+  const conversation = extra.toolContext?.runContext?.conversation;
   if (!conversation) {
     return new Err(
       new MCPError("No conversation context available.", { tracked: false })

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -142,9 +142,9 @@ async function catText(
 
 export async function catHandler(
   { path, offset, limit }: { path: string; offset?: number; limit?: number },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { copyHandler } from "@app/lib/api/actions/servers/files/tools/copy";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -15,10 +15,10 @@ function makeExtra(
   auth: Authenticator,
   conversation: ConversationType
 ): ToolHandlerExtra {
-  const agentLoopContext = {
+  const toolContext = {
     runContext: { conversation },
-  } as unknown as AgentLoopContextType;
-  return { auth, agentLoopContext } as unknown as ToolHandlerExtra;
+  } as unknown as ToolContextType;
+  return { auth, toolContext } as unknown as ToolHandlerExtra;
 }
 
 async function setupProjectConversation(

--- a/front/lib/api/actions/servers/files/tools/copy.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.ts
@@ -25,9 +25,9 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 export async function copyHandler(
   { source, dest }: { source: string; dest: string },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/create.test.ts
+++ b/front/lib/api/actions/servers/files/tools/create.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -14,10 +14,10 @@ function makeExtra(
   auth: Authenticator,
   conversation: ConversationType
 ): ToolHandlerExtra {
-  const agentLoopContext = {
+  const toolContext = {
     runContext: { conversation },
-  } as unknown as AgentLoopContextType;
-  return { auth, agentLoopContext } as unknown as ToolHandlerExtra;
+  } as unknown as ToolContextType;
+  return { auth, toolContext } as unknown as ToolHandlerExtra;
 }
 
 async function setupProjectConversation(): Promise<{

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -29,9 +29,9 @@ export async function createHandler(
     content,
     content_type,
   }: { path: string; content: string; content_type: string },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/delete.test.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { deleteHandler } from "@app/lib/api/actions/servers/files/tools/delete";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -21,10 +21,10 @@ function makeExtra(
   auth: Authenticator,
   conversation: ConversationType
 ): ToolHandlerExtra {
-  const agentLoopContext = {
+  const toolContext = {
     runContext: { conversation },
-  } as unknown as AgentLoopContextType;
-  return { auth, agentLoopContext } as unknown as ToolHandlerExtra;
+  } as unknown as ToolContextType;
+  return { auth, toolContext } as unknown as ToolHandlerExtra;
 }
 
 async function setupProjectConversation(): Promise<{

--- a/front/lib/api/actions/servers/files/tools/delete.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.ts
@@ -12,9 +12,9 @@ import { Err, Ok } from "@app/types/shared/result";
 
 export async function deleteHandler(
   { path }: { path: string },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/extract_text.ts
+++ b/front/lib/api/actions/servers/files/tools/extract_text.ts
@@ -28,9 +28,9 @@ function deriveExtractedPath(sourcePath: string): string {
 
 export async function extractTextHandler(
   { path }: { path: string },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/grep.ts
+++ b/front/lib/api/actions/servers/files/tools/grep.ts
@@ -21,9 +21,9 @@ import * as readline from "readline";
 
 export async function grepHandler(
   { path, pattern }: { path: string; pattern: string },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/list.test.ts
+++ b/front/lib/api/actions/servers/files/tools/list.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -57,10 +57,10 @@ function makeExtra(
   auth: Authenticator,
   conversation: ConversationType
 ): ToolHandlerExtra {
-  const agentLoopContext = {
+  const toolContext = {
     runContext: { conversation },
-  } as unknown as AgentLoopContextType;
-  return { auth, agentLoopContext } as unknown as ToolHandlerExtra;
+  } as unknown as ToolContextType;
+  return { auth, toolContext } as unknown as ToolHandlerExtra;
 }
 
 function makeStorageFile(

--- a/front/lib/api/actions/servers/files/tools/move.test.ts
+++ b/front/lib/api/actions/servers/files/tools/move.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { moveHandler } from "@app/lib/api/actions/servers/files/tools/move";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -15,10 +15,10 @@ function makeExtra(
   auth: Authenticator,
   conversation: ConversationType
 ): ToolHandlerExtra {
-  const agentLoopContext = {
+  const toolContext = {
     runContext: { conversation },
-  } as unknown as AgentLoopContextType;
-  return { auth, agentLoopContext } as unknown as ToolHandlerExtra;
+  } as unknown as ToolContextType;
+  return { auth, toolContext } as unknown as ToolHandlerExtra;
 }
 
 async function setupProjectConversation(

--- a/front/lib/api/actions/servers/files/tools/move.ts
+++ b/front/lib/api/actions/servers/files/tools/move.ts
@@ -20,9 +20,9 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 export async function moveHandler(
   { source, dest }: { source: string; dest: string },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/upload_from_url.ts
+++ b/front/lib/api/actions/servers/files/tools/upload_from_url.ts
@@ -21,9 +21,9 @@ export async function uploadFromUrlHandler(
     url,
     content_type,
   }: { path: string; url: string; content_type?: string },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/freshservice/index.ts
+++ b/front/lib/api/actions/servers/freshservice/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/freshservice/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("freshservice");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "freshservice",
     });
   }

--- a/front/lib/api/actions/servers/front/index.ts
+++ b/front/lib/api/actions/servers/front/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/front/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("front");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "front",
     });
   }

--- a/front/lib/api/actions/servers/github/index.ts
+++ b/front/lib/api/actions/servers/github/index.ts
@@ -1,19 +1,19 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createGithubTools } from "@app/lib/api/actions/servers/github/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("github");
 
   const tools = createGithubTools(auth);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "github",
     });
   }

--- a/front/lib/api/actions/servers/gmail/index.ts
+++ b/front/lib/api/actions/servers/gmail/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { GMAIL_TOOL_NAME } from "@app/lib/api/actions/servers/gmail/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/gmail/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("gmail");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: GMAIL_TOOL_NAME,
     });
   }

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -255,7 +255,7 @@ async function buildReplyContext(params: {
 async function fetchAttachment(
   auth: ToolHandlerExtra["auth"],
   attachmentFilePath: string | undefined,
-  agentLoopContext: ToolHandlerExtra["agentLoopContext"]
+  toolContext: ToolHandlerExtra["toolContext"]
 ): Promise<
   | Ok<{ buffer: Buffer; filename: string; contentType: string } | null>
   | Err<MCPError>
@@ -264,14 +264,14 @@ async function fetchAttachment(
     return new Ok(null);
   }
 
-  if (!agentLoopContext) {
+  if (!toolContext) {
     return new Err(new MCPError("No agent context available"));
   }
 
   const fileResult = await getFileFromConversationAttachment(
     auth,
     attachmentFilePath,
-    agentLoopContext
+    toolContext
   );
 
   if (fileResult.isErr()) {
@@ -365,7 +365,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       replyToMessageId,
       attachmentFilePath,
     },
-    { authInfo, auth, agentLoopContext }
+    { authInfo, auth, toolContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -399,7 +399,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     const attachmentResult = await fetchAttachment(
       auth,
       attachmentFilePath,
-      agentLoopContext
+      toolContext
     );
     if (attachmentResult.isErr()) {
       return attachmentResult;
@@ -978,7 +978,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       replyToMessageId,
       attachmentFilePath,
     },
-    { authInfo, auth, agentLoopContext }
+    { authInfo, auth, toolContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -1011,7 +1011,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     const attachmentResult = await fetchAttachment(
       auth,
       attachmentFilePath,
-      agentLoopContext
+      toolContext
     );
     if (attachmentResult.isErr()) {
       return attachmentResult;

--- a/front/lib/api/actions/servers/gong/index.ts
+++ b/front/lib/api/actions/servers/gong/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/gong/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("gong");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "gong",
     });
   }

--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -1,4 +1,4 @@
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { google } from "googleapis";
 import { DateTime, Interval } from "luxon";
@@ -172,10 +172,8 @@ export function normalizeTimezone(
   return null;
 }
 
-export function getUserTimezone(
-  agentLoopContext?: AgentLoopContextType
-): string | null {
-  const content = agentLoopContext?.runContext?.conversation?.content;
+export function getUserTimezone(toolContext?: ToolContextType): string | null {
+  const content = toolContext?.runContext?.conversation?.content;
   if (!content) {
     return null;
   }

--- a/front/lib/api/actions/servers/google_calendar/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/google_calendar/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("google_calendar");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "google_calendar",
     });
   }

--- a/front/lib/api/actions/servers/google_calendar/tools/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/tools/index.ts
@@ -48,7 +48,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
 
   list_events: async (
     { calendarId = "primary", q, timeMin, timeMax, maxResults, pageToken },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const calendar = await getCalendarClient(authInfo);
     assert(
@@ -68,7 +68,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         orderBy: "startTime",
       });
 
-      const userTimezone = getUserTimezone(agentLoopContext);
+      const userTimezone = getUserTimezone(toolContext);
 
       const enrichedEvents = res.data.items
         ? res.data.items
@@ -92,7 +92,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
 
   get_event: async (
     { calendarId = "primary", eventId },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const calendar = await getCalendarClient(authInfo);
     assert(
@@ -106,7 +106,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         eventId,
       });
 
-      const userTimezone = getUserTimezone(agentLoopContext);
+      const userTimezone = getUserTimezone(toolContext);
       const enrichedEvent = isGoogleCalendarEvent(res.data)
         ? enrichEventWithDayOfWeek(res.data, userTimezone)
         : null;
@@ -142,7 +142,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       extendedProperties,
       eventType,
     },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const calendar = await getCalendarClient(authInfo);
     assert(
@@ -192,7 +192,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         },
       });
 
-      const userTimezone = getUserTimezone(agentLoopContext);
+      const userTimezone = getUserTimezone(toolContext);
       const enrichedEvent = isGoogleCalendarEvent(res.data)
         ? enrichEventWithDayOfWeek(res.data, userTimezone)
         : null;
@@ -233,7 +233,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       reminders,
       extendedProperties,
     },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const calendar = await getCalendarClient(authInfo);
     assert(
@@ -271,7 +271,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         },
       });
 
-      const userTimezone = getUserTimezone(agentLoopContext);
+      const userTimezone = getUserTimezone(toolContext);
       const enrichedEvent = isGoogleCalendarEvent(res.data)
         ? enrichEventWithDayOfWeek(res.data, userTimezone)
         : null;

--- a/front/lib/api/actions/servers/google_drive/index.ts
+++ b/front/lib/api/actions/servers/google_drive/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { GOOGLE_DRIVE_TOOL_NAME } from "@app/lib/api/actions/servers/google_drive/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/google_drive/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 async function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("google_drive");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: GOOGLE_DRIVE_TOOL_NAME,
     });
   }

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -55,7 +55,7 @@ describe("handleFileAccessError", () => {
   const createMockExtra = (toolServerId?: string): ToolHandlerExtra =>
     ({
       authInfo: undefined,
-      agentLoopContext: toolServerId
+      toolContext: toolServerId
         ? {
             runContext: {
               toolConfiguration: {
@@ -249,11 +249,11 @@ describe("get_file_content", () => {
   const XLSX_MIMETYPE =
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
-  // Partial stub: the get_file_content handler only reads authInfo and
-  // agentLoopContext. Same pattern as the other MCP tool tests (files/tools).
+  // Partial stub: the get_file_content handler only reads authInfo and toolContext.
+  // Same pattern as the other MCP tool tests (files/tools).
   const extra = {
     authInfo: undefined,
-    agentLoopContext: undefined,
+    toolContext: undefined,
   } as unknown as ToolHandlerExtra;
 
   function isTextBlock(

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -146,10 +146,7 @@ function normalizeCode(code: string | number | undefined): string | undefined {
 export async function handleFileAccessError(
   err: unknown,
   fileId: string,
-  {
-    authInfo,
-    agentLoopContext,
-  }: Pick<ToolHandlerExtra, "authInfo" | "agentLoopContext">,
+  { authInfo, toolContext }: Pick<ToolHandlerExtra, "authInfo" | "toolContext">,
   fileMeta?: { name?: string; mimeType?: string }
 ): Promise<ToolHandlerResult> {
   if (err instanceof Common.GaxiosError) {
@@ -175,7 +172,7 @@ export async function handleFileAccessError(
         message.includes("write access"))
     ) {
       const connectionId =
-        agentLoopContext?.runContext?.toolConfiguration.toolServerId ??
+        toolContext?.runContext?.toolConfiguration.toolServerId ??
         "google_drive";
 
       return new Ok(
@@ -298,10 +295,10 @@ function handleDriveAccessError(
  */
 function addAgentAttribution(
   content: string,
-  { agentLoopContext }: Pick<ToolHandlerExtra, "agentLoopContext">
+  { toolContext }: Pick<ToolHandlerExtra, "toolContext">
 ): string {
-  if (agentLoopContext?.runContext?.agentConfiguration) {
-    const agentConfig = agentLoopContext.runContext.agentConfiguration;
+  if (toolContext?.runContext?.agentConfiguration) {
+    const agentConfig = toolContext.runContext.agentConfiguration;
     return `${content}\n\nSent via ${agentConfig.name} Agent on Dust`;
   }
   return content;
@@ -447,7 +444,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
 
   get_file_content: async (
     { fileId, offset = 0, limit = MAX_CONTENT_SIZE },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const drive = await getDriveClient(authInfo);
     if (!drive) {
@@ -646,14 +643,14 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
 
       return new Ok(responseBlocks);
     } catch (err) {
-      return handleFileAccessError(err, fileId, { authInfo, agentLoopContext });
+      return handleFileAccessError(err, fileId, {
+        authInfo,
+        toolContext,
+      });
     }
   },
 
-  get_spreadsheet: async (
-    { spreadsheetId },
-    { authInfo, agentLoopContext }
-  ) => {
+  get_spreadsheet: async ({ spreadsheetId }, { authInfo, toolContext }) => {
     const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
       return new Err(new MCPError("Failed to authenticate with Google Sheets"));
@@ -670,7 +667,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, spreadsheetId, {
         authInfo,
-        agentLoopContext,
+        toolContext,
       });
     }
   },
@@ -682,7 +679,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
       majorDimension = "ROWS",
       valueRenderOption = "FORMATTED_VALUE",
     },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
@@ -703,7 +700,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, spreadsheetId, {
         authInfo,
-        agentLoopContext,
+        toolContext,
       });
     }
   },
@@ -740,7 +737,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
 
   get_document_structure: async (
     { documentId, offset = 0, limit = 100 },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const docs = await getDocsClient(authInfo);
     if (!docs) {
@@ -754,14 +751,14 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, documentId, {
         authInfo,
-        agentLoopContext,
+        toolContext,
       });
     }
   },
 
   get_presentation_structure: async (
     { presentationId, offset = 0, limit = 10 },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const slides = await getSlidesClient(authInfo);
     if (!slides) {
@@ -775,14 +772,14 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, presentationId, {
         authInfo,
-        agentLoopContext,
+        toolContext,
       });
     }
   },
 
   list_file_permissions: async (
     { fileId, capabilities },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const shareError = await ensureCapability(
       "canShare",
@@ -822,7 +819,10 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleFileAccessError(err, fileId, { authInfo, agentLoopContext });
+      return handleFileAccessError(err, fileId, {
+        authInfo,
+        toolContext,
+      });
     }
   },
 };
@@ -968,7 +968,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   copy_file: async (
     { fileId, name, parentId, capabilities },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canCopy",
@@ -1001,7 +1001,10 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         fields: "id,name,mimeType,webViewLink",
       });
     } catch (err) {
-      return handleFileAccessError(err, fileId, { authInfo, agentLoopContext });
+      return handleFileAccessError(err, fileId, {
+        authInfo,
+        toolContext,
+      });
     }
 
     // Construct appropriate URL based on file type
@@ -1037,7 +1040,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   create_comment: async (
     { fileId, content, capabilities },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canComment",
@@ -1053,7 +1056,9 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
 
-    const finalContent = addAgentAttribution(content, { agentLoopContext });
+    const finalContent = addAgentAttribution(content, {
+      toolContext,
+    });
 
     try {
       const res = await drive.comments.create({
@@ -1078,13 +1083,16 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleFileAccessError(err, fileId, { authInfo, agentLoopContext });
+      return handleFileAccessError(err, fileId, {
+        authInfo,
+        toolContext,
+      });
     }
   },
 
   create_reply: async (
     { fileId, commentId, content, capabilities },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canComment",
@@ -1100,7 +1108,9 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
 
-    const finalContent = addAgentAttribution(content, { agentLoopContext });
+    const finalContent = addAgentAttribution(content, {
+      toolContext,
+    });
 
     try {
       const res = await drive.replies.create({
@@ -1128,13 +1138,16 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleFileAccessError(err, fileId, { authInfo, agentLoopContext });
+      return handleFileAccessError(err, fileId, {
+        authInfo,
+        toolContext,
+      });
     }
   },
 
   update_document: async (
     { documentId, operations, capabilities },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canEdit",
@@ -1185,7 +1198,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return handleFileAccessError(
         err,
         documentId,
-        { authInfo, agentLoopContext },
+        { authInfo, toolContext },
         {
           name: documentId,
           mimeType: "application/vnd.google-apps.document",
@@ -1204,7 +1217,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       insertDataOption = "INSERT_ROWS",
       capabilities,
     },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canEdit",
@@ -1239,7 +1252,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return handleFileAccessError(
         err,
         spreadsheetId,
-        { authInfo, agentLoopContext },
+        { authInfo, toolContext },
         {
           name: spreadsheetId,
           mimeType: "application/vnd.google-apps.spreadsheet",
@@ -1250,7 +1263,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   update_spreadsheet: async (
     { spreadsheetId, operations, capabilities },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canEdit",
@@ -1330,7 +1343,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return handleFileAccessError(
         err,
         spreadsheetId,
-        { authInfo, agentLoopContext },
+        { authInfo, toolContext },
         {
           name: spreadsheetId,
           mimeType: "application/vnd.google-apps.spreadsheet",
@@ -1341,7 +1354,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   update_presentation: async (
     { presentationId, operations, capabilities },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canEdit",
@@ -1392,7 +1405,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return handleFileAccessError(
         err,
         presentationId,
-        { authInfo, agentLoopContext },
+        { authInfo, toolContext },
         {
           name: presentationId,
           mimeType: "application/vnd.google-apps.presentation",
@@ -1413,7 +1426,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       emailMessage,
       capabilities,
     },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const shareError = await ensureCapability(
       "canShare",
@@ -1450,7 +1463,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, fileId, {
         authInfo,
-        agentLoopContext,
+        toolContext,
       });
     }
 
@@ -1476,7 +1489,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   update_file_permission: async (
     { fileId, permissionId, role, capabilities },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const shareError = await ensureCapability(
       "canShare",
@@ -1503,7 +1516,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, fileId, {
         authInfo,
-        agentLoopContext,
+        toolContext,
       });
     }
 
@@ -1525,7 +1538,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   revoke_file_sharing: async (
     { fileId, permissionId, capabilities },
-    { authInfo, agentLoopContext }
+    { authInfo, toolContext }
   ) => {
     const shareError = await ensureCapability(
       "canShare",
@@ -1551,7 +1564,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, fileId, {
         authInfo,
-        agentLoopContext,
+        toolContext,
       });
     }
 
@@ -1573,14 +1586,14 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   upload_file: async (
     { fileId, parentId, fileName },
-    { auth, authInfo, agentLoopContext }
+    { auth, authInfo, toolContext }
   ) => {
     const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
 
-    if (!agentLoopContext) {
+    if (!toolContext) {
       return new Err(
         new MCPError("No conversation context available for file access")
       );
@@ -1590,7 +1603,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       const fileResult = await getFileFromConversationAttachment(
         auth,
         fileId,
-        agentLoopContext
+        toolContext
       );
 
       if (fileResult.isErr()) {

--- a/front/lib/api/actions/servers/google_sheets/index.ts
+++ b/front/lib/api/actions/servers/google_sheets/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   GOOGLE_SHEETS_SERVER,
   GOOGLE_SHEETS_TOOL_NAME,
@@ -11,12 +11,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("google_sheets");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: GOOGLE_SHEETS_TOOL_NAME,
     });
   }

--- a/front/lib/api/actions/servers/helpers.ts
+++ b/front/lib/api/actions/servers/helpers.ts
@@ -1,4 +1,4 @@
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import type { ConversationMetadata } from "@app/types/assistant/conversation";
 
 // TODO(sidekick 2026-01-23): move all sidekick mcp servers and these helpers in dedicated folder
@@ -29,20 +29,20 @@ export function isSidekickConversation(
 }
 
 /**
- * Extracts the sidekick metadata from the agent loop context.
+ * Extracts the sidekick metadata from the tool context.
  *
- * AgentLoopContextType is a discriminated union with two variants:
+ * ToolContextType is a discriminated union with two variants:
  * - `runContext`: Present when executing a tool (the agent is running and calling tools)
  * - `listToolsContext`: Present when listing available tools (before tool execution, used for dynamic tool filtering)
  *
  * Both variants contain the conversation, so we check both to access conversation metadata.
  */
 export function getSidekickMetadataFromContext(
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): SidekickMetadata | null {
   const metadata =
-    agentLoopContext?.runContext?.conversation.metadata ??
-    agentLoopContext?.listToolsContext?.conversation.metadata;
+    toolContext?.runContext?.conversation.metadata ??
+    toolContext?.listToolsContext?.conversation.metadata;
 
   return metadata ? extractSidekickMetadata(metadata) : null;
 }

--- a/front/lib/api/actions/servers/http_client/index.ts
+++ b/front/lib/api/actions/servers/http_client/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { HTTP_CLIENT_TOOL_NAME } from "@app/lib/api/actions/servers/http_client/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/http_client/tools";
 import { TOOLS as WEB_TOOLS } from "@app/lib/api/actions/servers/web_search_browse/tools";
@@ -9,19 +9,19 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(HTTP_CLIENT_TOOL_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: HTTP_CLIENT_TOOL_NAME,
     });
   }
 
   // Register web tools (websearch, webbrowser)
   for (const tool of WEB_TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: HTTP_CLIENT_TOOL_NAME,
     });
   }

--- a/front/lib/api/actions/servers/http_client/tools/index.ts
+++ b/front/lib/api/actions/servers/http_client/tools/index.ts
@@ -4,7 +4,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
   DEFAULT_TIMEOUT_MS,
@@ -33,9 +33,9 @@ const SAFE_RESPONSE_HEADERS = ["content-type", "content-length"];
 
 async function getBearerToken(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<string | null> {
-  const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
+  const toolConfig = toolContext?.runContext?.toolConfiguration;
   if (
     !toolConfig ||
     !isLightServerSideMCPToolConfiguration(toolConfig) ||
@@ -113,7 +113,7 @@ async function handleSendRequest(
     body?: string;
     timeout_ms?: number;
   },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ) {
   const timeoutMs = timeout_ms ?? DEFAULT_TIMEOUT_MS;
   const controller = new AbortController();
@@ -121,7 +121,7 @@ async function handleSendRequest(
 
   const requestHeaders = validateAndSanitizeHeaders(headers);
 
-  const bearerToken = await getBearerToken(auth, agentLoopContext);
+  const bearerToken = await getBearerToken(auth, toolContext);
   if (bearerToken) {
     requestHeaders["Authorization"] = `Bearer ${bearerToken}`;
   }

--- a/front/lib/api/actions/servers/hubspot/index.ts
+++ b/front/lib/api/actions/servers/hubspot/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { HUBSPOT_SERVER } from "@app/lib/api/actions/servers/hubspot/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/hubspot/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("hubspot");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "hubspot",
     });
   }

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -4,7 +4,7 @@ import type {
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { resolveConversationFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import { uploadBase64ImageToFileStorage } from "@app/lib/api/files/upload";
 import type { ReferenceImageFile } from "@app/lib/api/llm/imageGeneration";
@@ -200,13 +200,13 @@ export function trackTokenUsage({
 
 export async function uploadAndFormatImageResponse(
   auth: Authenticator,
-  agentLoopContext: AgentLoopContextType | undefined,
+  toolContext: ToolContextType | undefined,
   images: Base64ImageData[],
   fileName: string
 ): Promise<
   Result<Array<{ type: "resource"; resource: ToolGeneratedFileType }>, MCPError>
 > {
-  if (!agentLoopContext?.runContext) {
+  if (!toolContext?.runContext) {
     return new Err(
       new MCPError("No conversation context available for file upload", {
         tracked: false,
@@ -214,7 +214,7 @@ export async function uploadAndFormatImageResponse(
     );
   }
 
-  const conversationId = agentLoopContext.runContext.conversation.sId;
+  const conversationId = toolContext.runContext.conversation.sId;
   const baseFileName = stripFileExtension(fileName);
 
   const resources: Array<{
@@ -278,13 +278,13 @@ async function processSingleImageFile(
     maxImageSize,
     supportedContentTypes,
     providerId,
-    agentLoopContext,
+    toolContext,
   }: {
     imageFileId: string;
     maxImageSize: number;
     supportedContentTypes: string[];
     providerId: ModelProviderIdType;
-    agentLoopContext: AgentLoopContextType | undefined;
+    toolContext: ToolContextType | undefined;
   }
 ): Promise<Ok<ReferenceImageFile> | Err<MCPError>> {
   const workspace = auth.getNonNullableWorkspace();
@@ -292,7 +292,7 @@ async function processSingleImageFile(
   const refResult = await resolveConversationFileRef(
     auth,
     imageFileId,
-    agentLoopContext
+    toolContext
   );
   if (refResult.isErr()) {
     return new Err(
@@ -347,17 +347,17 @@ export async function processImageFileIds(
   auth: Authenticator,
   {
     imageFileIds,
-    agentLoopContext,
+    toolContext,
     supportedContentTypes,
     providerId,
   }: {
     imageFileIds: string[];
-    agentLoopContext: AgentLoopContextType | undefined;
+    toolContext: ToolContextType | undefined;
     supportedContentTypes: string[];
     providerId: ModelProviderIdType;
   }
 ): Promise<Ok<ReferenceImageFile[]> | Err<MCPError>> {
-  if (!agentLoopContext?.runContext) {
+  if (!toolContext?.runContext) {
     return new Err(
       new MCPError("No conversation context available for file access", {
         tracked: false,
@@ -375,7 +375,7 @@ export async function processImageFileIds(
         maxImageSize,
         supportedContentTypes,
         providerId,
-        agentLoopContext,
+        toolContext,
       }),
     { concurrency: 8 }
   );

--- a/front/lib/api/actions/servers/image_generation/index.ts
+++ b/front/lib/api/actions/servers/image_generation/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { IMAGE_GENERATION_SERVER_NAME } from "@app/lib/api/actions/servers/image_generation/metadata";
 import { createImageGenerationTools } from "@app/lib/api/actions/servers/image_generation/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,13 +8,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(IMAGE_GENERATION_SERVER_NAME);
 
-  const tools = createImageGenerationTools(auth, agentLoopContext);
+  const tools = createImageGenerationTools(auth, toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: IMAGE_GENERATION_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -4,7 +4,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   checkImageGenerationRateLimit,
   computeImageGenerationCostDetails,
@@ -28,7 +28,7 @@ import { startObservation } from "@langfuse/tracing";
 
 export function createImageGenerationTools(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof IMAGE_GENERATION_TOOLS_METADATA> = {
     generate_image: async (
@@ -75,7 +75,7 @@ export function createImageGenerationTools(
       if (referenceImages && referenceImages.length > 0) {
         const processResult = await processImageFileIds(auth, {
           imageFileIds: referenceImages,
-          agentLoopContext,
+          toolContext,
           supportedContentTypes: imageGenerationModel.supportedContentTypes,
           providerId,
         });
@@ -174,7 +174,7 @@ export function createImageGenerationTools(
 
       return uploadAndFormatImageResponse(
         auth,
-        agentLoopContext,
+        toolContext,
         images,
         outputName
       );

--- a/front/lib/api/actions/servers/include_data/index.ts
+++ b/front/lib/api/actions/servers/include_data/index.ts
@@ -1,19 +1,19 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createIncludeDataTools } from "@app/lib/api/actions/servers/include_data/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("include_data");
 
-  const tools = createIncludeDataTools(auth, agentLoopContext);
+  const tools = createIncludeDataTools(auth, toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "include_data",
     });
   }

--- a/front/lib/api/actions/servers/include_data/tools/index.ts
+++ b/front/lib/api/actions/servers/include_data/tools/index.ts
@@ -1,7 +1,7 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
 import {
   INCLUDE_DATA_BASE_TOOLS_METADATA,
@@ -13,26 +13,25 @@ import type { Authenticator } from "@app/lib/auth";
 // Create tools with access to auth via closure
 export function createIncludeDataTools(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ) {
-  const areTagsDynamic = agentLoopContext
-    ? shouldAutoGenerateTags(agentLoopContext)
+  const areTagsDynamic = toolContext
+    ? shouldAutoGenerateTags(toolContext)
     : false;
 
   if (!areTagsDynamic) {
     // Return base tools without tags
     const handlers: ToolHandlers<typeof INCLUDE_DATA_BASE_TOOLS_METADATA> = {
       retrieve_recent_documents: async (params, _extra) => {
-        if (!agentLoopContext?.runContext) {
+        if (!toolContext?.runContext) {
           throw new Error(
             "agentLoopRunContext is required where the tool is called."
           );
         }
         return runIncludeDataRetrieval(auth, {
           ...params,
-          citationsOffset:
-            agentLoopContext.runContext.stepContext.citationsOffset,
-          retrievalTopK: agentLoopContext.runContext.stepContext.retrievalTopK,
+          citationsOffset: toolContext.runContext.stepContext.citationsOffset,
+          retrievalTopK: toolContext.runContext.stepContext.retrievalTopK,
         });
       },
     };
@@ -42,16 +41,15 @@ export function createIncludeDataTools(
   // Return tools with tags support
   const handlers: ToolHandlers<typeof INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA> = {
     retrieve_recent_documents: async (params, _extra) => {
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         throw new Error(
           "agentLoopRunContext is required where the tool is called."
         );
       }
       return runIncludeDataRetrieval(auth, {
         ...params,
-        citationsOffset:
-          agentLoopContext.runContext.stepContext.citationsOffset,
-        retrievalTopK: agentLoopContext.runContext.stepContext.retrievalTopK,
+        citationsOffset: toolContext.runContext.stepContext.citationsOffset,
+        retrievalTopK: toolContext.runContext.stepContext.retrievalTopK,
       });
     },
     find_tags: async ({ query, dataSources }, _extra) => {

--- a/front/lib/api/actions/servers/interactive_content/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { INTERACTIVE_CONTENT_SERVER_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { createInteractiveContentTools } from "@app/lib/api/actions/servers/interactive_content/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,13 +8,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 async function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<McpServer> {
   const server = makeInternalMCPServer(INTERACTIVE_CONTENT_SERVER_NAME);
 
-  const tools = await createInteractiveContentTools(auth, agentLoopContext);
+  const tools = await createInteractiveContentTools(auth, toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: INTERACTIVE_CONTENT_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -5,7 +5,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { buildInteractiveContentFileNotification } from "@app/lib/api/actions/servers/interactive_content/helpers";
 import { INTERACTIVE_CONTENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { fetchTemplateContent } from "@app/lib/api/actions/servers/interactive_content/template_utils";
@@ -32,14 +32,14 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 export async function createInteractiveContentTools(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<ToolDefinition[]> {
   const handlers: ToolHandlers<typeof INTERACTIVE_CONTENT_TOOLS_METADATA> = {
     create_interactive_content_file: async (
       { file_name, mime_type, mode, source, description },
       { sendNotification, _meta }
     ) => {
-      const { runContext } = agentLoopContext ?? {};
+      const { runContext } = toolContext ?? {};
 
       if (!runContext) {
         return new Err(
@@ -124,7 +124,7 @@ export async function createInteractiveContentTools(
       { file_id, old_string, new_string, expected_replacements },
       { sendNotification, _meta }
     ) => {
-      const { agentConfiguration } = agentLoopContext?.runContext ?? {};
+      const { agentConfiguration } = toolContext?.runContext ?? {};
 
       const result = await editClientExecutableFile(auth, {
         fileId: file_id,
@@ -183,13 +183,13 @@ export async function createInteractiveContentTools(
       { file_id },
       { sendNotification, _meta }
     ) => {
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         throw new Error(
           "Could not access Agent Loop Context from revert Interactive Content file tool."
         );
       }
 
-      const { agentConfiguration } = agentLoopContext.runContext;
+      const { agentConfiguration } = toolContext.runContext;
 
       const result = await revertClientExecutableFileChanges(auth, {
         fileId: file_id,
@@ -232,7 +232,7 @@ export async function createInteractiveContentTools(
       { file_id, new_file_name },
       { sendNotification, _meta }
     ) => {
-      const { agentConfiguration } = agentLoopContext?.runContext ?? {};
+      const { agentConfiguration } = toolContext?.runContext ?? {};
 
       const result = await renameClientExecutableFile(auth, {
         fileId: file_id,
@@ -360,7 +360,7 @@ export async function createInteractiveContentTools(
       { file_id, path },
       { sendNotification, _meta }
     ) => {
-      const { agentConfiguration } = agentLoopContext?.runContext ?? {};
+      const { agentConfiguration } = toolContext?.runContext ?? {};
 
       const file = await FileResource.fetchById(auth, file_id);
       if (!file) {

--- a/front/lib/api/actions/servers/jira/index.ts
+++ b/front/lib/api/actions/servers/jira/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/jira/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("jira");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "jira",
     });
   }

--- a/front/lib/api/actions/servers/jira/tools/index.ts
+++ b/front/lib/api/actions/servers/jira/tools/index.ts
@@ -862,7 +862,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   upload_attachment: async (
     { issueKey, attachment },
-    { auth, authInfo, agentLoopContext }
+    { auth, authInfo, toolContext }
   ) => {
     return withAuth({
       action: async (baseUrl, _resourceInfo, accessToken) => {
@@ -873,7 +873,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
         };
 
         if (attachment.type === "conversation_file") {
-          if (!agentLoopContext) {
+          if (!toolContext) {
             return new Err(
               new MCPError(
                 "Conversation context required for conversation file attachments"
@@ -884,7 +884,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           const fileResult = await getFileFromConversationAttachment(
             auth,
             attachment.fileId,
-            agentLoopContext
+            toolContext
           );
 
           if (fileResult.isErr()) {

--- a/front/lib/api/actions/servers/jit_testing/index.ts
+++ b/front/lib/api/actions/servers/jit_testing/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { JIT_TESTING_TOOL_NAME } from "@app/lib/api/actions/servers/jit_testing/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/jit_testing/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(JIT_TESTING_TOOL_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: JIT_TESTING_TOOL_NAME,
     });
   }

--- a/front/lib/api/actions/servers/luma/index.ts
+++ b/front/lib/api/actions/servers/luma/index.ts
@@ -1,19 +1,19 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createLumaTools } from "@app/lib/api/actions/servers/luma/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("luma");
 
-  const tools = createLumaTools(auth, agentLoopContext);
+  const tools = createLumaTools(auth, toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "luma",
     });
   }

--- a/front/lib/api/actions/servers/luma/tools/index.ts
+++ b/front/lib/api/actions/servers/luma/tools/index.ts
@@ -5,7 +5,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import type { LumaClient } from "@app/lib/api/actions/servers/luma/client";
 import { getLumaClient } from "@app/lib/api/actions/servers/luma/client";
 import { LUMA_TOOLS_METADATA } from "@app/lib/api/actions/servers/luma/metadata";
@@ -33,7 +33,7 @@ async function withClient(
 
 export function createLumaTools(
   _auth: Authenticator,
-  _agentLoopContext?: AgentLoopContextType
+  _toolContext?: ToolContextType
 ) {
   const handlers: ToolHandlers<typeof LUMA_TOOLS_METADATA> = {
     get_authenticated_user: async (_params, extra: ToolHandlerExtra) => {

--- a/front/lib/api/actions/servers/microsoft/utils.ts
+++ b/front/lib/api/actions/servers/microsoft/utils.ts
@@ -1,4 +1,4 @@
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -132,9 +132,9 @@ export interface TeamsUser {
 
 export async function getAllowedLabelsForMCPServer(
   auth: Authenticator,
-  agentLoopContext: AgentLoopContextType | undefined
+  toolContext: ToolContextType | undefined
 ): Promise<string[]> {
-  const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
+  const toolConfig = toolContext?.runContext?.toolConfiguration;
   const internalMCPServerId =
     toolConfig && isLightServerSideMCPToolConfiguration(toolConfig)
       ? toolConfig.internalMCPServerId

--- a/front/lib/api/actions/servers/microsoft_drive/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { MICROSOFT_DRIVE_SERVER_NAME } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/microsoft_drive/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(MICROSOFT_DRIVE_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: MICROSOFT_DRIVE_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -82,10 +82,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
     }
   },
 
-  search_drive_items: async (
-    { query },
-    { auth, authInfo, agentLoopContext }
-  ) => {
+  search_drive_items: async ({ query }, { auth, authInfo, toolContext }) => {
     const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
@@ -93,10 +90,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       );
     }
 
-    const allowedLabels = await getAllowedLabelsForMCPServer(
-      auth,
-      agentLoopContext
-    );
+    const allowedLabels = await getAllowedLabelsForMCPServer(auth, toolContext);
 
     try {
       const response = await searchMicrosoftDriveItems({
@@ -322,7 +316,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
 
   get_file_content: async (
     { itemId, driveId, siteId, offset, limit, getAsXml },
-    { auth, authInfo, agentLoopContext }
+    { auth, authInfo, toolContext }
   ) => {
     const client = await getGraphClient(authInfo);
     if (!client) {
@@ -331,10 +325,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       );
     }
 
-    const allowedLabels = await getAllowedLabelsForMCPServer(
-      auth,
-      agentLoopContext
-    );
+    const allowedLabels = await getAllowedLabelsForMCPServer(auth, toolContext);
 
     try {
       const endpoint = await getDriveItemEndpoint(itemId, driveId, siteId);
@@ -468,7 +459,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
 
   upload_file: async (
     { fileId, driveId, siteId, folderPath, fileName },
-    { auth, authInfo, agentLoopContext }
+    { auth, authInfo, toolContext }
   ) => {
     const client = await getGraphClient(authInfo);
     if (!client) {
@@ -477,7 +468,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       );
     }
 
-    if (!agentLoopContext) {
+    if (!toolContext) {
       return new Err(
         new MCPError("No conversation context available for file access")
       );
@@ -488,7 +479,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       const fileResult = await getFileFromConversationAttachment(
         auth,
         fileId,
-        agentLoopContext
+        toolContext
       );
 
       if (fileResult.isErr()) {

--- a/front/lib/api/actions/servers/microsoft_excel/index.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { MICROSOFT_EXCEL_SERVER_NAME } from "@app/lib/api/actions/servers/microsoft_excel/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/microsoft_excel/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(MICROSOFT_EXCEL_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: MICROSOFT_EXCEL_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/microsoft_teams/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { MICROSOFT_TEAMS_SERVER_NAME } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/microsoft_teams/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(MICROSOFT_TEAMS_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: MICROSOFT_TEAMS_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -394,7 +394,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       parentMessageId,
       mentions,
     },
-    { auth, authInfo, agentLoopContext }
+    { auth, authInfo, toolContext }
   ) => {
     const client = await getGraphClient(authInfo);
     if (!client) {
@@ -529,14 +529,14 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
 
       // Add footer with link to Dust conversation if agent context is available
       let finalContent = messageContent;
-      if (agentLoopContext?.runContext?.agentConfiguration) {
+      if (toolContext?.runContext?.agentConfiguration) {
         const agentUrl = getConversationRoute(
           auth.getNonNullableWorkspace().sId,
           "new",
-          `agentDetails=${agentLoopContext.runContext.agentConfiguration.sId}`,
+          `agentDetails=${toolContext.runContext.agentConfiguration.sId}`,
           config.getAppUrl()
         );
-        const agentName = agentLoopContext.runContext.agentConfiguration.name;
+        const agentName = toolContext.runContext.agentConfiguration.name;
         const footerMessage = `<em>Sent via <a href="${agentUrl}">${agentName} Agent</a> on Dust</em>`;
         finalContent = `${messageContent}<br/><br/>${footerMessage}`;
       }

--- a/front/lib/api/actions/servers/missing_action_catcher/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/index.ts
@@ -1,19 +1,19 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createMissingActionCatcherTools } from "@app/lib/api/actions/servers/missing_action_catcher/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("missing_action_catcher");
 
-  const tools = createMissingActionCatcherTools(agentLoopContext);
+  const tools = createMissingActionCatcherTools(toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "missing_action_catcher",
     });
   }

--- a/front/lib/api/actions/servers/missing_action_catcher/metadata.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/metadata.ts
@@ -1,6 +1,6 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
-// This server has dynamically created tools based on the agentLoopContext,
+// This server has dynamically created tools based on the tool context,
 // so we don't have fixed tools metadata. The tools are created at runtime
 // in the createServer function.
 
@@ -13,7 +13,7 @@ export const MISSING_ACTION_CATCHER_SERVER = {
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,
   },
-  // Tools are created dynamically at runtime based on the agentLoopContext.
+  // Tools are created dynamically at runtime based on the tool context.
   tools: [],
   tools_stakes: {},
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
@@ -1,12 +1,13 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { Err, Ok } from "@app/types/shared/result";
 
 // This server has dynamically created tools based on the agentLoopContext.
 // The tool name comes from the context at runtime.
+// TODO(spolu): move to AgentLoopRunContextType
 export function createMissingActionCatcherTools(
-  agentLoopContext?: AgentLoopContextType
+  agentLoopContext?: ToolContextType
 ): ToolDefinition[] {
   if (agentLoopContext) {
     const actionName = agentLoopContext.runContext

--- a/front/lib/api/actions/servers/monday/index.ts
+++ b/front/lib/api/actions/servers/monday/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/monday/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("monday");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "monday",
     });
   }

--- a/front/lib/api/actions/servers/notion/index.ts
+++ b/front/lib/api/actions/servers/notion/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { NOTION_TOOL_NAME } from "@app/lib/api/actions/servers/notion/metadata";
 import { createNotionTools } from "@app/lib/api/actions/servers/notion/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,13 +8,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("notion");
 
-  const tools = createNotionTools(agentLoopContext);
+  const tools = createNotionTools(toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: NOTION_TOOL_NAME,
     });
   }

--- a/front/lib/api/actions/servers/notion/tools/index.ts
+++ b/front/lib/api/actions/servers/notion/tools/index.ts
@@ -8,7 +8,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { NOTION_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import { NOTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/notion/metadata";
 import { getRefs } from "@app/lib/api/assistant/citations";
@@ -67,7 +67,7 @@ async function withNotionClient<T>(
 }
 
 export function createNotionTools(
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof NOTION_TOOLS_METADATA> = {
     search: async (
@@ -115,9 +115,9 @@ export function createNotionTools(
         ]);
       } else {
         const citationsOffset =
-          agentLoopContext?.runContext?.stepContext.citationsOffset ?? 0;
+          toolContext?.runContext?.stepContext.citationsOffset ?? 0;
 
-        const refs = agentLoopContext?.runContext?.stepContext.citationsOffset
+        const refs = toolContext?.runContext?.stepContext.citationsOffset
           ? getRefs().slice(
               citationsOffset,
               citationsOffset + NOTION_SEARCH_ACTION_NUM_RESULTS

--- a/front/lib/api/actions/servers/openai_usage/index.ts
+++ b/front/lib/api/actions/servers/openai_usage/index.ts
@@ -1,19 +1,19 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createOpenAIUsageTools } from "@app/lib/api/actions/servers/openai_usage/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("openai_usage");
 
-  const tools = createOpenAIUsageTools(auth, agentLoopContext);
+  const tools = createOpenAIUsageTools(auth, toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "openai_usage",
     });
   }

--- a/front/lib/api/actions/servers/openai_usage/tools/index.ts
+++ b/front/lib/api/actions/servers/openai_usage/tools/index.ts
@@ -5,7 +5,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import type { OpenAIUsageClient } from "@app/lib/api/actions/servers/openai_usage/client";
 import { getOpenAIUsageClient } from "@app/lib/api/actions/servers/openai_usage/client";
 import { OPENAI_USAGE_TOOLS_METADATA } from "@app/lib/api/actions/servers/openai_usage/metadata";
@@ -31,7 +31,7 @@ async function withClient(
 
 export function createOpenAIUsageTools(
   _auth: Authenticator,
-  _agentLoopContext?: AgentLoopContextType
+  _toolContext?: ToolContextType
 ) {
   const handlers: ToolHandlers<typeof OPENAI_USAGE_TOOLS_METADATA> = {
     get_completions_usage: async (params, extra: ToolHandlerExtra) => {

--- a/front/lib/api/actions/servers/outlook/calendar_server.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_server.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/outlook/tools/calendar";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("outlook_calendar");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "outlook_calendar",
     });
   }

--- a/front/lib/api/actions/servers/outlook/mail_server.ts
+++ b/front/lib/api/actions/servers/outlook/mail_server.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { OUTLOOK_TOOL_NAME } from "@app/lib/api/actions/servers/outlook/mail_metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/outlook/tools/mail";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("outlook");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: OUTLOOK_TOOL_NAME,
     });
   }

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -26,7 +26,7 @@ const MAX_ATTACHMENT_SIZE_BYTES = 3 * 1024 * 1024; // 3MB — Graph API inline a
 async function fetchAttachment(
   auth: ToolHandlerExtra["auth"],
   attachmentFilePath: string | undefined,
-  agentLoopContext: ToolHandlerExtra["agentLoopContext"]
+  toolContext: ToolHandlerExtra["toolContext"]
 ): Promise<
   | Ok<{ buffer: Buffer; filename: string; contentType: string } | null>
   | Err<MCPError>
@@ -35,14 +35,14 @@ async function fetchAttachment(
     return new Ok(null);
   }
 
-  if (!agentLoopContext) {
+  if (!toolContext) {
     return new Err(new MCPError("No agent context available"));
   }
 
   const fileResult = await getFileFromConversationAttachment(
     auth,
     attachmentFilePath,
-    agentLoopContext
+    toolContext
   );
 
   if (fileResult.isErr()) {
@@ -814,7 +814,7 @@ function validateMailParams({
 const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
   get_messages: async (
     { search, folderName, top = 10, skip = 0, select, sharedMailboxAddress },
-    { authInfo, auth, agentLoopContext }
+    { authInfo, auth, toolContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -841,10 +841,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       folderId = resolved.folderId;
     }
 
-    const allowedLabels = await getAllowedLabelsForMCPServer(
-      auth,
-      agentLoopContext
-    );
+    const allowedLabels = await getAllowedLabelsForMCPServer(auth, toolContext);
 
     if (allowedLabels.length > 0) {
       // Two parallel requests:
@@ -1485,7 +1482,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       sharedMailboxAddress,
       attachmentFilePath,
     },
-    { authInfo, auth, agentLoopContext }
+    { authInfo, auth, toolContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -1495,7 +1492,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     const attachmentResult = await fetchAttachment(
       auth,
       attachmentFilePath,
-      agentLoopContext
+      toolContext
     );
     if (attachmentResult.isErr()) {
       return attachmentResult;
@@ -1599,7 +1596,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       replyAll = false,
       attachmentFilePath,
     },
-    { authInfo, auth, agentLoopContext }
+    { authInfo, auth, toolContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -1619,7 +1616,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     const attachmentResult = await fetchAttachment(
       auth,
       attachmentFilePath,
-      agentLoopContext
+      toolContext
     );
     if (attachmentResult.isErr()) {
       return attachmentResult;

--- a/front/lib/api/actions/servers/plan_mode/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { PLAN_MODE_SERVER_NAME } from "@app/lib/api/actions/servers/plan_mode/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/plan_mode/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(PLAN_MODE_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: PLAN_MODE_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/plan_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/tools/index.ts
@@ -21,11 +21,11 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
-  create_plan: async ({ content }, { auth, agentLoopContext }) => {
-    if (!agentLoopContext?.runContext) {
+  create_plan: async ({ content }, { auth, toolContext }) => {
+    if (!toolContext?.runContext) {
       return new Err(new MCPError("Agent loop context is required."));
     }
-    const { conversation } = agentLoopContext.runContext;
+    const { conversation } = toolContext.runContext;
 
     return withPlanModeLock(conversation.sId, async () => {
       const existing = await getActivePlanContent(auth, conversation);
@@ -57,11 +57,11 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     });
   },
 
-  edit_plan: async ({ old_string, new_string }, { auth, agentLoopContext }) => {
-    if (!agentLoopContext?.runContext) {
+  edit_plan: async ({ old_string, new_string }, { auth, toolContext }) => {
+    if (!toolContext?.runContext) {
       return new Err(new MCPError("Agent loop context is required."));
     }
-    const { conversation } = agentLoopContext.runContext;
+    const { conversation } = toolContext.runContext;
 
     try {
       return await withPlanModeLock(conversation.sId, async () => {
@@ -130,11 +130,11 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     }
   },
 
-  close_plan: async ({ reason }, { auth, agentLoopContext }) => {
-    if (!agentLoopContext?.runContext) {
+  close_plan: async ({ reason }, { auth, toolContext }) => {
+    if (!toolContext?.runContext) {
       return new Err(new MCPError("Agent loop context is required."));
     }
-    const { conversation } = agentLoopContext.runContext;
+    const { conversation } = toolContext.runContext;
 
     const closed = await closeActivePlan(auth, conversation);
     if (closed.isErr()) {

--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -5,7 +5,7 @@ import type {
   DustPodConfigurationType,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { parsePodConfigurationURI } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import type { DataSourceFilter } from "@app/lib/api/assistant/configuration/types";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
@@ -101,7 +101,7 @@ export async function buildProjectRetrieveDataSources(
 export async function getPod(
   auth: Authenticator,
   from:
-    | { agentLoopContext?: AgentLoopContextType }
+    | { toolContext?: ToolContextType }
     | { dustPod?: DustPodConfigurationType }
 ): Promise<Result<PodContext, MCPError>> {
   if ("dustPod" in from && from.dustPod) {
@@ -142,9 +142,9 @@ export async function getPod(
   }
 
   // Otherwise, use the existing logic to get space from conversation context.
-  if ("agentLoopContext" in from && from.agentLoopContext) {
-    const { agentLoopContext } = from;
-    if (!agentLoopContext.runContext?.conversation) {
+  if ("toolContext" in from && from.toolContext) {
+    const { toolContext } = from;
+    if (!toolContext.runContext?.conversation) {
       return new Err(
         new MCPError("No conversation context available", { tracked: false })
       );
@@ -153,7 +153,7 @@ export async function getPod(
     const conversationRes =
       await ConversationResource.fetchConversationWithoutContent(
         auth,
-        agentLoopContext.runContext.conversation.sId
+        toolContext.runContext.conversation.sId
       );
 
     if (conversationRes.isErr()) {
@@ -214,7 +214,7 @@ export function checkWritePermission(
 export async function getWritablePodContext(
   auth: Authenticator,
   from:
-    | { agentLoopContext?: AgentLoopContextType }
+    | { toolContext?: ToolContextType }
     | { dustPod?: DustPodConfigurationType }
 ): Promise<Result<PodContext, MCPError>> {
   const contextRes = await getPod(auth, from);

--- a/front/lib/api/actions/servers/pod_manager/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { POD_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/pod_manager/metadata";
 import { createProjectManagerTools } from "@app/lib/api/actions/servers/pod_manager/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -18,13 +18,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
  */
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(POD_MANAGER_SERVER_NAME);
 
-  const tools = createProjectManagerTools(auth, agentLoopContext);
+  const tools = createProjectManagerTools(auth, toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: POD_MANAGER_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -6,7 +6,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   FILES_LIST_ACTION_NAME,
   FILES_SERVER_NAME,
@@ -99,13 +99,13 @@ function formatListedConversationWithoutMessages(
 
 export function createProjectManagerTools(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof POD_MANAGER_TOOLS_METADATA> = {
     add_content_node: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getWritablePodContext(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod: params.dustPod,
         });
         if (contextRes.isErr()) {
@@ -195,7 +195,7 @@ export function createProjectManagerTools(
     remove_content_node: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getWritablePodContext(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod: params.dustPod,
         });
         if (contextRes.isErr()) {
@@ -234,7 +234,7 @@ export function createProjectManagerTools(
     edit_information: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod: params.dustPod,
         });
         if (contextRes.isErr()) {
@@ -323,7 +323,7 @@ export function createProjectManagerTools(
     [UPDATE_MEMBERS_TOOL_NAME]: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod: params.dustPod,
         });
         if (contextRes.isErr()) {
@@ -469,7 +469,7 @@ export function createProjectManagerTools(
     get_information: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod: params.dustPod,
         });
         if (contextRes.isErr()) {
@@ -541,7 +541,7 @@ export function createProjectManagerTools(
     [LIST_MEMBERS_TOOL_NAME]: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod: params.dustPod,
         });
         if (contextRes.isErr()) {
@@ -942,7 +942,7 @@ export function createProjectManagerTools(
 
     retrieve_recent_documents: async (params) => {
       return withErrorHandling(async () => {
-        if (!agentLoopContext) {
+        if (!toolContext) {
           return new Err(
             new MCPError("No conversation context available", {
               tracked: false,
@@ -951,7 +951,7 @@ export function createProjectManagerTools(
         }
 
         const contextRes = await getPod(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod: params.dustPod,
         });
         if (contextRes.isErr()) {
@@ -973,7 +973,7 @@ export function createProjectManagerTools(
           );
         }
 
-        if (!agentLoopContext?.runContext) {
+        if (!toolContext?.runContext) {
           throw new Error(
             "agentLoopRunContext is required where the tool is called"
           );
@@ -983,16 +983,15 @@ export function createProjectManagerTools(
           timeFrame: params.timeFrame,
           dataSources,
           nodeIds: params.nodeIds,
-          citationsOffset:
-            agentLoopContext.runContext.stepContext.citationsOffset,
-          retrievalTopK: agentLoopContext.runContext.stepContext.retrievalTopK,
+          citationsOffset: toolContext.runContext.stepContext.citationsOffset,
+          retrievalTopK: toolContext.runContext.stepContext.retrievalTopK,
         });
       }, "Failed to retrieve recent Pod documents");
     },
 
     [SEMANTIC_SEARCH_TOOL_NAME]: async (params) => {
       return withErrorHandling(async () => {
-        if (!agentLoopContext?.runContext) {
+        if (!toolContext?.runContext) {
           return new Err(
             new MCPError("No conversation context available", {
               tracked: false,
@@ -1002,7 +1001,7 @@ export function createProjectManagerTools(
 
         const scope = params.searchScope ?? "all";
         const contextRes = await getPod(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod: params.dustPod,
         });
         if (contextRes.isErr()) {
@@ -1028,7 +1027,7 @@ export function createProjectManagerTools(
           relativeTimeFrame: params.relativeTimeFrame ?? "all",
           dataSources,
           nodeIds: params.nodeIds,
-          agentLoopContext,
+          toolContext,
         });
       }, "Failed to search Pod");
     },
@@ -1036,7 +1035,7 @@ export function createProjectManagerTools(
     create_conversation: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getWritablePodContext(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod: params.dustPod,
         });
         if (contextRes.isErr()) {
@@ -1051,8 +1050,8 @@ export function createProjectManagerTools(
         let origin: UserMessageOrigin = "web";
         let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-        if (agentLoopContext?.runContext?.conversation?.content) {
-          const userMessage = agentLoopContext.runContext.conversation.content
+        if (toolContext?.runContext?.conversation?.content) {
+          const userMessage = toolContext.runContext.conversation.content
             .flat()
             .findLast(isUserMessageType);
           if (userMessage?.context) {
@@ -1063,10 +1062,10 @@ export function createProjectManagerTools(
 
         // Get agent configuration name & profile picture URL
         const agentName =
-          agentLoopContext?.runContext?.agentConfiguration?.name ?? "Agent";
+          toolContext?.runContext?.agentConfiguration?.name ?? "Agent";
 
         const agentProfilePictureUrl =
-          agentLoopContext?.runContext?.agentConfiguration?.pictureUrl ?? null;
+          toolContext?.runContext?.agentConfiguration?.pictureUrl ?? null;
 
         let mentions: { configurationId: string }[] = [];
         if (params.agentName) {
@@ -1146,7 +1145,7 @@ export function createProjectManagerTools(
     list_conversations: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod: params.dustPod,
         });
         if (contextRes.isErr()) {
@@ -1294,7 +1293,7 @@ export function createProjectManagerTools(
     add_message_to_conversation: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getWritablePodContext(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod: params.dustPod,
         });
         if (contextRes.isErr()) {
@@ -1306,8 +1305,7 @@ export function createProjectManagerTools(
         const owner = auth.getNonNullableWorkspace();
 
         const conversationId =
-          params.conversationId ??
-          agentLoopContext?.runContext?.conversation?.sId;
+          params.conversationId ?? toolContext?.runContext?.conversation?.sId;
 
         if (!conversationId) {
           return new Err(
@@ -1343,8 +1341,8 @@ export function createProjectManagerTools(
         let origin: UserMessageOrigin = "web";
         let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-        if (agentLoopContext?.runContext?.conversation?.content) {
-          const userMessage = agentLoopContext.runContext.conversation.content
+        if (toolContext?.runContext?.conversation?.content) {
+          const userMessage = toolContext.runContext.conversation.content
             .flat()
             .findLast(isUserMessageType);
           if (userMessage?.context) {
@@ -1354,9 +1352,9 @@ export function createProjectManagerTools(
         }
 
         const agentName =
-          agentLoopContext?.runContext?.agentConfiguration?.name ?? "Agent";
+          toolContext?.runContext?.agentConfiguration?.name ?? "Agent";
         const agentProfilePictureUrl =
-          agentLoopContext?.runContext?.agentConfiguration?.pictureUrl ?? null;
+          toolContext?.runContext?.agentConfiguration?.pictureUrl ?? null;
 
         let mentions: { configurationId: string }[] = [];
         if (params.agentName) {

--- a/front/lib/api/actions/servers/pod_tasks/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { POD_TASKS_SERVER_NAME } from "@app/lib/api/actions/servers/pod_tasks/metadata";
 import { createProjectTasksTools } from "@app/lib/api/actions/servers/pod_tasks/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,13 +8,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(POD_TASKS_SERVER_NAME);
 
-  const tools = createProjectTasksTools(auth, agentLoopContext);
+  const tools = createProjectTasksTools(auth, toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: POD_TASKS_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/pod_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/tools/index.ts
@@ -4,7 +4,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   getPod,
   withErrorHandling,
@@ -201,7 +201,7 @@ function formatTaskListingLine(row: ProjectTaskResource): string {
 
 export function createProjectTasksTools(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): ToolDefinition[] {
   const owner = auth.getNonNullableWorkspace();
   const handlers: ToolHandlers<typeof POD_TASKS_TOOLS_METADATA> = {
@@ -213,7 +213,7 @@ export function createProjectTasksTools(
     }) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod,
         });
         if (contextRes.isErr()) {
@@ -285,7 +285,7 @@ export function createProjectTasksTools(
     [CREATE_TASKS_TOOL_NAME]: async ({ creatorType, tasks, dustPod }) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod,
         });
         if (contextRes.isErr()) {
@@ -300,7 +300,7 @@ export function createProjectTasksTools(
 
         const currentUser = auth.getNonNullableUser();
         const agentConfigId =
-          agentLoopContext?.runContext?.agentConfiguration?.sId ?? null;
+          toolContext?.runContext?.agentConfiguration?.sId ?? null;
 
         const created: string[] = [];
         const errors: string[] = [];
@@ -341,7 +341,7 @@ export function createProjectTasksTools(
 
           // Record the conversation where the task was created as a source so
           // it surfaces in the kickoff prompt when the task is started.
-          const sourceConversation = agentLoopContext?.runContext?.conversation;
+          const sourceConversation = toolContext?.runContext?.conversation;
           if (sourceConversation) {
             await row.upsertSource(auth, {
               itemId: sourceConversation.sId,
@@ -385,7 +385,7 @@ export function createProjectTasksTools(
     [UPDATE_TASKS_TOOL_NAME]: async ({ tasks, dustPod }) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod,
         });
         if (contextRes.isErr()) {
@@ -394,7 +394,7 @@ export function createProjectTasksTools(
         const { pod } = contextRes.value;
 
         const agentConfigId =
-          agentLoopContext?.runContext?.agentConfiguration?.sId ?? null;
+          toolContext?.runContext?.agentConfiguration?.sId ?? null;
 
         const updated: string[] = [];
         const errors: string[] = [];
@@ -451,7 +451,7 @@ export function createProjectTasksTools(
     }) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
-          agentLoopContext,
+          toolContext,
           dustPod,
         });
         if (contextRes.isErr()) {

--- a/front/lib/api/actions/servers/poke/index.ts
+++ b/front/lib/api/actions/servers/poke/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/poke/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("poke");
 
@@ -32,7 +32,7 @@ function createServer(
   }
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "poke",
     });
   }

--- a/front/lib/api/actions/servers/poke/tools/index.test.ts
+++ b/front/lib/api/actions/servers/poke/tools/index.test.ts
@@ -15,11 +15,11 @@ function getToolByName(name: string) {
   return tool;
 }
 
-function createTestExtra(auth: Authenticator, agentLoopContext?: unknown) {
+function createTestExtra(auth: Authenticator, toolContext?: unknown) {
   return {
     signal: new AbortController().signal,
     auth,
-    agentLoopContext,
+    toolContext,
   } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
 }
 

--- a/front/lib/api/actions/servers/primitive_types_debugger/index.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/primitive_types_debugger/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("primitive_types_debugger");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "primitive_types_debugger",
     });
   }

--- a/front/lib/api/actions/servers/productboard/index.ts
+++ b/front/lib/api/actions/servers/productboard/index.ts
@@ -1,19 +1,19 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createProductboardTools } from "@app/lib/api/actions/servers/productboard/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("productboard");
 
   const tools = createProductboardTools();
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "productboard",
     });
   }

--- a/front/lib/api/actions/servers/query_tables_v2/index.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TABLE_QUERY_V2_SERVER_NAME } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/query_tables_v2/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(TABLE_QUERY_V2_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: TABLE_QUERY_V2_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
@@ -236,14 +236,14 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
 
   [EXECUTE_DATABASE_QUERY_TOOL_NAME]: async (
     { tables, query, fileName },
-    { auth, agentLoopContext }
+    { auth, toolContext }
   ) => {
     // TODO(mcp): @fontanierh: we should not have a strict dependency on the agentLoopRunContext.
-    if (!agentLoopContext?.runContext) {
+    if (!toolContext?.runContext) {
       throw new Error("Unreachable: missing agentLoopContext.");
     }
 
-    const agentLoopRunContext = agentLoopContext.runContext;
+    const agentLoopRunContext = toolContext.runContext;
 
     const resolvedRes = await resolveTableConfigurations(auth, tables);
     if (resolvedRes.isErr()) {

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -21,7 +21,7 @@ import {
 } from "@app/lib/actions/tool_interruptions";
 import type {
   ActionGeneratedFileType,
-  AgentLoopContextType,
+  ToolContextType,
 } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
@@ -172,7 +172,7 @@ const runAgent = async (
   },
   {
     auth,
-    agentLoopContext,
+    toolContext,
     sendNotification,
     _meta,
     signal,
@@ -180,7 +180,7 @@ const runAgent = async (
     childAgentBlob,
   }: {
     auth: Authenticator;
-    agentLoopContext?: AgentLoopContextType;
+    toolContext?: ToolContextType;
     sendNotification?: (
       notification: MCPProgressNotificationType
     ) => Promise<void>;
@@ -191,7 +191,7 @@ const runAgent = async (
   }
 ): Promise<ToolHandlerResult> => {
   assert(
-    agentLoopContext?.runContext,
+    toolContext?.runContext,
     "agentLoopContext is required to run the run_agent tool"
   );
 
@@ -222,7 +222,7 @@ const runAgent = async (
   }
 
   const { agentConfiguration: mainAgent, conversation: mainConversation } =
-    agentLoopContext.runContext;
+    toolContext.runContext;
 
   const parsedChildAgentIdRes = parseAgentConfigurationUri(uri);
   if (parsedChildAgentIdRes.isErr()) {
@@ -261,8 +261,7 @@ const runAgent = async (
     logger
   );
 
-  const instructions =
-    agentLoopContext.runContext.agentConfiguration.instructions;
+  const instructions = toolContext.runContext.agentConfiguration.instructions;
 
   // Store the query resource early so the UI can show it immediately while the child
   // conversation is being created. A second store fires below once conversationId and
@@ -300,7 +299,7 @@ const runAgent = async (
   const convRes = await getOrCreateConversation(
     api,
     auth,
-    agentLoopContext.runContext,
+    toolContext.runContext,
     {
       childAgentBlob,
       childAgentId: parsedChildAgentId,
@@ -313,7 +312,7 @@ const runAgent = async (
       fileOrContentFragmentIds: fileOrContentFragmentIds ?? null,
       filePaths: filePaths ?? null,
       conversationId: isHandoff ? mainConversation.sId : null,
-      originMessage: agentLoopContext.runContext.agentMessage,
+      originMessage: toolContext.runContext.agentMessage,
     }
   );
 
@@ -505,7 +504,7 @@ const runAgent = async (
       conversationId,
       config.getAppUrl()
     );
-    const { citationsOffset } = agentLoopContext.runContext.stepContext;
+    const { citationsOffset } = toolContext.runContext.stepContext;
 
     const refs = getRefs().slice(
       citationsOffset,
@@ -754,17 +753,15 @@ const runAgent = async (
   );
 };
 
-function isRunAgentHandoffMode(
-  agentLoopContext?: AgentLoopContextType
-): boolean {
-  if (!agentLoopContext) {
+function isRunAgentHandoffMode(toolContext?: ToolContextType): boolean {
+  if (!toolContext) {
     return false;
   }
 
   // Check if we're in the listToolsContext (when presenting tools to the model).
-  if (agentLoopContext.listToolsContext) {
+  if (toolContext.listToolsContext) {
     const agentActionConfig =
-      agentLoopContext.listToolsContext.agentActionConfiguration;
+      toolContext.listToolsContext.agentActionConfiguration;
     if (
       isServerSideMCPServerConfiguration(agentActionConfig) &&
       agentActionConfig.additionalConfiguration?.executionMode
@@ -776,8 +773,8 @@ function isRunAgentHandoffMode(
   }
 
   // Check if we're in the runContext (when executing the tool).
-  if (agentLoopContext.runContext) {
-    const toolConfig = agentLoopContext.runContext.toolConfiguration;
+  if (toolContext.runContext) {
+    const toolConfig = toolContext.runContext.toolConfiguration;
     if (
       isLightServerSideMCPToolConfiguration(toolConfig) &&
       toolConfig.additionalConfiguration?.executionMode
@@ -845,31 +842,31 @@ async function leakyGetAgentNameAndDescriptionForChildAgent(
 
 async function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("run_agent");
 
   let childAgentId: string | null = null;
 
   if (
-    agentLoopContext?.listToolsContext &&
+    toolContext?.listToolsContext &&
     isServerSideMCPServerConfiguration(
-      agentLoopContext.listToolsContext.agentActionConfiguration
+      toolContext.listToolsContext.agentActionConfiguration
     ) &&
-    agentLoopContext.listToolsContext.agentActionConfiguration.childAgentId
+    toolContext.listToolsContext.agentActionConfiguration.childAgentId
   ) {
     childAgentId =
-      agentLoopContext.listToolsContext.agentActionConfiguration.childAgentId;
+      toolContext.listToolsContext.agentActionConfiguration.childAgentId;
   }
 
   if (
-    agentLoopContext?.runContext &&
+    toolContext?.runContext &&
     isLightServerSideMCPToolConfiguration(
-      agentLoopContext.runContext.toolConfiguration
+      toolContext.runContext.toolConfiguration
     ) &&
-    agentLoopContext.runContext.toolConfiguration.childAgentId
+    toolContext.runContext.toolConfiguration.childAgentId
   ) {
-    childAgentId = agentLoopContext.runContext.toolConfiguration.childAgentId;
+    childAgentId = toolContext.runContext.toolConfiguration.childAgentId;
   }
 
   let childAgentBlob: ChildAgentBlob | null = null;
@@ -885,7 +882,7 @@ async function createServer(
   if (!childAgentBlob) {
     registerTool(
       auth,
-      agentLoopContext,
+      toolContext,
       server,
       {
         name: "run_agent_tool_not_available",
@@ -908,7 +905,7 @@ async function createServer(
     return server;
   }
 
-  const isHandoffConfiguration = isRunAgentHandoffMode(agentLoopContext);
+  const isHandoffConfiguration = isRunAgentHandoffMode(toolContext);
 
   const toolName = `run_${childAgentBlob.name}`;
   const mentionChild = serializeMention({
@@ -952,13 +949,13 @@ async function createServer(
       runAgent(params, {
         ...extra,
         auth,
-        agentLoopContext,
+        toolContext,
         toolName,
         childAgentBlob,
       }),
   } as unknown as ToolDefinition;
 
-  registerTool(auth, agentLoopContext, server, toolDefinition, {
+  registerTool(auth, toolContext, server, toolDefinition, {
     monitoringName: RUN_AGENT_PLACEHOLDER_TOOL_NAME,
   });
 

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -7,7 +7,7 @@ import type {
 import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfigurationWithName,
   isServerSideMCPServerConfigurationWithName,
@@ -48,14 +48,14 @@ import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
  */
 export default async function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("run_dust_app");
   const owner = auth.getNonNullableWorkspace();
 
-  if (agentLoopContext?.listToolsContext) {
+  if (toolContext?.listToolsContext) {
     // Context: Listing tools for an agent
-    const { agentActionConfiguration } = agentLoopContext.listToolsContext;
+    const { agentActionConfiguration } = toolContext.listToolsContext;
     if (
       !isServerSideMCPServerConfigurationWithName(
         agentActionConfiguration,
@@ -93,12 +93,12 @@ export default async function createServer(
       },
     };
 
-    registerTool(auth, agentLoopContext, server, toolDefinition, {
+    registerTool(auth, toolContext, server, toolDefinition, {
       monitoringName: "run_dust_app",
     });
-  } else if (agentLoopContext?.runContext) {
+  } else if (toolContext?.runContext) {
     // Context: Running the Dust app
-    const { toolConfiguration } = agentLoopContext.runContext;
+    const { toolConfiguration } = toolContext.runContext;
     if (
       !isLightServerSideMCPToolConfigurationWithName(
         toolConfiguration,
@@ -138,7 +138,7 @@ export default async function createServer(
         const preparedParams = await prepareParamsWithHistory(
           params,
           schema,
-          agentLoopContext.runContext,
+          toolContext.runContext,
           auth
         );
 
@@ -203,12 +203,12 @@ export default async function createServer(
 
         if (
           containsFileOutput(sanitizedOutput) &&
-          agentLoopContext.runContext?.conversation
+          toolContext.runContext?.conversation
         ) {
           const fileContentResult = await processDustFileOutput(
             auth,
             sanitizedOutput,
-            agentLoopContext.runContext.conversation,
+            toolContext.runContext.conversation,
             app.name
           );
           if (fileContentResult.isErr()) {
@@ -226,7 +226,7 @@ export default async function createServer(
       },
     };
 
-    registerTool(auth, agentLoopContext, server, toolDefinition, {
+    registerTool(auth, toolContext, server, toolDefinition, {
       monitoringName: "run_dust_app",
     });
   } else {
@@ -254,7 +254,7 @@ export default async function createServer(
       },
     };
 
-    registerTool(auth, agentLoopContext, server, toolDefinition, {
+    registerTool(auth, toolContext, server, toolDefinition, {
       monitoringName: "run_dust_app",
     });
   }

--- a/front/lib/api/actions/servers/salesforce/index.ts
+++ b/front/lib/api/actions/servers/salesforce/index.ts
@@ -1,19 +1,19 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createSalesforceTools } from "@app/lib/api/actions/servers/salesforce/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("salesforce");
 
   const tools = createSalesforceTools(auth);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "salesforce",
     });
   }

--- a/front/lib/api/actions/servers/salesloft/index.ts
+++ b/front/lib/api/actions/servers/salesloft/index.ts
@@ -1,19 +1,19 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createSalesloftTools } from "@app/lib/api/actions/servers/salesloft/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("salesloft");
 
-  const tools = createSalesloftTools(auth, agentLoopContext);
+  const tools = createSalesloftTools(auth, toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "salesloft",
     });
   }

--- a/front/lib/api/actions/servers/salesloft/tools/index.ts
+++ b/front/lib/api/actions/servers/salesloft/tools/index.ts
@@ -4,7 +4,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   formatActionAsString,
   getActionsWithDetails,
@@ -16,7 +16,7 @@ import { Err, Ok } from "@app/types/shared/result";
 
 export function createSalesloftTools(
   auth: Authenticator,
-  _agentLoopContext?: AgentLoopContextType
+  _toolContext?: ToolContextType
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof SALESLOFT_TOOLS_METADATA> = {
     get_actions: async ({ include_due_actions_only }, extra) => {

--- a/front/lib/api/actions/servers/sandbox/index.ts
+++ b/front/lib/api/actions/servers/sandbox/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { createSandboxTools } from "@app/lib/api/actions/servers/sandbox/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,13 +8,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 async function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("sandbox");
 
-  const tools = await createSandboxTools(auth, agentLoopContext);
+  const tools = await createSandboxTools(auth, toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: SANDBOX_TOOL_NAME,
     });
   }

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -234,7 +234,7 @@ describe("runSandboxBashTool", () => {
           sId: "workspace-id",
         }),
       },
-      agentLoopContext: {
+      toolContext: {
         runContext: {
           agentConfiguration: {
             model: { providerId: "openai" },
@@ -670,7 +670,7 @@ describe("runSandboxBashTool", () => {
   describe("resume mode", () => {
     function resumeStepContext(execId: string) {
       return {
-        agentLoopContext: {
+        toolContext: {
           runContext: {
             agentConfiguration: {
               model: { providerId: "openai" },
@@ -781,7 +781,7 @@ describe("addEgressDomainTool", () => {
           },
         }),
       },
-      agentLoopContext: {
+      toolContext: {
         runContext: {
           conversation: { sId: "conversation-id" },
         },
@@ -934,7 +934,7 @@ describe("addEgressDomainTool", () => {
             sId: "workspace-id",
           }),
         },
-        agentLoopContext: undefined,
+        toolContext: undefined,
         signal: new AbortController().signal,
       } as never
     );

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -7,7 +7,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { isSandboxResumeState } from "@app/lib/actions/types";
 import {
   SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS,
@@ -222,13 +222,13 @@ function isSandboxAgentEgressRequestsAllowed(auth: Authenticator): boolean {
 
 export async function createSandboxTools(
   auth: Authenticator,
-  _agentLoopContext?: AgentLoopContextType
+  _toolContext?: ToolContextType
 ): Promise<ToolDefinition[]> {
   const handlers: ToolHandlers<typeof SANDBOX_TOOLS_METADATA> = {
     bash: runSandboxBashTool,
-    describe_toolset: async ({ format }, { auth, agentLoopContext }) => {
+    describe_toolset: async ({ format }, { auth, toolContext }) => {
       const providerId =
-        agentLoopContext?.runContext?.agentConfiguration.model.providerId;
+        toolContext?.runContext?.agentConfiguration.model.providerId;
       if (!providerId) {
         return new Err(new MCPError("Missing model provider ID"));
       }
@@ -285,7 +285,7 @@ export async function runSandboxBashTool(
     timeoutMs?: number;
     workingDirectory?: string;
   },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<
   Result<
     Array<
@@ -298,7 +298,7 @@ export async function runSandboxBashTool(
     MCPError
   >
 > {
-  const runContext = agentLoopContext?.runContext;
+  const runContext = toolContext?.runContext;
   if (!runContext) {
     return new Err(new MCPError("No conversation context available."));
   }
@@ -482,7 +482,7 @@ export async function runSandboxBashTool(
 
 export async function addEgressDomainTool(
   { domain, reason }: { domain: string; reason: string },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<Result<Array<{ type: "text"; text: string }>, MCPError>> {
   // Defense-in-depth: createSandboxTools already filters this tool out when
   // the workspace setting is off, so this metadata-only check is enough to
@@ -495,7 +495,7 @@ export async function addEgressDomainTool(
     );
   }
 
-  const conversation = agentLoopContext?.runContext?.conversation;
+  const conversation = toolContext?.runContext?.conversation;
   if (!conversation) {
     return new Err(new MCPError("No conversation context available."));
   }

--- a/front/lib/api/actions/servers/sandbox_functions/index.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/sandbox_functions/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(SANDBOX_FUNCTIONS_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: SANDBOX_FUNCTIONS_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
@@ -10,9 +10,9 @@ import { Err, Ok } from "@app/types/shared/result";
 
 export async function callHandler(
   { slug, input }: { slug: string; input?: Record<string, unknown> },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { agentLoopContext });
+  const podResult = await getPod(auth, { toolContext });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
@@ -17,9 +17,9 @@ export function formatSandboxFunction(fn: SandboxFunctionResource): string {
 
 export async function getHandler(
   { slug }: { slug: string },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { agentLoopContext });
+  const podResult = await getPod(auth, { toolContext });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
@@ -23,9 +23,9 @@ export function formatSandboxFunctionsList(
 
 export async function listHandler(
   _params: Record<string, never>,
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { agentLoopContext });
+  const podResult = await getPod(auth, { toolContext });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -19,9 +19,11 @@ export async function publishHandler(
     path: string;
     slug: string;
   },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getWritablePodContext(auth, { agentLoopContext });
+  const podResult = await getWritablePodContext(auth, {
+    toolContext,
+  });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/schedules_management/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/index.ts
@@ -1,20 +1,20 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createSchedulesManagementTools } from "@app/lib/api/actions/servers/schedules_management/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("schedules_management");
 
-  const tools = createSchedulesManagementTools(auth, agentLoopContext);
+  const tools = createSchedulesManagementTools(auth, toolContext);
 
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "schedules_management",
     });
   }

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -1,7 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { SCHEDULES_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/schedules_management/metadata";
 import { generateScheduleRule } from "@app/lib/api/assistant/configuration/triggers";
 import type { Authenticator } from "@app/lib/auth";
@@ -31,10 +31,8 @@ function renderSchedule(schedule: ScheduleTriggerType): string {
   return lines.join("\n");
 }
 
-function getUserTimezone(
-  agentLoopContext?: AgentLoopContextType
-): string | null {
-  const content = agentLoopContext?.runContext?.conversation?.content;
+function getUserTimezone(toolContext?: ToolContextType): string | null {
+  const content = toolContext?.runContext?.conversation?.content;
   if (!content) {
     return null;
   }
@@ -45,21 +43,21 @@ function getUserTimezone(
 
 export function createSchedulesManagementTools(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ) {
   const handlers: ToolHandlers<typeof SCHEDULES_MANAGEMENT_TOOLS_METADATA> = {
     create_schedule: async ({ name, schedule, prompt, timezone }) => {
       const owner = auth.getNonNullableWorkspace();
       const user = auth.getNonNullableUser();
 
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         logger.error("Agent context missing");
         return new Err(new MCPError("Agent context is required"));
       }
 
-      const { agentConfiguration } = agentLoopContext.runContext;
+      const { agentConfiguration } = toolContext.runContext;
 
-      const resolvedTimezone = timezone ?? getUserTimezone(agentLoopContext);
+      const resolvedTimezone = timezone ?? getUserTimezone(toolContext);
 
       if (!resolvedTimezone) {
         logger.error("resolved timezone missing");
@@ -147,11 +145,11 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
 
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         return new Err(new MCPError("Agent context is required"));
       }
 
-      const { agentConfiguration } = agentLoopContext.runContext;
+      const { agentConfiguration } = toolContext.runContext;
 
       const schedulesResult =
         await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
@@ -197,11 +195,11 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
 
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         return new Err(new MCPError("Agent context is required"));
       }
 
-      const { agentConfiguration } = agentLoopContext.runContext;
+      const { agentConfiguration } = toolContext.runContext;
 
       const triggersResult =
         await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {

--- a/front/lib/api/actions/servers/search/index.ts
+++ b/front/lib/api/actions/servers/search/index.ts
@@ -1,7 +1,7 @@
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   SEARCH_SERVER,
   SEARCH_SERVER_NAME,
@@ -15,16 +15,16 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(SEARCH_SERVER_NAME);
 
-  const areTagsDynamic = agentLoopContext
-    ? shouldAutoGenerateTags(agentLoopContext)
+  const areTagsDynamic = toolContext
+    ? shouldAutoGenerateTags(toolContext)
     : false;
 
   for (const tool of areTagsDynamic ? TOOLS_WITH_TAGS : TOOLS_WITHOUT_TAGS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: SEARCH_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/search/tools/index.ts
+++ b/front/lib/api/actions/servers/search/tools/index.ts
@@ -8,7 +8,7 @@ import {
   applyNodeIdsFilterToCoreSearchArgs,
   getCoreSearchArgs,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type { AgentLoopContextType, StepContext } from "@app/lib/actions/types";
+import type { StepContext, ToolContextType } from "@app/lib/actions/types";
 import {
   SEARCH_TOOL_METADATA_WITH_TAGS,
   SEARCH_TOOL_NAME,
@@ -43,7 +43,7 @@ export async function searchFunction(
     nodeIds,
     tagsIn,
     tagsNot,
-    agentLoopContext,
+    toolContext,
     stepContext,
   }: {
     query: string;
@@ -53,7 +53,7 @@ export async function searchFunction(
     nodeIds?: string[];
     tagsIn?: string[];
     tagsNot?: string[];
-    agentLoopContext?: AgentLoopContextType;
+    toolContext?: ToolContextType;
     stepContext?: StepContext;
   }
 ): Promise<Result<CallToolResult["content"], MCPError>> {
@@ -62,14 +62,14 @@ export async function searchFunction(
   const credentials = await getLlmCredentials(auth);
   const timeFrame = parseTimeFrame(relativeTimeFrame);
 
-  if (!agentLoopContext?.runContext?.stepContext && !stepContext) {
+  if (!toolContext?.runContext?.stepContext && !stepContext) {
     throw new Error(
       "agentLoopRunContext.stepContext or stepContext is required where the tool is called."
     );
   }
 
   const { retrievalTopK, citationsOffset } =
-    agentLoopContext?.runContext?.stepContext ?? stepContext!;
+    toolContext?.runContext?.stepContext ?? stepContext!;
 
   // Get the core search args for each data source, fail if any of them are invalid.
   const coreSearchArgsResults = await getCoreSearchArgs(auth, dataSources);
@@ -196,11 +196,11 @@ export async function searchFunction(
 }
 
 const handlers: ToolHandlers<typeof SEARCH_TOOLS_METADATA> = {
-  [SEARCH_TOOL_NAME]: (params, { auth, agentLoopContext }) =>
+  [SEARCH_TOOL_NAME]: (params, { auth, toolContext }) =>
     searchFunction(auth, {
       ...params,
       relativeTimeFrame: params.relativeTimeFrame ?? "all",
-      agentLoopContext,
+      toolContext,
     }),
 };
 

--- a/front/lib/api/actions/servers/skill_authoring/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { SKILL_AUTHORING_SERVER_NAME } from "@app/lib/api/actions/servers/skill_authoring/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/skill_authoring/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(SKILL_AUTHORING_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: SKILL_AUTHORING_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/skill_management/index.ts
+++ b/front/lib/api/actions/servers/skill_management/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/skill_management/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("skill_management");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "skill_management",
     });
   }

--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -108,7 +108,7 @@ describe("skill_management enable_skill tool", () => {
   } = {}) {
     return {
       auth,
-      agentLoopContext: {
+      toolContext: {
         runContext: {
           agentConfiguration,
           agentMessage,

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -95,16 +95,13 @@ async function findAvailableSkillForAgentLoop({
 }
 
 const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
-  [ENABLE_SKILL_TOOL_NAME]: async (
-    { skillName },
-    { auth, agentLoopContext }
-  ) => {
-    if (!agentLoopContext?.runContext) {
+  [ENABLE_SKILL_TOOL_NAME]: async ({ skillName }, { auth, toolContext }) => {
+    if (!toolContext?.runContext) {
       return new Err(new MCPError("No conversation context available"));
     }
 
     const { agentConfiguration, agentMessage, conversation, userMessage } =
-      agentLoopContext.runContext;
+      toolContext.runContext;
 
     const agentLoopData = {
       agentConfiguration,

--- a/front/lib/api/actions/servers/slab/index.ts
+++ b/front/lib/api/actions/servers/slab/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/slab/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("slab");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "slab",
     });
   }

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -1,6 +1,6 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   formatSlackMessageForLLM,
   renderFormattedMessage,
@@ -749,7 +749,7 @@ export async function executeListPublicChannels(
 
 export async function executePostMessage(
   auth: Authenticator,
-  agentLoopContext: AgentLoopContextType,
+  toolContext: ToolContextType,
   {
     accessToken,
     to,
@@ -794,10 +794,10 @@ export async function executePostMessage(
     const agentUrl = getConversationRoute(
       auth.getNonNullableWorkspace().sId,
       "new",
-      `agentDetails=${agentLoopContext.runContext?.agentConfiguration.sId}`,
+      `agentDetails=${toolContext.runContext?.agentConfiguration.sId}`,
       config.getAppUrl()
     );
-    message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentLoopContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
+    message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${toolContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
   } else {
     message = slackifyMarkdown(originalMessage);
   }
@@ -811,7 +811,7 @@ export async function executePostMessage(
     const fileResult = await getFileFromConversationAttachment(
       auth,
       fileId,
-      agentLoopContext
+      toolContext
     );
     if (fileResult.isErr()) {
       return new Err(
@@ -921,7 +921,7 @@ export async function executeUpdateMessage({
 
 export async function executeScheduleMessage(
   auth: Authenticator,
-  agentLoopContext: AgentLoopContextType,
+  toolContext: ToolContextType,
   {
     accessToken,
     to,
@@ -949,10 +949,10 @@ export async function executeScheduleMessage(
     const agentUrl = getConversationRoute(
       auth.getNonNullableWorkspace().sId,
       "new",
-      `agentDetails=${agentLoopContext.runContext?.agentConfiguration.sId}`,
+      `agentDetails=${toolContext.runContext?.agentConfiguration.sId}`,
       config.getAppUrl()
     );
-    message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentLoopContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
+    message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${toolContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
   } else {
     message = slackifyMarkdown(originalMessage);
   }

--- a/front/lib/api/actions/servers/slack_bot/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createSlackBotTools } from "@app/lib/api/actions/servers/slack_bot/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -8,13 +8,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 async function createServer(
   auth: Authenticator,
   mcpServerId: string,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("slack_bot");
 
-  const tools = createSlackBotTools(auth, mcpServerId, agentLoopContext);
+  const tools = createSlackBotTools(auth, mcpServerId, toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "slack_bot",
     });
   }

--- a/front/lib/api/actions/servers/slack_bot/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/tools/index.ts
@@ -4,7 +4,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   executeListPublicChannels,
   executePostMessage,
@@ -20,7 +20,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 export function createSlackBotTools(
   auth: Authenticator,
   mcpServerId: string,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof SLACK_BOT_TOOLS_METADATA> = {
     post_message: async (
@@ -32,12 +32,12 @@ export function createSlackBotTools(
         return new Err(new MCPError("Access token not found"));
       }
 
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         return new Err(new MCPError("Issue with agent context"));
       }
 
       try {
-        return await executePostMessage(auth, agentLoopContext, {
+        return await executePostMessage(auth, toolContext, {
           to,
           message,
           threadTs,

--- a/front/lib/api/actions/servers/slack_personal/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -18,7 +18,7 @@ const localLogger = logger.child({ module: "mcp_slack_personal" });
 async function createServer(
   auth: Authenticator,
   mcpServerId: string,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("slack");
 
@@ -38,26 +38,26 @@ async function createServer(
   );
 
   const { searchMessagesTool, semanticSearchMessagesTool, commonTools } =
-    createSlackPersonalTools(auth, mcpServerId, agentLoopContext);
+    createSlackPersonalTools(auth, mcpServerId, toolContext);
 
   // Register search tool based on Slack AI status.
   // If we're not connected to Slack, we arbitrarily include the keyword search tool,
   // just so there is one in the list. As soon as we're connected, it will show the correct one.
   if (slackAIStatus === "disabled" || slackAIStatus === "disconnected") {
-    registerTool(auth, agentLoopContext, server, searchMessagesTool, {
+    registerTool(auth, toolContext, server, searchMessagesTool, {
       monitoringName: SLACK_TOOL_LOG_NAME,
     });
   }
 
   if (slackAIStatus === "enabled") {
-    registerTool(auth, agentLoopContext, server, semanticSearchMessagesTool, {
+    registerTool(auth, toolContext, server, semanticSearchMessagesTool, {
       monitoringName: SLACK_TOOL_LOG_NAME,
     });
   }
 
   // Register all common tools.
   for (const tool of commonTools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: SLACK_TOOL_LOG_NAME,
     });
   }

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -7,7 +7,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { SLACK_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import {
   executeArchiveChannel,
@@ -367,7 +367,7 @@ export interface SlackPersonalToolsResult {
 export function createSlackPersonalTools(
   auth: Authenticator,
   mcpServerId: string,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): SlackPersonalToolsResult {
   const allowFooterRemoval =
     auth.workspace()?.metadata?.slackPersonalAllowFooterRemoval ?? false;
@@ -384,7 +384,7 @@ export function createSlackPersonalTools(
       },
       { authInfo }
     ) => {
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         return new Err(
           new MCPError("Unreachable: missing agentLoopRunContext.")
         );
@@ -446,7 +446,7 @@ export function createSlackPersonalTools(
           ]);
         }
 
-        const { citationsOffset } = agentLoopContext.runContext.stepContext;
+        const { citationsOffset } = toolContext.runContext.stepContext;
 
         const refs = getRefs().slice(
           citationsOffset,
@@ -492,7 +492,7 @@ export function createSlackPersonalTools(
       },
       { authInfo }
     ) => {
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         return new Err(
           new MCPError("Unreachable: missing agentLoopRunContext.")
         );
@@ -522,7 +522,7 @@ export function createSlackPersonalTools(
           ]);
         }
 
-        const { citationsOffset } = agentLoopContext.runContext.stepContext;
+        const { citationsOffset } = toolContext.runContext.stepContext;
 
         const refs = getRefs().slice(
           citationsOffset,
@@ -574,14 +574,14 @@ export function createSlackPersonalTools(
         return new Err(new MCPError("Access token not found"));
       }
 
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         return new Err(
           new MCPError("Unreachable: missing agentLoopRunContext.")
         );
       }
 
       try {
-        return await executePostMessage(auth, agentLoopContext, {
+        return await executePostMessage(auth, toolContext, {
           to,
           message,
           threadTs,
@@ -619,14 +619,14 @@ export function createSlackPersonalTools(
         return new Err(new MCPError("Access token not found"));
       }
 
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         return new Err(
           new MCPError("Unreachable: missing agentLoopRunContext.")
         );
       }
 
       try {
-        return await executeScheduleMessage(auth, agentLoopContext, {
+        return await executeScheduleMessage(auth, toolContext, {
           to,
           message,
           post_at,
@@ -711,7 +711,7 @@ export function createSlackPersonalTools(
     },
 
     list_messages: async ({ channel, relativeTimeFrame }, { authInfo }) => {
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         return new Err(
           new MCPError("Unreachable: missing agentLoopRunContext.")
         );
@@ -803,7 +803,7 @@ export function createSlackPersonalTools(
         accessToken,
       });
 
-      const { citationsOffset } = agentLoopContext.runContext.stepContext;
+      const { citationsOffset } = toolContext.runContext.stepContext;
 
       const refs = getRefs().slice(
         citationsOffset,

--- a/front/lib/api/actions/servers/snowflake/index.ts
+++ b/front/lib/api/actions/servers/snowflake/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/snowflake/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("snowflake");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "snowflake",
     });
   }

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -1,7 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { SnowflakeClient } from "@app/lib/api/actions/servers/snowflake/client";
 import {
   MAX_QUERY_ROWS,
@@ -32,14 +32,14 @@ interface SnowflakeQueryTagMetadata {
 // Builds Snowflake query tag for agent-level usage tracking.
 // Enables customers to track query costs per agent in QUERY_HISTORY.
 function buildQueryTagMetadata(
-  agentLoopContext?: AgentLoopContextType,
+  toolContext?: ToolContextType,
   auth?: Authenticator
 ): string | undefined {
-  if (!agentLoopContext?.runContext || !auth) {
+  if (!toolContext?.runContext || !auth) {
     return undefined;
   }
 
-  const { agentConfiguration, conversation } = agentLoopContext.runContext;
+  const { agentConfiguration, conversation } = toolContext.runContext;
   const workspace = auth.getNonNullableWorkspace();
   const user = auth.user();
 
@@ -63,10 +63,10 @@ async function getClientFromAuthInfo(
       }
     | null
     | undefined,
-  agentLoopContext?: AgentLoopContextType,
+  toolContext?: ToolContextType,
   auth?: Authenticator
 ): Promise<Result<SnowflakeClient, MCPError>> {
-  const queryTagMetadata = buildQueryTagMetadata(agentLoopContext, auth);
+  const queryTagMetadata = buildQueryTagMetadata(toolContext, auth);
 
   const account = authInfo?.extra?.snowflake_account;
   const warehouse = authInfo?.extra?.snowflake_warehouse;
@@ -127,12 +127,8 @@ async function getClientFromAuthInfo(
 }
 
 const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
-  list_databases: async (_params, { authInfo, agentLoopContext, auth }) => {
-    const clientRes = await getClientFromAuthInfo(
-      authInfo,
-      agentLoopContext,
-      auth
-    );
+  list_databases: async (_params, { authInfo, toolContext, auth }) => {
+    const clientRes = await getClientFromAuthInfo(authInfo, toolContext, auth);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -155,12 +151,8 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     ]);
   },
 
-  list_schemas: async ({ database }, { authInfo, agentLoopContext, auth }) => {
-    const clientRes = await getClientFromAuthInfo(
-      authInfo,
-      agentLoopContext,
-      auth
-    );
+  list_schemas: async ({ database }, { authInfo, toolContext, auth }) => {
+    const clientRes = await getClientFromAuthInfo(authInfo, toolContext, auth);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -185,13 +177,9 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
   list_tables: async (
     { database, schema },
-    { authInfo, agentLoopContext, auth }
+    { authInfo, toolContext, auth }
   ) => {
-    const clientRes = await getClientFromAuthInfo(
-      authInfo,
-      agentLoopContext,
-      auth
-    );
+    const clientRes = await getClientFromAuthInfo(authInfo, toolContext, auth);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -216,13 +204,9 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
   describe_table: async (
     { database, schema, table },
-    { authInfo, agentLoopContext, auth }
+    { authInfo, toolContext, auth }
   ) => {
-    const clientRes = await getClientFromAuthInfo(
-      authInfo,
-      agentLoopContext,
-      auth
-    );
+    const clientRes = await getClientFromAuthInfo(authInfo, toolContext, auth);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -256,13 +240,9 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
   describe_semantic_view: async (
     { database, schema, semantic_view },
-    { authInfo, agentLoopContext, auth }
+    { authInfo, toolContext, auth }
   ) => {
-    const clientRes = await getClientFromAuthInfo(
-      authInfo,
-      agentLoopContext,
-      auth
-    );
+    const clientRes = await getClientFromAuthInfo(authInfo, toolContext, auth);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -295,13 +275,9 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
   query: async (
     { sql, database, schema, warehouse, max_rows },
-    { authInfo, agentLoopContext, auth }
+    { authInfo, toolContext, auth }
   ) => {
-    const clientRes = await getClientFromAuthInfo(
-      authInfo,
-      agentLoopContext,
-      auth
-    );
+    const clientRes = await getClientFromAuthInfo(authInfo, toolContext, auth);
     if (clientRes.isErr()) {
       return clientRes;
     }

--- a/front/lib/api/actions/servers/sound_studio/index.ts
+++ b/front/lib/api/actions/servers/sound_studio/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { SOUND_STUDIO_SERVER_NAME } from "@app/lib/api/actions/servers/sound_studio/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/sound_studio/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(SOUND_STUDIO_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: SOUND_STUDIO_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/speech_generator/index.ts
+++ b/front/lib/api/actions/servers/speech_generator/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { SPEECH_GENERATOR_SERVER_NAME } from "@app/lib/api/actions/servers/speech_generator/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/speech_generator/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(SPEECH_GENERATOR_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: SPEECH_GENERATOR_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/statuspage/index.ts
+++ b/front/lib/api/actions/servers/statuspage/index.ts
@@ -1,19 +1,19 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createStatuspageTools } from "@app/lib/api/actions/servers/statuspage/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("statuspage");
 
-  const tools = createStatuspageTools(auth, agentLoopContext);
+  const tools = createStatuspageTools(auth, toolContext);
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "statuspage",
     });
   }

--- a/front/lib/api/actions/servers/statuspage/tools/index.ts
+++ b/front/lib/api/actions/servers/statuspage/tools/index.ts
@@ -5,7 +5,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import type { StatuspageClient } from "@app/lib/api/actions/servers/statuspage/client";
 import { getStatuspageClient } from "@app/lib/api/actions/servers/statuspage/client";
 import { STATUSPAGE_TOOLS_METADATA } from "@app/lib/api/actions/servers/statuspage/metadata";
@@ -32,7 +32,7 @@ async function withClient(
 
 export function createStatuspageTools(
   _auth: Authenticator,
-  _agentLoopContext?: AgentLoopContextType
+  _toolContext?: ToolContextType
 ) {
   const handlers: ToolHandlers<typeof STATUSPAGE_TOOLS_METADATA> = {
     list_pages: async (_params, extra: ToolHandlerExtra) => {

--- a/front/lib/api/actions/servers/toolsets/index.ts
+++ b/front/lib/api/actions/servers/toolsets/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/toolsets/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("toolsets");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "toolsets",
     });
   }

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -20,9 +20,9 @@ import { getHeaderFromUserEmail } from "@app/types/user";
 import { DustAPI, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
-  list: async (_, { auth, agentLoopContext }) => {
+  list: async (_, { auth, toolContext }) => {
     const mcpServerViewIdsFromAgentConfiguration =
-      agentLoopContext?.runContext?.agentConfiguration.actions
+      toolContext?.runContext?.agentConfiguration.actions
         .filter(isServerSideMCPServerConfiguration)
         .map((action) => action.mcpServerViewId) ?? [];
 
@@ -75,8 +75,8 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
     );
   },
 
-  enable: async ({ toolsetId }, { auth, agentLoopContext }) => {
-    const conversationId = agentLoopContext?.runContext?.conversation.sId;
+  enable: async ({ toolsetId }, { auth, toolContext }) => {
+    const conversationId = toolContext?.runContext?.conversation.sId;
     if (!conversationId) {
       return new Err(
         new MCPError("No active conversation context", { tracked: false })
@@ -108,7 +108,7 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
     );
 
     const agentConfigurationId =
-      agentLoopContext?.runContext?.agentConfiguration.sId;
+      toolContext?.runContext?.agentConfiguration.sId;
 
     const res = await api.postConversationTools({
       conversationId,

--- a/front/lib/api/actions/servers/ukg_ready/index.ts
+++ b/front/lib/api/actions/servers/ukg_ready/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/ukg_ready/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("ukg_ready");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "ukg_ready",
     });
   }

--- a/front/lib/api/actions/servers/user_mentions/index.ts
+++ b/front/lib/api/actions/servers/user_mentions/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { USER_MENTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/user_mentions/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/user_mentions/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(USER_MENTIONS_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: USER_MENTIONS_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/user_mentions/tools/index.ts
+++ b/front/lib/api/actions/servers/user_mentions/tools/index.ts
@@ -17,7 +17,7 @@ import { DustAPI } from "@dust-tt/client";
 const handlers: ToolHandlers<typeof USER_MENTIONS_TOOLS_METADATA> = {
   [SEARCH_AVAILABLE_USERS_TOOL_NAME]: async (
     { searchTerm },
-    { auth, agentLoopContext }
+    { auth, toolContext }
   ) => {
     const user = auth.user();
     const prodCredentials = await prodAPICredentialsForOwner(
@@ -41,7 +41,7 @@ const handlers: ToolHandlers<typeof USER_MENTIONS_TOOLS_METADATA> = {
     const r = await api.getMentionsSuggestions({
       query: searchTerm,
       select: ["users"],
-      conversationId: agentLoopContext?.runContext?.conversation?.sId,
+      conversationId: toolContext?.runContext?.conversation?.sId,
     });
 
     if (r.isErr()) {

--- a/front/lib/api/actions/servers/val_town/helpers.ts
+++ b/front/lib/api/actions/servers/val_town/helpers.ts
@@ -1,4 +1,4 @@
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
@@ -20,9 +20,9 @@ export function isValTownError(error: unknown): error is ValTownError {
 
 export async function getValTownClient(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): Promise<ValTown | null> {
-  const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
+  const toolConfig = toolContext?.runContext?.toolConfiguration;
   if (
     !toolConfig ||
     !isLightServerSideMCPToolConfiguration(toolConfig) ||

--- a/front/lib/api/actions/servers/val_town/index.ts
+++ b/front/lib/api/actions/servers/val_town/index.ts
@@ -1,20 +1,20 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { createValTownTools } from "@app/lib/api/actions/servers/val_town/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("val_town");
 
-  const tools = createValTownTools(auth, agentLoopContext);
+  const tools = createValTownTools(auth, toolContext);
 
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "val_town",
     });
   }

--- a/front/lib/api/actions/servers/val_town/tools/index.ts
+++ b/front/lib/api/actions/servers/val_town/tools/index.ts
@@ -1,7 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   getValTownClient,
   isValTownError,
@@ -18,11 +18,11 @@ const API_KEY_NOT_CONFIGURED_ERROR =
 
 export function createValTownTools(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ) {
   const handlers: ToolHandlers<typeof VAL_TOWN_TOOLS_METADATA> = {
     create_val: async ({ name, privacy, description, orgId }) => {
-      const client = await getValTownClient(auth, agentLoopContext);
+      const client = await getValTownClient(auth, toolContext);
       if (!client) {
         return new Err(
           new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
@@ -64,7 +64,7 @@ export function createValTownTools(
     },
 
     get_val: async ({ valId }) => {
-      const client = await getValTownClient(auth, agentLoopContext);
+      const client = await getValTownClient(auth, toolContext);
       if (!client) {
         return new Err(
           new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
@@ -108,7 +108,7 @@ export function createValTownTools(
       user_id,
       list_only_user_vals = true,
     }) => {
-      const client = await getValTownClient(auth, agentLoopContext);
+      const client = await getValTownClient(auth, toolContext);
       if (!client) {
         return new Err(
           new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
@@ -165,7 +165,7 @@ export function createValTownTools(
     },
 
     search_vals: async ({ query, limit = 20, cursor, privacy }) => {
-      const client = await getValTownClient(auth, agentLoopContext);
+      const client = await getValTownClient(auth, toolContext);
       if (!client) {
         return new Err(
           new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
@@ -222,7 +222,7 @@ export function createValTownTools(
     },
 
     list_val_files: async ({ valId, path = "", limit, offset }) => {
-      const client = await getValTownClient(auth, agentLoopContext);
+      const client = await getValTownClient(auth, toolContext);
       if (!client) {
         return new Err(
           new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
@@ -285,7 +285,7 @@ export function createValTownTools(
     },
 
     get_file_content: async ({ valId, filePath }) => {
-      const client = await getValTownClient(auth, agentLoopContext);
+      const client = await getValTownClient(auth, toolContext);
       if (!client) {
         return new Err(
           new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
@@ -317,7 +317,7 @@ export function createValTownTools(
     },
 
     delete_file: async ({ valId, filePath }) => {
-      const client = await getValTownClient(auth, agentLoopContext);
+      const client = await getValTownClient(auth, toolContext);
       if (!client) {
         return new Err(
           new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
@@ -344,7 +344,7 @@ export function createValTownTools(
     },
 
     update_file_content: async ({ valId, filePath, content }) => {
-      const client = await getValTownClient(auth, agentLoopContext);
+      const client = await getValTownClient(auth, toolContext);
       if (!client) {
         return new Err(
           new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
@@ -380,7 +380,7 @@ export function createValTownTools(
       type,
       parent_path,
     }) => {
-      const client = await getValTownClient(auth, agentLoopContext);
+      const client = await getValTownClient(auth, toolContext);
       if (!client) {
         return new Err(
           new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
@@ -412,7 +412,7 @@ export function createValTownTools(
     },
 
     create_file: async ({ valId, filePath }) => {
-      const client = await getValTownClient(auth, agentLoopContext);
+      const client = await getValTownClient(auth, toolContext);
       if (!client) {
         return new Err(
           new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
@@ -440,7 +440,7 @@ export function createValTownTools(
     },
 
     call_http_endpoint: async ({ valId, filePath, body, method = "POST" }) => {
-      const client = await getValTownClient(auth, agentLoopContext);
+      const client = await getValTownClient(auth, toolContext);
       if (!client) {
         return new Err(
           new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })

--- a/front/lib/api/actions/servers/vanta/index.ts
+++ b/front/lib/api/actions/servers/vanta/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/vanta/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("vanta");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "vanta",
     });
   }

--- a/front/lib/api/actions/servers/wakeups/index.ts
+++ b/front/lib/api/actions/servers/wakeups/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { WAKEUPS_SERVER_NAME } from "@app/lib/api/actions/servers/wakeups/metadata";
 import { createWakeupsTools } from "@app/lib/api/actions/servers/wakeups/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,14 +8,14 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(WAKEUPS_SERVER_NAME);
 
-  const tools = createWakeupsTools(auth, agentLoopContext);
+  const tools = createWakeupsTools(auth, toolContext);
 
   for (const tool of tools) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: WAKEUPS_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/wakeups/tools/index.ts
+++ b/front/lib/api/actions/servers/wakeups/tools/index.ts
@@ -1,7 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { WAKEUPS_TOOLS_METADATA } from "@app/lib/api/actions/servers/wakeups/metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -88,10 +88,8 @@ function parseWhen(when: string):
   return null;
 }
 
-function getUserTimezone(
-  agentLoopContext?: AgentLoopContextType
-): string | null {
-  const content = agentLoopContext?.runContext?.conversation?.content;
+function getUserTimezone(toolContext?: ToolContextType): string | null {
+  const content = toolContext?.runContext?.conversation?.content;
   if (!content) {
     return null;
   }
@@ -121,11 +119,11 @@ function renderWakeUp(wakeUp: WakeUpType): string {
 
 export function createWakeupsTools(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ) {
   const handlers: ToolHandlers<typeof WAKEUPS_TOOLS_METADATA> = {
     schedule_wakeup: async ({ when, reason, timezone }) => {
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         return new Err(
           new MCPError(
             "Wake-ups can only be scheduled from within a conversation."
@@ -134,7 +132,7 @@ export function createWakeupsTools(
       }
 
       const { conversation: runConversation, agentConfiguration } =
-        agentLoopContext.runContext;
+        toolContext.runContext;
 
       const parsed = parseWhen(when);
       if (!parsed) {
@@ -167,7 +165,7 @@ export function createWakeupsTools(
 
       let cronTimezone: string | null = null;
       if (parsed.kind === "cron") {
-        cronTimezone = timezone ?? getUserTimezone(agentLoopContext);
+        cronTimezone = timezone ?? getUserTimezone(toolContext);
         if (!cronTimezone) {
           return new Err(
             new MCPError(
@@ -248,7 +246,7 @@ export function createWakeupsTools(
     },
 
     list_wakeups: async () => {
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         return new Err(
           new MCPError(
             "Wake-ups can only be listed from within a conversation."
@@ -256,7 +254,7 @@ export function createWakeupsTools(
         );
       }
 
-      const { conversation } = agentLoopContext.runContext;
+      const { conversation } = toolContext.runContext;
 
       const wakeUps = await WakeUpResource.listByConversation(
         auth,
@@ -284,7 +282,7 @@ export function createWakeupsTools(
     },
 
     cancel_wakeup: async ({ wakeUpId }) => {
-      if (!agentLoopContext?.runContext) {
+      if (!toolContext?.runContext) {
         return new Err(
           new MCPError(
             "Wake-ups can only be cancelled from within a conversation."
@@ -292,7 +290,7 @@ export function createWakeupsTools(
         );
       }
 
-      const { conversation } = agentLoopContext.runContext;
+      const { conversation } = toolContext.runContext;
 
       const wakeUp = await WakeUpResource.fetchById(auth, wakeUpId);
       if (!wakeUp) {

--- a/front/lib/api/actions/servers/web_search_browse/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { WEB_SEARCH_BROWSE_SERVER_NAME } from "@app/lib/api/actions/servers/web_search_browse/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/web_search_browse/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer(WEB_SEARCH_BROWSE_SERVER_NAME);
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: WEB_SEARCH_BROWSE_SERVER_NAME,
     });
   }

--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -46,14 +46,14 @@ async function handleWebsearch(
   { query }: { query: string },
   extra: ToolHandlerExtra
 ) {
-  const { agentLoopContext } = extra;
-  if (!agentLoopContext?.runContext) {
+  const { toolContext } = extra;
+  if (!toolContext?.runContext) {
     return new Err(
       new MCPError("agentLoopRunContext is required where the tool is called.")
     );
   }
 
-  const agentLoopRunContext = agentLoopContext.runContext;
+  const agentLoopRunContext = toolContext.runContext;
 
   const { websearchResultCount, citationsOffset } =
     agentLoopRunContext.stepContext;
@@ -120,14 +120,14 @@ async function handleWebbrowser(
   },
   extra: ToolHandlerExtra
 ) {
-  const { agentLoopContext, auth } = extra;
-  if (!agentLoopContext?.runContext) {
+  const { toolContext, auth } = extra;
+  if (!toolContext?.runContext) {
     return new Err(new MCPError("No conversation context available"));
   }
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
   });
-  const { toolConfiguration } = agentLoopContext.runContext;
+  const { toolConfiguration } = toolContext.runContext;
   const useSummarization =
     isLightServerSideMCPToolConfiguration(toolConfiguration) &&
     toolConfiguration.additionalConfiguration[USE_SUMMARY_SWITCH] === true;
@@ -161,7 +161,7 @@ async function handleWebbrowser(
   });
 
   if (useSummarization) {
-    const runCtx = agentLoopContext.runContext;
+    const runCtx = toolContext.runContext;
     const { citationsOffset, websearchResultCount } = runCtx.stepContext;
     const refs = getRefs().slice(
       citationsOffset,

--- a/front/lib/api/actions/servers/workday/index.ts
+++ b/front/lib/api/actions/servers/workday/index.ts
@@ -1,17 +1,14 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/workday/tools";
 import type { Authenticator } from "@app/lib/auth";
 
-function createServer(
-  auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
-) {
+function createServer(auth: Authenticator, toolContext?: ToolContextType) {
   const server = makeInternalMCPServer("workday");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "workday",
     });
   }

--- a/front/lib/api/actions/servers/workspace_analytics/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/index.ts
@@ -1,18 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/workspace_analytics/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("workspace_analytics");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "workspace_analytics",
     });
   }

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -18,7 +18,7 @@ function createTestExtra(auth: Authenticator) {
   return {
     signal: new AbortController().signal,
     auth,
-    agentLoopContext: undefined,
+    toolContext: undefined,
   } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
 }
 

--- a/front/lib/api/actions/servers/zendesk/index.ts
+++ b/front/lib/api/actions/servers/zendesk/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/zendesk/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,12 +8,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
+  toolContext?: ToolContextType
 ): McpServer {
   const server = makeInternalMCPServer("zendesk");
 
   for (const tool of TOOLS) {
-    registerTool(auth, agentLoopContext, server, tool, {
+    registerTool(auth, toolContext, server, tool, {
       monitoringName: "zendesk",
     });
   }

--- a/front/lib/api/poke/mcp_diagnostics.ts
+++ b/front/lib/api/poke/mcp_diagnostics.ts
@@ -600,7 +600,7 @@ async function runConnectListToolsCheck(
 ): Promise<DiagnosticCheckResult> {
   const startedAt = Date.now();
 
-  const agentLoopContext =
+  const toolContext =
     connectionType === "personal"
       ? { runContext: {} as AgentLoopRunContextType }
       : undefined;
@@ -611,7 +611,7 @@ async function runConnectListToolsCheck(
       mcpServerId,
       oAuthUseCase,
     },
-    agentLoopContext,
+    toolContext,
   });
 
   if (connectRes.isErr()) {


### PR DESCRIPTION
## Description

- Rename type `AgentLoopContextType` to `ToolContextType`
- Rename most use of the `agentLoopContext` variable name to `toolContext`.

Following proposal here: https://dust4ai.slack.com/archives/C0AGY9MTNJV/p1782916827808779

Next steps: 

- Introduce SandboxFunctionRunContextType and add type guard based asserts to reify to `runcContext: AgentLoopRunContextType` in all tools requiring it.
- Filter listing of tools based on conversation context requirements
- Adapt tools implementations to support both `AgentLoopRunContextType` and `SandboxFunctionRunContextType`

## Tests

No change of behaviour. should be fully covered by type checking. A few `as` here and there are a bit dangerous but they are mostly in tests with a few exceptions:
- https://github.com/dust-tt/dust/compare/spolu/tool-context-rename?expand=1#diff-3573d0ffd07d87ec9f344a642da8876ee1824166d97247701e74c8e139b8c8c0R959

## Risk

High, local tests and pre-prod deploy tests required.

## Deploy Plan

- pre-prod deploy and test pre-merge
- deploy `front`