### PR TITLE
feat: add Claude Fable 5 to new LLM router

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -391,7 +391,16 @@ function getStreamEndpointLLM(
     return null;
   }
 
-  return new StreamEndpointTransition(auth, llmParameters, endpoint);
+  const modelConfig = getModelConfigByModelId(llmParameters.modelId);
+  const credentials = modelConfig?.useEapKey
+    ? withEapAnthropicKey(llmParameters.modelId, llmParameters.credentials)
+    : llmParameters.credentials;
+
+  return new StreamEndpointTransition(
+    auth,
+    { ...llmParameters, credentials },
+    endpoint
+  );
 }
 
 export async function getBatchEndpointLLM(
@@ -410,5 +419,14 @@ export async function getBatchEndpointLLM(
     return null;
   }
 
-  return new BatchEndpointTransition(auth, llmParameters, endpoint);
+  const modelConfig = getModelConfigByModelId(llmParameters.modelId);
+  const credentials = modelConfig?.useEapKey
+    ? withEapAnthropicKey(llmParameters.modelId, llmParameters.credentials)
+    : llmParameters.credentials;
+
+  return new BatchEndpointTransition(
+    auth,
+    { ...llmParameters, credentials },
+    endpoint
+  );
 }

--- a/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
@@ -1,0 +1,15 @@
+export function WithDustClaudeFableFiveConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustClaudeFableFive extends Base {
+    static readonly displayName = "Claude Fable 5";
+    static readonly description =
+      "Anthropic's Claude Fable 5 model, their most intelligent model, a new tier above Opus (250k context).";
+    static readonly defaultReasoningEffort = "medium";
+    static readonly byok = true;
+  }
+
+  return DustClaudeFableFive;
+}

--- a/front/lib/llms/stream/endpoints/anthropic_global_claude_fable_five.ts
+++ b/front/lib/llms/stream/endpoints/anthropic_global_claude_fable_five.ts
@@ -1,0 +1,13 @@
+import { WithDustClaudeFableFiveConfig } from "@app/lib/llms/providers/anthropic/models/claude_fable_five";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AnthropicGlobalClaudeFableFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_fable_five";
+
+export class DustAnthropicGlobalClaudeFableFiveStream extends WithDustClaudeFableFiveConfig(
+  AnthropicGlobalClaudeFableFiveStream
+) {
+  static readonly endpointFilter = {
+    featureFlags: { contains: "claude_fable_5_feature" as const },
+  };
+}
+
+defineDustStreamEndpoint(DustAnthropicGlobalClaudeFableFiveStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -3,6 +3,7 @@ import { DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/ll
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
 import { DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
+import { DustAnthropicGlobalClaudeFableFiveStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_fable_five";
 import { DustAnthropicGlobalClaudeHaikuFourDotFiveStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_haiku_four_dot_five";
 import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { DustAnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
@@ -36,6 +37,8 @@ import type {
 import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
 
 export const DUST_STREAM_ENDPOINTS = {
+  [DustAnthropicGlobalClaudeFableFiveStream.id]:
+    DustAnthropicGlobalClaudeFableFiveStream,
   [DustAnthropicGlobalClaudeSonnetFiveStream.id]:
     DustAnthropicGlobalClaudeSonnetFiveStream,
   [DustAnthropicGlobalClaudeSonnetFourDotSixStream.id]:

--- a/front/lib/model_constructors/providers/anthropic/models/claude_fable_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_fable_five.ts
@@ -1,0 +1,63 @@
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
+import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import {
+  inputConfigSchema,
+  temperatureSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
+import { CLAUDE_FABLE_5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+// Kept aligned with the existing static Fable 5 model config for this rollout.
+const CONTEXT_SIZE = 250_000;
+const DEFAULT_REASONING_EFFORT = "medium";
+const MAX_OUTPUT_TOKENS = 64_000;
+const MIN_REASONING_EFFORT = "low";
+
+const reasoningSchema = z
+  .union([
+    z.object({
+      effort: z.enum(ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS),
+    }),
+    // Fable has adaptive thinking always on. Preserve legacy-router behavior:
+    // callers that default to "none" are clamped to the minimum native effort.
+    z
+      .object({ effort: z.literal("none") })
+      .transform((): { effort: typeof MIN_REASONING_EFFORT } => ({
+        effort: MIN_REASONING_EFFORT,
+      })),
+  ])
+  .default({ effort: DEFAULT_REASONING_EFFORT });
+
+const configSchema = inputConfigSchema.extend({
+  cacheKey: z.undefined(),
+  reasoning: reasoningSchema,
+  // Fable has adaptive thinking always on; omit explicit temperature rather
+  // than sending a value that can conflict with the thinking configuration.
+  temperature: temperatureSchema.optional().transform(() => undefined),
+});
+
+export type ClaudeFableFive = z.infer<typeof configSchema>;
+
+export function WithAnthropicClaudeFableFiveConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class AnthropicClaudeFableFive extends Base {
+    declare ["constructor"]: BaseEndpointConfiguration<ClaudeFableFive>;
+
+    static readonly modelId = CLAUDE_FABLE_5_MODEL_ID;
+
+    static readonly configSchema: z.ZodType<
+      ClaudeFableFive,
+      z.ZodTypeDef,
+      unknown
+    > = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return AnthropicClaudeFableFive;
+}

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_fable_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_fable_five.ts
@@ -1,0 +1,36 @@
+import type {
+  MessageCreateParamsNonStreaming,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources";
+import {
+  type ClaudeFableFive,
+  WithAnthropicClaudeFableFiveConfig,
+} from "@app/lib/model_constructors/providers/anthropic/models/claude_fable_five";
+import { AnthropicStream } from "@app/lib/model_constructors/stream/clients/anthropic";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class AnthropicGlobalClaudeFableFiveStream extends WithAnthropicClaudeFableFiveConfig(
+  AnthropicStream
+) {
+  // https://platform.claude.com/docs/en/about-claude/pricing
+  static readonly tokenPricing = {
+    cacheCreated: 12.5,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 12.5,
+    longCacheCreated: 20.0,
+    cacheHit: 1.0,
+    standardInput: 10.0,
+    standardOutput: 50.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+AnthropicGlobalClaudeFableFiveStream satisfies StreamEndpointConstructor<
+  MessageCreateParamsNonStreaming,
+  RawMessageStreamEvent,
+  ClaudeFableFive
+>;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -3,6 +3,7 @@ import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
 import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
+import { AnthropicGlobalClaudeFableFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_fable_five";
 import { AnthropicGlobalClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five";
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { AnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
@@ -29,6 +30,8 @@ import { OpenAIResponsesGlobalGptFiveNanoStream } from "@app/lib/model_construct
 import { TogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/model_constructors/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo";
 
 export const STREAM_ENDPOINTS = {
+  [AnthropicGlobalClaudeFableFiveStream.id]:
+    AnthropicGlobalClaudeFableFiveStream,
   [AnthropicGlobalClaudeSonnetFiveStream.id]:
     AnthropicGlobalClaudeSonnetFiveStream,
   [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+
+import { AnthropicGlobalClaudeFableFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_fable_five";
+import {
+  HAS_REASONING,
+  INPUT_CONFIGURATION_ERROR,
+} from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new AnthropicGlobalClaudeFableFiveStream({
+      ANTHROPIC_API_KEY:
+        process.env.ANTHROPIC_EAP_API_KEY ??
+        process.env.DUST_MANAGED_ANTHROPIC_API_KEY ??
+        "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Minimal reasoning effort is not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    // Fable has adaptive thinking always on: "none" is clamped to low.
+    "reasoning/no-tools/t-default/r-none": [HAS_REASONING],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test.ts
+runStreamEndpointTests(AnthropicGlobalClaudeFableFiveStream, setup);

--- a/front/lib/model_constructors/test/vite.config.js
+++ b/front/lib/model_constructors/test/vite.config.js
@@ -4,12 +4,14 @@ import baseConfig from "../../../vite.config.mjs";
 
 const config = mergeConfig(baseConfig, {
   test: {
+    setupFiles: [],
     globalSetup: [],
     environment: "node",
   },
 });
 
 // mergeConfig deep-merges arrays, so we must override after merging.
+config.test.setupFiles = [];
 config.test.globalSetup = [];
 
 export default config;

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -10,6 +10,7 @@ export const GPT_5_NANO_MODEL_ID = "gpt-5-nano" as const;
 
 export const CLAUDE_SONNET_4_6_MODEL_ID = "claude-sonnet-4-6" as const;
 export const CLAUDE_SONNET_5_MODEL_ID = "claude-sonnet-5" as const;
+export const CLAUDE_FABLE_5_MODEL_ID = "claude-fable-5" as const;
 export const CLAUDE_OPUS_4_6_MODEL_ID = "claude-opus-4-6" as const;
 export const CLAUDE_OPUS_4_7_MODEL_ID = "claude-opus-4-7" as const;
 export const CLAUDE_OPUS_4_8_MODEL_ID = "claude-opus-4-8" as const;
@@ -57,6 +58,7 @@ export const MODEL_IDS = [
   GPT_5_NANO_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
   CLAUDE_SONNET_5_MODEL_ID,
+  CLAUDE_FABLE_5_MODEL_ID,
   CLAUDE_OPUS_4_6_MODEL_ID,
   CLAUDE_OPUS_4_7_MODEL_ID,
   CLAUDE_OPUS_4_8_MODEL_ID,
@@ -85,6 +87,7 @@ export function isModelId(value: string): value is ModelId {
 }
 
 export const ORDERED_LARGE_MODEL_IDS = [
+  CLAUDE_FABLE_5_MODEL_ID,
   CLAUDE_OPUS_4_8_MODEL_ID,
   CLAUDE_OPUS_4_7_MODEL_ID,
   CLAUDE_OPUS_4_6_MODEL_ID,


### PR DESCRIPTION
## Description

Adds Claude Fable 5 via EAP KEY to the new stream endpoint router, including model-constructor metadata, the Anthropic global stream endpoint, Dust endpoint metadata, registry wiring, and endpoint coverage.

Also applies the existing EAP Anthropic credential routing to new stream and batch router transitions so models configured with `useEapKey` use the dedicated key consistently.

## Tests

- Pre-commit hook: secret scan, front typecheck, and Biome passed.
- `NODE_ENV=test npm run test -- --config lib/model_constructors/test/vite.config.js lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test.ts` (imports cleanly; live cases skipped without `RUN_LLM_TEST`).
- `npx tsgo --noEmit 2>&1 | grep -v node_modules` produced no output.

## Risk

Low to moderate. The new endpoint is feature-gated behind `claude_fable_5_feature`, uses the existing Anthropic stream client, and keeps Fable 5 aligned with the existing 250k context / 64k output rollout values. 

## Deploy Plan

Deploy normally.