### PR TITLE
 Surface runner output when a sandbox function invocation fails

### DIFF
--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -490,6 +490,92 @@ describe("SandboxFunctionResource", () => {
     });
   });
 
+  async function setupInvokeTest() {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const file = await FileFactory.create(authenticator, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: "comments.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+    const sandboxFunction = await SandboxFunctionResource.makeNew(
+      authenticator,
+      {
+        space,
+        file,
+        slug: "add-comment",
+        description: "Add a comment.",
+        inputSchema,
+        outputSchema,
+      }
+    );
+    const sandbox = await SandboxResource.makeNew(authenticator, {
+      providerId: "test-provider-id",
+      status: "running",
+      baseImage: "dust-base",
+      version: "0.0.0-test",
+    });
+    vi.mocked(ensurePodSandboxReady).mockResolvedValue(
+      new Ok({ sandbox, freshlyCreated: false })
+    );
+    vi.mocked(generateSandboxFunctionInvocationToken).mockResolvedValue(
+      "sbt-function-token"
+    );
+
+    return { authenticator, sandboxFunction, sandbox };
+  }
+
+  it("surfaces the runner stderr when the invocation exits non-zero", async () => {
+    const { authenticator, sandboxFunction, sandbox } = await setupInvokeTest();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 1,
+        stdout: "some stdout",
+        stderr: "dsbx command failed: connection refused",
+      })
+    );
+
+    const result = await sandboxFunction.invoke(authenticator, {
+      input: { message: "hello" },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.message).toContain("exit code 1");
+    expect(result.error.message).toContain(
+      "dsbx command failed: connection refused"
+    );
+  });
+
+  it("falls back to the runner stdout when stderr is empty on failure", async () => {
+    const { authenticator, sandboxFunction, sandbox } = await setupInvokeTest();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 2,
+        stdout: "boom from stdout",
+        stderr: "",
+      })
+    );
+
+    const result = await sandboxFunction.invoke(authenticator, {
+      input: { message: "hello" },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.message).toContain("exit code 2");
+    expect(result.error.message).toContain("boom from stdout");
+  });
+
   it("overwrites the bundle and contract in place on re-publish", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -20,6 +20,7 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import logger from "@app/logger/logger";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   SandboxFunctionInvocationType,
@@ -30,6 +31,7 @@ import { isDevelopment } from "@app/types/shared/env";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { truncate } from "@app/types/shared/utils/string_utils";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { Attributes, Transaction } from "sequelize";
@@ -37,6 +39,10 @@ import type { Attributes, Transaction } from "sequelize";
 const SANDBOX_FUNCTION_WORKING_DIRECTORY = "/home/agent";
 const SANDBOX_FUNCTION_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
 const DSBX_BIN_PATH = "/opt/bin/dsbx";
+// Caps on runner output surfaced on failure: a small head for the error forwarded to the agent,
+// a larger one for the log fields.
+const SANDBOX_FUNCTION_ERROR_DETAIL_MAX_CHARS = 2_048;
+const SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS = 16_384;
 
 function dustAPIBaseUrlForSandbox(): string {
   return isDevelopment() && config.getSandboxDevFrontHostName()
@@ -386,9 +392,31 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         return execResult;
       }
       if (execResult.value.exitCode !== 0) {
+        const { exitCode, stdout, stderr } = execResult.value;
+        logger.error(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            spaceId: this.space.sId,
+            sandboxFunctionId: this.sId,
+            slug: this.slug,
+            invocationId: invocation.sId,
+            exitCode,
+            stdout: truncate(stdout, SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS),
+            stderr: truncate(stderr, SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS),
+          },
+          "Sandbox function invocation failed"
+        );
+        // Surface the runner's stderr (stdout when empty) so the agent sees the actual cause,
+        // not just the exit code.
+        const detail = truncate(
+          stderr || stdout,
+          SANDBOX_FUNCTION_ERROR_DETAIL_MAX_CHARS
+        ).trim();
         return new Err(
           new Error(
-            `Sandbox function invocation failed with exit code ${execResult.value.exitCode}.`
+            `Sandbox function invocation failed with exit code ${exitCode}${
+              detail ? `:\n${detail}` : "."
+            }`
           )
         );
       }


### PR DESCRIPTION
When `dsbx function run` exits non-zero, we only returned "Sandbox function invocation failed
with exit code N" and discarded the runner's output, making failures (e.g. the runner unable to
POST its result back to front) impossible to diagnose, both in logs and for the agent.

This PR changes `SandboxFunctionResource.invoke()` so that on a non-zero exit code:

- we log a `logger.error` with the full `stdout`/`stderr` plus identifiers (workspace, pod,
  function, invocation, exit code)
- the returned error message includes the runner's stderr (falling back to stdout, truncated to
  2048 chars), which flows through the `call` tool's `MCPError` to the agent so it can see the
  actual cause

Same pattern as sandbox root commands in `egress.ts` (`stderr || stdout` appended to the error
message).

## Risk

Low. Error path only; no behavior change on success.

## Deploy

Deploy front. 