### PR TITLE
[front] fix icon size incosistency

### DIFF
--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -8,6 +8,7 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
+import React from "react";
 
 export const SELECT_SKILL_SLASH_COMMAND_ACTION = "select-skill";
 export const SELECT_TOOL_SLASH_COMMAND_ACTION = "select-tool";
@@ -147,7 +148,7 @@ export function getSkillSlashCommandItem(
     },
     description: skill.userFacingDescription,
     hasDetails: true,
-    icon: getSkillAvatarIcon(skill),
+    icon: () => React.createElement(getSkillAvatarIcon(skill)),
     id: skill.sId,
     label: skill.name,
   };


### PR DESCRIPTION
## Description
This PR is to quickly fix an icon size inconsistency in the slash command dropdown. I tried to fix it cleanly but I had to fix so many components everywhere, so I sadly decided to throw a quick fix 🥲 (I'm aware that the icon size is too big but also it take a bit more time to shrink them all) 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
