### PR TITLE
feat(front): add feature flag to default @dust agent to light reasoning

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -87,6 +87,9 @@ interface DustLikeGlobalAgentArgs {
   // When set, the @dust agent defaults to GPT 5.5 (medium reasoning) instead of
   // Claude Sonnet 4.6. Gated by the `dust_agent_gpt_5_5_default` feature flag.
   preferGpt55DefaultModel?: boolean;
+  // When set, the @dust agent defaults to light reasoning instead of medium.
+  // Gated by the `dust_agent_light_reasoning_default` feature flag.
+  preferLightReasoningDefault?: boolean;
 }
 
 const INSTRUCTION_SECTIONS = {
@@ -468,7 +471,9 @@ export function _getDustGlobalAgent(
     preferredModelConfiguration: args.preferGpt55DefaultModel
       ? GPT_5_5_MODEL_CONFIG
       : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-    preferredReasoningEffort: "medium",
+    preferredReasoningEffort: args.preferLightReasoningDefault
+      ? "light"
+      : "medium",
   });
 }
 

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -670,6 +670,7 @@ function getGlobalAgent({
   globalAgentContext,
   excludeProviders,
   preferGpt55DefaultModel,
+  preferLightReasoningDefault,
   featureFlags,
 }: {
   auth: Authenticator;
@@ -683,6 +684,7 @@ function getGlobalAgent({
   globalAgentContext?: GlobalAgentContext;
   excludeProviders: ReadonlySet<ModelProviderIdType>;
   preferGpt55DefaultModel: boolean;
+  preferLightReasoningDefault: boolean;
   featureFlags: WhitelistableFeature[];
 }): AgentConfigurationType | null {
   const settings =
@@ -897,6 +899,7 @@ function getGlobalAgent({
         globalAgentContext,
         excludeProviders,
         preferGpt55DefaultModel,
+        preferLightReasoningDefault,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_HIGH:
@@ -1665,6 +1668,9 @@ export async function getGlobalAgents(
       globalAgentContext: options?.globalAgentContext,
       excludeProviders,
       preferGpt55DefaultModel: flags.includes("dust_agent_gpt_5_5_default"),
+      preferLightReasoningDefault: flags.includes(
+        "dust_agent_light_reasoning_default"
+      ),
       featureFlags: flags,
     })
   );

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -51,6 +51,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Use GPT 5.5 (medium reasoning) as the default model for the @dust agent",
     stage: "dust_only",
   },
+  dust_agent_light_reasoning_default: {
+    description:
+      "Use light reasoning (instead of medium) as the default for the @dust agent",
+    stage: "dust_only",
+  },
   notion_private_integration: {
     description: "Setup Notion private integration tokens",
     stage: "on_demand",


### PR DESCRIPTION
## Description

Adds a new `dust_only` feature flag, `dust_agent_light_reasoning_default`, that switches the default reasoning effort of the `@dust` global agent from `medium` to `light` when enabled on a workspace.

This mirrors the existing `dust_agent_gpt_5_5_default` flag pattern: the flag is read in `getGlobalAgents`, threaded through `getGlobalAgent` into `_getDustGlobalAgent`, and used to pick `preferredReasoningEffort`. When the flag is off (the default for every workspace), behavior is unchanged and the `@dust` agent keeps using Sonnet 4.6 medium reasoning.

The flag is intended to be enabled on the Dust workspace so we can run `@dust` on Sonnet 4.6 light reasoning without affecting any customer workspace.

## Tests

No automated tests: the change is a boolean flag threaded through existing plumbing. To verify manually, enable `dust_agent_light_reasoning_default` on a workspace and confirm the `@dust` agent runs with light reasoning; with the flag off, it stays on medium.

## Risk

Low. Behavior is gated behind an off-by-default `dust_only` flag; no change for any workspace until the flag is explicitly enabled.

## Deploy Plan

After deploy, enable the `dust_agent_light_reasoning_default` feature flag on the Dust workspace.
