### PR TITLE
db: add activation_recommendations table

### DIFF
--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -1,0 +1,144 @@
+import { ConversationModel } from "@app/lib/models/agent/conversation";
+import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
+import { SkillConfigurationModel } from "@app/lib/models/skill";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DANGEROUSLY_UNBOUNDED_TEXT, DataTypes } from "@app/lib/resources/storage/data_types";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+
+export type ActivationRecommendationStatus =
+  | "pending"
+  | "accepted"
+  | "rejected"
+  | "saved"
+  | "recurring";
+
+export class ActivationRecommendationModel extends WorkspaceAwareModel<ActivationRecommendationModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare userId: ForeignKey<UserModel["id"]>;
+  declare status: ActivationRecommendationStatus;
+  declare content: string;
+  declare rationale: string;
+
+  declare conversationModelId: ForeignKey<ConversationModel["id"]> | null;
+  declare skillModelId: ForeignKey<SkillConfigurationModel["id"]> | null;
+  declare triggerModelId: ForeignKey<TriggerModel["id"]> | null;
+
+  declare user: NonAttribute<UserModel>;
+  declare conversation: NonAttribute<ConversationModel | null>;
+  declare skillConfiguration: NonAttribute<SkillConfigurationModel | null>;
+  declare trigger: NonAttribute<TriggerModel | null>;
+}
+
+ActivationRecommendationModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    userId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "pending",
+    },
+    content: {
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
+      allowNull: false,
+    },
+    rationale: {
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
+      allowNull: false,
+    },
+    conversationModelId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
+    skillModelId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
+    triggerModelId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
+  },
+  {
+    modelName: "activation_recommendation",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["userId"],
+        concurrently: true,
+      },
+      {
+        fields: ["workspaceId"],
+        concurrently: true,
+      },
+      {
+        fields: ["conversationModelId"],
+        concurrently: true,
+      },
+      {
+        fields: ["skillModelId"],
+        concurrently: true,
+      },
+      {
+        fields: ["triggerModelId"],
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+ActivationRecommendationModel.belongsTo(UserModel, {
+  foreignKey: { name: "userId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "user",
+});
+UserModel.hasMany(ActivationRecommendationModel, {
+  foreignKey: { name: "userId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+
+ActivationRecommendationModel.belongsTo(ConversationModel, {
+  foreignKey: { name: "conversationModelId", allowNull: true },
+  onDelete: "SET NULL",
+  as: "conversation",
+});
+ConversationModel.hasMany(ActivationRecommendationModel, {
+  foreignKey: { name: "conversationModelId", allowNull: true },
+  onDelete: "SET NULL",
+});
+
+ActivationRecommendationModel.belongsTo(SkillConfigurationModel, {
+  foreignKey: { name: "skillModelId", allowNull: true },
+  onDelete: "SET NULL",
+  as: "skillConfiguration",
+});
+SkillConfigurationModel.hasMany(ActivationRecommendationModel, {
+  foreignKey: { name: "skillModelId", allowNull: true },
+  onDelete: "SET NULL",
+});
+
+ActivationRecommendationModel.belongsTo(TriggerModel, {
+  foreignKey: { name: "triggerModelId", allowNull: true },
+  onDelete: "SET NULL",
+  as: "trigger",
+});
+TriggerModel.hasMany(ActivationRecommendationModel, {
+  foreignKey: { name: "triggerModelId", allowNull: true },
+  onDelete: "SET NULL",
+});

--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -2,10 +2,7 @@ import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
-import {
-  DANGEROUSLY_UNBOUNDED_TEXT,
-  DataTypes,
-} from "@app/lib/resources/storage/data_types";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
@@ -58,11 +55,11 @@ ActivationRecommendationModel.init(
       defaultValue: "pending",
     },
     content: {
-      type: DANGEROUSLY_UNBOUNDED_TEXT,
+      type: DataTypes.STRING(4096),
       allowNull: false,
     },
     rationale: {
-      type: DANGEROUSLY_UNBOUNDED_TEXT,
+      type: DataTypes.STRING(4096),
       allowNull: false,
     },
     conversationModelId: {

--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -10,15 +10,11 @@ import type { CreationOptional, ForeignKey } from "sequelize";
 // "suggested": shown to the user, no action taken yet
 // "executed": user ran the recommended action immediately (one-off)
 // "dismissed": user declined the recommendation
-// "skill_created": user promoted the recommendation into a skill (createdSkillId is set)
-// "trigger_created": user promoted the recommendation into a trigger (createdTriggerId is set)
-// skill_created and trigger_created are independent terminal states, not a sequence
+// Creation outcomes are tracked independently via createdSkillId / createdTriggerId (either or both can be set)
 export type ActivationRecommendationStatus =
   | "suggested"
   | "executed"
-  | "dismissed"
-  | "skill_created"
-  | "trigger_created";
+  | "dismissed";
 
 export class ActivationRecommendationModel extends WorkspaceAwareModel<ActivationRecommendationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -2,7 +2,10 @@ import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { DANGEROUSLY_UNBOUNDED_TEXT, DataTypes } from "@app/lib/resources/storage/data_types";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";

--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -7,12 +7,18 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
 
+// "suggested": shown to the user, no action taken yet
+// "executed": user ran the recommended action immediately (one-off)
+// "dismissed": user declined the recommendation
+// "skill_created": user promoted the recommendation into a skill (createdSkillId is set)
+// "trigger_created": user promoted the recommendation into a trigger (createdTriggerId is set)
+// skill_created and trigger_created are independent terminal states, not a sequence
 export type ActivationRecommendationStatus =
-  | "pending"
-  | "accepted"
-  | "rejected"
-  | "saved"
-  | "recurring";
+  | "suggested"
+  | "executed"
+  | "dismissed"
+  | "skill_created"
+  | "trigger_created";
 
 export class ActivationRecommendationModel extends WorkspaceAwareModel<ActivationRecommendationModel> {
   declare createdAt: CreationOptional<Date>;
@@ -23,11 +29,12 @@ export class ActivationRecommendationModel extends WorkspaceAwareModel<Activatio
   declare content: string;
   declare rationale: string;
 
+  // The conversation in which the recommendation was (originally) made
   declare conversationId: ForeignKey<ConversationModel["id"]> | null;
-  // FK to skill_configurations.id — the skill artifact associated with this recommendation.
-  declare artifactSkillId: ForeignKey<SkillConfigurationModel["id"]> | null;
-  // FK to triggers.id — the trigger artifact associated with this recommendation.
-  declare artifactTriggerId: ForeignKey<TriggerModel["id"]> | null;
+  // FK to the skill created as a result of this recommendation (set when status = "skill_created")
+  declare createdSkillId: ForeignKey<SkillConfigurationModel["id"]> | null;
+  // FK to the trigger created as a result of this recommendation (set when status = "trigger_created")
+  declare createdTriggerId: ForeignKey<TriggerModel["id"]> | null;
 }
 
 ActivationRecommendationModel.init(
@@ -62,11 +69,11 @@ ActivationRecommendationModel.init(
       type: DataTypes.BIGINT,
       allowNull: true,
     },
-    artifactSkillId: {
+    createdSkillId: {
       type: DataTypes.BIGINT,
       allowNull: true,
     },
-    artifactTriggerId: {
+    createdTriggerId: {
       type: DataTypes.BIGINT,
       allowNull: true,
     },
@@ -88,11 +95,11 @@ ActivationRecommendationModel.init(
         concurrently: true,
       },
       {
-        fields: ["artifactSkillId"],
+        fields: ["createdSkillId"],
         concurrently: true,
       },
       {
-        fields: ["artifactTriggerId"],
+        fields: ["createdTriggerId"],
         concurrently: true,
       },
     ],
@@ -118,19 +125,19 @@ ConversationModel.hasMany(ActivationRecommendationModel, {
 });
 
 ActivationRecommendationModel.belongsTo(SkillConfigurationModel, {
-  foreignKey: { name: "artifactSkillId", allowNull: true },
+  foreignKey: { name: "createdSkillId", allowNull: true },
   onDelete: "SET NULL",
 });
 SkillConfigurationModel.hasMany(ActivationRecommendationModel, {
-  foreignKey: { name: "artifactSkillId", allowNull: true },
+  foreignKey: { name: "createdSkillId", allowNull: true },
   onDelete: "SET NULL",
 });
 
 ActivationRecommendationModel.belongsTo(TriggerModel, {
-  foreignKey: { name: "artifactTriggerId", allowNull: true },
+  foreignKey: { name: "createdTriggerId", allowNull: true },
   onDelete: "SET NULL",
 });
 TriggerModel.hasMany(ActivationRecommendationModel, {
-  foreignKey: { name: "artifactTriggerId", allowNull: true },
+  foreignKey: { name: "createdTriggerId", allowNull: true },
   onDelete: "SET NULL",
 });

--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -5,7 +5,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
 
 export type ActivationRecommendationStatus =
   | "pending"
@@ -23,14 +23,11 @@ export class ActivationRecommendationModel extends WorkspaceAwareModel<Activatio
   declare content: string;
   declare rationale: string;
 
-  declare conversationModelId: ForeignKey<ConversationModel["id"]> | null;
-  declare skillModelId: ForeignKey<SkillConfigurationModel["id"]> | null;
-  declare triggerModelId: ForeignKey<TriggerModel["id"]> | null;
-
-  declare user: NonAttribute<UserModel>;
-  declare conversation: NonAttribute<ConversationModel | null>;
-  declare skillConfiguration: NonAttribute<SkillConfigurationModel | null>;
-  declare trigger: NonAttribute<TriggerModel | null>;
+  declare conversationId: ForeignKey<ConversationModel["id"]> | null;
+  // FK to skill_configurations.id — the skill artifact associated with this recommendation.
+  declare artifactSkillId: ForeignKey<SkillConfigurationModel["id"]> | null;
+  // FK to triggers.id — the trigger artifact associated with this recommendation.
+  declare artifactTriggerId: ForeignKey<TriggerModel["id"]> | null;
 }
 
 ActivationRecommendationModel.init(
@@ -52,7 +49,6 @@ ActivationRecommendationModel.init(
     status: {
       type: DataTypes.STRING,
       allowNull: false,
-      defaultValue: "pending",
     },
     content: {
       type: DataTypes.STRING(4096),
@@ -62,15 +58,15 @@ ActivationRecommendationModel.init(
       type: DataTypes.STRING(4096),
       allowNull: false,
     },
-    conversationModelId: {
+    conversationId: {
       type: DataTypes.BIGINT,
       allowNull: true,
     },
-    skillModelId: {
+    artifactSkillId: {
       type: DataTypes.BIGINT,
       allowNull: true,
     },
-    triggerModelId: {
+    artifactTriggerId: {
       type: DataTypes.BIGINT,
       allowNull: true,
     },
@@ -88,15 +84,15 @@ ActivationRecommendationModel.init(
         concurrently: true,
       },
       {
-        fields: ["conversationModelId"],
+        fields: ["conversationId"],
         concurrently: true,
       },
       {
-        fields: ["skillModelId"],
+        fields: ["artifactSkillId"],
         concurrently: true,
       },
       {
-        fields: ["triggerModelId"],
+        fields: ["artifactTriggerId"],
         concurrently: true,
       },
     ],
@@ -106,7 +102,6 @@ ActivationRecommendationModel.init(
 ActivationRecommendationModel.belongsTo(UserModel, {
   foreignKey: { name: "userId", allowNull: false },
   onDelete: "RESTRICT",
-  as: "user",
 });
 UserModel.hasMany(ActivationRecommendationModel, {
   foreignKey: { name: "userId", allowNull: false },
@@ -114,31 +109,28 @@ UserModel.hasMany(ActivationRecommendationModel, {
 });
 
 ActivationRecommendationModel.belongsTo(ConversationModel, {
-  foreignKey: { name: "conversationModelId", allowNull: true },
+  foreignKey: { name: "conversationId", allowNull: true },
   onDelete: "SET NULL",
-  as: "conversation",
 });
 ConversationModel.hasMany(ActivationRecommendationModel, {
-  foreignKey: { name: "conversationModelId", allowNull: true },
+  foreignKey: { name: "conversationId", allowNull: true },
   onDelete: "SET NULL",
 });
 
 ActivationRecommendationModel.belongsTo(SkillConfigurationModel, {
-  foreignKey: { name: "skillModelId", allowNull: true },
+  foreignKey: { name: "artifactSkillId", allowNull: true },
   onDelete: "SET NULL",
-  as: "skillConfiguration",
 });
 SkillConfigurationModel.hasMany(ActivationRecommendationModel, {
-  foreignKey: { name: "skillModelId", allowNull: true },
+  foreignKey: { name: "artifactSkillId", allowNull: true },
   onDelete: "SET NULL",
 });
 
 ActivationRecommendationModel.belongsTo(TriggerModel, {
-  foreignKey: { name: "triggerModelId", allowNull: true },
+  foreignKey: { name: "artifactTriggerId", allowNull: true },
   onDelete: "SET NULL",
-  as: "trigger",
 });
 TriggerModel.hasMany(ActivationRecommendationModel, {
-  foreignKey: { name: "triggerModelId", allowNull: true },
+  foreignKey: { name: "artifactTriggerId", allowNull: true },
   onDelete: "SET NULL",
 });

--- a/front/migrations/pre-deploy/20260701100000_create_activation_recommendations.sql
+++ b/front/migrations/pre-deploy/20260701100000_create_activation_recommendations.sql
@@ -1,0 +1,165 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE SEQUENCE "public"."activation_recommendations_id_seq"
+	AS bigint
+	INCREMENT BY 1
+	MINVALUE 1 MAXVALUE 9223372036854775807
+	START WITH 1 CACHE 1 NO CYCLE
+;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."activation_recommendations" (
+	"createdAt" timestamp with time zone NOT NULL DEFAULT NOW(),
+	"updatedAt" timestamp with time zone NOT NULL DEFAULT NOW(),
+	"workspaceId" bigint NOT NULL,
+	"userId" bigint NOT NULL,
+	"status" character varying(50) NOT NULL DEFAULT 'pending',
+	"content" text NOT NULL,
+	"rationale" text NOT NULL,
+	"conversationModelId" bigint,
+	"skillModelId" bigint,
+	"triggerModelId" bigint,
+	"id" bigint DEFAULT nextval('activation_recommendations_id_seq'::regclass) NOT NULL
+);
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations"
+	ADD CONSTRAINT "activation_recommendations_status_check"
+	CHECK (status IN ('pending', 'accepted', 'rejected', 'saved', 'recurring'));
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY activation_recommendations_pkey ON public.activation_recommendations USING btree (id);
+
+/*
+Statement 4
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_pkey" PRIMARY KEY USING INDEX "activation_recommendations_pkey";
+
+/*
+Statement 5
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "idx_activation_recommendations_user" ON public.activation_recommendations USING btree ("userId");
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "activation_recommendations_workspace_id" ON public.activation_recommendations USING btree ("workspaceId");
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "activation_recommendations_conversation_model_id" ON public.activation_recommendations USING btree ("conversationModelId");
+
+/*
+Statement 8
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "activation_recommendations_skill_model_id" ON public.activation_recommendations USING btree ("skillModelId");
+
+/*
+Statement 9
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "activation_recommendations_trigger_model_id" ON public.activation_recommendations USING btree ("triggerModelId");
+
+/*
+Statement 10
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER SEQUENCE "public"."activation_recommendations_id_seq" OWNED BY "public"."activation_recommendations"."id";
+
+/*
+Statement 11
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 12
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_workspaceId_fkey";
+
+/*
+Statement 13
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_userId_fkey" FOREIGN KEY ("userId") REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 14
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_userId_fkey";
+
+/*
+Statement 15
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_conversationModelId_fkey" FOREIGN KEY ("conversationModelId") REFERENCES conversations(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
+
+/*
+Statement 16
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_conversationModelId_fkey";
+
+/*
+Statement 17
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_skillModelId_fkey" FOREIGN KEY ("skillModelId") REFERENCES skill_configurations(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
+
+/*
+Statement 18
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_skillModelId_fkey";
+
+/*
+Statement 19
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_triggerModelId_fkey" FOREIGN KEY ("triggerModelId") REFERENCES triggers(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
+
+/*
+Statement 20
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_triggerModelId_fkey";

--- a/front/migrations/pre-deploy/20260701100000_create_activation_recommendations.sql
+++ b/front/migrations/pre-deploy/20260701100000_create_activation_recommendations.sql
@@ -24,8 +24,8 @@ CREATE TABLE "public"."activation_recommendations" (
 	"content" character varying(4096) NOT NULL,
 	"rationale" character varying(4096) NOT NULL,
 	"conversationId" bigint,
-	"artifactSkillId" bigint,
-	"artifactTriggerId" bigint,
+	"createdSkillId" bigint,
+	"createdTriggerId" bigint,
 	"id" bigint DEFAULT nextval('activation_recommendations_id_seq'::regclass) NOT NULL
 );
 
@@ -69,14 +69,14 @@ Statement 7
 */
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
-CREATE INDEX CONCURRENTLY "activation_recommendations_artifact_skill_id" ON public.activation_recommendations USING btree ("artifactSkillId");
+CREATE INDEX CONCURRENTLY "activation_recommendations_created_skill_id" ON public.activation_recommendations USING btree ("createdSkillId");
 
 /*
 Statement 8
 */
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
-CREATE INDEX CONCURRENTLY "activation_recommendations_artifact_trigger_id" ON public.activation_recommendations USING btree ("artifactTriggerId");
+CREATE INDEX CONCURRENTLY "activation_recommendations_created_trigger_id" ON public.activation_recommendations USING btree ("createdTriggerId");
 
 /*
 Statement 9
@@ -132,25 +132,25 @@ Statement 16
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_artifactSkillId_fkey" FOREIGN KEY ("artifactSkillId") REFERENCES skill_configurations(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
+ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_createdSkillId_fkey" FOREIGN KEY ("createdSkillId") REFERENCES skill_configurations(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
 
 /*
 Statement 17
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_artifactSkillId_fkey";
+ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_createdSkillId_fkey";
 
 /*
 Statement 18
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_artifactTriggerId_fkey" FOREIGN KEY ("artifactTriggerId") REFERENCES triggers(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
+ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_createdTriggerId_fkey" FOREIGN KEY ("createdTriggerId") REFERENCES triggers(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
 
 /*
 Statement 19
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_artifactTriggerId_fkey";
+ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_createdTriggerId_fkey";

--- a/front/migrations/pre-deploy/20260701100000_create_activation_recommendations.sql
+++ b/front/migrations/pre-deploy/20260701100000_create_activation_recommendations.sql
@@ -20,146 +20,137 @@ CREATE TABLE "public"."activation_recommendations" (
 	"updatedAt" timestamp with time zone NOT NULL DEFAULT NOW(),
 	"workspaceId" bigint NOT NULL,
 	"userId" bigint NOT NULL,
-	"status" character varying(50) NOT NULL DEFAULT 'pending',
-	"content" text NOT NULL,
-	"rationale" text NOT NULL,
-	"conversationModelId" bigint,
-	"skillModelId" bigint,
-	"triggerModelId" bigint,
+	"status" character varying(50) NOT NULL,
+	"content" character varying(4096) NOT NULL,
+	"rationale" character varying(4096) NOT NULL,
+	"conversationId" bigint,
+	"artifactSkillId" bigint,
+	"artifactTriggerId" bigint,
 	"id" bigint DEFAULT nextval('activation_recommendations_id_seq'::regclass) NOT NULL
 );
 
 /*
 Statement 2
 */
-SET SESSION statement_timeout = 3000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."activation_recommendations"
-	ADD CONSTRAINT "activation_recommendations_status_check"
-	CHECK (status IN ('pending', 'accepted', 'rejected', 'saved', 'recurring'));
-
-/*
-Statement 3
-*/
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
 CREATE UNIQUE INDEX CONCURRENTLY activation_recommendations_pkey ON public.activation_recommendations USING btree (id);
 
 /*
-Statement 4
+Statement 3
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_pkey" PRIMARY KEY USING INDEX "activation_recommendations_pkey";
 
 /*
-Statement 5
+Statement 4
 */
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
 CREATE INDEX CONCURRENTLY "idx_activation_recommendations_user" ON public.activation_recommendations USING btree ("userId");
 
 /*
-Statement 6
+Statement 5
 */
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
 CREATE INDEX CONCURRENTLY "activation_recommendations_workspace_id" ON public.activation_recommendations USING btree ("workspaceId");
 
 /*
+Statement 6
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "activation_recommendations_conversation_id" ON public.activation_recommendations USING btree ("conversationId");
+
+/*
 Statement 7
 */
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
-CREATE INDEX CONCURRENTLY "activation_recommendations_conversation_model_id" ON public.activation_recommendations USING btree ("conversationModelId");
+CREATE INDEX CONCURRENTLY "activation_recommendations_artifact_skill_id" ON public.activation_recommendations USING btree ("artifactSkillId");
 
 /*
 Statement 8
 */
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
-CREATE INDEX CONCURRENTLY "activation_recommendations_skill_model_id" ON public.activation_recommendations USING btree ("skillModelId");
+CREATE INDEX CONCURRENTLY "activation_recommendations_artifact_trigger_id" ON public.activation_recommendations USING btree ("artifactTriggerId");
 
 /*
 Statement 9
-*/
-SET SESSION statement_timeout = 1200000;
-SET SESSION lock_timeout = 3000;
-CREATE INDEX CONCURRENTLY "activation_recommendations_trigger_model_id" ON public.activation_recommendations USING btree ("triggerModelId");
-
-/*
-Statement 10
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER SEQUENCE "public"."activation_recommendations_id_seq" OWNED BY "public"."activation_recommendations"."id";
 
 /*
-Statement 11
+Statement 10
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
 
 /*
-Statement 12
+Statement 11
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_workspaceId_fkey";
 
 /*
-Statement 13
+Statement 12
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_userId_fkey" FOREIGN KEY ("userId") REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
 
 /*
-Statement 14
+Statement 13
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_userId_fkey";
 
 /*
+Statement 14
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES conversations(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
+
+/*
 Statement 15
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_conversationModelId_fkey" FOREIGN KEY ("conversationModelId") REFERENCES conversations(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
+ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_conversationId_fkey";
 
 /*
 Statement 16
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_conversationModelId_fkey";
+ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_artifactSkillId_fkey" FOREIGN KEY ("artifactSkillId") REFERENCES skill_configurations(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
 
 /*
 Statement 17
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_skillModelId_fkey" FOREIGN KEY ("skillModelId") REFERENCES skill_configurations(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
+ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_artifactSkillId_fkey";
 
 /*
 Statement 18
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_skillModelId_fkey";
+ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_artifactTriggerId_fkey" FOREIGN KEY ("artifactTriggerId") REFERENCES triggers(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
 
 /*
 Statement 19
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_triggerModelId_fkey" FOREIGN KEY ("triggerModelId") REFERENCES triggers(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
-
-/*
-Statement 20
-*/
-SET SESSION statement_timeout = 3000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_triggerModelId_fkey";
+ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_artifactTriggerId_fkey";


### PR DESCRIPTION
## Summary

Main details on where this will be used is in [S1: Activation Skill](https://app.notion.com/p/dust-tt/S1-Activation-Skill-38628599d94181a5a4f8f94b47b139f0?source=copy_link)

* storing recommendation history so they can be surfaced to the agent in later runs to improve the quality of user recommendations + provide context on what the user already acted on
* Will be used in [S3: Measurement Loop, Metrics, & Dashboards](https://app.notion.com/p/dust-tt/S3-Measurement-Loop-Metrics-Dashboards-38628599d9418132aab3ef6ec99f1083?source=copy_link) to measure internally (1) are people acting on these recommendations (2) what recommendations are leading to the best outcomes. We  might need more metadata in the future, but started relatively simple and just planning to store references of skills/triggers created as a result of the user interaction

### DB schema (`pre-deploy` migration)
- Table with `workspaceId`, `userId`, `status`, `content`, `rationale`, and three nullable artifact FKs (`conversationModelId`, `skillModelId`, `triggerModelId`)
- `ON DELETE RESTRICT` on `workspaceId`/`userId` — a recommendation must not outlive the workspace or user
- `ON DELETE SET NULL` on the artifact FKs — a recommendation survives when a conversation/skill/trigger is deleted; the FK is nulled rather than cascading the delete, avoiding the loss of a recommendation just because the artifact that motivated it was cleaned up
- Every FK column is indexed to avoid table scans on parent-row deletion (BACK13)
- No `sId`: recommendations are internal state, never exposed in URLs or public API (SEC2)

## Testing
1. Ran locally

## Deploy
1. Pre deploy hook should handle migration deployment
2. Deploy front