### PR TITLE
fix(composer): stop agent picker flashing at top-left on first select

### DIFF
--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -67,19 +67,22 @@ export function AgentPicker({
       }}
     >
       <DropdownMenuTrigger asChild>
-        {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-        {pickerButton ? (
-          pickerButton
-        ) : (
-          <Button
-            icon={Robot}
-            variant="ghost-secondary"
-            isSelect={showDropdownArrow}
-            size={size}
-            tooltip="Pick an agent"
-            disabled={disabled || isLoading}
-          />
-        )}
+        {/* Stable anchor across pickerButton swaps: prevents a top-left flash on close. */}
+        <div className="inline-flex">
+          {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
+          {pickerButton ? (
+            pickerButton
+          ) : (
+            <Button
+              icon={Robot}
+              variant="ghost-secondary"
+              isSelect={showDropdownArrow}
+              size={size}
+              tooltip="Pick an agent"
+              disabled={disabled || isLoading}
+            />
+          )}
+        </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="h-96 w-80"


### PR DESCRIPTION
## Description

When the composer had no agent selected, the picker's DropdownMenuTrigger child was a Button, and selecting an agent swapped it for the chip div. That element-type swap unmounts/remounts the Radix popper anchor in the same commit that closes the menu, so floating-ui briefly positions the closing menu at (0,0). Wrap the trigger content in a stable element so the anchor node is preserved across the swap.

The glitch:


https://github.com/user-attachments/assets/56620ee7-7e7b-4d78-8b42-210c6c85b9b8

## Tests

Local
## Risk

None
## Deploy Plan

Front