### PR TITLE
Add HubSpot create ticket tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -288,6 +288,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "create_meeting": "high",
     "create_note": "high",
     "create_task": "high",
+    "create_ticket": "high",
     "export_crm_objects_csv": "never_ask",
     "get_associated_meetings": "never_ask",
     "get_company": "never_ask",

--- a/front/lib/api/actions/servers/hubspot/client.ts
+++ b/front/lib/api/actions/servers/hubspot/client.ts
@@ -781,6 +781,51 @@ export const createDeal = async ({
   return hubspotClient.crm.deals.basicApi.create(dealData);
 };
 
+export const createTicket = async ({
+  accessToken,
+  properties,
+  associations,
+}: {
+  accessToken: string;
+  properties: Record<string, string>;
+  associations?: Array<{
+    toObjectId: string;
+    toObjectType: string;
+  }>;
+}): Promise<SimplePublicObject> => {
+  const hubspotClient = new Client({ accessToken });
+
+  const builtAssociations: SimplePublicObjectInputForCreate["associations"] =
+    [];
+
+  if (associations && associations.length > 0) {
+    for (const assoc of associations) {
+      const associationTypeId = await getAssociationTypeId(
+        accessToken,
+        "tickets",
+        assoc.toObjectType
+      );
+      builtAssociations.push({
+        to: { id: assoc.toObjectId },
+        types: [
+          {
+            associationCategory:
+              AssociationSpecAssociationCategoryEnum.HubspotDefined,
+            associationTypeId: associationTypeId,
+          },
+        ],
+      });
+    }
+  }
+
+  const ticketData: SimplePublicObjectInputForCreate = {
+    properties,
+    associations: builtAssociations,
+  };
+
+  return hubspotClient.crm.tickets.basicApi.create(ticketData);
+};
+
 export const createNote = async ({
   accessToken,
   properties,

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -582,6 +582,25 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       done: "Create HubSpot deal",
     },
   },
+  create_ticket: {
+    description: "Create a new ticket in Hubspot, with optional associations.",
+    schema: {
+      properties: z
+        .record(z.string())
+        .describe(
+          "Properties for the ticket. `subject` is required; common fields include content, hs_pipeline, hs_pipeline_stage, hs_ticket_priority."
+        ),
+      associations: z
+        .array(associationSchema)
+        .optional()
+        .describe("Optional array of associations to create."),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Creating HubSpot ticket",
+      done: "Create HubSpot ticket",
+    },
+  },
   create_lead: {
     description:
       "Create a new lead in Hubspot (as a Deal), with optional associations. Ensure properties correctly define it as a lead.",

--- a/front/lib/api/actions/servers/hubspot/tools/index.ts
+++ b/front/lib/api/actions/servers/hubspot/tools/index.ts
@@ -12,6 +12,7 @@ import {
   createMeeting,
   createNote,
   createTask,
+  createTicket,
   getAssociatedMeetings,
   getCompany,
   getContact,
@@ -693,6 +694,24 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
       return new Ok([
         { type: "text" as const, text: "Deal created successfully." },
         { type: "text" as const, text: JSON.stringify(result, null, 2) },
+      ]);
+    });
+  },
+
+  create_ticket: async ({ properties, associations }, extra) => {
+    return withAuth(extra, async (accessToken) => {
+      const result = await createTicket({
+        accessToken,
+        properties,
+        associations,
+      });
+      const formatted = formatHubSpotCreateSuccess(result, "tickets");
+      return new Ok([
+        { type: "text" as const, text: formatted.message },
+        {
+          type: "text" as const,
+          text: JSON.stringify(formatted.result, null, 2),
+        },
       ]);
     });
   },


### PR DESCRIPTION
## Description

Adds a `create_ticket` tool to the HubSpot internal MCP server so agents can create a ticket in HubSpot.

## Tests

Tested locally creating a default ticket in the dev test hubspot

## Risk

Low additive only, a new internal MCP tool.

## Deploy Plan

 Standard deploy, no prerequisites (the `tickets` scope is already enabled on the HubSpot app from #28402).