### PR TITLE
[front] refactor: cleanup `SkillResource` method naming

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -193,7 +193,7 @@ app.patch(
     }
 
     // Check for existing active skill with the same name (excluding current skill).
-    const existingSkill = await SkillResource.fetchActiveByName(auth, name);
+    const existingSkill = await SkillResource.fetchByName(auth, name);
 
     if (existingSkill && existingSkill.id !== skill.id) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/skills/[sId]/restore.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/restore.ts
@@ -44,7 +44,7 @@ app.post(
     }
 
     // Check for existing active skill with the same name.
-    const existingSkill = await SkillResource.fetchActiveByName(
+    const existingSkill = await SkillResource.fetchByName(
       auth,
       skillResource.name
     );

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -230,7 +230,7 @@ app.post(
       });
     }
 
-    const existingSkill = await SkillResource.fetchActiveByName(auth, name);
+    const existingSkill = await SkillResource.fetchByName(auth, name);
 
     if (existingSkill) {
       return apiError(ctx, {

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -326,7 +326,7 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       );
     }
 
-    const existingSkill = await SkillResource.fetchBauth, trimmedName);
+    const existingSkill = await SkillResource.fetchByName(auth, trimmedName);
     if (existingSkill) {
       return new Err(
         new MCPError(`A skill with the name "${trimmedName}" already exists.`)
@@ -548,7 +548,7 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       return new Err(new MCPError("Skill name cannot be empty."));
     }
 
-    const existingSkill = await SkillResource.fetchBauth, trimmedName);
+    const existingSkill = await SkillResource.fetchByName(auth, trimmedName);
     if (existingSkill && existingSkill.id !== skill.id) {
       return new Err(
         new MCPError(`A skill with the name "${trimmedName}" already exists.`)

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -326,10 +326,7 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       );
     }
 
-    const existingSkill = await SkillResource.fetchActiveByName(
-      auth,
-      trimmedName
-    );
+    const existingSkill = await SkillResource.fetchBauth, trimmedName);
     if (existingSkill) {
       return new Err(
         new MCPError(`A skill with the name "${trimmedName}" already exists.`)
@@ -551,10 +548,7 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       return new Err(new MCPError("Skill name cannot be empty."));
     }
 
-    const existingSkill = await SkillResource.fetchActiveByName(
-      auth,
-      trimmedName
-    );
+    const existingSkill = await SkillResource.fetchBauth, trimmedName);
     if (existingSkill && existingSkill.id !== skill.id) {
       return new Err(
         new MCPError(`A skill with the name "${trimmedName}" already exists.`)

--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -6,16 +6,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockEnableForAgent,
   mockBatchFetchUsedBySkills,
-  mockFetchActiveByName,
-  mockFetchActiveByIdsForAgentLoop,
+  mockFetchByName,
+  mockFetchByIds,
   mockGetFileAttachments,
   mockListForAgentLoop,
   mockLoadSkillFilesToConversation,
 } = vi.hoisted(() => ({
   mockEnableForAgent: vi.fn(),
   mockBatchFetchUsedBySkills: vi.fn(),
-  mockFetchActiveByName: vi.fn(),
-  mockFetchActiveByIdsForAgentLoop: vi.fn(),
+  mockFetchByName: vi.fn(),
+  mockFetchByIds: vi.fn(),
   mockGetFileAttachments: vi.fn(),
   mockListForAgentLoop: vi.fn(),
   mockLoadSkillFilesToConversation: vi.fn(),
@@ -28,8 +28,8 @@ vi.mock("@app/lib/api/skills/conversation_files", () => ({
 vi.mock("@app/lib/resources/skill/skill_resource", () => ({
   SkillResource: {
     batchFetchUsedBySkills: mockBatchFetchUsedBySkills,
-    fetchActiveByName: mockFetchActiveByName,
-    fetchActiveByIdsForAgentLoop: mockFetchActiveByIdsForAgentLoop,
+    fetchByName: mockFetchByName,
+    fetchByIds: mockFetchByIds,
     listForAgentLoop: mockListForAgentLoop,
   },
 }));
@@ -88,8 +88,8 @@ describe("skill_management enable_skill tool", () => {
       systemSkills: [],
     });
     mockBatchFetchUsedBySkills.mockResolvedValue(new Map());
-    mockFetchActiveByName.mockResolvedValue(null);
-    mockFetchActiveByIdsForAgentLoop.mockResolvedValue([]);
+    mockFetchByName.mockResolvedValue(null);
+    mockFetchByIds.mockResolvedValue([]);
     mockEnableForAgent.mockResolvedValue({ wasAlreadyEnabled: false });
     mockGetFileAttachments.mockReturnValue([{ fileName: "SKILL.md" }]);
     mockLoadSkillFilesToConversation.mockResolvedValue(
@@ -228,7 +228,7 @@ describe("skill_management enable_skill tool", () => {
       equippedSkills: [parentSkill],
       systemSkills: [],
     });
-    mockFetchActiveByName.mockResolvedValue(skill);
+    mockFetchByName.mockResolvedValue(skill);
     mockBatchFetchUsedBySkills.mockResolvedValue(
       new Map([
         [
@@ -244,7 +244,7 @@ describe("skill_management enable_skill tool", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockFetchActiveByName).toHaveBeenCalledWith(auth, "commit", {
+    expect(mockFetchByName).toHaveBeenCalledWith(auth, "commit", {
       agentLoopData: {
         agentConfiguration,
         agentMessage,
@@ -265,7 +265,7 @@ describe("skill_management enable_skill tool", () => {
       equippedSkills: [],
       systemSkills: [],
     });
-    mockFetchActiveByName.mockResolvedValue(skill);
+    mockFetchByName.mockResolvedValue(skill);
     mockBatchFetchUsedBySkills.mockResolvedValue(
       new Map([
         [
@@ -294,7 +294,7 @@ describe("skill_management enable_skill tool", () => {
       equippedSkills: [unavailableParentSkill],
       systemSkills: [],
     });
-    mockFetchActiveByName.mockResolvedValue(skill);
+    mockFetchByName.mockResolvedValue(skill);
     mockBatchFetchUsedBySkills.mockResolvedValue(
       new Map([
         [
@@ -325,8 +325,8 @@ describe("skill_management enable_skill tool", () => {
       equippedSkills: [],
       systemSkills: [],
     });
-    mockFetchActiveByIdsForAgentLoop.mockResolvedValue([parentSkill]);
-    mockFetchActiveByName.mockResolvedValue(skill);
+    mockFetchByIds.mockResolvedValue([parentSkill]);
+    mockFetchByName.mockResolvedValue(skill);
     mockBatchFetchUsedBySkills.mockResolvedValue(
       new Map([
         [
@@ -360,7 +360,7 @@ describe("skill_management enable_skill tool", () => {
       equippedSkills: [],
       systemSkills: [],
     });
-    mockFetchActiveByIdsForAgentLoop.mockResolvedValue([skill]);
+    mockFetchByIds.mockResolvedValue([skill]);
 
     const result = await getTool().handler(
       { skillName: "commit" },
@@ -370,16 +370,15 @@ describe("skill_management enable_skill tool", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockFetchActiveByIdsForAgentLoop).toHaveBeenCalledWith(
-      auth,
-      ["skill-id"],
-      {
+    expect(mockFetchByIds).toHaveBeenCalledWith(auth, ["skill-id"], {
+      agentLoopData: {
         agentConfiguration,
         agentMessage,
         conversation,
         userMessage: currentUserMessage,
-      }
-    );
+      },
+      onlyActive: true,
+    });
     expect(mockEnableForAgent).toHaveBeenCalled();
   });
 
@@ -399,7 +398,7 @@ describe("skill_management enable_skill tool", () => {
       equippedSkills: [],
       systemSkills: [],
     });
-    mockFetchActiveByIdsForAgentLoop.mockResolvedValue([skill]);
+    mockFetchByIds.mockResolvedValue([skill]);
 
     const result = await getTool().handler(
       { skillName: "commit" },
@@ -409,16 +408,15 @@ describe("skill_management enable_skill tool", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockFetchActiveByIdsForAgentLoop).toHaveBeenCalledWith(
-      auth,
-      ["skill-id"],
-      {
+    expect(mockFetchByIds).toHaveBeenCalledWith(auth, ["skill-id"], {
+      agentLoopData: {
         agentConfiguration,
         agentMessage,
         conversation: conversationWithEarlierSkill,
         userMessage,
-      }
-    );
+      },
+      onlyActive: true,
+    });
     expect(mockEnableForAgent).toHaveBeenCalled();
   });
 
@@ -445,7 +443,7 @@ describe("skill_management enable_skill tool", () => {
       equippedSkills: [],
       systemSkills: [],
     });
-    mockFetchActiveByIdsForAgentLoop.mockResolvedValue([skill]);
+    mockFetchByIds.mockResolvedValue([skill]);
 
     const result = await getTool().handler(
       { skillName: "commit" },
@@ -455,16 +453,15 @@ describe("skill_management enable_skill tool", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockFetchActiveByIdsForAgentLoop).toHaveBeenCalledWith(
-      auth,
-      ["skill-id"],
-      {
+    expect(mockFetchByIds).toHaveBeenCalledWith(auth, ["skill-id"], {
+      agentLoopData: {
         agentConfiguration,
         agentMessage,
         conversation: conversationWithCompaction,
         userMessage,
-      }
-    );
+      },
+      onlyActive: true,
+    });
     expect(mockEnableForAgent).toHaveBeenCalled();
   });
 
@@ -493,11 +490,14 @@ describe("skill_management enable_skill tool", () => {
     );
 
     expect(result.isErr()).toBe(true);
-    expect(mockFetchActiveByIdsForAgentLoop).toHaveBeenCalledWith(auth, [], {
-      agentConfiguration,
-      agentMessage,
-      conversation: conversationWithLaterSkill,
-      userMessage,
+    expect(mockFetchByIds).toHaveBeenCalledWith(auth, [], {
+      agentLoopData: {
+        agentConfiguration,
+        agentMessage,
+        conversation: conversationWithLaterSkill,
+        userMessage,
+      },
+      onlyActive: true,
     });
     expect(mockEnableForAgent).not.toHaveBeenCalled();
   });

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -48,10 +48,10 @@ async function findAvailableSkillForAgentLoop({
 }): Promise<SkillResource | null> {
   const { enabledSkills, equippedSkills, systemSkills } =
     await SkillResource.listForAgentLoop(auth, agentLoopData);
-  const userMessageSkills = await SkillResource.fetchActiveByIdsForAgentLoop(
+  const userMessageSkills = await SkillResource.fetchByIds(
     auth,
     extractSkillIdsFromConversationMessages(agentLoopData),
-    agentLoopData
+    { agentLoopData, onlyActive: true }
   );
   const directlyAllowedSkills = [
     ...enabledSkills,

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -72,7 +72,7 @@ async function findAvailableSkillForAgentLoop({
       skill,
     ])
   );
-  const candidate = await SkillResource.fetchActiveByName(auth, skillName, {
+  const candidate = await SkillResource.fetchByName(auth, skillName, {
     agentLoopData,
   });
   if (!candidate) {

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1596,7 +1596,7 @@ describe("SkillResource", () => {
     });
   });
 
-  describe("fetchActiveByIdsForAgentLoop", () => {
+  describe("fetchByIds", () => {
     it("filters code-defined skills disabled for the current agent loop", async () => {
       const agent = await AgentConfigurationFactory.createTestAgent(
         testContext.authenticator,
@@ -1623,14 +1623,17 @@ describe("SkillResource", () => {
         }
       );
 
-      const skills = await SkillResource.fetchActiveByIdsForAgentLoop(
+      const skills = await SkillResource.fetchByIds(
         testContext.authenticator,
         ["mention_users"],
         {
-          agentConfiguration: agent,
-          agentMessage,
-          conversation,
-          userMessage,
+          agentLoopData: {
+            agentConfiguration: agent,
+            agentMessage,
+            conversation,
+            userMessage,
+          },
+          onlyActive: true,
         }
       );
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -862,7 +862,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     sIds: string[],
     {
       agentLoopData,
-      onlyActive = true,
+      onlyActive = false,
     }: { agentLoopData?: AgentLoopExecutionData; onlyActive?: boolean } = {}
   ): Promise<SkillResource[]> {
     if (sIds.length === 0) {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -888,7 +888,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       { customSkillIds: [], globalSkillIds: [] }
     );
 
-
     // When fetching by specific IDs, return skills regardless of status.
     return this.baseFetch(
       auth,
@@ -2578,7 +2577,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           agentFacingDescription,
           userFacingDescription,
           instructions,
-          ...(instructionsHtml !== undefined ? { instructionsHtml  : {}),
+          ...(instructionsHtml !== undefined ? { instructionsHtml } : {}),
           icon,
           requestedSpaceIds,
           editedBy,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -888,7 +888,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       { customSkillIds: [], globalSkillIds: [] }
     );
 
-    // When fetching by specific IDs, return skills regardless of status.
     return this.baseFetch(
       auth,
       {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1447,12 +1447,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       [conversation.spaceId]
     );
 
-    return this.fetchActiveByIdsForAgentLoop(
-      auth,
-      projectMetadata?.defaultSkillIds ?? [],
+    return this.fetchByIds(auth, projectMetadata?.defaultSkillIds ?? [], {
       agentLoopData,
-      { withInstructions: false, withTools: false }
-    );
+      onlyActive: true,
+    });
   }
 
   static async listForAgentLoop(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -869,7 +869,25 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return [];
     }
 
-    const { customSkillIds, globalSkillIds } = this.splitSkillSIds(sIds);
+    // Separate custom skill IDs from global skill IDs.
+    const { customSkillIds, globalSkillIds } = sIds.reduce<{
+      customSkillIds: ModelId[];
+      globalSkillIds: string[];
+    }>(
+      (acc, sId) => {
+        if (isResourceSId("skill", sId)) {
+          const modelId = getResourceIdFromSId(sId);
+          if (modelId !== null) {
+            acc.customSkillIds.push(modelId);
+          }
+        } else {
+          acc.globalSkillIds.push(sId);
+        }
+        return acc;
+      },
+      { customSkillIds: [], globalSkillIds: [] }
+    );
+
 
     // When fetching by specific IDs, return skills regardless of status.
     return this.baseFetch(
@@ -998,29 +1016,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     return null;
-  }
-
-  private static splitSkillSIds(sIds: string[]): {
-    customSkillIds: ModelId[];
-    globalSkillIds: string[];
-  } {
-    return sIds.reduce<{
-      customSkillIds: ModelId[];
-      globalSkillIds: string[];
-    }>(
-      (acc, sId) => {
-        if (isResourceSId("skill", sId)) {
-          const modelId = getResourceIdFromSId(sId);
-          if (modelId !== null) {
-            acc.customSkillIds.push(modelId);
-          }
-        } else {
-          acc.globalSkillIds.push(sId);
-        }
-        return acc;
-      },
-      { customSkillIds: [], globalSkillIds: [] }
-    );
   }
 
   async fetchChildSkills(auth: Authenticator): Promise<SkillResource[]> {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2584,14 +2584,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           agentFacingDescription,
           userFacingDescription,
           instructions,
-          ...(instructionsHtml !== undefined
-            ? {
-                instructionsHtml:
-                  instructionsHtml !== undefined
-                    ? instructionsHtml
-                    : this.instructionsHtml,
-              }
-            : {}),
+          ...(instructionsHtml !== undefined ? { instructionsHtml  : {}),
           icon,
           requestedSpaceIds,
           editedBy,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -885,7 +885,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
-  static async fetchActiveByName(
+  static async fetchByName(
     auth: Authenticator,
     name: string,
     { agentLoopData }: { agentLoopData?: AgentLoopExecutionData } = {}
@@ -895,7 +895,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       {
         where: {
           name,
-          status: "active",
         },
         limit: 1,
       },

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -859,7 +859,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async fetchByIds(
     auth: Authenticator,
-    sIds: string[]
+    sIds: string[],
+    {
+      agentLoopData,
+      onlyActive = true,
+    }: { agentLoopData?: AgentLoopExecutionData; onlyActive?: boolean } = {}
   ): Promise<SkillResource[]> {
     if (sIds.length === 0) {
       return [];
@@ -868,40 +872,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const { customSkillIds, globalSkillIds } = this.splitSkillSIds(sIds);
 
     // When fetching by specific IDs, return skills regardless of status.
-    return this.baseFetch(auth, {
-      where: {
-        id: customSkillIds,
-        sId: globalSkillIds,
-        status: ["active", "archived", "suggested"],
-      },
-    });
-  }
-
-  static async fetchActiveByIdsForAgentLoop(
-    auth: Authenticator,
-    sIds: string[],
-    agentLoopData?: AgentLoopExecutionData,
-    {
-      withInstructions = true,
-      withTools = true,
-    }: { withInstructions?: boolean; withTools?: boolean } = {}
-  ): Promise<SkillResource[]> {
-    if (sIds.length === 0) {
-      return [];
-    }
-
-    const { customSkillIds, globalSkillIds } = this.splitSkillSIds(sIds);
-
     return this.baseFetch(
       auth,
       {
         where: {
           id: customSkillIds,
           sId: globalSkillIds,
-          status: "active",
+          status: onlyActive ? ["active"] : ["active", "archived", "suggested"],
         },
-        withInstructions,
-        withTools,
       },
       { agentLoopData }
     );


### PR DESCRIPTION
## Description

This PR refactors the interface of `SkillResource` around a few main (pre-existing) design principles:
- `baseFetch` filters on active skills by default, making it implied in any use case that does not require archived skills (meaning that when you need the archived skills, you explicitly know that you need to list archived skills, rest of the time it's always active skills).
- The main entry points are the same regardless of the context, meaning that `fetchActiveByIdsForAgentLoop` is redundant with `fetchByIds`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
