### PR TITLE
fix(triggers): pass owner as prop to TriggerPodSelector instead of context

### DIFF
--- a/front/components/agent_builder/triggers/TriggerPodSelector.tsx
+++ b/front/components/agent_builder/triggers/TriggerPodSelector.tsx
@@ -1,8 +1,8 @@
-import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { PodType } from "@app/types/space";
 import { isProjectType } from "@app/types/space";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   DropdownMenu,
@@ -14,17 +14,18 @@ import {
 import { useCallback, useMemo, useState } from "react";
 
 interface TriggerPodSelectorProps {
+  owner: LightWorkspaceType;
   value: string | null | undefined;
   onChange: (spaceId: string | null) => void;
   disabled?: boolean;
 }
 
 export function TriggerPodSelector({
+  owner,
   value,
   onChange,
   disabled,
 }: TriggerPodSelectorProps) {
-  const { owner } = useAgentBuilderContext();
   const [searchQuery, setSearchQuery] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
 

--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionSheet.tsx
@@ -100,10 +100,12 @@ function ScheduleEditionMessageInput({
 
 interface ScheduleEditionPodSelectorProps {
   isEditor: boolean;
+  owner: LightWorkspaceType;
 }
 
 function ScheduleEditionPodSelector({
   isEditor,
+  owner,
 }: ScheduleEditionPodSelectorProps) {
   const { control } = useFormContext<TriggerViewsSheetFormValues>();
   const { field } = useController({ control, name: "schedule.spaceId" });
@@ -115,6 +117,7 @@ function ScheduleEditionPodSelector({
         Run this trigger's conversation inside a Pod instead.
       </p>
       <TriggerPodSelector
+        owner={owner}
         value={field.value}
         onChange={field.onChange}
         disabled={!isEditor}
@@ -155,7 +158,7 @@ export function ScheduleEditionSheetContent({
         <Separator />
         <ScheduleEditionMessageInput isEditor={isEditor} />
         <Separator />
-        <ScheduleEditionPodSelector isEditor={isEditor} />
+        <ScheduleEditionPodSelector isEditor={isEditor} owner={owner} />
       </div>
     </>
   );

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
@@ -245,10 +245,12 @@ function WebhookEditionMessageInput({
 
 interface WebhookEditionPodSelectorProps {
   isEditor: boolean;
+  owner: LightWorkspaceType;
 }
 
 function WebhookEditionPodSelector({
   isEditor,
+  owner,
 }: WebhookEditionPodSelectorProps) {
   const { control } = useFormContext<TriggerViewsSheetFormValues>();
   const { field } = useController({ control, name: "webhook.spaceId" });
@@ -260,6 +262,7 @@ function WebhookEditionPodSelector({
         Run this trigger's conversation inside a Pod instead.
       </p>
       <TriggerPodSelector
+        owner={owner}
         value={field.value}
         onChange={field.onChange}
         disabled={!isEditor}
@@ -346,7 +349,7 @@ export function WebhookEditionSheetContent({
 
         <Separator />
 
-        <WebhookEditionPodSelector isEditor={isEditor} />
+        <WebhookEditionPodSelector isEditor={isEditor} owner={owner} />
 
         {trigger && (
           <div className="space-y-1">


### PR DESCRIPTION
## Description

`TriggerPodSelector` read `owner` from `useAgentBuilderContext()`, which threw `useAgentBuilderContext must be used within an AgentBuilderProvider` when the component was rendered inside `AgentDetailsSheet` → `TriggerEditView` — a tree with no `AgentBuilderProvider`.

This removes the context dependency and passes `owner` down as a prop. Both `ScheduleEditionSheetContent` and `WebhookEditionSheetContent` already have `owner`, so it's threaded through their `*PodSelector` sub-components into `TriggerPodSelector`.

## Tests

Open a schedule/webhook trigger edit sheet from the agent details sheet (outside the agent builder) and confirm the Pod selector renders without crashing.
