### PR TITLE
log Anthropic pause_turn stop reason

### DIFF
--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -38,6 +38,7 @@ import type {
   ToolCallStartedEvent,
 } from "@app/lib/model_constructors/types/output/events";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import logger from "@app/logger/logger";
 import {
   assertNever,
   assertNeverAndIgnore,
@@ -906,6 +907,24 @@ export function messageDeltaToEvents(
 ): [ModelResponseEvent[], MessageDeltaUsage] {
   const stopReason = event.delta.stop_reason;
   if (stopReason) {
+    // Anthropic pauses a turn when the server-side sampling loop reaches its
+    // iteration limit while running server tools (tool search in our case).
+    // The recommended handling is to re-issue the request with the paused
+    // assistant response appended so the model can finish:
+    // https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons#pause-turn
+    // We do not continue yet: the turn ends with the content produced so far.
+    // Logged to measure how often this truncation happens before implementing
+    // the continuation.
+    if (stopReason === "pause_turn") {
+      logger.warn(
+        {
+          providerId: metadata.providerId,
+          api: metadata.api,
+          modelId: metadata.modelId,
+        },
+        "Anthropic pause_turn stop reason, turn ended with partial content"
+      );
+    }
     const errorEvent = converters.stopReasonToErrorEvent(metadata, stopReason);
     if (errorEvent) {
       return [[errorEvent], event.usage];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Anthropic ends a turn with a `pause_turn` stop reason when its server-side sampling loop hits the iteration limit while running server tools, which for us means tool search. The documented handling is to send the paused response back so the model can finish its turn. We currently don't do that: the agent loop sees no pending tool calls, finalizes the message, and the answer is silently truncated mid-work.

Before implementing the continuation, this adds a warning log whenever a `pause_turn` comes through the router, so we can measure how often the truncation actually happens in production and prioritize accordingly. No behavior change.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
