### PR TITLE
fix(llm): stop excluding agent-platform gemini endpoints for non-byok workspaces

### DIFF
--- a/front/lib/api/llm/index.test.ts
+++ b/front/lib/api/llm/index.test.ts
@@ -1,5 +1,5 @@
 import { getWorkspaceFilter } from "@app/lib/api/llm";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getStreamEndpoints } from "@app/lib/llms/stream";
 import type { WorkspaceConfig } from "@app/lib/llms/types/filter";
 import {
@@ -10,21 +10,32 @@ import {
   AGENT_PLATFORM_API,
   GOOGLE_AI_STUDIO_API,
 } from "@app/lib/model_constructors/types/provider_apis";
+import {
+  isCreditPricedPlanPrefix,
+  isEnterpriseOrDust,
+} from "@app/lib/plans/plan_codes";
 import { ProviderCredentialFactory } from "@app/tests/utils/ProviderCredentialFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { describe, expect, it } from "vitest";
 
-const workspaceConfig: WorkspaceConfig = {
-  featureFlags: [],
-  isEnterprise: false,
-  isCreditPriced: false,
-};
+async function getWorkspaceConfig(
+  auth: Authenticator
+): Promise<WorkspaceConfig> {
+  const plan = auth.getNonNullablePlan();
+
+  return {
+    featureFlags: await getFeatureFlags(auth),
+    isEnterprise: isEnterpriseOrDust(plan),
+    isCreditPriced: isCreditPricedPlanPrefix(plan.code),
+  };
+}
 
 describe("getWorkspaceFilter", () => {
   it("routes non-byok gemini to agent-platform endpoints, never the direct Google AI Studio API", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
+    const workspaceConfig = await getWorkspaceConfig(auth);
     const filter = getWorkspaceFilter(auth);
 
     const flashEndpoints = getStreamEndpoints(workspaceConfig, {
@@ -50,6 +61,7 @@ describe("getWorkspaceFilter", () => {
     await ProviderCredentialFactory.basic(workspace, "google_ai_studio");
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
+    const workspaceConfig = await getWorkspaceConfig(auth);
     const filter = getWorkspaceFilter(auth);
 
     const proEndpoints = getStreamEndpoints(workspaceConfig, {

--- a/front/lib/api/llm/index.test.ts
+++ b/front/lib/api/llm/index.test.ts
@@ -1,0 +1,61 @@
+import { getWorkspaceFilter } from "@app/lib/api/llm";
+import { Authenticator } from "@app/lib/auth";
+import { getStreamEndpoints } from "@app/lib/llms/stream";
+import type { WorkspaceConfig } from "@app/lib/llms/types/filter";
+import {
+  GEMINI_3_1_PRO_MODEL_ID,
+  GEMINI_3_5_FLASH_MODEL_ID,
+} from "@app/lib/model_constructors/types/model_ids";
+import {
+  AGENT_PLATFORM_API,
+  GOOGLE_AI_STUDIO_API,
+} from "@app/lib/model_constructors/types/provider_apis";
+import { ProviderCredentialFactory } from "@app/tests/utils/ProviderCredentialFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it } from "vitest";
+
+const workspaceConfig: WorkspaceConfig = {
+  featureFlags: [],
+  isEnterprise: false,
+  isCreditPriced: false,
+};
+
+describe("getWorkspaceFilter", () => {
+  it("routes non-byok gemini to agent-platform endpoints, never the direct Google AI Studio API", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const filter = getWorkspaceFilter(auth);
+
+    const flashEndpoints = getStreamEndpoints(workspaceConfig, {
+      ...filter,
+      modelId: { eq: GEMINI_3_5_FLASH_MODEL_ID },
+    });
+    expect(flashEndpoints.length).toBeGreaterThan(0);
+    expect(flashEndpoints.every((e) => e.api === AGENT_PLATFORM_API)).toBe(
+      true
+    );
+
+    const proEndpoints = getStreamEndpoints(workspaceConfig, {
+      ...filter,
+      modelId: { eq: GEMINI_3_1_PRO_MODEL_ID },
+    });
+    expect(proEndpoints.every((e) => e.api !== GOOGLE_AI_STUDIO_API)).toBe(
+      true
+    );
+  });
+
+  it("keeps the direct Google AI Studio API endpoints for byok workspaces", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    await ProviderCredentialFactory.basic(workspace, "google_ai_studio");
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const filter = getWorkspaceFilter(auth);
+
+    const proEndpoints = getStreamEndpoints(workspaceConfig, {
+      ...filter,
+      modelId: { eq: GEMINI_3_1_PRO_MODEL_ID },
+    });
+    expect(proEndpoints.some((e) => e.api === GOOGLE_AI_STUDIO_API)).toBe(true);
+  });
+});

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -40,6 +40,7 @@ import type {
 } from "@app/lib/llms/types/filter";
 import { sortEndpointsByPreferredRegion } from "@app/lib/llms/utils/sort_endpoints";
 import { isModelId } from "@app/lib/model_constructors/types/model_ids";
+import { GOOGLE_AI_STUDIO_API } from "@app/lib/model_constructors/types/provider_apis";
 import {
   isProviderId,
   type ProviderId,
@@ -308,19 +309,20 @@ function getProviderIdFilter(auth: Authenticator): ValueFilter<ProviderId> {
   const byok = auth.getNonNullablePlan().isByok;
   const providerIds = byok
     ? intersection(whitelistedProviderIds, BYOK_MODEL_PROVIDER_IDS)
-    : whitelistedProviderIds.filter(
-        // We route all non-byok gemini requests to agent platform
-        (providerId) => providerId !== "google_ai_studio"
-      );
+    : whitelistedProviderIds;
 
   return { in: providerIds };
 }
 
 // Temporary helper while we have both systems
 export function getWorkspaceFilter(auth: Authenticator): Where<EndpointConfig> {
+  const byok = auth.getNonNullablePlan().isByok;
+
   return {
     providerId: getProviderIdFilter(auth),
     region: getRegionFilter(auth),
+    // We route all non-byok gemini requests to agent platform.
+    ...(byok ? {} : { not: { api: { eq: GOOGLE_AI_STUDIO_API } } }),
   };
 }
 

--- a/front/lib/llms/types/filter.ts
+++ b/front/lib/llms/types/filter.ts
@@ -14,7 +14,7 @@ export type EndpointConfig = {
   region: Region;
   providerId: ProviderId;
   modelId: ModelId;
-  providerApi: ProviderApi;
+  api: ProviderApi;
 };
 
 export type ArrayValueFilter<T> = {

--- a/front/lib/llms/utils/matches_where.test.ts
+++ b/front/lib/llms/utils/matches_where.test.ts
@@ -221,7 +221,7 @@ describe("matchesWhere", () => {
       region: ["eu", "global"],
       providerId: ["anthropic"],
       modelId: ["claude-sonnet-4-6"],
-      providerApi: ["anthropic", "agent-platform"],
+      api: ["anthropic", "agent-platform"],
     };
 
     it("matches provider and region membership", () => {
@@ -240,14 +240,14 @@ describe("matchesWhere", () => {
       expect(
         matchesWhere(description, {
           providerId: { contains: "anthropic" },
-          providerApi: { containsAll: ["anthropic", "agent-platform"] },
+          api: { containsAll: ["anthropic", "agent-platform"] },
           region: { containsAny: ["eu"] },
         })
       ).toBe(true);
       expect(
         matchesWhere(description, {
           providerId: { contains: "anthropic" },
-          providerApi: { contains: "openai-responses" },
+          api: { contains: "openai-responses" },
         })
       ).toBe(false);
     });


### PR DESCRIPTION
## Description

Since enabling `use_new_llm_router` for all workspaces, ~78% of "Falling back to the old router" logs are gemini models, in both regions.

Root cause: `getProviderIdFilter` strips `google_ai_studio` from the allowed providers for every non-byok workspace (intent: route non-byok gemini through agent platform). But the agent-platform gemini endpoints also declare `providerId = google_ai_studio`, so the filter excluded them too. No gemini stream endpoint could ever match for a non-byok workspace.

Changes:
- Keep `google_ai_studio` in the provider filter and instead exclude endpoints whose `api` is the direct Google AI Studio API for non-byok workspaces. Agent-platform gemini endpoints stay eligible.
- Rename `EndpointConfig.providerApi` to `api` to match the endpoint constructors' static property — as written, a `providerApi` filter could never match a real endpoint.

Non-byok `gemini-3.1-pro-preview` still falls back after this: it has no agent-platform endpoint in the registry yet, only the direct google-ai-studio one (byok-only). Follow-up to add it.

## Tests

Added `lib/api/llm/index.test.ts`:
- a non-byok workspace resolves gemini-3.5-flash to agent-platform endpoints only, and never gets a direct google-ai-studio endpoint
- a byok workspace with a configured google credential still gets the direct google-ai-studio endpoint for gemini-3.1-pro

Updated `matches_where.test.ts` for the field rename. Ran the filter/sort/transition suites.

## Risk

Low.

## Deploy Plan

Deploy front.