### PR TITLE
Fix files edit tool after the tool context rename merge race

### DIFF
--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { editHandler } from "@app/lib/api/actions/servers/files/tools/edit";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -22,10 +22,10 @@ function makeExtra(
   auth: Authenticator,
   conversation: ConversationType
 ): ToolHandlerExtra {
-  const agentLoopContext = {
+  const toolContext = {
     runContext: { conversation },
-  } as unknown as AgentLoopContextType;
-  return { auth, agentLoopContext } as unknown as ToolHandlerExtra;
+  } as unknown as ToolContextType;
+  return { auth, toolContext } as unknown as ToolHandlerExtra;
 }
 
 async function setupProjectConversation(): Promise<{

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -34,9 +34,9 @@ export async function editHandler(
     new_string: string;
     expected_replacements?: number;
   },
-  { auth, agentLoopContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }


### PR DESCRIPTION
## Description

The path-keyed edit tool PR and the tool context rename merged the same day, and since the edit tool files were brand new they landed verbatim with the pre-rename harness types. Main currently fails type checking on them and the edit tool handler cannot resolve its conversation, which also fails its test suite. This renames the context accesses to the new shape, nothing else changes.

## Risk

None, mechanical rename aligning two already-merged changes.

## Deploy Plan

Deploy front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)