### PR TITLE
SSO: add a poke plugin to allow SSO event if the plan do not allow it

### DIFF
--- a/front-api/routes/w/[wId]/sso.ts
+++ b/front-api/routes/w/[wId]/sso.ts
@@ -8,6 +8,7 @@ import {
   generateWorkOSAdminPortalUrl,
   getWorkOSOrganizationSSOConnections,
 } from "@app/lib/api/workos/organization";
+import { isSSOAllowedForWorkspace } from "@app/lib/plans/sso";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -33,7 +34,7 @@ async function checkAccess(ctx: Context) {
   }
 
   const plan = auth.getNonNullablePlan();
-  if (!plan.limits.users.isSSOAllowed) {
+  if (!isSSOAllowedForWorkspace(workspace, plan)) {
     return apiError(ctx, {
       status_code: 403,
       api_error: {

--- a/front/components/workspace/SSOConnection.tsx
+++ b/front/components/workspace/SSOConnection.tsx
@@ -1,4 +1,5 @@
 import WorkOSSSOConnection from "@app/components/workspace/sso/WorkOSSSOConnection";
+import { isSSOAllowedForWorkspace } from "@app/lib/plans/sso";
 import type { PlanType } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
 import type { Organization } from "@workos-inc/node";
@@ -14,7 +15,7 @@ export default function SSOConnection({
   owner,
   plan,
 }: SSOConnectionProps) {
-  if (!plan.limits.users.isSSOAllowed) {
+  if (!isSSOAllowedForWorkspace(owner, plan)) {
     return null;
   }
 

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -43,6 +43,7 @@ export * from "./soft_delete_conversation";
 export * from "./sync_api_key_cap_alerts";
 export * from "./sync_default_pool_cap_alerts";
 export * from "./sync_metronome_seats";
+export * from "./toggle_allow_sso";
 export * from "./toggle_auto_create_space";
 export * from "./toggle_disable_manual_invitations";
 export * from "./toggle_feature_flag";

--- a/front/lib/api/poke/plugins/workspaces/toggle_allow_sso.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_allow_sso.ts
@@ -1,0 +1,54 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { updateWorkspaceMetadata } from "@app/lib/api/workspace";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const toggleAllowSSOPlugin = createPlugin({
+  manifest: {
+    id: "toggle-allow-sso",
+    name: "Toggle SSO Activation",
+    description:
+      "Enable/disable SSO for a workspace regardless of its plan. " +
+      "Used to activate SSO on demand for plans where it is not included by default " +
+      "(e.g. Business plans). Note: disabling only removes the workspace-level override; " +
+      "SSO remains available if the plan allows it.",
+    resourceTypes: ["workspaces"],
+    args: {
+      enabled: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Enable SSO",
+        description:
+          "When enabled, SSO is available for this workspace even if its plan does not allow it",
+        async: true,
+      },
+    },
+    requiredRoles: ["support"],
+  },
+  populateAsyncArgs: async (auth, workspace) => {
+    return new Ok({
+      enabled: workspace?.metadata?.allowSSO === true,
+    });
+  },
+  execute: async (auth, workspace, args) => {
+    if (!workspace) {
+      return new Err(new Error("Cannot find workspace."));
+    }
+
+    const { enabled } = args;
+
+    const result = await updateWorkspaceMetadata(workspace, {
+      allowSSO: enabled,
+    });
+
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+
+    return new Ok({
+      display: "text",
+      value: enabled
+        ? `✅ SSO is now ENABLED for workspace "${workspace.name}" (workspace-level override)`
+        : `❌ SSO workspace-level override is now DISABLED for workspace "${workspace.name}" (SSO remains available if the plan allows it)`,
+    });
+  },
+});

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -556,6 +556,9 @@ export interface WorkspaceMetadata {
   allowReinforcementBatchMode?: boolean;
   privateConversationUrlsByDefault?: boolean;
   autoCreateSpaceForProvisionedGroups?: boolean;
+  // Enables SSO for the workspace even if its plan does not allow it
+  // (on-demand SSO activation, set via poke plugin).
+  allowSSO?: boolean;
   disableManualInvitations?: boolean;
   disableExtensionMcpTools?: boolean;
   dustMcpServerDisabled?: boolean;

--- a/front/lib/plans/sso.ts
+++ b/front/lib/plans/sso.ts
@@ -1,0 +1,14 @@
+import type { PlanType } from "@app/types/plan";
+import type { LightWorkspaceType } from "@app/types/user";
+
+/**
+ * SSO is available when the plan allows it, or when it has been activated
+ * on demand for the workspace (workspace metadata `allowSSO`, set via the
+ * "Toggle SSO Activation" poke plugin).
+ */
+export function isSSOAllowedForWorkspace(
+  owner: LightWorkspaceType,
+  plan: PlanType
+): boolean {
+  return plan.limits.users.isSSOAllowed || owner.metadata?.allowSSO === true;
+}


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9374

Allow SSO activation on demand for a specific workspace via a new `allowSSO` workspace metadata flag (set through a new "Toggle SSO Activation" poke plugin).
The workspace metadata is ORed with the plan's `isSSOAllowed` to determined if the workspace has access to SSO.
Enables SSO for workspaces on plans where it is not included by default (e.g. CP Business), without changing the plan.
Implementation follows the existing workspace metadata override pattern (e.g.`autoCreateSpaceForProvisionedGroups`, `isBusiness`) and its poke toggle plugins.

The poke plugin:

<img width="1720" height="869" alt="Screenshot 2026-07-02 at 16 33 59" src="https://github.com/user-attachments/assets/97012bf8-6b28-4991-99bf-2f52e31bb8b2" />

This shows/hide the active SSO in the "Identity and Provisioning" tab:

<img width="1300" height="667" alt="Screenshot 2026-07-02 at 16 36 20" src="https://github.com/user-attachments/assets/9afb6dcf-4b71-460e-bdd1-37ee89319868" />

## Tests
Tested locally (but did actually test SSO)

## Risk


## Deploy Plan

deploy front
