### PR TITLE
[front] chore: cleanup `constructPromptMultiActions` signature

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -219,9 +219,7 @@ app.post(
       agentsList,
       conversation,
       serverToolsAndInstructions,
-      enabledSkills,
       systemSkills,
-      equippedSkills,
       projectContext,
       isNewFileExplorer,
     });

--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -120,8 +120,6 @@ export async function getPromptForProcessDustApp({
       model,
       hasAvailableActions: false,
       systemSkills: [],
-      enabledSkills: [],
-      equippedSkills: [],
       agentsList: null,
       conversation,
     })

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -22,7 +22,6 @@ import {
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { citationMetaPrompt } from "@app/lib/api/assistant/citations";
 import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/global_agents";
-import type { EnabledSkill } from "@app/lib/api/assistant/skills_rendering";
 import { TRUNCATED_SNIPPET_SIZE } from "@app/lib/api/files/snippet";
 import type {
   StructuredSystemPrompt,
@@ -64,11 +63,9 @@ function constructContextSection({
   errorContext?: string;
   disableFormattingPrompt: boolean;
 }): string {
-  const d = moment(new Date()).tz(userMessage.context.timezone);
-
   let context = "# CONTEXT\n\n";
   context += `assistant: @${agentConfiguration.name}\n`;
-  context += `current_date: ${d.format("YYYY-MM-DD (ddd)")}\n`;
+  context += `current_date: ${currentDate.format("YYYY-MM-DD (ddd)")}\n`;
   context += `model_id: ${model.modelId}\n`;
   if (owner) {
     context += `workspace: ${owner.name}\n`;
@@ -375,9 +372,7 @@ export function constructPromptMultiActions(
     agentsList,
     conversation,
     serverToolsAndInstructions,
-    enabledSkills,
     systemSkills,
-    equippedSkills,
     toolsetsContext,
     userContext,
     workspaceContext,
@@ -395,9 +390,7 @@ export function constructPromptMultiActions(
     agentsList: LightAgentConfigurationType[] | null;
     conversation?: ConversationWithoutContentType;
     serverToolsAndInstructions?: ServerToolsAndInstructions[];
-    enabledSkills: EnabledSkill[];
     systemSkills: SkillResource[];
-    equippedSkills: SkillResource[];
     toolsetsContext?: string;
     userContext?: string;
     workspaceContext?: string;

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -42,6 +42,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { WorkspaceType } from "@app/types/user";
+import moment from "moment-timezone";
 
 // This section is included in the system prompt, which benefits from prompt caching.
 // To maximize cache hits, avoid adding high-entropy data (e.g., timestamps with time precision,
@@ -62,9 +63,11 @@ function constructContextSection({
   errorContext?: string;
   disableFormattingPrompt: boolean;
 }): string {
+  const d = moment(new Date()).tz(userMessage.context.timezone);
+
   let context = "# CONTEXT\n\n";
   context += `assistant: @${agentConfiguration.name}\n`;
-  context += `current_date: ${currentDate.format("YYYY-MM-DD (ddd)")}\n`;
+  context += `current_date: ${d.format("YYYY-MM-DD (ddd)")}\n`;
   context += `model_id: ${model.modelId}\n`;
   if (owner) {
     context += `workspace: ${owner.name}\n`;

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -42,7 +42,6 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { WorkspaceType } from "@app/types/user";
-import moment from "moment-timezone";
 
 // This section is included in the system prompt, which benefits from prompt caching.
 // To maximize cache hits, avoid adding high-entropy data (e.g., timestamps with time precision,

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -194,9 +194,7 @@ makeScript(
       agentsList,
       conversation,
       serverToolsAndInstructions,
-      enabledSkills,
       systemSkills,
-      equippedSkills,
       projectContext,
       isNewFileExplorer,
     });

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -399,8 +399,6 @@ export async function runModel(
     conversation,
     serverToolsAndInstructions: filteredMcpActions,
     systemSkills,
-    enabledSkills,
-    equippedSkills,
     toolsetsContext,
     userContext,
     workspaceContext,
@@ -584,10 +582,7 @@ export async function runModel(
     "[LLM stream] Starting (agent loop)"
   );
 
-  if (
-    modelConversationRes.value.prunedContext === true &&
-    !agentMessage.prunedContext
-  ) {
+  if (modelConversationRes.value.prunedContext && !agentMessage.prunedContext) {
     await updateAgentMessageDBAndMemory(auth, {
       agentMessage,
       update: {


### PR DESCRIPTION
## Description

This PR removes `equippedSkills` and `enabledSkills` from the signature of `constructPromptMultiActions`.
These two fields are unused now that we moved skill rendering to user messages.
Goal is to have `constructPromptMultiActions` as lean as possible to avoid creating ways to add entropy to the system prompt.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
