### PR TITLE
Add HubSpot Tickets object support

### DIFF
--- a/front/lib/api/actions/servers/hubspot/client.ts
+++ b/front/lib/api/actions/servers/hubspot/client.ts
@@ -1344,7 +1344,8 @@ export const searchCrmObjects = async ({
     | "line_items"
     | "quotes"
     | "feedback_submissions"
-    | "products";
+    | "products"
+    | "tickets";
   filters?: Array<HubspotFilter>;
   query?: string;
   propertiesToReturn?: string[];
@@ -1450,6 +1451,10 @@ export const searchCrmObjects = async ({
           await hubspotClient.crm.objects.feedbackSubmissions.searchApi.doSearch(
             searchRequest
           );
+        break;
+      case "tickets":
+        searchResponse =
+          await hubspotClient.crm.tickets.searchApi.doSearch(searchRequest);
         break;
       default:
         throw new Error(

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -21,6 +21,7 @@ const searchableObjectTypes = [
   "line_items",
   "quotes",
   "feedback_submissions",
+  "tickets",
 ] as const;
 
 const filterSchema = z.object({

--- a/front/lib/api/actions/servers/hubspot/rendering.ts
+++ b/front/lib/api/actions/servers/hubspot/rendering.ts
@@ -50,6 +50,11 @@ const HS_CONTENT_FIELDS = new Set([
   "hs_task_priority",
   "hs_timestamp",
   "hs_engagement_type",
+  "hs_pipeline",
+  "hs_pipeline_stage",
+  "hs_ticket_priority",
+  "hs_ticket_category",
+  "hs_resolution",
 ]);
 
 export function formatHubSpotObject(
@@ -80,6 +85,8 @@ export function formatHubSpotObject(
       case "deals":
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         return object.properties.dealname || "Unnamed Deal";
+      case "tickets":
+        return object.properties.subject ?? "Unnamed Ticket";
 
       default:
         return (

--- a/front/lib/api/oauth/providers/hubspot.ts
+++ b/front/lib/api/oauth/providers/hubspot.ts
@@ -51,6 +51,7 @@ export class HubspotOAuthProvider implements BaseOAuthStrategyProvider {
       "crm.lists.write",
       "marketing-email",
       "content",
+      "tickets",
     ];
 
     const workspaceGrantedScopes = extraConfig?.workspace_granted_scopes;


### PR DESCRIPTION
## Description

Adds HubSpot **Tickets** object support to the HubSpot integration's search and export tools.
Scope: search + export only (read). No create/update/get ticket tools in this PR.

## Tests

Manual testing locally on the dev test hubspot account.

## Risk

Added as an optional scope so risk low as long as `tickets`scope is enabled.

## Deploy Plan

**Before deploy:** enable the `tickets` scope on the production HubSpot app. Already done 
