### PR TITLE
feat(conversations): flip conversation visibility writers to visible/hidden

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.test.ts
@@ -1,6 +1,7 @@
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { honoApp } from "@front-api/app";
-import { describe, expect, it, vi } from "vitest";
+import { assert, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/programmatic_usage/tracking", () => ({
   isProgrammaticUsage: () => false,
@@ -85,5 +86,47 @@ describe("POST /api/v1/w/[wId]/assistant/conversations", () => {
 
     expect(response.status).toBe(400);
     expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("normalizes legacy visibility values on write while preserving the wire contract", async () => {
+    const { workspace, key, auth } = await createPublicApiMockRequest();
+
+    const response = await postConversations(workspace, key, {
+      title: "Test conversation",
+      visibility: "test",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    // The public wire contract is preserved: legacy "test" round-trips as "test".
+    expect(body.conversation.visibility).toBe("test");
+
+    // Internally, "test" is stored under its renamed value "hidden".
+    const stored = await ConversationResource.fetchById(
+      auth,
+      body.conversation.sId
+    );
+    assert(stored, "conversation not found");
+    expect(stored.visibility).toBe("hidden");
+  });
+
+  it('defaults new conversations to the renamed "visible" visibility', async () => {
+    const { workspace, key, auth } = await createPublicApiMockRequest();
+
+    const response = await postConversations(workspace, key, {
+      title: "Test conversation",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    // The public wire contract is preserved: the default round-trips as "unlisted".
+    expect(body.conversation.visibility).toBe("unlisted");
+
+    const stored = await ConversationResource.fetchById(
+      auth,
+      body.conversation.sId
+    );
+    assert(stored, "conversation not found");
+    expect(stored.visibility).toBe("visible");
   });
 });

--- a/front/components/agent_builder/SidekickPanelContext.tsx
+++ b/front/components/agent_builder/SidekickPanelContext.tsx
@@ -124,9 +124,8 @@ export const SidekickPanelProvider = ({
         // and doing so races with SSE setup.
         clientSideMCPServerIds: [],
       },
-      // TODO(sidekick 2026-01-23): same visibility as the 'Preview' tab conversation.
-      // We should rename it.
-      visibility: "test",
+      // Same visibility as the 'Preview' tab conversation.
+      visibility: "hidden",
       title: `Sidekick conversation (useCase: ${useCase}, agentId: ${targetAgentConfigurationId})`,
       metadata: {
         sidekickTargetAgentConfigurationId: targetAgentConfigurationId,

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -165,7 +165,7 @@ export function useDraftConversation({
 
       const result = await createConversationWithMessage({
         messageData,
-        visibility: "test",
+        visibility: "hidden",
       });
 
       if (result.isOk()) {

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -50,7 +50,7 @@ export function useCreateConversationWithMessage({
       skipToolsValidation = false,
       spaceId,
       title,
-      visibility = "unlisted",
+      visibility = "visible",
       deferMessage = false,
       onError,
     }: {

--- a/front/hooks/useProjectKickoff.ts
+++ b/front/hooks/useProjectKickoff.ts
@@ -44,7 +44,7 @@ export function useProjectKickoff({
         origin: "project_kickoff",
       },
       spaceId: space.sId,
-      visibility: "unlisted",
+      visibility: "visible",
       title: `Kickoff: ${space.name}`,
     });
 

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -1087,7 +1087,7 @@ export function createProjectManagerTools(
         // Create conversation in the project space
         const conversation = await createConversation(auth, {
           title: params.title,
-          visibility: "unlisted",
+          visibility: "visible",
           spaceId: pod.id,
         });
 

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -820,7 +820,7 @@ export async function triggerFromEmail(
   if (!conversation) {
     conversation = await createConversation(auth, {
       title: `Email: ${email.subject}`,
-      visibility: "unlisted",
+      visibility: "visible",
       spaceId: null,
     });
   }

--- a/front/lib/api/assistant/onboarding.ts
+++ b/front/lib/api/assistant/onboarding.ts
@@ -558,7 +558,7 @@ export async function createOnboardingConversationIfNeeded(
 
   const conversation = await createConversation(auth, {
     title: "Welcome to Dust",
-    visibility: "unlisted",
+    visibility: "visible",
     spaceId: null,
   });
 

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -70,7 +70,7 @@ export async function writeBatchUserMessages(
     newMessages,
     existingConversationId,
     title,
-    visibility = "unlisted",
+    visibility = "visible",
     metadata = {},
     userContextUsername = "system",
     userContextOrigin,

--- a/front/lib/api/mcp_server/tools/conversations/create.ts
+++ b/front/lib/api/mcp_server/tools/conversations/create.ts
@@ -62,7 +62,7 @@ export function registerConversationsCreateTool(server: McpServer) {
       try {
         conversation = await createConversation(auth, {
           title,
-          visibility: "unlisted",
+          visibility: "visible",
           spaceId: resolvedSpaceModelId,
         });
       } catch (error) {

--- a/front/lib/api/poke/plugins/workspaces/restore_conversation.ts
+++ b/front/lib/api/poke/plugins/workspaces/restore_conversation.ts
@@ -44,7 +44,7 @@ export const restoreConversationPlugin = createPlugin({
     }
 
     for (const conversation of conversations) {
-      await conversation.updateVisibilityToUnlisted(auth);
+      await conversation.updateVisibilityToVisible(auth);
     }
 
     return new Ok({

--- a/front/lib/api/v1/backward_compatibility.ts
+++ b/front/lib/api/v1/backward_compatibility.ts
@@ -36,20 +36,31 @@ import type {
 } from "@dust-tt/client";
 
 /**
- * Normalizes deprecated visibility values to their current equivalents.
- * The "workspace" visibility value is deprecated and should be treated as "unlisted".
+ * Normalizes a visibility value received from the public API into the value
+ * stored internally. The public API keeps accepting the legacy wire names
+ * ("workspace", "unlisted", "test") indefinitely for backward compatibility;
+ * this maps them onto the current internal names ("visible", "hidden").
  *
- * @param visibility - The visibility value (may be deprecated)
- * @returns The normalized visibility value (defaults to "unlisted" if undefined)
+ * @param visibility - The visibility value from the public API request (may be a legacy name)
+ * @returns The internal visibility value to store (defaults to "visible" if undefined)
  */
 export function normalizeConversationVisibility(
   visibility: ConversationVisibility | "workspace" | undefined
 ): ConversationVisibility {
-  // Temporary translation layer for deprecated "workspace" visibility.
-  if (visibility === "workspace") {
-    return "unlisted";
+  switch (visibility) {
+    case undefined:
+    case "workspace":
+    case "unlisted":
+      return "visible";
+    case "test":
+      return "hidden";
+    case "visible":
+    case "hidden":
+    case "deleted":
+      return visibility;
+    default:
+      return assertNever(visibility);
   }
-  return visibility ?? "unlisted";
 }
 
 /**

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -71,7 +71,7 @@ ConversationModel.init(
     visibility: {
       type: DataTypes.STRING,
       allowNull: false,
-      defaultValue: "unlisted",
+      defaultValue: "visible",
     },
     depth: {
       type: DataTypes.INTEGER,

--- a/front/lib/project_task/start_agent.ts
+++ b/front/lib/project_task/start_agent.ts
@@ -230,7 +230,7 @@ export async function startAgentForProjectTask(
   if (!conversationId) {
     conversation = await createConversation(auth, {
       title: `Task · ${task.text.slice(0, 80)}`,
-      visibility: "unlisted",
+      visibility: "visible",
       spaceId: space.id,
       metadata: {
         projectTaskId: task.sId,

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -323,7 +323,7 @@ export async function createSkillSuggestionsConversation(
   const conversationTitle = `Reinforced suggestions for ${skillType.name} skill`;
   const conversation = await createConversation(auth, {
     title: conversationTitle,
-    visibility: "unlisted",
+    visibility: "visible",
     spaceId: null,
     metadata: {
       reinforcedSkillNotification: {

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -172,7 +172,7 @@ export function getReinforcedSkillsDefaultOptions(
   skillIds: string[]
 ) {
   return {
-    visibility: "test" as const,
+    visibility: "hidden" as const,
     metadata: getReinforcedSkillsMetadata(operationType, skillIds),
     userContextUsername: "reinforcement",
     userContextOrigin: "reinforcement" as const,

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -3705,8 +3705,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     await this.update({ visibility: "deleted" });
   }
 
-  async updateVisibilityToUnlisted(auth: Authenticator) {
-    await this.update({ visibility: "unlisted" });
+  async updateVisibilityToVisible(auth: Authenticator) {
+    await this.update({ visibility: "visible" });
   }
 
   async updateRequirements(

--- a/front/scripts/dev/seed_conversations.ts
+++ b/front/scripts/dev/seed_conversations.ts
@@ -136,7 +136,7 @@ async function createConversation(
     {
       sId: generateRandomModelSId(),
       title: conv.title,
-      visibility: "unlisted",
+      visibility: "visible",
       depth: 0,
       requestedSpaceIds: conv.space ? [conv.space.id] : [],
       spaceId: conv.space?.id ?? null,

--- a/front/scripts/seed/factories/seedConversations.ts
+++ b/front/scripts/seed/factories/seedConversations.ts
@@ -90,7 +90,7 @@ export async function seedConversations(
         {
           sId: conv.sId,
           title: conv.title,
-          visibility: "unlisted",
+          visibility: "visible",
           depth: 0,
           requestedSpaceIds: [],
         },

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -524,7 +524,7 @@ export async function processTranscriptActivity(
 
     const initialConversation = await createConversation(auth, {
       title: transcriptTitle,
-      visibility: "unlisted",
+      visibility: "visible",
       spaceId: null,
     });
 

--- a/front/temporal/triggers/activities.test.ts
+++ b/front/temporal/triggers/activities.test.ts
@@ -17,7 +17,7 @@ describe("wake-up activities", () => {
     });
     const conversation = await createConversation(authenticator, {
       title: null,
-      visibility: "unlisted",
+      visibility: "visible",
       spaceId: null,
     });
 

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -50,7 +50,7 @@ async function createConversationForAgentConfiguration({
 }): Promise<Result<ConversationType, APIErrorWithContentfulStatusCode>> {
   const newConversation = await createConversation(auth, {
     title: null,
-    visibility: "unlisted",
+    visibility: "visible",
     triggerId: trigger.id,
     spaceId: null,
   });

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -38,7 +38,7 @@ export class ConversationFactory {
       conversationCreatedAt,
       requestedSpaceIds,
       spaceId,
-      visibility = "unlisted",
+      visibility = "visible",
       t,
     }: {
       agentConfigurationId: string;

--- a/front/tests/utils/conversation_test_factories.ts
+++ b/front/tests/utils/conversation_test_factories.ts
@@ -167,7 +167,7 @@ export function mockConversation(
       metronomeCustomerId: null,
       regionalModelsOnly: false,
     },
-    visibility: "unlisted",
+    visibility: "visible",
     content: messages,
     isRunningAgentLoop: false,
   };


### PR DESCRIPTION
## Description

Second phase of renaming `ConversationVisibility` values: flips every internal writer from `unlisted`/`test` to `visible`/`hidden`. Stacked on #28409, which made all readers tolerant of both old and new values — this PR is safe to deploy on top of it.

- `ConversationModel`'s default value and all direct `createConversation` / `ConversationResource.makeNew` call sites (onboarding, email trigger, project tasks, temporal activities, reinforcement, MCP tool servers, sidekick/preview conversations, batch LLM, dev seed scripts) now write `visible` / `hidden`.
- `ConversationResource.updateVisibilityToUnlisted` renamed to `updateVisibilityToVisible` and updated accordingly (only caller: the poke "restore conversation" plugin).
- The public API write path is the one place that needed real logic, not just a literal swap: `normalizeConversationVisibility` (called from the public v1 POST conversations handler) now maps the legacy wire values it accepts forever (`workspace`, `unlisted`, `test`) onto the new internal storage values (`visible`, `hidden`), while the read-side `toPublicConversationVisibility` (added in #28409) keeps reporting the old names back to callers. The public wire contract is unchanged.
- Server-to-server calls that go through the public API SDK (the `run_agent` MCP tool's `DustAPI.createConversation`, and the Slack/Discord/Teams connectors) intentionally keep sending the legacy wire value `unlisted` — it gets normalized on the way in, same as any other API client.
- Test factory defaults (`ConversationFactory`, `mockConversation`) also flipped so new test data matches production's new default.

## Tests

- Added two functional tests on `POST /api/v1/w/[wId]/assistant/conversations` asserting the full round trip: sending the legacy `test`/default wire values stores `hidden`/`visible` internally while the response still reports the legacy `test`/`unlisted` values, so existing SDK clients see no change.
- Full existing suite for conversations, reinforcement, temporal triggers/labs activities, and batch LLM re-run and green after the flip.

## Deploy Plan

Deploy after #28409 is live and the backfill migration from that PR has been run (or at least deployed — readers tolerate both values regardless of ordering). No further migration needed here; this only changes what new writes look like.
