### PR TITLE
Add HubSpot update, complete, and delete task tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -278,6 +278,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "websearch": "never_ask",
   },
   "hubspot": {
+    "complete_task": "high",
     "count_objects_by_properties": "never_ask",
     "create_association": "high",
     "create_communication": "high",
@@ -289,6 +290,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "create_note": "high",
     "create_task": "high",
     "create_ticket": "high",
+    "delete_task": "high",
     "export_crm_objects_csv": "never_ask",
     "get_associated_meetings": "never_ask",
     "get_company": "never_ask",
@@ -317,6 +319,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "update_company": "high",
     "update_contact": "high",
     "update_deal": "high",
+    "update_task": "high",
   },
   "image_generation": {
     "generate_image": "never_ask",

--- a/front/lib/api/actions/servers/hubspot/client.ts
+++ b/front/lib/api/actions/servers/hubspot/client.ts
@@ -1772,6 +1772,58 @@ export const updateDeal = async ({
   }
 };
 
+export const updateTask = async ({
+  accessToken,
+  taskId,
+  properties,
+}: {
+  accessToken: string;
+  taskId: string;
+  properties: Record<string, string>;
+}): Promise<SimplePublicObject> => {
+  const hubspotClient = new Client({ accessToken });
+
+  const updateInput: SimplePublicObjectInput = {
+    properties,
+  };
+
+  try {
+    const result = await hubspotClient.crm.objects.basicApi.update(
+      "tasks",
+      taskId,
+      updateInput
+    );
+
+    return result;
+  } catch (error) {
+    localLogger.error(
+      { error, taskId },
+      `Error updating task with ID ${taskId}:`
+    );
+    throw normalizeError(error);
+  }
+};
+
+export const deleteTask = async ({
+  accessToken,
+  taskId,
+}: {
+  accessToken: string;
+  taskId: string;
+}): Promise<void> => {
+  const hubspotClient = new Client({ accessToken });
+
+  try {
+    await hubspotClient.crm.objects.basicApi.archive("tasks", taskId);
+  } catch (error) {
+    localLogger.error(
+      { error, taskId },
+      `Error deleting task with ID ${taskId}:`
+    );
+    throw normalizeError(error);
+  }
+};
+
 export const getUserDetails = async (accessToken: string) => {
   try {
     // eslint-disable-next-line no-restricted-globals

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -775,6 +775,46 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       done: "Update HubSpot deal",
     },
   },
+  update_task: {
+    description:
+      "Update properties of a HubSpot task by ID (e.g., hs_task_subject, hs_task_body, hs_timestamp, hs_task_priority, hs_task_status). Set hs_task_status to COMPLETED to mark the task as done.",
+    schema: {
+      taskId: z.string().describe("The ID of the task to update."),
+      properties: z
+        .record(z.string())
+        .describe(
+          "An object containing the properties to update with their new values."
+        ),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Updating HubSpot task",
+      done: "Update HubSpot task",
+    },
+  },
+  complete_task: {
+    description:
+      "Complete a HubSpot task by ID, setting its status to COMPLETED.",
+    schema: {
+      taskId: z.string().describe("The ID of the task to complete."),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Completing HubSpot task",
+      done: "Complete HubSpot task",
+    },
+  },
+  delete_task: {
+    description: "Delete a HubSpot task by ID.",
+    schema: {
+      taskId: z.string().describe("The ID of the task to delete."),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Deleting HubSpot task",
+      done: "Delete HubSpot task",
+    },
+  },
   remove_association: {
     description: "Remove an association between two HubSpot objects.",
     schema: {

--- a/front/lib/api/actions/servers/hubspot/tools/index.ts
+++ b/front/lib/api/actions/servers/hubspot/tools/index.ts
@@ -13,6 +13,7 @@ import {
   createNote,
   createTask,
   createTicket,
+  deleteTask,
   getAssociatedMeetings,
   getCompany,
   getContact,
@@ -41,6 +42,7 @@ import {
   updateCompany,
   updateContact,
   updateDeal,
+  updateTask,
 } from "@app/lib/api/actions/servers/hubspot/client";
 import {
   ERROR_MESSAGES,
@@ -853,6 +855,53 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
       });
       return new Ok([
         { type: "text" as const, text: JSON.stringify(result, null, 2) },
+      ]);
+    });
+  },
+
+  update_task: async ({ taskId, properties }, extra) => {
+    return withAuth(extra, async (accessToken) => {
+      const result = await updateTask({
+        accessToken,
+        taskId,
+        properties,
+      });
+      return new Ok([
+        { type: "text" as const, text: "Task updated successfully." },
+        { type: "text" as const, text: JSON.stringify(result, null, 2) },
+      ]);
+    });
+  },
+
+  complete_task: async ({ taskId }, extra) => {
+    return withAuth(extra, async (accessToken) => {
+      const result = await updateTask({
+        accessToken,
+        taskId,
+        properties: { hs_task_status: "COMPLETED" },
+      });
+      return new Ok([
+        { type: "text" as const, text: "Task marked as completed." },
+        { type: "text" as const, text: JSON.stringify(result, null, 2) },
+      ]);
+    });
+  },
+
+  delete_task: async ({ taskId }, extra) => {
+    return withAuth(extra, async (accessToken) => {
+      await deleteTask({
+        accessToken,
+        taskId,
+      });
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Task ${taskId} deleted successfully.`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify({ success: true }, null, 2),
+        },
       ]);
     });
   },


### PR DESCRIPTION
## Description
Added task lifecycle management to the Hubspot internal MCP server: 
  - **`update_task`** :  update a task's properties by ID (subject, body, due date, priority, and `hs_task_status`).
   - **`complete_task`** : mark a task as done by setting `hs_task_status` to `COMPLETED` 
   - **`delete_task`** :  delete a task by ID.

## Tests

Tested locally using the Hubspot dev test account. 

## Risk

Low. Additive only, three new MCP tools

## Deploy Plan

Standard deploy