### PR TITLE
fix(conversation): stop inline-step duplication from remount replay

### DIFF
--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -817,7 +817,7 @@ describe("useAgentMessageStream", () => {
       );
     });
 
-    // All three attempts are the SAME step (Temporal retries), so only the final
+    // All three attempts are the same step (Temporal retries), so only the final
     // attempt's thinking step survives — the earlier ones are dropped instead of
     // flooding the timeline with duplicates (the ticket-9287 bug).
     expect(currentMessage.streaming.inlineActivitySteps).toEqual([
@@ -997,6 +997,181 @@ describe("useAgentMessageStream", () => {
         content: "Final step-1 reasoning.",
         id: expect.stringContaining("thinking-pre-"),
         step: 1,
+      },
+    ]);
+  });
+
+  it("does not re-append steps when the message remounts and replays history", () => {
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({ content: null, chainOfThought: null })
+    );
+    let onEventCallback: ((event: string) => void) | null = null;
+
+    mockUseVirtuosoMethods.mockReturnValue(
+      makeVirtuosoMethodsMock(
+        (
+          updater: (message: typeof currentMessage) => typeof currentMessage
+        ) => {
+          currentMessage = updater(currentMessage);
+          return [currentMessage];
+        }
+      )
+    );
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+
+    const mountHook = () =>
+      renderHook(() =>
+        useAgentMessageStream({
+          agentMessage: currentMessage,
+          conversationId: "conv_123",
+          isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+          owner: mockOwner,
+          streamId: "stream_123",
+        })
+      );
+
+    // The history the server replays on every (re)connect: step 0 CoT → tool.
+    const history = [
+      {
+        eventId: "1-0",
+        data: {
+          type: "generation_tokens",
+          created: Date.now(),
+          configurationId: "agent_123",
+          messageId: currentMessage.sId,
+          text: "Reasoning about step 0.",
+          classification: "chain_of_thought",
+          traceId: "t0",
+          step: 0,
+        },
+      },
+      {
+        eventId: "2-0",
+        data: {
+          type: "tool_params",
+          created: Date.now(),
+          configurationId: "agent_123",
+          messageId: currentMessage.sId,
+          action: makeStreamAction({ id: 1, sId: "act_1" }),
+          runIds: [],
+          step: 0,
+        },
+      },
+    ];
+
+    const { unmount } = mountHook();
+    act(() => history.forEach((e) => onEventCallback!(JSON.stringify(e))));
+
+    const stepsAfterFirstMount =
+      currentMessage.streaming.inlineActivitySteps.length;
+    expect(stepsAfterFirstMount).toBeGreaterThan(0);
+
+    // Simulate a Virtuoso remount: unmount, mount a fresh hook instance for the
+    // same message (its steps persist in currentMessage), and replay the same
+    // history the server resends on reconnect.
+    unmount();
+    mountHook();
+    act(() => history.forEach((e) => onEventCallback!(JSON.stringify(e))));
+
+    expect(currentMessage.streaming.inlineActivitySteps.length).toBe(
+      stepsAfterFirstMount
+    );
+  });
+
+  it("commits the active CoT when tool_params arrives right after a remount", () => {
+    // Regression: after a remount the parser refs (lastClassification, ...) are
+    // reset. The replay must re-run so a live tool_params still flushes the
+    // in-progress CoT into a step instead of dropping it.
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({ content: null, chainOfThought: null })
+    );
+    let onEventCallback: ((event: string) => void) | null = null;
+
+    mockUseVirtuosoMethods.mockReturnValue(
+      makeVirtuosoMethodsMock(
+        (
+          updater: (message: typeof currentMessage) => typeof currentMessage
+        ) => {
+          currentMessage = updater(currentMessage);
+          return [currentMessage];
+        }
+      )
+    );
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+
+    const mountHook = () =>
+      renderHook(() =>
+        useAgentMessageStream({
+          agentMessage: currentMessage,
+          conversationId: "conv_123",
+          isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+          owner: mockOwner,
+          streamId: "stream_123",
+        })
+      );
+
+    const cotEvent = {
+      eventId: "1-0",
+      data: {
+        type: "generation_tokens",
+        created: Date.now(),
+        configurationId: "agent_123",
+        messageId: currentMessage.sId,
+        text: "Reasoning before the tool.",
+        classification: "chain_of_thought",
+        traceId: "t0",
+        step: 0,
+      },
+    };
+    const toolParamsEvent = {
+      eventId: "2-0",
+      data: {
+        type: "tool_params",
+        created: Date.now(),
+        configurationId: "agent_123",
+        messageId: currentMessage.sId,
+        action: makeStreamAction({ id: 1, sId: "act_1" }),
+        runIds: [],
+        step: 0,
+      },
+    };
+
+    // First mount: only the CoT arrives — it stays active, not yet flushed.
+    const { unmount } = mountHook();
+    act(() => onEventCallback!(JSON.stringify(cotEvent)));
+    expect(currentMessage.streaming.inlineActivitySteps).toHaveLength(0);
+
+    // Remount: the server replays the CoT (rebuilding parser state), then the
+    // live tool_params flushes it.
+    unmount();
+    mountHook();
+    act(() => {
+      onEventCallback!(JSON.stringify(cotEvent));
+      onEventCallback!(JSON.stringify(toolParamsEvent));
+    });
+
+    expect(currentMessage.streaming.inlineActivitySteps).toEqual([
+      {
+        type: "thinking",
+        content: "Reasoning before the tool.",
+        id: expect.stringContaining("thinking-toolparams-"),
+        step: 0,
       },
     ]);
   });

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -202,8 +202,11 @@ export function updateProgress(
 }
 
 /**
- * Append a thinking step to the inline activity steps if the content
- * is new (not a duplicate of the last thinking step).
+ * Append a thinking step to the inline activity steps, unless it is a duplicate.
+ *
+ * Two dedup guards: (1) the id is derived from the triggering event so a replay
+ * after a remount regenerates the same id — we skip it if already present; and
+ * (2) within a mount we skip content identical to the most recent thinking step.
  */
 export function appendThinkingStep(
   steps: InlineActivityStep[],
@@ -211,6 +214,9 @@ export function appendThinkingStep(
   id: string,
   stepIndex: number
 ): InlineActivityStep[] {
+  if (steps.some((step) => step.id === id)) {
+    return steps;
+  }
   for (let i = steps.length - 1; i >= 0; i--) {
     const step = steps[i];
     if (step.type === "thinking") {
@@ -232,6 +238,11 @@ function appendContentStep(
   id: string,
   stepIndex: number
 ): InlineActivityStep[] {
+  // Skip if already present — the id is event-derived, so a replay after a
+  // remount regenerates the same id instead of appending a duplicate.
+  if (steps.some((step) => step.id === id)) {
+    return steps;
+  }
   return [
     ...steps,
     { type: "content", content: textContent, id, step: stepIndex },
@@ -340,26 +351,12 @@ export function useAgentMessageStream({
     [methods, isAutoScrollEnabledRef]
   );
 
-  // Short-circuit replays of events we've already processed in this hook
-  // instance. The hook is mounted per agent message (via AgentMessage.tsx),
-  // so the ref is scoped to a single message and resets on remount or when a
-  // retry creates a new agentMessage.sId. Within a single mount,
-  // `useEventSource` reconnects on every server-side "done" frame and on
-  // network errors using `lastEventId`; if the server replays an event we
-  // already saw (e.g. just past the cursor boundary), the handlers downstream
-  // are not idempotent — inline activity step IDs are built from `Date.now()`
-  // and same-millisecond re-processing produces duplicate React keys.
+  // Short-circuit reconnect replays within this mount (useEventSource reconnects
+  // on every server "done" frame / network error and the server re-sends
+  // history). This ref resets on remount, which is fine: a remount re-runs the
+  // whole replay to rebuild the parser state, and steps are de-duplicated on
+  // insert by their stable, event-derived ids so nothing is appended twice.
   const seenEventIds = useRef<Set<string>>(new Set());
-
-  // Once a terminal event (agent_message_success, agent_error, etc.) is
-  // received, we must stop reconnecting entirely. Without this, a race between
-  // Virtuoso's deferred item re-render (which updates `agentMessage.status` and
-  // flips `shouldStream` to false) and the immediate React re-render triggered
-  // by the SSE `done` frame causes the effect to fire with `shouldStream` still
-  // true, reconnecting to the server. The server then replays history including
-  // `end-of-stream`, after which every subsequent reconnect gets an empty
-  // history and another immediate `done`, producing an infinite loop.
-  // Returning null from buildEventSourceURL breaks the loop at the source.
   const isStreamTerminated = useRef(false);
 
   useEffect(() => {
@@ -541,7 +538,7 @@ export function useAgentMessageStream({
                   chainOfThought,
                   content,
                   steps: m.streaming.inlineActivitySteps,
-                  suffix: `pre-${Date.now()}`,
+                  suffix: `pre-${eventPayload.eventId || Date.now()}`,
                   stepIndex: eventStep,
                   retryCoTBuffer,
                 });
@@ -663,7 +660,7 @@ export function useAgentMessageStream({
               chainOfThought,
               content,
               steps: m.streaming.inlineActivitySteps,
-              suffix: `toolparams-${Date.now()}`,
+              suffix: `toolparams-${eventPayload.eventId || Date.now()}`,
               stepIndex: toolParams.step,
               retryCoTBuffer,
             });
@@ -734,7 +731,7 @@ export function useAgentMessageStream({
               chainOfThought,
               content,
               steps: m.streaming.inlineActivitySteps,
-              suffix: `error-${Date.now()}`,
+              suffix: `error-${eventPayload.eventId || Date.now()}`,
               stepIndex: currentStep.current ?? 0,
               retryCoTBuffer,
             });
@@ -780,7 +777,7 @@ export function useAgentMessageStream({
               chainOfThought,
               content,
               steps: m.streaming.inlineActivitySteps,
-              suffix: `cancel-${Date.now()}`,
+              suffix: `cancel-${eventPayload.eventId || Date.now()}`,
               stepIndex: cancelData.step,
               retryCoTBuffer,
             });


### PR DESCRIPTION
## Description

Tickets:
* https://github.com/dust-tt/tasks/issues/9287
* https://github.com/dust-tt/tasks/issues/8022

Make inline steps idempotent instead of fighting the replay. Step ids are now derived from the triggering event id (stable across replays) rather than Date.now(), and appendThinkingStep/appendContentStep skip on insert if a step with that id already exists.

This complements the earlier retry-collapse fix in [PR28351](https://github.com/dust-tt/dust/pull/28351).

## Tests

Local + unit

## Risk

Can eventually break UX if there are unexpected side effects. Did not see any issue while testing locally

## Deploy Plan

Front