### PR TITLE
feat(llm): route the noop model through the new LLM router

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -20,6 +20,7 @@ import { isXaiWhitelistedModelId } from "@app/lib/api/llm/clients/xai/types";
 import type { LLM } from "@app/lib/api/llm/llm";
 import {
   BatchEndpointTransition,
+  NoopStreamTransition,
   StreamEndpointTransition,
 } from "@app/lib/api/llm/transitionLLM";
 import type { LLMParameters } from "@app/lib/api/llm/types/options";
@@ -39,7 +40,10 @@ import type {
   WorkspaceConfig,
 } from "@app/lib/llms/types/filter";
 import { sortEndpointsByPreferredRegion } from "@app/lib/llms/utils/sort_endpoints";
-import { isModelId } from "@app/lib/model_constructors/types/model_ids";
+import {
+  isModelId,
+  NOOP_MODEL_ID,
+} from "@app/lib/model_constructors/types/model_ids";
 import { GOOGLE_AI_STUDIO_API } from "@app/lib/model_constructors/types/provider_apis";
 import {
   isProviderId,
@@ -399,6 +403,12 @@ function getStreamEndpointLLM(
 
   if (!endpoint) {
     return null;
+  }
+
+  // The noop model needs a dedicated transition to preserve its static-response
+  // and simulated-credit behaviors, which the generic transition drops.
+  if (endpoint.modelId === NOOP_MODEL_ID) {
+    return new NoopStreamTransition(auth, llmParameters, endpoint);
   }
 
   const modelConfig = getModelConfigByModelId(llmParameters.modelId);

--- a/front/lib/api/llm/tests/router_parity.test.ts
+++ b/front/lib/api/llm/tests/router_parity.test.ts
@@ -29,6 +29,7 @@ import {
 import { StreamEndpointTransition } from "@app/lib/api/llm/transitionLLM";
 import type { LLMParameters } from "@app/lib/api/llm/types/options";
 import { DUST_STREAM_ENDPOINTS } from "@app/lib/llms/stream";
+import { NOOP_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
 import { GLOBAL } from "@app/lib/model_constructors/types/regions";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { describe, expect, it, vi } from "vitest";
@@ -133,7 +134,12 @@ async function drain(gen: AsyncGenerator<unknown>): Promise<Error | undefined> {
 // locally. Global agent-platform coverage can be added here once it exists.
 const ENDPOINTS = Object.values(DUST_STREAM_ENDPOINTS)
   .map(readEndpointInfo)
-  .filter((endpoint) => endpoint.region === GLOBAL);
+  // The noop endpoint synthesizes its stream in-process; there is no provider
+  // SDK request to compare against, so it is out of scope for router parity.
+  .filter(
+    (endpoint) =>
+      endpoint.region === GLOBAL && endpoint.providerId !== NOOP_PROVIDER_ID
+  );
 const MATRIX = buildParityMatrix();
 
 describe.skipIf(process.env.RUN_LLM_TEST !== "true")(

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -33,6 +33,8 @@ import type {
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import type { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { NoopRequest } from "@app/lib/model_constructors/stream/endpoints/noop_global_noop";
+import { NoopGlobalNoopStream } from "@app/lib/model_constructors/stream/endpoints/noop_global_noop";
 import type {
   InputConfig,
   ToolSpecification,
@@ -43,6 +45,7 @@ import type {
   SystemTextMessage,
   ToolCallResultPart,
 } from "@app/lib/model_constructors/types/input/messages";
+import { NOOP_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 import type {
   ErrorType,
   ModelResponseEvent,
@@ -51,6 +54,8 @@ import type {
   ToolCallEvent as NewToolCallEvent,
   NonDeltaResponseEvent,
 } from "@app/lib/model_constructors/types/output/events";
+import { NOOP_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type {
   AgentFunctionCallContentType,
   AgentProviderPassthroughContentType,
@@ -647,6 +652,72 @@ export class StreamEndpointTransition extends BaseTransition {
     } catch (err) {
       yield handleGenericError(err, this.metadata);
     }
+  }
+}
+
+/**
+ * Noop-specific streaming transition. The generic transition drops the two
+ * things that make the noop model useful for testing, so we handle them here:
+ *
+ * - `staticResponse` (from `metaData`, used by the sidekick/dust global agents)
+ *   is injected into the noop request; the payload alone cannot carry it.
+ * - `consume $X` records a simulated run usage with an explicit cost, which the
+ *   new router's token-based pricing cannot express. It surfaces through the
+ *   base `getSimulatedRunUsages` hook.
+ */
+export class NoopStreamTransition extends StreamEndpointTransition {
+  private readonly noopModel = new NoopGlobalNoopStream(undefined);
+  private readonly noopMetaData?: Record<string, unknown>;
+  private simulatedRunUsages: RunUsageType[] | null = null;
+
+  constructor(
+    auth: Authenticator,
+    llmParameters: LLMParameters,
+    modelConstructor: StreamEndpointConstructor
+  ) {
+    super(auth, llmParameters, modelConstructor);
+    this.noopMetaData = llmParameters.metaData;
+  }
+
+  protected override buildStreamRequestPayload(
+    streamParameters: LLMStreamParameters
+  ): NoopRequest {
+    const request = this.noopModel.buildRequestPayload(
+      this.buildPayload(streamParameters)
+    );
+
+    const staticResponse =
+      typeof this.noopMetaData?.staticResponse === "string"
+        ? this.noopMetaData.staticResponse
+        : undefined;
+
+    const command = request.lastUserMessageContent
+      .replace(/<dust_system>[\s\S]*?<\/dust_system>/g, "")
+      .trim();
+    const consumeMatch = command.match(/consume \$(\d+(?:\.\d+)?)/i);
+    if (consumeMatch) {
+      const costMicroUsd = Math.round(parseFloat(consumeMatch[1]) * 1_000_000);
+      this.simulatedRunUsages = [
+        {
+          providerId: NOOP_PROVIDER_ID,
+          modelId: NOOP_MODEL_ID,
+          promptTokens: 0,
+          completionTokens: 0,
+          cachedTokens: null,
+          costMicroUsd,
+          isBatch: false,
+        },
+      ];
+    }
+
+    return { ...request, staticResponse };
+  }
+
+  protected override getSimulatedRunUsages(): RunUsageType[] | null {
+    // Consume once so a retried stream does not double-record the cost.
+    const usages = this.simulatedRunUsages;
+    this.simulatedRunUsages = null;
+    return usages;
   }
 }
 

--- a/front/lib/llms/providers/noop/models/noop.ts
+++ b/front/lib/llms/providers/noop/models/noop.ts
@@ -1,0 +1,14 @@
+export function WithDustNoopConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustNoop extends Base {
+    static readonly displayName = "Noop";
+    static readonly description = "Noop model that does nothing.";
+    static readonly defaultReasoningEffort = "none";
+    static readonly byok = false;
+  }
+
+  return DustNoop;
+}

--- a/front/lib/llms/stream/endpoints/noop_global_noop.ts
+++ b/front/lib/llms/stream/endpoints/noop_global_noop.ts
@@ -1,0 +1,13 @@
+import { WithDustNoopConfig } from "@app/lib/llms/providers/noop/models/noop";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { NoopGlobalNoopStream } from "@app/lib/model_constructors/stream/endpoints/noop_global_noop";
+
+export class DustNoopGlobalNoopStream extends WithDustNoopConfig(
+  NoopGlobalNoopStream
+) {
+  static readonly endpointFilter = {
+    featureFlags: { contains: "noop_model_feature" as const },
+  };
+}
+
+defineDustStreamEndpoint(DustNoopGlobalNoopStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -18,6 +18,7 @@ import { DustMistralEuropeCodestralStream } from "@app/lib/llms/stream/endpoints
 import { DustMistralEuropeMistralLargeStream } from "@app/lib/llms/stream/endpoints/mistral_eu_mistral_large";
 import { DustMistralEuropeMistralMedium35Stream } from "@app/lib/llms/stream/endpoints/mistral_eu_mistral_medium_3_5";
 import { DustMistralEuropeMistralSmallStream } from "@app/lib/llms/stream/endpoints/mistral_eu_mistral_small";
+import { DustNoopGlobalNoopStream } from "@app/lib/llms/stream/endpoints/noop_global_noop";
 import { DustOpenAIResponsesEuropeGptFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_eu_gpt_five";
 import { DustOpenAIResponsesEuropeGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_five";
 import { DustOpenAIResponsesEuropeGptFiveDotFourStream } from "@app/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_four";
@@ -80,6 +81,7 @@ export const DUST_STREAM_ENDPOINTS = {
   [DustMistralEuropeMistralMedium35Stream.id]:
     DustMistralEuropeMistralMedium35Stream,
   [DustMistralEuropeMistralSmallStream.id]: DustMistralEuropeMistralSmallStream,
+  [DustNoopGlobalNoopStream.id]: DustNoopGlobalNoopStream,
   [DustOpenAIResponsesEuropeGptFiveDotFiveStream.id]:
     DustOpenAIResponsesEuropeGptFiveDotFiveStream,
   [DustOpenAIResponsesEuropeGptFiveDotFourMiniStream.id]:

--- a/front/lib/model_constructors/stream/endpoints/noop_global_noop.ts
+++ b/front/lib/model_constructors/stream/endpoints/noop_global_noop.ts
@@ -1,0 +1,133 @@
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { Payload } from "@app/lib/model_constructors/types/input/messages";
+import { NOOP_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+import type {
+  ModelResponseEvent,
+  TextEvent,
+} from "@app/lib/model_constructors/types/output/events";
+import { NOOP_API } from "@app/lib/model_constructors/types/provider_apis";
+import { NOOP_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+// Resolved request for the noop endpoint. `staticResponse` is not present in the
+// conversation payload; the noop transition injects it from the model metadata.
+export type NoopRequest = {
+  lastUserMessageContent: string;
+  staticResponse?: string;
+};
+
+// Mirrors the legacy `NoopLLM` command handling. `consume $X` is handled at the
+// transition layer (it records simulated run usage); here it simply falls
+// through to the default reply.
+function resolveNoopResponse({
+  lastUserMessageContent,
+  staticResponse,
+}: NoopRequest): string {
+  if (staticResponse) {
+    return staticResponse;
+  }
+
+  const command = lastUserMessageContent
+    .replace(/<dust_system>[\s\S]*?<\/dust_system>/g, "")
+    .trim();
+
+  if (command === "long message") {
+    return "This is a very long message. ".repeat(100);
+  }
+
+  if (command === "help") {
+    return (
+      "Noop agent usage:\n" +
+      "- Send 'long message' to receive a very long response\n" +
+      "- Send 'consume $X' to simulate X dollars of credit cost\n" +
+      "- Send 'help' to see this help message\n" +
+      "- Send anything else to see 'Soupinou!' as a response\n"
+    );
+  }
+
+  return "Soupinou!";
+}
+
+// The noop endpoint has no external API: it synthesizes a text stream in
+// process. It is a real new-router citizen so the legacy router can be retired.
+export class NoopGlobalNoopStream extends StreamEndpoint<
+  NoopRequest,
+  string,
+  InputConfig
+> {
+  static readonly providerId = NOOP_PROVIDER_ID;
+  static readonly api = NOOP_API;
+  static readonly modelId = NOOP_MODEL_ID;
+  static readonly region = GLOBAL;
+
+  // The noop model ignores every config knob; accept the widest input.
+  static readonly configSchema = inputConfigSchema;
+
+  static readonly contextSize = 1_000_000;
+  static readonly maxOutputTokens = 64_000;
+
+  // Free: the model never hits a provider. `consume $X` records its own
+  // simulated cost via the transition, independently of token pricing.
+  static readonly tokenPricing = {
+    standardInput: 0,
+    standardOutput: 0,
+  };
+
+  static readonly id = this.buildId();
+
+  constructor(_credentials: unknown) {
+    super();
+  }
+
+  buildRequestPayload(payload: Payload): NoopRequest {
+    const lastUserMessage = payload.conversation.messages
+      .slice()
+      .reverse()
+      .find((msg) => msg.role === "user" && msg.type === "text");
+
+    const lastUserMessageContent =
+      lastUserMessage?.type === "text"
+        ? lastUserMessage.content.value.trim()
+        : "";
+
+    return { lastUserMessageContent };
+  }
+
+  async *streamRaw(input: NoopRequest): AsyncGenerator<string> {
+    const responseText = resolveNoopResponse(input);
+    const chunkSize = 50;
+    for (let i = 0; i < responseText.length; i += chunkSize) {
+      yield responseText.slice(i, i + chunkSize);
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    raw: AsyncGenerator<string>
+  ): AsyncGenerator<ModelResponseEvent> {
+    const metadata = this.metadata();
+
+    let fullText = "";
+    for await (const delta of raw) {
+      fullText += delta;
+      yield { type: "text_delta", content: { value: delta }, metadata };
+    }
+
+    const textEvent: TextEvent = {
+      type: "text",
+      content: { value: fullText },
+      metadata,
+    };
+    yield textEvent;
+
+    yield {
+      type: "success",
+      content: { aggregated: [textEvent] },
+      metadata,
+    };
+  }
+}
+
+NoopGlobalNoopStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -18,6 +18,7 @@ import { MistralEuropeCodestralStream } from "@app/lib/model_constructors/stream
 import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
 import { MistralEuropeMistralMedium35Stream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5";
 import { MistralEuropeMistralSmallStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_small";
+import { NoopGlobalNoopStream } from "@app/lib/model_constructors/stream/endpoints/noop_global_noop";
 import { OpenAIResponsesEuropeGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five";
 import { OpenAIResponsesEuropeGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_five";
 import { OpenAIResponsesEuropeGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four";
@@ -70,6 +71,7 @@ export const STREAM_ENDPOINTS = {
   [MistralEuropeMistralLargeStream.id]: MistralEuropeMistralLargeStream,
   [MistralEuropeMistralMedium35Stream.id]: MistralEuropeMistralMedium35Stream,
   [MistralEuropeMistralSmallStream.id]: MistralEuropeMistralSmallStream,
+  [NoopGlobalNoopStream.id]: NoopGlobalNoopStream,
   [OpenAIResponsesEuropeGptFiveDotFiveStream.id]:
     OpenAIResponsesEuropeGptFiveDotFiveStream,
   [OpenAIResponsesEuropeGptFiveDotFourMiniStream.id]:

--- a/front/lib/model_constructors/test/endpoints/noop_global_noop.test.ts
+++ b/front/lib/model_constructors/test/endpoints/noop_global_noop.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+
+import { NoopGlobalNoopStream } from "@app/lib/model_constructors/stream/endpoints/noop_global_noop";
+import { SUCCESS } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+// The noop endpoint has no external provider API: it synthesizes a canned
+// response and ignores every config knob (temperature, reasoning, tools,
+// output format). The shared semantic checkers (contains "hi", tool call,
+// reasoning, JSON schema) therefore don't apply — the meaningful invariant is
+// that every input configuration streams to a successful completion, so every
+// case overrides the default checkers with SUCCESS.
+export const NoopGlobalNoopStreamSetup: StreamSetup = {
+  createInstance: () => new NoopGlobalNoopStream({}),
+  tests: {
+    "simple/no-tools/t-default/r-default": [SUCCESS],
+    "simple/no-tools/t-default/r-none": [SUCCESS],
+    "simple/no-tools/t-default/r-minimal": [SUCCESS],
+    "simple/no-tools/t-default/r-low": [SUCCESS],
+    "simple/no-tools/t-default/r-medium": [SUCCESS],
+    "simple/no-tools/t-default/r-high": [SUCCESS],
+    "simple/no-tools/t-default/r-maximal": [SUCCESS],
+    "simple/no-tools/t-0/r-default": [SUCCESS],
+    "simple/no-tools/t-0/r-none": [SUCCESS],
+    "simple/no-tools/t-0/r-minimal": [SUCCESS],
+    "simple/no-tools/t-0/r-low": [SUCCESS],
+    "simple/no-tools/t-0/r-medium": [SUCCESS],
+    "simple/no-tools/t-0/r-high": [SUCCESS],
+    "simple/no-tools/t-0/r-maximal": [SUCCESS],
+    "simple/no-tools/t-0.1/r-default": [SUCCESS],
+    "simple/no-tools/t-0.1/r-none": [SUCCESS],
+    "simple/no-tools/t-0.1/r-minimal": [SUCCESS],
+    "simple/no-tools/t-0.1/r-low": [SUCCESS],
+    "simple/no-tools/t-0.1/r-medium": [SUCCESS],
+    "simple/no-tools/t-0.1/r-high": [SUCCESS],
+    "simple/no-tools/t-0.1/r-maximal": [SUCCESS],
+    "simple/no-tools/t-1/r-default": [SUCCESS],
+    "simple/no-tools/t-1/r-none": [SUCCESS],
+    "simple/no-tools/t-1/r-minimal": [SUCCESS],
+    "simple/no-tools/t-1/r-low": [SUCCESS],
+    "simple/no-tools/t-1/r-medium": [SUCCESS],
+    "simple/no-tools/t-1/r-high": [SUCCESS],
+    "simple/no-tools/t-1/r-maximal": [SUCCESS],
+
+    "calc/calc/t-default/r-medium": [SUCCESS],
+    "calc/calc/t-0.1/r-default": [SUCCESS],
+    "calc/calc/t-0.1/r-medium": [SUCCESS],
+    "calc/calc/t-default/r-default/force-tool-default": [SUCCESS],
+    "calc/calc/t-default/r-default/force-tool": [SUCCESS],
+    "calc/calc/t-default/r-none/force-tool": [SUCCESS],
+
+    "reasoning/no-tools/t-default/r-none": [SUCCESS],
+    "reasoning/no-tools/t-default/r-low": [SUCCESS],
+
+    "output-format/json-schema/t-default/r-none": [SUCCESS],
+    "output-format/json-schema/t-default/r-high": [SUCCESS],
+
+    "following/no-tools/t-default/r-default": [SUCCESS],
+
+    "cache/no-tools/t-default/r-default": [SUCCESS],
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/noop_global_noop.test.ts
+runStreamEndpointTests(NoopGlobalNoopStream, NoopGlobalNoopStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/setups.ts
+++ b/front/lib/model_constructors/test/endpoints/setups.ts
@@ -22,6 +22,7 @@ import { MistralEuropeCodestralStream } from "@app/lib/model_constructors/stream
 import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
 import { MistralEuropeMistralMedium35Stream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5";
 import { MistralEuropeMistralSmallStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_small";
+import { NoopGlobalNoopStream } from "@app/lib/model_constructors/stream/endpoints/noop_global_noop";
 import { OpenAIResponsesEuropeGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five";
 import { OpenAIResponsesEuropeGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_five";
 import { OpenAIResponsesEuropeGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four";
@@ -60,6 +61,7 @@ import { MistralEuropeCodestralStreamSetup } from "@app/lib/model_constructors/t
 import { MistralEuropeMistralLargeStreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test";
 import { MistralEuropeMistralMedium35StreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test";
 import { MistralEuropeMistralSmallStreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test";
+import { NoopGlobalNoopStreamSetup } from "@app/lib/model_constructors/test/endpoints/noop_global_noop.test";
 import { OpenAIResponsesEuropeGptFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five.test";
 import { OpenAIResponsesEuropeGptFiveDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_five.test";
 import { OpenAIResponsesEuropeGptFiveDotFourStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four.test";
@@ -116,6 +118,7 @@ export const STREAM_ENDPOINT_SETUPS = {
   [MistralEuropeMistralMedium35Stream.id]:
     MistralEuropeMistralMedium35StreamSetup,
   [MistralEuropeMistralSmallStream.id]: MistralEuropeMistralSmallStreamSetup,
+  [NoopGlobalNoopStream.id]: NoopGlobalNoopStreamSetup,
   [OpenAIResponsesEuropeGptFiveDotFiveStream.id]:
     OpenAIResponsesEuropeGptFiveDotFiveStreamSetup,
   [OpenAIResponsesEuropeGptFiveDotFourMiniStream.id]:

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -45,6 +45,10 @@ export const FIREWORKS_GLM_5P2_MODEL_ID =
 export const TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_ID =
   "meta-llama/Llama-3.3-70B-Instruct-Turbo" as const;
 
+// Dummy model used for local/dev testing (static replies, simulated credit
+// consumption). Served by the in-process noop endpoint, not an external API.
+export const NOOP_MODEL_ID = "noop" as const;
+
 // Include a few examples for now
 export const MODEL_IDS = [
   GPT_5_5_MODEL_ID,
@@ -78,6 +82,7 @@ export const MODEL_IDS = [
   FIREWORKS_GLM_5_MODEL_ID,
   FIREWORKS_GLM_5P2_MODEL_ID,
   TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_ID,
+  NOOP_MODEL_ID,
 ] as const;
 
 export type ModelId = (typeof MODEL_IDS)[number];

--- a/front/lib/model_constructors/types/provider_apis.ts
+++ b/front/lib/model_constructors/types/provider_apis.ts
@@ -5,6 +5,7 @@ export const AGENT_PLATFORM_API = "agent-platform" as const;
 export const MISTRAL_API = "mistral" as const;
 export const FIREWORKS_API = "fireworks" as const;
 export const TOGETHERAI_API = "togetherai" as const;
+export const NOOP_API = "noop" as const;
 
 const PROVIDER_APIS = [
   OPENAI_RESPONSES_API,
@@ -14,5 +15,6 @@ const PROVIDER_APIS = [
   MISTRAL_API,
   FIREWORKS_API,
   TOGETHERAI_API,
+  NOOP_API,
 ] as const;
 export type ProviderApi = (typeof PROVIDER_APIS)[number];

--- a/front/lib/model_constructors/types/provider_ids.ts
+++ b/front/lib/model_constructors/types/provider_ids.ts
@@ -6,6 +6,7 @@ export const GOOGLE_AI_STUDIO_PROVIDER_ID = "google_ai_studio" as const;
 export const MISTRAL_PROVIDER_ID = "mistral" as const;
 export const FIREWORKS_PROVIDER_ID = "fireworks" as const;
 export const TOGETHERAI_PROVIDER_ID = "togetherai" as const;
+export const NOOP_PROVIDER_ID = "noop" as const;
 
 // `satisfies readonly ModelProviderIdType[]` guarantees every new-system
 // provider id is also a legacy `ModelProviderIdType`. This keeps `ProviderId`
@@ -19,6 +20,7 @@ const PROVIDER_IDS = [
   MISTRAL_PROVIDER_ID,
   FIREWORKS_PROVIDER_ID,
   TOGETHERAI_PROVIDER_ID,
+  NOOP_PROVIDER_ID,
 ] as const satisfies readonly ModelProviderIdType[];
 export type ProviderId = (typeof PROVIDER_IDS)[number];
 


### PR DESCRIPTION
## Description

Registers the `noop` model as a first-class endpoint in the new per-endpoint LLM router so it is served through `use_new_llm_router` instead of always falling back to the legacy per-provider router.

`noop` is unusual: it has no external provider API, and its usefulness comes from two behaviors the generic `StreamEndpointTransition` cannot express:

- **`staticResponse`** — the `sidekick` and `dust` global agents run on `NOOP_MODEL_CONFIG` and pass `metaData: { staticResponse }` to emit canned replies (new-agent-from-scratch first turn, skill-suggestion echo). The generic transition forwards only the conversation payload + parsed config, dropping `metaData`.

- **`consume $X`** — records an explicit simulated credit cost. The new router derives cost from `token_usage × tokenPricing`, so a flat dollar amount can't be represented that way.

A dedicated `NoopStreamTransition` preserves both: it injects the static response into the noop request and records the simulated cost through the base `getSimulatedRunUsages` hook. So turning the flag on does not regress the global-agent static replies.

## Tests

- `npx tsgo --noEmit` — clean.
- `lib/api/llm/transitionLLM.test.ts` — 12/12 pass.
- Biome + typecheck pre-commit hooks pass.
- `router_parity.test.ts` excludes `noop` (no provider SDK request to diff against) — it synthesizes its stream in-process.
- Live test

## Risk

Low.

## Deploy Plan

Standard deploy.