### PR TITLE
Pricing: display period and prorated period below each seat line of the billing 

### DIFF
--- a/front-api/routes/w/[wId]/metronome/invoice.ts
+++ b/front-api/routes/w/[wId]/metronome/invoice.ts
@@ -201,10 +201,18 @@ app.get(
           totalCents: itemCurrency
             ? amountCents(item.total, itemCurrency)
             : item.total,
+          isProrated: item.is_prorated ?? false,
+          periodStartMs: item.starting_at
+            ? new Date(item.starting_at).getTime()
+            : null,
+          // Exclusive end of the period covered by the line item.
+          periodEndMs: item.ending_before
+            ? new Date(item.ending_before).getTime()
+            : null,
         };
       });
 
-    return ctx.json({ currency, lineItems, items: invoice.line_items });
+    return ctx.json({ currency, lineItems });
   }
 );
 

--- a/front/components/workspace/billing/NextInvoicePreview.tsx
+++ b/front/components/workspace/billing/NextInvoicePreview.tsx
@@ -12,6 +12,7 @@ import {
   WORKSPACE_SEAT_PRODUCT_NAME,
 } from "@app/lib/metronome/setup_common";
 import { useMetronomeInvoiceLines } from "@app/lib/swr/workspaces";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import {
   Avatar,
   ChevronDown,
@@ -27,6 +28,7 @@ import { useSubscriptionContext } from "./SubscriptionContext";
 
 interface InvoiceRow {
   name: string;
+  period: string | null;
   quantity: string;
   cost: string;
   subtotal: string;
@@ -54,6 +56,14 @@ const PRODUCT_NAME_TO_SEAT_TYPE: Record<string, string> = {
   [OVERAGE_NAME]: "overage",
 };
 
+function formatLineItemPeriod(item: MetronomeInvoiceLineItem): string | null {
+  if (item.periodStartMs == null || item.periodEndMs == null) {
+    return null;
+  }
+  const period = `${formatTimestampToFriendlyDate(item.periodStartMs, "compactWithDay")} → ${formatTimestampToFriendlyDate(item.periodEndMs, "compactWithDay")}`;
+  return item.isProrated ? `Prorated · ${period}` : period;
+}
+
 function formatLineItem(
   item: MetronomeInvoiceLineItem,
   currency: string
@@ -61,6 +71,7 @@ function formatLineItem(
   const isOverage = item.name === CREDITS_CONVERSION_NAME;
   return {
     name: isOverage ? OVERAGE_NAME : item.name,
+    period: formatLineItemPeriod(item),
     quantity:
       item.quantity !== null
         ? `${item.quantity.toLocaleString()}${isOverage ? " credits" : ""}`
@@ -116,11 +127,21 @@ function buildColumns(currency: string): ColumnDef<InvoiceRow>[] {
                 iconColor={avatarColors.iconColor}
               />
             ) : null}
-            <span
-              className={cn("text-sm", row.original.isBold && "font-semibold")}
-            >
-              {name}
-            </span>
+            <div className="flex flex-col">
+              <span
+                className={cn(
+                  "text-sm",
+                  row.original.isBold && "font-semibold"
+                )}
+              >
+                {name}
+              </span>
+              {row.original.period ? (
+                <span className="text-xs text-muted-foreground">
+                  {row.original.period}
+                </span>
+              ) : null}
+            </div>
           </div>
         );
       },
@@ -224,6 +245,7 @@ export function NextInvoicePreview() {
         name === CREDITS_CONVERSION_NAME ? OVERAGE_NAME : name;
       rows.push({
         name: displayName,
+        period: null,
         quantity: "",
         cost: "",
         subtotal: formatAmount(subtotalCents, currency),
@@ -245,6 +267,7 @@ export function NextInvoicePreview() {
   );
   rows.push({
     name: "Total",
+    period: null,
     quantity: "",
     cost: "",
     subtotal: formatAmount(totalCents, currency),

--- a/front/lib/metronome/invoice.ts
+++ b/front/lib/metronome/invoice.ts
@@ -21,6 +21,12 @@ export type MetronomeInvoiceLineItem = {
   quantity: number | null;
   unitPriceCents: number | null;
   totalCents: number;
+  /** Whether the line item is prorated (partial billing period). */
+  isProrated?: boolean;
+  /** Start of the period covered by the line item. */
+  periodStartMs?: number | null;
+  /** Exclusive end of the period covered by the line item. */
+  periodEndMs?: number | null;
 };
 
 export type GetMetronomeInvoiceLinesResponseBody = {


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9399

When we add seat mid contract, they are billed prorated at the end of the period.
This means the bill next month will be higher (prorated seat + next seat) and without the period it is confusing to understand (bill is higher than normal bill afterwards).

This adds the period in the UI to clarify this

<img width="2370" height="1252" alt="image" src="https://github.com/user-attachments/assets/d3beab60-f924-4c8b-bc65-da16960c20d3" />


## Tests

tested locally

## Risk

low

## Deploy Plan

deploy front
