### PR TITLE
feat(conversations): add visible/hidden visibilities with backward-compatible readers and backfill

### DIFF
--- a/front/lib/api/v1/backward_compatibility.ts
+++ b/front/lib/api/v1/backward_compatibility.ts
@@ -53,6 +53,29 @@ export function normalizeConversationVisibility(
 }
 
 /**
+ * Translates an internal conversation visibility to the value exposed on the
+ * public API. During the "unlisted" -> "visible" / "test" -> "hidden" rename we
+ * keep the public wire contract on the legacy names so existing SDK clients are
+ * unaffected: "visible" is reported as "unlisted" and "hidden" as "test".
+ */
+export function toPublicConversationVisibility(
+  visibility: ConversationVisibility
+): ConversationPublicType["visibility"] {
+  switch (visibility) {
+    case "unlisted":
+    case "visible":
+      return "unlisted";
+    case "test":
+    case "hidden":
+      return "test";
+    case "deleted":
+      return "deleted";
+    default:
+      assertNever(visibility);
+  }
+}
+
+/**
  * Normalizes deprecated agent view values to their current equivalents.
  * The "workspace" view is deprecated and should be treated as "published".
  *
@@ -87,7 +110,7 @@ export function addBackwardCompatibleConversationWithoutContentFields(
     requestedGroupIds: [],
     // These properties are excluded from ConversationWithoutContentType used internally
     // but are still returned for the public API to stay backward compatible.
-    visibility: "unlisted" as ConversationVisibility, // Hardcoded as "deleted" conversations are not returned by the API
+    visibility: "unlisted", // Hardcoded as "deleted" conversations are not returned by the API
     owner: auth.getNonNullableWorkspace(),
   };
 }
@@ -116,6 +139,7 @@ export function addBackwardCompatibleConversationFields(
 ): ConversationPublicType {
   return {
     ...conversation,
+    visibility: toPublicConversationVisibility(conversation.visibility),
     requestedGroupIds: [],
     content: conversation.content.map((c) => {
       if (c.length === 0) {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -39,7 +39,10 @@ import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type {
+  ConversationVisibility,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import { Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
@@ -494,6 +497,54 @@ describe("ConversationResource", () => {
           fileCopyStatus: "pending",
         },
       });
+    });
+
+    it("tolerates both legacy and renamed visibilities when excluding test conversations", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      const makeConvo = async (visibility: ConversationVisibility) =>
+        ConversationModel.create({
+          workspaceId: workspace.id,
+          sId: generateRandomModelSId(),
+          title: `visibility ${visibility}`,
+          visibility,
+          requestedSpaceIds: [],
+        });
+
+      const unlisted = await makeConvo("unlisted");
+      const visible = await makeConvo("visible");
+      const test = await makeConvo("test");
+      const hidden = await makeConvo("hidden");
+      const deleted = await makeConvo("deleted");
+
+      const ids = [unlisted.id, visible.id, test.id, hidden.id, deleted.id];
+
+      // Default: deleted is always excluded, everything else (including the
+      // legacy "test" and the renamed "hidden") is returned.
+      const fetchedDefault = await ConversationResource.fetchByModelIds(
+        auth,
+        ids
+      );
+      expect(new Set(fetchedDefault.map((c) => c.id))).toEqual(
+        new Set([unlisted.id, visible.id, test.id, hidden.id])
+      );
+
+      // excludeTest excludes both the legacy "test" and the renamed "hidden",
+      // and keeps both the legacy "unlisted" and the renamed "visible".
+      const fetchedExcludingTest = await ConversationResource.fetchByModelIds(
+        auth,
+        ids,
+        { excludeTest: true }
+      );
+      expect(new Set(fetchedExcludingTest.map((c) => c.id))).toEqual(
+        new Set([unlisted.id, visible.id])
+      );
     });
   });
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -53,6 +53,8 @@ import {
   ConversationError,
   getConversationDisplayTitle,
   getConversationUrlAccessMode,
+  HIDDEN_CONVERSATION_VISIBILITIES,
+  LISTED_CONVERSATION_VISIBILITIES,
 } from "@app/types/assistant/conversation";
 import {
   ACTIVE_WAKE_UP_STATUSES,
@@ -277,7 +279,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const excludedVisibilities: ConversationVisibility[] = ["deleted"];
 
     if (excludeTest) {
-      excludedVisibilities.push("test");
+      excludedVisibilities.push(...HIDDEN_CONVERSATION_VISIBILITIES);
     }
 
     const conversations = await this.model.findAll({
@@ -865,7 +867,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     // Test conversations are included by default. Use excludeTest to exclude them.
     if (options?.excludeTest) {
-      excludedVisibilities.push("test");
+      excludedVisibilities.push(...HIDDEN_CONVERSATION_VISIBILITIES);
     }
 
     if (excludedVisibilities.length > 0) {
@@ -1710,7 +1712,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         where: {
           id: { [Op.in]: conversationIds },
           spaceId: { [Op.is]: null },
-          visibility: { [Op.eq]: "unlisted" },
+          visibility: { [Op.in]: LISTED_CONVERSATION_VISIBILITIES },
         },
       }
     );
@@ -1774,7 +1776,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const whereClause: WhereOptions<InferAttributes<ConversationModel>> = {
       id: { [Op.in]: conversationIds },
       spaceId: { [Op.is]: null },
-      visibility: { [Op.eq]: "unlisted" },
+      visibility: { [Op.in]: LISTED_CONVERSATION_VISIBILITIES },
       ...extraWhereClause,
     };
 
@@ -1946,7 +1948,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       {
         where: {
           spaceId: { [Op.in]: spaceIds },
-          visibility: { [Op.eq]: "unlisted" },
+          visibility: { [Op.in]: LISTED_CONVERSATION_VISIBILITIES },
         },
       }
     );
@@ -2022,7 +2024,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       {
         where: {
           spaceId: { [Op.eq]: spaceId },
-          visibility: { [Op.eq]: "unlisted" },
+          visibility: { [Op.in]: LISTED_CONVERSATION_VISIBILITIES },
         },
       }
     );

--- a/front/migrations/20260702_backfill_conversation_visibility_rename.ts
+++ b/front/migrations/20260702_backfill_conversation_visibility_rename.ts
@@ -1,0 +1,113 @@
+import { Op } from "sequelize";
+
+import { ConversationModel } from "@app/lib/models/agent/conversation";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { ConversationVisibility } from "@app/types/assistant/conversation";
+import type { LightWorkspaceType } from "@app/types/user";
+
+const BATCH_SIZE = 2000;
+
+// Legacy -> renamed visibility values. Readers already tolerate both, so this
+// backfill can run at any point after the "expand" phase is deployed.
+const VISIBILITY_RENAMES: {
+  from: ConversationVisibility;
+  to: ConversationVisibility;
+}[] = [
+  { from: "unlisted", to: "visible" },
+  { from: "test", to: "hidden" },
+];
+
+async function backfillVisibilityForWorkspace(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  for (const { from, to } of VISIBILITY_RENAMES) {
+    let updatedCount = 0;
+
+    // Rows stop matching `visibility = from` once updated, so we can keep
+    // reading the head of the table until nothing is left. In dry-run mode we
+    // only count (no update happens), so we break after the first read to avoid
+    // looping forever.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const batch = await ConversationModel.findAll({
+        attributes: ["id"],
+        where: {
+          workspaceId: workspace.id,
+          visibility: from,
+        },
+        order: [["id", "ASC"]],
+        limit: BATCH_SIZE,
+      });
+
+      if (batch.length === 0) {
+        break;
+      }
+
+      const ids = batch.map((c) => c.id);
+
+      if (!execute) {
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            from,
+            to,
+            batchSize: ids.length,
+          },
+          "[dry-run] Would rename conversation visibility batch"
+        );
+        break;
+      }
+
+      const [affected] = await ConversationModel.update(
+        { visibility: to },
+        {
+          where: {
+            workspaceId: workspace.id,
+            id: { [Op.in]: ids },
+            visibility: from,
+          },
+        }
+      );
+
+      updatedCount += affected;
+
+      if (batch.length < BATCH_SIZE) {
+        break;
+      }
+    }
+
+    if (execute && updatedCount > 0) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          from,
+          to,
+          updatedCount,
+        },
+        "Renamed conversation visibility"
+      );
+    }
+  }
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      demandOption: false,
+      description: "Run on a single workspace (optional)",
+    },
+  },
+  async ({ execute, workspaceId }, logger) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await backfillVisibilityForWorkspace(workspace, logger, execute);
+      },
+      { concurrency: 5, wId: workspaceId }
+    );
+  }
+);

--- a/front/types/api/assistant.ts
+++ b/front/types/api/assistant.ts
@@ -187,7 +187,10 @@ const ConversationMetadataSchema = z.record(z.unknown());
 
 export const InternalPostConversationsRequestBodySchema = z.object({
   title: z.string().nullable(),
-  visibility: z.enum(["unlisted", "deleted", "test"]),
+  // During the visibility rename migration both old ("unlisted"/"test") and new
+  // ("visible"/"hidden") values are accepted. Collapse to the new values once the
+  // migration is complete.
+  visibility: z.enum(["unlisted", "visible", "deleted", "test", "hidden"]),
   spaceId: z.string().nullable(),
   message: MessageBaseSchema.nullable(),
   contentFragments: z.array(InternalPostContentFragmentRequestBodySchema),

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -452,17 +452,44 @@ export function isCompactionMessageType(
 
 /**
  * Visibility of a conversation.
- *  - 'unlisted' default value
+ *  - 'unlisted' / 'visible': default value, listed in the user's history.
  *  - 'deleted' conversations are soft-deleted and not visible to any user.
- *  - 'test' for conversations happening when a user 'tests' an agent not in their list using the "test" button: those conversations do not show in users' histories.
+ *  - 'test' / 'hidden' for conversations that do not show in users' histories:
+ *    conversations happening when a user 'tests' an agent not in their list
+ *    using the "test" button, and conversations created by the platform
+ *    (like the journal entry generation).
  *
- * :warning: test is also used for conversations created by the platform (like the journal entry generation)
- *
- * TODO:
- *  - rename unlisted to visible
- *  - test to hidden
+ * Migration in progress: 'unlisted' is being renamed to 'visible' and 'test'
+ * to 'hidden'. During the migration the union carries both the old and the new
+ * values so readers tolerate a mixed dataset; use the transitional
+ * `LISTED_CONVERSATION_VISIBILITIES` / `HIDDEN_CONVERSATION_VISIBILITIES`
+ * helpers below when querying. Once the backfill has run and old clients have
+ * cycled out, drop 'unlisted' and 'test' from the union.
  */
-export type ConversationVisibility = "unlisted" | "deleted" | "test";
+export type ConversationVisibility =
+  | "unlisted"
+  | "visible"
+  | "deleted"
+  | "test"
+  | "hidden";
+
+/**
+ * Transitional: visibilities that represent a normally-listed conversation.
+ * Collapses to `["visible"]` once the rename migration is complete.
+ */
+export const LISTED_CONVERSATION_VISIBILITIES = [
+  "unlisted",
+  "visible",
+] as const satisfies ConversationVisibility[];
+
+/**
+ * Transitional: visibilities that hide a conversation from users' histories.
+ * Collapses to `["hidden"]` once the rename migration is complete.
+ */
+export const HIDDEN_CONVERSATION_VISIBILITIES = [
+  "test",
+  "hidden",
+] as const satisfies ConversationVisibility[];
 
 export const CONVERSATION_URL_ACCESS_MODES = [
   "participants_only",


### PR DESCRIPTION
## Description

First phase of renaming `ConversationVisibility` values: `unlisted` → `visible` and `test` → `hidden`. This is the backward-compatible "expand" step, so nothing is renamed on the wire yet.

- The `ConversationVisibility` union now carries both the old and the new values, with transitional `LISTED_CONVERSATION_VISIBILITIES` / `HIDDEN_CONVERSATION_VISIBILITIES` helpers.
- All conversation readers/queries tolerate a mixed dataset (`visibility IN (unlisted, visible)`, exclude `(test, hidden)`), so old rows and future rows both resolve correctly.
- The private POST conversations schema accepts both old and new values.
- The public API boundary keeps the legacy wire names: `toPublicConversationVisibility` maps `visible` → `unlisted` and `hidden` → `test`, so the published `@dust-tt/client` SDK is unaffected.
- Adds a batched backfill migration to rename existing rows (`unlisted` → `visible`, `test` → `hidden`) per workspace.

Writers still emit the old values in this PR — flipping the writers and dropping the old union members come in follow-up PRs.

## Tests

- Added a `fetchByModelIds` test that seeds all five visibilities and asserts the reader tolerates the mix: `deleted` is always excluded, and `excludeTest` drops both `test` and `hidden` while keeping both `unlisted` and `visible`.
- Backfill migration runs dry-run by default; execute with `--execute` (optionally `--workspaceId`).

## Deploy Plan

Deploy this PR first (readers become tolerant), then run the backfill migration to rename existing rows. Only after that do the follow-up PRs flip the writers and remove the legacy values.
