### PR TITLE
Introduce SandboxFunctionRunContextType, minimal fix of servers/tools

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -709,6 +709,7 @@ describe("tryCallMCPTool", () => {
 
     // Create agent loop run context
     const agentLoopRunContext: AgentLoopRunContextType = {
+      contextType: "agent_loop",
       agentConfiguration: agentConfig,
       agentMessage,
       conversation,
@@ -732,7 +733,7 @@ describe("tryCallMCPTool", () => {
         relativeTimeFrame: "all",
         dataSources: [],
       },
-      agentLoopRunContext,
+      { runContext: agentLoopRunContext },
       {
         progressToken: agentMessage.agentMessageId as number,
         makeToolNotificationEvent: async () => ({

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -65,9 +65,11 @@ import {
   shouldRetryToolInterruption,
 } from "@app/lib/actions/tool_interruptions";
 import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
-import type {
-  AgentLoopListToolsContextType,
-  AgentLoopRunContextType,
+import {
+  type AgentLoopListToolsContextType,
+  isAgentLoopRunContext,
+  isSandboxFunctionRunContext,
+  type ToolContextType,
 } from "@app/lib/actions/types";
 import {
   isClientSideMCPToolConfiguration,
@@ -343,7 +345,7 @@ export async function runToolCallWithDetachedSignal<T>(
 export async function* tryCallMCPTool(
   auth: Authenticator,
   inputs: Record<string, unknown> | undefined,
-  agentLoopRunContext: AgentLoopRunContextType,
+  toolContext: ToolContextType,
   {
     progressToken,
     makeToolNotificationEvent,
@@ -356,7 +358,7 @@ export async function* tryCallMCPTool(
     signal?: AbortSignal;
   }
 ): AsyncGenerator<ToolNotificationEvent, CallToolResult> {
-  const { toolConfiguration } = agentLoopRunContext;
+  const { toolConfiguration } = toolContext.runContext || {};
 
   if (!isMCPToolConfiguration(toolConfiguration)) {
     return {
@@ -370,16 +372,25 @@ export async function* tryCallMCPTool(
     };
   }
 
-  const conversationId = agentLoopRunContext.conversation.sId;
-  const messageId = agentLoopRunContext.agentMessage.sId;
   const workspaceId = auth.getNonNullableWorkspace().sId;
-  const toolLogContext = {
-    conversationId,
-    messageId,
+
+  const toolLogContext: Record<string, unknown> = {
     toolName: toolConfiguration.originalName,
     toolConfigurationId: toolConfiguration.sId,
     workspaceId,
   };
+
+  if (isAgentLoopRunContext(toolContext.runContext)) {
+    const conversationId = toolContext.runContext.conversation.sId;
+    const messageId = toolContext.runContext.agentMessage.sId;
+    toolLogContext["conversationId"] = conversationId;
+    toolLogContext["messageId"] = messageId;
+  }
+  if (isSandboxFunctionRunContext(toolContext.runContext)) {
+    toolLogContext["functionId"] =
+      toolContext.runContext.invocation.sandboxFunction.sId;
+    toolLogContext["invocationId"] = toolContext.runContext.invocation.sId;
+  }
 
   let mcpClient;
   try {
@@ -387,7 +398,7 @@ export async function* tryCallMCPTool(
       const connResult = await connectServerSideMCP(
         auth,
         toolConfiguration,
-        agentLoopRunContext
+        toolContext
       );
       if (connResult.isErr()) {
         switch (connResult.error.type) {
@@ -429,13 +440,27 @@ export async function* tryCallMCPTool(
       }
       mcpClient = connResult.value;
     } else {
+      if (!isAgentLoopRunContext(toolContext.runContext)) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "Client side MCP servers require an agent loop context.",
+            },
+          ],
+        };
+      }
+
+      const { conversation, agentMessage } = toolContext.runContext;
+
       const connectionParams = makeClientSideMCPConnectionParams(
         toolConfiguration,
-        { conversationId, messageId }
+        { conversationId: conversation.sId, messageId: agentMessage.sId }
       );
       const connectionResult = await connectToMCPServer(auth, {
         params: connectionParams,
-        toolContext: { runContext: agentLoopRunContext },
+        toolContext,
       });
       if (connectionResult.isErr()) {
         if (
@@ -641,13 +666,7 @@ export async function* tryCallMCPTool(
     }
 
     logger.error(
-      {
-        conversationId,
-        error,
-        messageId,
-        toolName: toolConfiguration.originalName,
-        workspaceId: auth.getNonNullableWorkspace().sId,
-      },
+      { error, ...toolLogContext },
       "Exception calling MCP tool in tryCallMCPTool()"
     );
 
@@ -742,7 +761,7 @@ type ServerSideMCPConnectionError =
 async function connectServerSideMCP(
   auth: Authenticator,
   toolConfiguration: ServerSideMCPToolConfigurationType,
-  agentLoopRunContext: AgentLoopRunContextType
+  toolContext: ToolContextType
 ): Promise<Result<Client, ServerSideMCPConnectionError>> {
   const mcpServerView = await MCPServerViewResource.fetchById(
     auth,
@@ -755,7 +774,7 @@ async function connectServerSideMCP(
   const connectionParams = makeServerSideMCPConnectionParams(mcpServerView);
   const connectionResult = await connectToMCPServer(auth, {
     params: connectionParams,
-    toolContext: { runContext: agentLoopRunContext },
+    toolContext,
   });
 
   if (connectionResult.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -48,7 +48,7 @@ vi.mock("@app/lib/api/file_system", async (importOriginal) => {
 
 function makeToolContext(conversation: ConversationType): ToolContextType {
   return {
-    runContext: { conversation },
+    runContext: { contextType: "agent_loop", conversation },
   } as unknown as ToolContextType;
 }
 
@@ -425,7 +425,7 @@ describe("resolveConversationFileRef", () => {
       const result = await resolveConversationFileRef(
         auth,
         `conversation-${conversation.sId}/missing.png`,
-        undefined
+        makeToolContext({ ...conversation, content: [] })
       );
 
       expect(result.isErr()).toBe(true);
@@ -434,22 +434,6 @@ describe("resolveConversationFileRef", () => {
       }
       expect(result.error).toContain("not found");
     });
-  });
-
-  it("returns Err when toolContext has no runContext", async () => {
-    const { authenticator: auth } = await createResourceTest({ role: "admin" });
-
-    const result = await resolveConversationFileRef(
-      auth,
-      "conversation/file.pdf",
-      undefined
-    );
-
-    expect(result.isErr()).toBe(true);
-    if (!result.isErr()) {
-      return;
-    }
-    expect(result.error).toContain("No conversation context");
   });
 
   it("returns the signed URL and metadata for a legacy fileId", async () => {

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -55,11 +55,6 @@ export async function resolveConversationFileRef(
   fileId: string,
   toolContext: ToolContextType | undefined
 ): Promise<Result<ConversationFileRef, string>> {
-  assert(
-    isAgentLoopRunContext(toolContext?.runContext),
-    "AgentLoopRunContext expected"
-  );
-
   // Canonical scoped paths (conversation-{id}/..., pod-{id}/...) produced by the new
   // DustFileSystem layer. Resolved directly — no conversation context needed.
   if (isCanonicalScopedPath(fileId)) {
@@ -109,9 +104,10 @@ export async function resolveConversationFileRef(
     });
   }
 
-  if (!toolContext?.runContext) {
-    return new Err("No conversation context available");
-  }
+  assert(
+    isAgentLoopRunContext(toolContext?.runContext),
+    "AgentLoopRunContext expected"
+  );
 
   const parsed = parseScopedFilePath(fileId);
   if (parsed) {

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -1,4 +1,7 @@
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { resolveFile } from "@app/lib/api/actions/servers/files/tools/utils";
 import {
   conversationAttachmentId,
@@ -20,6 +23,7 @@ import { isAgentMessageType } from "@app/types/assistant/conversation";
 import { isContentFragmentType } from "@app/types/content_fragment";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
+import assert from "assert";
 import { PassThrough } from "stream";
 
 export function sanitizeFilename(filename: string): string {
@@ -51,6 +55,11 @@ export async function resolveConversationFileRef(
   fileId: string,
   toolContext: ToolContextType | undefined
 ): Promise<Result<ConversationFileRef, string>> {
+  assert(
+    isAgentLoopRunContext(toolContext?.runContext),
+    "AgentLoopRunContext expected"
+  );
+
   // Canonical scoped paths (conversation-{id}/..., pod-{id}/...) produced by the new
   // DustFileSystem layer. Resolved directly — no conversation context needed.
   if (isCanonicalScopedPath(fileId)) {
@@ -167,9 +176,10 @@ export async function getFileFromConversationAttachment(
     string
   >
 > {
-  if (!toolContext?.runContext) {
-    return new Err("No conversation context available");
-  }
+  assert(
+    isAgentLoopRunContext(toolContext?.runContext),
+    "AgentLoopRunContext expected"
+  );
 
   // Canonical scoped paths (conversation-{id}/..., pod-{id}/...) — resolve via DustFileSystem.
   if (isCanonicalScopedPath(fileId)) {

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -3,7 +3,10 @@ import type {
   ToolDefinition,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
@@ -137,20 +140,22 @@ function withToolLogging<T>(
 
     // Adding agent loop context if available.
     if (toolContext?.runContext) {
-      const {
-        agentConfiguration,
-        toolConfiguration,
-        conversation,
-        agentMessage,
-      } = toolContext.runContext;
-      loggerArgs = {
-        ...loggerArgs,
-        actionConfigurationId: toolConfiguration.sId,
-        agentConfigurationId: agentConfiguration.sId,
-        agentConfigurationVersion: agentConfiguration.version,
-        agentMessageId: agentMessage.sId,
-        conversationId: conversation.sId,
-      };
+      if (isAgentLoopRunContext(toolContext.runContext)) {
+        const {
+          agentConfiguration,
+          toolConfiguration,
+          conversation,
+          agentMessage,
+        } = toolContext.runContext;
+        loggerArgs = {
+          ...loggerArgs,
+          actionConfigurationId: toolConfiguration.sId,
+          agentConfigurationId: agentConfiguration.sId,
+          agentConfigurationVersion: agentConfiguration.version,
+          agentMessageId: agentMessage.sId,
+          conversationId: conversation.sId,
+        };
+      }
     }
 
     logger.info(loggerArgs, "Tool execution start");

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -3,10 +3,8 @@ import type {
   LightMCPToolConfigurationType,
   MCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
-import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
-import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import type { AgentMCPActionType } from "@app/types/actions";
-import { SandboxFunctionInvocationType } from "@app/types/api/sandbox_functions";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageType,

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -3,7 +3,10 @@ import type {
   LightMCPToolConfigurationType,
   MCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { AgentMCPActionType } from "@app/types/actions";
+import { SandboxFunctionInvocationType } from "@app/types/api/sandbox_functions";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageType,
@@ -146,6 +149,7 @@ export type ActionGeneratedFileType =
   | ActionGeneratedFilePathType;
 
 export type AgentLoopRunContextType = {
+  contextType: "agent_loop";
   agentConfiguration: AgentConfigurationType;
   agentMessage: AgentMessageType;
   currentAction: AgentMCPActionType;
@@ -153,6 +157,12 @@ export type AgentLoopRunContextType = {
   stepContext: StepContext;
   toolConfiguration: LightMCPToolConfigurationType;
   userMessage: UserMessageType;
+};
+
+export type SandboxFunctionRunContextType = {
+  contextType: "sandbox_function";
+  invocation: SandboxFunctionInvocationResource;
+  toolConfiguration: LightMCPToolConfigurationType;
 };
 
 export type AgentLoopListToolsContextType = {
@@ -163,9 +173,21 @@ export type AgentLoopListToolsContextType = {
   agentMessage: AgentMessageType;
 };
 
+export function isSandboxFunctionRunContext(
+  value: AgentLoopRunContextType | SandboxFunctionRunContextType | undefined
+): value is SandboxFunctionRunContextType {
+  return value?.contextType === "sandbox_function";
+}
+
+export function isAgentLoopRunContext(
+  value: AgentLoopRunContextType | SandboxFunctionRunContextType | undefined
+): value is AgentLoopRunContextType {
+  return value?.contextType === "agent_loop";
+}
+
 export type ToolContextType =
   | {
-      runContext: AgentLoopRunContextType;
+      runContext: AgentLoopRunContextType | SandboxFunctionRunContextType;
       listToolsContext?: never;
     }
   | {

--- a/front/lib/api/actions/servers/agent_memory/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_memory/tools/index.ts
@@ -1,6 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
   AGENT_MEMORY_COMPACT_TOOL_NAME,
   AGENT_MEMORY_EDIT_TOOL_NAME,
@@ -47,8 +48,8 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      toolContext?.runContext,
-      "agentLoopContext is required to run the memory retrieve tool"
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
     );
     const { agentConfiguration } = toolContext.runContext;
 
@@ -73,8 +74,8 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      toolContext?.runContext,
-      "agentLoopContext is required to run the memory record_entries tool"
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
     );
     const { agentConfiguration } = toolContext.runContext;
 
@@ -105,8 +106,8 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      toolContext?.runContext,
-      "agentLoopContext is required to run the memory erase_entries tool"
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
     );
     const { agentConfiguration } = toolContext.runContext;
 
@@ -129,8 +130,8 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      toolContext?.runContext,
-      "agentLoopContext is required to run the memory edit_entries tool"
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
     );
     const { agentConfiguration } = toolContext.runContext;
 
@@ -161,8 +162,8 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      toolContext?.runContext,
-      "agentLoopContext is required to run the memory compact_memory tool"
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
     );
     const { agentConfiguration } = toolContext.runContext;
 

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -1,6 +1,9 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { isUserQuestionResumeState } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  isUserQuestionResumeState,
+} from "@app/lib/actions/types";
 import {
   formatUserQuestionAnswer,
   getUserQuestionSelections,
@@ -9,12 +12,18 @@ import {
 import { ASK_USER_QUESTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/ask_user_question/metadata";
 import { Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import assert from "assert";
 
 const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
   ask_user_question: async (
     { question, options, multiSelect },
     { toolContext }
   ) => {
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
+
     const resumeState = toolContext?.runContext?.stepContext?.resumeState;
     if (isUserQuestionResumeState(resumeState) && resumeState.answer) {
       const { answer } = resumeState;

--- a/front/lib/api/actions/servers/common_utilities/index.ts
+++ b/front/lib/api/actions/servers/common_utilities/index.ts
@@ -21,6 +21,7 @@ function createServer(
       : null) ?? toolContext?.listToolsContext?.conversation;
 
   for (const tool of TOOLS) {
+    // Skip `set_conversation_title` if there is no conversation in tool context.
     if (!conversation && tool.name === "set_conversation_title") {
       continue;
     }

--- a/front/lib/api/actions/servers/common_utilities/index.ts
+++ b/front/lib/api/actions/servers/common_utilities/index.ts
@@ -1,6 +1,9 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { COMMON_UTILITIES_SERVER_NAME } from "@app/lib/api/actions/servers/common_utilities/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/common_utilities/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -12,7 +15,15 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer(COMMON_UTILITIES_SERVER_NAME);
 
+  const conversation =
+    (isAgentLoopRunContext(toolContext?.runContext)
+      ? toolContext.runContext.conversation
+      : null) ?? toolContext?.listToolsContext?.conversation;
+
   for (const tool of TOOLS) {
+    if (!conversation && tool.name === "set_conversation_title") {
+      continue;
+    }
     registerTool(auth, toolContext, server, tool, {
       monitoringName: COMMON_UTILITIES_SERVER_NAME,
     });

--- a/front/lib/api/actions/servers/common_utilities/tools/index.ts
+++ b/front/lib/api/actions/servers/common_utilities/tools/index.ts
@@ -1,6 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { COMMON_UTILITIES_TOOLS_METADATA } from "@app/lib/api/actions/servers/common_utilities/metadata";
 import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import { Err, Ok } from "@app/types/shared/result";
@@ -97,8 +98,9 @@ const handlers: ToolHandlers<typeof COMMON_UTILITIES_TOOLS_METADATA> = {
 
   set_conversation_title: async ({ title }, { auth, toolContext }) => {
     const conversation =
-      toolContext?.runContext?.conversation ??
-      toolContext?.listToolsContext?.conversation;
+      (isAgentLoopRunContext(toolContext?.runContext)
+        ? toolContext.runContext.conversation
+        : null) ?? toolContext?.listToolsContext?.conversation;
 
     if (!conversation) {
       return new Err(

--- a/front/lib/api/actions/servers/conversation_files/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/index.ts
@@ -24,15 +24,10 @@ async function createServer(
       : null) ?? toolContext?.listToolsContext?.conversation;
   const useFileSystem = conversation?.metadata?.useFileSystem === true;
 
-  // Without a tool context (metadata extraction, server listing) expose the default toolset,
-  // otherwise the server would advertise no tools at all and `tools/list` would fail. With a tool
-  // context but no conversation (e.g. sandbox function run context), expose no tool at all.
-  if (!toolContext || conversation) {
-    for (const tool of useFileSystem ? TOOLS_WITH_FILESYSTEM : TOOLS) {
-      registerTool(auth, toolContext, server, tool, {
-        monitoringName: CONVERSATION_FILES_SERVER_NAME,
-      });
-    }
+  for (const tool of useFileSystem ? TOOLS_WITH_FILESYSTEM : TOOLS) {
+    registerTool(auth, toolContext, server, tool, {
+      monitoringName: CONVERSATION_FILES_SERVER_NAME,
+    });
   }
 
   return server;

--- a/front/lib/api/actions/servers/conversation_files/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/index.ts
@@ -1,6 +1,9 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { CONVERSATION_FILES_SERVER_NAME } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import {
   TOOLS,
@@ -16,14 +19,18 @@ async function createServer(
   const server = makeInternalMCPServer("conversation_files");
 
   const conversation =
-    toolContext?.runContext?.conversation ??
-    toolContext?.listToolsContext?.conversation;
+    (isAgentLoopRunContext(toolContext?.runContext)
+      ? toolContext.runContext.conversation
+      : null) ?? toolContext?.listToolsContext?.conversation;
   const useFileSystem = conversation?.metadata?.useFileSystem === true;
 
-  for (const tool of useFileSystem ? TOOLS_WITH_FILESYSTEM : TOOLS) {
-    registerTool(auth, toolContext, server, tool, {
-      monitoringName: CONVERSATION_FILES_SERVER_NAME,
-    });
+  // Returns no tool at all if there is no conversation in tool context.
+  if (conversation) {
+    for (const tool of useFileSystem ? TOOLS_WITH_FILESYSTEM : TOOLS) {
+      registerTool(auth, toolContext, server, tool, {
+        monitoringName: CONVERSATION_FILES_SERVER_NAME,
+      });
+    }
   }
 
   return server;

--- a/front/lib/api/actions/servers/conversation_files/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/index.ts
@@ -24,8 +24,10 @@ async function createServer(
       : null) ?? toolContext?.listToolsContext?.conversation;
   const useFileSystem = conversation?.metadata?.useFileSystem === true;
 
-  // Returns no tool at all if there is no conversation in tool context.
-  if (conversation) {
+  // Without a tool context (metadata extraction, server listing) expose the default toolset,
+  // otherwise the server would advertise no tools at all and `tools/list` would fail. With a tool
+  // context but no conversation (e.g. sandbox function run context), expose no tool at all.
+  if (!toolContext || conversation) {
     for (const tool of useFileSystem ? TOOLS_WITH_FILESYSTEM : TOOLS) {
       registerTool(auth, toolContext, server, tool, {
         monitoringName: CONVERSATION_FILES_SERVER_NAME,

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -6,6 +6,7 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getDataSourceURI } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
   CONVERSATION_CAT_FILE_ACTION_NAME,
   CONVERSATION_FILES_TOOLS_METADATA,
@@ -44,6 +45,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import assert from "assert";
 
 const MAX_FILE_SIZE_FOR_GREP = 20 * 1024 * 1024; // 20MB.
 const MAX_CONTENT_SIZE_FOR_LIST_FILES = 1024 * 256; // 256KB.
@@ -91,9 +93,10 @@ const listAttachmentsHandler: ToolHandlers<
   _,
   { auth, toolContext }
 ) => {
-  if (!toolContext?.runContext) {
-    return new Err(new MCPError("No conversation context available"));
-  }
+  assert(
+    isAgentLoopRunContext(toolContext?.runContext),
+    "AgentLoopRunContext expected"
+  );
 
   const conversation = toolContext.runContext.conversation;
   const allAttachments = await listAttachments(auth, { conversation });
@@ -137,9 +140,10 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
     { fileId, offset, limit, grep },
     { auth, toolContext }
   ) => {
-    if (!toolContext?.runContext) {
-      return new Err(new MCPError("No conversation context available"));
-    }
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
     const conversation = toolContext.runContext.conversation;
     const model = getSupportedModelConfig(
@@ -273,9 +277,10 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
     { query },
     { auth, toolContext }
   ) => {
-    if (!toolContext?.runContext) {
-      return new Err(new MCPError("No conversation context available"));
-    }
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
     const conversation = toolContext.runContext.conversation;
     const attachments = await listAttachments(auth, { conversation });

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
@@ -6,7 +6,10 @@ import {
   getAgentDataSourceConfigurations,
   makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -166,7 +169,9 @@ export async function cat(
     );
   }
 
-  const { citationsOffset } = toolContext.runContext.stepContext;
+  const { citationsOffset } = isAgentLoopRunContext(toolContext.runContext)
+    ? toolContext.runContext.stepContext
+    : { citationsOffset: 0 };
 
   if (citationsOffset >= getRefs().length) {
     return new Err(

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -34,7 +34,7 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 
-const AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K = 10;
+export const AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K = 10;
 
 export async function search(
   {

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -12,7 +12,10 @@ import type {
   SearchWithNodesInputType,
   TagsInputType,
 } from "@app/lib/actions/mcp_internal_actions/types";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
@@ -30,6 +33,8 @@ import {
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
+
+const AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K = 10;
 
 export async function search(
   {
@@ -52,7 +57,11 @@ export async function search(
     );
   }
 
-  const { retrievalTopK, citationsOffset } = toolContext.runContext.stepContext;
+  const { retrievalTopK, citationsOffset } = isAgentLoopRunContext(
+    toolContext.runContext
+  )
+    ? toolContext.runContext.stepContext
+    : { retrievalTopK: AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K, citationsOffset: 0 };
 
   const agentDataSourceConfigurationsResult =
     await getAgentDataSourceConfigurations(auth, dataSources);

--- a/front/lib/api/actions/servers/data_warehouses/tools/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/tools/index.ts
@@ -2,6 +2,7 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getAgentDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
   getAvailableWarehouses,
   getWarehouseNodes,
@@ -21,6 +22,7 @@ import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import assert from "assert";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
@@ -205,11 +207,11 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
     { dataSources, tableIds, query, fileName },
     { auth, toolContext }
   ) => {
-    if (!toolContext?.runContext) {
-      return new Err(
-        new MCPError("Missing agentLoopContext for file generation")
-      );
-    }
+    // TODO(spolu): move query CSV output to DFS
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
     const agentLoopRunContext = toolContext.runContext;
 

--- a/front/lib/api/actions/servers/extract_data/tools/index.test.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.test.ts
@@ -1,18 +1,18 @@
-import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type {LightServerSideMCPToolConfigurationType} from "@app/lib/actions/mcp";
+import type {ToolContextType} from "@app/lib/actions/types";
 import {
   generateProcessToolOutput,
   getCoreDataSourceSearchCriterias,
   getPromptForProcessDustApp,
 } from "@app/lib/api/actions/servers/extract_data/helpers";
-import { EXTRACT_DATA_MAIN_TOOL_NAME } from "@app/lib/api/actions/servers/extract_data/metadata";
-import { createExtractDataTools } from "@app/lib/api/actions/servers/extract_data/tools";
-import { processDataSources } from "@app/lib/api/assistant/process_data_sources";
-import type { Authenticator } from "@app/lib/auth";
-import { Ok } from "@app/types/shared/result";
-import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {EXTRACT_DATA_MAIN_TOOL_NAME} from "@app/lib/api/actions/servers/extract_data/metadata";
+import {createExtractDataTools} from "@app/lib/api/actions/servers/extract_data/tools";
+import {processDataSources} from "@app/lib/api/assistant/process_data_sources";
+import type {Authenticator} from "@app/lib/auth";
+import {Ok} from "@app/types/shared/result";
+import {INTERNAL_MIME_TYPES} from "@dust-tt/client";
+import type {JSONSchema7 as JSONSchema} from "json-schema";
+import {beforeEach, describe, expect, it, vi} from "vitest";
 
 vi.mock("@app/lib/api/actions/servers/extract_data/helpers", () => ({
   generateProcessToolOutput: vi.fn(),
@@ -66,6 +66,7 @@ function makeRunContext(): ToolContextType {
 
   return {
     runContext: {
+      contextType: "agent_loop",
       agentConfiguration: {
         model: {
           modelId: "test-model",

--- a/front/lib/api/actions/servers/extract_data/tools/index.test.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.test.ts
@@ -1,18 +1,18 @@
-import type {LightServerSideMCPToolConfigurationType} from "@app/lib/actions/mcp";
-import type {ToolContextType} from "@app/lib/actions/types";
+import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { ToolContextType } from "@app/lib/actions/types";
 import {
   generateProcessToolOutput,
   getCoreDataSourceSearchCriterias,
   getPromptForProcessDustApp,
 } from "@app/lib/api/actions/servers/extract_data/helpers";
-import {EXTRACT_DATA_MAIN_TOOL_NAME} from "@app/lib/api/actions/servers/extract_data/metadata";
-import {createExtractDataTools} from "@app/lib/api/actions/servers/extract_data/tools";
-import {processDataSources} from "@app/lib/api/assistant/process_data_sources";
-import type {Authenticator} from "@app/lib/auth";
-import {Ok} from "@app/types/shared/result";
-import {INTERNAL_MIME_TYPES} from "@dust-tt/client";
-import type {JSONSchema7 as JSONSchema} from "json-schema";
-import {beforeEach, describe, expect, it, vi} from "vitest";
+import { EXTRACT_DATA_MAIN_TOOL_NAME } from "@app/lib/api/actions/servers/extract_data/metadata";
+import { createExtractDataTools } from "@app/lib/api/actions/servers/extract_data/tools";
+import { processDataSources } from "@app/lib/api/assistant/process_data_sources";
+import type { Authenticator } from "@app/lib/auth";
+import { Ok } from "@app/types/shared/result";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/actions/servers/extract_data/helpers", () => ({
   generateProcessToolOutput: vi.fn(),

--- a/front/lib/api/actions/servers/extract_data/tools/index.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.ts
@@ -4,7 +4,10 @@ import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_inte
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
@@ -85,10 +88,9 @@ export function createExtractDataTools(
     tagsIn?: string[];
     tagsNot?: string[];
   }) {
-    // Unwrap and prepare variables.
     assert(
-      toolContext?.runContext,
-      "agentLoopContext is required to run the extract_data tool"
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
     );
     const { agentConfiguration, conversation } = toolContext.runContext;
     const { model } = agentConfiguration;

--- a/front/lib/api/actions/servers/files/tools/agent_loop_fs.ts
+++ b/front/lib/api/actions/servers/files/tools/agent_loop_fs.ts
@@ -1,5 +1,6 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 
 import { DustFileSystem } from "@app/lib/api/file_system";
 import type { Authenticator } from "@app/lib/auth";
@@ -12,7 +13,9 @@ type ToolConversationExtra = Pick<ToolHandlerExtra, "toolContext">;
 export function requireAgentLoopConversation(
   extra: ToolConversationExtra
 ): Result<ConversationWithoutContentType, MCPError> {
-  const conversation = extra.toolContext?.runContext?.conversation;
+  const conversation = isAgentLoopRunContext(extra.toolContext?.runContext)
+    ? extra.toolContext?.runContext?.conversation
+    : null;
   if (!conversation) {
     return new Err(
       new MCPError("No conversation context available.", { tracked: false })

--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -16,7 +16,7 @@ function makeExtra(
   conversation: ConversationType
 ): ToolHandlerExtra {
   const toolContext = {
-    runContext: { conversation },
+    runContext: { contextType: "agent_loop", conversation },
   } as unknown as ToolContextType;
   return { auth, toolContext } as unknown as ToolHandlerExtra;
 }

--- a/front/lib/api/actions/servers/files/tools/create.test.ts
+++ b/front/lib/api/actions/servers/files/tools/create.test.ts
@@ -15,7 +15,7 @@ function makeExtra(
   conversation: ConversationType
 ): ToolHandlerExtra {
   const toolContext = {
-    runContext: { conversation },
+    runContext: { contextType: "agent_loop", conversation },
   } as unknown as ToolContextType;
   return { auth, toolContext } as unknown as ToolHandlerExtra;
 }

--- a/front/lib/api/actions/servers/files/tools/delete.test.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.test.ts
@@ -22,7 +22,7 @@ function makeExtra(
   conversation: ConversationType
 ): ToolHandlerExtra {
   const toolContext = {
-    runContext: { conversation },
+    runContext: { contextType: "agent_loop", conversation },
   } as unknown as ToolContextType;
   return { auth, toolContext } as unknown as ToolHandlerExtra;
 }

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -22,7 +22,7 @@ function makeExtra(
   conversation: ConversationType
 ): ToolHandlerExtra {
   const toolContext = {
-    runContext: { conversation },
+    runContext: { contextType: "agent_loop", conversation },
   } as unknown as ToolContextType;
   return { auth, toolContext } as unknown as ToolHandlerExtra;
 }

--- a/front/lib/api/actions/servers/files/tools/list.test.ts
+++ b/front/lib/api/actions/servers/files/tools/list.test.ts
@@ -58,7 +58,7 @@ function makeExtra(
   conversation: ConversationType
 ): ToolHandlerExtra {
   const toolContext = {
-    runContext: { conversation },
+    runContext: { contextType: "agent_loop", conversation },
   } as unknown as ToolContextType;
   return { auth, toolContext } as unknown as ToolHandlerExtra;
 }

--- a/front/lib/api/actions/servers/files/tools/move.test.ts
+++ b/front/lib/api/actions/servers/files/tools/move.test.ts
@@ -16,7 +16,7 @@ function makeExtra(
   conversation: ConversationType
 ): ToolHandlerExtra {
   const toolContext = {
-    runContext: { conversation },
+    runContext: { contextType: "agent_loop", conversation },
   } as unknown as ToolContextType;
   return { auth, toolContext } as unknown as ToolHandlerExtra;
 }

--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -1,4 +1,7 @@
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { google } from "googleapis";
 import { DateTime, Interval } from "luxon";
@@ -173,31 +176,35 @@ export function normalizeTimezone(
 }
 
 export function getUserTimezone(toolContext?: ToolContextType): string | null {
-  const content = toolContext?.runContext?.conversation?.content;
-  if (!content) {
-    return null;
-  }
+  if (isAgentLoopRunContext(toolContext?.runContext)) {
+    const content = toolContext?.runContext?.conversation?.content;
+    if (!content) {
+      return null;
+    }
 
-  for (let i = content.length - 1; i >= 0; i--) {
-    const contentBlock = content[i];
-    if (Array.isArray(contentBlock)) {
-      const userMessage = contentBlock.find(
-        (msg) =>
-          msg.type === "user_message" &&
-          "context" in msg &&
-          msg.context &&
-          "timezone" in msg.context
-      );
-      if (
-        userMessage &&
-        "context" in userMessage &&
-        userMessage.context &&
-        "timezone" in userMessage.context
-      ) {
-        return normalizeTimezone(userMessage.context.timezone);
+    for (let i = content.length - 1; i >= 0; i--) {
+      const contentBlock = content[i];
+      if (Array.isArray(contentBlock)) {
+        const userMessage = contentBlock.find(
+          (msg) =>
+            msg.type === "user_message" &&
+            "context" in msg &&
+            msg.context &&
+            "timezone" in msg.context
+        );
+        if (
+          userMessage &&
+          "context" in userMessage &&
+          userMessage.context &&
+          "timezone" in userMessage.context
+        ) {
+          return normalizeTimezone(userMessage.context.timezone);
+        }
       }
     }
   }
+
+  // TODO(spolu): extract user timezone from sandbox function once available
 
   return null;
 }

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -14,6 +14,7 @@ import {
   getFileFromConversationAttachment,
   sanitizeFilename,
 } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { formatDocumentStructure } from "@app/lib/api/actions/servers/google_drive/format_document";
 import { formatPresentationStructure } from "@app/lib/api/actions/servers/google_drive/format_presentation";
 import {
@@ -297,7 +298,7 @@ function addAgentAttribution(
   content: string,
   { toolContext }: Pick<ToolHandlerExtra, "toolContext">
 ): string {
-  if (toolContext?.runContext?.agentConfiguration) {
+  if (isAgentLoopRunContext(toolContext?.runContext)) {
     const agentConfig = toolContext.runContext.agentConfiguration;
     return `${content}\n\nSent via ${agentConfig.name} Agent on Dust`;
   }

--- a/front/lib/api/actions/servers/helpers.ts
+++ b/front/lib/api/actions/servers/helpers.ts
@@ -1,5 +1,9 @@
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import type { ConversationMetadata } from "@app/types/assistant/conversation";
+import assert from "assert";
 
 // TODO(sidekick 2026-01-23): move all sidekick mcp servers and these helpers in dedicated folder
 export interface SidekickMetadata {
@@ -41,8 +45,9 @@ export function getSidekickMetadataFromContext(
   toolContext?: ToolContextType
 ): SidekickMetadata | null {
   const metadata =
-    toolContext?.runContext?.conversation.metadata ??
-    toolContext?.listToolsContext?.conversation.metadata;
+    (isAgentLoopRunContext(toolContext?.runContext)
+      ? toolContext?.runContext?.conversation.metadata
+      : null) ?? toolContext?.listToolsContext?.conversation.metadata;
 
   return metadata ? extractSidekickMetadata(metadata) : null;
 }

--- a/front/lib/api/actions/servers/helpers.ts
+++ b/front/lib/api/actions/servers/helpers.ts
@@ -3,7 +3,6 @@ import {
   type ToolContextType,
 } from "@app/lib/actions/types";
 import type { ConversationMetadata } from "@app/types/assistant/conversation";
-import assert from "assert";
 
 // TODO(sidekick 2026-01-23): move all sidekick mcp servers and these helpers in dedicated folder
 export interface SidekickMetadata {

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -4,7 +4,10 @@ import type {
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { resolveConversationFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import { uploadBase64ImageToFileStorage } from "@app/lib/api/files/upload";
 import type { ReferenceImageFile } from "@app/lib/api/llm/imageGeneration";
@@ -26,6 +29,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import assert from "assert";
 
 export type ImageGenerationErrorCode =
   | "api_error"
@@ -206,6 +210,10 @@ export async function uploadAndFormatImageResponse(
 ): Promise<
   Result<Array<{ type: "resource"; resource: ToolGeneratedFileType }>, MCPError>
 > {
+  assert(
+    isAgentLoopRunContext(toolContext?.runContext),
+    "AgentLoopRunContext expected"
+  );
   if (!toolContext?.runContext) {
     return new Err(
       new MCPError("No conversation context available for file upload", {

--- a/front/lib/api/actions/servers/include_data/tools/index.ts
+++ b/front/lib/api/actions/servers/include_data/tools/index.ts
@@ -5,6 +5,7 @@ import {
   isAgentLoopRunContext,
   type ToolContextType,
 } from "@app/lib/actions/types";
+import { AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K } from "@app/lib/api/actions/servers/data_sources_file_system/tools/search";
 import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
 import {
   INCLUDE_DATA_BASE_TOOLS_METADATA,
@@ -12,7 +13,6 @@ import {
 } from "@app/lib/api/actions/servers/include_data/metadata";
 import { executeFindTags } from "@app/lib/api/actions/tools/find_tags";
 import type { Authenticator } from "@app/lib/auth";
-import { AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K } from "../../data_sources_file_system/tools/search";
 
 // Create tools with access to auth via closure
 export function createIncludeDataTools(

--- a/front/lib/api/actions/servers/include_data/tools/index.ts
+++ b/front/lib/api/actions/servers/include_data/tools/index.ts
@@ -1,7 +1,10 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
 import {
   INCLUDE_DATA_BASE_TOOLS_METADATA,
@@ -9,6 +12,7 @@ import {
 } from "@app/lib/api/actions/servers/include_data/metadata";
 import { executeFindTags } from "@app/lib/api/actions/tools/find_tags";
 import type { Authenticator } from "@app/lib/auth";
+import { AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K } from "../../data_sources_file_system/tools/search";
 
 // Create tools with access to auth via closure
 export function createIncludeDataTools(
@@ -18,6 +22,12 @@ export function createIncludeDataTools(
   const areTagsDynamic = toolContext
     ? shouldAutoGenerateTags(toolContext)
     : false;
+
+  const { retrievalTopK, citationsOffset } = isAgentLoopRunContext(
+    toolContext?.runContext
+  )
+    ? toolContext.runContext.stepContext
+    : { retrievalTopK: AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K, citationsOffset: 0 };
 
   if (!areTagsDynamic) {
     // Return base tools without tags
@@ -30,8 +40,8 @@ export function createIncludeDataTools(
         }
         return runIncludeDataRetrieval(auth, {
           ...params,
-          citationsOffset: toolContext.runContext.stepContext.citationsOffset,
-          retrievalTopK: toolContext.runContext.stepContext.retrievalTopK,
+          citationsOffset,
+          retrievalTopK,
         });
       },
     };
@@ -48,8 +58,8 @@ export function createIncludeDataTools(
       }
       return runIncludeDataRetrieval(auth, {
         ...params,
-        citationsOffset: toolContext.runContext.stepContext.citationsOffset,
-        retrievalTopK: toolContext.runContext.stepContext.retrievalTopK,
+        citationsOffset,
+        retrievalTopK,
       });
     },
     find_tags: async ({ query, dataSources }, _extra) => {

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -5,7 +5,10 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { buildInteractiveContentFileNotification } from "@app/lib/api/actions/servers/interactive_content/helpers";
 import { INTERACTIVE_CONTENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { fetchTemplateContent } from "@app/lib/api/actions/servers/interactive_content/template_utils";
@@ -28,6 +31,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import assert from "assert";
 
 export async function createInteractiveContentTools(
   auth: Authenticator,
@@ -38,25 +42,23 @@ export async function createInteractiveContentTools(
       { file_name, mime_type, mode, source, description },
       { sendNotification, _meta }
     ) => {
-      const { runContext } = toolContext ?? {};
+      assert(
+        isAgentLoopRunContext(toolContext?.runContext),
+        "AgentLoopRunContext expected"
+      );
 
-      if (!runContext) {
-        return new Err(
-          new MCPError(
-            "Agent loop context is required to use template nodes.",
-            { tracked: false }
-          )
-        );
-      }
-
-      const { conversation, agentConfiguration } = runContext;
+      const { conversation, agentConfiguration } = toolContext.runContext;
 
       let fileContent: string;
 
       if (mode === "template") {
-        const templateResult = await fetchTemplateContent(auth, runContext, {
-          templateRef: source,
-        });
+        const templateResult = await fetchTemplateContent(
+          auth,
+          toolContext.runContext,
+          {
+            templateRef: source,
+          }
+        );
 
         if (templateResult.isErr()) {
           return templateResult;
@@ -123,7 +125,11 @@ export async function createInteractiveContentTools(
       { file_id, old_string, new_string, expected_replacements },
       { sendNotification, _meta }
     ) => {
-      const { agentConfiguration } = toolContext?.runContext ?? {};
+      const { agentConfiguration } = isAgentLoopRunContext(
+        toolContext?.runContext
+      )
+        ? toolContext?.runContext
+        : {};
 
       const result = await editClientExecutableFile(auth, {
         fileId: file_id,
@@ -182,7 +188,7 @@ export async function createInteractiveContentTools(
       { file_id },
       { sendNotification, _meta }
     ) => {
-      if (!toolContext?.runContext) {
+      if (!isAgentLoopRunContext(toolContext?.runContext)) {
         throw new Error(
           "Could not access Agent Loop Context from revert Interactive Content file tool."
         );
@@ -192,7 +198,7 @@ export async function createInteractiveContentTools(
 
       const result = await revertClientExecutableFileChanges(auth, {
         fileId: file_id,
-        revertedByAgentConfigurationId: agentConfiguration.sId,
+        revertedByAgentConfigurationId: agentConfiguration?.sId,
       });
 
       if (result.isErr()) {
@@ -231,7 +237,11 @@ export async function createInteractiveContentTools(
       { file_id, new_file_name },
       { sendNotification, _meta }
     ) => {
-      const { agentConfiguration } = toolContext?.runContext ?? {};
+      const { agentConfiguration } = isAgentLoopRunContext(
+        toolContext?.runContext
+      )
+        ? toolContext?.runContext
+        : {};
 
       const result = await renameClientExecutableFile(auth, {
         fileId: file_id,
@@ -359,7 +369,11 @@ export async function createInteractiveContentTools(
       { file_id, path },
       { sendNotification, _meta }
     ) => {
-      const { agentConfiguration } = toolContext?.runContext ?? {};
+      const { agentConfiguration } = isAgentLoopRunContext(
+        toolContext?.runContext
+      )
+        ? toolContext?.runContext
+        : {};
 
       const file = await FileResource.fetchById(auth, file_id);
       if (!file) {

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -42,6 +42,9 @@ export async function createInteractiveContentTools(
       { file_name, mime_type, mode, source, description },
       { sendNotification, _meta }
     ) => {
+      // TODO: enable craete and publish to be conversation agnostic for both templates (local) and
+      //       createClientExecutablefile direclty on pod DFS so that we can re-enable this server
+      //       when run without conversation context.
       assert(
         isAgentLoopRunContext(toolContext?.runContext),
         "AgentLoopRunContext expected"

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -42,7 +42,7 @@ export async function createInteractiveContentTools(
       { file_name, mime_type, mode, source, description },
       { sendNotification, _meta }
     ) => {
-      // TODO: enable craete and publish to be conversation agnostic for both templates (local) and
+      // TODO: enable create and publish to be conversation agnostic for both templates (local) and
       //       createClientExecutablefile direclty on pod DFS so that we can re-enable this server
       //       when run without conversation context.
       assert(

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -1,6 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import type {
   TeamsChannel,
   TeamsChat,
@@ -529,7 +530,8 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
 
       // Add footer with link to Dust conversation if agent context is available
       let finalContent = messageContent;
-      if (toolContext?.runContext?.agentConfiguration) {
+
+      if (isAgentLoopRunContext(toolContext?.runContext)) {
         const agentUrl = getConversationRoute(
           auth.getNonNullableWorkspace().sId,
           "new",

--- a/front/lib/api/actions/servers/notion/tools/index.ts
+++ b/front/lib/api/actions/servers/notion/tools/index.ts
@@ -8,7 +8,10 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { NOTION_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import { NOTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/notion/metadata";
 import { getRefs } from "@app/lib/api/assistant/citations";
@@ -114,15 +117,16 @@ export function createNotionTools(
           },
         ]);
       } else {
-        const citationsOffset =
-          toolContext?.runContext?.stepContext.citationsOffset ?? 0;
+        const { citationsOffset } = isAgentLoopRunContext(
+          toolContext?.runContext
+        )
+          ? toolContext.runContext.stepContext
+          : { citationsOffset: 0 };
 
-        const refs = toolContext?.runContext?.stepContext.citationsOffset
-          ? getRefs().slice(
-              citationsOffset,
-              citationsOffset + NOTION_SEARCH_ACTION_NUM_RESULTS
-            )
-          : [];
+        const refs = getRefs().slice(
+          citationsOffset,
+          citationsOffset + NOTION_SEARCH_ACTION_NUM_RESULTS
+        );
 
         const resultResources = results.map((result) => {
           if (isFullPage(result)) {

--- a/front/lib/api/actions/servers/plan_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/tools/index.ts
@@ -1,6 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
   CLOSE_PLAN_TOOL_NAME,
   CREATE_PLAN_TOOL_NAME,
@@ -19,12 +20,14 @@ import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import assert from "assert";
 
 const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
   create_plan: async ({ content }, { auth, toolContext }) => {
-    if (!toolContext?.runContext) {
-      return new Err(new MCPError("Agent loop context is required."));
-    }
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
     const { conversation } = toolContext.runContext;
 
     return withPlanModeLock(conversation.sId, async () => {
@@ -58,9 +61,10 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
   },
 
   edit_plan: async ({ old_string, new_string }, { auth, toolContext }) => {
-    if (!toolContext?.runContext) {
-      return new Err(new MCPError("Agent loop context is required."));
-    }
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
     const { conversation } = toolContext.runContext;
 
     try {
@@ -131,9 +135,10 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
   },
 
   close_plan: async ({ reason }, { auth, toolContext }) => {
-    if (!toolContext?.runContext) {
-      return new Err(new MCPError("Agent loop context is required."));
-    }
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
     const { conversation } = toolContext.runContext;
 
     const closed = await closeActivePlan(auth, conversation);

--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -5,7 +5,11 @@ import type {
   DustPodConfigurationType,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { parsePodConfigurationURI } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  isSandboxFunctionRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import type { DataSourceFilter } from "@app/lib/api/assistant/configuration/types";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
@@ -144,46 +148,47 @@ export async function getPod(
   // Otherwise, use the existing logic to get space from conversation context.
   if ("toolContext" in from && from.toolContext) {
     const { toolContext } = from;
-    if (!toolContext.runContext?.conversation) {
-      return new Err(
-        new MCPError("No conversation context available", { tracked: false })
-      );
+    if (isAgentLoopRunContext(toolContext.runContext)) {
+      const conversationRes =
+        await ConversationResource.fetchConversationWithoutContent(
+          auth,
+          toolContext.runContext.conversation.sId
+        );
+
+      if (conversationRes.isErr()) {
+        return new Err(
+          new MCPError(
+            `Conversation not found: ${conversationRes.error.message}`,
+            {
+              tracked: false,
+            }
+          )
+        );
+      }
+
+      const conversation = conversationRes.value;
+
+      if (!isPodConversation(conversation)) {
+        return new Err(
+          new MCPError(
+            "This conversation is not in a Pod. Pod context management is only available in Pod conversations.",
+            { tracked: false }
+          )
+        );
+      }
+
+      const space = await SpaceResource.fetchById(auth, conversation.spaceId);
+      if (!space) {
+        return new Err(new MCPError("Pod not found", { tracked: false }));
+      }
+
+      return new Ok({ pod: space });
     }
 
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        toolContext.runContext.conversation.sId
-      );
-
-    if (conversationRes.isErr()) {
-      return new Err(
-        new MCPError(
-          `Conversation not found: ${conversationRes.error.message}`,
-          {
-            tracked: false,
-          }
-        )
-      );
+    if (isSandboxFunctionRunContext(toolContext.runContext)) {
+      const space = toolContext.runContext.invocation.sandboxFunction.space;
+      return new Ok({ pod: space });
     }
-
-    const conversation = conversationRes.value;
-
-    if (!isPodConversation(conversation)) {
-      return new Err(
-        new MCPError(
-          "This conversation is not in a Pod. Pod context management is only available in Pod conversations.",
-          { tracked: false }
-        )
-      );
-    }
-
-    const space = await SpaceResource.fetchById(auth, conversation.spaceId);
-    if (!space) {
-      return new Err(new MCPError("Pod not found", { tracked: false }));
-    }
-
-    return new Ok({ pod: space });
   }
 
   return new Err(new MCPError("No Pod context available", { tracked: false }));

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -6,7 +6,10 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import {
   FILES_LIST_ACTION_NAME,
   FILES_SERVER_NAME,
@@ -71,6 +74,7 @@ import { extractDataSourceIdFromNodeId } from "@app/types/core/content_node";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K } from "../../data_sources_file_system/tools/search";
 import { formatConversationsForDisplay } from "./conversation_formatting";
 
 const LIST_CONVERSATIONS_DEFAULT_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
@@ -979,12 +983,21 @@ export function createProjectManagerTools(
           );
         }
 
+        const { retrievalTopK, citationsOffset } = isAgentLoopRunContext(
+          toolContext.runContext
+        )
+          ? toolContext.runContext.stepContext
+          : {
+              retrievalTopK: AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K,
+              citationsOffset: 0,
+            };
+
         return runIncludeDataRetrieval(auth, {
           timeFrame: params.timeFrame,
           dataSources,
           nodeIds: params.nodeIds,
-          citationsOffset: toolContext.runContext.stepContext.citationsOffset,
-          retrievalTopK: toolContext.runContext.stepContext.retrievalTopK,
+          citationsOffset,
+          retrievalTopK,
         });
       }, "Failed to retrieve recent Pod documents");
     },
@@ -1050,7 +1063,7 @@ export function createProjectManagerTools(
         let origin: UserMessageOrigin = "web";
         let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-        if (toolContext?.runContext?.conversation?.content) {
+        if (isAgentLoopRunContext(toolContext?.runContext)) {
           const userMessage = toolContext.runContext.conversation.content
             .flat()
             .findLast(isUserMessageType);
@@ -1061,11 +1074,15 @@ export function createProjectManagerTools(
         }
 
         // Get agent configuration name & profile picture URL
-        const agentName =
-          toolContext?.runContext?.agentConfiguration?.name ?? "Agent";
+        const agentName = isAgentLoopRunContext(toolContext?.runContext)
+          ? toolContext.runContext.agentConfiguration.name
+          : "Agent";
 
-        const agentProfilePictureUrl =
-          toolContext?.runContext?.agentConfiguration?.pictureUrl ?? null;
+        const agentProfilePictureUrl = isAgentLoopRunContext(
+          toolContext?.runContext
+        )
+          ? toolContext.runContext.agentConfiguration.pictureUrl
+          : null;
 
         let mentions: { configurationId: string }[] = [];
         if (params.agentName) {
@@ -1305,7 +1322,10 @@ export function createProjectManagerTools(
         const owner = auth.getNonNullableWorkspace();
 
         const conversationId =
-          params.conversationId ?? toolContext?.runContext?.conversation?.sId;
+          params.conversationId ??
+          (isAgentLoopRunContext(toolContext?.runContext)
+            ? toolContext.runContext.conversation.sId
+            : null);
 
         if (!conversationId) {
           return new Err(
@@ -1341,7 +1361,7 @@ export function createProjectManagerTools(
         let origin: UserMessageOrigin = "web";
         let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-        if (toolContext?.runContext?.conversation?.content) {
+        if (isAgentLoopRunContext(toolContext?.runContext)) {
           const userMessage = toolContext.runContext.conversation.content
             .flat()
             .findLast(isUserMessageType);
@@ -1351,10 +1371,15 @@ export function createProjectManagerTools(
           }
         }
 
-        const agentName =
-          toolContext?.runContext?.agentConfiguration?.name ?? "Agent";
-        const agentProfilePictureUrl =
-          toolContext?.runContext?.agentConfiguration?.pictureUrl ?? null;
+        const agentName = isAgentLoopRunContext(toolContext?.runContext)
+          ? toolContext.runContext.agentConfiguration.name
+          : "Agent";
+
+        const agentProfilePictureUrl = isAgentLoopRunContext(
+          toolContext?.runContext
+        )
+          ? toolContext.runContext.agentConfiguration.pictureUrl
+          : null;
 
         let mentions: { configurationId: string }[] = [];
         if (params.agentName) {

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -1071,6 +1071,7 @@ export function createProjectManagerTools(
             origin = userMessage.context.origin ?? origin;
             timezone = userMessage.context.timezone ?? timezone;
           }
+         // TODO(spolu): extract user timezone from sandbox function once available
         }
 
         // Get agent configuration name & profile picture URL

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -1071,7 +1071,7 @@ export function createProjectManagerTools(
             origin = userMessage.context.origin ?? origin;
             timezone = userMessage.context.timezone ?? timezone;
           }
-         // TODO(spolu): extract user timezone from sandbox function once available
+          // TODO(spolu): extract user timezone from sandbox function once available
         }
 
         // Get agent configuration name & profile picture URL

--- a/front/lib/api/actions/servers/pod_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/tools/index.ts
@@ -4,7 +4,10 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import {
   getPod,
   withErrorHandling,
@@ -299,8 +302,20 @@ export function createProjectTasksTools(
           assignmentPool.length === 1 ? assignmentPool[0]!.id : null;
 
         const currentUser = auth.getNonNullableUser();
-        const agentConfigId =
-          toolContext?.runContext?.agentConfiguration?.sId ?? null;
+        const agentConfigurationId = isAgentLoopRunContext(
+          toolContext?.runContext
+        )
+          ? toolContext.runContext.agentConfiguration.sId
+          : null;
+
+        if (creatorType === "agent" && !agentConfigurationId) {
+          return new Err(
+            new MCPError(
+              "Agent creator type specified, but no agent configuration ID found in the context.",
+              { tracked: false }
+            )
+          );
+        }
 
         const created: string[] = [];
         const errors: string[] = [];
@@ -330,7 +345,7 @@ export function createProjectTasksTools(
             userId: newUserId,
             createdByType: creatorType,
             createdByAgentConfigurationId:
-              creatorType === "agent" ? agentConfigId : null,
+              creatorType === "agent" ? agentConfigurationId : null,
             createdByUserId: creatorType === "user" ? currentUser.id : null,
             text: item.text,
             status: item.doneRationale ? "done" : "todo",
@@ -341,7 +356,11 @@ export function createProjectTasksTools(
 
           // Record the conversation where the task was created as a source so
           // it surfaces in the kickoff prompt when the task is started.
-          const sourceConversation = toolContext?.runContext?.conversation;
+          const sourceConversation = isAgentLoopRunContext(
+            toolContext?.runContext
+          )
+            ? toolContext?.runContext?.conversation
+            : null;
           if (sourceConversation) {
             await row.upsertSource(auth, {
               itemId: sourceConversation.sId,
@@ -393,8 +412,11 @@ export function createProjectTasksTools(
         }
         const { pod } = contextRes.value;
 
-        const agentConfigId =
-          toolContext?.runContext?.agentConfiguration?.sId ?? null;
+        const agentConfigurationId = isAgentLoopRunContext(
+          toolContext?.runContext
+        )
+          ? toolContext.runContext.agentConfiguration.sId
+          : null;
 
         const updated: string[] = [];
         const errors: string[] = [];
@@ -412,7 +434,7 @@ export function createProjectTasksTools(
             pod,
             row,
             item,
-            agentConfigId
+            agentConfigurationId
           );
           if (payloadRes.isErr()) {
             errors.push(payloadRes.error.message);

--- a/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
@@ -4,6 +4,7 @@ import { GET_DATABASE_SCHEMA_MARKER } from "@app/lib/actions/mcp_internal_action
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { fetchTableDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
   executeQuery,
   verifyDataSourceViewReadAccess,
@@ -27,6 +28,7 @@ import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import assert from "assert";
 
 function tablesFromUris(tableUris: string[]): TablesConfigurationToolType {
   return tableUris.map((uri) => ({
@@ -239,9 +241,10 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
     { auth, toolContext }
   ) => {
     // TODO(mcp): @fontanierh: we should not have a strict dependency on the agentLoopRunContext.
-    if (!toolContext?.runContext) {
-      throw new Error("Unreachable: missing agentLoopContext.");
-    }
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
     const agentLoopRunContext = toolContext.runContext;
 

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -19,9 +19,10 @@ import {
   type HandledToolAbortClassification,
   makeToolInterruptionError,
 } from "@app/lib/actions/tool_interruptions";
-import type {
-  ActionGeneratedFileType,
-  ToolContextType,
+import {
+  type ActionGeneratedFileType,
+  isAgentLoopRunContext,
+  type ToolContextType,
 } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
@@ -191,8 +192,8 @@ const runAgent = async (
   }
 ): Promise<ToolHandlerResult> => {
   assert(
-    toolContext?.runContext,
-    "agentLoopContext is required to run the run_agent tool"
+    isAgentLoopRunContext(toolContext?.runContext),
+    "AgentLoopRunContext expected"
   );
 
   const abortSignal = signal ?? null;
@@ -504,7 +505,9 @@ const runAgent = async (
       conversationId,
       config.getAppUrl()
     );
-    const { citationsOffset } = toolContext.runContext.stepContext;
+    const { citationsOffset } = isAgentLoopRunContext(toolContext.runContext)
+      ? toolContext.runContext.stepContext
+      : { citationsOffset: 0 };
 
     const refs = getRefs().slice(
       citationsOffset,

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -7,7 +7,10 @@ import type {
 import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfigurationWithName,
   isServerSideMCPServerConfigurationWithName,
@@ -96,12 +99,12 @@ export default async function createServer(
     registerTool(auth, toolContext, server, toolDefinition, {
       monitoringName: "run_dust_app",
     });
-  } else if (toolContext?.runContext) {
+  } else if (isAgentLoopRunContext(toolContext?.runContext)) {
     // Context: Running the Dust app
-    const { toolConfiguration } = toolContext.runContext;
+    const runContext = toolContext.runContext;
     if (
       !isLightServerSideMCPToolConfigurationWithName(
-        toolConfiguration,
+        runContext.toolConfiguration,
         "run_dust_app"
       )
     ) {
@@ -110,7 +113,7 @@ export default async function createServer(
 
     const { app, schema, appConfig } = await prepareAppContext(
       auth,
-      toolConfiguration
+      runContext.toolConfiguration
     );
 
     if (!app.description) {
@@ -138,7 +141,7 @@ export default async function createServer(
         const preparedParams = await prepareParamsWithHistory(
           params,
           schema,
-          toolContext.runContext,
+          runContext,
           auth
         );
 
@@ -201,14 +204,11 @@ export default async function createServer(
 
         const sanitizedOutput = sanitizeJSONOutput(lastBlockOutput);
 
-        if (
-          containsFileOutput(sanitizedOutput) &&
-          toolContext.runContext?.conversation
-        ) {
+        if (containsFileOutput(sanitizedOutput) && runContext.conversation) {
           const fileContentResult = await processDustFileOutput(
             auth,
             sanitizedOutput,
-            toolContext.runContext.conversation,
+            runContext.conversation,
             app.name
           );
           if (fileContentResult.isErr()) {

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -236,6 +236,7 @@ describe("runSandboxBashTool", () => {
       },
       toolContext: {
         runContext: {
+          contextType: "agent_loop",
           agentConfiguration: {
             model: { providerId: "openai" },
             sId: "agent-id",
@@ -672,6 +673,7 @@ describe("runSandboxBashTool", () => {
       return {
         toolContext: {
           runContext: {
+            contextType: "agent_loop",
             agentConfiguration: {
               model: { providerId: "openai" },
               sId: "agent-id",
@@ -783,6 +785,7 @@ describe("addEgressDomainTool", () => {
       },
       toolContext: {
         runContext: {
+          contextType: "agent_loop",
           conversation: { sId: "conversation-id" },
         },
       },
@@ -919,28 +922,6 @@ describe("addEgressDomainTool", () => {
     expect(result.isErr()).toBe(true);
     expect(mockAddSandboxPolicyDomain).not.toHaveBeenCalled();
     expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
-  });
-
-  it("returns an error without conversation context", async () => {
-    const result = await addEgressDomainTool(
-      {
-        domain: "example.org",
-        reason: "Retry a blocked request.",
-      },
-      {
-        auth: {
-          getNonNullableWorkspace: () => ({
-            name: "Workspace",
-            sId: "workspace-id",
-          }),
-        },
-        toolContext: undefined,
-        signal: new AbortController().signal,
-      } as never
-    );
-
-    expect(result.isErr()).toBe(true);
-    expect(mockEnsureSandboxReady).not.toHaveBeenCalled();
   });
 
   it("returns an error when no active sandbox is available", async () => {

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -8,7 +8,10 @@ import type {
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
 import type { ToolContextType } from "@app/lib/actions/types";
-import { isSandboxResumeState } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  isSandboxResumeState,
+} from "@app/lib/actions/types";
 import {
   SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS,
   SANDBOX_EXEC_TIMEOUT_BUFFER_MS,
@@ -52,6 +55,7 @@ import { isDevelopment } from "@app/types/shared/env";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import assert from "assert";
 import { z } from "zod";
 
 const DEFAULT_WORKING_DIRECTORY = "/home/agent";
@@ -227,8 +231,9 @@ export async function createSandboxTools(
   const handlers: ToolHandlers<typeof SANDBOX_TOOLS_METADATA> = {
     bash: runSandboxBashTool,
     describe_toolset: async ({ format }, { auth, toolContext }) => {
-      const providerId =
-        toolContext?.runContext?.agentConfiguration.model.providerId;
+      const providerId = isAgentLoopRunContext(toolContext?.runContext)
+        ? toolContext.runContext.agentConfiguration.model.providerId
+        : null;
       if (!providerId) {
         return new Err(new MCPError("Missing model provider ID"));
       }
@@ -298,10 +303,12 @@ export async function runSandboxBashTool(
     MCPError
   >
 > {
+  assert(
+    isAgentLoopRunContext(toolContext?.runContext),
+    "AgentLoopRunContext expected"
+  );
+
   const runContext = toolContext?.runContext;
-  if (!runContext) {
-    return new Err(new MCPError("No conversation context available."));
-  }
   const {
     conversation,
     agentConfiguration,
@@ -484,6 +491,10 @@ export async function addEgressDomainTool(
   { domain, reason }: { domain: string; reason: string },
   { auth, toolContext }: ToolHandlerExtra
 ): Promise<Result<Array<{ type: "text"; text: string }>, MCPError>> {
+  assert(
+    isAgentLoopRunContext(toolContext?.runContext),
+    "AgentLoopRunContext expected"
+  );
   // Defense-in-depth: createSandboxTools already filters this tool out when
   // the workspace setting is off, so this metadata-only check is enough to
   // reject any caller that bypasses tool-list filtering.
@@ -495,12 +506,10 @@ export async function addEgressDomainTool(
     );
   }
 
-  const conversation = toolContext?.runContext?.conversation;
-  if (!conversation) {
-    return new Err(new MCPError("No conversation context available."));
-  }
-
-  const ensureResult = await ensureConversationSandboxReady(auth, conversation);
+  const ensureResult = await ensureConversationSandboxReady(
+    auth,
+    toolContext.runContext.conversation
+  );
   if (ensureResult.isErr()) {
     return new Err(new MCPError(ensureResult.error.message));
   }

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -1,7 +1,10 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { SCHEDULES_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/schedules_management/metadata";
 import { generateScheduleRule } from "@app/lib/api/assistant/configuration/triggers";
 import type { Authenticator } from "@app/lib/auth";
@@ -13,6 +16,7 @@ import { isUserMessageType } from "@app/types/assistant/conversation";
 import type { ScheduleTriggerType } from "@app/types/assistant/triggers";
 import { isScheduleTrigger } from "@app/types/assistant/triggers";
 import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
 import { UniqueConstraintError } from "sequelize";
 
 function renderSchedule(schedule: ScheduleTriggerType): string {
@@ -32,6 +36,10 @@ function renderSchedule(schedule: ScheduleTriggerType): string {
 }
 
 function getUserTimezone(toolContext?: ToolContextType): string | null {
+  if (!isAgentLoopRunContext(toolContext?.runContext)) {
+    return null;
+  }
+
   const content = toolContext?.runContext?.conversation?.content;
   if (!content) {
     return null;
@@ -47,13 +55,13 @@ export function createSchedulesManagementTools(
 ) {
   const handlers: ToolHandlers<typeof SCHEDULES_MANAGEMENT_TOOLS_METADATA> = {
     create_schedule: async ({ name, schedule, prompt, timezone }) => {
+      assert(
+        isAgentLoopRunContext(toolContext?.runContext),
+        "AgentLoopRunContext expected"
+      );
+
       const owner = auth.getNonNullableWorkspace();
       const user = auth.getNonNullableUser();
-
-      if (!toolContext?.runContext) {
-        logger.error("Agent context missing");
-        return new Err(new MCPError("Agent context is required"));
-      }
 
       const { agentConfiguration } = toolContext.runContext;
 
@@ -142,12 +150,13 @@ export function createSchedulesManagementTools(
     },
 
     list_schedules: async () => {
+      assert(
+        isAgentLoopRunContext(toolContext?.runContext),
+        "AgentLoopRunContext expected"
+      );
+
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
-
-      if (!toolContext?.runContext) {
-        return new Err(new MCPError("Agent context is required"));
-      }
 
       const { agentConfiguration } = toolContext.runContext;
 
@@ -192,12 +201,13 @@ export function createSchedulesManagementTools(
     },
 
     disable_schedule: async ({ scheduleId }) => {
+      assert(
+        isAgentLoopRunContext(toolContext?.runContext),
+        "AgentLoopRunContext expected"
+      );
+
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
-
-      if (!toolContext?.runContext) {
-        return new Err(new MCPError("Agent context is required"));
-      }
 
       const { agentConfiguration } = toolContext.runContext;
 

--- a/front/lib/api/actions/servers/search/tools/index.ts
+++ b/front/lib/api/actions/servers/search/tools/index.ts
@@ -8,7 +8,11 @@ import {
   applyNodeIdsFilterToCoreSearchArgs,
   getCoreSearchArgs,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type { StepContext, ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
+import { AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K } from "@app/lib/api/actions/servers/data_sources_file_system/tools/search";
 import {
   SEARCH_TOOL_METADATA_WITH_TAGS,
   SEARCH_TOOL_NAME,
@@ -44,7 +48,6 @@ export async function searchFunction(
     tagsIn,
     tagsNot,
     toolContext,
-    stepContext,
   }: {
     query: string;
     relativeTimeFrame: string;
@@ -54,7 +57,6 @@ export async function searchFunction(
     tagsIn?: string[];
     tagsNot?: string[];
     toolContext?: ToolContextType;
-    stepContext?: StepContext;
   }
 ): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
@@ -62,14 +64,11 @@ export async function searchFunction(
   const credentials = await getLlmCredentials(auth);
   const timeFrame = parseTimeFrame(relativeTimeFrame);
 
-  if (!toolContext?.runContext?.stepContext && !stepContext) {
-    throw new Error(
-      "agentLoopRunContext.stepContext or stepContext is required where the tool is called."
-    );
-  }
-
-  const { retrievalTopK, citationsOffset } =
-    toolContext?.runContext?.stepContext ?? stepContext!;
+  const { retrievalTopK, citationsOffset } = isAgentLoopRunContext(
+    toolContext?.runContext
+  )
+    ? toolContext.runContext.stepContext
+    : { retrievalTopK: AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K, citationsOffset: 0 };
 
   // Get the core search args for each data source, fail if any of them are invalid.
   const coreSearchArgsResults = await getCoreSearchArgs(auth, dataSources);

--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -110,6 +110,7 @@ describe("skill_management enable_skill tool", () => {
       auth,
       toolContext: {
         runContext: {
+          contextType: "agent_loop",
           agentConfiguration,
           agentMessage,
           conversation: conversationOverride,

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -2,6 +2,7 @@ import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { SKILL_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/skill_management/metadata";
 import { makeEnableSkillResultOutput } from "@app/lib/api/actions/servers/skill_management/rendering";
 import { loadSkillFilesToConversation } from "@app/lib/api/skills/conversation_files";
@@ -11,6 +12,7 @@ import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { isUserMessageType } from "@app/types/assistant/conversation";
 import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
 
 function extractSkillIdsFromConversationMessages(
   agentLoopData: AgentLoopExecutionData
@@ -96,9 +98,10 @@ async function findAvailableSkillForAgentLoop({
 
 const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
   [ENABLE_SKILL_TOOL_NAME]: async ({ skillName }, { auth, toolContext }) => {
-    if (!toolContext?.runContext) {
-      return new Err(new MCPError("No conversation context available"));
-    }
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
     const { agentConfiguration, agentMessage, conversation, userMessage } =
       toolContext.runContext;

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -1,6 +1,9 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import {
   formatSlackMessageForLLM,
   renderFormattedMessage,
@@ -790,7 +793,10 @@ export async function executePostMessage(
 
   const originalMessage = message;
 
-  if (showSentByFooter !== false) {
+  if (
+    showSentByFooter !== false &&
+    isAgentLoopRunContext(toolContext.runContext)
+  ) {
     const agentUrl = getConversationRoute(
       auth.getNonNullableWorkspace().sId,
       "new",
@@ -945,7 +951,10 @@ export async function executeScheduleMessage(
   const slackClient = await getSlackClient(accessToken);
   const originalMessage = message;
 
-  if (showSentByFooter !== false) {
+  if (
+    showSentByFooter !== false &&
+    isAgentLoopRunContext(toolContext.runContext)
+  ) {
     const agentUrl = getConversationRoute(
       auth.getNonNullableWorkspace().sId,
       "new",

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -7,7 +7,10 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { SLACK_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import {
   executeArchiveChannel,
@@ -266,7 +269,7 @@ function formatDateForSlackQuery(date: Date): string {
 // Helper function to build search results from matches.
 function buildSearchResults<T>(
   matches: T[],
-  refs: string[],
+  refs: string[] | null,
   extractors: {
     permalink: (match: T) => string | undefined;
     text: (match: T) => string;
@@ -282,7 +285,7 @@ function buildSearchResults<T>(
       id: extractors.id(match),
       source: { provider: "slack" },
       tags: [],
-      ref: refs[index] ?? "",
+      ref: refs ? (refs[index] ?? "") : "",
       chunks: [stripNullBytes(extractors.content(match))],
     })
   );
@@ -446,12 +449,15 @@ export function createSlackPersonalTools(
           ]);
         }
 
-        const { citationsOffset } = toolContext.runContext.stepContext;
+        let refs: string[] | null = null;
+        if (isAgentLoopRunContext(toolContext.runContext)) {
+          const { citationsOffset } = toolContext.runContext.stepContext;
 
-        const refs = getRefs().slice(
-          citationsOffset,
-          citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
-        );
+          refs = getRefs().slice(
+            citationsOffset,
+            citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+          );
+        }
 
         const searchResults = buildSearchResults<SlackSearchMatch>(
           matches,
@@ -522,12 +528,15 @@ export function createSlackPersonalTools(
           ]);
         }
 
-        const { citationsOffset } = toolContext.runContext.stepContext;
+        let refs: string[] | null = null;
+        if (isAgentLoopRunContext(toolContext.runContext)) {
+          const { citationsOffset } = toolContext.runContext.stepContext;
 
-        const refs = getRefs().slice(
-          citationsOffset,
-          citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
-        );
+          refs = getRefs().slice(
+            citationsOffset,
+            citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+          );
+        }
 
         const searchResults = buildSearchResults<SlackSearchMatch>(
           matches,
@@ -803,12 +812,15 @@ export function createSlackPersonalTools(
         accessToken,
       });
 
-      const { citationsOffset } = toolContext.runContext.stepContext;
+      let refs: string[] | null = null;
+      if (isAgentLoopRunContext(toolContext.runContext)) {
+        const { citationsOffset } = toolContext.runContext.stepContext;
 
-      const refs = getRefs().slice(
-        citationsOffset,
-        citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
-      );
+        refs = getRefs().slice(
+          citationsOffset,
+          citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+        );
+      }
 
       // Resolve user display names for all thread authors.
       const threadsWithAuthors = await Promise.all(

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -269,7 +269,7 @@ function formatDateForSlackQuery(date: Date): string {
 // Helper function to build search results from matches.
 function buildSearchResults<T>(
   matches: T[],
-  refs: string[] | null,
+  refs: string[],
   extractors: {
     permalink: (match: T) => string | undefined;
     text: (match: T) => string;
@@ -285,7 +285,7 @@ function buildSearchResults<T>(
       id: extractors.id(match),
       source: { provider: "slack" },
       tags: [],
-      ref: refs ? (refs[index] ?? "") : "",
+      ref: refs[index] ?? "",
       chunks: [stripNullBytes(extractors.content(match))],
     })
   );
@@ -449,15 +449,16 @@ export function createSlackPersonalTools(
           ]);
         }
 
-        let refs: string[] | null = null;
-        if (isAgentLoopRunContext(toolContext.runContext)) {
-          const { citationsOffset } = toolContext.runContext.stepContext;
+        const { citationsOffset } = isAgentLoopRunContext(
+          toolContext.runContext
+        )
+          ? toolContext.runContext.stepContext
+          : { citationsOffset: 0 };
 
-          refs = getRefs().slice(
-            citationsOffset,
-            citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
-          );
-        }
+        const refs = getRefs().slice(
+          citationsOffset,
+          citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+        );
 
         const searchResults = buildSearchResults<SlackSearchMatch>(
           matches,
@@ -528,15 +529,16 @@ export function createSlackPersonalTools(
           ]);
         }
 
-        let refs: string[] | null = null;
-        if (isAgentLoopRunContext(toolContext.runContext)) {
-          const { citationsOffset } = toolContext.runContext.stepContext;
+        const { citationsOffset } = isAgentLoopRunContext(
+          toolContext.runContext
+        )
+          ? toolContext.runContext.stepContext
+          : { citationsOffset: 0 };
 
-          refs = getRefs().slice(
-            citationsOffset,
-            citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
-          );
-        }
+        const refs = getRefs().slice(
+          citationsOffset,
+          citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+        );
 
         const searchResults = buildSearchResults<SlackSearchMatch>(
           matches,
@@ -812,15 +814,14 @@ export function createSlackPersonalTools(
         accessToken,
       });
 
-      let refs: string[] | null = null;
-      if (isAgentLoopRunContext(toolContext.runContext)) {
-        const { citationsOffset } = toolContext.runContext.stepContext;
+      const { citationsOffset } = isAgentLoopRunContext(toolContext.runContext)
+        ? toolContext.runContext.stepContext
+        : { citationsOffset: 0 };
 
-        refs = getRefs().slice(
-          citationsOffset,
-          citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
-        );
-      }
+      let refs = getRefs().slice(
+        citationsOffset,
+        citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+      );
 
       // Resolve user display names for all thread authors.
       const threadsWithAuthors = await Promise.all(

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -1,7 +1,10 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { SnowflakeClient } from "@app/lib/api/actions/servers/snowflake/client";
 import {
   MAX_QUERY_ROWS,
@@ -22,9 +25,9 @@ const CONNECTION_ERROR = new MCPError(
 
 interface SnowflakeQueryTagMetadata {
   workspace_id: string;
-  agent_id: string;
-  agent_name: string;
-  conversation_id: string;
+  agent_id: string | null;
+  agent_name: string | null;
+  conversation_id: string | null;
   user_id: string | null;
   user_email: string | null;
 }
@@ -39,15 +42,20 @@ function buildQueryTagMetadata(
     return undefined;
   }
 
-  const { agentConfiguration, conversation } = toolContext.runContext;
+  const { agentConfiguration, conversation } = isAgentLoopRunContext(
+    toolContext.runContext
+  )
+    ? toolContext.runContext
+    : {};
+
   const workspace = auth.getNonNullableWorkspace();
   const user = auth.user();
 
   const metadata: SnowflakeQueryTagMetadata = {
     workspace_id: workspace.sId,
-    agent_id: agentConfiguration.sId,
-    agent_name: agentConfiguration.name,
-    conversation_id: conversation.sId,
+    agent_id: agentConfiguration?.sId ?? null,
+    agent_name: agentConfiguration?.name ?? null,
+    conversation_id: conversation?.sId ?? null,
     user_id: user?.sId ?? null,
     user_email: user?.email ?? null,
   };

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -8,6 +8,7 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import { getToolNamePrefix } from "@app/lib/actions/tool_name_utils";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { TOOLSETS_TOOLS_METADATA } from "@app/lib/api/actions/servers/toolsets/metadata";
 import apiConfig from "@app/lib/api/config";
@@ -18,9 +19,15 @@ import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { getHeaderFromUserEmail } from "@app/types/user";
 import { DustAPI, INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import assert from "assert";
 
 const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
   list: async (_, { auth, toolContext }) => {
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
+
     const mcpServerViewIdsFromAgentConfiguration =
       toolContext?.runContext?.agentConfiguration.actions
         .filter(isServerSideMCPServerConfiguration)
@@ -76,6 +83,11 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
   },
 
   enable: async ({ toolsetId }, { auth, toolContext }) => {
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
+
     const conversationId = toolContext?.runContext?.conversation.sId;
     if (!conversationId) {
       return new Err(

--- a/front/lib/api/actions/servers/user_mentions/tools/index.ts
+++ b/front/lib/api/actions/servers/user_mentions/tools/index.ts
@@ -1,6 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
   GET_MENTION_MARKDOWN_TOOL_NAME,
   SEARCH_AVAILABLE_USERS_TOOL_NAME,
@@ -41,7 +42,9 @@ const handlers: ToolHandlers<typeof USER_MENTIONS_TOOLS_METADATA> = {
     const r = await api.getMentionsSuggestions({
       query: searchTerm,
       select: ["users"],
-      conversationId: toolContext?.runContext?.conversation?.sId,
+      conversationId: isAgentLoopRunContext(toolContext?.runContext)
+        ? toolContext.runContext.conversation.sId
+        : undefined,
     });
 
     if (r.isErr()) {

--- a/front/lib/api/actions/servers/wakeups/tools/index.ts
+++ b/front/lib/api/actions/servers/wakeups/tools/index.ts
@@ -1,7 +1,10 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import { WAKEUPS_TOOLS_METADATA } from "@app/lib/api/actions/servers/wakeups/metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -10,6 +13,7 @@ import { isUserMessageType } from "@app/types/assistant/conversation";
 import { isActiveWakeUp, type WakeUpType } from "@app/types/assistant/wakeups";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import assert from "assert";
 
 // Per-conversation guardrails. Enforced at tool-call time so the agent gets a clear error instead
 // of silently over-scheduling.
@@ -89,6 +93,10 @@ function parseWhen(when: string):
 }
 
 function getUserTimezone(toolContext?: ToolContextType): string | null {
+  if (!isAgentLoopRunContext(toolContext?.runContext)) {
+    return null;
+  }
+
   const content = toolContext?.runContext?.conversation?.content;
   if (!content) {
     return null;
@@ -123,13 +131,10 @@ export function createWakeupsTools(
 ) {
   const handlers: ToolHandlers<typeof WAKEUPS_TOOLS_METADATA> = {
     schedule_wakeup: async ({ when, reason, timezone }) => {
-      if (!toolContext?.runContext) {
-        return new Err(
-          new MCPError(
-            "Wake-ups can only be scheduled from within a conversation."
-          )
-        );
-      }
+      assert(
+        isAgentLoopRunContext(toolContext?.runContext),
+        "AgentLoopRunContext expected"
+      );
 
       const { conversation: runConversation, agentConfiguration } =
         toolContext.runContext;
@@ -246,13 +251,10 @@ export function createWakeupsTools(
     },
 
     list_wakeups: async () => {
-      if (!toolContext?.runContext) {
-        return new Err(
-          new MCPError(
-            "Wake-ups can only be listed from within a conversation."
-          )
-        );
-      }
+      assert(
+        isAgentLoopRunContext(toolContext?.runContext),
+        "AgentLoopRunContext expected"
+      );
 
       const { conversation } = toolContext.runContext;
 
@@ -282,13 +284,10 @@ export function createWakeupsTools(
     },
 
     cancel_wakeup: async ({ wakeUpId }) => {
-      if (!toolContext?.runContext) {
-        return new Err(
-          new MCPError(
-            "Wake-ups can only be cancelled from within a conversation."
-          )
-        );
-      }
+      assert(
+        isAgentLoopRunContext(toolContext?.runContext),
+        "AgentLoopRunContext expected"
+      );
 
       const { conversation } = toolContext.runContext;
 

--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -11,6 +11,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { summarizeWithLLM } from "@app/lib/actions/mcp_internal_actions/utils/web_summarization";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { WEB_SEARCH_BROWSE_TOOLS_METADATA } from "@app/lib/api/actions/servers/web_search_browse/metadata";
 import { getRefs } from "@app/lib/api/assistant/citations";
@@ -41,22 +42,22 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 const MIN_CHARACTERS_TO_SUMMARIZE = 16_000;
 const BROWSE_MAX_TOKENS_LIMIT = 32_000;
 const DEFAULT_WEBSEARCH_MODEL_CONFIG = GPT_4O_MODEL_CONFIG;
+const AGENT_LESS_DEFAULT_WEBSEARCH_RESULT_COUNT = 10;
 
 async function handleWebsearch(
   { query }: { query: string },
   extra: ToolHandlerExtra
 ) {
   const { toolContext } = extra;
-  if (!toolContext?.runContext) {
-    return new Err(
-      new MCPError("agentLoopRunContext is required where the tool is called.")
-    );
-  }
 
-  const agentLoopRunContext = toolContext.runContext;
-
-  const { websearchResultCount, citationsOffset } =
-    agentLoopRunContext.stepContext;
+  const { websearchResultCount, citationsOffset } = isAgentLoopRunContext(
+    toolContext?.runContext
+  )
+    ? toolContext.runContext.stepContext
+    : {
+        websearchResultCount: AGENT_LESS_DEFAULT_WEBSEARCH_RESULT_COUNT,
+        citationsOffset: 0,
+      };
 
   const rawSearchProvider = (
     (extra.auth.getNonNullableWorkspace().metadata as WorkspaceMetadata) ?? {}
@@ -161,6 +162,14 @@ async function handleWebbrowser(
   });
 
   if (useSummarization) {
+    if (!isAgentLoopRunContext(toolContext.runContext)) {
+      return new Err(
+        new MCPError(
+          "Summarization cannot be enabled outside of an agent loop context."
+        )
+      );
+    }
+
     const runCtx = toolContext.runContext;
     const { citationsOffset, websearchResultCount } = runCtx.stepContext;
     const refs = getRefs().slice(

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -89,6 +89,7 @@ export async function* runToolWithStreaming(
   });
 
   const agentLoopRunContext: AgentLoopRunContextType = {
+    contextType: "agent_loop",
     agentConfiguration,
     agentMessage,
     currentAction: action.toJSON(),
@@ -106,7 +107,7 @@ export async function* runToolWithStreaming(
   const toolCallResult = yield* tryCallMCPTool(
     auth,
     inputs,
-    agentLoopRunContext,
+    { runContext: agentLoopRunContext },
     {
       progressToken: action.id,
       makeToolNotificationEvent: async (notification) => {

--- a/front/lib/api/mcp_server/tools/search/search.ts
+++ b/front/lib/api/mcp_server/tools/search/search.ts
@@ -94,13 +94,6 @@ export function registerSearchTool(server: McpServer) {
         nodeIds,
         tagsIn,
         tagsNot,
-        stepContext: {
-          citationsCount: topK,
-          citationsOffset: 0,
-          retrievalTopK: topK,
-          resumeState: null,
-          websearchResultCount: 0,
-        },
       });
 
       if (searchResult.isErr()) {

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -33,7 +33,7 @@
            // We don't know how to create frames directly in pods for now it seems.
            // Maybe we need just publish?
 [+]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
-[ ]     2  front/lib/api/actions/servers/notion/tools/index.ts:118
+[+]     2  front/lib/api/actions/servers/notion/tools/index.ts:118
 [ ]     3  front/lib/api/actions/servers/plan_mode/tools/index.ts:28
 [ ]     2  front/lib/api/actions/servers/pod_manager/helpers.ts:147
 [ ]    11  front/lib/api/actions/servers/pod_manager/tools/index.ts:986

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -20,7 +20,8 @@
 [+]     1  front/lib/api/actions/servers/google_calendar/helpers.ts:176
            // TODO: user timezone for calendar, once we have it in invocations
 [+]     2  front/lib/api/actions/servers/google_drive/tools/index.ts:300
-[ ]     1  front/lib/api/actions/servers/helpers.ts:44
+[+]     1  front/lib/api/actions/servers/helpers.ts:44
+           // TODO sidekick should be removed from list
 [ ]     1  front/lib/api/actions/servers/image_generation/helpers.ts:217
 [ ]     4  front/lib/api/actions/servers/include_data/tools/index.ts:33
 [ ]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -48,8 +48,8 @@
 [-]     7  front/lib/api/actions/servers/sandbox/tools/index.ts:231
 [-]     4  front/lib/api/actions/servers/schedules_management/tools/index.ts:35
            // Agent specific
-[ ]     2  front/lib/api/actions/servers/search/tools/index.ts:65
-[ ]     4  front/lib/api/actions/servers/skill_management/tools/index.ts:103
+[+]     2  front/lib/api/actions/servers/search/tools/index.ts:65
+[-]     4  front/lib/api/actions/servers/skill_management/tools/index.ts:103
 [+]     3  front/lib/api/actions/servers/slack_personal/tools/index.ts:449
 [ ]     2  front/lib/api/actions/servers/snowflake/tools/index.ts:42
 [ ]     4  front/lib/api/actions/servers/toolsets/tools/index.ts:25

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -53,7 +53,7 @@
 [+]     3  front/lib/api/actions/servers/slack_personal/tools/index.ts:449
 [+]     2  front/lib/api/actions/servers/snowflake/tools/index.ts:42
 [-]     4  front/lib/api/actions/servers/toolsets/tools/index.ts:25
-[ ]     1  front/lib/api/actions/servers/user_mentions/tools/index.ts:44
+[+]     1  front/lib/api/actions/servers/user_mentions/tools/index.ts:44
 [ ]     5  front/lib/api/actions/servers/wakeups/tools/index.ts:92
 [ ]     4  front/lib/api/actions/servers/web_search_browse/tools/index.ts:59
 [ ]     1  front/lib/api/mcp/run_tool.ts:91

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -29,7 +29,9 @@
            // TODO: similar to data_warehouse, we need a specific flow to write to the pod
                     tool_outputs when in sandbox function. See TODOs below.
 [+]     4  front/lib/api/actions/servers/include_data/tools/index.ts:33
-[ ]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
+[~]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
+           // We don't know how to create frames directly in pods for now it seems.
+           // Maybe we need just publish?
 [ ]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
 [ ]     2  front/lib/api/actions/servers/notion/tools/index.ts:118
 [ ]     3  front/lib/api/actions/servers/plan_mode/tools/index.ts:28
@@ -58,9 +60,10 @@ to dynamically express that a server is not usable.
 
 ### TODOs:
 
- - [ ] mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
- - [ ] data_warehouse: flow to tool_outputs if in sandbox function
- - [ ] image_generation: flow to tool_outputs if in sandbox function
+- [ ] mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
+- [ ] data_warehouse: flow to tool_outputs if in sandbox function
+- [ ] image_generation: flow to tool_outputs if in sandbox function
+- [ ] interactive_content: enable publish only when in sandbox function (update tools listing)
 
 ### files server
 
@@ -69,3 +72,8 @@ Maybe:
     getDustFileSystemForToolContext + getDustFileSystemForSandboxFunction
 
 But since we're in a sandbox we should never call these tools?
+
+### interactive_content server
+
+Interestingly only create/revert *require* an agent. I don't believe we know how to create a frame
+directly in the pod through these tools. Maybe we should only have the publish action here?

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -54,9 +54,9 @@
 [+]     2  front/lib/api/actions/servers/snowflake/tools/index.ts:42
 [-]     4  front/lib/api/actions/servers/toolsets/tools/index.ts:25
 [+]     1  front/lib/api/actions/servers/user_mentions/tools/index.ts:44
-[ ]     5  front/lib/api/actions/servers/wakeups/tools/index.ts:92
-[ ]     4  front/lib/api/actions/servers/web_search_browse/tools/index.ts:59
-[ ]     1  front/lib/api/mcp/run_tool.ts:91
+[-]     5  front/lib/api/actions/servers/wakeups/tools/index.ts:92
+[+]     4  front/lib/api/actions/servers/web_search_browse/tools/index.ts:59
+[+]     1  front/lib/api/mcp/run_tool.ts:91
 
 ## notes
 
@@ -74,6 +74,7 @@ to dynamically express that a server is not usable.
 - [ ] timezone on invocation for:
       - google_calendar
       - pod_manager/create_conversation
+- [ ] runToolWithStreaming is highly conversation centric, maybe dsbx does not use it.
 
 ### files server
 

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -14,15 +14,20 @@
 [+]     1  front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts:169
 [+]     1  front/lib/api/actions/servers/data_sources_file_system/tools/search.ts:55
 [~]     1  front/lib/api/actions/servers/data_warehouses/tools/index.ts:262
-           // TODO: migrate to CSV output to DFS
+           // TODO: end state is a migration of the whole system here but today it relies on table
+                    query. To re-enable likely different path when sandbox function that writes to
+                    the pod tool outputs. Will need to change the tool return (currently returns a
+                    file should now be a path for that flow). See TODOs below.
 [-]     2  front/lib/api/actions/servers/extract_data/tools/index.ts:56
 [-]     1  front/lib/api/actions/servers/files/tools/agent_loop_fs.ts:15
 [+]     1  front/lib/api/actions/servers/google_calendar/helpers.ts:176
            // TODO: user timezone for calendar, once we have it in invocations
 [+]     2  front/lib/api/actions/servers/google_drive/tools/index.ts:300
 [+]     1  front/lib/api/actions/servers/helpers.ts:44
-           // TODO sidekick should be removed from list
-[ ]     1  front/lib/api/actions/servers/image_generation/helpers.ts:217
+           // TODO: sidekick should be removed from list
+[~]     1  front/lib/api/actions/servers/image_generation/helpers.ts:217
+           // TODO: similar to data_warehouse, we need a specific flow to write to the pod
+                    tool_outputs when in sandbox function. See TODOs below.
 [ ]     4  front/lib/api/actions/servers/include_data/tools/index.ts:33
 [ ]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
 [ ]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
@@ -50,6 +55,12 @@
 
 Ideally if createServer returns 0 tools we should not expose the server at all. Would be a nice way
 to dynamically express that a server is not usable.
+
+### TODOs:
+
+ - [ ] mcp_execution: introduce pod tool_outputs
+ - [ ] data_warehouse: flow to tool_outputs if in sandbox function
+ - [ ] image_generation: flow to tool_outputs if in sandbox function
 
 ### files server
 

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -34,7 +34,7 @@
            // Maybe we need just publish?
 [+]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
 [+]     2  front/lib/api/actions/servers/notion/tools/index.ts:118
-[ ]     3  front/lib/api/actions/servers/plan_mode/tools/index.ts:28
+[-]     3  front/lib/api/actions/servers/plan_mode/tools/index.ts:28
 [ ]     2  front/lib/api/actions/servers/pod_manager/helpers.ts:147
 [ ]    11  front/lib/api/actions/servers/pod_manager/tools/index.ts:986
 [ ]     3  front/lib/api/actions/servers/pod_tasks/tools/index.ts:303
@@ -60,7 +60,7 @@ to dynamically express that a server is not usable.
 
 ### TODOs:
 
-- [ ] mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
+- [ ] run_tool/mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
 - [ ] data_warehouse: flow to tool_outputs if in sandbox function
 - [ ] image_generation: flow to tool_outputs if in sandbox function
 - [ ] interactive_content: enable publish only when in sandbox function (update tools listing)

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -42,7 +42,8 @@
 [+]     3  front/lib/api/actions/servers/pod_tasks/tools/index.ts:303
 [~]     1  front/lib/api/actions/servers/query_tables_v2/tools/index.ts:284
            // TODO: similar to data_warehouse, relies on generateCSVFileAndSnippet.
-[ ]     6  front/lib/api/actions/servers/run_agent/index.ts:224
+[-]     6  front/lib/api/actions/servers/run_agent/index.ts:224
+           // Deeply tied to main conversation for now :/
 [ ]     3  front/lib/api/actions/servers/run_dust_app/index.ts:141
 [ ]     7  front/lib/api/actions/servers/sandbox/tools/index.ts:231
 [ ]     4  front/lib/api/actions/servers/schedules_management/tools/index.ts:35

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -35,8 +35,10 @@
 [+]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
 [+]     2  front/lib/api/actions/servers/notion/tools/index.ts:118
 [-]     3  front/lib/api/actions/servers/plan_mode/tools/index.ts:28
-[ ]     2  front/lib/api/actions/servers/pod_manager/helpers.ts:147
-[ ]    11  front/lib/api/actions/servers/pod_manager/tools/index.ts:986
+[+]     2  front/lib/api/actions/servers/pod_manager/helpers.ts:147
+[+]    11  front/lib/api/actions/servers/pod_manager/tools/index.ts:986
+           // TODO: create_conversation should have timezone
+                    origin defaults to "web" which is fine for now
 [ ]     3  front/lib/api/actions/servers/pod_tasks/tools/index.ts:303
 [ ]     1  front/lib/api/actions/servers/query_tables_v2/tools/index.ts:284
 [ ]     6  front/lib/api/actions/servers/run_agent/index.ts:224
@@ -64,6 +66,10 @@ to dynamically express that a server is not usable.
 - [ ] data_warehouse: flow to tool_outputs if in sandbox function
 - [ ] image_generation: flow to tool_outputs if in sandbox function
 - [ ] interactive_content: enable publish only when in sandbox function (update tools listing)
+- [ ] pod_manager: filter add_message_to_conversation tool when in sandbox function 
+- [ ] timezone on invocation for:
+      - google_calendar
+      - pod_manager/create_conversation
 
 ### files server
 

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -29,7 +29,7 @@
            // TODO: similar to data_warehouse, we need a specific flow to write to the pod
                     tool_outputs when in sandbox function. See TODOs below.
 [+]     4  front/lib/api/actions/servers/include_data/tools/index.ts:33
-[-]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
+[~]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
            // We don't know how to create frames directly in pods for now.
            // Create still conversation tied. Will have to skip for now the server.
 [+]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
@@ -40,7 +40,8 @@
            // TODO: create_conversation should have timezone
                     origin defaults to "web" which is fine for now
 [+]     3  front/lib/api/actions/servers/pod_tasks/tools/index.ts:303
-[ ]     1  front/lib/api/actions/servers/query_tables_v2/tools/index.ts:284
+[~]     1  front/lib/api/actions/servers/query_tables_v2/tools/index.ts:284
+           // TODO: similar to data_warehouse, relies on generateCSVFileAndSnippet.
 [ ]     6  front/lib/api/actions/servers/run_agent/index.ts:224
 [ ]     3  front/lib/api/actions/servers/run_dust_app/index.ts:141
 [ ]     7  front/lib/api/actions/servers/sandbox/tools/index.ts:231
@@ -65,6 +66,8 @@ to dynamically express that a server is not usable.
 - [ ] run_tool/mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
 - [ ] data_warehouse: flow to tool_outputs if in sandbox function
 - [ ] image_generation: flow to tool_outputs if in sandbox function
+- [ ] query_tables_v2: flow to tool_outputs if in sandbox function
+- [ ] interactive_content: allow converstaion less create and publish (big one, flavien has context)
 - [ ] pod_manager: filter add_message_to_conversation tool when in sandbox function 
 - [ ] timezone on invocation for:
       - google_calendar

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -44,7 +44,7 @@
            // TODO: similar to data_warehouse, relies on generateCSVFileAndSnippet.
 [-]     6  front/lib/api/actions/servers/run_agent/index.ts:224
            // Deeply tied to main conversation for now :/
-[ ]     3  front/lib/api/actions/servers/run_dust_app/index.ts:141
+[+]     3  front/lib/api/actions/servers/run_dust_app/index.ts:141
 [ ]     7  front/lib/api/actions/servers/sandbox/tools/index.ts:231
 [ ]     4  front/lib/api/actions/servers/schedules_management/tools/index.ts:35
 [ ]     2  front/lib/api/actions/servers/search/tools/index.ts:65

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -45,8 +45,9 @@
 [-]     6  front/lib/api/actions/servers/run_agent/index.ts:224
            // Deeply tied to main conversation for now :/
 [+]     3  front/lib/api/actions/servers/run_dust_app/index.ts:141
-[ ]     7  front/lib/api/actions/servers/sandbox/tools/index.ts:231
-[ ]     4  front/lib/api/actions/servers/schedules_management/tools/index.ts:35
+[-]     7  front/lib/api/actions/servers/sandbox/tools/index.ts:231
+[-]     4  front/lib/api/actions/servers/schedules_management/tools/index.ts:35
+           // Agent specific
 [ ]     2  front/lib/api/actions/servers/search/tools/index.ts:65
 [ ]     4  front/lib/api/actions/servers/skill_management/tools/index.ts:103
 [+]     3  front/lib/api/actions/servers/slack_personal/tools/index.ts:449

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -51,8 +51,8 @@
 [+]     2  front/lib/api/actions/servers/search/tools/index.ts:65
 [-]     4  front/lib/api/actions/servers/skill_management/tools/index.ts:103
 [+]     3  front/lib/api/actions/servers/slack_personal/tools/index.ts:449
-[ ]     2  front/lib/api/actions/servers/snowflake/tools/index.ts:42
-[ ]     4  front/lib/api/actions/servers/toolsets/tools/index.ts:25
+[+]     2  front/lib/api/actions/servers/snowflake/tools/index.ts:42
+[-]     4  front/lib/api/actions/servers/toolsets/tools/index.ts:25
 [ ]     1  front/lib/api/actions/servers/user_mentions/tools/index.ts:44
 [ ]     5  front/lib/api/actions/servers/wakeups/tools/index.ts:92
 [ ]     4  front/lib/api/actions/servers/web_search_browse/tools/index.ts:59

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -29,9 +29,9 @@
            // TODO: similar to data_warehouse, we need a specific flow to write to the pod
                     tool_outputs when in sandbox function. See TODOs below.
 [+]     4  front/lib/api/actions/servers/include_data/tools/index.ts:33
-[~]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
-           // We don't know how to create frames directly in pods for now it seems.
-           // Maybe we need just publish?
+[-]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
+           // We don't know how to create frames directly in pods for now.
+           // Create still conversation tied. Will have to skip for now the server.
 [+]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
 [+]     2  front/lib/api/actions/servers/notion/tools/index.ts:118
 [-]     3  front/lib/api/actions/servers/plan_mode/tools/index.ts:28
@@ -65,7 +65,6 @@ to dynamically express that a server is not usable.
 - [ ] run_tool/mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
 - [ ] data_warehouse: flow to tool_outputs if in sandbox function
 - [ ] image_generation: flow to tool_outputs if in sandbox function
-- [ ] interactive_content: enable publish only when in sandbox function (update tools listing)
 - [ ] pod_manager: filter add_message_to_conversation tool when in sandbox function 
 - [ ] timezone on invocation for:
       - google_calendar

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -32,7 +32,7 @@
 [~]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
            // We don't know how to create frames directly in pods for now it seems.
            // Maybe we need just publish?
-[ ]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
+[+]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
 [ ]     2  front/lib/api/actions/servers/notion/tools/index.ts:118
 [ ]     3  front/lib/api/actions/servers/plan_mode/tools/index.ts:28
 [ ]     2  front/lib/api/actions/servers/pod_manager/helpers.ts:147

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -39,7 +39,7 @@
 [+]    11  front/lib/api/actions/servers/pod_manager/tools/index.ts:986
            // TODO: create_conversation should have timezone
                     origin defaults to "web" which is fine for now
-[ ]     3  front/lib/api/actions/servers/pod_tasks/tools/index.ts:303
+[+]     3  front/lib/api/actions/servers/pod_tasks/tools/index.ts:303
 [ ]     1  front/lib/api/actions/servers/query_tables_v2/tools/index.ts:284
 [ ]     6  front/lib/api/actions/servers/run_agent/index.ts:224
 [ ]     3  front/lib/api/actions/servers/run_dust_app/index.ts:141

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -1,0 +1,59 @@
+# Failing files post introduction of SandboxFunctionRunContextType
+
++ means compatible and done
+~ means compatible and needs work (asserts now)
+- means should be filtered (some are libs so all callers should be filtered)
+
+[-]     4  front/lib/actions/mcp_internal_actions/utils/file_utils.ts:109
+[+]     3  front/lib/actions/mcp_internal_actions/wrappers.ts:141
+[-]     5  front/lib/api/actions/servers/agent_memory/tools/index.ts:53
+[-]     1  front/lib/api/actions/servers/ask_user_question/tools/index.ts:18
+[+]     1  front/lib/api/actions/servers/common_utilities/tools/index.ts:100
+[-]     1  front/lib/api/actions/servers/conversation_files/index.ts:19
+[-]     4  front/lib/api/actions/servers/conversation_files/tools/index.ts:98
+[+]     1  front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts:169
+[+]     1  front/lib/api/actions/servers/data_sources_file_system/tools/search.ts:55
+[~]     1  front/lib/api/actions/servers/data_warehouses/tools/index.ts:262
+           // TODO: migrate to CSV output to DFS
+[-]     2  front/lib/api/actions/servers/extract_data/tools/index.ts:56
+[-]     1  front/lib/api/actions/servers/files/tools/agent_loop_fs.ts:15
+[+]     1  front/lib/api/actions/servers/google_calendar/helpers.ts:176
+           // TODO: user timezone for calendar, once we have it in invocations
+[+]     2  front/lib/api/actions/servers/google_drive/tools/index.ts:300
+[ ]     1  front/lib/api/actions/servers/helpers.ts:44
+[ ]     1  front/lib/api/actions/servers/image_generation/helpers.ts:217
+[ ]     4  front/lib/api/actions/servers/include_data/tools/index.ts:33
+[ ]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
+[ ]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
+[ ]     2  front/lib/api/actions/servers/notion/tools/index.ts:118
+[ ]     3  front/lib/api/actions/servers/plan_mode/tools/index.ts:28
+[ ]     2  front/lib/api/actions/servers/pod_manager/helpers.ts:147
+[ ]    11  front/lib/api/actions/servers/pod_manager/tools/index.ts:986
+[ ]     3  front/lib/api/actions/servers/pod_tasks/tools/index.ts:303
+[ ]     1  front/lib/api/actions/servers/query_tables_v2/tools/index.ts:284
+[ ]     6  front/lib/api/actions/servers/run_agent/index.ts:224
+[ ]     3  front/lib/api/actions/servers/run_dust_app/index.ts:141
+[ ]     7  front/lib/api/actions/servers/sandbox/tools/index.ts:231
+[ ]     4  front/lib/api/actions/servers/schedules_management/tools/index.ts:35
+[ ]     2  front/lib/api/actions/servers/search/tools/index.ts:65
+[ ]     4  front/lib/api/actions/servers/skill_management/tools/index.ts:103
+[+]     3  front/lib/api/actions/servers/slack_personal/tools/index.ts:449
+[ ]     2  front/lib/api/actions/servers/snowflake/tools/index.ts:42
+[ ]     4  front/lib/api/actions/servers/toolsets/tools/index.ts:25
+[ ]     1  front/lib/api/actions/servers/user_mentions/tools/index.ts:44
+[ ]     5  front/lib/api/actions/servers/wakeups/tools/index.ts:92
+[ ]     4  front/lib/api/actions/servers/web_search_browse/tools/index.ts:59
+[ ]     1  front/lib/api/mcp/run_tool.ts:91
+
+## notes
+
+Ideally if createServer returns 0 tools we should not expose the server at all. Would be a nice way
+to dynamically express that a server is not usable.
+
+### files server
+
+Maybe:
+  getDustFileSystemForAgentLoop => 
+    getDustFileSystemForToolContext + getDustFileSystemForSandboxFunction
+
+But since we're in a sandbox we should never call these tools?

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -28,7 +28,7 @@
 [~]     1  front/lib/api/actions/servers/image_generation/helpers.ts:217
            // TODO: similar to data_warehouse, we need a specific flow to write to the pod
                     tool_outputs when in sandbox function. See TODOs below.
-[ ]     4  front/lib/api/actions/servers/include_data/tools/index.ts:33
+[+]     4  front/lib/api/actions/servers/include_data/tools/index.ts:33
 [ ]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
 [ ]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
 [ ]     2  front/lib/api/actions/servers/notion/tools/index.ts:118
@@ -58,7 +58,7 @@ to dynamically express that a server is not usable.
 
 ### TODOs:
 
- - [ ] mcp_execution: introduce pod tool_outputs
+ - [ ] mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
  - [ ] data_warehouse: flow to tool_outputs if in sandbox function
  - [ ] image_generation: flow to tool_outputs if in sandbox function
 


### PR DESCRIPTION
## Description

- Introduces `SandboxFunctionRunContextType` 
  - Fixes servers that are easy to fix
  - Asserts for servers that are agent run loop dependant
  - Asserts and leaves TODO for the ones that need more involved fixing

Files of particular interest:
- `front/lib/actions/mcp_actions.ts`
- `front/lib/actions/types/index.ts`
- `front/lib/api/mcp/run_tool.ts`
- `x/spolu/tool_context/WORK.md` for the blueprint and follow-ups

First high-level review is eased by collapsing on the left menu the `front/lib/api/actions/servers` directory.

r? @PopDaph I am so sorry. Really. Very hard to not do in one go :(
cc @flvndvd interactive_content TODO left
cc @adrsimon for visibility given you reviewed the previous one

No agent was involved in this one.

## Tests

Covered by TS and tests.

- tested locally that tool calling is operational 
- tsgo on ALL `front` also passing locally

## Risk

Low. Can be reverted at any time

## Deploy Plan

- deploy `front`