### PR TITLE
Retrieve agent memories on demand instead of injecting them into the prompt

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -1,7 +1,5 @@
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
-import { buildMemoriesContext } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import {
-  globalAgentInjectsMemory,
   globalAgentInjectsUserContext,
   globalAgentInjectsWorkspaceContext,
 } from "@app/lib/api/assistant/global_agents/global_agents";
@@ -11,7 +9,6 @@ import {
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
-import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -452,49 +449,6 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     );
   });
 
-  it("should include memoriesContext in prompt output when provided", () => {
-    const memoriesContext =
-      "<existing_memories>\n- User prefers TypeScript (saved Jan 15, 2025).\n</existing_memories>";
-
-    const params = {
-      userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
-      hasAvailableActions: true,
-      agentsList: null,
-      systemSkills: [],
-      enabledSkills: [],
-      equippedSkills: [],
-      memoriesContext,
-    };
-
-    const sections = constructPromptMultiActions(authenticator1, params);
-    const text = systemPromptToText(sections);
-
-    expect(text).toContain("<existing_memories>");
-    expect(text).toContain("User prefers TypeScript");
-  });
-
-  it("should produce a valid prompt when memoriesContext is omitted", () => {
-    const params = {
-      userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
-      hasAvailableActions: true,
-      agentsList: null,
-      systemSkills: [],
-      enabledSkills: [],
-      equippedSkills: [],
-    };
-
-    const sections = constructPromptMultiActions(authenticator1, params);
-    const text = systemPromptToText(sections);
-
-    // Prompt works without memoriesContext (no crash, contains instructions).
-    expect(text).toContain("# INSTRUCTIONS");
-    expect(text).not.toContain("<existing_memories>");
-  });
-
   it("should keep equipped skills out of the system prompt", async () => {
     const equippedSkills = [
       await SkillFactory.create(authenticator1, {
@@ -632,77 +586,6 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     expect(text).toContain("### SYSTEM SKILLS");
     expect(text).toContain(discoverSkills.instructions);
   });
-
-  it("should keep memory_guidelines in instructions but existing_memories in ephemeral tier for dust-like agents", () => {
-    const dustConfig = {
-      ...agentConfig1,
-      sId: GLOBAL_AGENTS_SID.DUST,
-      scope: "global" as const,
-      instructions: agentConfig1.instructions + "\n<memory_guidelines>\n",
-    };
-
-    const memoriesContext =
-      "<existing_memories>\n- Some memory (saved Jan 1, 2025).\n</existing_memories>";
-
-    const params = {
-      userMessage: userMessage1,
-      agentConfiguration: dustConfig,
-      model: modelConfig,
-      hasAvailableActions: true,
-      agentsList: null,
-      systemSkills: [],
-      enabledSkills: [],
-      equippedSkills: [],
-      memoriesContext,
-    };
-
-    const sections = constructPromptMultiActions(authenticator1, params);
-    const { instructions, ephemeralContext } = normalizePrompt(sections);
-
-    // Dust-like agents: memory_guidelines are in instructions.
-    expect(instructions).toHaveLength(1);
-    expect(instructions[0].content).toContain("<memory_guidelines>");
-    expect(instructions[0].content).not.toContain("<existing_memories>");
-
-    // existing_memories should be in the ephemeral tier (per-user).
-    const memoriesSection = ephemeralContext.find((s) =>
-      s.content.includes("<existing_memories>")
-    );
-    expect(memoriesSection).toBeDefined();
-    expect(memoriesSection?.content).toContain("Some memory");
-  });
-});
-
-describe("globalAgentInjectsMemory", () => {
-  it("should return true for dust-like agents", () => {
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST)).toBe(true);
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_EDGE)).toBe(true);
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_QUICK)).toBe(true);
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_OAI)).toBe(true);
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_GOOG)).toBe(true);
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_NEXT)).toBe(true);
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_NEXT_HIGH)).toBe(
-      true
-    );
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_CHAWI)).toBe(true);
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_SOUPINOU)).toBe(
-      true
-    );
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_SUNDAE)).toBe(true);
-  });
-
-  it("should return false for non-dust global agents", () => {
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DEEP_DIVE)).toBe(false);
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.GPT4)).toBe(false);
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.HELPER)).toBe(false);
-    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.GEMINI_PRO)).toBe(false);
-  });
-
-  it("should return false for arbitrary non-global-agent strings", () => {
-    expect(globalAgentInjectsMemory("my-custom-agent")).toBe(false);
-    expect(globalAgentInjectsMemory("random-string")).toBe(false);
-    expect(globalAgentInjectsMemory("")).toBe(false);
-  });
 });
 
 describe("globalAgentInjectsUserContext", () => {
@@ -735,39 +618,5 @@ describe("globalAgentInjectsWorkspaceContext", () => {
     expect(
       globalAgentInjectsWorkspaceContext(GLOBAL_AGENTS_SID.DEEP_DIVE)
     ).toBe(false);
-  });
-});
-
-describe("buildMemoriesContext", () => {
-  it("should output 'No existing memories' for an empty array", async () => {
-    const result = buildMemoriesContext([]);
-
-    expect(result).toContain("<existing_memories>");
-    expect(result).toContain("</existing_memories>");
-    expect(result).toContain("No existing memories");
-  });
-
-  it("should include each memory's content and a saved date marker", async () => {
-    const { authenticator } = await createResourceTest({ role: "admin" });
-
-    const memory1 = await AgentMemoryResource.makeNew(authenticator, {
-      agentConfigurationId: "test-agent",
-      content: "User is a backend engineer",
-      userId: null,
-    });
-    const memory2 = await AgentMemoryResource.makeNew(authenticator, {
-      agentConfigurationId: "test-agent",
-      content: "Prefers dark mode",
-      userId: null,
-    });
-
-    const result = buildMemoriesContext([memory1, memory2]);
-
-    expect(result).toContain("<existing_memories>");
-    expect(result).toContain("</existing_memories>");
-    expect(result).toContain("User is a backend engineer");
-    expect(result).toContain("Prefers dark mode");
-    // Each memory should have a "saved" date marker from formatTimestampToFriendlyDate.
-    expect(result).toContain("(saved ");
   });
 });

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -378,7 +378,6 @@ export function constructPromptMultiActions(
     enabledSkills,
     systemSkills,
     equippedSkills,
-    memoriesContext,
     toolsetsContext,
     userContext,
     workspaceContext,
@@ -399,7 +398,6 @@ export function constructPromptMultiActions(
     enabledSkills: EnabledSkill[];
     systemSkills: SkillResource[];
     equippedSkills: SkillResource[];
-    memoriesContext?: string;
     toolsetsContext?: string;
     userContext?: string;
     workspaceContext?: string;
@@ -414,7 +412,7 @@ export function constructPromptMultiActions(
   // The system prompt is composed of multiple sections that provide instructions and context to the model.
   // Global agents with fully static instructions (no per-user data baked in) use the tuple form
   // [instructions, context] which enables extended prompt caching. Per-user dynamic content like
-  // memories is passed as a separate context section so it doesn't pollute instruction caching.
+  // the user profile is passed as a separate context section so it doesn't pollute instruction caching.
   // Only enabled for `deep-dive` and `dust(-x)` agents.
   const hasStaticInstructions =
     agentConfiguration.sId === GLOBAL_AGENTS_SID.DEEP_DIVE ||
@@ -462,7 +460,7 @@ export function constructPromptMultiActions(
     // section (directives + server listing), date, toolsets, and workspace info. A cache breakpoint
     // here lets different users in the same workspace share this prefix.
     //
-    // Ephemeral context (no breakpoint): per-call data, covering branch lineage, memories, and user
+    // Ephemeral context (no breakpoint): per-call data, covering branch lineage and user
     // profile.
     const fullInstructions = [
       instructionsContent,
@@ -487,7 +485,6 @@ export function constructPromptMultiActions(
 
     const ephemeralContext: SystemPromptContext[] = [
       { role: "context" as const, content: branchContextSection },
-      { role: "context" as const, content: memoriesContext ?? "" },
       { role: "context" as const, content: userContext ?? "" },
       { role: "context" as const, content: projectContext ?? "" },
     ].filter((s) => s.content.trim() !== "");
@@ -512,7 +509,6 @@ export function constructPromptMultiActions(
     { role: "context" as const, content: pastedContentSection },
     { role: "context" as const, content: guidelinesSection },
     { role: "context" as const, content: toolsetsContext ?? "" },
-    { role: "context" as const, content: memoriesContext ?? "" },
     { role: "context" as const, content: userContext ?? "" },
     { role: "context" as const, content: workspaceContext ?? "" },
     { role: "context" as const, content: projectContext ?? "" },

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -31,9 +31,7 @@ import {
   isDustCompanyPlan,
   isEnterprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
-import type { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
@@ -136,8 +134,7 @@ Do not enable it for generic help requests, non-Dust products, or ambiguous ment
 You have access to a persistent, user-specific memory system. Each user has their own private memory store.
 
 <critical_behavior>
-Existing memories are critical to your success. Always use them to tailor your responses and improve your performance over time.
-They are available to you directly in the <existing_memories> section.
+Memories are not included in your context automatically. Retrieve them with the \`agent_memory\` tool when prior context about the user is likely to change your answer: recurring workflows, personal preferences, ongoing projects, or requests that assume context you don't have. Do not retrieve memories for self-contained requests that any user would want answered the same way.
 To add or edit memories, use the \`agent_memory\` tool.
 </critical_behavior>
 
@@ -183,19 +180,6 @@ Never explicitly say "I remember" or "based on our previous conversation" - just
 </memory_hygiene>
 </memory_guidelines>`,
 };
-
-const formatMemory = (memory: AgentMemoryResource) =>
-  `- ${memory.content} (saved ${formatTimestampToFriendlyDate(new Date(memory.updatedAt).getTime(), "compactWithDay")}).`;
-
-export function buildMemoriesContext(memories: AgentMemoryResource[]): string {
-  const memoryList = memories.length
-    ? memories.map(formatMemory).join("\n")
-    : "No existing memories.";
-
-  return `<existing_memories>
-${memoryList.trim()}
-</existing_memories>`;
-}
 
 export function buildToolsetsContext(
   availableToolsets: MCPServerViewResource[]

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -134,7 +134,7 @@ Do not enable it for generic help requests, non-Dust products, or ambiguous ment
 You have access to a persistent, user-specific memory system. Each user has their own private memory store.
 
 <critical_behavior>
-Memories are not included in your context automatically. Retrieve them with the \`agent_memory\` tool when prior context about the user is likely to change your answer: recurring workflows, personal preferences, ongoing projects, or requests that assume context you don't have. Do not retrieve memories for self-contained requests that any user would want answered the same way.
+Retrieve them with the \`agent_memory\` tool when prior context about the user is likely to change your answer: recurring workflows, personal preferences, ongoing projects, or requests that assume context you don't have. Do not retrieve memories for self-contained requests that any user would want answered the same way.
 To add or edit memories, use the \`agent_memory\` tool.
 </critical_behavior>
 

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -136,611 +136,509 @@ import {
 } from "@app/types/shared/feature_flags";
 
 // Exhaustive map of flags for each global agent. This is used to control which agents inject
-// per-user dynamic content (like memories) into the prompt context. This approach is not ideal but
-// allows us to move dynamic content out of instructions and into context sections, improving prompt
-// cache hit rates. Will be properly refactored if we manage to improve cache hit rates.
+// per-user dynamic content (like the user profile) into the prompt context. This approach is not
+// ideal but allows us to move dynamic content out of instructions and into context sections,
+// improving prompt cache hit rates. Will be properly refactored if we manage to improve cache hit
+// rates.
 const GLOBAL_AGENT_FLAGS: Record<
   GLOBAL_AGENTS_SID,
   {
-    injectsMemory: boolean;
     injectsToolsets: boolean;
     injectsUserContext: boolean;
     injectsWorkspaceContext: boolean;
   }
 > = {
   [GLOBAL_AGENTS_SID.DUST]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_OMITTED]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_HIGH_OMITTED]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_EDGE]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_QUICK]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_OAI]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_OAI_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_OAI_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_OAI_NANO_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_GOOG]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_GOOG_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_GOOG_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_GOOG_LITE]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_GOOG_PRO]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_GOOG_PRO_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_GOOG_PRO_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_ANT]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_ANT_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM_OMITTED]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE_LIGHT]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_HAIKU]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_LIGHT]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_KIMI]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_KIMI_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_KIMI_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_GLM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_GLM_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_GLM_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_MINIMAX]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_MINIMAX_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_MINIMAX_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_DEEPSEEK]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_NONE]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_NEXT]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_NEXT_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_CHAWI]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_CHAWI_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_CHAWI_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_SOUPINOU]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_SOUPINOU_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_SOUPINOU_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_SOUPINOU_NONE]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_SUNDAE]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_SUNDAE_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_SUNDAE_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_PISTACHE]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_PISTACHE_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_PISTACHE_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_CHALOM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_LIONEL]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_LIONEL_MEDIUM]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_LIONEL_HIGH]: {
-    injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.HELPER]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DEEP_DIVE]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_TASK]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_PLANNING]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.SIDEKICK]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: true,
     injectsWorkspaceContext: true,
   },
   [GLOBAL_AGENTS_SID.REINFORCEMENT]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.ANALYST]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.SLACK]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GOOGLE_DRIVE]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.NOTION]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GITHUB]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.INTERCOM]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GPT35_TURBO]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GPT4]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GPT5]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GPT5_THINKING]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GPT5_NANO]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GPT5_MINI]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.O1]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.O1_MINI]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.O1_HIGH_REASONING]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.O3_MINI]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.O3]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_4_5_HAIKU]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_5_SONNET]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_4_SONNET]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_3_OPUS]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_3_SONNET]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_3_HAIKU]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_3_7_SONNET]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.MISTRAL_LARGE]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.MISTRAL_MEDIUM]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.MISTRAL_SMALL]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GEMINI_PRO]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.NOOP]: {
-    injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
 };
-
-export function globalAgentInjectsMemory(sId: string): boolean {
-  return isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsMemory;
-}
 
 export function globalAgentInjectsToolsets(sId: string): boolean {
   return isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsToolsets;
@@ -757,11 +655,7 @@ export function globalAgentInjectsWorkspaceContext(sId: string): boolean {
 }
 
 export function isDustLikeAgent(sId: string): boolean {
-  return (
-    isGlobalAgentId(sId) &&
-    GLOBAL_AGENT_FLAGS[sId].injectsMemory &&
-    GLOBAL_AGENT_FLAGS[sId].injectsToolsets
-  );
+  return isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsToolsets;
 }
 
 function getGlobalAgent({

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -12,12 +12,8 @@ import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configurat
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { categorizeConversationRenderErrorMessage } from "@app/lib/api/assistant/errors";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
+import { buildToolsetsContext } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import {
-  buildMemoriesContext,
-  buildToolsetsContext,
-} from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
-import {
-  globalAgentInjectsMemory,
   globalAgentInjectsToolsets,
   globalAgentInjectsUserContext,
   globalAgentInjectsWorkspaceContext,
@@ -52,7 +48,6 @@ import {
   getDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
-import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -334,22 +329,6 @@ export async function runModel(
       })
     : null;
 
-  let memoriesContext: string | undefined;
-  const hasAgentMemoryAction = agentConfiguration.actions.some((action) =>
-    isServerSideMCPServerConfigurationWithName(action, "agent_memory")
-  );
-  if (
-    globalAgentInjectsMemory(agentConfiguration.sId) &&
-    hasAgentMemoryAction &&
-    auth.user()
-  ) {
-    const memories =
-      await AgentMemoryResource.findByAgentConfigurationIdAndUser(auth, {
-        agentConfigurationId: agentConfiguration.sId,
-      });
-    memoriesContext = buildMemoriesContext(memories);
-  }
-
   let toolsetsContext: string | undefined;
   const hasToolsetsAction = agentConfiguration.actions.some((action) =>
     isServerSideMCPServerConfigurationWithName(action, "toolsets")
@@ -405,7 +384,6 @@ export async function runModel(
     systemSkills,
     enabledSkills,
     equippedSkills,
-    memoriesContext,
     toolsetsContext,
     userContext,
     workspaceContext,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Agent memories were injected into the system prompt on every request to the dust agents. Memories are per-user and sat ahead of everything shared in the prompt cache prefix, so two users of the same workspace always diverged before the largest common part of the prompt, and any memory write mid-conversation invalidated the cached prefix. With this change the system prompt no longer contains memories at all and becomes identical across users of a workspace, which is a prerequisite for sharing the cached prefix between them.

The model is instead instructed to fetch memories with the memory tool when prior context about the user is likely to change the answer.

Might be revisited later.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
