### PR TITLE
fix(conv rendering): drop errored steps entirely to unblock conversations

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -339,6 +339,136 @@ The following skills are available for use with the skill_management__enable_ski
   });
 });
 
+describe("error content handling in getSteps", () => {
+  async function buildErroredMessage(contents: AgentMessageType["contents"]) {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Test Agent",
+        description: "A test agent for error content rendering",
+      }
+    );
+    const model = getSupportedModelConfig(agentConfig.model);
+    assert(model, "Expected a supported model configuration.");
+
+    const message = {
+      id: 1,
+      agentMessageId: 1,
+      type: "agent_message",
+      sId: "agent_msg_err",
+      version: 1,
+      rank: 1,
+      branchId: null,
+      created: Date.now(),
+      completedTs: null,
+      parentMessageId: "user_msg_1",
+      parentAgentMessageId: null,
+      status: "succeeded",
+      content: null,
+      chainOfThought: null,
+      error: null,
+      visibility: "visible",
+      configuration: agentConfig,
+      skipToolsValidation: false,
+      actions: [],
+      contents,
+      modelInteractionDurationMs: null,
+      richMentions: [],
+      completionDurationMs: null,
+      reactions: [],
+      costCredits: null,
+    } satisfies AgentMessageType;
+
+    return { authenticator, message, model };
+  }
+
+  it("drops the whole step (including a truncated function call) when it errored", async () => {
+    const { authenticator, message, model } = await buildErroredMessage([
+      {
+        step: 0,
+        content: {
+          type: "function_call",
+          value: {
+            id: "toolu_truncated",
+            name: "some_tool",
+            // Truncated arguments left over from a stream cut off by the error.
+            arguments: '{"query":"foo',
+          },
+        },
+      },
+      {
+        step: 0,
+        content: {
+          type: "error",
+          value: {
+            code: "multi_actions_error",
+            message: "The request was invalid.",
+            metadata: null,
+          },
+        },
+      },
+    ]);
+
+    const steps = await getSteps(authenticator, {
+      enabledSkillById: new Map(),
+      model,
+      message,
+      workspaceId: "workspace_123",
+      conversationId: "conv_1",
+      // Default used by the agent loop: without the fix, this injects a bogus
+      // placeholder result for the dangling function call.
+      onMissingAction: "inject-placeholder",
+    });
+
+    expect(steps).toHaveLength(0);
+  });
+
+  it("keeps prior successful steps and drops only the errored one", async () => {
+    const { authenticator, message, model } = await buildErroredMessage([
+      {
+        step: 0,
+        content: {
+          type: "text_content",
+          value: "Here is the completed first step.",
+        },
+      },
+      {
+        step: 1,
+        content: {
+          type: "text_content",
+          value: "Partial answer before the provider errored...",
+        },
+      },
+      {
+        step: 1,
+        content: {
+          type: "error",
+          value: {
+            code: "multi_actions_error",
+            message: "The request was invalid.",
+            metadata: null,
+          },
+        },
+      },
+    ]);
+
+    const steps = await getSteps(authenticator, {
+      enabledSkillById: new Map(),
+      model,
+      message,
+      workspaceId: "workspace_123",
+      conversationId: "conv_1",
+      onMissingAction: "inject-placeholder",
+    });
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].contents).toEqual([
+      { type: "text_content", value: "Here is the completed first step." },
+    ]);
+  });
+});
+
 describe("vision image rendering in getSteps", () => {
   const buildVisionTest = async (gcsPathOverride?: string) => {
     const { authenticator, conversationsSpace } = await createResourceTest({

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -231,6 +231,28 @@ export async function getSteps(
   }
   const actions = removeNulls(message.actions);
 
+  // Steps that contain error content correspond to model generations that failed (e.g. an upstream
+  // provider error). Their partial output (in particular a function call whose arguments were
+  // truncated when the stream was cut off) must not be replayed to the model: doing so makes the
+  // provider reject every subsequent request and permanently breaks the conversation. We drop the
+  // whole errored step rather than only the error content item.
+  const erroredStepIndexes = new Set<number>();
+  for (const content of message.contents) {
+    if (content.content.type === "error") {
+      erroredStepIndexes.add(content.step);
+      logger.warn(
+        {
+          workspaceId,
+          conversationId,
+          agentMessageId: message.sId,
+          step: content.step,
+          errorContent: content.content.value,
+        },
+        "agent message step with error content in renderConversationForModelMultiActions"
+      );
+    }
+  }
+
   // We store for each step (identified by its index) the "contents" array (raw model outputs, including
   // text content, reasoning and function calls) and "actions", i.e the function results.
   const stepByStepIndex = {} as Record<number, Step>;
@@ -257,6 +279,9 @@ export async function getSteps(
 
   for (const { action, result, enabledSkillMessages } of renderedActions) {
     const stepIndex = action.step;
+    if (erroredStepIndexes.has(stepIndex)) {
+      continue;
+    }
     stepByStepIndex[stepIndex] = stepByStepIndex[stepIndex] || emptyStep();
     stepByStepIndex[stepIndex].actions.push({
       call: {
@@ -271,16 +296,12 @@ export async function getSteps(
 
   for (const content of message.contents) {
     if (content.content.type === "error") {
-      // Don't render error content.
-      logger.warn(
-        {
-          workspaceId,
-          conversationId,
-          agentMessageId: message.sId,
-          errorContent: content.content.value,
-        },
-        "agent message step with error content in renderConversationForModelMultiActions"
-      );
+      // Error content is never rendered; its whole step is dropped above.
+      continue;
+    }
+
+    if (erroredStepIndexes.has(content.step)) {
+      // Don't render any content from a step whose generation errored.
       continue;
     }
 


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9222

An upstream provider error left a truncated function_call in the errored step's content. renderConversationForModelMultiActions only skipped the error content item, replaying the malformed call to the model which rejected every retry with multi_actions_error, permanently blocking the conversation. Drop the whole errored step (contents + actions) instead.

## Tests

Unit

## Risk

Low
## Deploy Plan

Front