### PR TITLE
feat(scripts): add scrub_agent script for GDPR agent purge

### DIFF
--- a/front/scripts/scrub_agent.ts
+++ b/front/scripts/scrub_agent.ts
@@ -1,0 +1,81 @@
+import {
+  listsAgentConfigurationVersions,
+  unsafeHardDeleteAgentConfiguration,
+} from "@app/lib/api/assistant/configuration/agent";
+import { Authenticator } from "@app/lib/auth";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      describe: "The sId of the workspace owning the agent.",
+      demandOption: true,
+    },
+    agentId: {
+      type: "string",
+      describe: "The sId of the agent configuration to scrub.",
+      demandOption: true,
+    },
+  },
+  async ({ workspaceId, agentId, execute }, logger) => {
+    // Request all groups so archived agents living in restricted spaces are not
+    // filtered out when listing their versions.
+    const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
+      dangerouslyRequestAllGroups: true,
+    });
+
+    // Archiving flips every version row sharing the `sId` to `archived`, so a
+    // full purge must delete all versions, not just the latest one.
+    const versions = await listsAgentConfigurationVersions(auth, {
+      agentId,
+      variant: "light",
+    });
+
+    if (versions.length === 0) {
+      logger.error({ workspaceId, agentId }, "Agent not found in workspace.");
+      return;
+    }
+
+    const [latest] = versions;
+
+    if (!execute) {
+      logger.info(
+        {
+          workspaceId,
+          agentId,
+          name: latest.name,
+          scope: latest.scope,
+          status: latest.status,
+          versionCount: versions.length,
+          versions: versions.map((v) => v.version),
+        },
+        "Would hard-delete all versions of the agent."
+      );
+      return;
+    }
+
+    logger.info(
+      {
+        workspaceId,
+        agentId,
+        name: latest.name,
+        versionCount: versions.length,
+      },
+      "Hard-deleting all versions of the agent."
+    );
+
+    for (const version of versions) {
+      await unsafeHardDeleteAgentConfiguration(auth, version);
+      logger.info(
+        { workspaceId, agentId, version: version.version },
+        "Agent version hard-deleted."
+      );
+    }
+
+    logger.info(
+      { workspaceId, agentId, versionCount: versions.length },
+      "Agent scrubbed successfully."
+    );
+  }
+);


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9343

Wraps unsafeHardDeleteAgentConfiguration in an operator script following the scrub_conversation pattern, purging all version rows of an archived agent (archiving flips every sId row, so a single-version delete would leave PII behind).
## Tests

Local

## Risk

Low. It's a script with a big blast radius, but scoped to a workspace/agent. Should be dry-run first.

## Deploy Plan

Front