### PR TITLE
feat(global-agents): fall back to Sonnet 4.6 for claude-sonnet in EU-only workspaces

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/anthropic.ts
+++ b/front/lib/api/assistant/global_agents/configurations/anthropic.ts
@@ -339,7 +339,7 @@ export function _getClaude5SonnetGlobalAgent({
     versionCreatedAt: null,
     versionAuthorId: null,
     name: metadata.name,
-    description: metadata.description,
+    description: modelConfig.description,
     instructions: `${globalAgentGuidelines}\n${globalAgentWebSearchGuidelines}`,
     instructionsHtml: null,
     pictureUrl: metadata.pictureUrl,

--- a/front/lib/api/assistant/global_agents/configurations/anthropic.ts
+++ b/front/lib/api/assistant/global_agents/configurations/anthropic.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/api/assistant/global_agents/guidelines";
 import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
 import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
+import { selectEnabledModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
@@ -20,6 +21,7 @@ import {
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
 /**
  * GLOBAL AGENTS CONFIGURATION
@@ -303,10 +305,12 @@ export function _getClaude5SonnetGlobalAgent({
   auth,
   settings,
   mcpServerViews,
+  featureFlags,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
+  featureFlags: WhitelistableFeature[];
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -315,6 +319,18 @@ export function _getClaude5SonnetGlobalAgent({
 
   const sId = GLOBAL_AGENTS_SID.CLAUDE_5_SONNET;
   const metadata = getGlobalAgentMetadata(sId);
+
+  // Serve Sonnet 5 by default and fall back to Sonnet 4.6 for EU-models-only
+  // workspaces, where Sonnet 5 is not regionally available.
+  const modelConfig =
+    selectEnabledModel(
+      auth,
+      [
+        CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
+        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+      ],
+      { featureFlags }
+    ) ?? CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
 
   return {
     id: -1,
@@ -331,11 +347,10 @@ export function _getClaude5SonnetGlobalAgent({
     scope: "global",
     userFavorite: false,
     model: {
-      providerId: CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.providerId,
-      modelId: CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.modelId,
+      providerId: modelConfig.providerId,
+      modelId: modelConfig.modelId,
       temperature: 0.7,
-      reasoningEffort:
-        CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+      reasoningEffort: modelConfig.defaultReasoningEffort,
     },
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -880,6 +880,7 @@ function getGlobalAgent({
         auth,
         settings,
         mcpServerViews,
+        featureFlags,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET:


### PR DESCRIPTION
## Description

The `claude-sonnet` global agent (`CLAUDE_5_SONNET`) hardcoded Claude Sonnet 5 as its model. Sonnet 5 declares `regionalAvailability: { "europe-west1": false }`, so for EU-models-only workspaces the agent pointed at a model that is not enabled in the region.

This changes the agent to serve **Sonnet 5** by default and fall back to **Sonnet 4.6** when Sonnet 5 is not enabled for the workspace. It reuses the existing `selectEnabledModel` picker (already used by the deep-dive / dust / sidekick global agents), which runs the same `isModelEnabled` predicate enforced at message-post time — so the selected model can never be rejected later as "not supported". EU-only workspaces (`regionalModelsOnly` + `europe-west1`) fall through to Sonnet 4.6 automatically; everyone else gets Sonnet 5.

`featureFlags` is threaded into the builder so the availability check uses the workspace's real flags, matching the other global-agent builders.

## Tests

- `npx tsgo --noEmit` passes.
- biome + front typecheck pass via the pre-commit hook.

## Risk

Low. The change is scoped to the model selection for a single global agent. Non-EU workspaces keep the same model (Sonnet 5); only EU-models-only workspaces change (from an unavailable Sonnet 5 to the available Sonnet 4.6, which is the intended fix).

## Deploy Plan

Standard `front` deploy. No migrations or config changes required.