### PR TITLE
Add SandboxFunctionMCPAction model & migration

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -132,6 +132,7 @@ import {
   SandboxFunctionInvocationModel,
   SandboxFunctionModel,
 } from "@app/lib/resources/storage/models/sandbox_function";
+import { SandboxFunctionMCPActionModel } from "@app/lib/resources/storage/models/sandbox_function_mcp_action";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import {
   TakeawaySourcesModel,
@@ -223,6 +224,7 @@ export function loadAllModels() {
     RemoteMCPServerToolMetadataModel,
     InternalMCPServerCredentialModel,
     ConversationMCPServerViewModel,
+    SandboxFunctionMCPActionModel,
     AgentMCPServerConfigurationModel,
     AgentTablesQueryConfigurationTableModel,
     AgentDataSourceConfigurationModel,

--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -6,13 +6,41 @@ const TOOL_EXECUTION_FINAL_STATUSES = [
 
 type ToolExecutionFinalStatus = (typeof TOOL_EXECUTION_FINAL_STATUSES)[number];
 
+// Base lifecycle shared by every MCP tool execution, regardless of context: the tool runs, may be
+// blocked awaiting user approval, and ends succeeded, errored, or denied. AgentMCPActionModel and
+// SandboxFunctionMCPActionModel both draw from this vocabulary; the agent loop extends it with its
+// scheduling and conversation-interaction states below.
+export const TOOL_EXECUTION_BASE_STATUSES = [
+  "running",
+  "blocked_validation_required",
+  ...TOOL_EXECUTION_FINAL_STATUSES,
+] as const;
+
+export type ToolExecutionBaseStatus =
+  (typeof TOOL_EXECUTION_BASE_STATUSES)[number];
+
+// The agent loop's extension over the base lifecycle: batch scheduling within a step (ready_*)
+// and conversation interactions the action can be parked on (the other blocked_*).
+const TOOL_EXECUTION_AGENT_LOOP_EXTENSION_STATUSES = [
+  "ready_allowed_explicitly",
+  "ready_allowed_implicitly",
+  "blocked_authentication_required",
+  "blocked_file_authorization_required",
+  "blocked_child_action_input_required",
+  "blocked_user_answer_required",
+] as const;
+
+export type ToolExecutionStatus =
+  | ToolExecutionBaseStatus
+  | (typeof TOOL_EXECUTION_AGENT_LOOP_EXTENSION_STATUSES)[number];
+
 export const TOOL_EXECUTION_BLOCKED_STATUSES = [
   "blocked_authentication_required",
   "blocked_file_authorization_required",
   "blocked_validation_required",
   "blocked_child_action_input_required",
   "blocked_user_answer_required",
-] as const;
+] as const satisfies readonly ToolExecutionStatus[];
 
 export type ToolExecutionBlockedStatus =
   (typeof TOOL_EXECUTION_BLOCKED_STATUSES)[number];
@@ -22,14 +50,10 @@ const TOOL_EXECUTION_TRANSIENT_STATUSES = [
   "ready_allowed_implicitly",
   ...TOOL_EXECUTION_BLOCKED_STATUSES,
   "running",
-] as const;
+] as const satisfies readonly ToolExecutionStatus[];
 
 type ToolExecutionTransientStatus =
   (typeof TOOL_EXECUTION_TRANSIENT_STATUSES)[number];
-
-export type ToolExecutionStatus =
-  | ToolExecutionFinalStatus
-  | ToolExecutionTransientStatus;
 
 export function isToolExecutionStatusFinal(
   state: ToolExecutionStatus

--- a/front/lib/models/agent/actions/mcp_server_view_helper.ts
+++ b/front/lib/models/agent/actions/mcp_server_view_helper.ts
@@ -7,6 +7,7 @@ import {
 } from "@app/lib/models/agent/actions/mcp";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
+import { SandboxFunctionMCPActionModel } from "@app/lib/resources/storage/models/sandbox_function_mcp_action";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
@@ -80,6 +81,18 @@ export async function destroyMCPServerViewDependencies(
   });
 
   await SkillMCPServerConfigurationModel.destroy({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      mcpServerViewId: mcpServerViewIds,
+    },
+    transaction,
+  });
+
+  // Sandbox-function tool calls FK the view with RESTRICT, so their rows must go before the view.
+  // TODO(2026-07-03 sandbox-functions): route through SandboxFunctionMCPActionResource once it
+  // exists so `outputGcsPath` objects are deleted too — rows destroyed here would orphan their GCS
+  // output objects (none are written yet; the resource lands in the next PR).
+  await SandboxFunctionMCPActionModel.destroy({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       mcpServerViewId: mcpServerViewIds,

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -134,6 +134,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     sandboxFunction: SandboxFunctionResource,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<number> {
+    // SandboxFunctionMCPActionModel FKs invocations with RESTRICT, but has no writer yet.
+    // TODO(2026-07-03 sandbox-functions): delete actions (rows + `outputGcsPath` GCS objects)
+    // before invocations, through SandboxFunctionMCPActionResource — lands with the resource,
+    // before any writer exists.
     return this.model.destroy({
       where: {
         sandboxFunctionId: sandboxFunction.id,
@@ -148,6 +152,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
     try {
+      // SandboxFunctionMCPActionModel FKs invocations with RESTRICT, but has no writer yet.
+      // TODO(2026-07-03 sandbox-functions): delete actions (rows + `outputGcsPath` GCS objects)
+      // first, through SandboxFunctionMCPActionResource — lands with the resource, before any
+      // writer exists.
       await this.model.destroy({
         where: {
           id: this.id,

--- a/front/lib/resources/storage/models/sandbox_function_mcp_action.ts
+++ b/front/lib/resources/storage/models/sandbox_function_mcp_action.ts
@@ -1,0 +1,132 @@
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { ToolExecutionBaseStatus } from "@app/lib/actions/statuses";
+import { TOOL_EXECUTION_BASE_STATUSES } from "@app/lib/actions/statuses";
+import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
+import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
+import { SandboxFunctionInvocationModel } from "@app/lib/resources/storage/models/sandbox_function";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+
+// An MCP tool call made from inside a running sandbox function invocation. The invocation-keyed
+// counterpart of AgentMCPActionModel, without its agent-loop coupling (no agent message, no step
+// content, no citations) — hence status is the base tool-execution lifecycle, not the agent-loop
+// extension. The tool is identified by (mcpServerViewId, toolName); the toolConfiguration snapshot
+// is synthesized at creation from the view + internal-server manifest and drives execution. The
+// tool output is a single GCS object (outputGcsPath), written once at completion — not per-block
+// output-item rows.
+export class SandboxFunctionMCPActionModel extends WorkspaceAwareModel<SandboxFunctionMCPActionModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare sandboxFunctionInvocationId: ForeignKey<
+    SandboxFunctionInvocationModel["id"]
+  >;
+  declare mcpServerViewId: ForeignKey<MCPServerViewModel["id"]>;
+  declare toolName: string;
+  declare inputs: Record<string, unknown>;
+  declare toolConfiguration: LightMCPToolConfigurationType;
+  declare status: ToolExecutionBaseStatus;
+  declare outputGcsPath: string | null;
+  declare executionDurationMs: number | null;
+
+  declare sandboxFunctionInvocation: NonAttribute<SandboxFunctionInvocationModel>;
+  declare mcpServerView: NonAttribute<MCPServerViewModel>;
+}
+
+SandboxFunctionMCPActionModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    sandboxFunctionInvocationId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    mcpServerViewId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    toolName: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    inputs: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: {},
+    },
+    toolConfiguration: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.STRING(64),
+      allowNull: false,
+      validate: {
+        isIn: [TOOL_EXECUTION_BASE_STATUSES],
+      },
+    },
+    outputGcsPath: {
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
+      allowNull: true,
+      defaultValue: null,
+    },
+    executionDurationMs: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+  },
+  {
+    modelName: "sandbox_function_mcp_action",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["sandboxFunctionInvocationId"],
+        concurrently: true,
+      },
+      {
+        fields: ["mcpServerViewId"],
+        concurrently: true,
+      },
+      {
+        fields: ["workspaceId", "sandboxFunctionInvocationId"],
+        name: "sandbox_function_mcp_actions_workspace_invocation",
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+SandboxFunctionMCPActionModel.belongsTo(SandboxFunctionInvocationModel, {
+  foreignKey: { name: "sandboxFunctionInvocationId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "sandboxFunctionInvocation",
+});
+
+SandboxFunctionInvocationModel.hasMany(SandboxFunctionMCPActionModel, {
+  foreignKey: { name: "sandboxFunctionInvocationId", allowNull: false },
+  as: "mcpActions",
+});
+
+SandboxFunctionMCPActionModel.belongsTo(MCPServerViewModel, {
+  foreignKey: { name: "mcpServerViewId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "mcpServerView",
+});
+
+MCPServerViewModel.hasMany(SandboxFunctionMCPActionModel, {
+  foreignKey: { name: "mcpServerViewId", allowNull: false },
+  as: "sandboxFunctionMCPActions",
+});

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -76,6 +76,7 @@ export const RESOURCES_PREFIX = {
   // Sandbox functions.
   sandbox_function: "sfn",
   sandbox_function_invocation: "sfi",
+  sandbox_function_mcp_action: "sfa",
 
   // Academy quiz attempts.
   academy_quiz_attempt: "aqz",

--- a/front/migrations/pre-deploy/20260703094819_create_sandbox_function_mcp_actions.sql
+++ b/front/migrations/pre-deploy/20260703094819_create_sandbox_function_mcp_actions.sql
@@ -1,0 +1,115 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE SEQUENCE "public"."sandbox_function_mcp_actions_id_seq"
+	AS bigint
+	INCREMENT BY 1
+	MINVALUE 1 MAXVALUE 9223372036854775807
+	START WITH 1 CACHE 1 NO CYCLE
+;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."sandbox_function_mcp_actions" (
+	"createdAt" timestamp with time zone NOT NULL,
+	"updatedAt" timestamp with time zone NOT NULL,
+	"sandboxFunctionInvocationId" bigint NOT NULL,
+	"mcpServerViewId" bigint NOT NULL,
+	"workspaceId" bigint NOT NULL,
+	"id" bigint DEFAULT nextval('sandbox_function_mcp_actions_id_seq'::regclass) NOT NULL,
+	"executionDurationMs" integer,
+	"toolName" character varying(255) NOT NULL,
+	"inputs" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"toolConfiguration" jsonb NOT NULL,
+	"status" character varying(64) NOT NULL,
+	"outputGcsPath" text
+);
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_mcp_actions" ADD CONSTRAINT "sandbox_function_mcp_actions_mcpServerViewId_fkey" FOREIGN KEY ("mcpServerViewId") REFERENCES mcp_server_views(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_mcp_actions" VALIDATE CONSTRAINT "sandbox_function_mcp_actions_mcpServerViewId_fkey";
+
+/*
+Statement 4
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_mcp_actions" ADD CONSTRAINT "sandbox_function_mcp_actions_sandboxFunctionInvocationId_fkey" FOREIGN KEY ("sandboxFunctionInvocationId") REFERENCES sandbox_function_invocations(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 5
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_mcp_actions" VALIDATE CONSTRAINT "sandbox_function_mcp_actions_sandboxFunctionInvocationId_fkey";
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_mcp_actions" ADD CONSTRAINT "sandbox_function_mcp_actions_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_mcp_actions" VALIDATE CONSTRAINT "sandbox_function_mcp_actions_workspaceId_fkey";
+
+/*
+Statement 8
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY sandbox_function_mcp_actions_pkey ON public.sandbox_function_mcp_actions USING btree (id);
+
+/*
+Statement 9
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_mcp_actions" ADD CONSTRAINT "sandbox_function_mcp_actions_pkey" PRIMARY KEY USING INDEX "sandbox_function_mcp_actions_pkey";
+
+/*
+Statement 10
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY sandbox_function_mcp_actions_workspace_invocation ON public.sandbox_function_mcp_actions USING btree ("workspaceId", "sandboxFunctionInvocationId");
+
+/*
+Statement 11
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY sandbox_function_mcp_actions_mcp_server_view_id ON public.sandbox_function_mcp_actions USING btree ("mcpServerViewId");
+
+/*
+Statement 12
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY sandbox_function_mcp_actions_sandbox_function_invocation_id ON public.sandbox_function_mcp_actions USING btree ("sandboxFunctionInvocationId");
+
+/*
+Statement 13
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER SEQUENCE "public"."sandbox_function_mcp_actions_id_seq" OWNED BY "public"."sandbox_function_mcp_actions"."id";


### PR DESCRIPTION
## Description

Sandbox functions cannot call MCP tools today: the `/v1/w/:wId/sandbox/actions/*` endpoints require a conversation-bound token and persist an `AgentMCPAction`, which mandates a conversation, an agent message and a step content. A function invocation has none of those.


This PR lays the foundations, with **no behavior change**:

1. `SandboxFunctionMCPActionModel` + pre-deploy migration: an MCP tool call made from a sandbox function invocation.
2. `ToolExecutionStatus` split into a base lifecycle + agent-loop extension.
3. RESTRICT-FK deletion wiring: view hard-delete flows clean up action rows (`destroyMCPServerViewDependencies`); the invocation-deletion side is a dated TODO, landing with the resource in PR2 — safe because nothing writes to the table until PR3.

The `agent_loop_context_required` manifest flag (whether a server's tools need an agent loop to run) ships as its own mechanical PR, consumed by PR3.

## The model, vs `AgentMCPActionModel`

| `AgentMCPActionModel` | Ours | Why |
|---|---|---|
| `agentMessageId` FK (NOT NULL) | → `sandboxFunctionInvocationId` FK | the parent swap, that's the whole point of the new model |
| `stepContentId` FK (+ join row) | dropped | ties the action to the LLM's function-call step content; no LLM step exists here |
| `mcpServerConfigurationId` (string) | → `mcpServerViewId` FK | theirs is the sId of a virtual agent-config object (can't FK); ours is a real view row |
| `version` (default 0) | dropped | versioning of re-executed actions within an agent message step; no such concept here |
| `status` (`ToolExecutionStatus`, nullable) | `ToolExecutionBaseStatus`, NOT NULL | theirs carries `ready_*` scheduling + conversation `blocked_*` states; ours is the base lifecycle (nullable was a backfill artifact) |
| `citationsAllocated` (default 0) | dropped | citation ref accounting per agent message; no conversation to cite into |
| `augmentedInputs` JSONB | → `inputs` JSONB | same role; nothing gets "augmented" without an agent config injecting configured values |
| `toolConfiguration` JSONB | same (minimal, synthesized) | execution snapshot (timeout, retry, wire name); derived + gated at creation, executed from the row, same pattern as `create_child_action.ts` |
| `stepContext` JSONB | dropped | citations offsets / resume state / sandbox-child info, all agent-loop step machinery |
| `AgentMCPActionOutputItemModel` (per-block rows) | → single `outputGcsPath` column | per-block rows exist for conversation rendering; dsbx reads the output exactly once as one array, written once to one GCS object |

## Statuses

`ToolExecutionBaseStatus` (`running | blocked_validation_required | succeeded | errored | denied`) is the lifecycle any tool execution has; `ToolExecutionStatus` extends it with the agent-loop-only states. Same values as before, now with the relationship explicit and `satisfies`-pinned.

Note: `blocked_validation_required` / `denied` have no writer yet: v1 rejects approval-requiring tools at call time. They are in the base because approvals will be bubbled up to the user later (gated on invocation durability).

## Follow-ups

- `agent_loop_context_required` manifest flag (mechanical, already branched)
- PR2: `SandboxFunctionMCPActionResource` (GCS output helpers, deletion wiring + regression tests)
- PR3: endpoints + Temporal execution, first e2e with `common_utilities`
- PR4: pod file outputs, flipping real servers

## Risk

Worst case, a dead table. Safe to rollback. Migration is addition-only.

## Deploy Plan

- [ ] Apply pre-deploy migration
- [ ] Deploy front