### PR TITLE
Steer the model away from mixing tool searches with tool calls

### DIFF
--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.ts
@@ -18,13 +18,18 @@ const TOOL_SEARCH_TOOL_TYPE = TOOL_SEARCH_TOOL.type;
 
 // Added to the system prompt only when the search tool is in the request. Phrased
 // without naming the bm25 tool so it stays accurate across search implementations.
+//
+// The last sentence steers the model away from mixing a tool search with a
+// regular tool call in the same turn: the API leaves such searches un-run (the
+// turn ends on the tool call), and replaying the un-run blocks is fragile.
 export const TOOL_SEARCH_INSTRUCTION =
   "You can search for and load far more tools than are visible to you now, " +
   "including ones that fetch live or account-specific data and act in external " +
   "systems. When a request needs current state, the user's own systems, or an " +
   "action your visible tools cannot take, search for a tool before making " +
   "something up, answering from stale memory, or telling the user it is not " +
-  "possible.";
+  "possible. Do not combine tool searches with other tool calls in the same " +
+  "turn: search first, wait for the results, then call the tools you need.";
 
 export function includesToolSearchTool(
   tools: ReadonlyArray<{ type?: string | null }>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When the model issues a tool search and a regular tool call in the same turn, Anthropic ends the turn on the tool call and never runs the search. Replaying that un-run search block on the next request is fragile: the API only resumes it when the follow-up message contains nothing but tool results, which our rendering does not guarantee, and rejects the whole request otherwise. This is what has been killing agent turns right after a skill gets enabled.

This adds one sentence to the tool search instruction telling the model to search first, wait for the results, then call tools. It shrinks how often the fragile shape forms and keeps searches effective instead of wasted. Will assess if it keeps happening and might send another PR to parse messages before sending them.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
