### PR TITLE
feat: allow business admins to see usage page

### DIFF
--- a/front-api/routes/w/[wId]/analytics/awu-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/awu-usage.ts
@@ -5,7 +5,7 @@ import {
 } from "@app/lib/api/analytics/awu_usage";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -17,7 +17,7 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.get(
   "/",
-  ensureIsAdmin(),
+  ensureIsBusinessAdmin(),
   validate("query", AwuUsageQuerySchema),
   async (ctx) => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
@@ -3,7 +3,7 @@ import { getAwuPoolSummary } from "@app/lib/api/credits/awu_pool_summary";
 import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import type { Context } from "hono";
@@ -45,7 +45,7 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.get(
   "/",
-  ensureIsAdmin(),
+  ensureIsBusinessAdmin(),
   async (ctx): HandlerResult<AwuPoolSummaryResponseBody> => {
     const auth = ctx.get("auth");
 

--- a/front-api/routes/w/[wId]/credits/members-usage.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.ts
@@ -4,7 +4,7 @@ import {
   MembersUsagePaginationSchema,
 } from "@app/lib/api/credits/members_usage";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -14,7 +14,7 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.get(
   "/",
-  ensureIsAdmin(),
+  ensureIsBusinessAdmin(),
   validate("query", MembersUsagePaginationSchema),
   async (ctx): HandlerResult<GetMembersUsageResponseBody> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/credits/purchase.ts
+++ b/front-api/routes/w/[wId]/credits/purchase.ts
@@ -12,7 +12,10 @@ import {
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import {
+  ensureIsAdmin,
+  ensureIsBusinessAdmin,
+} from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -99,7 +102,7 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.get(
   "/",
-  ensureIsAdmin(),
+  ensureIsBusinessAdmin(),
   async (ctx): HandlerResult<GetCreditPurchaseInfoResponseBody> => {
     const auth = ctx.get("auth");
 

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -13,7 +13,7 @@ import type {
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -66,11 +66,10 @@ function upgradeRequestErrorToApiError(
 // Mounted at /api/w/:wId/credits/upgrade-requests.
 const app = workspaceApp();
 
-// Admin-only: list pending upgrade requests for the workspace.
 /** @ignoreswagger */
 app.get(
   "/",
-  ensureIsAdmin(),
+  ensureIsBusinessAdmin(),
   async (ctx): HandlerResult<GetUpgradeRequestsResponseBody> => {
     const auth = ctx.get("auth");
     const requests = await listPendingUpgradeRequests(auth);
@@ -91,11 +90,10 @@ app.post("/", async (ctx): HandlerResult<PostUpgradeRequestResponseBody> => {
   return ctx.json({ request: result.value });
 });
 
-// Admin-only: resolve (approve/deny) a pending request.
 /** @ignoreswagger */
 app.patch(
   "/:requestId",
-  ensureIsAdmin(),
+  ensureIsBusinessAdmin(),
   validate("param", ParamsSchema),
   validate("json", ResolveBodySchema),
   async (ctx): HandlerResult<PatchUpgradeRequestResponseBody> => {

--- a/front-api/routes/w/[wId]/credits/usage-configuration.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.ts
@@ -8,7 +8,10 @@ import type {
 } from "@app/types/api/credits/usage_configuration";
 import { PatchCreditUsageConfigurationRequestBody } from "@app/types/api/credits/usage_configuration";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import {
+  ensureIsAdmin,
+  ensureIsBusinessAdmin,
+} from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -18,7 +21,7 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.get(
   "/",
-  ensureIsAdmin(),
+  ensureIsBusinessAdmin(),
   async (ctx): HandlerResult<GetCreditUsageConfigurationResponseBody> => {
     const auth = ctx.get("auth");
 

--- a/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
@@ -8,7 +8,7 @@ import {
 } from "@app/types/memberships";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -33,7 +33,7 @@ const app = workspaceApp();
 app.patch(
   "/",
   validate("param", ParamsSchema),
-  ensureIsAdmin(),
+  ensureIsBusinessAdmin(),
   validate("json", UpdateMemberSeatTypeBodySchema),
   async (ctx) => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -13,7 +13,7 @@ import type {
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -74,7 +74,7 @@ const app = workspaceApp();
 app.get(
   "/",
   validate("param", ParamsSchema),
-  ensureIsAdmin(),
+  ensureIsBusinessAdmin(),
   async (ctx): HandlerResult<GetUserSpendLimitResponseBody> => {
     const auth = ctx.get("auth");
 
@@ -102,7 +102,7 @@ app.get(
 app.put(
   "/",
   validate("param", ParamsSchema),
-  ensureIsAdmin(),
+  ensureIsBusinessAdmin(),
   validate("json", UpdateUserSpendLimitBodySchema),
   async (ctx): HandlerResult<PutUserSpendLimitResponseBody> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/members/bulk-spend-limit.ts
+++ b/front-api/routes/w/[wId]/members/bulk-spend-limit.ts
@@ -9,7 +9,7 @@ import {
 import { hasFeatureFlag } from "@app/lib/auth";
 import { runBulkSetUserSpendLimitWorkflow } from "@app/temporal/bulk_spend_limit/client";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -42,7 +42,7 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsAdmin(),
+  ensureIsBusinessAdmin(),
   validate("json", BodySchema),
   async (ctx): HandlerResult<BulkSetUserSpendLimitResponseBody> => {
     const auth = ctx.get("auth");

--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -100,6 +100,7 @@ export const adminRoutes: RouteObject[] = [
     children: [
       { path: "members", element: <MembersPage /> },
       { path: "analytics", element: <AnalyticsPage /> },
+      { path: "usage", element: <UsagePage /> },
     ],
   },
   {
@@ -113,7 +114,6 @@ export const adminRoutes: RouteObject[] = [
       { path: "model-providers", element: <ModelProvidersPage /> },
       { path: "workspace", element: <WorkspaceSettingsPage /> },
       { path: "branding", element: <WorkspaceBrandingPage /> },
-      { path: "usage", element: <UsagePage /> },
       { path: "subscription", element: <SubscriptionPage /> },
       { path: "billing", element: <BillingPage /> },
       { path: "developers/api-keys", element: <APIKeysPage /> },

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -318,7 +318,7 @@ export const subNavigationAdmin = ({
               icon: PieChart01,
               href: `/w/${owner.sId}/usage`,
               current: isCurrent("usage"),
-              disabled: !hasAdminRole,
+              disabled: !hasBusinessAdminRole,
             },
           ]
         : []),

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -239,8 +239,6 @@ export function UsagePage() {
       }),
     []
   );
-  // Admin-only Requests tab: pending member-initiated upgrade requests, resolved
-  // by approving (via the seat / spend-limit modals) or denying.
   const isWorkspaceAdmin = isAdmin(owner);
   const modelsPickerEnabled = hasFeature("models_picker") && isWorkspaceAdmin;
   const [membersTab, setMembersTab] = useState<"members" | "requests">(
@@ -248,7 +246,6 @@ export function UsagePage() {
   );
   const { upgradeRequests, isUpgradeRequestsLoading } = useUpgradeRequests({
     workspaceId: owner.sId,
-    disabled: !isWorkspaceAdmin,
   });
 
   const filteredUpgradeRequests = useMemo(() => {
@@ -449,8 +446,7 @@ export function UsagePage() {
   const { groups } = useGroups({
     owner,
     kinds: ["provisioned"],
-    disabled:
-      !isWorkspaceAdmin || (!pricingGroupsEnabled && !modelsPickerEnabled),
+    disabled: !pricingGroupsEnabled && !modelsPickerEnabled,
   });
   const selectedGroupName =
     groups.find((g) => g.sId === groupFilter)?.name ?? null;
@@ -839,7 +835,7 @@ export function UsagePage() {
       sorting={sorting}
       setSorting={handleSetSorting}
       showGroupsColumn={pricingGroupsEnabled && groups.length > 0}
-      enableSelection={pricingGroupsEnabled && isWorkspaceAdmin && !isReadOnly}
+      enableSelection={pricingGroupsEnabled && !isReadOnly}
       rowSelection={selection.rowSelection}
       onRowSelectionChange={selection.onRowSelectionChange}
     />
@@ -874,7 +870,7 @@ export function UsagePage() {
       <div className="flex flex-col items-stretch gap-10 pb-20">
         <div className="flex items-center justify-between">
           <Page.Header title="Usage" icon={PieChart01} />
-          {!isReadOnly && usageSettings.topUpEnabled && (
+          {!isReadOnly && usageSettings.topUpEnabled && isWorkspaceAdmin && (
             <Button
               label="Top up"
               icon={ArrowUp}
@@ -972,79 +968,70 @@ export function UsagePage() {
             {isWorkspaceAdmin && pricingGroupsEnabled && (
               <TabsTrigger value="groups" label="Groups" />
             )}
-            <TabsTrigger value="settings" label="Settings" />
+            {isWorkspaceAdmin && (
+              <TabsTrigger value="settings" label="Settings" />
+            )}
           </TabsList>
 
           <TabsContent value="members">
             <Page.Vertical gap="sm" align="stretch">
               {searchAndInviteRow}
-              {isWorkspaceAdmin ? (
-                <div className="flex flex-col gap-2">
-                  <div className="flex flex-row items-center justify-between gap-2">
-                    <ButtonsSwitchList
-                      size="xs"
-                      defaultValue="members"
-                      onValueChange={(v: string) =>
-                        setMembersTab(v === "requests" ? "requests" : "members")
+              <div className="flex flex-col gap-2">
+                <div className="flex flex-row items-center justify-between gap-2">
+                  <ButtonsSwitchList
+                    size="xs"
+                    defaultValue="members"
+                    onValueChange={(v: string) =>
+                      setMembersTab(v === "requests" ? "requests" : "members")
+                    }
+                  >
+                    <ButtonsSwitch value="members" label="Members" />
+                    <ButtonsSwitch
+                      value="requests"
+                      label="Requests"
+                      isCounter
+                      counterValue={
+                        filteredUpgradeRequests.length > 0
+                          ? String(filteredUpgradeRequests.length)
+                          : undefined
                       }
-                    >
-                      <ButtonsSwitch value="members" label="Members" />
-                      <ButtonsSwitch
-                        value="requests"
-                        label="Requests"
-                        isCounter
-                        counterValue={
-                          filteredUpgradeRequests.length > 0
-                            ? String(filteredUpgradeRequests.length)
-                            : undefined
-                        }
-                      />
-                    </ButtonsSwitchList>
-                    {membersTab === "members" && (
-                      <div className="flex flex-row items-center gap-2">
-                        {groupsFilterDropdown}
-                        {modelsPickerEnabled && groupFilter && (
-                          <Button
-                            label="Edit group advanced models"
-                            variant="outline"
-                            size="sm"
-                            disabled={isReadOnly}
-                            onClick={handleEditGroupAdvancedModels}
-                          />
-                        )}
-                        {seatFilterDropdown}
-                      </div>
-                    )}
-                  </div>
-                  <div className="flex flex-col gap-2 pt-2">
-                    {membersTab === "members" ? (
-                      <>
-                        {selectionBanner}
-                        {membersTable}
-                      </>
-                    ) : (
-                      <UpgradeRequestsTable
-                        requests={filteredUpgradeRequests}
-                        isLoading={isUpgradeRequestsLoading}
-                        seatPlans={seatPlans}
-                        pendingRequestIds={resolvingRequestIds}
-                        onUpgradePlan={handleUpgradePlanRequest}
-                        onEditLimit={handleEditLimitRequest}
-                        onDeny={handleDenyRequest}
-                      />
-                    )}
-                  </div>
-                </div>
-              ) : (
-                <>
-                  {seatFilterDropdown && (
-                    <div className="flex flex-row justify-end">
+                    />
+                  </ButtonsSwitchList>
+                  {membersTab === "members" && (
+                    <div className="flex flex-row items-center gap-2">
+                      {groupsFilterDropdown}
+                      {modelsPickerEnabled && groupFilter && (
+                        <Button
+                          label="Edit group advanced models"
+                          variant="outline"
+                          size="sm"
+                          disabled={isReadOnly}
+                          onClick={handleEditGroupAdvancedModels}
+                        />
+                      )}
                       {seatFilterDropdown}
                     </div>
                   )}
-                  {membersTable}
-                </>
-              )}
+                </div>
+                <div className="flex flex-col gap-2 pt-2">
+                  {membersTab === "members" ? (
+                    <>
+                      {selectionBanner}
+                      {membersTable}
+                    </>
+                  ) : (
+                    <UpgradeRequestsTable
+                      requests={filteredUpgradeRequests}
+                      isLoading={isUpgradeRequestsLoading}
+                      seatPlans={seatPlans}
+                      pendingRequestIds={resolvingRequestIds}
+                      onUpgradePlan={handleUpgradePlanRequest}
+                      onEditLimit={handleEditLimitRequest}
+                      onDeny={handleDenyRequest}
+                    />
+                  )}
+                </div>
+              </div>
             </Page.Vertical>
           </TabsContent>
 
@@ -1054,37 +1041,39 @@ export function UsagePage() {
             </TabsContent>
           )}
 
-          <TabsContent value="settings">
-            <div className="flex flex-col gap-10">
-              <UsageSettingsCard
-                workspaceId={owner.sId}
-                readOnly={isReadOnly}
-                hasPool={hasPool}
-              />
-              {modelsPickerEnabled && (
-                <AdvancedModelsSettingsCard
-                  owner={owner}
-                  readOnly={isReadOnly}
-                  onEditWorkspaceAdvancedModels={
-                    handleEditWorkspaceAdvancedModels
-                  }
-                />
-              )}
-              <LockedSection
-                locked={!isAwuPoolSummaryLoading && !hasPool}
-                className="flex flex-col gap-10"
-              >
-                <UsageProgrammaticLimitCard
+          {isWorkspaceAdmin && (
+            <TabsContent value="settings">
+              <div className="flex flex-col gap-10">
+                <UsageSettingsCard
                   workspaceId={owner.sId}
                   readOnly={isReadOnly}
+                  hasPool={hasPool}
                 />
-                <UsageNotificationsCard
-                  workspaceId={owner.sId}
-                  readOnly={isReadOnly}
-                />
-              </LockedSection>
-            </div>
-          </TabsContent>
+                {modelsPickerEnabled && (
+                  <AdvancedModelsSettingsCard
+                    owner={owner}
+                    readOnly={isReadOnly}
+                    onEditWorkspaceAdvancedModels={
+                      handleEditWorkspaceAdvancedModels
+                    }
+                  />
+                )}
+                <LockedSection
+                  locked={!isAwuPoolSummaryLoading && !hasPool}
+                  className="flex flex-col gap-10"
+                >
+                  <UsageProgrammaticLimitCard
+                    workspaceId={owner.sId}
+                    readOnly={isReadOnly}
+                  />
+                  <UsageNotificationsCard
+                    workspaceId={owner.sId}
+                    readOnly={isReadOnly}
+                  />
+                </LockedSection>
+              </div>
+            </TabsContent>
+          )}
         </Tabs>
       </div>
 


### PR DESCRIPTION
## Description

This PR extends access to the usage page and related credits/analytics APIs to users with the `business admin` role, in addition to regular admins.

We want business admins to see and interact with the members tab. Business admins should not however be able to edit the spend limits of groups or the settings in the settings tab.

## Tests

Manually.

## Risks
Low. The `ensureIsBusinessAdmin` middleware should be verified to correctly scope access and not inadvertently grant more permissions than intended.

## Deploy Plan

Standard deployment.

