### PR TITLE
[front] tool credit cost: moved to internalMCP server and tool levels

### DIFF
--- a/extension/shared/tools/metadata.ts
+++ b/extension/shared/tools/metadata.ts
@@ -64,6 +64,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       running: "Getting page content...",
       done: "Page content retrieved",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME]: {
     description:
@@ -88,6 +90,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       running: "Attaching tab content...",
       done: "Tab content attached",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [LIST_BROWSER_TABS_TOOL_NAME]: {
     description:
@@ -101,6 +105,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       running: "Listing browser tabs...",
       done: "Browser tabs listed",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [SWITCH_TO_BROWSER_TAB_TOOL_NAME]: {
     description:
@@ -114,6 +120,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       running: "Activating browser tab...",
       done: "Browser tab activated",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [CLOSE_BROWSER_TAB_TOOL_NAME]: {
     description: `Closes the specified browser tab. Use ${LIST_BROWSER_TABS_TOOL_NAME} to discover tab IDs.`,
@@ -125,6 +133,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       running: "Closing browser tab...",
       done: "Browser tab closed",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [OPEN_BROWSER_TAB_TOOL_NAME]: {
     description: "Opens a new browser tab with the specified URL.",
@@ -136,6 +146,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       running: "Opening new browser tab...",
       done: "Browser tab opened",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [MOVE_BROWSER_TAB_TOOL_NAME]: {
     description:
@@ -154,6 +166,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       running: "Moving browser tab...",
       done: "Browser tab moved",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [RELOAD_BROWSER_TAB_TOOL_NAME]: {
     description:
@@ -167,6 +181,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       running: "Reloading browser tab...",
       done: "Browser tab reloaded",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [INTERACT_WITH_PAGE_TOOL_NAME]: {
     description: `Interact with a browser tab of the user's browser window.
@@ -222,5 +238,7 @@ Avoid unnecessary actions.`,
       running: "Interacting with page...",
       done: "Page interaction completed",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -1,5 +1,2503 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`MCP Servers Metadata Snapshot > should have stable tool billing info across all servers 1`] = `
+{
+  "agent_memory": {
+    "compact_memory": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "edit_entries": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "erase_entries": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "record_entries": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "retrieve": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "agent_router": {
+    "list_all_published_agents": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "suggest_agents_for_content": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "agent_sidekick_agent_state": {
+    "get_agent_info": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "agent_sidekick_context": {
+    "describe_mcp": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_agent_feedback": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_agent_insights": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_agent_template": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_available_agents": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_available_models": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_available_skills": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_available_tools": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "inspect_available_agent": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "inspect_conversation": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "inspect_message": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_suggestions": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "search_agent_templates": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "search_knowledge": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "suggest_knowledge": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "suggest_model": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "suggest_prompt_edits": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "suggest_skills": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "suggest_sub_agent": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "suggest_tools": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "update_suggestions_state": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "ashby": {
+    "create_candidate_note": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_referral": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_candidate_notes": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_hire_data": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_interview_feedback": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_referral_form": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_report_data": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_job_postings": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_openings": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_candidates": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_job_posting": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "ask_user_question": {
+    "ask_user_question": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "clari_copilot": {
+    "get_call_details": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_calls": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "common_utilities": {
+    "generate_random_float": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "generate_random_number": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_current_time": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "math_operation": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "set_conversation_title": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "wait": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "confluence": {
+    "create_page": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_current_user": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_page": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_pages": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_spaces": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_page": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "conversation_files": {
+    "cat": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_content_nodes_and_tables": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "semantic_search": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "data_sources_file_system": {
+    "cat": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "find": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "locate_in_tree": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "semantic_search": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "data_warehouses": {
+    "describe_tables": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "find": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "query": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "databricks": {
+    "list_warehouses": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "exa_people_and_company": {
+    "search_companies": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_people": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "extract_data": {
+    "extract_information_from_documents": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "fathom": {
+    "get_transcript": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_meetings": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "file_generation": {
+    "convert_file_format": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "generate_file": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_supported_source_formats_for_output_format": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "files": {
+    "cat": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "copy": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "create": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "delete": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "edit": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "extract_text": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "grep": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "move": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "resolve": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "upload_from_url": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "freshservice": {
+    "add_ticket_note": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "add_ticket_reply": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_solution_article": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_ticket": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_ticket_task": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_ticket_task": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_canned_response": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_requester": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_service_item": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_service_item_fields": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_solution_article": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_ticket": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_ticket_approval": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_ticket_read_fields": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_ticket_task": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_ticket_write_fields": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_canned_responses": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_departments": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_oncall_schedules": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_products": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_purchase_orders": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_requesters": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_service_categories": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_service_items": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_sla_policies": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_solution_articles": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_solution_categories": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_solution_folders": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_ticket_approvals": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_ticket_requested_items": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_ticket_tasks": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_tickets": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "request_service_approval": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "request_service_item": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_service_items": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_ticket": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_ticket_task": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "front": {
+    "add_comment": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "add_links": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "add_tags": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "assign_conversation": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_conversation": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_draft": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_draft": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_contact": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_conversation": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_conversation_drafts": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_conversation_messages": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_customer_history": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_inboxes": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_tags": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_teammates": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_conversations": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "send_message": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_conversation_status": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "github": {
+    "add_issue_to_project": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "comment_on_discussion": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "comment_on_issue": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_discussion": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_issue": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_pull_request_review": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_discussion": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_discussion_comments": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_issue": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_issue_custom_fields": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_pull_request": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_discussion_categories": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_discussions": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_issues": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_organization_projects": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_pull_requests": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_advanced": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_issue": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "gmail": {
+    "create_draft": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_draft": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_attachment": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_drafts": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_labels": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_messages": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_thread": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "send_mail": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "set_message_labels": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "gong": {
+    "get_call": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_call_transcript": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_calls": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "google_calendar": {
+    "check_availability": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_event": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_event": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_event": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_user_timezones": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_calendars": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_events": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_event": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "google_drive": {
+    "append_to_spreadsheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "copy_file": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_comment": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_document": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_folder": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_presentation": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_reply": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_spreadsheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_document_structure": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_file_content": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_presentation_structure": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_spreadsheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_worksheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_comments": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_drives": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_file_permissions": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "revoke_file_sharing": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_files": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "share_file": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_document": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_file_permission": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_presentation": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_spreadsheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "upload_file": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "google_sheets": {
+    "add_worksheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "append_data": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "clear_range": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "copy_sheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_spreadsheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_worksheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "format_cells": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_spreadsheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_worksheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_spreadsheets": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "move_worksheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "rename_worksheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_cells": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "http_client": {
+    "send_request": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "webbrowser": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "websearch": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+  },
+  "hubspot": {
+    "complete_task": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "count_objects_by_properties": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_association": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_communication": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_company": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_contact": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_deal": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_lead": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_meeting": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_note": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_task": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_ticket": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_task": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "export_crm_objects_csv": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_associated_meetings": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_company": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_contact": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_current_user_id": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_deal": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_email_campaign": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_file_public_url": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_hubspot_link": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_hubspot_portal_id": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_latest_objects": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_marketing_email": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_marketing_email_statistics": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_meeting": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_object_by_email": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_object_properties": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_user_activity": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_association_labels": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_associations": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_email_campaigns": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_email_events": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_marketing_emails": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_owners": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "remove_association": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_crm_objects": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_owners": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_company": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_contact": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_deal": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_task": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "image_generation": {
+    "generate_image": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "include_data": {
+    "retrieve_recent_documents": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "interactive_content": {
+    "create_interactive_content_file": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "edit_interactive_content_file": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "export_interactive_content_file": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "get_interactive_content_file_share_url": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "publish_interactive_content_file": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "rename_interactive_content_file": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "retrieve_interactive_content_file": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "revert_interactive_content_file": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+  },
+  "jira": {
+    "create_comment": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_issue": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_issue_link": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_issue_link": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_attachments": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_connection_info": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_issue": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_issue_create_fields": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_issue_link_types": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_issue_read_fields": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_issue_types": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_issues": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_issues_using_jql": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_project": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_project_versions": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_projects": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_transitions": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_users": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "read_attachment": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "transition_issue": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_issue": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "upload_attachment": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "jit_testing": {
+    "jit_all_optionals_and_defaults": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "luma": {
+    "add_guests": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_event": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_authenticated_user": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_event": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_event_insights": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_guest": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_events": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_guests": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_guests": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "send_invites": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_event": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_guest_status": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "microsoft_drive": {
+    "copy_file": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_file_content": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_drive_items": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "rename_drive_item": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_drive_items": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_in_files": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_word_document": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "upload_file": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "microsoft_excel": {
+    "clear_range": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_worksheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_worksheets": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_excel_files": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "read_worksheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "write_worksheet": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "microsoft_teams": {
+    "get_transcript_content": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_channels": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_chats": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_meetings": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_messages": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_teams": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_users": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "post_message": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_messages_content": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "missing_action_catcher": {},
+  "monday": {
+    "create_board": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_column": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_group": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_item": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_multiple_items": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_subitem": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_update": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_group": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_item": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "duplicate_group": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "find_user_by_name": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_activity_logs": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_board_analytics": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_board_items": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_board_values": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_boards": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_column_values": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_file_column_values": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_group_details": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_item_details": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_items_by_column_value": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_subitem_values": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_user_details": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "move_item_to_board": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_items": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_item": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_item_name": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_subitem": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "upload_file_to_column": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "notion": {
+    "add_page_content": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_comment": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_database": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_page": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_block": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_page": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "fetch_comments": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_about_user": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "insert_row_into_database": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_users": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "query_database": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "retrieve_block": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "retrieve_block_children": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "retrieve_database_content": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "retrieve_database_schema": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "retrieve_page": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_page": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_row_database": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_schema_database": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "openai_usage": {
+    "get_completions_usage": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_organization_costs": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "outlook": {
+    "create_contact": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_draft": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_draft": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_attachment": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_attachments": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_contacts": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_drafts": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_message_body": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_messages": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_attachments": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_folders": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "move_messages": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "send_mail": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_contact": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "outlook_calendar": {
+    "check_availability": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "check_self_availability": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_event": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_event": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_event": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_user_timezone": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_calendars": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_events": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_event": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "plan_mode": {
+    "close_plan": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "create_plan": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "edit_plan": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "pod_manager": {
+    "add_content_node": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "add_message_to_conversation": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "create_conversation": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "create_pod": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "edit_information": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_information": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_conversations": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_members": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_pods": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "remove_content_node": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "retrieve_recent_documents": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "semantic_search": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "update_members": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "pod_tasks": {
+    "create_tasks": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_tasks": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "start_task_agent": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "update_tasks": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "poke": {
+    "check_notion_page": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "check_slack_channel": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "find_workspace_by_connector_id": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_connector_details": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_conversation_details": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_mcp_server_details": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_workspace_agent": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_workspace_credits": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_workspace_feature_flags": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_workspace_members": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_workspace_metadata": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_workspace_plan_and_subscription": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_workspace_skill": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_workspace_spaces": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_data_sources": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_workspace_agents": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_workspace_groups": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_workspace_skills": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "search_workspaces": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "primitive_types_debugger": {
+    "pass_through": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "tool_without_user_config": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "productboard": {
+    "create_entity": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_note": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_configuration": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_note": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_relationships": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "query_entities": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "query_notes": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_entity": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_note": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "query_tables_v2": {
+    "execute_database_query": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_database_schema": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_tables": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "run_agent": {
+    "run_agent": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+  },
+  "run_dust_app": {
+    "run_dust_app": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+  },
+  "salesforce": {
+    "create_object": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "describe_object": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "execute_read_query": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_attachments": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_objects": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "read_attachment": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_object": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "salesloft": {
+    "get_actions": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "sandbox": {
+    "add_egress_domain": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "bash": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "describe_toolset": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "sandbox_functions": {
+    "call": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "publish": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "schedules_management": {
+    "create_schedule": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "disable_schedule": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_schedules": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "search": {
+    "semantic_search": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "skill_authoring": {
+    "create_skill": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_skill": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_skills": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "update_skill": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "skill_management": {
+    "enable_skill": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "slab": {
+    "get_post_contents": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_post_metadata": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_topics": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_posts": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "slack": {
+    "archive_channel": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_channel": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_channel_canvases": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "invite_to_channel": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_messages": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_user_groups": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "post_message": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "read_canvas": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "read_thread_messages": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "schedule_message": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_channels": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_messages": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_user": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "semantic_search_messages": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "write_canvas": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "slack_bot": {
+    "add_reaction": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "edit_message": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_public_channels": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "post_message": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "read_channel_history": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "read_thread_messages": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "remove_reaction": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_user": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "snowflake": {
+    "describe_semantic_view": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "describe_table": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_databases": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_schemas": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_tables": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "query": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "sound_studio": {
+    "generate_sound_effects": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "speech_generator": {
+    "speech_to_text": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "text_to_dialogue": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "text_to_speech": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "statuspage": {
+    "create_incident": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_incident": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_components": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_incidents": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_pages": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_incident": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "toolsets": {
+    "enable": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "ukg_ready": {
+    "create_pto_request": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_pto_request": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_accrual_balances": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_employees": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_my_info": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_pto_request_notes": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_pto_requests": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_schedules": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "user_mentions": {
+    "get_mention_markdown": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "search_available_users": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "val_town": {
+    "call_http_endpoint": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_file": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "create_val": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "delete_file": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_file_content": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_val": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_val_files": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_vals": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_vals": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_file_content": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "write_file": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "vanta": {
+    "list_control_documents": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_control_tests": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_controls": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_document_resources": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_documents": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_framework_controls": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_frameworks": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_integrations": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_people": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_risks": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_test_entities": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_tests": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_vulnerabilities": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "wakeups": {
+    "cancel_wakeup": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_wakeups": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "schedule_wakeup": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+  },
+  "web_search_&_browse": {
+    "webbrowser": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "websearch": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+  },
+  "workday": {
+    "get_workers": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+  "workspace_analytics": {
+    "get_agent_details": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "get_credit_timeseries": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "get_credit_usage": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "get_source_breakdown": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "get_top_agents": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "get_top_skills": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "get_top_tools": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "get_top_users": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+    "get_usage_timeseries": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
+  },
+  "zendesk": {
+    "draft_reply": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_ticket": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_ticket_fields": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "post_reply": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "search_tickets": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_ticket_tags": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
+}
+`;
+
 exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across all servers 1`] = `
 {
   "agent_memory": {

--- a/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
+++ b/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
@@ -2,14 +2,14 @@
  * MCP Server Metadata Snapshot Test
  *
  * This test ensures that MCP server metadata (tools, their descriptions, input schemas,
- * and tool stakes) remains stable across code changes. It helps detect unintended changes
- * when refactoring MCP servers from old-style (inline tool definitions) to new-style
- * (separate metadata files).
+ * tool stakes, and billing info) remains stable across code changes. It helps detect
+ * unintended changes when refactoring MCP servers from old-style (inline tool definitions)
+ * to new-style (separate metadata files).
  *
  * How it works:
  * 1. Instantiates each server with a mock authenticator
  * 2. Extracts the registered tools via the MCP protocol
- * 3. Fetches tool stakes from the server configuration
+ * 3. Fetches tool stakes and billing info from the server configuration
  * 4. Compares the extracted metadata against a saved snapshot file
  *
  * Usage:
@@ -27,13 +27,16 @@ import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
+  getInternalMCPServerMetadata,
   getInternalMCPServerToolStakes,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import { getInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/servers";
+import type { InternalMCPToolType } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { extractMetadataFromTools } from "@app/lib/actions/mcp_metadata";
-import type { MCPToolType } from "@app/lib/api/mcp";
+import type { MCPToolType, ToolCostCategory } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
+import { getToolBillingInfo } from "@app/lib/metronome/events";
 import { LEGACY_REGION_BIT } from "@app/lib/resources/string_ids";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { describe, expect, it } from "vitest";
@@ -48,6 +51,11 @@ interface ToolMetadataSnapshot {
   name: string;
   description: string;
   inputSchema?: unknown;
+}
+
+interface ToolBillingSnapshot {
+  toolCostCategory: ToolCostCategory;
+  freeUsage: boolean;
 }
 
 /**
@@ -249,6 +257,48 @@ describe("MCP Servers Metadata Snapshot", () => {
       throw new Error(
         `Failed to extract metadata from ${serversWithErrors.length} server(s):\n${errorDetails}`
       );
+    }
+  });
+
+  it("should have stable tool billing info across all servers", () => {
+    const allBilling: Record<string, Record<string, ToolBillingSnapshot>> = {};
+
+    for (const serverName of [...AVAILABLE_INTERNAL_MCP_SERVER_NAMES].sort()) {
+      const tools = getInternalMCPServerMetadata(serverName)
+        .tools as InternalMCPToolType[];
+
+      const toolSnapshots: Record<string, ToolBillingSnapshot> = {};
+      for (const tool of [...tools].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      )) {
+        const billing = getToolBillingInfo(serverName, tool.name);
+        expect(
+          billing.toolCostCategory,
+          `${serverName}/${tool.name} must have toolCostCategory defined`
+        ).toBeDefined();
+        expect(
+          billing.freeUsage,
+          `${serverName}/${tool.name} must have freeUsage defined`
+        ).toBeDefined();
+        toolSnapshots[tool.name] = billing;
+      }
+
+      allBilling[serverName] = toolSnapshots;
+    }
+
+    try {
+      expect(allBilling).toMatchSnapshot();
+    } catch (error) {
+      const hint =
+        "\n\nTool billing info changed. Review the diff above and run:\n" +
+        "  NODE_ENV=test npm test -w front -- --update lib/actions/" +
+        "mcp_internal_actions/mcp_servers_metadata.test.ts\n" +
+        "to update the snapshot.";
+
+      if (error instanceof Error) {
+        error.message += hint;
+      }
+      throw error;
     }
   });
 

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -4,7 +4,7 @@ import type { ToolContextType } from "@app/lib/actions/types";
 import type {
   InternalMCPServerDefinitionType,
   MCPToolType,
-  ToolCategory,
+  ToolCostCategory,
   ToolDisplayLabels,
 } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -55,8 +55,8 @@ export interface ToolDefinition<
   schema: TSchema;
   stake: MCPToolStakeLevelType;
   displayLabels: ToolDisplayLabels;
-  toolCategory?: ToolCategory;
-  freeUsage?: boolean;
+  toolCostCategory: ToolCostCategory;
+  freeUsage: boolean;
   handler: (
     params: z.infer<z.ZodObject<TSchema>>,
     extra: ToolHandlerExtra
@@ -73,8 +73,8 @@ interface ClientToolDefinition<
   schema: TSchema;
   stake: MCPToolStakeLevelType;
   displayLabels: ToolDisplayLabels;
-  toolCategory?: ToolCategory;
-  freeUsage?: boolean;
+  toolCostCategory: ToolCostCategory;
+  freeUsage: boolean;
   argumentsRequiringApproval?: Array<
     Extract<keyof z.infer<z.ZodObject<TSchema>>, string>
   >;
@@ -149,8 +149,8 @@ export type InternalMCPToolType<TName extends string = string> = Omit<
 > & {
   name: TName;
   displayLabels: ToolDisplayLabels;
-  toolCategory?: ToolCategory;
-  freeUsage?: boolean;
+  toolCostCategory: ToolCostCategory;
+  freeUsage: boolean;
 };
 
 export type ServerMetadata<

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -4,6 +4,7 @@ import type { ToolContextType } from "@app/lib/actions/types";
 import type {
   InternalMCPServerDefinitionType,
   MCPToolType,
+  ToolCategory,
   ToolDisplayLabels,
 } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -54,6 +55,8 @@ export interface ToolDefinition<
   schema: TSchema;
   stake: MCPToolStakeLevelType;
   displayLabels: ToolDisplayLabels;
+  toolCategory?: ToolCategory;
+  freeUsage?: boolean;
   handler: (
     params: z.infer<z.ZodObject<TSchema>>,
     extra: ToolHandlerExtra
@@ -70,6 +73,8 @@ interface ClientToolDefinition<
   schema: TSchema;
   stake: MCPToolStakeLevelType;
   displayLabels: ToolDisplayLabels;
+  toolCategory?: ToolCategory;
+  freeUsage?: boolean;
   argumentsRequiringApproval?: Array<
     Extract<keyof z.infer<z.ZodObject<TSchema>>, string>
   >;
@@ -138,12 +143,14 @@ export function buildTools<T extends Record<string, ToolMeta>>(
 }
 
 // Internal MCP server tools must have displayLabels (unlike remote servers).
-type InternalMCPToolType<TName extends string = string> = Omit<
+export type InternalMCPToolType<TName extends string = string> = Omit<
   MCPToolType,
   "name" | "displayLabels"
 > & {
   name: TName;
   displayLabels: ToolDisplayLabels;
+  toolCategory?: ToolCategory;
+  freeUsage?: boolean;
 };
 
 export type ServerMetadata<

--- a/front/lib/actions/mcp_internal_actions/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.test.ts
@@ -26,12 +26,16 @@ const TEST_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: { running: "Running", done: "Ran" },
+    toolCostCategory: "basic" as const,
+    freeUsage: false,
   },
   open_tool: {
     description: "Unguarded test tool.",
     schema: {},
     stake: "never_ask",
     displayLabels: { running: "Running", done: "Ran" },
+    toolCostCategory: "basic" as const,
+    freeUsage: false,
   },
 });
 

--- a/front/lib/api/actions/servers/agent_memory/metadata.ts
+++ b/front/lib/api/actions/servers/agent_memory/metadata.ts
@@ -21,6 +21,8 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving memories",
       done: "Retrieve memories",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [AGENT_MEMORY_RECORD_TOOL_NAME]: {
     description:
@@ -37,6 +39,8 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
       running: "Recording memories",
       done: "Record memories",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [AGENT_MEMORY_ERASE_TOOL_NAME]: {
     description:
@@ -53,6 +57,8 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
       running: "Erasing memory entries",
       done: "Erase memory entries",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [AGENT_MEMORY_EDIT_TOOL_NAME]: {
     description:
@@ -76,6 +82,8 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
       running: "Editing memory entries",
       done: "Edit memory entries",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [AGENT_MEMORY_COMPACT_TOOL_NAME]: {
     description:
@@ -103,6 +111,8 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
       running: "Compacting memory",
       done: "Compact memory",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -114,14 +124,14 @@ export const AGENT_MEMORY_SERVER = {
     authorization: null,
     icon: "ActionLightbulbIcon",
     documentationUrl: null,
-    toolCategory: "basic",
-    freeUsage: true,
   },
   tools: Object.values(AGENT_MEMORY_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(AGENT_MEMORY_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/agent_memory/metadata.ts
+++ b/front/lib/api/actions/servers/agent_memory/metadata.ts
@@ -114,6 +114,8 @@ export const AGENT_MEMORY_SERVER = {
     authorization: null,
     icon: "ActionLightbulbIcon",
     documentationUrl: null,
+    toolCategory: "basic",
+    freeUsage: true,
   },
   tools: Object.values(AGENT_MEMORY_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/agent_router/metadata.ts
+++ b/front/lib/api/actions/servers/agent_router/metadata.ts
@@ -24,6 +24,8 @@ export const AGENT_ROUTER_TOOLS_METADATA = createToolsRecord({
       running: "Listing agents",
       done: "List agents",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   suggest_agents_for_content: {
     description:
@@ -42,6 +44,8 @@ export const AGENT_ROUTER_TOOLS_METADATA = createToolsRecord({
       running: "Suggesting agents",
       done: "Suggest agents",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -53,14 +57,14 @@ export const AGENT_ROUTER_SERVER = {
     authorization: null,
     icon: "ActionRobotIcon",
     documentationUrl: null,
-    toolCategory: "basic",
-    freeUsage: true,
   },
   tools: Object.values(AGENT_ROUTER_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(AGENT_ROUTER_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/agent_router/metadata.ts
+++ b/front/lib/api/actions/servers/agent_router/metadata.ts
@@ -53,6 +53,8 @@ export const AGENT_ROUTER_SERVER = {
     authorization: null,
     icon: "ActionRobotIcon",
     documentationUrl: null,
+    toolCategory: "basic",
+    freeUsage: true,
   },
   tools: Object.values(AGENT_ROUTER_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
@@ -17,18 +17,17 @@ export const AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA = createToolsRecord({
   },
 });
 
-export const AGENT_SIDEKICK_AGENT_STATE_SERVER_INFO = {
-  name: "agent_sidekick_agent_state" as const,
-  version: "1.0.0",
-  description:
-    "Retrieve information about the current agent's configuration, including name, description, instructions, model, and tools.",
-  authorization: null,
-  icon: "ActionRobotIcon" as const,
-  documentationUrl: null,
-};
-
 export const AGENT_SIDEKICK_AGENT_STATE_SERVER = {
-  serverInfo: AGENT_SIDEKICK_AGENT_STATE_SERVER_INFO,
+  serverInfo: {
+    name: "agent_sidekick_agent_state",
+    version: "1.0.0",
+    description:
+      "Retrieve information about the current agent's configuration, including name, description, instructions, model, and tools.",
+    authorization: null,
+    icon: "ActionRobotIcon",
+    documentationUrl: null,
+    toolCategory: "basic",
+  },
   tools: Object.values(AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
@@ -14,6 +14,8 @@ export const AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA = createToolsRecord({
       running: "Getting agent info",
       done: "Get agent info",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -26,13 +28,14 @@ export const AGENT_SIDEKICK_AGENT_STATE_SERVER = {
     authorization: null,
     icon: "ActionRobotIcon",
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -553,6 +553,7 @@ export const AGENT_SIDEKICK_CONTEXT_SERVER = {
     authorization: null,
     icon: "ActionRobotIcon",
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: Object.values(AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -118,6 +118,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Listing available models",
       done: "List available models",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   get_available_skills: {
     description:
@@ -128,6 +130,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Listing available skills",
       done: "List available skills",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   get_available_tools: {
     description:
@@ -138,6 +142,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Listing available tools",
       done: "List available tools",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [DESCRIBE_MCP_TOOL_NAME]: {
     description:
@@ -150,6 +156,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Describing MCP server",
       done: "Describe MCP server",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   get_available_agents: {
     description:
@@ -172,6 +180,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Listing available agents",
       done: "List available agents",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   inspect_available_agent: {
     description:
@@ -184,6 +194,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Inspecting agent",
       done: "Inspect agent",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   get_agent_feedback: {
     description: "Get user feedback for the agent.",
@@ -213,6 +225,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Listing agent feedback",
       done: "List agent feedback",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   get_agent_insights: {
     description:
@@ -230,6 +244,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Listing agent insights",
       done: "List agent insights",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   // Suggestion tools
   suggest_prompt_edits: {
@@ -253,6 +269,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Suggesting prompt edits",
       done: "Suggest prompt edits",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   suggest_tools: {
     description:
@@ -280,6 +298,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Suggesting tools",
       done: "Suggest tools",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   suggest_sub_agent: {
     description:
@@ -306,6 +326,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Suggesting sub-agent",
       done: "Suggest sub-agent",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   suggest_skills: {
     description:
@@ -332,6 +354,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Suggesting skills",
       done: "Suggest skills",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   suggest_model: {
     description:
@@ -350,6 +374,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Suggesting model",
       done: "Suggest model",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   search_knowledge: {
     description:
@@ -385,6 +411,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Searching knowledge sources",
       done: "Search knowledge sources",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   suggest_knowledge: {
     description:
@@ -407,6 +435,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Suggesting knowledge",
       done: "Suggest knowledge",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   list_suggestions: {
     description:
@@ -439,6 +469,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Listing suggestions",
       done: "List suggestions",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   update_suggestions_state: {
     description:
@@ -464,6 +496,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Updating suggestion state",
       done: "Update suggestion state",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   search_agent_templates: {
     description:
@@ -488,6 +522,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Searching templates",
       done: "Search templates",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   get_agent_template: {
     description:
@@ -502,6 +538,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Fetching template",
       done: "Fetch template",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   inspect_conversation: {
     description:
@@ -526,6 +564,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Inspecting conversation",
       done: "Inspect conversation",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   inspect_message: {
     description:
@@ -541,6 +581,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Inspecting message",
       done: "Inspect message",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -553,13 +595,14 @@ export const AGENT_SIDEKICK_CONTEXT_SERVER = {
     authorization: null,
     icon: "ActionRobotIcon",
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -32,6 +32,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       running: "Searching candidates on Ashby",
       done: "Search candidates on Ashby",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_report_data: {
     description: "Retrieve report data and save it as a CSV file.",
@@ -47,6 +49,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Ashby report data",
       done: "Retrieve Ashby report data",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_interview_feedback: {
     description:
@@ -59,6 +63,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving interview feedback from Ashby",
       done: "Retrieve interview feedback from Ashby",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_candidate_notes: {
     description:
@@ -70,6 +76,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving candidate notes from Ashby",
       done: "Retrieve candidate notes from Ashby",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_openings: {
     description:
@@ -99,6 +107,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       running: "Listing openings from Ashby",
       done: "List openings from Ashby",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_candidate_note: {
     description:
@@ -115,6 +125,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       running: "Creating candidate note on Ashby",
       done: "Create candidate note on Ashby",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   [GET_REFERRAL_FORM_TOOL_NAME]: {
     description:
@@ -127,6 +139,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving referral form from Ashby",
       done: "Retrieve referral form from Ashby",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   [CREATE_REFERRAL_TOOL_NAME]: {
     description:
@@ -141,6 +155,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       running: "Creating referral on Ashby",
       done: "Create referral on Ashby",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_job_postings: {
     description:
@@ -171,6 +187,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       running: "Listing job postings from Ashby",
       done: "List job postings from Ashby",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_hire_data: {
     description:
@@ -186,6 +204,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving hire data from Ashby",
       done: "Retrieve hire data from Ashby",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_job_posting: {
     description:
@@ -235,6 +255,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       running: "Updating job posting on Ashby",
       done: "Update job posting on Ashby",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -247,13 +269,14 @@ export const ASHBY_SERVER = {
     authorization: null,
     icon: "AshbyLogo",
     documentationUrl: "https://docs.dust.tt/docs/ashby-mcp",
-    toolCategory: "advanced",
   },
   tools: Object.values(ASHBY_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(ASHBY_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -247,6 +247,7 @@ export const ASHBY_SERVER = {
     authorization: null,
     icon: "AshbyLogo",
     documentationUrl: "https://docs.dust.tt/docs/ashby-mcp",
+    toolCategory: "advanced",
   },
   tools: Object.values(ASHBY_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -38,6 +38,8 @@ export const ASK_USER_QUESTION_TOOLS_METADATA = createToolsRecord({
       running: "Asking user...",
       done: "User answered",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -49,13 +51,14 @@ export const ASK_USER_QUESTION_SERVER = {
     icon: "ActionChatBubbleThoughtIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(ASK_USER_QUESTION_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(ASK_USER_QUESTION_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -49,6 +49,7 @@ export const ASK_USER_QUESTION_SERVER = {
     icon: "ActionChatBubbleThoughtIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: Object.values(ASK_USER_QUESTION_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/clari_copilot/metadata.ts
+++ b/front/lib/api/actions/servers/clari_copilot/metadata.ts
@@ -93,6 +93,7 @@ export const CLARI_COPILOT_SERVER = {
     authorization: null,
     icon: "ClariLogo",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(CLARI_COPILOT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/clari_copilot/metadata.ts
+++ b/front/lib/api/actions/servers/clari_copilot/metadata.ts
@@ -55,6 +55,8 @@ export const CLARI_COPILOT_TOOLS_METADATA = createToolsRecord({
       running: "Searching Clari Copilot calls",
       done: "Search Clari Copilot calls",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_call_details: {
     description:
@@ -81,6 +83,8 @@ export const CLARI_COPILOT_TOOLS_METADATA = createToolsRecord({
       running: "Fetching Clari Copilot call details",
       done: "Fetch Clari Copilot call details",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -93,13 +97,14 @@ export const CLARI_COPILOT_SERVER = {
     authorization: null,
     icon: "ClariLogo",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(CLARI_COPILOT_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(CLARI_COPILOT_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/common_utilities/metadata.ts
+++ b/front/lib/api/actions/servers/common_utilities/metadata.ts
@@ -28,6 +28,8 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
       running: "Generating random number",
       done: "Generate random number",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   generate_random_float: {
     description:
@@ -38,6 +40,8 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
       running: "Generating random float",
       done: "Generate random float",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   wait: {
     description: `Pause execution for the provided number of milliseconds (maximum ${MAX_WAIT_DURATION_MS}).`,
@@ -57,6 +61,8 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
       running: "Waiting",
       done: "Wait",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   get_current_time: {
     description:
@@ -76,6 +82,8 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
       running: "Getting current time",
       done: "Get current time",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   math_operation: {
     description:
@@ -90,6 +98,8 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
       running: "Calculating",
       done: "Calculate",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   set_conversation_title: {
     description:
@@ -105,6 +115,8 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
       running: "Setting conversation title",
       done: "Set conversation title",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -116,14 +128,14 @@ export const COMMON_UTILITIES_SERVER = {
     icon: "ActionAtomIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "basic",
-    freeUsage: true,
   },
   tools: Object.values(COMMON_UTILITIES_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(COMMON_UTILITIES_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/common_utilities/metadata.ts
+++ b/front/lib/api/actions/servers/common_utilities/metadata.ts
@@ -116,6 +116,8 @@ export const COMMON_UTILITIES_SERVER = {
     icon: "ActionAtomIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "basic",
+    freeUsage: true,
   },
   tools: Object.values(COMMON_UTILITIES_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/confluence/metadata.ts
+++ b/front/lib/api/actions/servers/confluence/metadata.ts
@@ -170,6 +170,7 @@ export const CONFLUENCE_SERVER = {
     },
     icon: "ConfluenceLogo",
     documentationUrl: "https://docs.dust.tt/docs/confluence-tool",
+    toolCategory: "advanced",
   },
   tools: Object.values(CONFLUENCE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/confluence/metadata.ts
+++ b/front/lib/api/actions/servers/confluence/metadata.ts
@@ -16,6 +16,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
       running: "Getting current Confluence user",
       done: "Get current Confluence user",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_spaces: {
     description:
@@ -26,6 +28,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Confluence spaces",
       done: "List Confluence spaces",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_pages: {
     description:
@@ -53,6 +57,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
       running: "Searching Confluence pages",
       done: "Search Confluence pages",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_page: {
     description:
@@ -72,6 +78,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Confluence page",
       done: "Retrieve Confluence page",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_page: {
     description:
@@ -107,6 +115,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
       running: "Creating Confluence page",
       done: "Create Confluence page",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_page: {
     description:
@@ -156,6 +166,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
       running: "Updating Confluence page",
       done: "Update Confluence page",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -170,13 +182,14 @@ export const CONFLUENCE_SERVER = {
     },
     icon: "ConfluenceLogo",
     documentationUrl: "https://docs.dust.tt/docs/confluence-tool",
-    toolCategory: "advanced",
   },
   tools: Object.values(CONFLUENCE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(CONFLUENCE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -136,6 +136,7 @@ export const CONVERSATION_FILES_SERVER = {
     icon: "ActionDocumentTextIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: ALL_CONVERSATION_FILES_TOOLS.map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -60,6 +60,8 @@ const CAT_FILE_TOOL = {
     running: "Reading file from conversation",
     done: "Read file from conversation",
   },
+  toolCostCategory: "advanced" as const,
+  freeUsage: false,
 };
 
 export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
@@ -74,6 +76,8 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
       running: "Listing files in conversation",
       done: "List files in conversation",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [CONVERSATION_CAT_FILE_ACTION_NAME]: CAT_FILE_TOOL,
   [CONVERSATION_SEARCH_FILES_ACTION_NAME]: {
@@ -93,6 +97,8 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
       running: "Searching files in conversation",
       done: "Search files in conversation",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -114,6 +120,8 @@ export const CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM =
         running: "Listing conversation attachments",
         done: "List conversation attachments",
       },
+      toolCostCategory: "basic",
+      freeUsage: true,
     },
     [CONVERSATION_CAT_FILE_ACTION_NAME]: CAT_FILE_TOOL,
   });
@@ -136,13 +144,14 @@ export const CONVERSATION_FILES_SERVER = {
     icon: "ActionDocumentTextIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: ALL_CONVERSATION_FILES_TOOLS.map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     ALL_CONVERSATION_FILES_TOOLS.map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -143,6 +143,7 @@ export const DATA_SOURCES_FILE_SYSTEM_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -37,6 +37,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
       running: "Reading file from data source",
       done: "Read file from data source",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
     enableAlerting: true,
   },
   [FILESYSTEM_LIST_TOOL_NAME]: {
@@ -51,6 +53,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
       running: "Listing data source contents",
       done: "List data source contents",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
     enableAlerting: true,
   },
   [FILESYSTEM_SEARCH_TOOL_NAME]: {
@@ -66,6 +70,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
       running: "Searching data sources",
       done: "Search data sources",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
     enableAlerting: true,
   },
   [FILESYSTEM_FIND_TOOL_NAME]: {
@@ -80,6 +86,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
       running: "Finding in data sources",
       done: "Find in data sources",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
     enableAlerting: true,
   },
   [FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME]: {
@@ -94,6 +102,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
       running: "Locating content in hierarchy",
       done: "Locate content in hierarchy",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
     enableAlerting: true,
   },
 });
@@ -131,6 +141,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_WITH_TAGS_METADATA =
         running: "Finding tags",
         done: "Find tags",
       },
+      toolCostCategory: "advanced",
+      freeUsage: false,
       enableAlerting: true,
     },
   });
@@ -143,13 +155,14 @@ export const DATA_SOURCES_FILE_SYSTEM_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -52,6 +52,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
       running: "Listing warehouse contents",
       done: "List warehouse contents",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   find: {
     description:
@@ -97,6 +99,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
       running: "Finding tables in warehouse",
       done: "Find tables in warehouse",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   describe_tables: {
     description:
@@ -120,6 +124,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
       running: "Describing warehouse tables",
       done: "Describe warehouse tables",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   query: {
     description:
@@ -156,6 +162,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
       running: "Running warehouse query",
       done: "Run warehouse query",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -168,13 +176,14 @@ export const DATA_WAREHOUSES_SERVER = {
     authorization: null,
     icon: "ActionTableIcon",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(DATA_WAREHOUSES_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(DATA_WAREHOUSES_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -168,6 +168,7 @@ export const DATA_WAREHOUSES_SERVER = {
     authorization: null,
     icon: "ActionTableIcon",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(DATA_WAREHOUSES_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/databricks/metadata.ts
+++ b/front/lib/api/actions/servers/databricks/metadata.ts
@@ -28,6 +28,7 @@ export const DATABRICKS_SERVER = {
     },
     icon: "ActionTableIcon",
     documentationUrl: "https://docs.dust.tt/docs/databricks",
+    toolCategory: "advanced",
   },
   tools: Object.values(DATABRICKS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/databricks/metadata.ts
+++ b/front/lib/api/actions/servers/databricks/metadata.ts
@@ -14,6 +14,8 @@ export const DATABRICKS_TOOLS_METADATA = createToolsRecord({
       running: "Listing warehouses on Databricks",
       done: "List warehouses on Databricks",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -28,13 +30,14 @@ export const DATABRICKS_SERVER = {
     },
     icon: "ActionTableIcon",
     documentationUrl: "https://docs.dust.tt/docs/databricks",
-    toolCategory: "advanced",
   },
   tools: Object.values(DATABRICKS_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(DATABRICKS_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/exa/metadata.ts
+++ b/front/lib/api/actions/servers/exa/metadata.ts
@@ -88,6 +88,7 @@ export const EXA_SERVER = {
     authorization: null,
     icon: "ActionMagnifyingGlassIcon",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(EXA_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/exa/metadata.ts
+++ b/front/lib/api/actions/servers/exa/metadata.ts
@@ -39,6 +39,8 @@ export const EXA_TOOLS_METADATA = createToolsRecord({
       running: "Searching for people",
       done: "Search people",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_companies: {
     description:
@@ -74,6 +76,8 @@ export const EXA_TOOLS_METADATA = createToolsRecord({
       running: "Searching for companies",
       done: "Search companies",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -88,13 +92,14 @@ export const EXA_SERVER = {
     authorization: null,
     icon: "ActionMagnifyingGlassIcon",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(EXA_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(EXA_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/extract_data/metadata.ts
+++ b/front/lib/api/actions/servers/extract_data/metadata.ts
@@ -187,6 +187,7 @@ export const EXTRACT_DATA_SERVER = {
     icon: "ActionScanIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(EXTRACT_DATA_BASE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/extract_data/metadata.ts
+++ b/front/lib/api/actions/servers/extract_data/metadata.ts
@@ -109,6 +109,8 @@ export function makeExtractDataBaseToolsMetadata({
         running: "Extracting data from documents",
         done: "Extract data from documents",
       },
+      toolCostCategory: "advanced",
+      freeUsage: false,
     },
   });
 }
@@ -147,6 +149,8 @@ export function makeExtractDataToolsWithTagsMetadata({
         running: "Finding tags",
         done: "Find tags",
       },
+      toolCostCategory: "advanced",
+      freeUsage: false,
     },
   });
 }
@@ -187,13 +191,14 @@ export const EXTRACT_DATA_SERVER = {
     icon: "ActionScanIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(EXTRACT_DATA_BASE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(EXTRACT_DATA_BASE_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/fathom/metadata.ts
+++ b/front/lib/api/actions/servers/fathom/metadata.ts
@@ -108,6 +108,7 @@ export const FATHOM_SERVER = {
     },
     icon: "FathomLogo",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(FATHOM_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/fathom/metadata.ts
+++ b/front/lib/api/actions/servers/fathom/metadata.ts
@@ -78,6 +78,8 @@ export const FATHOM_TOOLS_METADATA = createToolsRecord({
       running: "Listing Fathom meetings",
       done: "List Fathom meetings",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_transcript: {
     description:
@@ -93,6 +95,8 @@ export const FATHOM_TOOLS_METADATA = createToolsRecord({
       running: "Getting Fathom transcript",
       done: "Get Fathom transcript",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -108,13 +112,14 @@ export const FATHOM_SERVER = {
     },
     icon: "FathomLogo",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(FATHOM_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(FATHOM_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/file_generation/metadata.ts
+++ b/front/lib/api/actions/servers/file_generation/metadata.ts
@@ -49,6 +49,8 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
       running: "Listing supported formats",
       done: "List supported formats",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   convert_file_format: {
     description:
@@ -78,6 +80,8 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
       running: "Converting file",
       done: "Convert file",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   generate_file: {
     description:
@@ -107,6 +111,8 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
       running: "Generating file",
       done: "Generate file",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -118,13 +124,14 @@ export const FILE_GENERATION_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(FILE_GENERATION_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(FILE_GENERATION_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/file_generation/metadata.ts
+++ b/front/lib/api/actions/servers/file_generation/metadata.ts
@@ -118,6 +118,7 @@ export const FILE_GENERATION_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(FILE_GENERATION_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -407,6 +407,7 @@ export const FILES_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(FILES_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -91,6 +91,8 @@ const LIST_TOOL = {
     running: "Listing available files",
     done: "Listed available files",
   },
+  toolCostCategory: "basic" as const,
+  freeUsage: true,
 };
 
 // `copy` tool variants. The conversation-only build keeps the description scoped to within-
@@ -130,6 +132,8 @@ const COPY_TOOL = {
     running: "Copying file",
     done: "Copied file",
   },
+  toolCostCategory: "basic" as const,
+  freeUsage: true,
 };
 
 const MOVE_TOOL = {
@@ -151,6 +155,8 @@ const MOVE_TOOL = {
     running: "Moving file",
     done: "Moved file",
   },
+  toolCostCategory: "basic" as const,
+  freeUsage: true,
 };
 
 // Stake levels in this record are typed via `as const` so the object can be spread into
@@ -178,6 +184,8 @@ const FILES_TOOLS_COMMON_METADATA = {
       running: "Resolving file ID",
       done: "Resolved file ID",
     },
+    toolCostCategory: "basic" as const,
+    freeUsage: true,
   },
   [FILES_CAT_ACTION_NAME]: {
     description:
@@ -216,6 +224,8 @@ const FILES_TOOLS_COMMON_METADATA = {
       running: "Reading file",
       done: "Read file",
     },
+    toolCostCategory: "basic" as const,
+    freeUsage: true,
   },
   [FILES_GREP_ACTION_NAME]: {
     description:
@@ -240,6 +250,8 @@ const FILES_TOOLS_COMMON_METADATA = {
       running: "Searching file",
       done: "Searched file",
     },
+    toolCostCategory: "basic" as const,
+    freeUsage: true,
   },
   [FILES_CREATE_ACTION_NAME]: {
     description:
@@ -270,6 +282,8 @@ const FILES_TOOLS_COMMON_METADATA = {
       running: "Writing file",
       done: "Write file",
     },
+    toolCostCategory: "basic" as const,
+    freeUsage: true,
   },
   [FILES_UPLOAD_FROM_URL_ACTION_NAME]: {
     description:
@@ -304,6 +318,8 @@ const FILES_TOOLS_COMMON_METADATA = {
       running: "Uploading file from URL",
       done: "Uploaded file from URL",
     },
+    toolCostCategory: "basic" as const,
+    freeUsage: true,
   },
   [FILES_DELETE_ACTION_NAME]: {
     description:
@@ -321,6 +337,8 @@ const FILES_TOOLS_COMMON_METADATA = {
       running: "Deleting file",
       done: "Deleted file",
     },
+    toolCostCategory: "basic" as const,
+    freeUsage: true,
   },
 };
 
@@ -360,6 +378,8 @@ const EDIT_TOOL = {
     running: "Editing file",
     done: "Edited file",
   },
+  toolCostCategory: "basic" as const,
+  freeUsage: true,
 };
 
 const EXTRACT_TEXT_TOOL = {
@@ -382,6 +402,8 @@ const EXTRACT_TEXT_TOOL = {
     running: "Extracting text from document",
     done: "Extracted text from document",
   },
+  toolCostCategory: "basic" as const,
+  freeUsage: true,
 };
 
 export const FILES_TOOLS_METADATA = createToolsRecord({
@@ -407,13 +429,14 @@ export const FILES_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(FILES_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(FILES_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -54,6 +54,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice tickets",
       done: "List Freshservice tickets",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_ticket: {
     description:
@@ -74,6 +76,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Getting Freshservice ticket",
       done: "Get Freshservice ticket",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_ticket_read_fields: {
     description:
@@ -84,6 +88,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Getting Freshservice ticket read fields",
       done: "Get Freshservice ticket read fields",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_ticket_write_fields: {
     description:
@@ -99,6 +105,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Getting Freshservice ticket write fields",
       done: "Get Freshservice ticket write fields",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_ticket: {
     description:
@@ -127,6 +135,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Creating Freshservice ticket",
       done: "Create Freshservice ticket",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_ticket: {
     description: "Update an existing Freshservice ticket.",
@@ -153,6 +163,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Updating Freshservice ticket",
       done: "Update Freshservice ticket",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   add_ticket_note: {
     description:
@@ -171,6 +183,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Adding note to Freshservice ticket",
       done: "Add note to Freshservice ticket",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   add_ticket_reply: {
     description:
@@ -184,6 +198,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Adding reply to Freshservice ticket",
       done: "Add reply to Freshservice ticket",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Service request items
@@ -198,6 +214,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice ticket requested items",
       done: "List Freshservice ticket requested items",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Ticket tasks
@@ -211,6 +229,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice ticket tasks",
       done: "List Freshservice ticket tasks",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_ticket_task: {
     description: "Get detailed information about a specific task on a ticket",
@@ -223,6 +243,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Getting Freshservice ticket task",
       done: "Get Freshservice ticket task",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_ticket_task: {
     description:
@@ -248,6 +270,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Creating Freshservice ticket task",
       done: "Create Freshservice ticket task",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_ticket_task: {
     description: "Update an existing task on a ticket",
@@ -282,6 +306,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Updating Freshservice ticket task",
       done: "Update Freshservice ticket task",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_ticket_task: {
     description: "Delete a task from a ticket",
@@ -294,6 +320,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Deleting Freshservice ticket task",
       done: "Delete Freshservice ticket task",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Ticket approvals
@@ -308,6 +336,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Getting Freshservice ticket approval",
       done: "Get Freshservice ticket approval",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_ticket_approvals: {
     description: "List all approvals for a specific ticket",
@@ -319,6 +349,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice ticket approvals",
       done: "List Freshservice ticket approvals",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   request_service_approval: {
     description:
@@ -345,6 +377,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Requesting Freshservice approval",
       done: "Request Freshservice approval",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Departments, Products, On-call schedules
@@ -359,6 +393,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice departments",
       done: "List Freshservice departments",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_products: {
     description: "List all products in Freshservice",
@@ -371,6 +407,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice products",
       done: "List Freshservice products",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_oncall_schedules: {
     description: "List on-call schedules",
@@ -383,6 +421,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice on-call schedules",
       done: "List Freshservice on-call schedules",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Service catalog
@@ -398,6 +438,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice service categories",
       done: "List Freshservice service categories",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_service_items: {
     description:
@@ -417,6 +459,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice service items",
       done: "List Freshservice service items",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_service_items: {
     description:
@@ -448,6 +492,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Searching Freshservice service items",
       done: "Search Freshservice service items",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_service_item: {
     description:
@@ -462,6 +508,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Getting Freshservice service item",
       done: "Get Freshservice service item",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_service_item_fields: {
     description:
@@ -476,6 +524,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Getting Freshservice service item fields",
       done: "Get Freshservice service item fields",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   request_service_item: {
     description:
@@ -506,6 +556,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Requesting Freshservice service item",
       done: "Request Freshservice service item",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Solutions (Knowledge Base)
@@ -521,6 +573,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice solution categories",
       done: "List Freshservice solution categories",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_solution_folders: {
     description:
@@ -535,6 +589,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice solution folders",
       done: "List Freshservice solution folders",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_solution_articles: {
     description:
@@ -557,6 +613,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice solution articles",
       done: "List Freshservice solution articles",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_solution_article: {
     description:
@@ -569,6 +627,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Getting Freshservice solution article",
       done: "Get Freshservice solution article",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_solution_article: {
     description:
@@ -592,6 +652,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Creating Freshservice solution article",
       done: "Create Freshservice solution article",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Requesters
@@ -610,6 +672,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice requesters",
       done: "List Freshservice requesters",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_requester: {
     description: "Get detailed information about a specific requester",
@@ -621,6 +685,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Getting Freshservice requester",
       done: "Get Freshservice requester",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Purchase Orders
@@ -635,6 +701,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice purchase orders",
       done: "List Freshservice purchase orders",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // SLA Policies
@@ -646,6 +714,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice SLA policies",
       done: "List Freshservice SLA policies",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Canned responses
@@ -670,6 +740,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Freshservice canned responses",
       done: "List Freshservice canned responses",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_canned_response: {
     description: "Get detailed information about a specific canned response",
@@ -681,6 +753,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       running: "Getting Freshservice canned response",
       done: "Get Freshservice canned response",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -696,13 +770,14 @@ export const FRESHSERVICE_SERVER = {
     },
     icon: "FreshserviceLogo",
     documentationUrl: "https://docs.dust.tt/docs/freshservice",
-    toolCategory: "advanced",
   },
   tools: Object.values(FRESHSERVICE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(FRESHSERVICE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -696,6 +696,7 @@ export const FRESHSERVICE_SERVER = {
     },
     icon: "FreshserviceLogo",
     documentationUrl: "https://docs.dust.tt/docs/freshservice",
+    toolCategory: "advanced",
   },
   tools: Object.values(FRESHSERVICE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -311,6 +311,7 @@ export const FRONT_SERVER = {
     authorization: null,
     icon: "FrontLogo",
     documentationUrl: "https://docs.dust.tt/docs/front-mcp",
+    toolCategory: "advanced",
   },
   tools: Object.values(FRONT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -27,6 +27,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Searching Front conversations",
       done: "Search Front conversations",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_conversation: {
     description:
@@ -42,6 +44,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Front conversation",
       done: "Retrieve Front conversation",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_conversation_messages: {
     description:
@@ -57,6 +61,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Front messages",
       done: "Retrieve Front messages",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_contact: {
     description:
@@ -77,6 +83,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Looking up Front contact",
       done: "Look up Front contact",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_tags: {
     description: "Get all available tags for categorizing conversations.",
@@ -86,6 +94,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Listing Front tags",
       done: "List Front tags",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_teammates: {
     description:
@@ -96,6 +106,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Listing Front teammates",
       done: "List Front teammates",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_customer_history: {
     description:
@@ -117,6 +129,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Front customer history",
       done: "Retrieve Front customer history",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_inboxes: {
     description: "Get all inboxes/channels available in the workspace.",
@@ -126,6 +140,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Listing Front inboxes",
       done: "List Front inboxes",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_conversation_drafts: {
     description:
@@ -140,6 +156,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Front conversation drafts",
       done: "Retrieve Front conversation drafts",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_conversation: {
     description: "Start a new outbound conversation with a customer.",
@@ -160,6 +178,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Creating Front conversation",
       done: "Create Front conversation",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_draft: {
     description:
@@ -177,6 +197,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Creating draft on Front",
       done: "Create draft on Front",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_draft: {
     description:
@@ -198,6 +220,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Deleting draft on Front",
       done: "Delete draft on Front",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   add_tags: {
     description:
@@ -213,6 +237,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Adding tags on Front",
       done: "Add tags on Front",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   add_comment: {
     description:
@@ -230,6 +256,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Adding comment on Front",
       done: "Add comment on Front",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   add_links: {
     description:
@@ -245,6 +273,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Linking Front conversations",
       done: "Link Front conversations",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   send_message: {
     description:
@@ -270,6 +300,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Sending message on Front",
       done: "Send message on Front",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_conversation_status: {
     description:
@@ -287,6 +319,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Updating Front conversation status",
       done: "Update Front conversation status",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   assign_conversation: {
     description: "Assign a conversation to a specific teammate for handling.",
@@ -299,6 +333,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
       running: "Assigning Front conversation",
       done: "Assign Front conversation",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -311,13 +347,14 @@ export const FRONT_SERVER = {
     authorization: null,
     icon: "FrontLogo",
     documentationUrl: "https://docs.dust.tt/docs/front-mcp",
-    toolCategory: "advanced",
   },
   tools: Object.values(FRONT_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(FRONT_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -32,6 +32,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Creating GitHub issue",
       done: "Create GitHub issue",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_issue: {
     description:
@@ -92,6 +94,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Updating GitHub issue",
       done: "Update GitHub issue",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_pull_request: {
     description:
@@ -112,6 +116,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving GitHub pull request",
       done: "Retrieve GitHub pull request",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_pull_request_review: {
     description:
@@ -158,6 +164,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Reviewing GitHub pull request",
       done: "Review GitHub pull request",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_organization_projects: {
     description:
@@ -174,6 +182,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Listing GitHub organization projects",
       done: "List GitHub organization projects",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   add_issue_to_project: {
     description:
@@ -212,6 +222,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Adding GitHub issue to project",
       done: "Add GitHub issue to project",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   comment_on_issue: {
     description: "Add a comment to an existing GitHub issue.",
@@ -232,6 +244,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Commenting on GitHub issue",
       done: "Comment on GitHub issue",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_discussion_categories: {
     description:
@@ -257,6 +271,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Listing GitHub discussion categories",
       done: "List GitHub discussion categories",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_discussion: {
     description:
@@ -283,6 +299,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Creating GitHub discussion",
       done: "Create GitHub discussion",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   comment_on_discussion: {
     description:
@@ -310,6 +328,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Commenting on GitHub discussion",
       done: "Comment on GitHub discussion",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_discussion: {
     description:
@@ -328,6 +348,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving GitHub discussion",
       done: "Retrieve GitHub discussion",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_discussion_comments: {
     description:
@@ -354,6 +376,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving GitHub discussion comments",
       done: "Retrieve GitHub discussion comments",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_discussions: {
     description:
@@ -395,6 +419,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Listing GitHub discussions",
       done: "List GitHub discussions",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_issue: {
     description:
@@ -413,6 +439,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving GitHub issue",
       done: "Retrieve GitHub issue",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_issue_custom_fields: {
     description:
@@ -437,6 +465,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving GitHub issue custom fields",
       done: "Retrieve GitHub issue custom fields",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_issues: {
     description:
@@ -478,6 +508,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Listing GitHub issues",
       done: "List GitHub issues",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_advanced: {
     description:
@@ -506,6 +538,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Searching GitHub issues and pull requests",
       done: "Search GitHub issues and pull requests",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_pull_requests: {
     description:
@@ -543,6 +577,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       running: "Listing GitHub pull requests",
       done: "List GitHub pull requests",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -557,13 +593,14 @@ export const GITHUB_SERVER = {
     },
     icon: "GithubLogo",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(GITHUB_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(GITHUB_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -557,6 +557,7 @@ export const GITHUB_SERVER = {
     },
     icon: "GithubLogo",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(GITHUB_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -293,6 +293,7 @@ export const GMAIL_SERVER = {
     },
     icon: "GmailLogo",
     documentationUrl: "https://docs.dust.tt/docs/gmail",
+    toolCategory: "advanced",
   },
   tools: Object.values(GMAIL_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -27,6 +27,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       running: "Getting Gmail drafts",
       done: "Get Gmail drafts",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_draft: {
     description: `Create a new email draft in Gmail, or a reply draft to an existing message.
@@ -89,6 +91,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       running: "Creating Gmail draft",
       done: "Create Gmail draft",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_draft: {
     description: "Delete a draft email from Gmail.",
@@ -102,6 +106,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       running: "Deleting Gmail draft",
       done: "Delete Gmail draft",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_messages: {
     description:
@@ -135,6 +141,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       running: "Getting Gmail messages",
       done: "Get Gmail messages",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_attachment: {
     description:
@@ -172,6 +180,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       running: "Getting Gmail attachment",
       done: "Get Gmail attachment",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_labels: {
     description:
@@ -182,6 +192,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       running: "Getting Gmail labels",
       done: "Get Gmail labels",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   set_message_labels: {
     description: `Modify the labels on a Gmail message to mark it read or unread, star it, archive it, or move it into or out of the inbox. Adds and removes label IDs on the message. System label IDs can be used directly (INBOX, SPAM, TRASH, UNREAD, STARRED, IMPORTANT, ...). User labels should be retrieved first via get_labels to get their IDs.`,
@@ -198,6 +210,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       running: "Modifying Gmail message labels",
       done: "Modify Gmail message labels",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   send_mail: {
     description: `Send an email directly via Gmail.
@@ -261,6 +275,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       running: "Sending Gmail email",
       done: "Send Gmail email",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_thread: {
     description: "Get all messages in a Gmail thread/conversation.",
@@ -276,6 +292,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       running: "Getting Gmail thread",
       done: "Get Gmail thread",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -293,13 +311,14 @@ export const GMAIL_SERVER = {
     },
     icon: "GmailLogo",
     documentationUrl: "https://docs.dust.tt/docs/gmail",
-    toolCategory: "advanced",
   },
   tools: Object.values(GMAIL_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(GMAIL_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/gong/metadata.ts
+++ b/front/lib/api/actions/servers/gong/metadata.ts
@@ -33,6 +33,8 @@ export const GONG_TOOLS_METADATA = createToolsRecord({
       running: "Listing calls",
       done: "List calls",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_call: {
     description:
@@ -48,6 +50,8 @@ export const GONG_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving call",
       done: "Retrieve call",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_call_transcript: {
     description:
@@ -65,6 +69,8 @@ export const GONG_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving transcript",
       done: "Retrieve transcript",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -80,13 +86,14 @@ export const GONG_SERVER = {
     },
     icon: "GongLogo",
     documentationUrl: "https://docs.dust.tt/update/docs/gong-mcp",
-    toolCategory: "advanced",
   },
   tools: Object.values(GONG_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(GONG_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/gong/metadata.ts
+++ b/front/lib/api/actions/servers/gong/metadata.ts
@@ -80,6 +80,7 @@ export const GONG_SERVER = {
     },
     icon: "GongLogo",
     documentationUrl: "https://docs.dust.tt/update/docs/gong-mcp",
+    toolCategory: "advanced",
   },
   tools: Object.values(GONG_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -310,6 +310,7 @@ export const GOOGLE_CALENDAR_SERVER = {
     },
     icon: "GcalLogo",
     documentationUrl: "https://docs.dust.tt/docs/google-calendar",
+    toolCategory: "advanced",
   },
   tools: Object.values(GOOGLE_CALENDAR_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -57,6 +57,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Listing Google calendars",
       done: "List Google calendars",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_events: {
     description:
@@ -89,6 +91,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Listing Google Calendar events",
       done: "List Google Calendar events",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_event: {
     description:
@@ -105,6 +109,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Google Calendar event",
       done: "Retrieve Google Calendar event",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_event: {
     description:
@@ -152,6 +158,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Creating Google Calendar event",
       done: "Create Google Calendar event",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_event: {
     description:
@@ -196,6 +204,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Updating Google Calendar event",
       done: "Update Google Calendar event",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_event: {
     description: "Delete, cancel, or remove an event from a Google Calendar.",
@@ -211,6 +221,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Deleting Google Calendar event",
       done: "Delete Google Calendar event",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   check_availability: {
     description:
@@ -278,6 +290,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Checking Google Calendar availability",
       done: "Check Google Calendar availability",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_user_timezones: {
     description:
@@ -293,6 +307,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Checking Google Calendar user timezones",
       done: "Check Google Calendar user timezones",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -310,13 +326,14 @@ export const GOOGLE_CALENDAR_SERVER = {
     },
     icon: "GcalLogo",
     documentationUrl: "https://docs.dust.tt/docs/google-calendar",
-    toolCategory: "advanced",
   },
   tools: Object.values(GOOGLE_CALENDAR_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(GOOGLE_CALENDAR_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -35,6 +35,8 @@ export const GOOGLE_DRIVE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Google drives",
       done: "List Google drives",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_files: {
     description:
@@ -108,6 +110,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       running: "Searching Google Drive files",
       done: "Search Google Drive files",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_file_content: {
     description:
@@ -137,6 +141,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       running: "Getting Google Drive file content",
       done: "Get Google Drive file content",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_document_structure: {
     description:
@@ -165,6 +171,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       running: "Getting Google Docs structure",
       done: "Get Google Docs structure",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_presentation_structure: {
     description:
@@ -191,6 +199,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       running: "Getting Google Slides structure",
       done: "Get Google Slides structure",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_spreadsheet: {
     description:
@@ -206,6 +216,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       running: "Retrieving Google spreadsheet",
       done: "Retrieve Google spreadsheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_worksheet: {
     description:
@@ -231,6 +243,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       running: "Retrieving Google worksheet",
       done: "Retrieve Google worksheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_file_permissions: {
     description:
@@ -244,6 +258,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       running: "Listing file permissions",
       done: "List file permissions",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_comments: {
     description:
@@ -267,6 +283,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       running: "Listing comments on Google Drive",
       done: "List comments on Google Drive",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -288,6 +306,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Creating Google document",
       done: "Create Google document",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_spreadsheet: {
     description:
@@ -306,6 +326,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Creating Google spreadsheet",
       done: "Create Google spreadsheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_presentation: {
     description:
@@ -324,6 +346,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Creating Google presentation",
       done: "Create Google presentation",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_folder: {
     description:
@@ -342,6 +366,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Creating Google Drive folder",
       done: "Create Google Drive folder",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   copy_file: {
     description:
@@ -369,6 +395,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Copying Google Drive file",
       done: "Copy Google Drive file",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_comment: {
     description:
@@ -383,6 +411,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Adding comment on Google Drive",
       done: "Add comment on Google Drive",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_reply: {
     description:
@@ -398,6 +428,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Replying to comment on Google Drive",
       done: "Reply to comment on Google Drive",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_document: {
     description:
@@ -414,6 +446,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Updating Google document",
       done: "Update Google document",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   append_to_spreadsheet: {
     description:
@@ -449,6 +483,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Appending to Google spreadsheet",
       done: "Append to Google spreadsheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_spreadsheet: {
     description:
@@ -467,6 +503,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Updating Google spreadsheet",
       done: "Update Google spreadsheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_presentation: {
     description:
@@ -485,6 +523,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Updating Google presentation",
       done: "Update Google presentation",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   share_file: {
     description:
@@ -534,6 +574,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Sharing Google Drive file",
       done: "Share Google Drive file",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_file_permission: {
     description:
@@ -555,6 +597,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Updating file permission",
       done: "Update file permission",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   revoke_file_sharing: {
     description:
@@ -575,6 +619,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Removing file access",
       done: "Remove file access",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   upload_file: {
     description:
@@ -603,6 +649,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       running: "Uploading file to Google Drive",
       done: "Upload file to Google Drive",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -629,13 +677,14 @@ export function getGoogleDriveServerMetadata() {
       },
       icon: "DriveLogo",
       documentationUrl: "https://docs.dust.tt/docs/google-drive",
-      toolCategory: "advanced",
     },
     tools: Object.values(ALL_TOOLS_METADATA).map((t) => ({
       name: t.name,
       description: t.description,
       inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
       displayLabels: t.displayLabels,
+      toolCostCategory: t.toolCostCategory,
+      freeUsage: t.freeUsage,
     })),
     tools_stakes: Object.fromEntries(
       Object.values(ALL_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -629,6 +629,7 @@ export function getGoogleDriveServerMetadata() {
       },
       icon: "DriveLogo",
       documentationUrl: "https://docs.dust.tt/docs/google-drive",
+      toolCategory: "advanced",
     },
     tools: Object.values(ALL_TOOLS_METADATA).map((t) => ({
       name: t.name,

--- a/front/lib/api/actions/servers/google_sheets/metadata.ts
+++ b/front/lib/api/actions/servers/google_sheets/metadata.ts
@@ -28,6 +28,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Listing Google Sheets spreadsheets",
       done: "List Google Sheets spreadsheets",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_spreadsheet: {
     description:
@@ -42,6 +44,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Getting Google Sheets spreadsheet",
       done: "Get Google Sheets spreadsheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_worksheet: {
     description:
@@ -67,6 +71,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Getting Google Sheets worksheet",
       done: "Get Google Sheets worksheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_cells: {
     description: "Update cells in a Google Sheets spreadsheet.",
@@ -94,6 +100,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Updating Google Sheets cells",
       done: "Update Google Sheets cells",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   append_data: {
     description: "Append data to a Google Sheets spreadsheet.",
@@ -125,6 +133,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Appending data to Google Sheets",
       done: "Append data to Google Sheets",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   clear_range: {
     description: "Clear values from a range in a Google Sheets spreadsheet.",
@@ -141,6 +151,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Clearing Google Sheets range",
       done: "Clear Google Sheets range",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_spreadsheet: {
     description: "Create a new Google Sheets spreadsheet.",
@@ -158,6 +170,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Creating Google Sheets spreadsheet",
       done: "Create Google Sheets spreadsheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   add_worksheet: {
     description:
@@ -179,6 +193,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Adding Google Sheets worksheet",
       done: "Add Google Sheets worksheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_worksheet: {
     description: "Delete a worksheet from a Google Sheets spreadsheet.",
@@ -191,6 +207,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Deleting Google Sheets worksheet",
       done: "Delete Google Sheets worksheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   format_cells: {
     description:
@@ -234,6 +252,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Formatting Google Sheets cells",
       done: "Format Google Sheets cells",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   copy_sheet: {
     description:
@@ -258,6 +278,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Copying Google Sheets sheet",
       done: "Copy Google Sheets sheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   rename_worksheet: {
     description: "Rename a worksheet in a Google Sheets spreadsheet.",
@@ -271,6 +293,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Renaming Google Sheets worksheet",
       done: "Rename Google Sheets worksheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   move_worksheet: {
     description:
@@ -290,6 +314,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       running: "Moving Google Sheets worksheet",
       done: "Move Google Sheets worksheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -306,13 +332,14 @@ export const GOOGLE_SHEETS_SERVER = {
     },
     icon: "GoogleSpreadsheetLogo",
     documentationUrl: "https://docs.dust.tt/docs/google-sheets",
-    toolCategory: "advanced",
   },
   tools: Object.values(GOOGLE_SHEETS_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(GOOGLE_SHEETS_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/google_sheets/metadata.ts
+++ b/front/lib/api/actions/servers/google_sheets/metadata.ts
@@ -306,6 +306,7 @@ export const GOOGLE_SHEETS_SERVER = {
     },
     icon: "GoogleSpreadsheetLogo",
     documentationUrl: "https://docs.dust.tt/docs/google-sheets",
+    toolCategory: "advanced",
   },
   tools: Object.values(GOOGLE_SHEETS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/http_client/metadata.ts
+++ b/front/lib/api/actions/servers/http_client/metadata.ts
@@ -57,6 +57,8 @@ export const HTTP_CLIENT_TOOLS_METADATA = createToolsRecord({
       running: "Sending HTTP request",
       done: "Send HTTP request",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -75,7 +77,6 @@ export const HTTP_CLIENT_SERVER = {
     authorization: null,
     icon: "ActionGlobeAltIcon" as const,
     documentationUrl: null,
-    toolCategory: "advanced",
     developerSecretSelection: "optional" as const,
     developerSecretSelectionDescription:
       "This is optional. If set, this secret will be used as a default Bearer token (Authorization header) for HTTP requests.",
@@ -85,6 +86,8 @@ export const HTTP_CLIENT_SERVER = {
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(ALL_HTTP_CLIENT_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/http_client/metadata.ts
+++ b/front/lib/api/actions/servers/http_client/metadata.ts
@@ -75,6 +75,7 @@ export const HTTP_CLIENT_SERVER = {
     authorization: null,
     icon: "ActionGlobeAltIcon" as const,
     documentationUrl: null,
+    toolCategory: "advanced",
     developerSecretSelection: "optional" as const,
     developerSecretSelectionDescription:
       "This is optional. If set, this secret will be used as a default Bearer token (Authorization header) for HTTP requests.",

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -880,6 +880,7 @@ export const HUBSPOT_SERVER = {
     },
     icon: "HubspotLogo",
     documentationUrl: "https://docs.dust.tt/docs/hubspot",
+    toolCategory: "advanced",
   },
   tools: Object.values(HUBSPOT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -77,6 +77,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot object properties",
       done: "Retrieve HubSpot object properties",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_object_by_email: {
     description: `Retrieve a Hubspot object using an email address. Supports ${ALL_OBJECTS.join(", ")}.`,
@@ -89,6 +91,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot object by email",
       done: "Retrieve HubSpot object by email",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_owners: {
     description:
@@ -101,6 +105,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Listing HubSpot owners",
       done: "List HubSpot owners",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_owners: {
     description:
@@ -119,6 +125,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Searching HubSpot owners",
       done: "Search HubSpot owners",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   count_objects_by_properties: {
     description: `Count objects in Hubspot with matching properties. Supports ${SIMPLE_OBJECTS.join(", ")}. Max limit is 10000 objects.`,
@@ -133,6 +141,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Counting HubSpot objects by properties",
       done: "Count HubSpot objects by properties",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_latest_objects: {
     description: `Get latest objects from Hubspot. Supports ${SIMPLE_OBJECTS.join(", ")}. Limit is 200.`,
@@ -145,6 +155,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving latest HubSpot objects",
       done: "Retrieve latest HubSpot objects",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_contact: {
     description:
@@ -157,6 +169,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot contact",
       done: "Retrieve HubSpot contact",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_company: {
     description:
@@ -176,6 +190,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot company",
       done: "Retrieve HubSpot company",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_deal: {
     description:
@@ -195,6 +211,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot deal",
       done: "Retrieve HubSpot deal",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_meeting: {
     description: "Retrieve a Hubspot meeting (engagement) by its ID.",
@@ -208,6 +226,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot meeting",
       done: "Retrieve HubSpot meeting",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_file_public_url: {
     description: "Retrieve a publicly available URL for a file in HubSpot.",
@@ -219,6 +239,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot file public URL",
       done: "Retrieve HubSpot file public URL",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_associated_meetings: {
     description:
@@ -234,6 +256,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot associated meetings",
       done: "Retrieve HubSpot associated meetings",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_crm_objects: {
     description:
@@ -263,6 +287,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Searching HubSpot CRM objects",
       done: "Search HubSpot CRM objects",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   export_crm_objects_csv: {
     description:
@@ -286,6 +312,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Exporting HubSpot CRM objects to CSV",
       done: "Export HubSpot CRM objects to CSV",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_hubspot_link: {
     description:
@@ -304,6 +332,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot UI link",
       done: "Retrieve HubSpot UI link",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_hubspot_portal_id: {
     description:
@@ -314,6 +344,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot portal ID",
       done: "Retrieve HubSpot portal ID",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_associations: {
     description:
@@ -333,6 +365,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Listing HubSpot associations",
       done: "List HubSpot associations",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_association_labels: {
     description:
@@ -352,6 +386,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Listing HubSpot association labels",
       done: "List HubSpot association labels",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_current_user_id: {
     description:
@@ -365,6 +401,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot current user ID",
       done: "Retrieve HubSpot current user ID",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_user_activity: {
     description:
@@ -403,6 +441,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot user activity",
       done: "Retrieve HubSpot user activity",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Marketing email operations
@@ -432,6 +472,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Listing HubSpot marketing emails",
       done: "List HubSpot marketing emails",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_marketing_email: {
     description:
@@ -446,6 +488,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot marketing email",
       done: "Retrieve HubSpot marketing email",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_marketing_email_statistics: {
     description:
@@ -467,6 +511,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot marketing email statistics",
       done: "Retrieve HubSpot marketing email statistics",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_email_events: {
     description:
@@ -511,6 +557,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Listing HubSpot email events",
       done: "List HubSpot email events",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_email_campaigns: {
     description:
@@ -532,6 +580,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Listing HubSpot email campaigns",
       done: "List HubSpot email campaigns",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_email_campaign: {
     description:
@@ -548,6 +598,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving HubSpot email campaign",
       done: "Retrieve HubSpot email campaign",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Create operations
@@ -567,6 +619,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Creating HubSpot contact",
       done: "Create HubSpot contact",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_company: {
     description: "Create a new company in Hubspot, with optional associations.",
@@ -584,6 +638,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Creating HubSpot company",
       done: "Create HubSpot company",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_deal: {
     description: "Create a new deal in Hubspot, with optional associations.",
@@ -601,6 +657,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Creating HubSpot deal",
       done: "Create HubSpot deal",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_ticket: {
     description: "Create a new ticket in Hubspot, with optional associations.",
@@ -620,6 +678,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Creating HubSpot ticket",
       done: "Create HubSpot ticket",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_lead: {
     description:
@@ -640,6 +700,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Creating HubSpot lead",
       done: "Create HubSpot lead",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_task: {
     description: "Create a new task in Hubspot, with optional associations.",
@@ -659,6 +721,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Creating HubSpot task",
       done: "Create HubSpot task",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_note: {
     description: "Create a new note in Hubspot, with optional associations.",
@@ -687,6 +751,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Creating HubSpot note",
       done: "Create HubSpot note",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_communication: {
     description:
@@ -706,6 +772,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Creating HubSpot communication",
       done: "Create HubSpot communication",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_meeting: {
     description:
@@ -725,6 +793,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Creating HubSpot meeting",
       done: "Create HubSpot meeting",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_association: {
     description:
@@ -758,6 +828,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Creating HubSpot association",
       done: "Create HubSpot association",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Update operations
@@ -776,6 +848,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Updating HubSpot contact",
       done: "Update HubSpot contact",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_company: {
     description: "Update properties of a HubSpot company by ID.",
@@ -792,6 +866,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Updating HubSpot company",
       done: "Update HubSpot company",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_deal: {
     description: "Update properties of a HubSpot deal by ID.",
@@ -808,6 +884,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Updating HubSpot deal",
       done: "Update HubSpot deal",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_task: {
     description:
@@ -825,6 +903,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Updating HubSpot task",
       done: "Update HubSpot task",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   complete_task: {
     description:
@@ -837,6 +917,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Completing HubSpot task",
       done: "Complete HubSpot task",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_task: {
     description: "Delete a HubSpot task by ID.",
@@ -848,6 +930,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Deleting HubSpot task",
       done: "Delete HubSpot task",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   remove_association: {
     description: "Remove an association between two HubSpot objects.",
@@ -866,6 +950,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       running: "Removing HubSpot association",
       done: "Remove HubSpot association",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -880,13 +966,14 @@ export const HUBSPOT_SERVER = {
     },
     icon: "HubspotLogo",
     documentationUrl: "https://docs.dust.tt/docs/hubspot",
-    toolCategory: "advanced",
   },
   tools: Object.values(HUBSPOT_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(HUBSPOT_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -90,6 +90,7 @@ export const IMAGE_GENERATION_SERVER = {
     authorization: null,
     icon: "ActionImageIcon",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(IMAGE_GENERATION_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -78,6 +78,8 @@ export const IMAGE_GENERATION_TOOLS_METADATA = createToolsRecord({
       running: "Generating image",
       done: "Generate image",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -90,13 +92,14 @@ export const IMAGE_GENERATION_SERVER = {
     authorization: null,
     icon: "ActionImageIcon",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(IMAGE_GENERATION_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(IMAGE_GENERATION_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -69,6 +69,7 @@ export const INCLUDE_DATA_SERVER = {
     icon: "ActionTimeIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(INCLUDE_DATA_BASE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -27,6 +27,8 @@ export const INCLUDE_DATA_BASE_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving recent documents",
       done: "Retrieve recent documents",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -45,6 +47,8 @@ export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving recent documents",
       done: "Retrieve recent documents",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   find_tags: {
     description:
@@ -56,6 +60,8 @@ export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
       running: "Finding tags",
       done: "Find tags",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -69,13 +75,14 @@ export const INCLUDE_DATA_SERVER = {
     icon: "ActionTimeIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(INCLUDE_DATA_BASE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(INCLUDE_DATA_BASE_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -89,6 +89,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
       running: "Creating new Frame",
       done: "Create new Frame",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   [EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
@@ -141,6 +143,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
       running: "Updating Frame",
       done: "Update Frame",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   [REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
@@ -159,6 +163,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
       running: "Reverting changes on Frame",
       done: "Revert changes on Frame",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   [RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
@@ -181,6 +187,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
       running: "Renaming Frame",
       done: "Rename Frame",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
@@ -201,6 +209,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
       running: "Reading Frame content",
       done: "Read Frame content",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   [GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME]: {
     description:
@@ -219,6 +229,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
       running: "Getting share URL",
       done: "Get share URL",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [EXPORT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
@@ -251,6 +263,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
       running: "Exporting Frame",
       done: "Export Frame",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   [PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
@@ -287,6 +301,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
       running: "Publishing Frame",
       done: "Publish Frame",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
 });
 
@@ -299,13 +315,14 @@ export const INTERACTIVE_CONTENT_SERVER = {
     authorization: null,
     icon: "ActionFrameIcon",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(INTERACTIVE_CONTENT_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(INTERACTIVE_CONTENT_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -299,6 +299,7 @@ export const INTERACTIVE_CONTENT_SERVER = {
     authorization: null,
     icon: "ActionFrameIcon",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(INTERACTIVE_CONTENT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -389,6 +389,7 @@ export const JIRA_SERVER = {
     },
     icon: "JiraLogo",
     documentationUrl: "https://docs.dust.tt/docs/jira",
+    toolCategory: "advanced",
   },
   tools: Object.values(JIRA_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -23,6 +23,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Jira issue fields",
       done: "List Jira issue fields",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_issue: {
     description:
@@ -41,6 +43,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Jira issue",
       done: "Retrieve Jira issue",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_projects: {
     description: "List Jira projects available in the workspace.",
@@ -50,6 +54,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Jira projects",
       done: "List Jira projects",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_project: {
     description: "Retrieve one Jira project by project key (e.g., 'PROJ').",
@@ -61,6 +67,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Jira project",
       done: "Retrieve Jira project",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_project_versions: {
     description:
@@ -73,6 +81,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Jira project versions",
       done: "Retrieve Jira project versions",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_transitions: {
     description:
@@ -85,6 +95,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Jira transitions",
       done: "Retrieve Jira transitions",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_issues: {
     description:
@@ -107,6 +119,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Searching Jira issues",
       done: "Search Jira issues",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_issues_using_jql: {
     description:
@@ -137,6 +151,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Searching Jira issues with JQL",
       done: "Search Jira issues with JQL",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_issue_types: {
     description: "Retrieve available issue types for a JIRA project.",
@@ -148,6 +164,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Jira issue types",
       done: "Retrieve Jira issue types",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_issue_create_fields: {
     description:
@@ -163,6 +181,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Jira create fields",
       done: "Retrieve Jira create fields",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_connection_info: {
     description:
@@ -173,6 +193,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Jira connection info",
       done: "Retrieve Jira connection info",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_issue_link_types: {
     description:
@@ -183,6 +205,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Jira link types",
       done: "Retrieve Jira link types",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_users: {
     description: "Find or search Jira users by email address or display name.",
@@ -216,6 +240,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Searching Jira users",
       done: "Search Jira users",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_attachments: {
     description:
@@ -228,6 +254,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Jira attachments",
       done: "Retrieve Jira attachments",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   read_attachment: {
     description:
@@ -241,6 +269,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Reading attachment from Jira",
       done: "Read attachment from Jira",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 
   // Write operations
@@ -268,6 +298,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Adding comment on Jira",
       done: "Add comment on Jira",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   transition_issue: {
     description:
@@ -281,6 +313,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Transitioning Jira issue",
       done: "Transition Jira issue",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_issue: {
     description:
@@ -295,6 +329,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Creating Jira issue",
       done: "Create Jira issue",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_issue: {
     description:
@@ -310,6 +346,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Updating Jira issue",
       done: "Update Jira issue",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_issue_link: {
     description:
@@ -324,6 +362,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Creating Jira issue link",
       done: "Create Jira issue link",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_issue_link: {
     description: "Delete an existing link between JIRA issues.",
@@ -335,6 +375,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Deleting Jira issue link",
       done: "Delete Jira issue link",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   upload_attachment: {
     description:
@@ -375,6 +417,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       running: "Uploading attachment to Jira",
       done: "Upload attachment to Jira",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -389,13 +433,14 @@ export const JIRA_SERVER = {
     },
     icon: "JiraLogo",
     documentationUrl: "https://docs.dust.tt/docs/jira",
-    toolCategory: "advanced",
   },
   tools: Object.values(JIRA_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(JIRA_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/jit_testing/metadata.ts
+++ b/front/lib/api/actions/servers/jit_testing/metadata.ts
@@ -80,6 +80,7 @@ export const JIT_TESTING_SERVER = {
     icon: "ActionEmotionLaughIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: Object.values(JIT_TESTING_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/jit_testing/metadata.ts
+++ b/front/lib/api/actions/servers/jit_testing/metadata.ts
@@ -69,6 +69,8 @@ export const JIT_TESTING_TOOLS_METADATA = createToolsRecord({
       running: "Testing JIT",
       done: "Test JIT",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -80,13 +82,14 @@ export const JIT_TESTING_SERVER = {
     icon: "ActionEmotionLaughIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(JIT_TESTING_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(JIT_TESTING_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/luma/metadata.ts
+++ b/front/lib/api/actions/servers/luma/metadata.ts
@@ -20,6 +20,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
       running: "Getting Luma account info",
       done: "Get Luma account info",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_event: {
     description:
@@ -32,6 +34,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
       running: "Getting Luma event",
       done: "Get Luma event",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_events: {
     description:
@@ -52,6 +56,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Luma events",
       done: "List Luma events",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_event: {
     description:
@@ -98,6 +104,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
       running: "Creating Luma event",
       done: "Create Luma event",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_event: {
     description:
@@ -149,6 +157,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
       running: "Updating Luma event",
       done: "Update Luma event",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_guests: {
     description:
@@ -189,6 +199,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Luma guests",
       done: "List Luma guests",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_guest: {
     description:
@@ -202,6 +214,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
       running: "Getting Luma guest",
       done: "Get Luma guest",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_guest_status: {
     description:
@@ -227,6 +241,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
       running: "Updating Luma guest status",
       done: "Update Luma guest status",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   add_guests: {
     description:
@@ -250,6 +266,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
       running: "Adding Luma guests",
       done: "Add Luma guests",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   send_invites: {
     description:
@@ -268,6 +286,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
       running: "Sending Luma invites",
       done: "Send Luma invites",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_guests: {
     description:
@@ -289,6 +309,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
       running: "Searching Luma guests",
       done: "Search Luma guests",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_event_insights: {
     description:
@@ -306,6 +328,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
       running: "Getting Luma event insights",
       done: "Get Luma event insights",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -317,13 +341,14 @@ export const LUMA_SERVER = {
     authorization: null,
     icon: "LumaLogo",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(LUMA_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(LUMA_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/luma/metadata.ts
+++ b/front/lib/api/actions/servers/luma/metadata.ts
@@ -317,6 +317,7 @@ export const LUMA_SERVER = {
     authorization: null,
     icon: "LumaLogo",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(LUMA_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -32,6 +32,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
       running: "Searching in OneDrive/SharePoint files",
       done: "Search in OneDrive/SharePoint files",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_drive_items: {
     description:
@@ -48,6 +50,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
       running: "Searching OneDrive/SharePoint items",
       done: "Search OneDrive/SharePoint items",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_drive_items: {
     description:
@@ -97,6 +101,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
       running: "Listing OneDrive/SharePoint items",
       done: "List OneDrive/SharePoint items",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_word_document: {
     description:
@@ -126,6 +132,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
       running: "Updating Microsoft Word document",
       done: "Update Microsoft Word document",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_file_content: {
     description:
@@ -170,6 +178,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
       running: "Getting OneDrive/SharePoint file content",
       done: "Get OneDrive/SharePoint file content",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   upload_file: {
     description:
@@ -210,6 +220,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
       running: "Uploading file to OneDrive/SharePoint",
       done: "Upload file to OneDrive/SharePoint",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   rename_drive_item: {
     description:
@@ -235,6 +247,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
       running: "Renaming OneDrive/SharePoint item",
       done: "Rename OneDrive/SharePoint item",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   copy_file: {
     description:
@@ -271,6 +285,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
       running: "Copying file",
       done: "Copy file",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -327,13 +343,14 @@ export const MICROSOFT_DRIVE_SERVER = {
       ],
     },
     documentationUrl: "https://docs.dust.tt/docs/microsoft-drive-tool-setup",
-    toolCategory: "advanced",
   },
   tools: Object.values(MICROSOFT_DRIVE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(MICROSOFT_DRIVE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -327,6 +327,7 @@ export const MICROSOFT_DRIVE_SERVER = {
       ],
     },
     documentationUrl: "https://docs.dust.tt/docs/microsoft-drive-tool-setup",
+    toolCategory: "advanced",
   },
   tools: Object.values(MICROSOFT_DRIVE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -20,6 +20,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
       running: "Listing Microsoft Excel files",
       done: "List Microsoft Excel files",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_worksheets: {
     description:
@@ -46,6 +48,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
       running: "Getting Excel worksheets",
       done: "Get Excel worksheets",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   read_worksheet: {
     description:
@@ -79,6 +83,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
       running: "Reading Excel worksheet",
       done: "Read Excel worksheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   write_worksheet: {
     description: "Write data to a specific range in an Excel worksheet.",
@@ -117,6 +123,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
       running: "Writing to Excel worksheet",
       done: "Write to Excel worksheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_worksheet: {
     description: "Create a new worksheet (sheet/tab) in an Excel workbook.",
@@ -145,6 +153,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
       running: "Creating Excel worksheet",
       done: "Create Excel worksheet",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   clear_range: {
     description: "Clear data from a specific range in an Excel worksheet.",
@@ -182,6 +192,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
       running: "Clearing Excel range",
       done: "Clear Excel range",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -231,13 +243,14 @@ export const MICROSOFT_EXCEL_SERVER = {
       ],
     },
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(MICROSOFT_EXCEL_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(MICROSOFT_EXCEL_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -231,6 +231,7 @@ export const MICROSOFT_EXCEL_SERVER = {
       ],
     },
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(MICROSOFT_EXCEL_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -20,6 +20,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
       running: "Searching Teams messages",
       done: "Search Teams messages",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_teams: {
     description:
@@ -30,6 +32,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
       running: "Listing Teams teams",
       done: "List Teams teams",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_users: {
     description:
@@ -50,6 +54,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
       running: "Listing Teams users",
       done: "List Teams users",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_channels: {
     description:
@@ -68,6 +74,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
       running: "Listing Teams channels",
       done: "List Teams channels",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_chats: {
     description:
@@ -96,6 +104,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
       running: "Listing Teams chats",
       done: "List Teams chats",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_messages: {
     description:
@@ -141,6 +151,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
       running: "Listing Teams messages",
       done: "List Teams messages",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   post_message: {
     description:
@@ -215,6 +227,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
       running: "Posting Teams message",
       done: "Post Teams message",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_meetings: {
     description:
@@ -244,6 +258,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
       running: "Listing Teams meetings",
       done: "List Teams meetings",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_transcript_content: {
     description:
@@ -260,6 +276,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
       running: "Fetching meeting transcript",
       done: "Fetch meeting transcript",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -349,13 +367,14 @@ export const MICROSOFT_TEAMS_SERVER = {
       ],
     },
     documentationUrl: "https://docs.dust.tt/docs/microsoft-teams-tool-setup",
-    toolCategory: "advanced",
   },
   tools: Object.values(MICROSOFT_TEAMS_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(MICROSOFT_TEAMS_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -349,6 +349,7 @@ export const MICROSOFT_TEAMS_SERVER = {
       ],
     },
     documentationUrl: "https://docs.dust.tt/docs/microsoft-teams-tool-setup",
+    toolCategory: "advanced",
   },
   tools: Object.values(MICROSOFT_TEAMS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/missing_action_catcher/metadata.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/metadata.ts
@@ -12,7 +12,6 @@ export const MISSING_ACTION_CATCHER_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,
-    toolCategory: "basic",
   },
   // Tools are created dynamically at runtime based on the tool context.
   tools: [],

--- a/front/lib/api/actions/servers/missing_action_catcher/metadata.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/metadata.ts
@@ -12,6 +12,7 @@ export const MISSING_ACTION_CATCHER_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,
+    toolCategory: "basic",
   },
   // Tools are created dynamically at runtime based on the tool context.
   tools: [],

--- a/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
@@ -28,6 +28,8 @@ export function createMissingActionCatcherTools(
           running: "Processing action",
           done: "Process action",
         },
+        toolCostCategory: "basic" as const,
+        freeUsage: true,
         handler: async () => {
           return new Err(
             new MCPError(
@@ -58,6 +60,8 @@ export function createMissingActionCatcherTools(
         running: "Processing action",
         done: "Process action",
       },
+      toolCostCategory: "basic" as const,
+      freeUsage: true,
       handler: async () => {
         return new Ok([{ type: "text", text: "No action name found" }]);
       },

--- a/front/lib/api/actions/servers/monday/metadata.ts
+++ b/front/lib/api/actions/servers/monday/metadata.ts
@@ -14,6 +14,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Listing Monday boards",
       done: "List Monday boards",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_board_items: {
     description:
@@ -26,6 +28,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Monday board items",
       done: "Retrieve Monday board items",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_item_details: {
     description:
@@ -38,6 +42,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Monday item details",
       done: "Retrieve Monday item details",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_items: {
     description:
@@ -76,6 +82,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Searching Monday items",
       done: "Search Monday items",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_items_by_column_value: {
     description: "Retrieve items from a board by column value",
@@ -89,6 +97,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Monday items by column value",
       done: "Retrieve Monday items by column value",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   find_user_by_name: {
     description: "Find a Monday.com user by name",
@@ -100,6 +110,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Finding Monday user",
       done: "Find Monday user",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_board_values: {
     description:
@@ -112,6 +124,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Monday board details",
       done: "Retrieve Monday board details",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_column_values: {
     description: "Retrieve column values for a specific item and column",
@@ -125,6 +139,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Monday column values",
       done: "Retrieve Monday column values",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_file_column_values: {
     description: "Retrieve file column values for a specific item and column",
@@ -139,6 +155,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Monday file column values",
       done: "Retrieve Monday file column values",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_group_details: {
     description:
@@ -152,6 +170,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Monday group details",
       done: "Retrieve Monday group details",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_subitem_values: {
     description: "Retrieve subitems for a specific Monday.com item",
@@ -163,6 +183,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Monday subitems",
       done: "Retrieve Monday subitems",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_user_details: {
     description: "Retrieve details about a specific Monday.com user",
@@ -174,6 +196,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Monday user details",
       done: "Retrieve Monday user details",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_activity_logs: {
     description:
@@ -200,6 +224,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Monday activity logs",
       done: "Retrieve Monday activity logs",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_board_analytics: {
     description:
@@ -212,6 +238,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Monday board analytics",
       done: "Retrieve Monday board analytics",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_item: {
     description: "Create a new item in a Monday.com board",
@@ -234,6 +262,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Creating Monday item",
       done: "Create Monday item",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_item: {
     description: "Update column values of an existing Monday.com item",
@@ -250,6 +280,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Updating Monday item",
       done: "Update Monday item",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_item_name: {
     description: "Update the name of a Monday.com item",
@@ -262,6 +294,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Updating Monday item name",
       done: "Update Monday item name",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_update: {
     description: "Add an update (comment) to a Monday.com item",
@@ -274,6 +308,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Adding Monday update",
       done: "Add Monday update",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_board: {
     description: "Create a new board in Monday.com",
@@ -297,6 +333,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Creating Monday board",
       done: "Create Monday board",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_column: {
     description: "Create a new column in a Monday.com board",
@@ -316,6 +354,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Creating Monday column",
       done: "Create Monday column",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_group: {
     description: "Create a new group in a Monday.com board",
@@ -332,6 +372,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Creating Monday group",
       done: "Create Monday group",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_subitem: {
     description: "Create a new subitem for a Monday.com item",
@@ -348,6 +390,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Creating Monday subitem",
       done: "Create Monday subitem",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_subitem: {
     description: "Update column values of a Monday.com subitem",
@@ -362,6 +406,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Updating Monday subitem",
       done: "Update Monday subitem",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   duplicate_group: {
     description: "Duplicate a group in a Monday.com board",
@@ -382,6 +428,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Duplicating Monday group",
       done: "Duplicate Monday group",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   upload_file_to_column: {
     description: "Upload a file to a Monday.com column",
@@ -395,6 +443,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Uploading file to Monday",
       done: "Upload file to Monday",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_item: {
     description: "Delete a Monday.com item",
@@ -406,6 +456,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Deleting Monday item",
       done: "Delete Monday item",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_group: {
     description: "Delete a group from a Monday.com board",
@@ -418,6 +470,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Deleting Monday group",
       done: "Delete Monday group",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   move_item_to_board: {
     description:
@@ -447,6 +501,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Moving Monday item to board",
       done: "Move Monday item to board",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_multiple_items: {
     description:
@@ -474,6 +530,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
       running: "Creating multiple Monday items",
       done: "Create multiple Monday items",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -489,13 +547,14 @@ export const MONDAY_SERVER = {
     },
     icon: "MondayLogo",
     documentationUrl: "https://docs.dust.tt/docs/monday",
-    toolCategory: "advanced",
   },
   tools: Object.values(MONDAY_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(MONDAY_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/monday/metadata.ts
+++ b/front/lib/api/actions/servers/monday/metadata.ts
@@ -489,6 +489,7 @@ export const MONDAY_SERVER = {
     },
     icon: "MondayLogo",
     documentationUrl: "https://docs.dust.tt/docs/monday",
+    toolCategory: "advanced",
   },
   tools: Object.values(MONDAY_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/notion/metadata.ts
+++ b/front/lib/api/actions/servers/notion/metadata.ts
@@ -536,6 +536,7 @@ export const NOTION_SERVER = {
     },
     icon: "NotionLogo",
     documentationUrl: "https://docs.dust.tt/docs/notion-mcp",
+    toolCategory: "advanced",
   },
   tools: Object.values(NOTION_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/notion/metadata.ts
+++ b/front/lib/api/actions/servers/notion/metadata.ts
@@ -242,6 +242,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Searching Notion",
       done: "Search Notion",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   retrieve_page: {
     description: "Retrieve a Notion page by its ID.",
@@ -253,6 +255,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Notion page",
       done: "Retrieve Notion page",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   retrieve_database_schema: {
     description:
@@ -265,6 +269,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Notion database schema",
       done: "Retrieve Notion database schema",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   retrieve_database_content: {
     description:
@@ -284,6 +290,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Notion database content",
       done: "Retrieve Notion database content",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   query_database: {
     description: "Query a Notion database.",
@@ -302,6 +310,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Querying Notion database",
       done: "Query Notion database",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_page: {
     description: "Create a new Notion page.",
@@ -318,6 +328,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Creating Notion page",
       done: "Create Notion page",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   insert_row_into_database: {
     description: "Create a new Notion page in a database.",
@@ -332,6 +344,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Inserting Notion row",
       done: "Insert Notion row",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_database: {
     description: "Create a new Notion database (table).",
@@ -353,6 +367,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Creating Notion database",
       done: "Create Notion database",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_page: {
     description: "Update a Notion page's properties.",
@@ -365,6 +381,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Updating Notion page",
       done: "Update Notion page",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   retrieve_block: {
     description: "Retrieve a Notion block by its ID.",
@@ -376,6 +394,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Notion block",
       done: "Retrieve Notion block",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   retrieve_block_children: {
     description: "Retrieve the children of a Notion block or page by its ID.",
@@ -392,6 +412,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Notion block children",
       done: "Retrieve Notion block children",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   add_page_content: {
     description:
@@ -413,6 +435,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Adding Notion page content",
       done: "Add Notion page content",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_comment: {
     description:
@@ -438,6 +462,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Adding comment on Notion",
       done: "Add comment on Notion",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_block: {
     description:
@@ -450,6 +476,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Deleting Notion block",
       done: "Delete Notion block",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_page: {
     description:
@@ -462,6 +490,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Deleting Notion page",
       done: "Delete Notion page",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   fetch_comments: {
     description:
@@ -476,6 +506,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Fetching comments from Notion",
       done: "Fetch comments from Notion",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_row_database: {
     description:
@@ -489,6 +521,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Updating Notion row",
       done: "Update Notion row",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_schema_database: {
     description:
@@ -502,6 +536,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Updating Notion database schema",
       done: "Update Notion database schema",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_users: {
     description: "List all users in the Notion workspace.",
@@ -511,6 +547,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Listing Notion users",
       done: "List Notion users",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_about_user: {
     description: "Get information about a specific user by userId.",
@@ -522,6 +560,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Notion user info",
       done: "Retrieve Notion user info",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -536,13 +576,14 @@ export const NOTION_SERVER = {
     },
     icon: "NotionLogo",
     documentationUrl: "https://docs.dust.tt/docs/notion-mcp",
-    toolCategory: "advanced",
   },
   tools: Object.values(NOTION_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(NOTION_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/openai_usage/metadata.ts
+++ b/front/lib/api/actions/servers/openai_usage/metadata.ts
@@ -74,6 +74,8 @@ export const OPENAI_USAGE_TOOLS_METADATA = createToolsRecord({
       running: "Getting completions usage",
       done: "Get completions usage",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_organization_costs: {
     description:
@@ -120,6 +122,8 @@ export const OPENAI_USAGE_TOOLS_METADATA = createToolsRecord({
       running: "Getting organization costs",
       done: "Get organization costs",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -132,13 +136,14 @@ export const OPENAI_USAGE_SERVER = {
     authorization: null,
     icon: "OpenaiLogo",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(OPENAI_USAGE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(OPENAI_USAGE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/openai_usage/metadata.ts
+++ b/front/lib/api/actions/servers/openai_usage/metadata.ts
@@ -132,6 +132,7 @@ export const OPENAI_USAGE_SERVER = {
     authorization: null,
     icon: "OpenaiLogo",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(OPENAI_USAGE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/outlook/calendar_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_metadata.ts
@@ -362,6 +362,7 @@ export const OUTLOOK_CALENDAR_SERVER = {
     },
     icon: "MicrosoftOutlookLogo",
     documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",
+    toolCategory: "advanced",
   },
   tools: Object.values(OUTLOOK_CALENDAR_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/outlook/calendar_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_metadata.ts
@@ -14,6 +14,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Getting user timezone from Outlook",
       done: "Get user timezone from Outlook",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_calendars: {
     description: "List all calendars accessible by the user in Outlook.",
@@ -38,6 +40,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Listing calendars",
       done: "List calendars",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_events: {
     description:
@@ -83,6 +87,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Listing events",
       done: "List events",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_event: {
     description: "Get a single event from an Outlook Calendar by event ID.",
@@ -106,6 +112,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving event",
       done: "Retrieve event",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_event: {
     description:
@@ -170,6 +178,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Creating event",
       done: "Create event",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_event: {
     description:
@@ -220,6 +230,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Updating event",
       done: "Update event",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_event: {
     description: "Delete an event from an Outlook Calendar.",
@@ -243,6 +255,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Deleting event",
       done: "Delete event",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   check_availability: {
     description:
@@ -277,6 +291,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Checking availability",
       done: "Check availability",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   check_self_availability: {
     description:
@@ -312,6 +328,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
       running: "Checking self availability",
       done: "Check self availability",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -362,13 +380,14 @@ export const OUTLOOK_CALENDAR_SERVER = {
     },
     icon: "MicrosoftOutlookLogo",
     documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",
-    toolCategory: "advanced",
   },
   tools: Object.values(OUTLOOK_CALENDAR_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(OUTLOOK_CALENDAR_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -598,6 +598,7 @@ export const OUTLOOK_MAIL_SERVER = {
     },
     icon: "MicrosoftOutlookLogo",
     documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",
+    toolCategory: "advanced",
   },
   tools: Object.values(OUTLOOK_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -51,6 +51,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Fetching messages",
       done: "Fetch messages",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_folders: {
     description:
@@ -76,6 +78,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Listing folders",
       done: "List folders",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_attachments: {
     description:
@@ -104,6 +108,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Listing attachments",
       done: "List attachments",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_attachment: {
     description:
@@ -129,6 +135,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Downloading attachment",
       done: "Download attachment",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_attachments: {
     description:
@@ -153,6 +161,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Getting Outlook attachments",
       done: "Get Outlook attachments",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_drafts: {
     description:
@@ -186,6 +196,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Fetching drafts",
       done: "Fetch drafts",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_draft: {
     description: `Create a new email draft in Outlook, or a reply draft to an existing message.
@@ -265,6 +277,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Creating draft",
       done: "Create draft",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_draft: {
     description: "Delete a draft email from Outlook.",
@@ -284,6 +298,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Deleting draft",
       done: "Delete draft",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   send_mail: {
     description: `Send an email directly via Outlook.
@@ -363,6 +379,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Sending email",
       done: "Send email",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   move_messages: {
     description:
@@ -392,6 +410,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Moving messages",
       done: "Move messages",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_message_body: {
     description:
@@ -432,6 +452,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Fetching message body",
       done: "Fetch message body",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_contacts: {
     description:
@@ -463,6 +485,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Fetching contacts",
       done: "Fetch contacts",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_contact: {
     description: "Create a new contact in Outlook.",
@@ -495,6 +519,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Creating contact",
       done: "Create contact",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_contact: {
     description: "Update an existing contact in Outlook.",
@@ -531,6 +557,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       running: "Updating contact",
       done: "Update contact",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -598,13 +626,14 @@ export const OUTLOOK_MAIL_SERVER = {
     },
     icon: "MicrosoftOutlookLogo",
     documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",
-    toolCategory: "advanced",
   },
   tools: Object.values(OUTLOOK_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(OUTLOOK_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -107,6 +107,7 @@ export const PLAN_MODE_SERVER = {
     icon: "ActionDocumentTextIcon" as const,
     authorization: null,
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: Object.values(PLAN_MODE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -46,6 +46,8 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
       running: "Creating plan",
       done: "Plan created",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   edit_plan: {
     description:
@@ -72,6 +74,8 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
       running: "Updating plan",
       done: "Plan updated",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   close_plan: {
     description:
@@ -93,6 +97,8 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
       running: "Closing plan",
       done: "Plan closed",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -107,13 +113,14 @@ export const PLAN_MODE_SERVER = {
     icon: "ActionDocumentTextIcon" as const,
     authorization: null,
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(PLAN_MODE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(PLAN_MODE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -471,6 +471,7 @@ export const POD_MANAGER_SERVER = {
     icon: "ActionDocumentTextIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: Object.values(POD_MANAGER_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -47,6 +47,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Adding content node to Pod",
       done: "Add content node to Pod",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   remove_content_node: {
     description:
@@ -72,6 +74,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Removing content node from Pod",
       done: "Remove content node from Pod",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   edit_information: {
     description:
@@ -106,6 +110,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Editing Pod information",
       done: "Edit Pod information",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [UPDATE_MEMBERS_TOOL_NAME]: {
     description:
@@ -134,6 +140,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Updating Pod members",
       done: "Update Pod members",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   get_information: {
     description:
@@ -157,6 +165,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Getting Pod information",
       done: "Get Pod information",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [LIST_MEMBERS_TOOL_NAME]: {
     description:
@@ -192,6 +202,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Listing Pod members",
       done: "List Pod members",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   list_pods: {
     description:
@@ -231,6 +243,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Listing Pods",
       done: "List Pods",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   create_pod: {
     description:
@@ -264,6 +278,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Creating Pod",
       done: "Create Pod",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   retrieve_recent_documents: {
     description:
@@ -281,6 +297,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving recent Pod documents",
       done: "Retrieve recent Pod documents",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   [SEMANTIC_SEARCH_TOOL_NAME]: {
     description:
@@ -320,6 +338,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Searching Pod",
       done: "Search Pod",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   create_conversation: {
     description:
@@ -357,6 +377,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Creating conversation",
       done: "Create conversation",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   list_conversations: {
     description:
@@ -412,6 +434,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Listing Pod conversations",
       done: "List conversations",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   add_message_to_conversation: {
     description:
@@ -457,6 +481,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       running: "Adding message to conversation",
       done: "Add message to conversation",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -471,13 +497,14 @@ export const POD_MANAGER_SERVER = {
     icon: "ActionDocumentTextIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(POD_MANAGER_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(POD_MANAGER_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/pod_tasks/metadata.ts
+++ b/front/lib/api/actions/servers/pod_tasks/metadata.ts
@@ -56,6 +56,8 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
       running: "Listing tasks",
       done: "List tasks",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [CREATE_TASKS_TOOL_NAME]: {
     description:
@@ -66,6 +68,8 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
       running: "Creating tasks",
       done: "Create tasks",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [UPDATE_TASKS_TOOL_NAME]: {
     description: "Update one or more existing tasks at once in the Pod.",
@@ -75,6 +79,8 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
       running: "Updating tasks",
       done: "Update tasks",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [START_TASK_AGENT_TOOL_NAME]: {
     description:
@@ -108,6 +114,8 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
       running: "Starting task work",
       done: "Start task work",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
 });
 
@@ -120,13 +128,14 @@ export const POD_TASKS_SERVER = {
     icon: "ActionCheckCircleIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(POD_TASKS_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(POD_TASKS_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/pod_tasks/metadata.ts
+++ b/front/lib/api/actions/servers/pod_tasks/metadata.ts
@@ -120,6 +120,7 @@ export const POD_TASKS_SERVER = {
     icon: "ActionCheckCircleIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: Object.values(POD_TASKS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -68,6 +68,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Fetching workspace metadata",
       done: "Fetched workspace metadata",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [GET_WORKSPACE_PLAN_TOOL_NAME]: {
@@ -80,6 +82,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Fetching plan and subscription",
       done: "Fetched plan and subscription",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [GET_WORKSPACE_FEATURE_FLAGS_TOOL_NAME]: {
@@ -90,6 +94,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Fetching feature flags",
       done: "Fetched feature flags",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [GET_WORKSPACE_MEMBERS_TOOL_NAME]: {
@@ -101,6 +107,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Fetching workspace members",
       done: "Fetched workspace members",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [GET_WORKSPACE_SPACES_TOOL_NAME]: {
@@ -112,6 +120,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Fetching workspace spaces",
       done: "Fetched workspace spaces",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [GET_WORKSPACE_CREDITS_TOOL_NAME]: {
@@ -123,6 +133,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Fetching workspace credits",
       done: "Fetched workspace credits",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   // ── Connectors & Data Sources ────────────────────────────────────────────
@@ -136,6 +148,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Listing data sources",
       done: "Listed data sources",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [GET_CONNECTOR_DETAILS_TOOL_NAME]: {
@@ -153,6 +167,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Fetching connector details",
       done: "Fetched connector details",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [CHECK_NOTION_PAGE_TOOL_NAME]: {
@@ -168,6 +184,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Checking Notion page",
       done: "Checked Notion page",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [CHECK_SLACK_CHANNEL_TOOL_NAME]: {
@@ -182,6 +200,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Checking Slack channel",
       done: "Checked Slack channel",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   // ── Conversations & Agents ───────────────────────────────────────────────
@@ -198,6 +218,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Fetching conversation",
       done: "Fetched conversation",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [GET_MCP_SERVER_DETAILS_TOOL_NAME]: {
@@ -215,6 +237,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Fetching MCP server details",
       done: "Fetched MCP server details",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   // ── Search ───────────────────────────────────────────────────────────────
@@ -236,6 +260,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Searching workspaces",
       done: "Searched workspaces",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   // ── Users & Cross-Reference ──────────────────────────────────────────────
@@ -248,6 +274,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Listing groups",
       done: "Listed groups",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [FIND_WORKSPACE_BY_CONNECTOR_ID_TOOL_NAME]: {
@@ -263,6 +291,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
       running: "Looking up workspace",
       done: "Found workspace",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   // ── Agents & Skills ──────────────────────────────────────────────────────
@@ -294,6 +324,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: { running: "Listing agents", done: "Listed agents" },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [GET_WORKSPACE_AGENT_TOOL_NAME]: {
@@ -305,6 +337,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: { running: "Fetching agent", done: "Fetched agent" },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [LIST_WORKSPACE_SKILLS_TOOL_NAME]: {
@@ -334,6 +368,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: { running: "Listing skills", done: "Listed skills" },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 
   [GET_WORKSPACE_SKILL_TOOL_NAME]: {
@@ -345,6 +381,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: { running: "Fetching skill", done: "Fetched skill" },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -357,13 +395,14 @@ export const POKE_SERVER = {
     authorization: null,
     icon: "ActionLightbulbIcon",
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(POKE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(POKE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -357,6 +357,7 @@ export const POKE_SERVER = {
     authorization: null,
     icon: "ActionLightbulbIcon",
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: Object.values(POKE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
@@ -110,6 +110,7 @@ export const PRIMITIVE_TYPES_DEBUGGER_SERVER = {
     icon: "ActionEmotionLaughIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: Object.values(PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
@@ -88,6 +88,8 @@ export const PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA = createToolsRecord({
       running: "Running debug tool",
       done: "Run debug tool",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   pass_through: {
     description: "Pass through inputs for primitive type debugging.",
@@ -97,6 +99,8 @@ export const PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA = createToolsRecord({
       running: "Passing through",
       done: "Pass through",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -110,13 +114,14 @@ export const PRIMITIVE_TYPES_DEBUGGER_SERVER = {
     icon: "ActionEmotionLaughIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -38,6 +38,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
       running: "Creating note in Productboard",
       done: "Create Productboard note",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_note: {
     description:
@@ -73,6 +75,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
       running: "Updating note in Productboard",
       done: "Update Productboard note",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_note: {
     description:
@@ -89,6 +93,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
       running: "Getting note from Productboard",
       done: "Get Productboard note",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   query_notes: {
     description:
@@ -163,6 +169,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
       running: "Querying notes in Productboard",
       done: "Query Productboard notes",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   query_entities: {
     description:
@@ -223,6 +231,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
       running: "Querying entities in Productboard",
       done: "Query Productboard entities",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_entity: {
     description:
@@ -272,6 +282,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
       running: "Creating entity in Productboard",
       done: "Create Productboard entity",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_entity: {
     description:
@@ -307,6 +319,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
       running: "Updating entity in Productboard",
       done: "Update Productboard entity",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_relationships: {
     description:
@@ -326,6 +340,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
       running: "Getting relationships from Productboard",
       done: "Get Productboard relationships",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_configuration: {
     description:
@@ -356,6 +372,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
       running: "Getting configuration from Productboard",
       done: "Get Productboard configuration",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -371,13 +389,14 @@ export const PRODUCTBOARD_SERVER = {
     },
     icon: "ProductboardLogo",
     documentationUrl: "https://docs.dust.tt/docs/productboard",
-    toolCategory: "advanced",
   },
   tools: Object.values(PRODUCTBOARD_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(PRODUCTBOARD_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -371,6 +371,7 @@ export const PRODUCTBOARD_SERVER = {
     },
     icon: "ProductboardLogo",
     documentationUrl: "https://docs.dust.tt/docs/productboard",
+    toolCategory: "advanced",
   },
   tools: Object.values(PRODUCTBOARD_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -101,6 +101,7 @@ export const QUERY_TABLES_V2_SERVER = {
     icon: "ActionTableIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(QUERY_TABLES_V2_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -44,6 +44,8 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
       running: "Listing available tables",
       done: "List available tables",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   [GET_DATABASE_SCHEMA_TOOL_NAME]: {
     description:
@@ -58,6 +60,8 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
       running: "Getting database schema",
       done: "Get database schema",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   [EXECUTE_DATABASE_QUERY_TOOL_NAME]: {
     description:
@@ -88,6 +92,8 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
       running: "Executing database query",
       done: "Execute database query",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -101,13 +107,14 @@ export const QUERY_TABLES_V2_SERVER = {
     icon: "ActionTableIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(QUERY_TABLES_V2_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(QUERY_TABLES_V2_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -898,6 +898,8 @@ async function createServer(
           done: "No child agent configured",
         },
         schema: RUN_AGENT_CONFIGURABLE_PROPERTIES,
+        toolCostCategory: "basic" as const,
+        freeUsage: false,
         handler: async () => new Err(new MCPError("No child agent configured")),
       },
       {

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -145,6 +145,7 @@ export const RUN_AGENT_SERVER = {
     authorization: null,
     icon: "ActionRobotIcon",
     documentationUrl: null,
+    toolCategory: "basic",
   },
   // The actual tool name is dynamic, but we need a placeholder tool
   // with the configurable properties schema so that the UI can detect that this server

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -145,7 +145,6 @@ export const RUN_AGENT_SERVER = {
     authorization: null,
     icon: "ActionRobotIcon",
     documentationUrl: null,
-    toolCategory: "basic",
   },
   // The actual tool name is dynamic, but we need a placeholder tool
   // with the configurable properties schema so that the UI can detect that this server
@@ -164,6 +163,8 @@ export const RUN_AGENT_SERVER = {
         running: "Running agent",
         done: "Run agent",
       },
+      toolCostCategory: "basic",
+      freeUsage: false,
     },
   ],
   // Default stake for dynamically created run_agent tools.

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -86,6 +86,8 @@ export default async function createServer(
         running: "Listing Dust App configuration",
         done: "List Dust App configuration",
       },
+      toolCostCategory: "basic",
+      freeUsage: false,
       handler: async () => {
         return new Ok([
           {
@@ -129,6 +131,8 @@ export default async function createServer(
         running: "Running Dust app",
         done: "Run Dust app",
       },
+      toolCostCategory: "basic",
+      freeUsage: false,
       handler: async (params) => {
         const content: (
           | TextContent
@@ -245,6 +249,8 @@ export default async function createServer(
         running: "Running Dust app",
         done: "Run Dust app",
       },
+      toolCostCategory: "basic",
+      freeUsage: false,
       handler: async () => {
         return new Ok([
           {

--- a/front/lib/api/actions/servers/run_dust_app/metadata.ts
+++ b/front/lib/api/actions/servers/run_dust_app/metadata.ts
@@ -25,6 +25,8 @@ export const RUN_DUST_APP_TOOLS_METADATA = createToolsRecord({
       running: "Running Dust app",
       done: "Run Dust app",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
 });
 
@@ -36,13 +38,14 @@ export const RUN_DUST_APP_SERVER = {
     icon: "CommandLineIcon" as const,
     authorization: null,
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(RUN_DUST_APP_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(RUN_DUST_APP_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/run_dust_app/metadata.ts
+++ b/front/lib/api/actions/servers/run_dust_app/metadata.ts
@@ -36,6 +36,7 @@ export const RUN_DUST_APP_SERVER = {
     icon: "CommandLineIcon" as const,
     authorization: null,
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: Object.values(RUN_DUST_APP_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -155,6 +155,7 @@ export const SALESFORCE_SERVER = {
     },
     icon: "SalesforceLogo",
     documentationUrl: "https://docs.dust.tt/docs/salesforce",
+    toolCategory: "advanced",
   },
   tools: Object.values(SALESFORCE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -22,6 +22,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
       running: "Executing Salesforce query",
       done: "Execute Salesforce query",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_objects: {
     description:
@@ -39,6 +41,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Salesforce objects",
       done: "List Salesforce objects",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   describe_object: {
     description:
@@ -54,6 +58,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
       running: "Describing Salesforce object",
       done: "Describe Salesforce object",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_object: {
     description:
@@ -80,6 +86,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
       running: "Creating Salesforce records",
       done: "Create Salesforce records",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_object: {
     description:
@@ -112,6 +120,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
       running: "Updating Salesforce records",
       done: "Update Salesforce records",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_attachments: {
     description:
@@ -125,6 +135,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
       running: "Listing attachments on Salesforce",
       done: "List attachments on Salesforce",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   read_attachment: {
     description:
@@ -141,6 +153,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
       running: "Reading attachment from Salesforce",
       done: "Read attachment from Salesforce",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -155,13 +169,14 @@ export const SALESFORCE_SERVER = {
     },
     icon: "SalesforceLogo",
     documentationUrl: "https://docs.dust.tt/docs/salesforce",
-    toolCategory: "advanced",
   },
   tools: Object.values(SALESFORCE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SALESFORCE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/salesloft/metadata.ts
+++ b/front/lib/api/actions/servers/salesloft/metadata.ts
@@ -28,6 +28,8 @@ export const SALESLOFT_TOOLS_METADATA = createToolsRecord({
       running: "Getting Salesloft actions",
       done: "Get Salesloft actions",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -40,13 +42,14 @@ export const SALESLOFT_SERVER = {
     authorization: null,
     icon: "SalesloftLogo",
     documentationUrl: "https://docs.dust.tt/docs/salesloft-mcp",
-    toolCategory: "advanced",
   },
   tools: Object.values(SALESLOFT_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SALESLOFT_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/salesloft/metadata.ts
+++ b/front/lib/api/actions/servers/salesloft/metadata.ts
@@ -40,6 +40,7 @@ export const SALESLOFT_SERVER = {
     authorization: null,
     icon: "SalesloftLogo",
     documentationUrl: "https://docs.dust.tt/docs/salesloft-mcp",
+    toolCategory: "advanced",
   },
   tools: Object.values(SALESLOFT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -133,6 +133,7 @@ export const SANDBOX_SERVER = {
     authorization: null,
     icon: "CommandLineIcon",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   // Note: The `as JSONSchema` cast is standard pattern across all metadata files.
   // zodToJsonSchema returns a compatible type but TypeScript can't verify it statically.

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -68,6 +68,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       running: "Executing command",
       done: "Execute command in the Computer",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
     enableAlerting: true,
   },
   describe_toolset: {
@@ -84,6 +86,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       running: "Describing Computer toolset",
       done: "Describe Computer toolset",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   add_egress_domain: {
     description:
@@ -121,6 +125,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       done: "Allow domain in the Computer",
       icon: "ActionGlobeAltIcon",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -133,7 +139,6 @@ export const SANDBOX_SERVER = {
     authorization: null,
     icon: "CommandLineIcon",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   // Note: The `as JSONSchema` cast is standard pattern across all metadata files.
   // zodToJsonSchema returns a compatible type but TypeScript can't verify it statically.
@@ -142,6 +147,8 @@ export const SANDBOX_SERVER = {
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SANDBOX_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -109,6 +109,7 @@ export const SANDBOX_FUNCTIONS_SERVER = {
     icon: "CommandLineIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(SANDBOX_FUNCTIONS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -19,6 +19,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
       running: "Listing sandbox functions...",
       done: "Listed sandbox functions",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get: {
     description:
@@ -36,6 +38,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
       running: "Getting sandbox function...",
       done: "Got sandbox function",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   publish: {
     description:
@@ -71,6 +75,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
       running: "Publishing sandbox function...",
       done: "Published sandbox function",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   call: {
     description:
@@ -96,6 +102,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
       running: "Calling sandbox function...",
       done: "Called sandbox function",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -109,13 +117,14 @@ export const SANDBOX_FUNCTIONS_SERVER = {
     icon: "CommandLineIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(SANDBOX_FUNCTIONS_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SANDBOX_FUNCTIONS_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -75,6 +75,7 @@ export const SCHEDULES_MANAGEMENT_SERVER = {
     authorization: null,
     icon: "ActionTimeIcon" as const,
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: (
     Object.keys(

--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -38,6 +38,8 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
       running: "Creating schedule",
       done: "Create schedule",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   list_schedules: {
     description:
@@ -48,6 +50,8 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
       running: "Listing schedules",
       done: "List schedules",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   disable_schedule: {
     description: "Disable a schedule.",
@@ -61,6 +65,8 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
       running: "Disabling schedule",
       done: "Disable schedule",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -75,7 +81,6 @@ export const SCHEDULES_MANAGEMENT_SERVER = {
     authorization: null,
     icon: "ActionTimeIcon" as const,
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: (
     Object.keys(
@@ -88,6 +93,8 @@ export const SCHEDULES_MANAGEMENT_SERVER = {
       z.object(SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].schema)
     ) as JSONSchema,
     displayLabels: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].displayLabels,
+    toolCostCategory: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].toolCostCategory,
+    freeUsage: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     (

--- a/front/lib/api/actions/servers/search/metadata.ts
+++ b/front/lib/api/actions/servers/search/metadata.ts
@@ -26,6 +26,8 @@ export const SEARCH_TOOLS_METADATA = createToolsRecord({
       running: "Searching data sources",
       done: "Search data sources",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -54,6 +56,8 @@ export const SEARCH_TOOL_METADATA_WITH_TAGS = createToolsRecord({
       running: "Finding tags",
       done: "Find tags",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
     enableAlerting: true,
   },
 });
@@ -67,13 +71,14 @@ export const SEARCH_SERVER = {
     icon: "ActionMagnifyingGlassIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(SEARCH_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SEARCH_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/search/metadata.ts
+++ b/front/lib/api/actions/servers/search/metadata.ts
@@ -67,6 +67,7 @@ export const SEARCH_SERVER = {
     icon: "ActionMagnifyingGlassIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(SEARCH_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -140,6 +140,7 @@ export const SKILL_AUTHORING_SERVER = {
     authorization: null,
     icon: "ActionListCheckIcon",
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: Object.values(SKILL_AUTHORING_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -20,6 +20,8 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
       running: "Listing skills",
       done: "List skills",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [GET_SKILL_TOOL_NAME]: {
     description:
@@ -32,6 +34,8 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
       running: "Getting skill",
       done: "Get skill",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [CREATE_SKILL_TOOL_NAME]: {
     description:
@@ -66,6 +70,8 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
       running: "Creating skill",
       done: "Create skill",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [UPDATE_SKILL_TOOL_NAME]: {
     description:
@@ -129,6 +135,8 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
       running: "Updating skill",
       done: "Update skill",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -140,13 +148,14 @@ export const SKILL_AUTHORING_SERVER = {
     authorization: null,
     icon: "ActionListCheckIcon",
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(SKILL_AUTHORING_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SKILL_AUTHORING_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/skill_management/metadata.ts
+++ b/front/lib/api/actions/servers/skill_management/metadata.ts
@@ -19,6 +19,8 @@ export const SKILL_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
       running: "Enabling skill",
       done: "Enable skill",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -32,7 +34,6 @@ export const SKILL_MANAGEMENT_SERVER = {
     authorization: null,
     icon: "PuzzleIcon" as const,
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: (
     Object.keys(SKILL_MANAGEMENT_TOOLS_METADATA) as SkillManagementToolKey[]
@@ -43,6 +44,8 @@ export const SKILL_MANAGEMENT_SERVER = {
       z.object(SKILL_MANAGEMENT_TOOLS_METADATA[key].schema)
     ) as JSONSchema,
     displayLabels: SKILL_MANAGEMENT_TOOLS_METADATA[key].displayLabels,
+    toolCostCategory: SKILL_MANAGEMENT_TOOLS_METADATA[key].toolCostCategory,
+    freeUsage: SKILL_MANAGEMENT_TOOLS_METADATA[key].freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     (

--- a/front/lib/api/actions/servers/skill_management/metadata.ts
+++ b/front/lib/api/actions/servers/skill_management/metadata.ts
@@ -32,6 +32,7 @@ export const SKILL_MANAGEMENT_SERVER = {
     authorization: null,
     icon: "PuzzleIcon" as const,
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: (
     Object.keys(SKILL_MANAGEMENT_TOOLS_METADATA) as SkillManagementToolKey[]

--- a/front/lib/api/actions/servers/slab/metadata.ts
+++ b/front/lib/api/actions/servers/slab/metadata.ts
@@ -110,6 +110,7 @@ export const SLAB_SERVER = {
     authorization: null,
     icon: "SlabLogo",
     documentationUrl: "https://docs.dust.tt/docs/slab-mcp",
+    toolCategory: "advanced",
   },
   tools: Object.values(SLAB_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/slab/metadata.ts
+++ b/front/lib/api/actions/servers/slab/metadata.ts
@@ -47,6 +47,8 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
       running: "Searching Slab posts",
       done: "Search Slab posts",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_post_contents: {
     description:
@@ -77,6 +79,8 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Slab post contents",
       done: "Get Slab post contents",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_topics: {
     description:
@@ -87,6 +91,8 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Slab topics",
       done: "Get Slab topics",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_post_metadata: {
     description:
@@ -99,6 +105,8 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Slab post metadata",
       done: "Get Slab post metadata",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -110,13 +118,14 @@ export const SLAB_SERVER = {
     authorization: null,
     icon: "SlabLogo",
     documentationUrl: "https://docs.dust.tt/docs/slab-mcp",
-    toolCategory: "advanced",
   },
   tools: Object.values(SLAB_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SLAB_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -249,6 +249,7 @@ export const SLACK_BOT_SERVER = {
     },
     icon: "SlackLogo",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(SLACK_BOT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -60,6 +60,8 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
       running: "Posting Slack message",
       done: "Post Slack message",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   edit_message: {
     description:
@@ -93,6 +95,8 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
       running: "Editing Slack message",
       done: "Edit Slack message",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_user: {
     description: `Search for a Slack user by user ID or email address.
@@ -119,6 +123,8 @@ The search_all parameter should only be set to true if the user explicitly reque
       running: "Searching Slack user",
       done: "Search Slack user",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_public_channels: {
     description: "List all public Slack channels in the workspace",
@@ -133,6 +139,8 @@ The search_all parameter should only be set to true if the user explicitly reque
       running: "Listing Slack public channels",
       done: "List Slack public channels",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   read_channel_history: {
     description:
@@ -163,6 +171,8 @@ The search_all parameter should only be set to true if the user explicitly reque
       running: "Reading Slack channel history",
       done: "Read Slack channel history",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   read_thread_messages: {
     description:
@@ -196,6 +206,8 @@ The search_all parameter should only be set to true if the user explicitly reque
       running: "Reading Slack thread messages",
       done: "Read Slack thread messages",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   add_reaction: {
     description: "Add a reaction emoji to a Slack message",
@@ -215,6 +227,8 @@ The search_all parameter should only be set to true if the user explicitly reque
       running: "Adding Slack reaction",
       done: "Add Slack reaction",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   remove_reaction: {
     description: "Remove a reaction emoji from a Slack message",
@@ -234,6 +248,8 @@ The search_all parameter should only be set to true if the user explicitly reque
       running: "Removing Slack reaction",
       done: "Remove Slack reaction",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -249,13 +265,14 @@ export const SLACK_BOT_SERVER = {
     },
     icon: "SlackLogo",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(SLACK_BOT_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SLACK_BOT_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -522,6 +522,7 @@ export const SLACK_PERSONAL_SERVER = {
     },
     icon: "SlackLogo",
     documentationUrl: "https://docs.dust.tt/docs/slack-mcp",
+    toolCategory: "advanced",
   },
   tools: Object.values(SLACK_PERSONAL_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -68,6 +68,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       running: "Searching Slack messages (keyword)",
       done: "Search Slack messages (keyword)",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   semantic_search_messages: {
     description:
@@ -85,6 +87,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       running: "Searching Slack messages (semantic)",
       done: "Search Slack messages (semantic)",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   post_message: {
     description:
@@ -142,6 +146,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       running: "Posting Slack message",
       done: "Post Slack message",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   schedule_message: {
     description:
@@ -197,6 +203,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       running: "Scheduling Slack message",
       done: "Schedule Slack message",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_user: {
     description: `Search for a Slack user by Slack user ID or email address.
@@ -228,6 +236,8 @@ The search_all parameter should only be set to true if the user explicitly reque
       running: "Searching Slack user",
       done: "Search Slack user",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_user_groups: {
     description:
@@ -238,6 +248,8 @@ The search_all parameter should only be set to true if the user explicitly reque
       running: "Listing Slack user groups",
       done: "List Slack user groups",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_channels: {
     description: `Search for Slack channels by channel ID or name.
@@ -267,6 +279,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
       running: "Searching Slack channels",
       done: "Search Slack channels",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_messages: {
     description:
@@ -292,6 +306,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
       running: "Listing Slack messages",
       done: "List Slack messages",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   read_thread_messages: {
     description:
@@ -329,6 +345,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
       running: "Reading Slack thread messages",
       done: "Read Slack thread messages",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_channel_canvases: {
     description:
@@ -344,6 +362,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
       running: "Getting channel canvases",
       done: "Got channel canvases",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   read_canvas: {
     description:
@@ -369,6 +389,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
       running: "Reading Slack canvas sections",
       done: "Read Slack canvas sections",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   write_canvas: {
     description:
@@ -437,6 +459,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
       running: "Writing Slack canvas",
       done: "Write Slack canvas",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_channel: {
     description:
@@ -467,6 +491,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
       running: "Creating Slack channel",
       done: "Create Slack channel",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   invite_to_channel: {
     description:
@@ -490,6 +516,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
       running: "Inviting users to Slack channel",
       done: "Invite users to Slack channel",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   archive_channel: {
     description:
@@ -506,6 +534,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
       running: "Archiving Slack channel",
       done: "Archive Slack channel",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -522,13 +552,14 @@ export const SLACK_PERSONAL_SERVER = {
     },
     icon: "SlackLogo",
     documentationUrl: "https://docs.dust.tt/docs/slack-mcp",
-    toolCategory: "advanced",
   },
   tools: Object.values(SLACK_PERSONAL_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SLACK_PERSONAL_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -130,6 +130,7 @@ export const SNOWFLAKE_SERVER = {
     },
     icon: "SnowflakeLogo",
     documentationUrl: "https://docs.dust.tt/docs/snowflake-tool",
+    toolCategory: "advanced",
   },
   tools: Object.values(SNOWFLAKE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -24,6 +24,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Snowflake databases",
       done: "List Snowflake databases",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   [SNOWFLAKE_LIST_SCHEMAS_TOOL_NAME]: {
     description: "List all schemas within a specified Snowflake database.",
@@ -37,6 +39,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Snowflake schemas",
       done: "List Snowflake schemas",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   [SNOWFLAKE_LIST_TABLES_TOOL_NAME]: {
     description:
@@ -52,6 +56,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Snowflake tables",
       done: "List Snowflake tables",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   [SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME]: {
     description:
@@ -66,6 +72,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       running: "Describing Snowflake table",
       done: "Describe Snowflake table",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   [SNOWFLAKE_DESCRIBE_SEMANTIC_VIEW_TOOL_NAME]: {
     description: `Get the structure (dimensions and metrics) of a Snowflake semantic view. Use this instead of ${SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME} when the object kind is SEMANTIC_VIEW.`,
@@ -81,6 +89,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       running: "Describing Snowflake semantic view",
       done: "Describe Snowflake semantic view",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   [SNOWFLAKE_QUERY_TOOL_NAME]: {
     description: `Execute a read-only SQL SELECT query against Snowflake to analyze data, answer questions, calculate metrics such as revenue, or retrieve rows. Write operations are not permitted. Before writing a query, use ${SNOWFLAKE_LIST_DATABASES_TOOL_NAME}, ${SNOWFLAKE_LIST_SCHEMAS_TOOL_NAME}, ${SNOWFLAKE_LIST_TABLES_TOOL_NAME}, and ${SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME} (or ${SNOWFLAKE_DESCRIBE_SEMANTIC_VIEW_TOOL_NAME} for semantic views) to explore the schema when database, schema, table, view, or column names are unknown.`,
@@ -115,6 +125,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       running: "Executing Snowflake query",
       done: "Execute Snowflake query",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -130,13 +142,14 @@ export const SNOWFLAKE_SERVER = {
     },
     icon: "SnowflakeLogo",
     documentationUrl: "https://docs.dust.tt/docs/snowflake-tool",
-    toolCategory: "advanced",
   },
   tools: Object.values(SNOWFLAKE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SNOWFLAKE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/sound_studio/metadata.ts
+++ b/front/lib/api/actions/servers/sound_studio/metadata.ts
@@ -54,6 +54,7 @@ export const SOUND_STUDIO_SERVER = {
     authorization: null,
     icon: "ActionNoiseIcon",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(SOUND_STUDIO_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/sound_studio/metadata.ts
+++ b/front/lib/api/actions/servers/sound_studio/metadata.ts
@@ -43,6 +43,8 @@ export const SOUND_STUDIO_TOOLS_METADATA = createToolsRecord({
       running: "Generating sound effect",
       done: "Generate sound effect",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -54,13 +56,14 @@ export const SOUND_STUDIO_SERVER = {
     authorization: null,
     icon: "ActionNoiseIcon",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(SOUND_STUDIO_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SOUND_STUDIO_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -147,6 +147,8 @@ export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
       running: "Transcribing audio",
       done: "Transcribe audio",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   text_to_speech: {
     description: "Generate speech audio from a text prompt with desired voice.",
@@ -189,6 +191,8 @@ export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
       running: "Generating speech",
       done: "Generate speech",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   text_to_dialogue: {
     description: "Generate dialogue audio from multiple lines with speakers.",
@@ -229,6 +233,8 @@ export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
       running: "Generating dialogue",
       done: "Generate dialogue",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -240,13 +246,14 @@ export const SPEECH_GENERATOR_SERVER = {
     authorization: null,
     icon: "ActionSpeakIcon",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(SPEECH_GENERATOR_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SPEECH_GENERATOR_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -240,6 +240,7 @@ export const SPEECH_GENERATOR_SERVER = {
     authorization: null,
     icon: "ActionSpeakIcon",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(SPEECH_GENERATOR_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/statuspage/metadata.ts
+++ b/front/lib/api/actions/servers/statuspage/metadata.ts
@@ -172,6 +172,7 @@ export const STATUSPAGE_SERVER = {
     authorization: null,
     icon: "StatuspageLogo",
     documentationUrl: "https://docs.dust.tt/docs/statuspage-mcp",
+    toolCategory: "advanced",
   },
   tools: Object.values(STATUSPAGE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/statuspage/metadata.ts
+++ b/front/lib/api/actions/servers/statuspage/metadata.ts
@@ -20,6 +20,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Statuspage pages",
       done: "List Statuspage pages",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_components: {
     description:
@@ -37,6 +39,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Statuspage components",
       done: "List Statuspage components",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_incidents: {
     description:
@@ -62,6 +66,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
       running: "Listing Statuspage incidents",
       done: "List Statuspage incidents",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_incident: {
     description:
@@ -84,6 +90,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
       running: "Getting Statuspage incident",
       done: "Get Statuspage incident",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_incident: {
     description:
@@ -122,6 +130,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
       running: "Creating Statuspage incident",
       done: "Create Statuspage incident",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_incident: {
     description:
@@ -161,6 +171,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
       running: "Updating Statuspage incident",
       done: "Update Statuspage incident",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -172,13 +184,14 @@ export const STATUSPAGE_SERVER = {
     authorization: null,
     icon: "StatuspageLogo",
     documentationUrl: "https://docs.dust.tt/docs/statuspage-mcp",
-    toolCategory: "advanced",
   },
   tools: Object.values(STATUSPAGE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(STATUSPAGE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/toolsets/metadata.ts
+++ b/front/lib/api/actions/servers/toolsets/metadata.ts
@@ -38,6 +38,8 @@ export const TOOLSETS_SERVER = {
     authorization: null,
     icon: "ActionLightbulbIcon",
     documentationUrl: null,
+    toolCategory: "basic",
+    freeUsage: true,
   },
   tools: Object.values(TOOLSETS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/toolsets/metadata.ts
+++ b/front/lib/api/actions/servers/toolsets/metadata.ts
@@ -15,6 +15,8 @@ export const TOOLSETS_TOOLS_METADATA = createToolsRecord({
       running: "Listing tools",
       done: "List tools",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   enable: {
     description: "Enable a toolset for this conversation.",
@@ -27,6 +29,8 @@ export const TOOLSETS_TOOLS_METADATA = createToolsRecord({
       running: "Enabling tool",
       done: "Enabled tool",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -38,14 +42,14 @@ export const TOOLSETS_SERVER = {
     authorization: null,
     icon: "ActionLightbulbIcon",
     documentationUrl: null,
-    toolCategory: "basic",
-    freeUsage: true,
   },
   tools: Object.values(TOOLSETS_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(TOOLSETS_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/ukg_ready/metadata.ts
+++ b/front/lib/api/actions/servers/ukg_ready/metadata.ts
@@ -14,6 +14,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving UKG Ready employee info",
       done: "Retrieve UKG Ready employee info",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_pto_requests: {
     description:
@@ -37,6 +39,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving UKG Ready PTO requests",
       done: "Retrieve UKG Ready PTO requests",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_accrual_balances: {
     description: "Get accrual balances for yourself or a specific employee.",
@@ -59,6 +63,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving UKG Ready accrual balances",
       done: "Retrieve UKG Ready accrual balances",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_pto_request_notes: {
     description: "Get notes/comments for a specific PTO request.",
@@ -74,6 +80,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving UKG Ready PTO notes",
       done: "Retrieve UKG Ready PTO notes",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_pto_request: {
     description:
@@ -131,6 +139,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
       running: "Creating UKG Ready PTO request",
       done: "Create UKG Ready PTO request",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_pto_request: {
     description: "Delete one or more PTO/time-off requests.",
@@ -148,6 +158,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
       running: "Deleting UKG Ready PTO request",
       done: "Delete UKG Ready PTO request",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_schedules: {
     description: "Get work schedules for yourself or a specific employee.",
@@ -172,6 +184,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
       running: "Listing UKG Ready schedules",
       done: "List UKG Ready schedules",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_employees: {
     description: "Get a list of active employees.",
@@ -181,6 +195,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
       running: "Listing UKG Ready employees",
       done: "List UKG Ready employees",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -196,13 +212,14 @@ export const UKG_READY_SERVER = {
     },
     icon: "UkgLogo",
     documentationUrl: "https://docs.dust.tt/docs/ukg-ready",
-    toolCategory: "advanced",
   },
   tools: Object.values(UKG_READY_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(UKG_READY_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/ukg_ready/metadata.ts
+++ b/front/lib/api/actions/servers/ukg_ready/metadata.ts
@@ -196,6 +196,7 @@ export const UKG_READY_SERVER = {
     },
     icon: "UkgLogo",
     documentationUrl: "https://docs.dust.tt/docs/ukg-ready",
+    toolCategory: "advanced",
   },
   tools: Object.values(UKG_READY_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/user_mentions/metadata.ts
+++ b/front/lib/api/actions/servers/user_mentions/metadata.ts
@@ -23,6 +23,8 @@ export const USER_MENTIONS_TOOLS_METADATA = createToolsRecord({
       running: "Searching users",
       done: "Search users",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   [GET_MENTION_MARKDOWN_TOOL_NAME]: {
     description:
@@ -42,6 +44,8 @@ export const USER_MENTIONS_TOOLS_METADATA = createToolsRecord({
       running: "Getting mention markdown",
       done: "Get mention markdown",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -53,13 +57,14 @@ export const USER_MENTIONS_SERVER = {
     icon: "ActionMegaphoneIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(USER_MENTIONS_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(USER_MENTIONS_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/user_mentions/metadata.ts
+++ b/front/lib/api/actions/servers/user_mentions/metadata.ts
@@ -53,6 +53,7 @@ export const USER_MENTIONS_SERVER = {
     icon: "ActionMegaphoneIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: Object.values(USER_MENTIONS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/val_town/metadata.ts
+++ b/front/lib/api/actions/servers/val_town/metadata.ts
@@ -269,6 +269,7 @@ export const VAL_TOWN_SERVER = {
     authorization: null,
     icon: "ValTownLogo",
     documentationUrl: "https://docs.dust.tt/docs/val-town",
+    toolCategory: "advanced",
     developerSecretSelection: "required",
   },
   tools: Object.values(VAL_TOWN_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/val_town/metadata.ts
+++ b/front/lib/api/actions/servers/val_town/metadata.ts
@@ -39,6 +39,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
       running: "Creating val",
       done: "Create val",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_val: {
     description:
@@ -51,6 +53,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving val",
       done: "Retrieve val",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_vals: {
     description:
@@ -81,6 +85,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
       running: "Listing vals",
       done: "List vals",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_vals: {
     description:
@@ -108,6 +114,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
       running: "Searching vals",
       done: "Search vals",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_val_files: {
     description:
@@ -138,6 +146,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
       running: "Listing val files",
       done: "List val files",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   get_file_content: {
     description:
@@ -153,6 +163,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving file content",
       done: "Retrieve file content",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   delete_file: {
     description:
@@ -168,6 +180,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
       running: "Deleting file",
       done: "Delete file",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_file_content: {
     description:
@@ -187,6 +201,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
       running: "Updating file content",
       done: "Update file content",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   write_file: {
     description:
@@ -216,6 +232,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
       running: "Writing file",
       done: "Write file",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   create_file: {
     description:
@@ -231,6 +249,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
       running: "Creating file",
       done: "Create file",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   call_http_endpoint: {
     description:
@@ -257,6 +277,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
       running: "Calling HTTP endpoint",
       done: "Call HTTP endpoint",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -269,7 +291,6 @@ export const VAL_TOWN_SERVER = {
     authorization: null,
     icon: "ValTownLogo",
     documentationUrl: "https://docs.dust.tt/docs/val-town",
-    toolCategory: "advanced",
     developerSecretSelection: "required",
   },
   tools: Object.values(VAL_TOWN_TOOLS_METADATA).map((t) => ({
@@ -277,6 +298,8 @@ export const VAL_TOWN_SERVER = {
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(VAL_TOWN_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/vanta/metadata.ts
+++ b/front/lib/api/actions/servers/vanta/metadata.ts
@@ -70,6 +70,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: { running: "Listing Vanta tests", done: "List Vanta tests" },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_test_entities: {
     description:
@@ -87,6 +89,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Vanta test entities",
       done: "List Vanta test entities",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_controls: {
     description:
@@ -107,6 +111,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Vanta controls",
       done: "List Vanta controls",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_control_tests: {
     description:
@@ -120,6 +126,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Vanta control tests",
       done: "List Vanta control tests",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_control_documents: {
     description:
@@ -135,6 +143,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Vanta control documents",
       done: "List Vanta control documents",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_documents: {
     description:
@@ -153,6 +163,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Vanta documents",
       done: "List Vanta documents",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_document_resources: {
     description:
@@ -169,6 +181,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Vanta document resources",
       done: "List Vanta document resources",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_integrations: {
     description:
@@ -185,6 +199,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Vanta integrations",
       done: "List Vanta integrations",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_frameworks: {
     description:
@@ -201,6 +217,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Vanta frameworks",
       done: "List Vanta frameworks",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_framework_controls: {
     description:
@@ -216,6 +234,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       running: "Listing Vanta framework controls",
       done: "List Vanta framework controls",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_people: {
     description:
@@ -232,6 +252,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       running: "Listing people on Vanta",
       done: "List people on Vanta",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_risks: {
     description:
@@ -248,6 +270,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       running: "Listing risks on Vanta",
       done: "List risks on Vanta",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_vulnerabilities: {
     description:
@@ -310,6 +334,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       running: "Listing vulnerabilities on Vanta",
       done: "List vulnerabilities on Vanta",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -325,13 +351,14 @@ export const VANTA_SERVER = {
     },
     icon: "VantaLogo",
     documentationUrl: "https://docs.dust.tt/docs/vanta",
-    toolCategory: "advanced",
   },
   tools: Object.values(VANTA_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(VANTA_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/vanta/metadata.ts
+++ b/front/lib/api/actions/servers/vanta/metadata.ts
@@ -325,6 +325,7 @@ export const VANTA_SERVER = {
     },
     icon: "VantaLogo",
     documentationUrl: "https://docs.dust.tt/docs/vanta",
+    toolCategory: "advanced",
   },
   tools: Object.values(VANTA_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -89,6 +89,7 @@ export const WAKEUPS_SERVER = {
     authorization: null,
     icon: "ActionTimeIcon",
     documentationUrl: null,
+    toolCategory: "basic",
     displayedAs: "agent",
   },
   tools: Object.values(WAKEUPS_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -46,6 +46,8 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
       running: "Scheduling wake-up",
       done: "Schedule wake-up",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   list_wakeups: {
     description:
@@ -59,6 +61,8 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
       running: "Listing wake-ups",
       done: "List wake-ups",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   cancel_wakeup: {
     description:
@@ -78,6 +82,8 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
       running: "Cancelling wake-up",
       done: "Cancel wake-up",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
 });
 
@@ -89,7 +95,6 @@ export const WAKEUPS_SERVER = {
     authorization: null,
     icon: "ActionTimeIcon",
     documentationUrl: null,
-    toolCategory: "basic",
     displayedAs: "agent",
   },
   tools: Object.values(WAKEUPS_TOOLS_METADATA).map((t) => ({
@@ -97,6 +102,8 @@ export const WAKEUPS_SERVER = {
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(WAKEUPS_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -26,6 +26,8 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
       running: "Searching the web",
       done: "Web search",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   webbrowser: {
     description:
@@ -40,6 +42,8 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
       running: "Browsing web page",
       done: "Browse web page",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
 });
 
@@ -51,13 +55,14 @@ export const WEB_SEARCH_BROWSE_SERVER = {
     authorization: null,
     icon: "ActionGlobeAltIcon" as const,
     documentationUrl: null,
-    toolCategory: "basic",
   },
   tools: Object.values(WEB_SEARCH_BROWSE_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(WEB_SEARCH_BROWSE_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -51,6 +51,7 @@ export const WEB_SEARCH_BROWSE_SERVER = {
     authorization: null,
     icon: "ActionGlobeAltIcon" as const,
     documentationUrl: null,
+    toolCategory: "basic",
   },
   tools: Object.values(WEB_SEARCH_BROWSE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/workday/metadata.ts
+++ b/front/lib/api/actions/servers/workday/metadata.ts
@@ -22,6 +22,8 @@ export const WORKDAY_TOOLS_METADATA = createToolsRecord({
       running: "Listing workers on Workday",
       done: "Listed workers on Workday",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -37,13 +39,14 @@ export const WORKDAY_SERVER = {
     },
     icon: "ActionTableIcon",
     documentationUrl: "https://docs.dust.tt/docs/workday",
-    toolCategory: "advanced",
   },
   tools: Object.values(WORKDAY_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(WORKDAY_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/workday/metadata.ts
+++ b/front/lib/api/actions/servers/workday/metadata.ts
@@ -37,6 +37,7 @@ export const WORKDAY_SERVER = {
     },
     icon: "ActionTableIcon",
     documentationUrl: "https://docs.dust.tt/docs/workday",
+    toolCategory: "advanced",
   },
   tools: Object.values(WORKDAY_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -265,6 +265,7 @@ export const WORKSPACE_ANALYTICS_SERVER = {
     icon: "ActionPieChartIcon",
     authorization: null,
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(WORKSPACE_ANALYTICS_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -128,6 +128,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving top agents",
       done: "Retrieved top agents",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   get_top_users: {
     description:
@@ -142,6 +144,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving top users",
       done: "Retrieved top users",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   get_agent_details: {
     description:
@@ -155,6 +159,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving agent details",
       done: "Retrieved agent details",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   get_top_skills: {
     description:
@@ -168,6 +174,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving top skills",
       done: "Retrieved top skills",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   get_top_tools: {
     description:
@@ -183,6 +191,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving top tools",
       done: "Retrieved top tools",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   get_source_breakdown: {
     description:
@@ -202,6 +212,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving source breakdown",
       done: "Retrieved source breakdown",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   get_credit_usage: {
     description:
@@ -219,6 +231,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       running: "Estimating credit usage",
       done: "Estimated credit usage",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   get_credit_timeseries: {
     description:
@@ -238,6 +252,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       running: "Estimating credit trend",
       done: "Estimated credit trend",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
   get_usage_timeseries: {
     description:
@@ -252,6 +268,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving usage time series",
       done: "Retrieved usage time series",
     },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
 });
 
@@ -265,13 +283,14 @@ export const WORKSPACE_ANALYTICS_SERVER = {
     icon: "ActionPieChartIcon",
     authorization: null,
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(WORKSPACE_ANALYTICS_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(WORKSPACE_ANALYTICS_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -156,6 +156,7 @@ export const ZENDESK_SERVER = {
     },
     icon: "ZendeskLogo",
     documentationUrl: null,
+    toolCategory: "advanced",
   },
   tools: Object.values(ZENDESK_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -36,6 +36,8 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
       running: "Retrieving Zendesk ticket",
       done: "Retrieve Zendesk ticket",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   search_tickets: {
     description:
@@ -62,6 +64,8 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
       running: "Searching Zendesk tickets",
       done: "Search Zendesk tickets",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   list_ticket_fields: {
     description:
@@ -77,6 +81,8 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
       running: "Listing Zendesk ticket fields",
       done: "List Zendesk ticket fields",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   draft_reply: {
     description:
@@ -96,6 +102,8 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
       running: "Drafting reply to Zendesk",
       done: "Draft reply to Zendesk",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   post_reply: {
     description:
@@ -113,6 +121,8 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
       running: "Posting reply to Zendesk",
       done: "Post reply to Zendesk",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
   update_ticket_tags: {
     description:
@@ -141,6 +151,8 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
       running: "Updating Zendesk ticket tags",
       done: "Update Zendesk ticket tags",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 
@@ -156,13 +168,14 @@ export const ZENDESK_SERVER = {
     },
     icon: "ZendeskLogo",
     documentationUrl: null,
-    toolCategory: "advanced",
   },
   tools: Object.values(ZENDESK_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(ZENDESK_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/analytics/awu_usage.ts
+++ b/front/lib/api/analytics/awu_usage.ts
@@ -27,8 +27,8 @@ import {
   USAGE_TYPE_USER,
 } from "@app/lib/metronome/constants";
 import {
-  isToolCategory,
-  TOOL_CATEGORY_AWU_WEIGHTS,
+  isToolCostCategory,
+  TOOL_COST_CATEGORY_AWU_WEIGHTS,
 } from "@app/lib/metronome/events";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -66,7 +66,7 @@ const USAGE_TYPE_LABELS: Record<string, string> = {
 // Human-readable labels for the "tool_category" grouping. Besides the real
 // tool_category values, it carries a synthetic "llm" bucket for all LLM usage,
 // so the breakdown reads Tokens / Basic actions / Advanced actions.
-const TOOL_CATEGORY_LABELS: Record<string, string> = {
+const TOOL_COST_CATEGORY_LABELS: Record<string, string> = {
   llm: "Tokens",
   basic: "Basic actions",
   advanced: "Advanced actions",
@@ -324,7 +324,7 @@ async function resolveGroupLabels(
       break;
     case "tool_category":
       for (const key of groupKeys) {
-        labelMap.set(key, TOOL_CATEGORY_LABELS[key] ?? key);
+        labelMap.set(key, TOOL_COST_CATEGORY_LABELS[key] ?? key);
       }
       break;
     case "user": {
@@ -547,10 +547,14 @@ export async function getAwuUsage(
         toolCfg.bucketProp,
         (entry) => {
           const category = entry.group?.["tool_category"];
-          if (entry.value === null || !category || !isToolCategory(category)) {
+          if (
+            entry.value === null ||
+            !category ||
+            !isToolCostCategory(category)
+          ) {
             return null;
           }
-          return entry.value * TOOL_CATEGORY_AWU_WEIGHTS[category];
+          return entry.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
         },
         periodStartMs,
         aggregateToMs

--- a/front/lib/api/assistant/credit_cost.test.ts
+++ b/front/lib/api/assistant/credit_cost.test.ts
@@ -121,8 +121,11 @@ describe("toolAwuFromActions", () => {
     expect(
       toolAwuFromActions(
         [
-          { internalMCPServerName: "web_search_&_browse" }, // basic = 1
-          { internalMCPServerName: "search" }, // advanced = 3
+          {
+            toolName: "websearch",
+            internalMCPServerName: "web_search_&_browse",
+          }, // basic = 1
+          { toolName: "semantic_search", internalMCPServerName: "search" }, // advanced = 3
         ],
         TEST_CONTEXT_ORIGIN
       )
@@ -131,21 +134,24 @@ describe("toolAwuFromActions", () => {
 
   it("treats unknown / external servers as advanced (3)", () => {
     expect(
-      toolAwuFromActions([{ internalMCPServerName: null }], TEST_CONTEXT_ORIGIN)
+      toolAwuFromActions(
+        [{ toolName: "custom_tool", internalMCPServerName: null }],
+        TEST_CONTEXT_ORIGIN
+      )
     ).toBe(3);
   });
 
   it("does not charge for free tools (priced at 0 in the rate card)", () => {
-    // agent_memory is in FREE_TOOL_SERVERS — billed free, so contributes 0.
+    // agent_memory has toolCategory "basic" + freeUsage true — contributes 0.
     expect(
       toolAwuFromActions(
-        [{ internalMCPServerName: "agent_memory" }],
+        [{ toolName: "retrieve", internalMCPServerName: "agent_memory" }],
         TEST_CONTEXT_ORIGIN
       )
     ).toBe(0);
     expect(
       toolAwuFromActions(
-        [{ internalMCPServerName: "agent_memory" }],
+        [{ toolName: "record_entries", internalMCPServerName: "agent_memory" }],
         TEST_CONTEXT_ORIGIN
       )
     ).toBe(0);
@@ -156,7 +162,13 @@ describe("computeAgentMessageCredits", () => {
   it("sums intelligence and tool credits", () => {
     const credits = computeAgentMessageCredits({
       runUsages: [usage({ costMicroUsd: 8500 })], // 1 intelligence credit
-      actions: [{ internalMCPServerName: "search", status: "succeeded" }], // 3 tool credits
+      actions: [
+        {
+          toolName: "semantic_search",
+          internalMCPServerName: "search",
+          status: "succeeded",
+        },
+      ], // 3 tool credits
       contextOrigin: TEST_CONTEXT_ORIGIN,
     });
     expect(credits).toBe(4);
@@ -165,7 +177,13 @@ describe("computeAgentMessageCredits", () => {
   it("ignores non-final actions", () => {
     const credits = computeAgentMessageCredits({
       runUsages: [],
-      actions: [{ internalMCPServerName: "search", status: "running" }],
+      actions: [
+        {
+          toolName: "semantic_search",
+          internalMCPServerName: "search",
+          status: "running",
+        },
+      ],
       contextOrigin: TEST_CONTEXT_ORIGIN,
     });
     expect(credits).toBeNull();
@@ -184,7 +202,13 @@ describe("computeAgentMessageCredits", () => {
   it("costs 0 for free-origin usage (e.g. agent_sidekick), LLM and tools alike", () => {
     const credits = computeAgentMessageCredits({
       runUsages: [usage({ costMicroUsd: 8500 })], // would be 1 intelligence credit
-      actions: [{ internalMCPServerName: "search", status: "succeeded" }], // would be 3 tool credits
+      actions: [
+        {
+          toolName: "semantic_search",
+          internalMCPServerName: "search",
+          status: "succeeded",
+        },
+      ], // would be 3 tool credits
       contextOrigin: "agent_sidekick",
     });
     expect(credits).toBe(0);

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -1,6 +1,7 @@
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -23,6 +24,7 @@ import {
 } from "@app/types/assistant/conversation";
 
 interface CreditActionMinimalInput {
+  toolName: string;
   internalMCPServerName: InternalMCPServerNameType | null;
   status: ToolExecutionStatus;
 }
@@ -117,6 +119,7 @@ export async function computeAndStoreAgentMessageCredits(
   const costCredits = computeAgentMessageCredits({
     runUsages,
     actions: actions.map((action) => ({
+      toolName: getToolNameFromFunctionCallName(action.functionCallName),
       internalMCPServerName: action.metadata.internalMCPServerName,
       status: action.status,
     })),

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -49,6 +49,9 @@ export function getRetryPolicyFromToolConfiguration(
       DEFAULT_MCP_TOOL_RETRY_POLICY;
 }
 
+export const TOOL_CATEGORIES = ["basic", "advanced"] as const;
+export type ToolCategory = (typeof TOOL_CATEGORIES)[number];
+
 // Schemas are in mcp_schemas.ts to avoid pulling zod + heavy dependencies
 // into the Temporal workflow sandbox.
 // Import schemas from "@app/lib/api/mcp_schemas" directly.
@@ -150,7 +153,10 @@ export type MCPServerDefinitionType = Omit<
   "tools" | "sId" | "availability" | "allowMultipleInstances"
 >;
 
-type InternalMCPServerType = MCPServerType & {
+export type InternalMCPServerDefinitionType = Omit<
+  MCPServerType,
+  "tools" | "sId" | "availability" | "allowMultipleInstances"
+> & {
   name: InternalMCPServerNameType;
   // We enforce that we pass an icon here.
   icon: InternalAllowedIconType;
@@ -159,12 +165,9 @@ type InternalMCPServerType = MCPServerType & {
   // "Allow Linear to create an issue?"). Use "agent" for self-contained agent
   // capabilities; leave undefined for third-party integrations.
   displayedAs?: "agent" | "server";
+  toolCategory: ToolCategory;
+  freeUsage?: boolean;
 };
-
-export type InternalMCPServerDefinitionType = Omit<
-  InternalMCPServerType,
-  "tools" | "sId" | "availability" | "allowMultipleInstances"
->;
 
 export type MCPServerTypeWithViews = MCPServerType & {
   views: MCPServerViewType[];

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -49,8 +49,8 @@ export function getRetryPolicyFromToolConfiguration(
       DEFAULT_MCP_TOOL_RETRY_POLICY;
 }
 
-export const TOOL_CATEGORIES = ["basic", "advanced"] as const;
-export type ToolCategory = (typeof TOOL_CATEGORIES)[number];
+export const TOOL_COST_CATEGORIES = ["basic", "advanced"] as const;
+export type ToolCostCategory = (typeof TOOL_COST_CATEGORIES)[number];
 
 // Schemas are in mcp_schemas.ts to avoid pulling zod + heavy dependencies
 // into the Temporal workflow sandbox.
@@ -165,8 +165,6 @@ export type InternalMCPServerDefinitionType = Omit<
   // "Allow Linear to create an issue?"). Use "agent" for self-contained agent
   // capabilities; leave undefined for third-party integrations.
   displayedAs?: "agent" | "server";
-  toolCategory: ToolCategory;
-  freeUsage?: boolean;
 };
 
 export type MCPServerTypeWithViews = MCPServerType & {

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -4,11 +4,7 @@ import {
   isInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { InternalMCPToolType } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import {
-  type InternalMCPServerDefinitionType,
-  TOOL_CATEGORIES,
-  type ToolCategory,
-} from "@app/lib/api/mcp";
+import { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { createHash } from "crypto";
@@ -59,41 +55,39 @@ function truncatePropertyValue(value: string): string {
 // basic: 1 AWU, advanced: 3 AWU; freeUsage overrides to 0 AWU regardless of category
 
 // Re-export from mcp so consumers can import from one place.
-export { TOOL_CATEGORIES, type ToolCategory } from "@app/lib/api/mcp";
+export { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
 
 // AWU price per tool invocation by category (1 AWU = $0.01). Canonical source
 // for both the Tool Usage rate-card prices (scripts/metronome_setup.ts) and the
 // runtime per-user AWU spend computation (per_user_usage.ts) — keep both in
 // sync by importing from here rather than redefining.
-export const TOOL_CATEGORY_AWU_WEIGHTS: Record<ToolCategory, number> = {
-  basic: 1,
-  advanced: 3,
-};
+export const TOOL_COST_CATEGORY_AWU_WEIGHTS: Record<ToolCostCategory, number> =
+  {
+    basic: 1,
+    advanced: 3,
+  };
 
-export function isToolCategory(value: string): value is ToolCategory {
-  return TOOL_CATEGORIES.includes(value as ToolCategory);
+export function isToolCostCategory(value: string): value is ToolCostCategory {
+  return TOOL_COST_CATEGORIES.includes(value as ToolCostCategory);
 }
 
 export function getToolBillingInfo(
   serverName: string | null,
   toolName: string
-): { toolCategory: ToolCategory; freeUsage: boolean } {
+): { toolCostCategory: ToolCostCategory; freeUsage: boolean } {
   if (!serverName || !isInternalMCPServerName(serverName)) {
     // External MCP servers (user-configured remote servers) are always advanced.
-    return { toolCategory: "advanced", freeUsage: false };
+    return { toolCostCategory: "advanced", freeUsage: false };
   }
   const metadata = getInternalMCPServerMetadata(serverName);
-  // Both casts are safe: each metadata file satisfies ServerMetadata which uses InternalMCPToolType
-  // and InternalMCPServerDefinitionType. The narrow as-const type drops optional fields absent from
-  // that specific object, so we cast to access them uniformly.
-  const serverInfo = metadata.serverInfo as InternalMCPServerDefinitionType;
   const tool = (metadata.tools as InternalMCPToolType[]).find(
     (t) => t.name === toolName
   );
-  return {
-    toolCategory: tool?.toolCategory ?? serverInfo.toolCategory,
-    freeUsage: tool?.freeUsage ?? serverInfo.freeUsage ?? false,
-  };
+  // Unknown tool on a known internal server — default to advanced, not free.
+  if (!tool) {
+    return { toolCostCategory: "advanced", freeUsage: false };
+  }
+  return { toolCostCategory: tool.toolCostCategory, freeUsage: tool.freeUsage };
 }
 
 // ---------------------------------------------------------------------------
@@ -251,14 +245,14 @@ export function toolAwuFromAction(
   if (isFreeOrigin(contextOrigin)) {
     return 0;
   }
-  const { toolCategory, freeUsage } = getToolBillingInfo(
+  const { toolCostCategory, freeUsage } = getToolBillingInfo(
     action.internalMCPServerName,
     action.toolName
   );
   if (freeUsage) {
     return 0;
   }
-  return TOOL_CATEGORY_AWU_WEIGHTS[toolCategory];
+  return TOOL_COST_CATEGORY_AWU_WEIGHTS[toolCostCategory];
 }
 
 // ---------------------------------------------------------------------------
@@ -468,7 +462,7 @@ export function buildToolUseEvents({
   }
 
   return [...groups.values()].map(({ action, count, totalDurationMs }) => {
-    const { toolCategory, freeUsage } = getToolBillingInfo(
+    const { toolCostCategory, freeUsage } = getToolBillingInfo(
       action.internalMCPServerName,
       action.toolName
     );
@@ -499,7 +493,7 @@ export function buildToolUseEvents({
         internal_mcp_server_name: truncatePropertyValue(
           action.internalMCPServerName ?? ""
         ),
-        tool_category: toolCategory,
+        tool_category: toolCostCategory,
         // Constant grouping key — used as presentation_group_key in Metronome to
         // aggregate all tool categories into a single "Tool Usage" invoice line.
         tool_group: "tools",

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -1,7 +1,14 @@
 import {
+  getInternalMCPServerMetadata,
   type InternalMCPServerNameType,
   isInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { InternalMCPToolType } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  type InternalMCPServerDefinitionType,
+  TOOL_CATEGORIES,
+  type ToolCategory,
+} from "@app/lib/api/mcp";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { createHash } from "crypto";
@@ -47,13 +54,12 @@ function truncatePropertyValue(value: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Tool category mapping
+// Tool category and billing info
 // ---------------------------------------------------------------------------
-// Basic: 1 AWU
-// Advanced: 3 AWU
-export const TOOL_CATEGORIES = ["basic", "advanced"] as const;
+// basic: 1 AWU, advanced: 3 AWU; freeUsage overrides to 0 AWU regardless of category
 
-export type ToolCategory = (typeof TOOL_CATEGORIES)[number];
+// Re-export from mcp so consumers can import from one place.
+export { TOOL_CATEGORIES, type ToolCategory } from "@app/lib/api/mcp";
 
 // AWU price per tool invocation by category (1 AWU = $0.01). Canonical source
 // for both the Tool Usage rate-card prices (scripts/metronome_setup.ts) and the
@@ -65,106 +71,29 @@ export const TOOL_CATEGORY_AWU_WEIGHTS: Record<ToolCategory, number> = {
 };
 
 export function isToolCategory(value: string): value is ToolCategory {
-  return value in TOOL_CATEGORY_AWU_WEIGHTS;
+  return TOOL_CATEGORIES.includes(value as ToolCategory);
 }
 
-// Exhaustive map — TypeScript will error if a new internal MCP server is added
-// without being categorized here.
-const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
-  // Set as basic but overridden as free
-  agent_memory: "basic",
-  agent_router: "basic",
-  common_utilities: "basic",
-  toolsets: "basic",
-
-  // Basic (1 AWU) — web search, orchestration, platform utilities.
-  "web_search_&_browse": "basic",
-  run_agent: "basic",
-  agent_sidekick_agent_state: "basic",
-  agent_sidekick_context: "basic",
-  run_dust_app: "basic",
-  user_mentions: "basic",
-  missing_action_catcher: "basic",
-  primitive_types_debugger: "basic",
-  jit_testing: "basic",
-  skill_authoring: "basic",
-  skill_management: "basic",
-  schedules_management: "basic",
-  pod_manager: "basic",
-  pod_tasks: "basic",
-  poke: "basic",
-  ask_user_question: "basic",
-  wakeups: "basic",
-  plan_mode: "basic",
-
-  // Advanced (3 AWU) — retrieval, MCP read/write, data warehouse, generation, sandbox
-  search: "advanced",
-  query_tables_v2: "advanced",
-  data_warehouses: "advanced",
-  data_sources_file_system: "advanced",
-  include_data: "advanced",
-  conversation_files: "advanced",
-  files: "advanced",
-  extract_data: "advanced",
-  http_client: "advanced",
-  sandbox: "advanced",
-  sandbox_functions: "advanced",
-  file_generation: "advanced",
-  image_generation: "advanced",
-  sound_studio: "advanced",
-  speech_generator: "advanced",
-  interactive_content: "advanced",
-  confluence: "advanced",
-  databricks: "advanced",
-  exa_people_and_company: "advanced",
-  fathom: "advanced",
-  freshservice: "advanced",
-  github: "advanced",
-  gmail: "advanced",
-  google_calendar: "advanced",
-  google_drive: "advanced",
-  google_sheets: "advanced",
-  hubspot: "advanced",
-  jira: "advanced",
-  luma: "advanced",
-  microsoft_drive: "advanced",
-  microsoft_excel: "advanced",
-  microsoft_teams: "advanced",
-  monday: "advanced",
-  notion: "advanced",
-  openai_usage: "advanced",
-  workspace_analytics: "advanced",
-  outlook_calendar: "advanced",
-  outlook: "advanced",
-  productboard: "advanced",
-  salesforce: "advanced",
-  salesloft: "advanced",
-  slab: "advanced",
-  slack: "advanced",
-  slack_bot: "advanced",
-  snowflake: "advanced",
-  statuspage: "advanced",
-  ukg_ready: "advanced",
-  val_town: "advanced",
-  vanta: "advanced",
-  workday: "advanced",
-  front: "advanced",
-  gong: "advanced",
-  zendesk: "advanced",
-  ashby: "advanced",
-  clari_copilot: "advanced",
-};
-
-function getToolCategory(internalMCPServerName: string | null): ToolCategory {
-  if (
-    !internalMCPServerName ||
-    !isInternalMCPServerName(internalMCPServerName)
-  ) {
-    // External MCP servers (user-configured remote servers) fall into advanced
-    // as "Custom MCP call".
-    return "advanced";
+export function getToolBillingInfo(
+  serverName: string | null,
+  toolName: string
+): { toolCategory: ToolCategory; freeUsage: boolean } {
+  if (!serverName || !isInternalMCPServerName(serverName)) {
+    // External MCP servers (user-configured remote servers) are always advanced.
+    return { toolCategory: "advanced", freeUsage: false };
   }
-  return TOOL_CATEGORY_MAP[internalMCPServerName];
+  const metadata = getInternalMCPServerMetadata(serverName);
+  // Both casts are safe: each metadata file satisfies ServerMetadata which uses InternalMCPToolType
+  // and InternalMCPServerDefinitionType. The narrow as-const type drops optional fields absent from
+  // that specific object, so we cast to access them uniformly.
+  const serverInfo = metadata.serverInfo as InternalMCPServerDefinitionType;
+  const tool = (metadata.tools as InternalMCPToolType[]).find(
+    (t) => t.name === toolName
+  );
+  return {
+    toolCategory: tool?.toolCategory ?? serverInfo.toolCategory,
+    freeUsage: tool?.freeUsage ?? serverInfo.freeUsage ?? false,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -175,15 +104,6 @@ function getToolCategory(internalMCPServerName: string | null): ToolCategory {
 // user-requested output).
 export const FREE_ORIGINS: ReadonlySet<UserMessageOrigin> =
   new Set<UserMessageOrigin>(["agent_sidekick"]);
-
-// Internal MCP servers whose tool invocations are always free regardless of
-// the message-level usage type (platform plumbing, not user output).
-const FREE_TOOL_SERVERS: ReadonlySet<string> = new Set<string>([
-  "agent_memory",
-  "agent_router",
-  "common_utilities",
-  "toolsets",
-]);
 
 function isFreeOrigin(origin: UserMessageOrigin | null): boolean {
   if (origin == null) {
@@ -203,25 +123,11 @@ export function getUsageType(
   return isProgrammaticUsage ? USAGE_TYPE_PROGRAMMATIC : USAGE_TYPE_USER;
 }
 
-// A tool invocation is always free (priced at 0 in the rate card) when its
-// internal MCP server is platform plumbing — see FREE_TOOL_SERVERS.
-function isFreeToolServer(
-  internalMCPServerName: InternalMCPServerNameType | null
-): boolean {
-  return (
-    internalMCPServerName !== null &&
-    FREE_TOOL_SERVERS.has(internalMCPServerName)
-  );
-}
-
 function getToolUsageType(
   baseUsageType: UsageType,
-  internalMCPServerName: InternalMCPServerNameType | null
+  freeUsage: boolean
 ): UsageType {
-  if (isFreeToolServer(internalMCPServerName)) {
-    return USAGE_TYPE_FREE;
-  }
-  return baseUsageType;
+  return freeUsage ? USAGE_TYPE_FREE : baseUsageType;
 }
 
 // ---------------------------------------------------------------------------
@@ -320,34 +226,39 @@ export function intelligenceAwuFromRunUsagesGroupedByRunKey(
 }
 
 // Tool (platform action) credits for a set of executed actions. Each action
-// costs a fixed number of credits depending on its category (basic = 1,
-// advanced = 3), except free tools (FREE_TOOL_SERVERS, e.g. agent_memory) which
-// are priced at 0 in the rate card and therefore contribute nothing. Callers
-// should pass only final-status actions (matching the usage_queue extraction)
-// so this equals the billed amount.
+// costs a fixed number of credits depending on its credit cost category
+// (free = 0, basic = 1, advanced = 3). Callers should pass only final-status
+// actions (matching the usage_queue extraction) so this equals the billed amount.
 export function toolAwuFromActions(
-  actions: { internalMCPServerName: InternalMCPServerNameType | null }[],
+  actions: {
+    internalMCPServerName: InternalMCPServerNameType | null;
+    toolName: string;
+  }[],
   contextOrigin: UserMessageOrigin | null
 ): number {
   return actions.reduce((total, action) => {
-    return (
-      total + toolAwuFromServerName(action.internalMCPServerName, contextOrigin)
-    );
+    return total + toolAwuFromAction(action, contextOrigin);
   }, 0);
 }
 
-export function toolAwuFromServerName(
-  internalMCPServerName: InternalMCPServerNameType | null,
+export function toolAwuFromAction(
+  action: {
+    toolName: string;
+    internalMCPServerName: InternalMCPServerNameType | null;
+  },
   contextOrigin: UserMessageOrigin | null
 ): number {
   if (isFreeOrigin(contextOrigin)) {
     return 0;
   }
-
-  if (isFreeToolServer(internalMCPServerName)) {
+  const { toolCategory, freeUsage } = getToolBillingInfo(
+    action.internalMCPServerName,
+    action.toolName
+  );
+  if (freeUsage) {
     return 0;
   }
-  return TOOL_CATEGORY_AWU_WEIGHTS[getToolCategory(internalMCPServerName)];
+  return TOOL_CATEGORY_AWU_WEIGHTS[toolCategory];
 }
 
 // ---------------------------------------------------------------------------
@@ -557,10 +468,11 @@ export function buildToolUseEvents({
   }
 
   return [...groups.values()].map(({ action, count, totalDurationMs }) => {
-    const effectiveUsageType = getToolUsageType(
-      usageType,
-      action.internalMCPServerName
+    const { toolCategory, freeUsage } = getToolBillingInfo(
+      action.internalMCPServerName,
+      action.toolName
     );
+    const effectiveUsageType = getToolUsageType(usageType, freeUsage);
     return {
       transaction_id: truncateTransactionId(
         `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`
@@ -587,7 +499,7 @@ export function buildToolUseEvents({
         internal_mcp_server_name: truncatePropertyValue(
           action.internalMCPServerName ?? ""
         ),
-        tool_category: getToolCategory(action.internalMCPServerName),
+        tool_category: toolCategory,
         // Constant grouping key — used as presentation_group_key in Metronome to
         // aggregate all tool categories into a single "Tool Usage" invoice line.
         tool_group: "tools",

--- a/front/lib/metronome/per_api_key_usage.ts
+++ b/front/lib/metronome/per_api_key_usage.ts
@@ -5,8 +5,8 @@ import {
 } from "@app/lib/metronome/constants";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import {
-  isToolCategory,
-  TOOL_CATEGORY_AWU_WEIGHTS,
+  isToolCostCategory,
+  TOOL_COST_CATEGORY_AWU_WEIGHTS,
 } from "@app/lib/metronome/events";
 import { buildUsageQuerySegments } from "@app/lib/metronome/per_user_usage";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -151,11 +151,11 @@ export async function fetchPerApiKeyAwuUsage({
       new Date(entry.startingOn).getTime() < cycleStartMs ||
       new Date(entry.startingOn).getTime() >= cycleEndMs ||
       !category ||
-      !isToolCategory(category)
+      !isToolCostCategory(category)
     ) {
       continue;
     }
-    const awuSpent = entry.value * TOOL_CATEGORY_AWU_WEIGHTS[category];
+    const awuSpent = entry.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
     perKey.set(keyName, (perKey.get(keyName) ?? 0) + awuSpent);
   }
 

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -12,8 +12,8 @@ import {
 } from "@app/lib/metronome/constants";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import {
-  isToolCategory,
-  TOOL_CATEGORY_AWU_WEIGHTS,
+  isToolCostCategory,
+  TOOL_COST_CATEGORY_AWU_WEIGHTS,
 } from "@app/lib/metronome/events";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
@@ -248,11 +248,11 @@ export async function fetchPerUserAwuUsage({
       new Date(entry.startingOn).getTime() < cycleStartMs ||
       new Date(entry.startingOn).getTime() >= cycleEndMs ||
       !category ||
-      !isToolCategory(category)
+      !isToolCostCategory(category)
     ) {
       continue;
     }
-    const awuSpent = entry.value * TOOL_CATEGORY_AWU_WEIGHTS[category];
+    const awuSpent = entry.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
     perUser.set(userId, (perUser.get(userId) ?? 0) + awuSpent);
   }
 

--- a/front/lib/metronome/programmatic_awu_usage.ts
+++ b/front/lib/metronome/programmatic_awu_usage.ts
@@ -12,8 +12,8 @@ import {
 } from "@app/lib/metronome/constants";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import {
-  isToolCategory,
-  TOOL_CATEGORY_AWU_WEIGHTS,
+  isToolCostCategory,
+  TOOL_COST_CATEGORY_AWU_WEIGHTS,
 } from "@app/lib/metronome/events";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import logger from "@app/logger/logger";
@@ -165,11 +165,11 @@ export async function fetchProgrammaticAwuSpend({
       entry.group?.[USAGE_TYPE_GROUP_KEY] !== USAGE_TYPE_PROGRAMMATIC ||
       new Date(entry.startingOn).getTime() < cycleStartMs ||
       !category ||
-      !isToolCategory(category)
+      !isToolCostCategory(category)
     ) {
       continue;
     }
-    spentAwuCredits += entry.value * TOOL_CATEGORY_AWU_WEIGHTS[category];
+    spentAwuCredits += entry.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
   }
 
   return new Ok(spentAwuCredits);

--- a/front/lib/metronome/setup_new_pricing.ts
+++ b/front/lib/metronome/setup_new_pricing.ts
@@ -24,7 +24,7 @@ import {
   USAGE_TYPE_PROGRAMMATIC,
   USAGE_TYPE_USER,
 } from "@app/lib/metronome/constants";
-import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
+import { TOOL_COST_CATEGORIES } from "@app/lib/metronome/events";
 import {
   BILLING_CYCLE_CONFIG,
   BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
@@ -196,8 +196,8 @@ export const NEW_METRICS: MetricDef[] = [
 ];
 
 // Per-tier AWU price for Tool Usage rates. Shared across all AWU-priced rate cards
-const TOOL_CATEGORY_PRICES_AWU: Record<
-  (typeof TOOL_CATEGORIES)[number],
+const TOOL_COST_CATEGORY_PRICES_AWU: Record<
+  (typeof TOOL_COST_CATEGORIES)[number],
   number
 > = {
   basic: 1,
@@ -210,14 +210,14 @@ const TOOL_CATEGORY_PRICES_AWU: Record<
 const PAID_USAGE_TYPES = [USAGE_TYPE_USER, USAGE_TYPE_PROGRAMMATIC] as const;
 
 function buildAwuToolUsageRates(): RateDef[] {
-  return TOOL_CATEGORIES.flatMap((category): RateDef[] => [
+  return TOOL_COST_CATEGORIES.flatMap((category): RateDef[] => [
     ...PAID_USAGE_TYPES.map(
       (usageType): RateDef => ({
         product_name: "Tool Usage",
         starting_at: "2026-04-01T00:00:00.000Z",
         entitled: true,
         rate_type: "FLAT",
-        price: TOOL_CATEGORY_PRICES_AWU[category],
+        price: TOOL_COST_CATEGORY_PRICES_AWU[category],
         credit_type_id: getCreditTypeAwuId(),
         pricing_group_values: {
           tool_category: category,

--- a/front/scripts/debug_user_awu_spend.ts
+++ b/front/scripts/debug_user_awu_spend.ts
@@ -31,8 +31,8 @@ import {
 } from "@app/lib/metronome/constants";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import {
-  isToolCategory,
-  TOOL_CATEGORY_AWU_WEIGHTS,
+  isToolCostCategory,
+  TOOL_COST_CATEGORY_AWU_WEIGHTS,
 } from "@app/lib/metronome/events";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
@@ -197,10 +197,10 @@ makeScript(
     let toolTrimmed = 0;
     for (const e of toolResult.value) {
       const category = e.group?.["tool_category"];
-      if (e.value === null || !category || !isToolCategory(category)) {
+      if (e.value === null || !category || !isToolCostCategory(category)) {
         continue;
       }
-      const awuSpent = e.value * TOOL_CATEGORY_AWU_WEIGHTS[category];
+      const awuSpent = e.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
       const tsMs = new Date(e.startingOn).getTime();
       const usageType = e.group?.[USAGE_TYPE_GROUP_KEY] ?? "?";
       const trimmed = tsMs < cycleStartMs;
@@ -277,12 +277,12 @@ makeScript(
           e.group?.["user_id"] !== userId ||
           e.value === null ||
           !category ||
-          !isToolCategory(category) ||
+          !isToolCostCategory(category) ||
           new Date(e.startingOn).getTime() < cycleStartMs
         ) {
           continue;
         }
-        canonTool += e.value * TOOL_CATEGORY_AWU_WEIGHTS[category];
+        canonTool += e.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
       }
     }
     logger.info(
@@ -389,12 +389,12 @@ makeScript(
           e.value === null ||
           e.group?.[USAGE_TYPE_GROUP_KEY] === "free" ||
           !category ||
-          !isToolCategory(category) ||
+          !isToolCostCategory(category) ||
           new Date(e.startingOn).getTime() < cycleStartMs
         ) {
           continue;
         }
-        fixTool += e.value * TOOL_CATEGORY_AWU_WEIGHTS[category];
+        fixTool += e.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
       }
     }
     logger.info(

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -20,7 +20,7 @@ import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import {
   intelligenceAwuFromRunUsages,
-  toolAwuFromServerName,
+  toolAwuFromAction,
 } from "@app/lib/metronome/events";
 import type { AgentMessageFeedbackModel } from "@app/lib/models/agent/conversation";
 import {
@@ -374,16 +374,17 @@ async function collectToolUsageFromMessage(
       mcpServerId ??
       "unknown";
 
+    const toolName =
+      actionResource.functionCallName.split(TOOL_NAME_SEPARATOR).pop() ??
+      actionResource.functionCallName;
     const cost_awu = isToolExecutionStatusFinal(actionResource.status)
-      ? toolAwuFromServerName(internalMCPServerName, contextOrigin)
+      ? toolAwuFromAction({ toolName, internalMCPServerName }, contextOrigin)
       : 0;
 
     return {
       step_index: actionResource.stepContent.step,
       server_name: serverName,
-      tool_name:
-        actionResource.functionCallName.split(TOOL_NAME_SEPARATOR).pop() ??
-        actionResource.functionCallName,
+      tool_name: toolName,
       mcp_server_configuration_sid:
         configIdToSId.get(actionResource.mcpServerConfigurationId) ?? undefined,
       execution_time_ms: actionResource.executionDurationMs,


### PR DESCRIPTION
## Description

Replaces the hardcoded per-server billing maps in events.ts with toolCostCategory and freeUsage declared directly on every tool in each server's metadata, and sets the actual decided cost values for all tools.

* Before: A TOOL_CATEGORY_MAP (a ~75-entry exhaustive record in events.ts) assigned a single "basic" | "advanced" category to each internal MCP server. Free servers were tracked separately in a FREE_TOOL_SERVERS set. Adding a new server required updating two places in events.ts; per-tool pricing was impossible.
* After: toolCostCategory and freeUsage are mandatory on every tool individually in each server's metadata.ts. There are no server-level defaults and no fallback logic. getToolBillingInfo is a direct lookup on the tool entry. Adding a tool requires explicitly declaring its billing intent.

**Two orthogonal billing fields, mandatory at tool level**
* toolCostCategory: "basic" | "advanced" — the intrinsic pricing tier. 1 AWU for basic, 3 AWU for advanced.
* freeUsage: boolean — whether this tool's invocations are free regardless of category. Overrides the AWU charge to 0, while still recording the real tier in Metronome for analytics (so we can track what is being subsidised and switching from free to paid only requires flipping one field).

**Snapshot test for billing values**
A Vitest snapshot test (mcp_servers_metadata.test.ts) asserts toolCostCategory and freeUsage for every tool on every internal MCP server. Any accidental change to a tool's billing values or any new tool added without billing fields will break the snapshot, making regressions visible in CI.

**Changes**
* front/lib/api/mcp.ts: Renamed ToolCategory → ToolCostCategory, TOOL_CATEGORIES → TOOL_COST_CATEGORIES. Removed toolCategory and freeUsage from InternalMCPServerDefinitionType.
* front/lib/actions/mcp_internal_actions/tool_definition.ts: toolCostCategory: ToolCostCategory and freeUsage: boolean added as mandatory fields to ToolDefinition, ClientToolDefinition, and InternalMCPToolType.
* front/lib/metronome/events.ts: Deleted TOOL_CATEGORY_MAP, FREE_TOOL_SERVERS. getToolBillingInfo(serverName, toolName) replaces the old map lookup with a direct read from metadata. Renamed TOOL_CATEGORY_AWU_WEIGHTS → TOOL_COST_CATEGORY_AWU_WEIGHTS, isToolCategory → isToolCostCategory.
* ~77 servers/*/metadata.ts files: toolCostCategory and freeUsage added to every tool entry with explicit decided values (e.g. poke tools → basic/freeUsage: true, files/search/sandbox → advanced/freeUsage: false, formerly-free servers like agent_memory and toolsets → basic/freeUsage: true per tool).
* Consumers (per_user_usage.ts, per_api_key_usage.ts, programmatic_awu_usage.ts, awu_usage.ts, debug_user_awu_spend.ts, setup_new_pricing.ts): updated to renamed exports.

## Tests

 * npx tsgo --noEmit passes with 0 errors
 * credit_cost.test.ts passes — covers free-server (0 AWU), basic (1 AWU), advanced (3 AWU) cases, and the toolName threading
 * Tested locally with:
   * a free origin (sidekick) => all free => OK
   * a tool with freeUsage = true => tool usage = 0 => OK
   * a tool with freeUsage = false and basic or advanced => tool usage based on category => OK

## Risk

Medium, as it impacts the usage computation via credits

## Deploy Plan

Deploy front