### PR TITLE
feat: add allow_sso feature flag to enable SSO independently of plan

### DIFF
--- a/front-api/routes/w/[wId]/sso.ts
+++ b/front-api/routes/w/[wId]/sso.ts
@@ -8,6 +8,7 @@ import {
   generateWorkOSAdminPortalUrl,
   getWorkOSOrganizationSSOConnections,
 } from "@app/lib/api/workos/organization";
+import { hasFeatureFlag } from "@app/lib/auth";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -33,7 +34,8 @@ async function checkAccess(ctx: Context) {
   }
 
   const plan = auth.getNonNullablePlan();
-  if (!plan.limits.users.isSSOAllowed) {
+  const hasSSOFeatureFlag = await hasFeatureFlag(auth, "allow_sso");
+  if (!plan.limits.users.isSSOAllowed && !hasSSOFeatureFlag) {
     return apiError(ctx, {
       status_code: 403,
       api_error: {

--- a/front/components/workspace/SSOConnection.tsx
+++ b/front/components/workspace/SSOConnection.tsx
@@ -1,4 +1,5 @@
 import WorkOSSSOConnection from "@app/components/workspace/sso/WorkOSSSOConnection";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { PlanType } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
 import type { Organization } from "@workos-inc/node";
@@ -14,7 +15,9 @@ export default function SSOConnection({
   owner,
   plan,
 }: SSOConnectionProps) {
-  if (!plan.limits.users.isSSOAllowed) {
+  const { hasFeature } = useFeatureFlags();
+
+  if (!plan.limits.users.isSSOAllowed && !hasFeature("allow_sso")) {
     return null;
   }
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -1,4 +1,9 @@
 export const WHITELISTABLE_FEATURES_CONFIG = {
+  allow_sso: {
+    description:
+      "Allow this workspace to configure SSO, independently of the plan's isSSOAllowed flag. Enable on demand for Business plan workspaces.",
+    stage: "on_demand",
+  },
   live_speech_to_text: {
     description:
       "Enable real-time speech-to-text in the input bar via ElevenLabs WebSocket streaming",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -701,6 +701,7 @@ export type RetrievalDocumentPublicType = z.infer<
 
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_notion_management"
+  | "allow_sso"
   | "agent_builder_copilot"
   | "agent_builder_copilot_builders"
   | "agent_builder_shrink_wrap"


### PR DESCRIPTION
## Description

Business plan workspaces have isSSOAllowed=false, so there was no way to turn on SSO for a single workspace without changing the plan. The new allow_sso flag (toggleable via the existing Poke feature flag plugin) bypasses the plan.limits.users.isSSOAllowed check in the SSO route and SSOConnection component.

## Tests

Tested locally that the SSO button was displayed with feature flag (but did not go through the whole SSO setup)

## Risk

Low, only additive with feature flag enabled

## Deploy Plan

Deploy front