### PR TITLE
chore(scripts): add qdrant shards-by-peer mapping script

### DIFF
--- a/scripts/qdrant_shards_by_peer.sh
+++ b/scripts/qdrant_shards_by_peer.sh
@@ -6,13 +6,25 @@
 # peer from /cluster has answered at least once (coupon collector), collecting its
 # local_shards each time.
 #
-# Usage: QDRANT_CLUSTER_0_URL=... QDRANT_CLUSTER_0_API_KEY=... ./qdrant_shards_by_peer.sh <collection>
+# Usage: QDRANT_CLUSTER_0_URL=... QDRANT_CLUSTER_0_API_KEY=... ./qdrant_shards_by_peer.sh [--verbose] <collection>
 set -euo pipefail
 
-COLLECTION="${1:?usage: $0 <collection>}"
+VERBOSE=""
+COLLECTION=""
+for arg in "$@"; do
+  case "$arg" in
+    --verbose | -v) VERBOSE=1 ;;
+    *) COLLECTION="$arg" ;;
+  esac
+done
+: "${COLLECTION:?usage: $0 [--verbose] <collection>}"
+
 BASE="$QDRANT_CLUSTER_0_URL"
 AUTH=(-H "api-key: $QDRANT_CLUSTER_0_API_KEY")
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-100}"
+
+# Progress goes to stderr, only when --verbose. stdout stays pure JSON for piping.
+log() { [[ -n "$VERBOSE" ]] && echo "$@" >&2; return 0; }
 
 # peer_id -> pod ordinal (ordinal = number before ".qdrant-headless" in the p2p uri).
 ORDINALS="$(curl -s "${AUTH[@]}" "$BASE/cluster" \
@@ -32,7 +44,7 @@ for ((i = 1; i <= MAX_ATTEMPTS; i++)); do
   collected="$(jq -c --arg pid "$pid" --argjson r "$resp" \
     '.[$pid] = $r.result.local_shards' <<<"$collected")"
   seen="$(jq 'keys | length' <<<"$collected")"
-  echo "attempt $i: peer $pid answered — $seen/$want_count peers covered" >&2
+  log "attempt $i: peer $pid answered — $seen/$want_count peers covered"
   [[ "$seen" -ge "$want_count" ]] && break
 done
 

--- a/scripts/qdrant_shards_by_peer.sh
+++ b/scripts/qdrant_shards_by_peer.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Map, by pod ordinal, the shards (shard_id, shard_key, points_count) each peer holds.
+#
+# points_count is only present in a peer's own `local_shards`, and the API has no way to
+# target a specific peer. So we poll the LB (which routes to a random peer) until every
+# peer from /cluster has answered at least once (coupon collector), collecting its
+# local_shards each time.
+#
+# Usage: QDRANT_CLUSTER_0_URL=... QDRANT_CLUSTER_0_API_KEY=... ./qdrant_shards_by_peer.sh <collection>
+set -euo pipefail
+
+COLLECTION="${1:?usage: $0 <collection>}"
+BASE="$QDRANT_CLUSTER_0_URL"
+AUTH=(-H "api-key: $QDRANT_CLUSTER_0_API_KEY")
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-500}"
+
+# peer_id -> pod ordinal (ordinal = number before ".qdrant-headless" in the p2p uri).
+ORDINALS="$(curl -s "${AUTH[@]}" "$BASE/cluster" \
+  | jq -c '.result.peers | to_entries
+      | map({key: .key, value: (.value.uri | capture("-(?<n>[0-9]+)\\.").n | tonumber)})
+      | from_entries')"
+
+want="$(jq -r 'keys[]' <<<"$ORDINALS" | sort -u)"
+want_count="$(wc -l <<<"$want" | tr -d ' ')"
+
+# Accumulate: peer_id -> local_shards array. Overwrites on repeat hits (idempotent).
+collected='{}'
+seen=0
+for ((i = 1; i <= MAX_ATTEMPTS; i++)); do
+  resp="$(curl -s "${AUTH[@]}" "$BASE/collections/$COLLECTION/cluster")"
+  pid="$(jq -r '.result.peer_id' <<<"$resp")"
+  collected="$(jq -c --arg pid "$pid" --argjson r "$resp" \
+    '.[$pid] = $r.result.local_shards' <<<"$collected")"
+  seen="$(jq 'keys | length' <<<"$collected")"
+  echo "attempt $i: peer $pid answered — $seen/$want_count peers covered" >&2
+  [[ "$seen" -ge "$want_count" ]] && break
+done
+
+if [[ "$seen" -lt "$want_count" ]]; then
+  echo "WARNING: only covered $seen/$want_count peers after $MAX_ATTEMPTS attempts" >&2
+fi
+
+# Join with ordinals, sort by ordinal, emit shards per peer.
+jq -n --argjson collected "$collected" --argjson ordinals "$ORDINALS" '
+  $collected | to_entries
+  | map({
+      ordinal: ($ordinals[.key]),
+      peer_id: (.key | tonumber),
+      shards: (.value | map({shard_id, shard_key, points_count}) | sort_by(.shard_id))
+    })
+  | sort_by(.ordinal)
+'

--- a/scripts/qdrant_shards_by_peer.sh
+++ b/scripts/qdrant_shards_by_peer.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 COLLECTION="${1:?usage: $0 <collection>}"
 BASE="$QDRANT_CLUSTER_0_URL"
 AUTH=(-H "api-key: $QDRANT_CLUSTER_0_API_KEY")
-MAX_ATTEMPTS="${MAX_ATTEMPTS:-500}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-100}"
 
 # peer_id -> pod ordinal (ordinal = number before ".qdrant-headless" in the p2p uri).
 ORDINALS="$(curl -s "${AUTH[@]}" "$BASE/cluster" \


### PR DESCRIPTION
## Description

Adds `scripts/qdrant_shards_by_peer.sh`, which maps every shard (`shard_id`, `shard_key`, `points_count`) to the peer that holds it, keyed by pod ordinal.

Motivation: 
- `GET /collections/{c}/cluster` only exposes `points_count` in a peer's own `local_shards` (remote shards omit it), and the API offers no way to target a specific peer. The load balancer routes each request to a random one.  
- The ordinal number to peer_id was opaque. The script includes it and associates a node number (`0`) to the `peer_id` (`4066614124317144`)

The script polls the endpoint until every peer from `GET /cluster` has answered at least once, collecting each peer's `local_shards`, then joins with the `peer_id → ordinal` map and sorts by ordinal.

Usage:

```bash
QDRANT_CLUSTER_0_URL=... QDRANT_CLUSTER_0_API_KEY=... \
  ./scripts/qdrant_shards_by_peer.sh <collection>
```

## Result

Output is a JSON array, one entry per peer sorted by pod ordinal, listing that peer's shards with point counts:

```json
[
  {
    "ordinal": 0,
    "peer_id": 4066614124317144,
    "shards": [
      { "shard_id": 5,  "shard_key": "key_2",  "points_count": 6685150 },
      { "shard_id": 19, "shard_key": "key_9",  "points_count": 15484147 },
      { "shard_id": 42, "shard_key": "key_20", "points_count": 4308563 }
    ]
  },
  ...
]
```

## Tests

Ran manually against `c_openai_text-embedding-3-large-1536`: covered all 28 peers in ~58 requests and produced the full per-ordinal shard map with point counts. Replica placement (RF=2) and counts matched the raw `/cluster` output.

## Risk

Low. Read-only ops script, not wired into any runtime path. Worst case is extra read traffic to the Qdrant LB; `MAX_ATTEMPTS` (default 100, override via env) caps the polling loop.

## Deploy Plan

None.