### PR TITLE
Add HubSpot association labels support

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -306,6 +306,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_object_by_email": "never_ask",
     "get_object_properties": "never_ask",
     "get_user_activity": "never_ask",
+    "list_association_labels": "never_ask",
     "list_associations": "never_ask",
     "list_email_campaigns": "never_ask",
     "list_email_events": "never_ask",

--- a/front/lib/api/actions/servers/hubspot/client.ts
+++ b/front/lib/api/actions/servers/hubspot/client.ts
@@ -1809,12 +1809,16 @@ export const createAssociation = async ({
   fromObjectId,
   toObjectType,
   toObjectId,
+  associationCategory,
+  associationTypeId,
 }: {
   accessToken: string;
   fromObjectType: string;
   fromObjectId: string;
   toObjectType: string;
   toObjectId: string;
+  associationCategory?: AssociationSpecAssociationCategoryEnum;
+  associationTypeId?: number;
 }) => {
   try {
     const hubspotClient = new Client({ accessToken });
@@ -1827,8 +1831,9 @@ export const createAssociation = async ({
       [
         {
           associationCategory:
+            associationCategory ??
             AssociationSpecAssociationCategoryEnum.HubspotDefined,
-          associationTypeId: 1,
+          associationTypeId: associationTypeId ?? 1,
         },
       ]
     );
@@ -1841,6 +1846,29 @@ export const createAssociation = async ({
     );
     throw normalizeError(error);
   }
+};
+
+interface HubSpotAssociationLabel {
+  category: AssociationSpecAssociationCategoryEnum;
+  typeId: number;
+  label?: string;
+}
+
+export const listAssociationLabels = async ({
+  accessToken,
+  fromObjectType,
+  toObjectType,
+}: {
+  accessToken: string;
+  fromObjectType: string;
+  toObjectType: string;
+}): Promise<HubSpotAssociationLabel[]> => {
+  const data = await hubspotApiFetch<{ results: HubSpotAssociationLabel[] }>({
+    accessToken,
+    path: `/crm/v4/associations/${fromObjectType}/${toObjectType}/labels`,
+  });
+
+  return data.results;
 };
 
 export const listAssociations = async ({

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -1,6 +1,7 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { FilterOperatorEnum } from "@hubspot/api-client/lib/codegen/crm/contacts";
+import { AssociationSpecAssociationCategoryEnum } from "@hubspot/api-client/lib/codegen/crm/objects/models/AssociationSpec";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
@@ -331,6 +332,25 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Listing HubSpot associations",
       done: "List HubSpot associations",
+    },
+  },
+  list_association_labels: {
+    description:
+      "List the available association labels between two HubSpot object types " +
+      "(e.g., the 'Parent Company'/'Child Company' labels between companies). " +
+      "Returns each label's category and typeId, to be passed to create_association.",
+    schema: {
+      fromObjectType: z
+        .enum(["contacts", "companies", "deals"])
+        .describe("The type of the source object"),
+      toObjectType: z
+        .enum(["contacts", "companies", "deals"])
+        .describe("The type of the target object"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing HubSpot association labels",
+      done: "List HubSpot association labels",
     },
   },
   get_current_user_id: {
@@ -708,7 +728,9 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   create_association: {
     description:
-      "Create an association between two existing HubSpot objects (e.g., associate a contact with a company).",
+      "Create an association between two existing HubSpot objects (e.g., associate a contact with a company). " +
+      "To create a labeled association (e.g., set a company as the parent/child of another), first call " +
+      "list_association_labels to get the label's category and typeId, then pass them here.",
     schema: {
       fromObjectType: z
         .enum(["contacts", "companies", "deals"])
@@ -718,6 +740,18 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .enum(["contacts", "companies", "deals"])
         .describe("The type of the target object"),
       toObjectId: z.string().describe("The ID of the target object"),
+      associationCategory: z
+        .nativeEnum(AssociationSpecAssociationCategoryEnum)
+        .optional()
+        .describe(
+          "Optional association category for a labeled association, from list_association_labels. Defaults to HUBSPOT_DEFINED."
+        ),
+      associationTypeId: z
+        .number()
+        .optional()
+        .describe(
+          "Optional association type id for a labeled association, from list_association_labels. Defaults to the primary unlabeled association."
+        ),
     },
     stake: "high",
     displayLabels: {

--- a/front/lib/api/actions/servers/hubspot/tools/index.ts
+++ b/front/lib/api/actions/servers/hubspot/tools/index.ts
@@ -28,6 +28,7 @@ import {
   getObjectProperties,
   getUserActivity,
   getUserDetails,
+  listAssociationLabels,
   listAssociations,
   listEmailCampaigns,
   listEmailEvents,
@@ -488,6 +489,23 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
     });
   },
 
+  list_association_labels: async ({ fromObjectType, toObjectType }, extra) => {
+    return withAuth(extra, async (accessToken) => {
+      const result = await listAssociationLabels({
+        accessToken,
+        fromObjectType,
+        toObjectType,
+      });
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Association labels retrieved successfully between ${fromObjectType} and ${toObjectType}`,
+        },
+        { type: "text" as const, text: JSON.stringify(result, null, 2) },
+      ]);
+    });
+  },
+
   get_current_user_id: async (_params, extra) => {
     return withAuth(extra, async (accessToken) => {
       const result = await getCurrentUserId(accessToken);
@@ -791,7 +809,14 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
   },
 
   create_association: async (
-    { fromObjectType, fromObjectId, toObjectType, toObjectId },
+    {
+      fromObjectType,
+      fromObjectId,
+      toObjectType,
+      toObjectId,
+      associationCategory,
+      associationTypeId,
+    },
     extra
   ) => {
     return withAuth(extra, async (accessToken) => {
@@ -801,6 +826,8 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
         fromObjectId,
         toObjectType,
         toObjectId,
+        associationCategory,
+        associationTypeId,
       });
       return new Ok([
         {


### PR DESCRIPTION
## Description

Adds the ability to create labeled associations between HubSpot objects via the HubSpot MCP server (e.g. making one company the parent/child of another) Fixes #8158.

Two changes:
- **New `list_association_labels` tool** lists the available association labels between two object types (e.g. company↔company "Parent Company" / "Child Company"), returning each label's `category` and `typeId`. Read-only (`stake: never_ask`).
- **Extended `create_association`** — now accepts optional `associationCategory` and `associationTypeId` so an agent can create a *labeled* association using the values discovered via `list_association_labels`. When omitted, behavior is unchanged (default unlabeled `HUBSPOT_DEFINED` / typeId `1` association).

## Tests

Tested locally with the Hubspot dev test account. 

## Risk

Low. Additive: one new read-only tool plus two optional, backward-compatible parameters on `create_association`

## Deploy Plan

Standard deploy