### PR TITLE
Pricing: refresh the limit after bulk edit

### DIFF
--- a/front-api/routes/w/[wId]/members/bulk-spend-limit.test.ts
+++ b/front-api/routes/w/[wId]/members/bulk-spend-limit.test.ts
@@ -10,7 +10,7 @@ import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/temporal/bulk_spend_limit/client", () => ({
-  launchBulkSetUserSpendLimitWorkflow: vi.fn(),
+  runBulkSetUserSpendLimitWorkflow: vi.fn(),
 }));
 
 function bulkSpendLimitUrl(wId: string) {
@@ -30,7 +30,7 @@ function post(wId: string, body: unknown) {
 }
 
 beforeEach(() => {
-  vi.mocked(bulkClient.launchBulkSetUserSpendLimitWorkflow).mockResolvedValue(
+  vi.mocked(bulkClient.runBulkSetUserSpendLimitWorkflow).mockResolvedValue(
     new Ok({ workflowId: "wf_test_bulk" })
   );
   // The workspace-scoped search that validates membership. Default to "no
@@ -56,9 +56,7 @@ describe("POST /api/w/[wId]/members/bulk-spend-limit", () => {
 
     expect(response.status).toBe(403);
     expect((await response.json()).error.type).toBe("workspace_auth_error");
-    expect(
-      bulkClient.launchBulkSetUserSpendLimitWorkflow
-    ).not.toHaveBeenCalled();
+    expect(bulkClient.runBulkSetUserSpendLimitWorkflow).not.toHaveBeenCalled();
   });
 
   it("returns 403 when the pricing_groups flag is off", async () => {
@@ -76,9 +74,7 @@ describe("POST /api/w/[wId]/members/bulk-spend-limit", () => {
 
     expect(response.status).toBe(403);
     expect((await response.json()).error.type).toBe("feature_flag_not_found");
-    expect(
-      bulkClient.launchBulkSetUserSpendLimitWorkflow
-    ).not.toHaveBeenCalled();
+    expect(bulkClient.runBulkSetUserSpendLimitWorkflow).not.toHaveBeenCalled();
   });
 
   it("returns 403 when the workspace is not on Metronome billing", async () => {
@@ -95,9 +91,7 @@ describe("POST /api/w/[wId]/members/bulk-spend-limit", () => {
 
     expect(response.status).toBe(403);
     expect((await response.json()).error.type).toBe("plan_limit_error");
-    expect(
-      bulkClient.launchBulkSetUserSpendLimitWorkflow
-    ).not.toHaveBeenCalled();
+    expect(bulkClient.runBulkSetUserSpendLimitWorkflow).not.toHaveBeenCalled();
   });
 
   it("returns 400 when the explicit selection is empty", async () => {
@@ -115,9 +109,7 @@ describe("POST /api/w/[wId]/members/bulk-spend-limit", () => {
     });
 
     expect(response.status).toBe(400);
-    expect(
-      bulkClient.launchBulkSetUserSpendLimitWorkflow
-    ).not.toHaveBeenCalled();
+    expect(bulkClient.runBulkSetUserSpendLimitWorkflow).not.toHaveBeenCalled();
   });
 
   it("returns 400 when awuCredits is out of range", async () => {
@@ -166,7 +158,7 @@ describe("POST /api/w/[wId]/members/bulk-spend-limit", () => {
       workflowId: "wf_test_bulk",
       memberCount: 2,
     });
-    expect(bulkClient.launchBulkSetUserSpendLimitWorkflow).toHaveBeenCalledWith(
+    expect(bulkClient.runBulkSetUserSpendLimitWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId: workspace.sId,
         userIds: [member1.sId, member2.sId],
@@ -195,9 +187,7 @@ describe("POST /api/w/[wId]/members/bulk-spend-limit", () => {
 
     expect(response.status).toBe(400);
     expect((await response.json()).error.type).toBe("invalid_request_error");
-    expect(
-      bulkClient.launchBulkSetUserSpendLimitWorkflow
-    ).not.toHaveBeenCalled();
+    expect(bulkClient.runBulkSetUserSpendLimitWorkflow).not.toHaveBeenCalled();
   });
 
   it("returns 500 when member resolution fails (e.g. search outage)", async () => {
@@ -218,8 +208,6 @@ describe("POST /api/w/[wId]/members/bulk-spend-limit", () => {
     });
 
     expect(response.status).toBe(500);
-    expect(
-      bulkClient.launchBulkSetUserSpendLimitWorkflow
-    ).not.toHaveBeenCalled();
+    expect(bulkClient.runBulkSetUserSpendLimitWorkflow).not.toHaveBeenCalled();
   });
 });

--- a/front-api/routes/w/[wId]/members/bulk-spend-limit.ts
+++ b/front-api/routes/w/[wId]/members/bulk-spend-limit.ts
@@ -7,7 +7,7 @@ import {
   MIN_USER_SPEND_LIMIT_AWU_CREDITS,
 } from "@app/lib/api/users/spend_limit";
 import { hasFeatureFlag } from "@app/lib/auth";
-import { launchBulkSetUserSpendLimitWorkflow } from "@app/temporal/bulk_spend_limit/client";
+import { runBulkSetUserSpendLimitWorkflow } from "@app/temporal/bulk_spend_limit/client";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -91,7 +91,7 @@ app.post(
       });
     }
 
-    const result = await launchBulkSetUserSpendLimitWorkflow({
+    const result = await runBulkSetUserSpendLimitWorkflow({
       workspaceId: auth.getNonNullableWorkspace().sId,
       actorUserId: auth.getNonNullableUser().sId,
       userIds,

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -545,7 +545,6 @@ export function UsagePage() {
       searchTerm,
       doBulkSetSpendLimit,
       pageItemIds,
-      setTotalAllowedUsagePendingMemberIds,
     ]
   );
 

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -506,18 +506,47 @@ export function UsagePage() {
               excludeUserIds: descriptor.excludeUserIds,
             };
 
-      const body = await doBulkSetSpendLimit({
-        selection: selectionBody,
-        limit,
+      // Spin the affected rows while the update runs — the request returns
+      // once the bulk workflow has completed. For an "all matching" selection
+      // only the current page is visible, so spin its non-excluded rows.
+      const pendingMemberIds =
+        descriptor.mode === "ids"
+          ? descriptor.userIds
+          : pageItemIds.filter((id) => !descriptor.excludeUserIds.includes(id));
+      setTotalAllowedUsagePendingMemberIds((prev) => {
+        const next = new Set(prev);
+        pendingMemberIds.forEach((id) => next.add(id));
+        return next;
       });
-      if (!body) {
-        return false;
-      }
 
-      selection.clearSelection();
-      return true;
+      try {
+        const body = await doBulkSetSpendLimit({
+          selection: selectionBody,
+          limit,
+        });
+        if (!body) {
+          return false;
+        }
+
+        selection.clearSelection();
+        return true;
+      } finally {
+        setTotalAllowedUsagePendingMemberIds((prev) => {
+          const next = new Set(prev);
+          pendingMemberIds.forEach((id) => next.delete(id));
+          return next;
+        });
+      }
     },
-    [selection, seatTypeFilter, groupFilter, searchTerm, doBulkSetSpendLimit]
+    [
+      selection,
+      seatTypeFilter,
+      groupFilter,
+      searchTerm,
+      doBulkSetSpendLimit,
+      pageItemIds,
+      setTotalAllowedUsagePendingMemberIds,
+    ]
   );
 
   const { hasAvailableSeats } = useWorkspaceSeatAvailability({

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -274,12 +274,14 @@ export function useBulkSetUserSpendLimit({
       const body = BulkSetUserSpendLimitResponseSchema.parse(await res.json());
       sendNotification({
         type: "success",
-        title: "Updating spend limit",
+        title: "Spend limit updated",
         description:
           limit.kind === "limited"
-            ? `Applying a ${limit.awuCredits.toLocaleString("en-US")} credit limit to ${body.memberCount.toLocaleString("en-US")} members.`
-            : `Removing the spend limit for ${body.memberCount.toLocaleString("en-US")} members.`,
+            ? `Applied a ${limit.awuCredits.toLocaleString("en-US")} credit limit to ${body.memberCount.toLocaleString("en-US")} members.`
+            : `Removed the spend limit for ${body.memberCount.toLocaleString("en-US")} members.`,
       });
+
+      await invalidateMembersUsage(workspaceId);
       return body;
     },
     [workspaceId, sendNotification]

--- a/front/temporal/bulk_spend_limit/client.ts
+++ b/front/temporal/bulk_spend_limit/client.ts
@@ -10,7 +10,14 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
 
-export async function launchBulkSetUserSpendLimitWorkflow({
+/**
+ * Start a bulk spend-limit workflow and wait for it to complete, so callers
+ * (the members table) can refresh the updated limits as soon as the request
+ * returns. The wait is bounded by the caller's HTTP timeout — acceptable while
+ * selections stay in the hundreds of members (one Metronome alert upsert per
+ * member); revisit with an async status-polling flow if that stops holding.
+ */
+export async function runBulkSetUserSpendLimitWorkflow({
   workspaceId,
   actorUserId,
   userIds,
@@ -28,18 +35,19 @@ export async function launchBulkSetUserSpendLimitWorkflow({
   });
 
   try {
-    await client.workflow.start(bulkSetUserSpendLimitWorkflow, {
+    const handle = await client.workflow.start(bulkSetUserSpendLimitWorkflow, {
       args: [{ workspaceId, actorUserId, userIds, limit }],
       taskQueue: QUEUE_NAME,
       workflowId,
       memo: { workspaceId, actorUserId, memberCount: userIds.length },
     });
+    await handle.result();
     return new Ok({ workflowId });
   } catch (e) {
     if (!(e instanceof WorkflowExecutionAlreadyStartedError)) {
       logger.error(
         { workflowId, workspaceId, err: e },
-        "[BulkSpendLimit] Failed to start workflow"
+        "[BulkSpendLimit] Failed to run workflow"
       );
     }
     return new Err(normalizeError(e));


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9338

Make the endpoint synchronous.
I think it is is reasonnable as updating the limit should not take too long even with many users.

Alternative would be to have a poll mecanism on the workflow status which adds complexity



https://github.com/user-attachments/assets/d907cbde-6b86-491d-8ea2-9252f3ebe8b8




## Tests

Tested locally
Updated unit tests

## Risk

May make a long request if we update many users at once, but should be reasonnably fast.

## Deploy Plan

deploy front 
