### PR TITLE
front: skip space permission filtering when rendering historical messages

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -163,7 +163,10 @@ export async function getAgentConfigurationsWithVersion<
 >(
   auth: Authenticator,
   agentIdsWithVersion: { agentId: string; agentVersion: number }[],
-  { variant }: { variant: V }
+  {
+    variant,
+    dangerouslySkipPermissionFiltering,
+  }: { variant: V; dangerouslySkipPermissionFiltering?: boolean }
 ): Promise<
   V extends "light" ? LightAgentConfigurationType[] : AgentConfigurationType[]
 > {
@@ -193,10 +196,9 @@ export async function getAgentConfigurationsWithVersion<
     },
   });
 
-  const allowedAgentModels = await filterAgentsByRequestedSpaces(
-    auth,
-    workspaceAgentModels
-  );
+  const allowedAgentModels = dangerouslySkipPermissionFiltering
+    ? workspaceAgentModels
+    : await filterAgentsByRequestedSpaces(auth, workspaceAgentModels);
   const workspaceAgents = await enrichAgentConfigurations(
     auth,
     allowedAgentModels,
@@ -299,10 +301,12 @@ export async function getAgentConfigurations<V extends AgentFetchVariant>(
     agentIds,
     variant,
     globalAgentContext,
+    dangerouslySkipPermissionFiltering,
   }: {
     agentIds: string[];
     variant: V;
     globalAgentContext?: GlobalAgentContext;
+    dangerouslySkipPermissionFiltering?: boolean;
   }
 ): Promise<
   V extends "full" ? AgentConfigurationType[] : LightAgentConfigurationType[]
@@ -334,10 +338,9 @@ export async function getAgentConfigurations<V extends AgentFetchVariant>(
         workspaceAgentIds
       );
 
-      const allowedAgentModels = await filterAgentsByRequestedSpaces(
-        auth,
-        agentModels
-      );
+      const allowedAgentModels = dangerouslySkipPermissionFiltering
+        ? agentModels
+        : await filterAgentsByRequestedSpaces(auth, agentModels);
       workspaceAgents = await enrichAgentConfigurations(
         auth,
         allowedAgentModels,
@@ -365,11 +368,13 @@ export async function getAgentConfiguration<V extends AgentFetchVariant>(
     agentVersion,
     variant,
     globalAgentContext,
+    dangerouslySkipPermissionFiltering,
   }: {
     agentId: string;
     agentVersion?: number;
     variant: V;
     globalAgentContext?: GlobalAgentContext;
+    dangerouslySkipPermissionFiltering?: boolean;
   }
 ): Promise<
   | (V extends "light" ? LightAgentConfigurationType : AgentConfigurationType)
@@ -382,6 +387,7 @@ export async function getAgentConfiguration<V extends AgentFetchVariant>(
         [{ agentId, agentVersion }],
         {
           variant,
+          dangerouslySkipPermissionFiltering,
         }
       );
       return (
@@ -394,6 +400,7 @@ export async function getAgentConfiguration<V extends AgentFetchVariant>(
       agentIds: [agentId],
       variant,
       globalAgentContext,
+      dangerouslySkipPermissionFiltering,
     });
     return (
       (agent as V extends "light"

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -3203,13 +3203,10 @@ export async function updateAgentMessageWithFinalStatus(
       }
     );
 
-    const promotedUserMessages = await batchRenderUserMessagesWithoutMentions(
-      auth,
-      {
-        messages: pendingMessages,
-        transaction: t,
-      }
-    );
+    const promotedUserMessages = await batchRenderUserMessagesWithoutMentions({
+      messages: pendingMessages,
+      transaction: t,
+    });
 
     // The new agent message is triggered by the last steering message (being promoted here from
     // pending to visible). We need to use the promotedAuth of the associated user if it differs

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -267,6 +267,12 @@ async function batchRenderUserMessages(
       ? await getAgentConfigurations(auth, {
           agentIds: agentConfigurationIds,
           variant: "extra_light",
+          // Skip permission filtering: we are rendering the mentions of a
+          // conversation the user already has access to. We want to keep
+          // displaying the agents that were mentioned historically even if the
+          // user has since lost access to the space that hosts them, otherwise
+          // those past messages would render without their agent metadata.
+          dangerouslySkipPermissionFiltering: true,
         })
       : [];
   const reactionsByMessageId = await getMessagesReactions(auth, {
@@ -308,13 +314,13 @@ type RenderedAgentMessage = AgentMessageType | LightAgentMessageType;
  * Render user messages without mentions or reactions.
  * No DB calls beyond the provided transaction — safe to use inside an advisory lock.
  */
-export async function batchRenderUserMessagesWithoutMentions(
-  auth: Authenticator,
-  {
-    messages,
-    transaction,
-  }: { messages: MessageModel[]; transaction: Transaction }
-): Promise<UserMessageTypeWithoutMentions[]> {
+export async function batchRenderUserMessagesWithoutMentions({
+  messages,
+  transaction,
+}: {
+  messages: MessageModel[];
+  transaction: Transaction;
+}): Promise<UserMessageTypeWithoutMentions[]> {
   const userMessages = messages.filter(
     (m) => m.userMessage !== null && m.userMessage !== undefined
   );
@@ -397,6 +403,13 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         ? getAgentConfigurations(auth, {
             agentIds: [...agentConfigurationIds],
             variant: "extra_light",
+            // Skip permission filtering: we are rendering the agents that
+            // produced (or were mentioned in) messages of a conversation the
+            // user already has access to. We want to keep displaying these
+            // agents even if the user has since lost access to the space that
+            // hosts them, otherwise those past messages would render without
+            // their agent metadata.
+            dangerouslySkipPermissionFiltering: true,
           })
         : [],
   ];


### PR DESCRIPTION
## Description

Conversation message rendering (`batchRenderMessages`) was filtering out agent configurations referenced by user mentions and agent messages based on the viewer's current space access (`filterAgentsByRequestedSpaces`). This meant an agent mentioned in an old message, or a message sent by an agent, could disappear or error out of the conversation history if the viewer's access to the agent's space changed after the fact (e.g. removed from a space, agent moved spaces).

Adds a `dangerouslySkipPermissionFiltering` option to `getAgentConfigurations`, `getAgentConfigurationsWithVersion`, and `getAgentConfiguration` (mirroring the existing pattern in `configuration/views.ts`), and uses it when resolving agent configurations for both user and agent message rendering in `messages.ts`. Historical messages now render consistently regardless of the viewer's current space access.

## Tests

Verified with `npx tsgo --noEmit`.
