### PR TITLE
Opt: custom method to optimize fetching what's needed to render the conversations list in a pod.

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
@@ -1,15 +1,14 @@
-import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { getPaginationParams } from "@app/lib/api/pagination";
+import { toPodConversationListItem } from "@app/lib/api/projects/conversations";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { GetSpaceConversationsResponseBody } from "@app/types/api/assistant/conversation/spaces";
-import { removeNulls } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
+import unread from "./unread";
 
 const ParamsSchema = z.object({
   spaceId: z.string(),
@@ -27,8 +26,6 @@ function parseFilter(value: string | undefined): SpaceConversationsFilter {
       return "all";
   }
 }
-
-import unread from "./unread";
 
 // Mounted at /api/w/:wId/assistant/conversations/spaces/:spaceId.
 const app = workspaceApp();
@@ -89,30 +86,29 @@ app.get(
       filter: conversationFilter,
     });
 
-    const { conversations: allConversations } =
-      await ConversationResource.listConversationsInSpacePaginated(auth, {
-        spaceId,
-        options: { excludeTest: true },
-        pagination: {
-          limit: 1,
-          orderDirection: pagination.orderDirection,
-        },
-        filter: "all",
-      });
-    const isEmpty = allConversations.length === 0;
+    let isEmpty = spaceConversations.length === 0;
 
-    // Fetch full conversation details for the paginated results.
-    // N+1 queries here, bad for scaling — TODO(@jd) find a better way.
-    const spaceConversationsFull = await concurrentExecutor(
-      spaceConversations,
-      async (conv) => getLightConversation(auth, conv.sId),
-      { concurrency: 10 }
-    );
+    // If the page is empty, check if there are any conversations in the space.
+    if (isEmpty) {
+      const { conversations: allConversations } =
+        await ConversationResource.listConversationsInSpacePaginated(auth, {
+          spaceId,
+          options: { excludeTest: true },
+          pagination: {
+            limit: 1,
+            orderDirection: pagination.orderDirection,
+          },
+          filter: "all",
+        });
+      isEmpty = allConversations.length === 0;
+    }
+
+    const conversations = await toPodConversationListItem(auth, {
+      conversations: spaceConversations,
+    });
 
     return ctx.json({
-      conversations: removeNulls(
-        spaceConversationsFull.map((res) => (res.isOk() ? res.value : null))
-      ),
+      conversations,
       hasMore,
       lastValue,
       isEmpty,

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -1,4 +1,5 @@
 import { removeDiacritics, subFilter } from "@app/lib/utils";
+import type { PodConversationListItemType } from "@app/types/api/assistant/conversation/spaces";
 import type {
   AgentMessageType,
   CompactionMessageType,
@@ -16,7 +17,6 @@ import {
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import moment from "moment";
-
 import type { VirtuosoMessage } from "./types";
 
 const MAX_SOURCE_CONVERSATION_TITLE_LENGTH = 50;
@@ -91,7 +91,7 @@ export function getGroupConversationsByUnreadAndActionRequired(
 }
 
 export function getGroupConversationsByDate<
-  T extends ConversationListItemType,
+  T extends ConversationListItemType | PodConversationListItemType,
 >({ conversations, titleFilter }: { conversations: T[]; titleFilter: string }) {
   const today = moment().startOf("day");
   const yesterday = moment().subtract(1, "days").startOf("day");

--- a/front/components/pod/PodPageContent.tsx
+++ b/front/components/pod/PodPageContent.tsx
@@ -12,23 +12,16 @@ import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversati
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { PodUiScopedPreferences } from "@app/hooks/useScopedUIPreferences";
 import type { PodTab } from "@app/hooks/useSpaceProjectTabs";
-import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
 import type { useSpaceInfo } from "@app/lib/swr/spaces";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { LightConversationType } from "@app/types/assistant/conversation";
-import {
-  isAgentMessageType,
-  isUserMessageType,
-} from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import { toMentionType } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { removeNulls } from "@app/types/shared/utils/general";
 import { TabsContent } from "@dust-tt/sparkle";
 import { useCallback, useState } from "react";
 
@@ -155,48 +148,7 @@ export function PodPageContent({
         { shallow: true }
       );
 
-      const lightConversation: LightConversationType = {
-        ...conversationRes.value,
-        content: removeNulls(
-          conversationRes.value.content.map((v) => {
-            const lastVersion = v[v.length - 1];
-            if (isUserMessageType(lastVersion)) {
-              return {
-                ...lastVersion,
-                contentFragments: [],
-              };
-            }
-            if (isAgentMessageType(lastVersion)) {
-              return getLightAgentMessageFromAgentMessage(lastVersion);
-            }
-            return null;
-          })
-        ),
-      };
-
-      await mutateConversations(
-        (currentData) => {
-          if (!currentData || currentData.length === 0) {
-            return [
-              {
-                conversations: [lightConversation],
-                hasMore: false,
-                lastValue: null,
-                isEmpty: false,
-              },
-            ];
-          }
-          const [firstPage, ...restPages] = currentData;
-          return [
-            {
-              ...firstPage,
-              conversations: [lightConversation, ...firstPage.conversations],
-            },
-            ...restPages,
-          ];
-        },
-        { revalidate: false }
-      );
+      void mutateConversations();
 
       return new Ok(undefined);
     },

--- a/front/components/pod/conversation/PodConversationListItem.tsx
+++ b/front/components/pod/conversation/PodConversationListItem.tsx
@@ -1,26 +1,13 @@
-import { isHiddenMessage } from "@app/components/assistant/conversation/types";
-import { isMessageUnread } from "@app/components/assistant/conversation/utils";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
-import {
-  getConversationDisplayTitle,
-  isCompactionMessageType,
-  isLightAgentMessageType,
-  isUserMessageTypeWithContentFragments,
-  isVisibleMessage,
-  type LightConversationType,
-} from "@app/types/assistant/conversation";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { PodConversationListItemType } from "@app/types/api/assistant/conversation/spaces";
 import { stripMarkdown } from "@app/types/shared/utils/markdown";
 import type { WorkspaceType } from "@app/types/user";
-import type { Avatar } from "@dust-tt/sparkle";
 import { ConversationListItem, ReplySection } from "@dust-tt/sparkle";
-import uniqBy from "lodash/uniqBy";
 import moment from "moment";
-import { useMemo } from "react";
 
 interface PodConversationListItemProps {
-  conversation: LightConversationType;
+  conversation: PodConversationListItemType;
   owner: WorkspaceType;
 }
 
@@ -29,115 +16,38 @@ export function PodConversationListItem({
   owner,
 }: PodConversationListItemProps) {
   const router = useAppRouter();
-
-  const validMessages = conversation.content.filter((message) => {
-    if (isCompactionMessageType(message)) {
-      return false;
-    }
-    return (
-      (isUserMessageTypeWithContentFragments(message) &&
-        message.visibility === "visible" &&
-        !isHiddenMessage(message)) ||
-      (!isUserMessageTypeWithContentFragments(message) &&
-        message.status === "succeeded")
-    );
-  });
-
-  const firstVisibleMessage = conversation.content.find(isVisibleMessage);
-
-  // Compute the reply section avatars.
-  const avatars = useMemo(() => {
-    const avatars: Parameters<typeof Avatar.Stack>[0]["avatars"] = [];
-    // Lookup the messages in reverse order and collect the users and agents icons
-    // Slice to skip the first message as it's not a reply.
-    for (const message of validMessages.slice(1)) {
-      if (isUserMessageTypeWithContentFragments(message)) {
-        avatars.push({
-          isRounded: true,
-          name: message.user?.fullName ?? message.context?.fullName ?? "",
-          visual:
-            message.user?.image ?? message.context?.profilePictureUrl ?? "",
-        });
-      } else if (isCompactionMessageType(message)) {
-        // Nothing to do unless we want to show that the conversation was compacted.
-      } else if (isLightAgentMessageType(message)) {
-        avatars.push({
-          isRounded: false,
-          name: "@" + (message.configuration.name ?? ""),
-          visual: message.configuration.pictureUrl ?? "",
-        });
-      } else {
-        assertNeverAndIgnore(message);
-      }
-    }
-    return uniqBy(avatars.reverse(), "visual");
-  }, [validMessages]);
-
-  const countUnreadMessages = useMemo(() => {
-    return validMessages.filter((message) => {
-      return isMessageUnread(message, conversation.lastReadMs);
-    }).length;
-  }, [validMessages, conversation.lastReadMs]);
-
-  if (!firstVisibleMessage || isCompactionMessageType(firstVisibleMessage)) {
-    return null;
-  }
-
-  const conversationLabel = getConversationDisplayTitle(conversation);
-
   const time = moment(conversation.updated).fromNow();
-
-  const replyCount = validMessages.length - 1;
-
-  let creatorName = "Unknown";
-  let creatorVisual: string | undefined;
-
-  if (isUserMessageTypeWithContentFragments(firstVisibleMessage)) {
-    creatorName =
-      firstVisibleMessage.user?.fullName ??
-      firstVisibleMessage.context?.fullName ??
-      "Unknown";
-    creatorVisual =
-      firstVisibleMessage.user?.image ??
-      firstVisibleMessage.context?.profilePictureUrl ??
-      undefined;
-  } else if (isLightAgentMessageType(firstVisibleMessage)) {
-    creatorName = `@${firstVisibleMessage.configuration.name}`;
-    creatorVisual = firstVisibleMessage.configuration.pictureUrl || undefined;
-  } else {
-    assertNeverAndIgnore(firstVisibleMessage);
-  }
 
   return (
     <>
       <ConversationListItem
         className="border-t-0 border-b-0"
-        key={conversation.sId}
+        key={conversation.id}
         textAnimation={conversation.isRunningAgentLoop ? "streaming" : "none"}
         conversation={{
-          id: conversation.sId,
-          title: conversationLabel,
-          description: stripMarkdown(firstVisibleMessage.content ?? ""),
+          id: conversation.id,
+          title: conversation.title,
+          description: stripMarkdown(conversation.description ?? ""),
           updatedAt: new Date(conversation.updated),
         }}
         creator={{
-          fullName: creatorName,
-          portrait: creatorVisual,
+          fullName: conversation.creator?.name ?? "",
+          portrait: conversation.creator?.visual ?? "",
         }}
         time={time}
         replySection={
-          replyCount || countUnreadMessages ? (
+          conversation.replyCount || conversation.unreadMessageCount ? (
             <ReplySection
-              replyCount={replyCount}
-              unreadCount={countUnreadMessages}
-              avatars={avatars}
-              lastMessageBy={avatars[0]?.name ?? "Unknown"}
+              replyCount={conversation.replyCount}
+              unreadCount={conversation.unreadMessageCount}
+              avatars={conversation.avatars}
+              lastMessageBy={conversation.avatars[0]?.name ?? "Unknown"}
             />
           ) : null
         }
         onClick={async () => {
           await router.push(
-            getConversationRoute(owner.sId, conversation.sId),
+            getConversationRoute(owner.sId, conversation.id),
             undefined,
             { shallow: true }
           );

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -16,11 +16,9 @@ import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import { useAppRouter } from "@app/lib/platform";
 import { usePodDefaultSkills, usePodMetadata } from "@app/lib/swr/pods";
 import { getConversationRoute } from "@app/lib/utils/router";
+import type { PodConversationListItemType } from "@app/types/api/assistant/conversation/spaces";
 import type { GetSpaceResponseBody } from "@app/types/api/spaces";
-import type {
-  ConversationWithoutContentType,
-  LightConversationType,
-} from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
@@ -58,7 +56,7 @@ type GroupLabel =
 interface PodConversationsTabProps {
   owner: WorkspaceType;
   user: UserType;
-  conversations: LightConversationType[];
+  conversations: PodConversationListItemType[];
   isConversationsLoading: boolean;
   hasMore: boolean;
   loadMore: () => void;
@@ -151,13 +149,13 @@ export function PodConversationsTab({
     initialSearchText: "",
   });
 
-  const conversationsByDate: Record<GroupLabel, LightConversationType[]> =
+  const conversationsByDate: Record<GroupLabel, PodConversationListItemType[]> =
     useMemo(() => {
       return conversations.length
         ? (getGroupConversationsByDate({
             conversations,
             titleFilter: "",
-          }) as Record<GroupLabel, LightConversationType[]>)
+          }) as Record<GroupLabel, PodConversationListItemType[]>)
         : ({} as Record<GroupLabel, typeof conversations>);
     }, [conversations]);
 
@@ -379,7 +377,7 @@ export function PodConversationsTab({
                               .toSorted((a, b) => b.updated - a.updated)
                               .map((conversation) => (
                                 <PodConversationListItem
-                                  key={conversation.sId}
+                                  key={conversation.id}
                                   conversation={conversation}
                                   owner={owner}
                                 />

--- a/front/hooks/conversations/usePodConversations.ts
+++ b/front/hooks/conversations/usePodConversations.ts
@@ -8,8 +8,8 @@ import type {
   GetBySpacesSummaryResponseBody,
   GetSpaceConversationsResponseBody,
   GetSpaceUnreadConversationsResponseBody,
+  PodConversationListItemType,
 } from "@app/types/api/assistant/conversation/spaces";
-import type { LightConversationType } from "@app/types/assistant/conversation";
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 
@@ -97,7 +97,7 @@ export function usePodConversations({
 
   const conversations = useMemo(() => {
     if (!data) {
-      return emptyArray<LightConversationType>();
+      return emptyArray<PodConversationListItemType>();
     }
     return data.flatMap((page) => page.conversations);
   }, [data]);

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -1,11 +1,17 @@
 import {
   moveConversationOutOfProject,
   moveConversationToProject,
+  toPodConversationListItem,
 } from "@app/lib/api/projects/conversations";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import { UserConversationReadsModel } from "@app/lib/models/agent/conversation";
+import {
+  AgentMessageModel,
+  MessageModel,
+  UserConversationReadsModel,
+} from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -13,7 +19,37 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { isPodConversation } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { WorkspaceType } from "@app/types/user";
+import { Op } from "sequelize";
 import { beforeEach, describe, expect, it } from "vitest";
+
+async function markConversationAgentMessagesAsSucceeded(
+  workspace: WorkspaceType,
+  conversationId: ModelId,
+  completedAt = new Date()
+) {
+  const messages = await MessageModel.findAll({
+    where: { conversationId, workspaceId: workspace.id },
+  });
+  const agentMessageIds = messages
+    .map((message) => message.agentMessageId)
+    .filter((id): id is ModelId => id !== null);
+
+  if (agentMessageIds.length === 0) {
+    return;
+  }
+
+  await AgentMessageModel.update(
+    { status: "succeeded", completedAt },
+    {
+      where: {
+        id: { [Op.in]: agentMessageIds },
+        workspaceId: workspace.id,
+      },
+    }
+  );
+}
 
 describe("moveConversationToProject", () => {
   let auth: Authenticator;
@@ -1155,5 +1191,290 @@ describe("moveConversationOutOfProject", () => {
     if (user2After?.lastReadAt) {
       expect(user2After.lastReadAt < newUpdatedAt).toBe(true);
     }
+  });
+});
+
+describe("toPodConversationListItem", () => {
+  let auth: Authenticator;
+  let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+  });
+
+  it("returns an empty array when no conversations are provided", async () => {
+    const result = await toPodConversationListItem(auth, { conversations: [] });
+    expect(result).toEqual([]);
+  });
+
+  it("maps conversations with user and succeeded agent messages to list items", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Pod List Agent",
+    });
+
+    const conversationType = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date("2024-06-01T10:00:00Z")],
+    });
+
+    await markConversationAgentMessagesAsSucceeded(
+      workspace,
+      conversationType.id
+    );
+
+    const [conversationResource] =
+      await ConversationResource.fetchByIdsWithReadState(auth, [
+        conversationType.sId,
+      ]);
+    if (!conversationResource) {
+      throw new Error("Conversation not found");
+    }
+
+    const [item] = await toPodConversationListItem(auth, {
+      conversations: [conversationResource],
+    });
+
+    expect(item.id).toBe(conversationType.sId);
+    expect(item.title).toBe("Test Conversation");
+    expect(item.description).toBe("Test user Message.");
+    expect(item.replyCount).toBe(1);
+    expect(item.creator).toMatchObject({
+      name: expect.any(String),
+      visual: expect.any(String),
+      isRounded: true,
+    });
+    expect(item.avatars).toHaveLength(1);
+    expect(item.avatars[0]).toMatchObject({
+      name: "Pod List Agent",
+      visual: agentConfig.pictureUrl,
+      isRounded: false,
+    });
+    expect(item.isRunningAgentLoop).toBe(false);
+    expect(item.created).toBe(conversationResource.createdAt.getTime());
+    expect(item.updated).toBe(conversationResource.updatedAt.getTime());
+  });
+
+  it("excludes agent messages that have not succeeded", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const conversationType = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date("2024-06-01T10:00:00Z")],
+    });
+
+    const [conversationResource] =
+      await ConversationResource.fetchByIdsWithReadState(auth, [
+        conversationType.sId,
+      ]);
+    if (!conversationResource) {
+      throw new Error("Conversation not found");
+    }
+
+    const [item] = await toPodConversationListItem(auth, {
+      conversations: [conversationResource],
+    });
+
+    expect(item.replyCount).toBe(0);
+    expect(item.avatars).toHaveLength(0);
+  });
+
+  it("excludes user messages with hidden origins", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const conversationType = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation: conversationType,
+      content: "Hidden anchor message",
+      origin: "branch_anchor",
+      rank: 0,
+    });
+
+    const [conversationResource] =
+      await ConversationResource.fetchByIdsWithReadState(auth, [
+        conversationType.sId,
+      ]);
+    if (!conversationResource) {
+      throw new Error("Conversation not found");
+    }
+
+    const [item] = await toPodConversationListItem(auth, {
+      conversations: [conversationResource],
+    });
+
+    expect(item.description).toBe("");
+    expect(item.replyCount).toBe(0);
+    expect(item.creator).toBeUndefined();
+  });
+
+  it("keeps only the latest version per message rank", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Latest Version Agent",
+    });
+
+    const conversationType = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation: conversationType,
+      content: "Visible user message",
+      rank: 0,
+    });
+
+    const oldAgentMessage = await AgentMessageModel.create({
+      status: "succeeded",
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: agentConfig.version,
+      workspaceId: workspace.id,
+      skipToolsValidation: false,
+      completedAt: new Date("2024-06-01T10:00:00Z"),
+    });
+    await MessageModel.create({
+      sId: generateRandomModelSId(),
+      rank: 1,
+      version: 0,
+      conversationId: conversationType.id,
+      parentId: null,
+      agentMessageId: oldAgentMessage.id,
+      workspaceId: workspace.id,
+    });
+
+    const newAgentMessage = await AgentMessageModel.create({
+      status: "succeeded",
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: agentConfig.version,
+      workspaceId: workspace.id,
+      skipToolsValidation: false,
+      completedAt: new Date("2024-06-01T11:00:00Z"),
+    });
+    await MessageModel.create({
+      sId: generateRandomModelSId(),
+      rank: 1,
+      version: 1,
+      conversationId: conversationType.id,
+      parentId: null,
+      agentMessageId: newAgentMessage.id,
+      workspaceId: workspace.id,
+    });
+
+    const [conversationResource] =
+      await ConversationResource.fetchByIdsWithReadState(auth, [
+        conversationType.sId,
+      ]);
+    if (!conversationResource) {
+      throw new Error("Conversation not found");
+    }
+
+    const [item] = await toPodConversationListItem(auth, {
+      conversations: [conversationResource],
+    });
+
+    expect(item.replyCount).toBe(1);
+    expect(item.avatars).toHaveLength(1);
+    expect(item.avatars[0]?.name).toBe("Latest Version Agent");
+  });
+
+  it("computes unreadMessageCount from the user's last read timestamp", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+    const messageTime = new Date("2024-06-01T12:00:00Z");
+
+    const conversationType = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [messageTime],
+    });
+
+    await markConversationAgentMessagesAsSucceeded(
+      workspace,
+      conversationType.id,
+      messageTime
+    );
+
+    const user = auth.getNonNullableUser();
+    await UserConversationReadsModel.upsert({
+      conversationId: conversationType.id,
+      userId: user.id,
+      workspaceId: workspace.id,
+      lastReadAt: new Date("2024-06-01T10:00:00Z"),
+    });
+
+    const [conversationResource] =
+      await ConversationResource.fetchByIdsWithReadState(auth, [
+        conversationType.sId,
+      ]);
+    if (!conversationResource) {
+      throw new Error("Conversation not found");
+    }
+
+    const [item] = await toPodConversationListItem(auth, {
+      conversations: [conversationResource],
+    });
+
+    expect(item.unreadMessageCount).toBe(2);
+
+    await ConversationResource.markAsReadForAuthUser(auth, {
+      conversation: conversationType,
+    });
+
+    const [readConversationResource] =
+      await ConversationResource.fetchByIdsWithReadState(auth, [
+        conversationType.sId,
+      ]);
+    if (!readConversationResource) {
+      throw new Error("Conversation not found after mark as read");
+    }
+
+    const [readItem] = await toPodConversationListItem(auth, {
+      conversations: [readConversationResource],
+    });
+
+    expect(readItem.unreadMessageCount).toBe(0);
+  });
+
+  it("maps multiple conversations in a single call", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const firstConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date("2024-06-01T10:00:00Z")],
+    });
+    const secondConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date("2024-06-02T10:00:00Z")],
+    });
+
+    await markConversationAgentMessagesAsSucceeded(
+      workspace,
+      firstConversation.id
+    );
+    await markConversationAgentMessagesAsSucceeded(
+      workspace,
+      secondConversation.id
+    );
+
+    const conversationResources =
+      await ConversationResource.fetchByIdsWithReadState(auth, [
+        firstConversation.sId,
+        secondConversation.sId,
+      ]);
+
+    const items = await toPodConversationListItem(auth, {
+      conversations: conversationResources,
+    });
+
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.id).sort()).toEqual(
+      [firstConversation.sId, secondConversation.sId].sort()
+    );
   });
 });

--- a/front/lib/api/projects/conversations.ts
+++ b/front/lib/api/projects/conversations.ts
@@ -4,14 +4,30 @@ import {
 } from "@app/lib/api/assistant/conversation/permissions";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
+import {
+  AgentMessageModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { PodConversationListItemType } from "@app/types/api/assistant/conversation/spaces";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import { isPodConversation } from "@app/types/assistant/conversation";
+import {
+  getConversationDisplayTitle,
+  HIDDEN_MESSAGE_ORIGINS,
+  isPodConversation,
+} from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { Transaction } from "sequelize";
+import { removeNulls } from "@app/types/shared/utils/general";
+import uniq from "lodash/uniq";
+import uniqBy from "lodash/uniqBy";
+import type { Transaction, WhereOptions } from "sequelize";
+import { Op } from "sequelize";
+import { getAgentConfigurations } from "../assistant/configuration/agent";
 
 export async function moveConversationToProject(
   auth: Authenticator,
@@ -237,4 +253,185 @@ export async function moveConversationOutOfProject(
   }
 
   return new Ok(undefined);
+}
+
+export async function toPodConversationListItem(
+  auth: Authenticator,
+  { conversations }: { conversations: ConversationResource[] }
+): Promise<PodConversationListItemType[]> {
+  if (conversations.length === 0) {
+    return [];
+  }
+  const where: WhereOptions<MessageModel> = {
+    workspaceId: auth.getNonNullableWorkspace().id,
+    conversationId: {
+      [Op.in]: conversations.map((conv) => conv.id),
+    },
+    visibility: "visible",
+    branchId: null,
+    [Op.or]: [
+      {
+        userMessageId: {
+          [Op.not]: null,
+        },
+        "$userMessage.userContextOrigin$": {
+          [Op.notIn]: HIDDEN_MESSAGE_ORIGINS,
+        },
+      },
+      {
+        agentMessageId: {
+          [Op.not]: null,
+        },
+        "$agentMessage.status$": {
+          [Op.eq]: "succeeded",
+        },
+      },
+    ],
+  };
+
+  const rawMessages = await MessageModel.findAll({
+    where,
+    include: [
+      {
+        model: UserMessageModel,
+        as: "userMessage",
+        required: false,
+        attributes: [
+          "id",
+          "userId",
+          "content",
+          "userContextFullName",
+          "userContextProfilePictureUrl",
+        ],
+      },
+      {
+        model: AgentMessageModel,
+        as: "agentMessage",
+        required: false,
+        attributes: ["id", "completedAt", "agentConfigurationId"],
+      },
+    ],
+    attributes: ["id", "conversationId", "rank", "version", "updatedAt"],
+    // Latest version first within each rank so we can keep one row per rank below.
+    order: [
+      ["rank", "ASC"],
+      ["version", "DESC"],
+    ],
+  });
+
+  // Messages can have multiple versions at the same rank (e.g. agent retries).
+  // Keep only the latest version per (conversationId, rank); same pattern as
+  // reaction_update.ts and branches.ts.
+  const latestMessages: MessageModel[] = [];
+  const seenRankByConversationId = new Map<number, Set<number>>();
+  for (const message of rawMessages) {
+    const seenRanks =
+      seenRankByConversationId.get(message.conversationId) ?? new Set<number>();
+    if (seenRanks.has(message.rank)) {
+      continue;
+    }
+    seenRanks.add(message.rank);
+    seenRankByConversationId.set(message.conversationId, seenRanks);
+    latestMessages.push(message);
+  }
+
+  const rawMessagesByConversationId = latestMessages.reduce(
+    (acc, message) => {
+      acc[message.conversationId] = [
+        ...(acc[message.conversationId] || []),
+        message,
+      ];
+      return acc;
+    },
+    {} as Record<number, MessageModel[]>
+  );
+
+  const [users, agents] = await Promise.all([
+    UserResource.fetchByModelIds(
+      uniq(
+        removeNulls(
+          latestMessages.map((message) => message.userMessage?.userId)
+        )
+      )
+    ),
+    getAgentConfigurations(auth, {
+      agentIds: uniq(
+        removeNulls(
+          latestMessages.map(
+            (message) => message.agentMessage?.agentConfigurationId
+          )
+        )
+      ),
+      variant: "extra_light",
+      // We already checked the permissions for the space conversations.
+      // We need to skip the permission filtering as we don't want to filter agents that might be using restricted spaces now.
+      dangerouslySkipPermissionFiltering: true,
+    }),
+  ]);
+
+  return removeNulls(
+    conversations.map((conv) => {
+      const convJSON = conv.toJSON();
+      const firstUserMessage = rawMessagesByConversationId[conv.id]?.find(
+        (message) => !!message.userMessage
+      );
+      const avatars = removeNulls(
+        (rawMessagesByConversationId[conv.id] ?? []).map((message) => {
+          if (message.userMessage) {
+            const user = users.find(
+              (user) => user.id === message.userMessage!.userId
+            );
+            return user
+              ? {
+                  name:
+                    user.fullName() ??
+                    message.userMessage?.userContextFullName ??
+                    "",
+                  visual:
+                    user.imageUrl ??
+                    message.userMessage?.userContextProfilePictureUrl ??
+                    "",
+                  isRounded: true,
+                }
+              : {
+                  name: message.userMessage?.userContextFullName ?? "",
+                  visual:
+                    message.userMessage?.userContextProfilePictureUrl ?? "",
+                  isRounded: false,
+                };
+          }
+
+          const agent = agents.find(
+            (agent) => agent.sId === message.agentMessage?.agentConfigurationId
+          );
+          return agent
+            ? {
+                name: agent.name ?? "",
+                visual: agent.pictureUrl ?? "",
+                isRounded: false,
+              }
+            : null;
+        })
+      );
+
+      return {
+        id: conv.sId,
+        title: getConversationDisplayTitle(convJSON),
+        created: conv.createdAt.getTime(),
+        updated: conv.updatedAt.getTime(),
+        replyCount: (rawMessagesByConversationId[conv.id]?.length ?? 1) - 1,
+        unreadMessageCount:
+          rawMessagesByConversationId[conv.id]?.filter(
+            (message) =>
+              (message.agentMessage?.completedAt?.getTime() ??
+                message.updatedAt.getTime()) >
+              (convJSON.lastReadMs ?? Date.now())
+          ).length ?? 0,
+        description: firstUserMessage?.userMessage?.content ?? "",
+        creator: avatars[0],
+        avatars: uniqBy(avatars.slice(1).reverse(), "name"),
+        isRunningAgentLoop: conv.isRunningAgentLoop,
+      };
+    })
+  );
 }

--- a/front/types/api/assistant/conversation/spaces.ts
+++ b/front/types/api/assistant/conversation/spaces.ts
@@ -1,8 +1,5 @@
 // Shared contract types for the assistant conversation "spaces" API endpoints.
-import type {
-  ConversationWithoutContentType,
-  LightConversationType,
-} from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { PodListItemType } from "@app/types/space";
 
 export type GetBySpacesSummaryResponseBody = {
@@ -13,8 +10,29 @@ export type GetBySpacesSummaryResponseBody = {
   }>;
 };
 
+export type PodConversationListItemType = {
+  id: string;
+  title: string;
+  created: number;
+  updated: number;
+  replyCount: number;
+  unreadMessageCount: number;
+  isRunningAgentLoop: boolean;
+  description: string;
+  creator: {
+    name: string;
+    visual: string;
+    isRounded: boolean;
+  } | null;
+  avatars: {
+    name: string;
+    visual: string;
+    isRounded: boolean;
+  }[];
+};
+
 export type GetSpaceConversationsResponseBody = {
-  conversations: LightConversationType[];
+  conversations: PodConversationListItemType[];
   hasMore: boolean;
   lastValue: string | null;
   isEmpty: boolean;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -124,6 +124,14 @@ export type UserMessageOrigin =
   // a branch can be created before any user-visible message exists.
   | "branch_anchor";
 
+export const HIDDEN_MESSAGE_ORIGINS: UserMessageOrigin[] = [
+  "onboarding_conversation",
+  "project_kickoff",
+  "reinforced_skill_notification",
+  "branch_anchor",
+  "wakeup",
+];
+
 /**
  * @swaggerschema Context (swagger_schemas.ts), PrivateUserMessageContext (swagger_private_schemas.ts)
  */
@@ -209,13 +217,7 @@ export function isUserMessageTypeWithContentFragments(
 }
 
 export function isHiddenMessageOrigin(origin: UserMessageOrigin): boolean {
-  return (
-    origin === "onboarding_conversation" ||
-    origin === "project_kickoff" ||
-    origin === "reinforced_skill_notification" ||
-    origin === "branch_anchor" ||
-    origin === "wakeup"
-  );
+  return HIDDEN_MESSAGE_ORIGINS.includes(origin);
 }
 
 export function isVisibleMessage(m: LightMessageType): boolean {


### PR DESCRIPTION
## Description

Replaced the N+1 `getLightConversation` fan-out in the pod conversation list endpoint with a single batched `MessageModel.findAll` via `toPodConversationListItem`. The new function fetches all visible messages for the paginated conversation set in one query, then joins users and agent configurations in parallel, and returns the lean `PodConversationListItemType` — exactly what `PodConversationListItem` needs to render (title, description, creator, avatars, message count, unread count).

- Introduced `PodConversationListItemType` in `front/types/api/assistant/conversation/spaces.ts`; `GetSpaceConversationsResponseBody` now uses it instead of `LightConversationType`.
- Extracted `HIDDEN_MESSAGE_ORIGINS` as a constant so it can be used directly in Sequelize `Op.notIn` clauses.
- Deferred the "is space empty?" fallback query to run only when the current page returns zero results, eliminating an unconditional extra query.
- Simplified `PodConversationListItem` significantly — all avatar computation, message filtering, and unread counting moved server-side.

## Tests

Tested locally — pod conversation list renders correctly with the new response shape.

Before (team bi-weekly)
<img width="1501" height="28" alt="image" src="https://github.com/user-attachments/assets/d05d2c3f-00fc-46ef-91f5-d8e5686a1bba" />

After
<img width="1503" height="26" alt="dyn-f721c9fc60331aed698b01c81d199e19" src="https://github.com/user-attachments/assets/087dae9e-19ad-42f9-9af2-ede0b8d0e68a" />


## Risk

Low. The change is internal to the pod conversation list rendering path. The API response type narrows from `LightConversationType` (full conversation content) to `PodConversationListItemType`; no external consumers depend on the old shape. Rollback is safe — revert front deploy.

## Deploy Plan

Deploy front.
