### PR TITLE
Strengthen the tool search instruction against mixing searches with skill activations

### DIFF
--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.ts
@@ -19,17 +19,23 @@ const TOOL_SEARCH_TOOL_TYPE = TOOL_SEARCH_TOOL.type;
 // Added to the system prompt only when the search tool is in the request. Phrased
 // without naming the bm25 tool so it stays accurate across search implementations.
 //
-// The last sentence steers the model away from mixing a tool search with a
+// The second paragraph steers the model away from mixing a tool search with a
 // regular tool call in the same turn: the API leaves such searches un-run (the
 // turn ends on the tool call), and replaying the un-run blocks is fragile.
+// Skill-enabling tools are called out explicitly because they are the most
+// frequent offender observed in practice.
 export const TOOL_SEARCH_INSTRUCTION =
   "You can search for and load far more tools than are visible to you now, " +
   "including ones that fetch live or account-specific data and act in external " +
   "systems. When a request needs current state, the user's own systems, or an " +
   "action your visible tools cannot take, search for a tool before making " +
   "something up, answering from stale memory, or telling the user it is not " +
-  "possible. Do not combine tool searches with other tool calls in the same " +
-  "turn: search first, wait for the results, then call the tools you need.";
+  "possible.\n\n" +
+  "Never mix tool searches with other tool calls in the same turn. Issuing " +
+  "several searches together is fine, but if you call any other tool " +
+  "(including enabling a skill) in the same turn as a search, the search is " +
+  "discarded and never runs. Search first, wait for the results, and only " +
+  "then call the other tools you need.";
 
 export function includesToolSearchTool(
   tools: ReadonlyArray<{ type?: string | null }>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow-up to #28403. The single sentence added there was not enough: the model still frequently issues a tool search alongside a skill activation in the same turn. That combination is the worst case for us, because enabling a skill injects a composite user message with the skill instructions into the next request, which guarantees the un-run search cannot be resumed and the whole request gets rejected.

If this still does not eliminate the failure, the robust fix remains stripping unresumable dangling search blocks from the request before sending, as mentioned in the previous PR.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
