### PR TITLE
Do not report programmatic and stripe usqge for credit based plans

### DIFF
--- a/front/lib/api/programmatic_usage/tracking.test.ts
+++ b/front/lib/api/programmatic_usage/tracking.test.ts
@@ -4,6 +4,7 @@ import {
   computeCreditAlertThresholdKey,
   decreaseProgrammaticCredits,
   isProgrammaticUsage,
+  trackProgrammaticCost,
 } from "@app/lib/api/programmatic_usage/tracking";
 import { Authenticator } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
@@ -548,6 +549,39 @@ describe("decreaseProgrammaticCredits", () => {
       expect(refreshedPaygEarlier.consumedAmountMicroUsd).toBe(500_000);
       expect(refreshedPaygLater.consumedAmountMicroUsd).toBe(0);
     });
+  });
+});
+
+describe("trackProgrammaticCost", () => {
+  async function makeAuth(workspace: WorkspaceType): Promise<Authenticator> {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    await GroupFactory.defaults(workspace);
+    return Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+  }
+
+  it("skips tracking for credit-priced (Metronome-billed) subscriptions", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    const auth = await makeAuth(workspace);
+
+    const result = await trackProgrammaticCost(auth, {
+      dustRunIds: [],
+      userMessageOrigin: "api",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("tracks cost for non-Metronome subscriptions", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await makeAuth(workspace);
+
+    const result = await trackProgrammaticCost(auth, {
+      dustRunIds: [],
+      userMessageOrigin: "api",
+    });
+
+    expect(result).toEqual({ runsCostMicroUsd: 0 });
   });
 });
 

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -20,7 +20,10 @@ import {
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import {
+  FREE_TEST_PLAN_CODE,
+  isCreditPricedPlanPrefix,
+} from "@app/lib/plans/plan_codes";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { reportUsageForSubscriptionItems } from "@app/lib/plans/usage";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -77,6 +80,11 @@ export async function recordUsageActivity(workspaceId: string) {
       "[UsageQueue] Subscription is on free test plan -- skipping reporting usage."
     );
 
+    return;
+  }
+
+  // Credit-priced (Metronome-billed) plans: skip Stripe reporting entirely.
+  if (isCreditPricedPlanPrefix(subscription.plan.code)) {
     return;
   }
 


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/7506

Skip reporting stripe usage for metronome plans (Credit Priced plans)
Programmatic usage is alredy skipped:

https://github.com/dust-tt/dust/blob/7b04305dffcf5dff9a45577049f0f194620c687a/front/lib/api/programmatic_usage/tracking.ts#L305-L308

## Tests

Added one unit test

## Risk



## Deploy Plan

deploy front
