### PR TITLE
Deprecate the file-id Frame edit tool in favor of editing the source and publishing

### DIFF
--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -3,7 +3,6 @@ import {
   type LabeledQuery,
   SERVERS,
 } from "@app/lib/api/actions/servers/bm25_tool_search_utils.test";
-import { EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { describe, expect, it } from "vitest";
 
 const QUERIES: LabeledQuery[] = [
@@ -759,10 +758,9 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "edit the code of my frame",
     expected: "interactive_content.edit_interactive_content_file",
-    // pod_manager.edit_information and files.edit collide on "edit" (files.edit is the
-    // intended winner in file-system conversations, see the frame-edit block below). The
-    // tool is deprecated (kept for conversations without the file system), so a low rank
-    // is acceptable.
+    // "edit" collides with several tools in this all-tools index (pod_manager.edit_information,
+    // files.edit, agent_memory.edit_entries). This tool is deprecated (kept only for
+    // conversations without the file system), so a low rank is acceptable.
     maxRank: 5,
   },
   {
@@ -1675,61 +1673,13 @@ const QUERIES: LabeledQuery[] = [
 
 export const fullIndexWithAllServers = buildIndex(buildDocs(SERVERS));
 
-// File-system conversations drop the deprecated file-id edit tool from the interactive_content
-// server: updating a Frame goes through files.edit on the source plus publish (retrieve stays,
-// as a fallback for Frames whose mount path hasn't been resolved). files.edit is loaded eagerly
-// (see its `eager: true` in files/metadata.ts), so it no longer depends on winning tool search
-// to be reachable — these queries are a secondary description-quality guard, same as the
-// files.list/files.cat entries above, catching wording changes that steer an edit intent toward
-// create_interactive_content_file (which regenerates the whole Frame and burns tokens) in case
-// eager loading is ever removed or a client falls back to search-based discovery.
-const FRAME_EDIT_QUERIES: LabeledQuery[] = [
-  { query: "edit the frame", expected: "files.edit", maxRank: 2 },
-  { query: "edit the code of my frame", expected: "files.edit", maxRank: 2 },
-  { query: "update my frame", expected: "files.edit", maxRank: 2 },
-  { query: "update the dashboard frame", expected: "files.edit" },
-  {
-    query: "change the chart colors in my dashboard",
-    expected: "files.edit",
-    maxRank: 2,
-  },
-  { query: "fix the chart in the frame", expected: "files.edit", maxRank: 2 },
-  { query: "edit frame source file", expected: "files.edit" },
-  { query: "update the existing visualization", expected: "files.edit" },
-];
-
-const fileSystemConversationIndex = buildIndex(
-  buildDocs(
-    SERVERS.map((server) =>
-      server.name === "interactive_content"
-        ? {
-            ...server,
-            tools: server.tools.filter(
-              (tool) => tool.name !== EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME
-            ),
-          }
-        : server
-    )
-  )
-);
-
-describe("BM25 tool-search retrieval (file-system conversation, frame edits)", () => {
-  for (const { query, expected, maxRank = 1 } of FRAME_EDIT_QUERIES) {
-    it(`"${query}" → ${expected} (rank ≤ ${maxRank})`, () => {
-      const ranked = rank(query, fileSystemConversationIndex);
-      const pos = ranked.findIndex((r) => r.name === expected) + 1;
-      expect(
-        pos,
-        `Expected "${expected}" in top ${maxRank} but got rank ${pos}. Top hit: "${ranked[0]?.name}"`
-      ).toBeGreaterThan(0);
-      expect(
-        pos,
-        `Expected "${expected}" in top ${maxRank} but got rank ${pos}. Top hit: "${ranked[0]?.name}"`
-      ).toBeLessThanOrEqual(maxRank);
-    });
-  }
-});
-
+// A file-system conversation drops the deprecated file-id edit tool from the interactive_content
+// server, but there is no BM25 coverage here for routing an edit intent to files.edit instead of
+// create_interactive_content_file: files.edit is loaded eagerly (`eager: true` in
+// files/metadata.ts), so Anthropic's server-side tool search never operates over it at all
+// (defer_loading is only set on non-eager tools) — it is simply always present in the tools
+// array, regardless of any query or ranking. A BM25 assertion on its rank would test a scenario
+// that cannot occur at runtime.
 describe("BM25 tool-search retrieval (single-server index)", () => {
   for (const { query, expected } of QUERIES) {
     const serverName = expected.split(".")[0];

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1677,10 +1677,12 @@ export const fullIndexWithAllServers = buildIndex(buildDocs(SERVERS));
 
 // File-system conversations drop the deprecated file-id edit tool from the interactive_content
 // server: updating a Frame goes through files.edit on the source plus publish (retrieve stays,
-// as a fallback for Frames whose mount path hasn't been resolved). These queries pin the
-// routing a model relies on there — an edit intent must surface files.edit near the top instead
-// of steering to create_interactive_content_file (which regenerates the whole Frame and burns
-// tokens).
+// as a fallback for Frames whose mount path hasn't been resolved). files.edit is loaded eagerly
+// (see its `eager: true` in files/metadata.ts), so it no longer depends on winning tool search
+// to be reachable — these queries are a secondary description-quality guard, same as the
+// files.list/files.cat entries above, catching wording changes that steer an edit intent toward
+// create_interactive_content_file (which regenerates the whole Frame and burns tokens) in case
+// eager loading is ever removed or a client falls back to search-based discovery.
 const FRAME_EDIT_QUERIES: LabeledQuery[] = [
   { query: "edit the frame", expected: "files.edit", maxRank: 2 },
   { query: "edit the code of my frame", expected: "files.edit", maxRank: 2 },

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -758,9 +758,11 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "edit the code of my frame",
     expected: "interactive_content.edit_interactive_content_file",
-    // pod_manager.edit_information and files.edit collide on "edit". The tool is deprecated
-    // (kept for conversations without the file system), so a low rank is acceptable.
-    maxRank: 4,
+    // pod_manager.edit_information and files.edit collide on "edit" (files.edit is the
+    // intended winner in file-system conversations, see the frame-edit block below). The
+    // tool is deprecated (kept for conversations without the file system), so a low rank
+    // is acceptable.
+    maxRank: 5,
   },
   {
     query: "change the chart colors in my dashboard",
@@ -1671,6 +1673,60 @@ const QUERIES: LabeledQuery[] = [
 ];
 
 export const fullIndexWithAllServers = buildIndex(buildDocs(SERVERS));
+
+// File-system conversations drop the deprecated file-id edit and retrieve tools from the
+// interactive_content server: updating a Frame goes through files.edit on the source plus
+// publish, and reading it through files.cat. These queries pin the routing a model relies on
+// there — an edit intent must surface files.edit near the top instead of steering to
+// create_interactive_content_file (which regenerates the whole Frame and burns tokens).
+const FRAME_EDIT_QUERIES: LabeledQuery[] = [
+  { query: "edit the frame", expected: "files.edit", maxRank: 2 },
+  { query: "edit the code of my frame", expected: "files.edit", maxRank: 2 },
+  { query: "update my frame", expected: "files.edit", maxRank: 2 },
+  { query: "update the dashboard frame", expected: "files.edit" },
+  {
+    query: "change the chart colors in my dashboard",
+    expected: "files.edit",
+    maxRank: 2,
+  },
+  { query: "fix the chart in the frame", expected: "files.edit", maxRank: 2 },
+  { query: "edit frame source file", expected: "files.edit" },
+  { query: "update the existing visualization", expected: "files.edit" },
+];
+
+const fileSystemConversationIndex = buildIndex(
+  buildDocs(
+    SERVERS.map((server) =>
+      server.name === "interactive_content"
+        ? {
+            ...server,
+            tools: server.tools.filter(
+              (tool) =>
+                tool.name !== "edit_interactive_content_file" &&
+                tool.name !== "retrieve_interactive_content_file"
+            ),
+          }
+        : server
+    )
+  )
+);
+
+describe("BM25 tool-search retrieval (file-system conversation, frame edits)", () => {
+  for (const { query, expected, maxRank = 1 } of FRAME_EDIT_QUERIES) {
+    it(`"${query}" → ${expected} (rank ≤ ${maxRank})`, () => {
+      const ranked = rank(query, fileSystemConversationIndex);
+      const pos = ranked.findIndex((r) => r.name === expected) + 1;
+      expect(
+        pos,
+        `Expected "${expected}" in top ${maxRank} but got rank ${pos}. Top hit: "${ranked[0]?.name}"`
+      ).toBeGreaterThan(0);
+      expect(
+        pos,
+        `Expected "${expected}" in top ${maxRank} but got rank ${pos}. Top hit: "${ranked[0]?.name}"`
+      ).toBeLessThanOrEqual(maxRank);
+    });
+  }
+});
 
 describe("BM25 tool-search retrieval (single-server index)", () => {
   for (const { query, expected } of QUERIES) {

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -758,10 +758,6 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "edit the code of my frame",
     expected: "interactive_content.edit_interactive_content_file",
-    // "edit" collides with several tools in this all-tools index (pod_manager.edit_information,
-    // files.edit, agent_memory.edit_entries). This tool is deprecated (kept only for
-    // conversations without the file system), so a low rank is acceptable.
-    maxRank: 5,
   },
   {
     query: "change the chart colors in my dashboard",
@@ -1673,13 +1669,6 @@ const QUERIES: LabeledQuery[] = [
 
 export const fullIndexWithAllServers = buildIndex(buildDocs(SERVERS));
 
-// A file-system conversation drops the deprecated file-id edit tool from the interactive_content
-// server, but there is no BM25 coverage here for routing an edit intent to files.edit instead of
-// create_interactive_content_file: files.edit is loaded eagerly (`eager: true` in
-// files/metadata.ts), so Anthropic's server-side tool search never operates over it at all
-// (defer_loading is only set on non-eager tools) — it is simply always present in the tools
-// array, regardless of any query or ranking. A BM25 assertion on its rank would test a scenario
-// that cannot occur at runtime.
 describe("BM25 tool-search retrieval (single-server index)", () => {
   for (const { query, expected } of QUERIES) {
     const serverName = expected.split(".")[0];

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -3,6 +3,7 @@ import {
   type LabeledQuery,
   SERVERS,
 } from "@app/lib/api/actions/servers/bm25_tool_search_utils.test";
+import { EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { describe, expect, it } from "vitest";
 
 const QUERIES: LabeledQuery[] = [
@@ -1674,11 +1675,12 @@ const QUERIES: LabeledQuery[] = [
 
 export const fullIndexWithAllServers = buildIndex(buildDocs(SERVERS));
 
-// File-system conversations drop the deprecated file-id edit and retrieve tools from the
-// interactive_content server: updating a Frame goes through files.edit on the source plus
-// publish, and reading it through files.cat. These queries pin the routing a model relies on
-// there — an edit intent must surface files.edit near the top instead of steering to
-// create_interactive_content_file (which regenerates the whole Frame and burns tokens).
+// File-system conversations drop the deprecated file-id edit tool from the interactive_content
+// server: updating a Frame goes through files.edit on the source plus publish (retrieve stays,
+// as a fallback for Frames whose mount path hasn't been resolved). These queries pin the
+// routing a model relies on there — an edit intent must surface files.edit near the top instead
+// of steering to create_interactive_content_file (which regenerates the whole Frame and burns
+// tokens).
 const FRAME_EDIT_QUERIES: LabeledQuery[] = [
   { query: "edit the frame", expected: "files.edit", maxRank: 2 },
   { query: "edit the code of my frame", expected: "files.edit", maxRank: 2 },
@@ -1701,9 +1703,7 @@ const fileSystemConversationIndex = buildIndex(
         ? {
             ...server,
             tools: server.tools.filter(
-              (tool) =>
-                tool.name !== "edit_interactive_content_file" &&
-                tool.name !== "retrieve_interactive_content_file"
+              (tool) => tool.name !== EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME
             ),
           }
         : server

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -758,7 +758,9 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "edit the code of my frame",
     expected: "interactive_content.edit_interactive_content_file",
-    maxRank: 3, // pod_manager.edit_information and files__edit collides on "edit"
+    // pod_manager.edit_information and files.edit collide on "edit". The tool is deprecated
+    // (kept for conversations without the file system), so a low rank is acceptable.
+    maxRank: 4,
   },
   {
     query: "change the chart colors in my dashboard",

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -4,6 +4,7 @@ import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   INTERACTIVE_CONTENT_SERVER_NAME,
+  PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { FILE_PREVIEW_DIRECTIVE_EXAMPLE } from "@app/lib/markdown/file_preview";
 import { frameContentType, frameSlideshowContentType } from "@app/types/files";
@@ -258,11 +259,15 @@ const FILES_TOOLS_COMMON_METADATA = {
       "Create or overwrite a file in a conversation or Pod file system. " +
       "Accepts UTF-8 text content only. Binary files cannot be created via this tool. " +
       `Content is capped at ${CREATE_CONTENT_MAX_BYTES / 1024} KB. ` +
-      "If the file already exists it is silently overwritten (shell \`>\` semantics). " +
-      "A file written with a Frame content type is only a source file on the mount. To turn it " +
-      `into a shareable rendered Frame, use \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` ` +
-      "with mode='template' and this path as source. " +
-      "Overwriting an existing Frame file updates only its source, never the rendered Frame directly. " +
+      "If the file already exists it is silently overwritten (shell \`>\` semantics); for " +
+      `partial changes to an existing file, prefer \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_EDIT_ACTION_NAME)}\` ` +
+      "over resending the full content. " +
+      "A new file written with a Frame content type is only a source file on the mount. To turn " +
+      `it into a shareable rendered Frame, use \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` ` +
+      "with mode='template' and this path as source, but never do this for a Frame that " +
+      "already exists. " +
+      "Overwriting an existing Frame file updates only its source, never the rendered Frame " +
+      "directly. " +
       "Returns whether the file was created or updated, along with its path and size.",
     schema: {
       path: z
@@ -345,12 +350,15 @@ const FILES_TOOLS_COMMON_METADATA = {
 const EDIT_TOOL = {
   description:
     "Edit a text file by replacing an exact string match with new content. " +
+    "This is also how to update an existing Frame (interactive dashboard, data visualization, " +
+    "chart, or slideshow): make targeted edits to the Frame's source file, then publish it with " +
+    `\`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\`. ` +
+    "Never create a new Frame or rewrite the whole source to change an existing one. " +
     "`old_string` must match the file content exactly, including whitespace and indentation. " +
     "Fails if `old_string` is not found or if the number of occurrences does not match " +
     "`expected_replacements` (default 1); make `old_string` unique by including surrounding lines. " +
     `Files larger than ${CREATE_CONTENT_MAX_BYTES / 1024} KB cannot be edited with this tool. ` +
-    "Editing a Frame source file updates only its source, never the rendered Frame directly. " +
-    "The tool result explains how to apply the change to the rendered Frame.",
+    "Editing a Frame source file updates only its source, never the rendered Frame directly.",
   schema: {
     path: z
       .string()

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -3,7 +3,12 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import {
+  CREATE_CONTENT_MAX_BYTES,
+  FILES_CAT_ACTION_NAME,
+  FILES_SERVER_NAME,
+} from "@app/lib/api/actions/servers/files/metadata";
 import {
   getDustFileSystemForAgentLoop,
   requireAgentLoopConversation,
@@ -104,9 +109,14 @@ export async function editHandler(
 
   if (occurrences === 0) {
     return new Err(
-      new MCPError(`String not found in file: "${old_string}"`, {
-        tracked: false,
-      })
+      new MCPError(
+        `String not found in file: "${old_string}". The file may have changed since you last ` +
+          `read it: re-read it with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` ` +
+          "and retry with the exact current text. Never resend the whole file content.",
+        {
+          tracked: false,
+        }
+      )
     );
   }
 

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -110,7 +110,7 @@ export async function editHandler(
   if (occurrences === 0) {
     return new Err(
       new MCPError(
-        `String not found in file: "${old_string}". The file may have changed since you last ` +
+        `String "${old_string}" not found in file. The file may have changed since you last ` +
           `read it: re-read it with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` ` +
           "and retry with the exact current text. Never resend the whole file content.",
         {

--- a/front/lib/api/actions/servers/files/tools/utils.test.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.test.ts
@@ -15,10 +15,10 @@ describe("frameFileCreateRejectedError", () => {
 });
 
 describe("frameFileEditRejectedError", () => {
-  it("names the files list and interactive_content edit tools", () => {
-    expect(frameFileEditRejectedError().message).toContain("files__list");
+  it("names the files edit and interactive_content publish tools", () => {
+    expect(frameFileEditRejectedError().message).toContain("files__edit");
     expect(frameFileEditRejectedError().message).toContain(
-      "interactive_content__edit_interactive_content_file"
+      "interactive_content__publish_interactive_content_file"
     );
   });
 });

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -2,12 +2,11 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   FILES_CREATE_ACTION_NAME,
-  FILES_LIST_ACTION_NAME,
+  FILES_EDIT_ACTION_NAME,
   FILES_SERVER_NAME,
 } from "@app/lib/api/actions/servers/files/metadata";
 import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
-  EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   INTERACTIVE_CONTENT_SERVER_NAME,
   PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
@@ -158,8 +157,8 @@ export function frameFileCreateRejectedError(): MCPError {
 export function frameFileEditRejectedError(): MCPError {
   return new MCPError(
     "Frame files cannot be edited with this tool. " +
-      `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` to get the file id, ` +
-      `then \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` to update it.`,
+      `Edit the Frame's source with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_EDIT_ACTION_NAME)}\`, ` +
+      `then publish it with \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\`.`,
     { tracked: false }
   );
 }

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -1,7 +1,13 @@
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   VIZ_MIME_TYPE,
   VIZ_SLIDESHOW_MIME_TYPE,
 } from "@app/lib/api/actions/servers/common/viz/instructions";
+import {
+  FILES_CAT_ACTION_NAME,
+  FILES_EDIT_ACTION_NAME,
+  FILES_SERVER_NAME,
+} from "@app/lib/api/actions/servers/files/metadata";
 import {
   INTERACTIVE_CONTENT_AUTHORING_PROSE_V2,
   INTERACTIVE_CONTENT_CHART_EXAMPLES_V2,
@@ -16,6 +22,15 @@ import {
   RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
+
+const FILES_EDIT_TOOL = getPrefixedToolName(
+  FILES_SERVER_NAME,
+  FILES_EDIT_ACTION_NAME
+);
+const FILES_CAT_TOOL = getPrefixedToolName(
+  FILES_SERVER_NAME,
+  FILES_CAT_ACTION_NAME
+);
 
 const UPDATING_SECTION_LEGACY = `\
 ### Updating Existing Files:
@@ -47,25 +62,42 @@ ${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
 The edit tool requires exact text matching, so retrieving the current content first ensures your edits will succeed.
 `;
 
+const PUBLISH_PARAGRAPH = `\
+Publishing rebuilds the Frame from its source so viewers and shares see the new version. Until you publish, edits to the source do not change the rendered Frame. Multi-file Frames work the same way: edit any source file under that directory, keep every source file under it, then publish. A TypeScript or JSX syntax error blocks publishing and is reported back so you can fix it.`;
+
 // Computer-first variant, used when the Computer is available. The Frame's source is mounted in
-// the Computer, so the model edits the file in place and republishes instead of round-tripping
-// through the retrieve and edit tools.
+// the Computer, so the model edits the file in place and republishes.
 const UPDATING_SECTION_COMPUTER_FIRST = `\
-### Updating Existing Files (preferred: edit in the Computer):
+### Updating Existing Files (edit the source, then publish):
 
 After a Frame is created, its source file is already mounted in the Computer at \`/files/conversation-<conversationId>/<FrameName>.tsx\`. To update the Frame:
-1. Edit that file in place with your file tools.
+1. Edit that file in place with your file tools. When the Computer is not available, edit it with \`${FILES_EDIT_TOOL}\` using the scoped path \`conversation-<conversationId>/<FrameName>.tsx\`.
 2. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` using \`path: conversation-<conversationId>\` (the directory holding the file, not a subdirectory).
 
-Publishing rebuilds the Frame from its source so viewers and shares see the new version. Multi-file Frames work the same way: edit any source file under that directory, keep every source file under it, then publish. A TypeScript or JSX syntax error blocks publishing and is reported back so you can fix it.
-
-### Updating Existing Files (fallback, when the Computer is not available):
-- Use \`${RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` first to read the current content, then \`${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` to make targeted changes by replacing specific text
-- The edit tool requires exact text matching, include surrounding context for unique identification
-- Never attempt to edit without first retrieving the current file content
+${PUBLISH_PARAGRAPH}
 `;
 
-const interactiveContentProseBeforeAuthoring = (updatingSection: string) => `\
+// Files-tools variant, used when the conversation has the file system but no Computer. The
+// model edits the Frame's source through the files server, then republishes.
+const UPDATING_SECTION_FILES_FIRST = `\
+### Updating Existing Files (edit the source, then publish):
+
+After a Frame is created, its source file is available to your file tools at \`conversation-<conversationId>/<FrameName>.tsx\`. To update the Frame:
+1. Edit that file in place with \`${FILES_EDIT_TOOL}\` (read it with \`${FILES_CAT_TOOL}\` if you need the current content).
+2. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` using \`path: conversation-<conversationId>\` (the directory holding the file, not a subdirectory).
+
+${PUBLISH_PARAGRAPH}
+`;
+
+interface InstructionsVariant {
+  updatingSection: string;
+  validationFixExample: string;
+}
+
+const interactiveContentProseBeforeAuthoring = ({
+  updatingSection,
+  validationFixExample,
+}: InstructionsVariant) => `\
 ## CREATING VISUALIZATIONS WITH INTERACTIVE CONTENT
 
 You have access to an Interactive Content system that allows you to create and update executable files. When creating visualizations, you should create files instead of using the :::visualization directive.
@@ -103,7 +135,7 @@ How it works:
 - Reference existing content by its ID (found in <knowledge id="..."> tags from company data searches)
 - Pass that ID to the source parameter
 - Content is fetched server-side without consuming context tokens
-- You can then customize it using \`${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\`
+- You can then customize it (see Updating Existing Files below)
 Example:
 \`\`\`
 // After finding code with <knowledge id="template_node_id">
@@ -117,7 +149,7 @@ ${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
 \`\`\`
 When using template mode, you don't need to read the template content first.
 Just pass the knowledge ID to the tool and the content will be fetched server-side.
-Common pattern: Create from template, then use \`${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` to customize.
+Common pattern: Create from template, then customize it with targeted edits.
 This approach works well when adapting existing templates (preserves structure/style, no token cost for base content).
 Typical use cases: Suitable template exists, adapting existing code, saving tokens on large files.
 
@@ -129,11 +161,11 @@ Validation is performed automatically when you create or edit files.
 
 **Tailwind validation (non-blocking):** Files are saved even with Tailwind warnings. When you
 receive warnings in the tool response, they include the exact \`old_string\` and
-\`expected_replacements\` count. Fix these warnings using \`${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\`
-with the provided values. If you receive multiple warnings, fix all of them in a single response
-using multiple edit tool calls. Common warning: "Forbidden Tailwind arbitrary value 'h-[600px]'"
-means you should replace with predefined classes like h-96 or use inline styles. Do not regenerate
-the entire file; use targeted edits only.
+\`expected_replacements\` count. Fix these warnings with targeted edits using the provided values.
+If you receive multiple warnings, fix all of them in a single response using multiple edit tool
+calls. Common warning: "Forbidden Tailwind arbitrary value 'h-[600px]'" means you should replace
+with predefined classes like h-96 or use inline styles. Do not regenerate the entire file; use
+targeted edits only.
 
 When fixing validation warnings, use the exact values provided. Do not add context, modify them,
 interpret them, or retrieve the file first.
@@ -148,12 +180,7 @@ Example warning response:
 
 Correct fix:
 \`\`\`
-${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
-  file_id: "fil_abc123",
-  old_string: "className=\\"text-[14px]\\"",  // EXACTLY as provided in warning
-  new_string: "className=\\"text-sm\\"",
-  expected_replacements: 5  // EXACTLY as provided in warning
-})
+${validationFixExample}
 \`\`\`
 
 **TypeScript validation (blocking):** Files are rejected if TypeScript/JSX syntax is invalid.
@@ -257,14 +284,43 @@ Examples:
 ${INTERACTIVE_CONTENT_CHART_EXAMPLES_V2}
 `;
 
-const buildInstructions = (updatingSection: string) =>
-  `${interactiveContentProseBeforeAuthoring(updatingSection)}\n${INTERACTIVE_CONTENT_AUTHORING_PROSE_V2}\n${INTERACTIVE_CONTENT_TOOLS_PROSE_AFTER_AUTHORING}`;
+const VALIDATION_FIX_EXAMPLE_LEGACY = `\
+${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
+  file_id: "fil_abc123",
+  old_string: "className=\\"text-[14px]\\"",  // EXACTLY as provided in warning
+  new_string: "className=\\"text-sm\\"",
+  expected_replacements: 5  // EXACTLY as provided in warning
+})`;
 
-// Default (no Computer): the model updates Frames through the retrieve and edit tools.
-export const INTERACTIVE_CONTENT_INSTRUCTIONS = buildInstructions(
-  UPDATING_SECTION_LEGACY
-);
+const VALIDATION_FIX_EXAMPLE_SOURCE_EDIT = `\
+${FILES_EDIT_TOOL}({
+  path: "conversation-<conversationId>/Dashboard.tsx",
+  old_string: "className=\\"text-[14px]\\"",  // EXACTLY as provided in warning
+  new_string: "className=\\"text-sm\\"",
+  expected_replacements: 5  // EXACTLY as provided in warning
+})
+// Then publish the Frame so the fixes reach the rendered version.`;
+
+const buildInstructions = (variant: InstructionsVariant) =>
+  `${interactiveContentProseBeforeAuthoring(variant)}\n${INTERACTIVE_CONTENT_AUTHORING_PROSE_V2}\n${INTERACTIVE_CONTENT_TOOLS_PROSE_AFTER_AUTHORING}`;
+
+// Legacy conversations (no conversation file system): the Frame's source is not reachable by
+// path, so the model updates Frames through the retrieve and file-id edit tools.
+export const INTERACTIVE_CONTENT_INSTRUCTIONS = buildInstructions({
+  updatingSection: UPDATING_SECTION_LEGACY,
+  validationFixExample: VALIDATION_FIX_EXAMPLE_LEGACY,
+});
+
+// Conversation file system available, no Computer: the model edits the source through the
+// files server and republishes.
+export const INTERACTIVE_CONTENT_INSTRUCTIONS_FILES_FIRST = buildInstructions({
+  updatingSection: UPDATING_SECTION_FILES_FIRST,
+  validationFixExample: VALIDATION_FIX_EXAMPLE_SOURCE_EDIT,
+});
 
 // Computer available: the model edits the mounted source in the Computer and republishes.
 export const INTERACTIVE_CONTENT_INSTRUCTIONS_COMPUTER_FIRST =
-  buildInstructions(UPDATING_SECTION_COMPUTER_FIRST);
+  buildInstructions({
+    updatingSection: UPDATING_SECTION_COMPUTER_FIRST,
+    validationFixExample: VALIDATION_FIX_EXAMPLE_SOURCE_EDIT,
+  });

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -19,6 +19,7 @@ import {
 import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  FRAME_RECREATE_WASTE_RATIONALE,
   PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
@@ -80,7 +81,7 @@ Publishing rebuilds the Frame from its source so viewers and shares see the new 
 const CREATE_VS_UPDATE_SECTION = `\
 ### Creating vs. Updating
 
-Create a Frame only when the content does not exist yet. When the user asks for changes to a Frame that already exists in the conversation (fixing a bug, updating data, changing colors, text, charts, or layout, adding a section), update that Frame in place following "Updating Existing Files" below. Never create a new Frame, and never resend the full source, to change an existing one: a replacement Frame loses the original's identity and share URL and wastes tokens regenerating content that did not change, while targeted edits are cheap.
+Create a Frame only when the content does not exist yet. When the user asks for changes to a Frame that already exists in the conversation (fixing a bug, updating data, changing colors, text, charts, or layout, adding a section), update that Frame in place following "Updating Existing Files" below. Never create a new Frame, and never resend the full source, to change an existing one: ${FRAME_RECREATE_WASTE_RATIONALE}, while targeted edits are cheap.
 `;
 
 // Computer-first variant, used when the Computer is available. The Frame's source is mounted in
@@ -172,7 +173,7 @@ How it works:
 - Reference existing content by its ID (found in <knowledge id="..."> tags from company data searches)
 - Pass that ID to the source parameter
 - Content is fetched server-side without consuming context tokens
-- You can then customize it (see Updating Existing Files below)
+- You can then customize it with targeted edits
 Example:
 \`\`\`
 // After finding code with <knowledge id="template_node_id">

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -6,6 +6,8 @@ import {
 import {
   FILES_CAT_ACTION_NAME,
   FILES_EDIT_ACTION_NAME,
+  FILES_LIST_ACTION_NAME,
+  FILES_RESOLVE_ACTION_NAME,
   FILES_SERVER_NAME,
 } from "@app/lib/api/actions/servers/files/metadata";
 import {
@@ -30,6 +32,14 @@ const FILES_EDIT_TOOL = getPrefixedToolName(
 const FILES_CAT_TOOL = getPrefixedToolName(
   FILES_SERVER_NAME,
   FILES_CAT_ACTION_NAME
+);
+const FILES_LIST_TOOL = getPrefixedToolName(
+  FILES_SERVER_NAME,
+  FILES_LIST_ACTION_NAME
+);
+const FILES_RESOLVE_TOOL = getPrefixedToolName(
+  FILES_SERVER_NAME,
+  FILES_RESOLVE_ACTION_NAME
 );
 
 const UPDATING_SECTION_LEGACY = `\
@@ -63,7 +73,15 @@ The edit tool requires exact text matching, so retrieving the current content fi
 `;
 
 const PUBLISH_PARAGRAPH = `\
-Publishing rebuilds the Frame from its source so viewers and shares see the new version. Until you publish, edits to the source do not change the rendered Frame. Multi-file Frames work the same way: edit any source file under that directory, keep every source file under it, then publish. A TypeScript or JSX syntax error blocks publishing and is reported back so you can fix it.`;
+Publishing rebuilds the Frame from its source so viewers and shares see the new version. It updates the existing Frame in place, keeping its identity and share URL. Until you publish, edits to the source do not change the rendered Frame. Multi-file Frames work the same way: edit any source file under that directory, keep every source file under it, then publish. A TypeScript or JSX syntax error blocks publishing and is reported back so you can fix it.`;
+
+// Shared decision gate between the creating and updating flows. Kept generic so it holds for
+// every variant, including legacy conversations whose edit flow goes through the file-id tool.
+const CREATE_VS_UPDATE_SECTION = `\
+### Creating vs. Updating
+
+Create a Frame only when the content does not exist yet. When the user asks for changes to a Frame that already exists in the conversation (fixing a bug, updating data, changing colors, text, charts, or layout, adding a section), update that Frame in place following "Updating Existing Files" below. Never create a new Frame, and never resend the full source, to change an existing one: a replacement Frame loses the original's identity and share URL and wastes tokens regenerating content that did not change, while targeted edits are cheap.
+`;
 
 // Computer-first variant, used when the Computer is available. The Frame's source is mounted in
 // the Computer, so the model edits the file in place and republishes.
@@ -71,8 +89,10 @@ const UPDATING_SECTION_COMPUTER_FIRST = `\
 ### Updating Existing Files (edit the source, then publish):
 
 After a Frame is created, its source file is already mounted in the Computer at \`/files/conversation-<conversationId>/<FrameName>.tsx\`. To update the Frame:
-1. Edit that file in place with your file tools. When the Computer is not available, edit it with \`${FILES_EDIT_TOOL}\` using the scoped path \`conversation-<conversationId>/<FrameName>.tsx\`.
+1. Edit that file in place with your file tools, changing only the parts that need to change. Do not rewrite the whole file for partial changes. When the Computer is not available, edit it with \`${FILES_EDIT_TOOL}\` using the scoped path \`conversation-<conversationId>/<FrameName>.tsx\`.
 2. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` using \`path: conversation-<conversationId>\` (the directory holding the file, not a subdirectory).
+
+If an edit fails because the text to replace is not found, the file differs from what you remember: re-read it and retry the targeted edit. Never respond to a failed match by resending the whole file.
 
 ${PUBLISH_PARAGRAPH}
 `;
@@ -83,8 +103,24 @@ const UPDATING_SECTION_FILES_FIRST = `\
 ### Updating Existing Files (edit the source, then publish):
 
 After a Frame is created, its source file is available to your file tools at \`conversation-<conversationId>/<FrameName>.tsx\`. To update the Frame:
-1. Edit that file in place with \`${FILES_EDIT_TOOL}\` (read it with \`${FILES_CAT_TOOL}\` if you need the current content).
-2. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` using \`path: conversation-<conversationId>\` (the directory holding the file, not a subdirectory).
+1. Read the source with \`${FILES_CAT_TOOL}\` if you need the current content. If you are unsure of the exact path, list the directory with \`${FILES_LIST_TOOL}\` or resolve the Frame's file id with \`${FILES_RESOLVE_TOOL}\`.
+2. Make targeted edits with \`${FILES_EDIT_TOOL}\`, replacing only the text that changes. Do not rewrite the whole file for partial changes.
+3. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` using \`path: conversation-<conversationId>\` (the directory holding the file, not a subdirectory).
+
+If an edit fails because the text to replace is not found, the file differs from what you remember: re-read it with \`${FILES_CAT_TOOL}\` and retry the targeted edit. Never respond to a failed match by resending the whole file.
+
+Example, updating one value of an existing Frame:
+\`\`\`
+${FILES_EDIT_TOOL}({
+  path: "conversation-<conversationId>/Dashboard.tsx",
+  old_string: "const REGIONS = [\\"EMEA\\", \\"AMER\\"];",
+  new_string: "const REGIONS = [\\"EMEA\\", \\"AMER\\", \\"APAC\\"];",
+})
+${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
+  file_id: "fil_abc123",
+  path: "conversation-<conversationId>",
+})
+\`\`\`
 
 ${PUBLISH_PARAGRAPH}
 `;
@@ -103,6 +139,7 @@ const interactiveContentProseBeforeAuthoring = ({
 You have access to an Interactive Content system that allows you to create and update executable files. When creating visualizations, you should create files instead of using the :::visualization directive.
 This toolset is called Frame in the product, users may refer to it as such.
 
+${CREATE_VS_UPDATE_SECTION}
 ### Creating Files
 
 Use the \`${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` tool to create JavaScript/TypeScript files:

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -193,9 +193,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
   [RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
       "Read back the current content of an existing Frame by its file ID. " +
-      "Use this to inspect a Frame you have previously created " +
-      `or edited. Use this tool before calling ${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME} to ` +
-      "understand the current file state and identify the exact text to replace.",
+      "Use this to inspect a Frame you have previously created or edited, and to identify " +
+      "the exact text to replace before an edit.",
     schema: {
       file_id: z
         .string()

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -31,6 +31,14 @@ export const EXPORT_INTERACTIVE_CONTENT_FILE_TOOL_NAME =
 export const PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME =
   "publish_interactive_content_file";
 
+// Shared rationale for why an existing Frame must be edited in place rather than recreated.
+// Interpolated verbatim wherever this constraint is taught (this server's create tool, the
+// files server's create/edit tools, the Frames skill instructions) so the "why" stays a single
+// source of truth instead of independently drifting prose in each place.
+export const FRAME_RECREATE_WASTE_RATIONALE =
+  "a replacement Frame loses the original's identity and share URL and wastes tokens " +
+  "regenerating content that did not change";
+
 export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
   [CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -38,7 +38,9 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
       "presentation that users can run and interact with, beyond static viewing. Choose 'template' " +
       "mode to base it on an existing knowledge node, or 'inline' mode to provide the content " +
       "directly. Validation (Tailwind, TypeScript) is non-blocking: the file is saved even with " +
-      "warnings, which you should fix immediately.",
+      "warnings, which you should fix immediately. Only for a Frame that does not already " +
+      "exist: to alter a Frame the conversation already has, go through its source file (see " +
+      "the Frames skill instructions) rather than creating a replacement.",
     schema: {
       file_name: z
         .string()
@@ -267,10 +269,12 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
   },
   [PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
     description:
-      "Publish a Frame from its source files in the Computer. A Frame you created is already " +
-      "mounted in the Computer at `/files/conversation-<conversationId>/<filename>`, so edit it " +
-      "there in place rather than copying it elsewhere, then call this to build it into the live " +
-      "Frame. It resolves the Frame's dependency tree from the given directory (inlining relative " +
+      "Publish a Frame from its source files, applying source edits to the live rendered Frame. " +
+      "A Frame's source lives on the conversation file system at " +
+      "`conversation-<conversationId>/<filename>` (mounted in the Computer at " +
+      "`/files/conversation-<conversationId>/<filename>` when the Computer is available), so " +
+      "edit it in place rather than copying it elsewhere, then call this to build it into the " +
+      "live Frame. It resolves the Frame's dependency tree from the given directory (inlining relative " +
       "imports), validates TypeScript and JSX, then updates the canonical Frame so viewers and " +
       "shares see the new version. A syntax error blocks publishing and is reported back so you " +
       "can fix it. Tailwind warnings are returned but do not block. Pass the `file_id` of the " +

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -106,7 +106,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     description:
       "Edit an existing Frame: change its code, for example to fix a chart, adjust colors, or " +
       "update text and layout. Replaces a specified text segment with new text; each edit creates " +
-      "a new version. " +
+      "a new version of the Frame. " +
       `Use the ${RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME} tool first to read the current text ` +
       "to replace. `old_string` must match the existing text exactly (including all spacing, " +
       "formatting, and line breaks), with at least 3 lines of surrounding context before and after " +

--- a/front/lib/api/actions/servers/interactive_content/tools/index.test.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.test.ts
@@ -1,5 +1,9 @@
 import type { ToolContextType } from "@app/lib/actions/types";
-import { EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import {
+  CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+} from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { createInteractiveContentTools } from "@app/lib/api/actions/servers/interactive_content/tools";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { describe, expect, it } from "vitest";
@@ -23,8 +27,8 @@ describe("createInteractiveContentTools", () => {
     const names = tools.map((tool) => tool.name);
 
     expect(names).not.toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
-    expect(names).toContain("publish_interactive_content_file");
-    expect(names).toContain("create_interactive_content_file");
+    expect(names).toContain(PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
+    expect(names).toContain(CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
   });
 
   it("keeps the file-id edit tool for legacy conversations", async () => {

--- a/front/lib/api/actions/servers/interactive_content/tools/index.test.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.test.ts
@@ -13,12 +13,15 @@ function toolContextWithUseFileSystem(
   useFileSystem: boolean | undefined
 ): ToolContextType {
   return {
-    runContext: { conversation: { metadata: { useFileSystem } } },
+    runContext: {
+      contextType: "agent_loop",
+      conversation: { metadata: { useFileSystem } },
+    },
   } as unknown as ToolContextType;
 }
 
 describe("createInteractiveContentTools", () => {
-  it("drops the file-id edit and retrieve tools when the conversation has the file system", async () => {
+  it("drops the file-id edit tool but keeps retrieve when the conversation has the file system", async () => {
     const { authenticator: auth } = await createResourceTest({});
 
     const tools = await createInteractiveContentTools(
@@ -28,7 +31,7 @@ describe("createInteractiveContentTools", () => {
     const names = tools.map((tool) => tool.name);
 
     expect(names).not.toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
-    expect(names).not.toContain(RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
+    expect(names).toContain(RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
     expect(names).toContain(PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
     expect(names).toContain(CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
   });

--- a/front/lib/api/actions/servers/interactive_content/tools/index.test.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.test.ts
@@ -3,6 +3,7 @@ import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { createInteractiveContentTools } from "@app/lib/api/actions/servers/interactive_content/tools";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -17,7 +18,7 @@ function toolContextWithUseFileSystem(
 }
 
 describe("createInteractiveContentTools", () => {
-  it("drops the file-id edit tool when the conversation has the file system", async () => {
+  it("drops the file-id edit and retrieve tools when the conversation has the file system", async () => {
     const { authenticator: auth } = await createResourceTest({});
 
     const tools = await createInteractiveContentTools(
@@ -27,30 +28,31 @@ describe("createInteractiveContentTools", () => {
     const names = tools.map((tool) => tool.name);
 
     expect(names).not.toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
+    expect(names).not.toContain(RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
     expect(names).toContain(PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
     expect(names).toContain(CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
   });
 
-  it("keeps the file-id edit tool for legacy conversations", async () => {
+  it("keeps the file-id edit and retrieve tools for legacy conversations", async () => {
     const { authenticator: auth } = await createResourceTest({});
 
     const tools = await createInteractiveContentTools(
       auth,
       toolContextWithUseFileSystem(undefined)
     );
+    const names = tools.map((tool) => tool.name);
 
-    expect(tools.map((tool) => tool.name)).toContain(
-      EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME
-    );
+    expect(names).toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
+    expect(names).toContain(RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
   });
 
-  it("keeps the file-id edit tool when no conversation is available", async () => {
+  it("keeps the file-id edit and retrieve tools when no conversation is available", async () => {
     const { authenticator: auth } = await createResourceTest({});
 
     const tools = await createInteractiveContentTools(auth, undefined);
+    const names = tools.map((tool) => tool.name);
 
-    expect(tools.map((tool) => tool.name)).toContain(
-      EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME
-    );
+    expect(names).toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
+    expect(names).toContain(RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
   });
 });

--- a/front/lib/api/actions/servers/interactive_content/tools/index.test.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.test.ts
@@ -1,0 +1,52 @@
+import type { ToolContextType } from "@app/lib/actions/types";
+import { EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import { createInteractiveContentTools } from "@app/lib/api/actions/servers/interactive_content/tools";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { describe, expect, it } from "vitest";
+
+function toolContextWithUseFileSystem(
+  useFileSystem: boolean | undefined
+): ToolContextType {
+  return {
+    runContext: { conversation: { metadata: { useFileSystem } } },
+  } as unknown as ToolContextType;
+}
+
+describe("createInteractiveContentTools", () => {
+  it("drops the file-id edit tool when the conversation has the file system", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const tools = await createInteractiveContentTools(
+      auth,
+      toolContextWithUseFileSystem(true)
+    );
+    const names = tools.map((tool) => tool.name);
+
+    expect(names).not.toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
+    expect(names).toContain("publish_interactive_content_file");
+    expect(names).toContain("create_interactive_content_file");
+  });
+
+  it("keeps the file-id edit tool for legacy conversations", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const tools = await createInteractiveContentTools(
+      auth,
+      toolContextWithUseFileSystem(undefined)
+    );
+
+    expect(tools.map((tool) => tool.name)).toContain(
+      EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+    );
+  });
+
+  it("keeps the file-id edit tool when no conversation is available", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const tools = await createInteractiveContentTools(auth, undefined);
+
+    expect(tools.map((tool) => tool.name)).toContain(
+      EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+    );
+  });
+});

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -13,6 +13,7 @@ import { buildInteractiveContentFileNotification } from "@app/lib/api/actions/se
 import {
   EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   INTERACTIVE_CONTENT_TOOLS_METADATA,
+  RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { fetchTemplateContent } from "@app/lib/api/actions/servers/interactive_content/template_utils";
 import { DustFileSystem } from "@app/lib/api/file_system";
@@ -445,16 +446,20 @@ export async function createInteractiveContentTools(
 
   const tools = buildTools(INTERACTIVE_CONTENT_TOOLS_METADATA, handlers);
 
-  // Deprecated in favor of editing the Frame's mounted source by path with the files
-  // server, then publishing. Conversations without the file system (created before it
-  // defaulted on) have no path tools, so they keep the file-id edit tool.
+  // Deprecated in favor of reading and editing the Frame's mounted source by path with the
+  // files server, then publishing. The file-id retrieve tool is not just redundant with the
+  // path tools: it reads the canonical original, which only refreshes on publish, so it shows
+  // stale content while unpublished source edits sit on the mount. Conversations without the
+  // file system (created before it defaulted on) have no path tools, so they keep both.
   const conversation =
     toolContext?.runContext?.conversation ??
     toolContext?.listToolsContext?.conversation;
   if (conversation?.metadata?.useFileSystem === true) {
-    return tools.filter(
-      (tool) => tool.name !== EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME
-    );
+    const legacyFileIdToolNames: string[] = [
+      EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+      RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+    ];
+    return tools.filter((tool) => !legacyFileIdToolNames.includes(tool.name));
   }
 
   return tools;

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -10,7 +10,10 @@ import {
   type ToolContextType,
 } from "@app/lib/actions/types";
 import { buildInteractiveContentFileNotification } from "@app/lib/api/actions/servers/interactive_content/helpers";
-import { INTERACTIVE_CONTENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import {
+  EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  INTERACTIVE_CONTENT_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { fetchTemplateContent } from "@app/lib/api/actions/servers/interactive_content/template_utils";
 import { DustFileSystem } from "@app/lib/api/file_system";
 import {
@@ -440,5 +443,19 @@ export async function createInteractiveContentTools(
     },
   };
 
-  return buildTools(INTERACTIVE_CONTENT_TOOLS_METADATA, handlers);
+  const tools = buildTools(INTERACTIVE_CONTENT_TOOLS_METADATA, handlers);
+
+  // Deprecated in favor of editing the Frame's mounted source by path with the files
+  // server, then publishing. Conversations without the file system (created before it
+  // defaulted on) have no path tools, so they keep the file-id edit tool.
+  const conversation =
+    toolContext?.runContext?.conversation ??
+    toolContext?.listToolsContext?.conversation;
+  if (conversation?.metadata?.useFileSystem === true) {
+    return tools.filter(
+      (tool) => tool.name !== EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+    );
+  }
+
+  return tools;
 }

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -13,7 +13,6 @@ import { buildInteractiveContentFileNotification } from "@app/lib/api/actions/se
 import {
   EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   INTERACTIVE_CONTENT_TOOLS_METADATA,
-  RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { fetchTemplateContent } from "@app/lib/api/actions/servers/interactive_content/template_utils";
 import { DustFileSystem } from "@app/lib/api/file_system";
@@ -446,20 +445,24 @@ export async function createInteractiveContentTools(
 
   const tools = buildTools(INTERACTIVE_CONTENT_TOOLS_METADATA, handlers);
 
-  // Deprecated in favor of reading and editing the Frame's mounted source by path with the
-  // files server, then publishing. The file-id retrieve tool is not just redundant with the
-  // path tools: it reads the canonical original, which only refreshes on publish, so it shows
-  // stale content while unpublished source edits sit on the mount. Conversations without the
-  // file system (created before it defaulted on) have no path tools, so they keep both.
-  const conversation =
-    toolContext?.runContext?.conversation ??
-    toolContext?.listToolsContext?.conversation;
+  // The file-id edit tool is deprecated in favor of editing the Frame's mounted source by path
+  // with the files server, then publishing. Conversations without the file system (created
+  // before it defaulted on) have no path tools, so they keep it.
+  //
+  // The file-id retrieve tool stays everywhere, including file-system conversations: unlike
+  // edit, it reads the canonical original directly by FileResource id rather than through the
+  // mount, so it still works for a Frame whose mountFilePath hasn't been resolved (e.g. one
+  // predating the mount system that has not gone through the backfill). The path-based files
+  // tools have no fallback for that case (files.resolve and the mount read both require
+  // mountFilePath to be set), so removing retrieve would leave such a Frame unreadable.
+  const { runContext } = toolContext ?? {};
+  const conversation = isAgentLoopRunContext(runContext)
+    ? runContext.conversation
+    : toolContext?.listToolsContext?.conversation;
   if (conversation?.metadata?.useFileSystem === true) {
-    const legacyFileIdToolNames: string[] = [
-      EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
-      RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
-    ];
-    return tools.filter((tool) => !legacyFileIdToolNames.includes(tool.name));
+    return tools.filter(
+      (tool) => tool.name !== EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+    );
   }
 
   return tools;

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -1146,7 +1146,7 @@ describe("FileResource", () => {
     // revert() reads versions and refreshes the mount entirely through getPrivateUploadBucket(),
     // which fileStorageMock already stubs globally (see tests/utils/mocks/file_storage.ts).
     // setSortedFileVersions/setCopyFileFails drive it without reaching into FileResource's
-    // private methods; fileStorageMock.reset() (global beforeEach) clears both between tests.
+    // private methods. fileStorageMock.reset() (global beforeEach) clears both between tests.
     function mockVersion(): MockFileVersion {
       return {
         copy: vi.fn().mockResolvedValue(undefined),

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -21,8 +21,17 @@ import {
   isUnverifiableFrameFileRefsShareError,
   sandboxFunctionContentType,
 } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
 import { Readable } from "stream";
-import { assert, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  assert,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 // Mock copyContent from utils/files.ts
 vi.mock("@app/lib/utils/files", () => ({
@@ -1137,6 +1146,118 @@ describe("FileResource", () => {
 
       // Only canonical write, no mount path write.
       expect(allUploadCalls).toHaveLength(1);
+    });
+  });
+
+  describe("revert", () => {
+    // revert() reads versions and refreshes the mount entirely through the storage object
+    // returned by getPrivateUploadBucket(), so stubbing that call covers both the version
+    // listing (getSortedFileVersions) and the mount refresh (copyFile) without reaching into
+    // FileResource's private methods. Restore the default implementation afterwards: other
+    // describe blocks in this file rely on it and only clear call history, not implementations.
+    const defaultUploadBucketImpl = vi
+      .mocked(getPrivateUploadBucket)
+      .getMockImplementation();
+
+    afterEach(() => {
+      vi.mocked(getPrivateUploadBucket).mockImplementation(
+        defaultUploadBucketImpl!
+      );
+    });
+
+    function mockVersion() {
+      return {
+        copy: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+      };
+    }
+
+    function mockStorageForRevert({
+      copyFile,
+    }: {
+      copyFile: ReturnType<typeof vi.fn>;
+    }) {
+      return {
+        file: vi.fn(() => ({ delete: vi.fn().mockResolvedValue(undefined) })),
+        copyFile,
+        getSortedFileVersions: vi
+          .fn()
+          .mockResolvedValue(new Ok([mockVersion(), mockVersion()])),
+      } as unknown as ReturnType<typeof getPrivateUploadBucket>;
+    }
+
+    it("refreshes the mount copy from the restored canonical version", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const frameFile = await FileFactory.create(auth, null, {
+        contentType: frameContentType,
+        fileName: "frame.html",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "conv-revert" },
+      });
+
+      const row = await FileModel.findOne({
+        where: { id: frameFile.id, workspaceId: workspace.id },
+      });
+      assert(row?.mountFilePath, "Mount path should be set");
+
+      const copyFile = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(getPrivateUploadBucket).mockImplementation(() =>
+        mockStorageForRevert({ copyFile })
+      );
+
+      const result = await frameFile.revert(auth, {
+        revertedByAgentConfigurationId: "agent-1",
+      });
+
+      expect(result.isOk()).toBe(true);
+      // The mount copy must be refreshed to the restored canonical version, so reads through
+      // the mount and the next publish see the reverted content rather than the stale mount.
+      expect(copyFile).toHaveBeenCalledWith(
+        expect.any(String),
+        row.mountFilePath
+      );
+    });
+
+    it("still succeeds when refreshing the mount copy fails", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const frameFile = await FileFactory.create(auth, null, {
+        contentType: frameContentType,
+        fileName: "frame.html",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "conv-revert-fail" },
+      });
+
+      // The restore copy succeeds (the version object's own .copy() call), but the mount
+      // refresh's copyFile() call fails. Best-effort: the revert must not fail because of it,
+      // since the canonical restore already succeeded by that point. setUseCaseMetadata
+      // (called earlier in revert(), unrelated to this fix) also refreshes the mount as a
+      // side effect, so only the call after the restore should fail.
+      let copyFileCallCount = 0;
+      const copyFile = vi.fn().mockImplementation(() => {
+        copyFileCallCount += 1;
+        return copyFileCallCount === 1
+          ? Promise.resolve(undefined)
+          : Promise.reject(new Error("simulated failure"));
+      });
+      vi.mocked(getPrivateUploadBucket).mockImplementation(() =>
+        mockStorageForRevert({ copyFile })
+      );
+
+      const result = await frameFile.revert(auth, {
+        revertedByAgentConfigurationId: "agent-1",
+      });
+
+      expect(result.isOk()).toBe(true);
     });
   });
 

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -13,6 +13,8 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import type { MockFileVersion } from "@app/tests/utils/mocks/file_storage";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -21,17 +23,8 @@ import {
   isUnverifiableFrameFileRefsShareError,
   sandboxFunctionContentType,
 } from "@app/types/files";
-import { Ok } from "@app/types/shared/result";
 import { Readable } from "stream";
-import {
-  afterEach,
-  assert,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock copyContent from utils/files.ts
 vi.mock("@app/lib/utils/files", () => ({
@@ -1150,40 +1143,15 @@ describe("FileResource", () => {
   });
 
   describe("revert", () => {
-    // revert() reads versions and refreshes the mount entirely through the storage object
-    // returned by getPrivateUploadBucket(), so stubbing that call covers both the version
-    // listing (getSortedFileVersions) and the mount refresh (copyFile) without reaching into
-    // FileResource's private methods. Restore the default implementation afterwards: other
-    // describe blocks in this file rely on it and only clear call history, not implementations.
-    const defaultUploadBucketImpl = vi
-      .mocked(getPrivateUploadBucket)
-      .getMockImplementation();
-
-    afterEach(() => {
-      vi.mocked(getPrivateUploadBucket).mockImplementation(
-        defaultUploadBucketImpl!
-      );
-    });
-
-    function mockVersion() {
+    // revert() reads versions and refreshes the mount entirely through getPrivateUploadBucket(),
+    // which fileStorageMock already stubs globally (see tests/utils/mocks/file_storage.ts).
+    // setSortedFileVersions/setCopyFileFails drive it without reaching into FileResource's
+    // private methods; fileStorageMock.reset() (global beforeEach) clears both between tests.
+    function mockVersion(): MockFileVersion {
       return {
         copy: vi.fn().mockResolvedValue(undefined),
         delete: vi.fn().mockResolvedValue(undefined),
       };
-    }
-
-    function mockStorageForRevert({
-      copyFile,
-    }: {
-      copyFile: ReturnType<typeof vi.fn>;
-    }) {
-      return {
-        file: vi.fn(() => ({ delete: vi.fn().mockResolvedValue(undefined) })),
-        copyFile,
-        getSortedFileVersions: vi
-          .fn()
-          .mockResolvedValue(new Ok([mockVersion(), mockVersion()])),
-      } as unknown as ReturnType<typeof getPrivateUploadBucket>;
     }
 
     it("refreshes the mount copy from the restored canonical version", async () => {
@@ -1205,22 +1173,28 @@ describe("FileResource", () => {
       });
       assert(row?.mountFilePath, "Mount path should be set");
 
-      const copyFile = vi.fn().mockResolvedValue(undefined);
-      vi.mocked(getPrivateUploadBucket).mockImplementation(() =>
-        mockStorageForRevert({ copyFile })
-      );
+      fileStorageMock.setSortedFileVersions(() => [
+        mockVersion(),
+        mockVersion(),
+      ]);
 
       const result = await frameFile.revert(auth, {
         revertedByAgentConfigurationId: "agent-1",
       });
 
       expect(result.isOk()).toBe(true);
+
+      const allCopyFileCalls = vi
+        .mocked(getPrivateUploadBucket)
+        .mock.results.flatMap((r) =>
+          r.type === "return" ? vi.mocked(r.value.copyFile).mock.calls : []
+        );
+
       // The mount copy must be refreshed to the restored canonical version, so reads through
       // the mount and the next publish see the reverted content rather than the stale mount.
-      expect(copyFile).toHaveBeenCalledWith(
-        expect.any(String),
-        row.mountFilePath
-      );
+      expect(
+        allCopyFileCalls.some((call) => call[1] === row.mountFilePath)
+      ).toBe(true);
     });
 
     it("still succeeds when refreshing the mount copy fails", async () => {
@@ -1237,21 +1211,21 @@ describe("FileResource", () => {
         useCaseMetadata: { conversationId: "conv-revert-fail" },
       });
 
+      fileStorageMock.setSortedFileVersions(() => [
+        mockVersion(),
+        mockVersion(),
+      ]);
+
       // The restore copy succeeds (the version object's own .copy() call), but the mount
       // refresh's copyFile() call fails. Best-effort: the revert must not fail because of it,
       // since the canonical restore already succeeded by that point. setUseCaseMetadata
       // (called earlier in revert(), unrelated to this fix) also refreshes the mount as a
       // side effect, so only the call after the restore should fail.
       let copyFileCallCount = 0;
-      const copyFile = vi.fn().mockImplementation(() => {
+      fileStorageMock.setCopyFileFails(() => {
         copyFileCallCount += 1;
-        return copyFileCallCount === 1
-          ? Promise.resolve(undefined)
-          : Promise.reject(new Error("simulated failure"));
+        return copyFileCallCount > 1;
       });
-      vi.mocked(getPrivateUploadBucket).mockImplementation(() =>
-        mockStorageForRevert({ copyFile })
-      );
 
       const result = await frameFile.revert(auth, {
         revertedByAgentConfigurationId: "agent-1",

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -877,6 +877,24 @@ export class FileResource extends BaseResource<FileModel> {
       );
     }
 
+    // Keep the mount in sync with the restored canonical version. Frame edits write to the
+    // mount, so leaving it stale would make the revert invisible to source reads and resurrect
+    // the reverted content on the next publish. Best-effort like the version cleanup below:
+    // the restore copy above already created a new canonical generation, so failing the revert
+    // here would leave a state where retrying it restores the reverted-away content.
+    try {
+      await this.copyMountFiles(auth);
+    } catch (error) {
+      logger.error(
+        {
+          fileId: this.sId,
+          workspaceId: this.workspaceId,
+          error: normalizeError(error),
+        },
+        "Failed to refresh the mount copy after revert, source reads and publish may see stale content"
+      );
+    }
+
     // Delete old versions to prevent accumulation and infinite loops
     try {
       // Decrement version after deletion to ensure version counter only changes on success

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -1,3 +1,13 @@
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import {
+  FILES_EDIT_ACTION_NAME,
+  FILES_SERVER_NAME,
+} from "@app/lib/api/actions/servers/files/metadata";
+import {
+  EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+} from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { framesSkill } from "@app/lib/resources/skill/code_defined/global/frames";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -9,6 +19,11 @@ const COMPUTER_FIRST_MARKER =
   "mounted in the Computer at `/files/conversation-";
 const FILES_FIRST_MARKER =
   "available to your file tools at `conversation-<conversationId>";
+
+const FILES_EDIT_TOOL = getPrefixedToolName(
+  FILES_SERVER_NAME,
+  FILES_EDIT_ACTION_NAME
+);
 
 function agentLoopDataWithUseFileSystem(
   useFileSystem: boolean | undefined
@@ -27,8 +42,8 @@ describe("framesSkill.fetchInstructions", () => {
     });
 
     expect(instructions).toContain(COMPUTER_FIRST_MARKER);
-    expect(instructions).toContain("publish_interactive_content_file");
-    expect(instructions).not.toContain("edit_interactive_content_file");
+    expect(instructions).toContain(PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
+    expect(instructions).not.toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
   });
 
   it("teaches the files-tools flow when the Computer is disabled", async () => {
@@ -41,9 +56,9 @@ describe("framesSkill.fetchInstructions", () => {
 
     expect(instructions).not.toContain(COMPUTER_FIRST_MARKER);
     expect(instructions).toContain(FILES_FIRST_MARKER);
-    expect(instructions).toContain("files__edit");
-    expect(instructions).toContain("publish_interactive_content_file");
-    expect(instructions).not.toContain("edit_interactive_content_file");
+    expect(instructions).toContain(FILES_EDIT_TOOL);
+    expect(instructions).toContain(PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
+    expect(instructions).not.toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
   });
 
   it("keeps the retrieve and file-id edit flow for legacy conversations", async () => {
@@ -56,8 +71,8 @@ describe("framesSkill.fetchInstructions", () => {
 
     expect(instructions).not.toContain(COMPUTER_FIRST_MARKER);
     expect(instructions).not.toContain(FILES_FIRST_MARKER);
-    expect(instructions).toContain("edit_interactive_content_file");
-    expect(instructions).toContain("retrieve_interactive_content_file");
+    expect(instructions).toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
+    expect(instructions).toContain(RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
   });
 
   it("treats a conversation with the file system like a new conversation", async () => {
@@ -69,6 +84,6 @@ describe("framesSkill.fetchInstructions", () => {
     });
 
     expect(instructions).toContain(COMPUTER_FIRST_MARKER);
-    expect(instructions).not.toContain("edit_interactive_content_file");
+    expect(instructions).not.toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
   });
 });

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -44,6 +44,9 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain(COMPUTER_FIRST_MARKER);
     expect(instructions).toContain(PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
     expect(instructions).not.toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
+    expect(instructions).not.toContain(
+      RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+    );
   });
 
   it("teaches the files-tools flow when the Computer is disabled", async () => {
@@ -59,6 +62,9 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain(FILES_EDIT_TOOL);
     expect(instructions).toContain(PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
     expect(instructions).not.toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
+    expect(instructions).not.toContain(
+      RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+    );
   });
 
   it("keeps the retrieve and file-id edit flow for legacy conversations", async () => {

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -1,10 +1,22 @@
 import { framesSkill } from "@app/lib/resources/skill/code_defined/global/frames";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { describe, expect, it } from "vitest";
 
-// Marker only present in the computer-first variant of the Frames instructions.
-const COMPUTER_FIRST_MARKER = "preferred: edit in the Computer";
+// Markers unique to each variant of the updating section.
+const COMPUTER_FIRST_MARKER =
+  "mounted in the Computer at `/files/conversation-";
+const FILES_FIRST_MARKER =
+  "available to your file tools at `conversation-<conversationId>";
+
+function agentLoopDataWithUseFileSystem(
+  useFileSystem: boolean | undefined
+): AgentLoopExecutionData {
+  return {
+    conversation: { metadata: { useFileSystem } },
+  } as unknown as AgentLoopExecutionData;
+}
 
 describe("framesSkill.fetchInstructions", () => {
   it("teaches the computer-first flow when the Computer is enabled", async () => {
@@ -15,13 +27,11 @@ describe("framesSkill.fetchInstructions", () => {
     });
 
     expect(instructions).toContain(COMPUTER_FIRST_MARKER);
-    expect(instructions).toContain(
-      "/files/conversation-<conversationId>/<FrameName>.tsx"
-    );
     expect(instructions).toContain("publish_interactive_content_file");
+    expect(instructions).not.toContain("edit_interactive_content_file");
   });
 
-  it("falls back to the retrieve and edit flow when the Computer is disabled", async () => {
+  it("teaches the files-tools flow when the Computer is disabled", async () => {
     const { authenticator: auth } = await createResourceTest({});
     await FeatureFlagFactory.basic(auth, "disable_computer_feature");
 
@@ -30,6 +40,35 @@ describe("framesSkill.fetchInstructions", () => {
     });
 
     expect(instructions).not.toContain(COMPUTER_FIRST_MARKER);
-    expect(instructions).toContain("### Updating Existing Files:");
+    expect(instructions).toContain(FILES_FIRST_MARKER);
+    expect(instructions).toContain("files__edit");
+    expect(instructions).toContain("publish_interactive_content_file");
+    expect(instructions).not.toContain("edit_interactive_content_file");
+  });
+
+  it("keeps the retrieve and file-id edit flow for legacy conversations", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const instructions = await framesSkill.fetchInstructions(auth, {
+      spaceIds: [],
+      agentLoopData: agentLoopDataWithUseFileSystem(false),
+    });
+
+    expect(instructions).not.toContain(COMPUTER_FIRST_MARKER);
+    expect(instructions).not.toContain(FILES_FIRST_MARKER);
+    expect(instructions).toContain("edit_interactive_content_file");
+    expect(instructions).toContain("retrieve_interactive_content_file");
+  });
+
+  it("treats a conversation with the file system like a new conversation", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const instructions = await framesSkill.fetchInstructions(auth, {
+      spaceIds: [],
+      agentLoopData: agentLoopDataWithUseFileSystem(true),
+    });
+
+    expect(instructions).toContain(COMPUTER_FIRST_MARKER);
+    expect(instructions).not.toContain("edit_interactive_content_file");
   });
 });

--- a/front/lib/resources/skill/code_defined/global/frames.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.ts
@@ -1,6 +1,7 @@
 import {
   INTERACTIVE_CONTENT_INSTRUCTIONS,
   INTERACTIVE_CONTENT_INSTRUCTIONS_COMPUTER_FIRST,
+  INTERACTIVE_CONTENT_INSTRUCTIONS_FILES_FIRST,
 } from "@app/lib/api/actions/servers/interactive_content/instructions";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -22,17 +23,23 @@ export const framesSkill = {
     "using when tsx or React code is shared or available in the conversation. " +
     "Frames used to a be a tool, now deprecated. Use this skill when the Frames/interactive " +
     "content tool is mentioned.",
-  // Computer-first guidance (edit the mounted source in place, then publish) is taught only when
-  // the Computer is available. Otherwise the model updates Frames through the retrieve and edit
-  // tools.
+  // Edit-the-source-then-publish guidance requires the conversation file system, which exposes
+  // the Frame's source by path. Legacy conversations (created before the file system defaulted
+  // on) keep the retrieve and file-id edit flow. Without a conversation at hand, assume the
+  // file system is on since every new conversation has it.
   fetchInstructions: async (
     auth: Authenticator,
-    _params: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
+    params: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
   ) => {
+    const conversation = params.agentLoopData?.conversation;
+    if (conversation && conversation.metadata?.useFileSystem !== true) {
+      return INTERACTIVE_CONTENT_INSTRUCTIONS;
+    }
+
     const flags = await getFeatureFlags(auth);
     return isComputerFeatureEnabled(flags)
       ? INTERACTIVE_CONTENT_INSTRUCTIONS_COMPUTER_FIRST
-      : INTERACTIVE_CONTENT_INSTRUCTIONS;
+      : INTERACTIVE_CONTENT_INSTRUCTIONS_FILES_FIRST;
   },
   mcpServers: [{ name: "interactive_content" }],
   version: 3,

--- a/front/lib/resources/skill/code_defined/global/frames.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.ts
@@ -18,11 +18,12 @@ export const framesSkill = {
     " and share. Living documents that adapt to different stakeholders.",
   agentFacingDescription:
     "Create interactive visualizations, charts, dashboards, and presentations as executable React " +
-    "components. These visualizations are typically called 'Frames' or 'Dust Frames' and can be " +
+    "components, and update existing ones (fix a chart, change data, colors, text, or layout). " +
+    "These visualizations are typically called 'Frames' or 'Dust Frames' and can be " +
     "used in various contexts: daily digests, data analytics, sales reports, and more. Consider " +
     "using when tsx or React code is shared or available in the conversation. " +
-    "Frames used to a be a tool, now deprecated. Use this skill when the Frames/interactive " +
-    "content tool is mentioned.",
+    "Frames used to be a tool, now deprecated. Use this skill when the Frames/interactive " +
+    "content tool is mentioned, and whenever asked to modify an existing Frame.",
   // Edit-the-source-then-publish guidance requires the conversation file system, which exposes
   // the Frame's source by path. Legacy conversations (created before the file system defaulted
   // on) keep the retrieve and file-id edit flow. Without a conversation at hand, assume the

--- a/front/scripts/backfill_frame_mount_paths.ts
+++ b/front/scripts/backfill_frame_mount_paths.ts
@@ -1,0 +1,129 @@
+import { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FileModel } from "@app/lib/resources/storage/models/files";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { frameContentType, frameSlideshowContentType } from "@app/types/files";
+import { Op } from "sequelize";
+
+const BATCH_SIZE_DEFAULT = 200;
+const CONCURRENCY_DEFAULT = 4;
+
+// Frames created before the mount dual-write (2026-03-10) have no mount path, so the
+// path-based edit and publish flow cannot reach their source. ensureMountFilePath claims
+// the mount path and copies the canonical original to it.
+makeScript(
+  {
+    wId: {
+      type: "string",
+      describe: "Workspace sId to backfill (omit to run on all workspaces).",
+    },
+    fromWorkspaceModelId: {
+      type: "number",
+      describe:
+        "Skip workspaces with model id below this value (for resuming).",
+    },
+    batchSize: {
+      type: "number",
+      default: BATCH_SIZE_DEFAULT,
+      describe: "Number of files to fetch per DB query.",
+    },
+    concurrency: {
+      type: "number",
+      default: CONCURRENCY_DEFAULT,
+      describe: "Concurrent file mount-path resolutions per batch.",
+    },
+  },
+  async (
+    { execute, wId, fromWorkspaceModelId, batchSize, concurrency },
+    logger
+  ) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const workspaceId = workspace.sId;
+
+        const auth =
+          await Authenticator.internalBuilderForWorkspace(workspaceId);
+
+        logger.info(
+          { workspaceId, execute },
+          "[backfill_frame_mount_paths] Starting workspace"
+        );
+
+        let lastId = 0;
+        let totalProcessed = 0;
+        let totalUpdated = 0;
+
+        while (true) {
+          const rows = await FileModel.findAll({
+            attributes: ["id"],
+            where: {
+              workspaceId: workspace.id,
+              contentType: {
+                [Op.in]: [frameContentType, frameSlideshowContentType],
+              },
+              mountFilePath: null,
+              id: { [Op.gt]: lastId },
+            },
+            order: [["id", "ASC"]],
+            limit: batchSize,
+          });
+
+          if (rows.length === 0) {
+            break;
+          }
+
+          lastId = rows[rows.length - 1].id;
+
+          const files = await FileResource.fetchByModelIdsWithAuth(
+            auth,
+            rows.map((r) => r.id)
+          );
+
+          await concurrentExecutor(
+            files,
+            async (file) => {
+              totalProcessed++;
+
+              // Skip files that can't be mounted (no conversation in their metadata).
+              if (!file.useCaseMetadata?.conversationId) {
+                return;
+              }
+
+              if (!execute) {
+                logger.info(
+                  {
+                    fileId: file.sId,
+                    fileName: file.fileName,
+                    conversationId: file.useCaseMetadata.conversationId,
+                  },
+                  "[backfill_frame_mount_paths] Would set mount path (dry-run)"
+                );
+                totalUpdated++;
+                return;
+              }
+
+              try {
+                await file.ensureMountFilePath(auth);
+                totalUpdated++;
+              } catch (err) {
+                logger.error(
+                  { err, fileId: file.sId },
+                  "[backfill_frame_mount_paths] Failed to set mount path"
+                );
+              }
+            },
+            { concurrency }
+          );
+        }
+
+        logger.info(
+          { workspaceId, totalProcessed, totalUpdated, execute },
+          "[backfill_frame_mount_paths] Workspace done"
+        );
+      },
+      { wId, fromWorkspaceId: fromWorkspaceModelId }
+    );
+  }
+);

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -13,8 +13,8 @@ export interface SaveFileCall {
   contentType: string | undefined;
 }
 
-// Minimal duck-typed stand-in for the GCS `File` objects `getSortedFileVersions` resolves to;
-// callers (e.g. FileResource.revert()) only ever call `.copy(dest)` and `.delete()` on them.
+// Minimal duck-typed stand-in for the GCS `File` objects `getSortedFileVersions` resolves to.
+// Callers (e.g. FileResource.revert()) only ever call `.copy(dest)` and `.delete()` on them.
 export interface MockFileVersion {
   copy: (dest: unknown) => Promise<void>;
   delete: () => Promise<void>;

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -1,3 +1,4 @@
+import { Ok } from "@app/types/shared/result";
 import { PassThrough, Readable } from "stream";
 import { vi } from "vitest";
 
@@ -10,6 +11,13 @@ export interface SaveFileCall {
   filePath: string;
   content: Buffer | string;
   contentType: string | undefined;
+}
+
+// Minimal duck-typed stand-in for the GCS `File` objects `getSortedFileVersions` resolves to;
+// callers (e.g. FileResource.revert()) only ever call `.copy(dest)` and `.delete()` on them.
+export interface MockFileVersion {
+  copy: (dest: unknown) => Promise<void>;
+  delete: () => Promise<void>;
 }
 
 /**
@@ -32,6 +40,10 @@ class FileStorageMock {
     filePath: string
   ) => { contentType: string; size: string } | null = () => null;
   private _contentForPath: (filePath: string) => string | null = () => null;
+  private _sortedFileVersions: (filePath: string) => MockFileVersion[] | null =
+    () => null;
+  private _copyFileShouldFail: (src: string, dest: string) => boolean = () =>
+    false;
 
   get writeStreamCalls(): readonly WriteStreamCall[] {
     return this._writeStreamCalls;
@@ -76,6 +88,25 @@ class FileStorageMock {
     this._contentForPath = fn;
   }
 
+  /**
+   * Controls what `bucket.getSortedFileVersions({ filePath })` resolves to (newest first),
+   * keyed by the file path. Return null (the default) to resolve an empty list, matching "no
+   * previous version available". Reset between tests via `reset()`.
+   */
+  setSortedFileVersions(
+    fn: (filePath: string) => MockFileVersion[] | null
+  ): void {
+    this._sortedFileVersions = fn;
+  }
+
+  /**
+   * Makes `bucket.copyFile(src, dest)` reject for (src, dest) pairs matching the predicate.
+   * Defaults to never failing. Reset between tests via `reset()`.
+   */
+  setCopyFileFails(predicate: (src: string, dest: string) => boolean): void {
+    this._copyFileShouldFail = predicate;
+  }
+
   reset(): void {
     this._writeStreamCalls.length = 0;
     this._saveFileCalls.length = 0;
@@ -83,6 +114,8 @@ class FileStorageMock {
     this._saveShouldFail = () => false;
     this._metadataForPath = () => null;
     this._contentForPath = () => null;
+    this._sortedFileVersions = () => null;
+    this._copyFileShouldFail = () => false;
   }
 
   /**
@@ -186,9 +219,19 @@ class FileStorageMock {
         .mockResolvedValue(undefined),
       fetchFileContent: vi.fn().mockResolvedValue("mock content"),
       fetchFileBuffer: vi.fn().mockResolvedValue(new Uint8Array()),
-      copyFile: vi.fn().mockResolvedValue(undefined),
+      copyFile: vi.fn((src: string, dest: string) => {
+        if (this._copyFileShouldFail(src, dest)) {
+          return Promise.reject(
+            new Error(`Simulated GCS copy failure: ${src} -> ${dest}`)
+          );
+        }
+        return Promise.resolve(undefined);
+      }),
       delete: vi.fn().mockResolvedValue(undefined),
       deleteFiles: vi.fn().mockResolvedValue(undefined),
+      getSortedFileVersions: vi.fn(({ filePath }: { filePath: string }) =>
+        Promise.resolve(new Ok(this._sortedFileVersions(filePath) ?? []))
+      ),
     };
   }
 }


### PR DESCRIPTION
## Description

Frames are now updated by editing their source files by path and publishing. This deprecates the tool that edits a Frame through its file id: conversations with the conversation file system no longer expose it, while conversations created before the file system defaulted on keep it since they have no path-based alternative. The tool that reads a Frame's content by file id stays available everywhere, though: it reads the canonical file directly rather than through the mount, so it remains the only way to reach a Frame whose mount path hasn't been resolved yet, such as one created before the mount system existed and not yet covered by the backfill below.

The Frames skill instructions teach the new flow. With the Computer available the model edits the mounted source, without it the model edits through the files tools, and legacy conversations keep the retrieve-then-edit guidance. Across all three, the instructions and the relevant tool descriptions now also steer the model away from recreating a Frame it was only asked to change, since doing so loses the Frame's identity and share URL and burns tokens regenerating content that didn't need to change.

The rejection message shown when another tool touches a Frame file now points at the source-edit and publish flow as well.

A backfill script gives Frames created before the mount dual-write a mount path by copying their canonical content, so publishing and path-based editing work for them too.

Reverting a Frame now also refreshes its mount copy from the restored version, so the revert is visible to a source read and isn't silently undone by the next publish. This refresh is best-effort: a failure here still lets the revert succeed and is only logged, since the canonical restore has already happened by that point.

## Risk

Low. Agents in file-system conversations lose the file-id edit tool on deploy; the toolset is recomputed at each step and the updated instructions and rejection messages redirect to the source-edit and publish flow. The file-id read tool is unaffected everywhere, and legacy conversations are unaffected. The revert mount refresh is a data-integrity fix with no change to revert's success or failure contract.

## Deploy Plan

Deploy front, then run the backfill script (dry run first, then with execute).