### PR TITLE
fix(front): focus composer when clicking "New" on the home page

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -665,16 +665,16 @@ export function AgentSidebarMenu({
 
   const handleNewClick = useCallback(async () => {
     setSidebarOpen(false);
-    const { cId } = router.query;
+    // Already on the new-conversation page: clicking "New" doesn't navigate, so
+    // the input bar isn't remounted and mount-time autofocus won't run. Request
+    // an explicit refocus instead. (activeConversationId is null on "new".)
     const isNewConversation =
-      (router.pathname === "/w/[wId]/conversation/[cId]" ||
-        router.pathname.match(/^\/w\/[^/]+\/conversation\/[^/]+$/)) &&
-      typeof cId === "string" &&
-      cId === "new";
+      router.pathname.match(/^\/w\/[^/]+\/conversation\/[^/]+$/) !== null &&
+      activeConversationId === null;
     if (isNewConversation) {
       setAnimate(true);
     }
-  }, [setSidebarOpen, router, setAnimate]);
+  }, [setSidebarOpen, router, activeConversationId, setAnimate]);
 
   const hasTriggeredConversations = useMemo(
     () =>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -661,7 +661,7 @@ export function AgentSidebarMenu({
     setShowDeleteDialog(null);
   }, [conversations, doDelete, sendNotification]);
 
-  const { setAnimate } = useContext(InputBarContext);
+  const { setShouldFocusInput } = useContext(InputBarContext);
 
   const handleNewClick = useCallback(async () => {
     setSidebarOpen(false);
@@ -672,9 +672,9 @@ export function AgentSidebarMenu({
       router.pathname.match(/^\/w\/[^/]+\/conversation\/[^/]+$/) !== null &&
       activeConversationId === null;
     if (isNewConversation) {
-      setAnimate(true);
+      setShouldFocusInput(true);
     }
-  }, [setSidebarOpen, router, activeConversationId, setAnimate]);
+  }, [setSidebarOpen, router, activeConversationId, setShouldFocusInput]);
 
   const hasTriggeredConversations = useMemo(
     () =>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1130,9 +1130,10 @@ const InputBarContainer = ({
     isSpacesLoading,
   ]);
 
-  // When input bar animation is requested, it means the new button was clicked (removing focus from
-  // the input bar), we grab it back.
-  const { animate, setAnimate, captureActions } = useContext(InputBarContext);
+  // When an input bar refocus is requested (e.g. the "New" button was clicked, removing focus from
+  // the input bar), we grab focus back.
+  const { shouldFocusInput, setShouldFocusInput, captureActions } =
+    useContext(InputBarContext);
 
   const handleSingleAgentSelect = useCallback(
     (mention: RichMention) => {
@@ -1180,14 +1181,14 @@ const InputBarContainer = ({
   }, [captureActions, disableInput, fileUploaderService.isProcessingFiles]);
 
   useEffect(() => {
-    if (animate) {
+    if (shouldFocusInput) {
       // Schedule focus to avoid flushing during render lifecycle.
       queueMicrotask(() => editorService.focusEnd());
       // Consume the flag so a later request (e.g. clicking "New" again) re-runs
       // this effect instead of being swallowed as a no-op state update.
-      setAnimate(false);
+      setShouldFocusInput(false);
     }
-  }, [animate, editorService, setAnimate]);
+  }, [shouldFocusInput, editorService, setShouldFocusInput]);
 
   // Focus the input bar when the extension panel is opened (content-script sidebar or Front iframe).
   // Not gated by disableAutoFocus: that flag prevents autofocus on mount (to avoid mobile keyboard

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1132,7 +1132,7 @@ const InputBarContainer = ({
 
   // When input bar animation is requested, it means the new button was clicked (removing focus from
   // the input bar), we grab it back.
-  const { animate, captureActions } = useContext(InputBarContext);
+  const { animate, setAnimate, captureActions } = useContext(InputBarContext);
 
   const handleSingleAgentSelect = useCallback(
     (mention: RichMention) => {
@@ -1183,8 +1183,11 @@ const InputBarContainer = ({
     if (animate) {
       // Schedule focus to avoid flushing during render lifecycle.
       queueMicrotask(() => editorService.focusEnd());
+      // Consume the flag so a later request (e.g. clicking "New" again) re-runs
+      // this effect instead of being swallowed as a no-op state update.
+      setAnimate(false);
     }
-  }, [animate, editorService]);
+  }, [animate, editorService, setAnimate]);
 
   // Focus the input bar when the extension panel is opened (content-script sidebar or Front iframe).
   // Not gated by disableAutoFocus: that flag prevents autofocus on mount (to avoid mobile keyboard

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -38,9 +38,9 @@ type CaptureActions = {
 };
 
 export const InputBarContext = createContext<{
-  animate: boolean;
+  shouldFocusInput: boolean;
   getAndClearSelectedAgent: () => RichAgentMention | null;
-  setAnimate: React.Dispatch<React.SetStateAction<boolean>>;
+  setShouldFocusInput: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
   selectedSingleAgent: RichAgentMention | null;
   setSelectedSingleAgent: (agentMention: RichAgentMention | null) => void;
@@ -62,9 +62,9 @@ export const InputBarContext = createContext<{
   fileUploaderService: FileUploaderService;
   captureActions?: CaptureActions;
 }>({
-  animate: false,
+  shouldFocusInput: false,
   getAndClearSelectedAgent: () => null,
-  setAnimate: () => {},
+  setShouldFocusInput: () => {},
   setSelectedAgent: () => {},
   selectedSingleAgent: null,
   setSelectedSingleAgent: () => {},
@@ -99,7 +99,7 @@ export function InputBarContextProvider({
   fileUploaderService,
   captureActions,
 }: InputBarContextProviderProps) {
-  const [animate, setAnimate] = useState<boolean>(false);
+  const [shouldFocusInput, setShouldFocusInput] = useState<boolean>(false);
 
   // Useful when a component needs to set the selected agent for the input bar but do not have direct access to the input bar.
   const [selectedAgent, setSelectedAgent] = useState<RichAgentMention | null>(
@@ -148,9 +148,9 @@ export function InputBarContextProvider({
   const setSelectedAgentOuter = useCallback(
     (agentMention: RichAgentMention | null) => {
       if (agentMention) {
-        setAnimate(true);
+        setShouldFocusInput(true);
       } else {
-        setAnimate(false);
+        setShouldFocusInput(false);
       }
       setSelectedAgent(agentMention);
     },
@@ -187,8 +187,8 @@ export function InputBarContextProvider({
 
   const value = useMemo(
     () => ({
-      animate,
-      setAnimate,
+      shouldFocusInput,
+      setShouldFocusInput,
       getAndClearSelectedAgent,
       setSelectedAgent: setSelectedAgentOuter,
       selectedSingleAgent,
@@ -204,7 +204,7 @@ export function InputBarContextProvider({
       fileUploaderService,
     }),
     [
-      animate,
+      shouldFocusInput,
       getAndClearSelectedAgent,
       setSelectedAgentOuter,
       selectedSingleAgent,


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9376

Clicking "New" while already on the new-conversation page did not focus the input bar. Two issues:

1. handleNewClick read the conversation id from `router.query.cId`, but in the react-router SPA the id is a path param (usePathParam), never present in `router.query`. So `isNewConversation` was always false and setAnimate(true) was never called. Derive it from useActiveConversationId (null on "new").

2. The `animate` focus flag was never reset, so once true (e.g. after agent selection) later setAnimate(true) calls were swallowed as no-ops. Consume the flag after focusing so each request re-triggers the effect.
## Tests

Local

## Risk

Low
## Deploy Plan

Front