### PR TITLE
feat(Clari MCP) include transcript by default and not the opposite

### DIFF
--- a/front/lib/api/actions/servers/clari_copilot/metadata.ts
+++ b/front/lib/api/actions/servers/clari_copilot/metadata.ts
@@ -59,9 +59,9 @@ export const CLARI_COPILOT_TOOLS_METADATA = createToolsRecord({
   get_call_details: {
     description:
       "Retrieve details for a specific Clari Copilot call, including the AI summary, " +
-      "topics discussed, action items, and competitor mentions. " +
-      "The turn-by-turn transcript is excluded by default to limit context size; " +
-      "set include_transcript to true only when the full transcript is needed. " +
+      "topics discussed, action items, competitor mentions, and the turn-by-turn transcript. " +
+      "Set include_transcript to false to omit the transcript and limit context size " +
+      "when only the summary and action items are needed. " +
       "Requires a call ID from search_calls.",
     schema: {
       call_id: z
@@ -71,9 +71,9 @@ export const CLARI_COPILOT_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether to include the turn-by-turn transcript (default: false). " +
+          "Whether to include the turn-by-turn transcript (default: true). " +
             "The AI summary, topics, and action items are always included. " +
-            "Set to true only when the full transcript is needed."
+            "Set to false to reduce context size when the transcript isn't needed."
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/actions/servers/clari_copilot/tools/index.ts
+++ b/front/lib/api/actions/servers/clari_copilot/tools/index.ts
@@ -61,7 +61,8 @@ const handlers: ToolHandlers<typeof CLARI_COPILOT_TOOLS_METADATA> = {
     }
 
     const call = result.value;
-    const callToReturn = include_transcript
+    const shouldIncludeTranscript = include_transcript ?? true;
+    const callToReturn = shouldIncludeTranscript
       ? call
       : { ...call, transcript: undefined };
     return new Ok([


### PR DESCRIPTION
## Description

The `get_call_details` tool in the Clari Copilot MCP server previously excluded the turn-by-turn transcript by default (`include_transcript` defaulted to `false`). This PR flips the default to `true`, so the transcript is now included by default. The `include_transcript` parameter can be explicitly set to `false` to reduce context size when only the summary and action items are needed. Tool descriptions and schema docs are updated to reflect the new default behavior.

## Tests

Manually verify that calling `get_call_details` without specifying `include_transcript` now returns the transcript, and that passing `include_transcript: false` correctly omits it.

## Risk

Low. This is a behavioral change for AI agents using the Clari Copilot MCP tool: calls that previously omitted the transcript will now include it by default, which may increase context size for agents not explicitly opting out.

## Deploy Plan

Deploy front.