### PR TITLE
[front] fix: prevent duplicate skill authoring

### DIFF
--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -53,6 +53,13 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe("Optional icon name; auto-suggested if omitted."),
+      bypassSimilarSkillCheck: z
+        .boolean()
+        .optional()
+        .describe(
+          "Bypass the similar skill check and create the skill anyway. Set to true " +
+            "only after the user explicitly confirms they want a separate skill."
+        ),
     },
     stake: "high",
     displayLabels: {

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
@@ -13,7 +13,8 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { describe, expect, it, vi } from "vitest";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Force a deterministic icon suggestion so the invalid-icon fallback does not
 // depend on a live LLM call.
@@ -24,7 +25,15 @@ vi.mock("@app/lib/api/skills/icon_suggestion", async () => {
   };
 });
 
+// Keep existing create_skill tests hermetic: getSimilarSkills calls an LLM.
+vi.mock("@app/lib/api/skills/existing_skill_checker", () => ({
+  getSimilarSkills: vi.fn(),
+}));
+
+import { getSimilarSkills } from "@app/lib/api/skills/existing_skill_checker";
 import { TOOLS } from "./index";
+
+const mockGetSimilarSkills = vi.mocked(getSimilarSkills);
 
 function getTool(name: string) {
   const tool = TOOLS.find((t) => t.name === name);
@@ -59,6 +68,11 @@ async function seedSkill(
 }
 
 describe("skill_authoring tools", () => {
+  beforeEach(() => {
+    mockGetSimilarSkills.mockReset();
+    mockGetSimilarSkills.mockResolvedValue(new Ok({ similar_skills: [] }));
+  });
+
   it("creates, lists, reads, and updates a skill", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "builder",

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -15,6 +15,7 @@ import {
 } from "@app/lib/api/actions/servers/skill_authoring/metadata";
 import { makeSkillAuthoringResultOutput } from "@app/lib/api/actions/servers/skill_authoring/rendering";
 import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
+import { getSimilarSkills } from "@app/lib/api/skills/existing_skill_checker";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import type { Authenticator } from "@app/lib/auth";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
@@ -68,6 +69,79 @@ function makeJsonText(value: unknown) {
     type: "text" as const,
     text: JSON.stringify(value, null, 2),
   };
+}
+
+type SimilarSkillSummary = {
+  sId: string;
+  name: string;
+  agentFacingDescription: string;
+};
+
+async function findSimilarSkillSummaries(
+  auth: Authenticator,
+  naturalDescription: string
+): Promise<Result<SimilarSkillSummary[], MCPError>> {
+  const result = await getSimilarSkills(auth, {
+    naturalDescription,
+    excludeSkillId: null,
+  });
+
+  if (result.isErr()) {
+    logger.warn(
+      { err: result.error },
+      "Failed to check for similar skills before creating skill"
+    );
+    return new Err(
+      new MCPError(
+        "Could not check whether a similar skill already exists. Retry, or set " +
+          "`bypassSimilarSkillCheck` to true only if the user explicitly wants " +
+          "to create a separate skill."
+      )
+    );
+  }
+
+  const similarSkillIds = result.value.similar_skills;
+  if (similarSkillIds.length === 0) {
+    return new Ok([]);
+  }
+
+  const skills = await SkillResource.fetchByIds(auth, similarSkillIds);
+  const skillsById = new Map<string, SkillResource>();
+  for (const skill of skills) {
+    skillsById.set(skill.sId, skill);
+  }
+
+  const summaries: SimilarSkillSummary[] = [];
+  for (const skillId of similarSkillIds) {
+    const skill = skillsById.get(skillId);
+    if (skill) {
+      summaries.push({
+        sId: skill.sId,
+        name: skill.name,
+        agentFacingDescription: skill.agentFacingDescription,
+      });
+    }
+  }
+
+  return new Ok(summaries);
+}
+
+function makeSimilarSkillsErrorMessage(
+  similarSkills: SimilarSkillSummary[]
+): string {
+  const summaries = similarSkills
+    .map(
+      (skill) =>
+        `- ${skill.name} (${skill.sId}): ${skill.agentFacingDescription}`
+    )
+    .join("\n");
+
+  return (
+    "Similar skills already exist. Reuse or update them instead of creating a " +
+    `duplicate skill:\n${summaries}\n` +
+    "If the user explicitly wants a separate skill, call `create_skill` again " +
+    "with `bypassSimilarSkillCheck` set to true."
+  );
 }
 
 const SPECIAL_TAG_CATEGORIES = ["nested skills", "knowledge", "tools"] as const;
@@ -218,7 +292,14 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
   },
 
   [CREATE_SKILL_TOOL_NAME]: async (
-    { agentFacingDescription, icon, instructions, name, userFacingDescription },
+    {
+      agentFacingDescription,
+      bypassSimilarSkillCheck,
+      icon,
+      instructions,
+      name,
+      userFacingDescription,
+    },
     { auth }
   ) => {
     const user = requireInteractiveBuilder(auth);
@@ -253,6 +334,21 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       return new Err(
         new MCPError(`A skill with the name "${trimmedName}" already exists.`)
       );
+    }
+
+    if (bypassSimilarSkillCheck !== true) {
+      const similarSkills = await findSimilarSkillSummaries(
+        auth,
+        agentFacingDescription
+      );
+      if (similarSkills.isErr()) {
+        return new Err(similarSkills.error);
+      }
+      if (similarSkills.value.length > 0) {
+        return new Err(
+          new MCPError(makeSimilarSkillsErrorMessage(similarSkills.value))
+        );
+      }
     }
 
     // Ignore an invalid agent-supplied icon and fall back to a suggestion

--- a/front/lib/resources/skill/code_defined/skill_authoring.ts
+++ b/front/lib/resources/skill/code_defined/skill_authoring.ts
@@ -5,6 +5,8 @@ You can create and revise workspace Skills when the user wants to capture a repe
 
 Use create_skill when the workflow is new. Use list_skills and get_skill first when the user asks to improve, rename, rewrite, or refine an existing skill.
 
+If create_skill reports similar existing skills, reuse or update one of those skills instead of creating a duplicate. Only set bypassSimilarSkillCheck when the user explicitly confirms they want a separate skill anyway.
+
 Create instructions-only skills. Do not try to attach tools, knowledge, files, or other skills. If the user asks for those, explain that this authoring tool can capture the instructions now and that tool or knowledge wiring needs to be handled separately.
 
 Write concise skill names that describe the reusable capability, not the current conversation. Good names are action-oriented and stable, for example "Write Release Notes" or "Triage Support Escalations".


### PR DESCRIPTION
## Description

- Prevent the skill authoring MCP `create_skill` tool from creating likely duplicate Skills by checking `getSimilarSkills` before creation.
- When similar skills are found, return an actionable error with the matching skill summaries so the agent can reuse or update them.
- Add an explicit `bypassSimilarSkillCheck` escape hatch for confirmed separate skills, and update the Author Skills instructions to avoid defaulting to that bypass.

## Tests

- Tested locally.
- Existing skill authoring tests mock `getSimilarSkills` so they do not need to call an LLM.

## Risk

- Low. Scoped to skill_authoring create behavior.

## Deploy Plan

- Deploy front.
