### PR TITLE
[Admin Gov] Rename Identity & Provisioning to IT & Security

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -281,7 +281,9 @@ export const subNavigationAdmin = ({
       },
       {
         id: "identity_and_provisioning",
-        label: "Identity & Provisioning",
+        label: featureFlags.includes("admin_governance")
+          ? "IT & Security"
+          : "Identity & Provisioning",
         icon: Fingerprint04,
         href: `/w/${owner.sId}/identity-and-provisioning`,
         current: isCurrent("identity_and_provisioning"),

--- a/front/components/pages/workspace/WorkspaceIdentityProvisioningPage.tsx
+++ b/front/components/pages/workspace/WorkspaceIdentityProvisioningPage.tsx
@@ -1,5 +1,9 @@
 import WorkspaceAccessPanel from "@app/components/workspace/WorkspaceAccessPanel";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { useWorkspaceVerifiedDomains } from "@app/lib/swr/workspaces";
 import { Fingerprint04, Page, Spinner } from "@dust-tt/sparkle";
 
@@ -7,6 +11,7 @@ export function WorkspaceIdentityProvisioningPage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
   const plan = subscription.plan;
+  const { hasFeature } = useFeatureFlags();
 
   const { verifiedDomains, isVerifiedDomainsLoading } =
     useWorkspaceVerifiedDomains({ workspaceId: owner.sId });
@@ -23,7 +28,11 @@ export function WorkspaceIdentityProvisioningPage() {
     <div className="mb-4">
       <Page.Vertical gap="lg" align="stretch">
         <Page.Header
-          title="Identity and Provisioning"
+          title={
+            hasFeature("admin_governance")
+              ? "IT & Security"
+              : "Identity and Provisioning"
+          }
           icon={Fingerprint04}
           description="Verify your domain, manage team members and their permissions."
         />


### PR DESCRIPTION
## Description

Renames the "Identity & Provisioning" page to "IT & Security" when the `admin_governance` feature flag is enabled. Without the flag, the page keeps its current name, so this is a no-op for workspaces that don't have admin governance turned on.

The rename applies to both surfaces where the name is shown:
- the admin sidebar nav label (`components/navigation/config.ts`);
- the page header title (`WorkspaceIdentityProvisioningPage.tsx`).

## Risks

Blast radius: admin sidebar label and page header for the identity/provisioning admin page.
Risk: none

## Deploy Plan
- pmrr
- deploy front