### PR TITLE
feat(front-billing): grant free programmatic credits via Stripe webhook

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1363,11 +1363,7 @@ export async function processMetronomeWebhook({
 
     case "credit.segment.start":
     case "credit.edit": {
-      const {
-        customer_id: metronomeCustomerId,
-        contract_id: contractId,
-        credit_id: creditId,
-      } = event;
+      const { customer_id: metronomeCustomerId, credit_id: creditId } = event;
 
       const creditResult = await getMetronomeCredit({
         metronomeCustomerId,
@@ -1406,25 +1402,10 @@ export async function processMetronomeWebhook({
         }
       }
 
-      if (event.type === "credit.segment.start") {
-        // Special case: only a contract-bound managed free credit drives the
-        // free monthly/yearly credit grant. Customer-level credits with no
-        // parent contract can't be the managed free credit, so stop here.
-        if (!contractId) {
-          break;
-        }
-
-        const grantResult = await handleFreeCreditSegmentGrant({
-          workspace,
-          metronomeCustomerId,
-          contractId,
-          creditId,
-          segmentId: event.segment_id,
-        });
-        if (grantResult.isErr()) {
-          return grantResult;
-        }
-      }
+      // The free monthly/yearly credit grant is now driven by the Stripe
+      // `customer.subscription.updated` webhook (see
+      // `grantFreeCreditsForSubscription`), which creates the DB credit and
+      // syncs the amount back into Metronome. We no longer grant it here.
       break;
     }
 

--- a/front/lib/api/stripe/webhook_handler.ts
+++ b/front/lib/api/stripe/webhook_handler.ts
@@ -13,6 +13,7 @@ import {
   startCreditFromProOneOffInvoice,
   voidFailedProCreditPurchaseInvoice,
 } from "@app/lib/credits/committed";
+import { grantFreeCreditsForSubscription } from "@app/lib/credits/free";
 import {
   allocatePAYGCreditsOnCycleRenewal,
   invoiceEnterprisePAYGCredits,
@@ -1137,6 +1138,37 @@ export async function processStripeWebhookEvent({
         );
       }
 
+      const createdSubscription = await SubscriptionResource.fetchByStripeId(
+        stripeSubscriptionCreated.id
+      );
+      if (createdSubscription) {
+        const workspace = await WorkspaceResource.fetchByModelId(
+          createdSubscription.workspaceId
+        );
+        assert(
+          workspace !== null,
+          "Workspace not found for subscription in customer.subscription.created."
+        );
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId
+        );
+
+        const freeCreditsResult = await grantFreeCreditsForSubscription({
+          auth,
+          stripeSubscription: stripeSubscriptionCreated,
+        });
+        if (freeCreditsResult.isErr()) {
+          logger.error(
+            {
+              error: freeCreditsResult.error,
+              subscriptionId: stripeSubscriptionCreated.id,
+              workspaceId: workspace.sId,
+            },
+            "[Stripe Webhook] Error granting free credits on subscription created"
+          );
+        }
+      }
+
       break;
     }
 
@@ -1189,6 +1221,21 @@ export async function processStripeWebhookEvent({
         const auth = await Authenticator.internalAdminForWorkspace(
           workspace.sId
         );
+
+        const freeCreditsResult = await grantFreeCreditsForSubscription({
+          auth,
+          stripeSubscription,
+        });
+        if (freeCreditsResult.isErr()) {
+          logger.error(
+            {
+              error: freeCreditsResult.error,
+              subscriptionId: stripeSubscription.id,
+              workspaceId: workspace.sId,
+            },
+            "[Stripe Webhook] Error granting free credits"
+          );
+        }
 
         if (subscriptionCycleChanged) {
           const paygEnabled = await isPAYGEnabled(auth);

--- a/front/lib/credits/free.test.ts
+++ b/front/lib/credits/free.test.ts
@@ -1,13 +1,19 @@
+import type { Authenticator } from "@app/lib/auth";
 import {
   calculateFreeCreditAmountMicroUsd,
   countEligibleUsersForFreeCredits,
   getCustomerPaymentStatus,
+  grantFreeCreditFromSubscriptionStateChangeYearly,
+  grantFreeCreditsFromSubscriptionStateChange,
 } from "@app/lib/credits/free";
 import {
   getSubscriptionInvoices,
   isEnterpriseSubscription,
 } from "@app/lib/plans/stripe";
+import { CreditResource } from "@app/lib/resources/credit_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { LightWorkspaceType } from "@app/types/user";
 import type Stripe from "stripe";
 import type { MockInstance } from "vitest";
@@ -317,5 +323,404 @@ describe("calculateFreeCreditAmountMicroUsd", () => {
 
   it("should return 0 for 0 users", () => {
     expect(calculateFreeCreditAmountMicroUsd(0)).toBe(0);
+  });
+});
+
+function makeFullSubscription(
+  overrides: Partial<Stripe.Subscription> = {}
+): Stripe.Subscription {
+  return {
+    id: "sub_test",
+    current_period_start: NOW,
+    current_period_end: NOW + MONTH_SECONDS,
+    start_date: NOW - MONTH_SECONDS * 3,
+    status: "active",
+    items: { data: [], has_more: false, object: "list", url: "" },
+    ...overrides,
+  } as Stripe.Subscription;
+}
+
+describe("grantFreeCreditsOnSubscriptionRenewal", () => {
+  let auth: Authenticator;
+  let getMembersCountSpy: MockInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    auth = authenticator;
+
+    vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([
+      makeInvoice(NOW - MONTH_SECONDS * 0.5),
+    ]);
+    getMembersCountSpy = vi
+      .spyOn(MembershipResource, "getMembersCountForWorkspace")
+      .mockResolvedValue(10);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    getMembersCountSpy.mockRestore();
+  });
+
+  it("should skip when credit already exists for billing cycle (idempotency)", async () => {
+    const subscription = makeFullSubscription();
+    const idempotencyKey = `free-renewal-${subscription.id}-${subscription.current_period_start}`;
+
+    await CreditResource.makeNew(auth, {
+      type: "free",
+      initialAmountMicroUsd: 50_000_000,
+      consumedAmountMicroUsd: 0,
+      invoiceOrLineItemId: idempotencyKey,
+    });
+
+    const result = await grantFreeCreditsFromSubscriptionStateChange({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits.length).toBe(1);
+  });
+
+  it("should return error for non-paying/non-trialing Pro subscription", async () => {
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
+    const oldSubscription = makeFullSubscription({
+      start_date: NOW - MONTH_SECONDS * 3,
+      status: "active",
+    });
+
+    const result = await grantFreeCreditsFromSubscriptionStateChange({
+      auth,
+      stripeSubscription: oldSubscription,
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("should always grant credits for enterprise subscriptions", async () => {
+    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
+
+    const subscription = makeFullSubscription();
+
+    const result = await grantFreeCreditsFromSubscriptionStateChange({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(isEnterpriseSubscription).toHaveBeenCalledWith(subscription);
+  });
+
+  it("should use programmatic config override when freeCreditMicroUsd is set", async () => {
+    const configResult = await ProgrammaticUsageConfigurationResource.makeNew(
+      auth,
+      {
+        freeCreditMicroUsd: 250_000_000,
+        defaultDiscountPercent: 0,
+        paygCapMicroUsd: null,
+      }
+    );
+    expect(configResult.isOk()).toBe(true);
+
+    const subscription = makeFullSubscription();
+
+    const result = await grantFreeCreditsFromSubscriptionStateChange({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].initialAmountMicroUsd).toBe(250_000_000);
+  });
+
+  it("should grant trial credit amount ($5) for trialing customers", async () => {
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
+    const subscription = makeFullSubscription({
+      status: "trialing",
+      start_date: NOW,
+    });
+
+    const result = await grantFreeCreditsFromSubscriptionStateChange({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].initialAmountMicroUsd).toBe(5_000_000);
+  });
+
+  it("should calculate bracket-based credits for paying customers", async () => {
+    getMembersCountSpy.mockResolvedValue(25);
+
+    const subscription = makeFullSubscription();
+
+    const result = await grantFreeCreditsFromSubscriptionStateChange({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].initialAmountMicroUsd).toBe(50_000_000 + 30_000_000);
+  });
+
+  it("should create credit with correct expiration date (period end)", async () => {
+    const subscription = makeFullSubscription();
+
+    const result = await grantFreeCreditsFromSubscriptionStateChange({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].expirationDate?.getTime()).toBe(
+      subscription.current_period_end * 1000
+    );
+  });
+
+  it("should start credit immediately after creation", async () => {
+    const subscription = makeFullSubscription();
+
+    const result = await grantFreeCreditsFromSubscriptionStateChange({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].startDate).not.toBeNull();
+  });
+
+  it("should use correct idempotency key format", async () => {
+    const subscription = makeFullSubscription({ id: "sub_abc123" });
+
+    await grantFreeCreditsFromSubscriptionStateChange({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].invoiceOrLineItemId).toBe(
+      `free-renewal-sub_abc123-${subscription.current_period_start}`
+    );
+  });
+
+  it("should verify isEnterpriseSubscription is called with correct subscription", async () => {
+    const subscription = makeFullSubscription({ id: "sub_verify" });
+
+    await grantFreeCreditsFromSubscriptionStateChange({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(isEnterpriseSubscription).toHaveBeenCalledWith(subscription);
+  });
+});
+
+function makeYearlySubscription(
+  overrides: Partial<Stripe.Subscription> = {}
+): Stripe.Subscription {
+  return {
+    id: "sub_yearly_test",
+    current_period_start: NOW,
+    current_period_end: NOW + YEAR_SECONDS,
+    start_date: NOW - YEAR_SECONDS,
+    status: "active",
+    items: { data: [], has_more: false, object: "list", url: "" },
+    ...overrides,
+  } as Stripe.Subscription;
+}
+
+describe("grantFreeCreditFromSubscriptionStateChangeYearly", () => {
+  let auth: Authenticator;
+  let getMembersCountSpy: MockInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    auth = authenticator;
+
+    vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([
+      makeInvoice(NOW - MONTH_SECONDS * 0.5),
+    ]);
+    getMembersCountSpy = vi
+      .spyOn(MembershipResource, "getMembersCountForWorkspace")
+      .mockResolvedValue(10);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    getMembersCountSpy.mockRestore();
+  });
+
+  it("should skip when credit already exists for billing cycle (idempotency)", async () => {
+    const subscription = makeYearlySubscription();
+    const idempotencyKey = `free-renewal-yearly-${subscription.id}-${subscription.current_period_start}`;
+
+    await CreditResource.makeNew(auth, {
+      type: "free",
+      initialAmountMicroUsd: 600_000_000,
+      consumedAmountMicroUsd: 0,
+      invoiceOrLineItemId: idempotencyKey,
+    });
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits.length).toBe(1);
+  });
+
+  it("should return error for non-paying subscription (no trials for yearly)", async () => {
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
+    const subscription = makeYearlySubscription({
+      start_date: NOW - YEAR_SECONDS * 2,
+      status: "active",
+    });
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error.message).toContain(
+      "Yearly subscription not eligible for free credits"
+    );
+  });
+
+  it("should return error for trialing subscription (no trials for yearly)", async () => {
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
+    const subscription = makeYearlySubscription({
+      status: "trialing",
+      start_date: NOW,
+    });
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error.message).toContain(
+      "Yearly subscription not eligible for free credits"
+    );
+  });
+
+  it("should use programmatic config override when freeCreditMicroUsd is set (yearly amount)", async () => {
+    const configResult = await ProgrammaticUsageConfigurationResource.makeNew(
+      auth,
+      {
+        freeCreditMicroUsd: 1_200_000_000, // $1200 yearly
+        defaultDiscountPercent: 0,
+        paygCapMicroUsd: null,
+      }
+    );
+    expect(configResult.isOk()).toBe(true);
+
+    const subscription = makeYearlySubscription();
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].initialAmountMicroUsd).toBe(1_200_000_000);
+  });
+
+  it("should calculate bracket-based credits times 12 for paying customers", async () => {
+    getMembersCountSpy.mockResolvedValue(10);
+    // 10 users = $50/month -> $600/year
+
+    const subscription = makeYearlySubscription();
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].initialAmountMicroUsd).toBe(50_000_000 * 12);
+  });
+
+  it("should calculate correct yearly amount for 25 users", async () => {
+    getMembersCountSpy.mockResolvedValue(25);
+    // 25 users = $50 (first 10) + $30 (15 users @ $2) = $80/month -> $960/year
+
+    const subscription = makeYearlySubscription();
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].initialAmountMicroUsd).toBe(
+      (50_000_000 + 30_000_000) * 12
+    );
+  });
+
+  it("should create credit with correct expiration date (period end = 1 year)", async () => {
+    const subscription = makeYearlySubscription();
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].expirationDate?.getTime()).toBe(
+      subscription.current_period_end * 1000
+    );
+  });
+
+  it("should use correct yearly idempotency key format", async () => {
+    const subscription = makeYearlySubscription({ id: "sub_yearly_abc123" });
+
+    await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].invoiceOrLineItemId).toBe(
+      `free-renewal-yearly-sub_yearly_abc123-${subscription.current_period_start}`
+    );
+  });
+
+  it("should always grant credits for enterprise subscriptions", async () => {
+    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
+
+    const subscription = makeYearlySubscription();
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(isEnterpriseSubscription).toHaveBeenCalledWith(subscription);
   });
 });

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -1,14 +1,25 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
+  getMetronomeClient,
+  updateMetronomeCreditSegmentAmount,
+} from "@app/lib/metronome/client";
+import { getProductFreeCreditId } from "@app/lib/metronome/constants";
+import {
   getSubscriptionInvoices,
   isEnterpriseSubscription,
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import assert from "assert";
 import type Stripe from "stripe";
 
 const BRACKET_1_USERS = 10;
@@ -17,6 +28,8 @@ const BRACKET_2_USERS = 40; // 11-50
 const BRACKET_2_MICRO_USD_PER_USER = 2_000_000; // $2
 const BRACKET_3_USERS = 50; // 51-100
 const BRACKET_3_MICRO_USD_PER_USER = 1_000_000; // $1
+
+const TRIAL_CREDIT_MICRO_USD = 5_000_000; // $5
 
 const MONTHLY_BILLING_CYCLE_SECONDS = 30 * 24 * 60 * 60; // ~30 days
 const YEARLY_BILLING_CYCLE_SECONDS = 365 * 24 * 60 * 60; // ~365 days
@@ -281,4 +294,544 @@ export async function grantFreeCreditFromMetronomeSegment({
   );
 
   return new Ok({ credit, created, alreadyExisted: false });
+}
+
+/**
+ * Link the DB free credit to the workspace's Metronome recurring free credit
+ * and push the granted amount into Metronome so programmatic usage is offset
+ * on the invoice by the same amount we granted in the DB.
+ *
+ * Best-effort: the DB credit is the source of truth for the app and has
+ * already been committed by the caller. A Metronome hiccup here only affects
+ * invoice offsetting, which the credit sync script reconciles — so we log and
+ * move on rather than failing the grant.
+ *
+ * No-op when the workspace has no Metronome customer/contract (e.g. enterprise
+ * after shadow contracts were sunset) or when the contract carries no recurring
+ * free credit.
+ */
+async function linkAndSyncMetronomeRecurringCredit({
+  workspace,
+  credit,
+  amountMicroUsd,
+}: {
+  workspace: LightWorkspaceType;
+  credit: CreditResource;
+  amountMicroUsd: number;
+}): Promise<void> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return;
+  }
+
+  try {
+    const client = getMetronomeClient();
+    const nowISO = new Date().toISOString();
+    const contractsResponse = await client.v2.contracts.list({
+      customer_id: metronomeCustomerId,
+      covering_date: nowISO,
+    });
+    const contract = contractsResponse.data[0];
+    if (!contract) {
+      logger.info(
+        { workspaceId: workspace.sId, creditId: credit.id },
+        "[Free Credits] No active Metronome contract, skipping link/sync"
+      );
+      return;
+    }
+
+    const freeCreditProductId = getProductFreeCreditId();
+    const existingRecurringCredit = contract.recurring_credits?.find(
+      (rc) => rc.product.id === freeCreditProductId
+    );
+    if (!existingRecurringCredit) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          contractId: contract.id,
+          creditId: credit.id,
+        },
+        "[Free Credits] No recurring free credit on contract, skipping link/sync"
+      );
+      return;
+    }
+
+    const creditsResponse = await client.v1.customers.credits.list({
+      customer_id: metronomeCustomerId,
+      covering_date: nowISO,
+      include_contract_credits: true,
+    });
+    const currentRecurringCredit = creditsResponse.data.find(
+      (c) => c.recurring_credit_id === existingRecurringCredit.id
+    );
+    if (!currentRecurringCredit) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          contractId: contract.id,
+          creditId: credit.id,
+        },
+        "[Free Credits] No active credit for recurring credit, skipping link/sync"
+      );
+      return;
+    }
+
+    // Metronome credit amounts for the free credit type are denominated in USD.
+    const nowMs = Date.now();
+    const segment = currentRecurringCredit.access_schedule?.schedule_items.find(
+      (s) =>
+        new Date(s.starting_at).getTime() <= nowMs &&
+        nowMs < new Date(s.ending_before).getTime()
+    );
+    if (segment?.id) {
+      const updateResult = await updateMetronomeCreditSegmentAmount({
+        metronomeCustomerId,
+        contractId: contract.id,
+        creditId: currentRecurringCredit.id,
+        segmentId: segment.id,
+        amount: amountMicroUsd / 1_000_000,
+      });
+      if (updateResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            creditId: credit.id,
+            metronomeCreditId: currentRecurringCredit.id,
+            error: updateResult.error,
+          },
+          "[Free Credits] Failed to sync Metronome recurring credit amount"
+        );
+      }
+    } else {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          creditId: credit.id,
+          metronomeCreditId: currentRecurringCredit.id,
+        },
+        "[Free Credits] No active segment on recurring credit, skipping amount sync"
+      );
+    }
+
+    await credit.setMetronomeCreditId(currentRecurringCredit.id);
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        creditId: credit.id,
+        metronomeCreditId: currentRecurringCredit.id,
+        amountMicroUsd,
+      },
+      "[Free Credits] Linked DB credit to Metronome recurring credit and synced amount"
+    );
+  } catch (err) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        creditId: credit.id,
+        err: normalizeError(err),
+      },
+      "[Free Credits] Failed to link/sync Metronome recurring credit"
+    );
+  }
+}
+
+/**
+ * Grant the monthly free programmatic-usage credit on a Stripe subscription
+ * state change (renewal / activation), anchored to the Stripe billing period.
+ * Creates the DB free credit, then syncs the amount into Metronome so
+ * Metronome-billed plans have their usage offset on the invoice.
+ *
+ * Idempotent per billing cycle via the `free-renewal-<sub>-<periodStart>` key.
+ */
+export async function grantFreeCreditsFromSubscriptionStateChange({
+  auth,
+  stripeSubscription,
+}: {
+  auth: Authenticator;
+  stripeSubscription: Stripe.Subscription;
+}): Promise<Result<undefined, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const workspaceId = workspace.sId;
+
+  // Check if credit already exists for this billing cycle (idempotency)
+  const idempotencyKey = `free-renewal-${stripeSubscription.id}-${stripeSubscription.current_period_start}`;
+  const existingCredit = await CreditResource.fetchByInvoiceOrLineItemId(
+    auth,
+    idempotencyKey
+  );
+
+  if (existingCredit) {
+    logger.info(
+      {
+        workspaceId,
+        creditId: existingCredit.id,
+        subscriptionId: stripeSubscription.id,
+      },
+      "[Free Credits] Credit already exists for this billing cycle, skipping"
+    );
+    return new Ok(undefined);
+  }
+
+  // Enterprise subscriptions are always eligible
+  const isEnterprise = isEnterpriseSubscription(stripeSubscription);
+  const customerPaymentStatus: CustomerPaymentStatus =
+    await getCustomerPaymentStatus(stripeSubscription);
+
+  logger.info(
+    {
+      workspaceId,
+      subscriptionId: stripeSubscription.id,
+      isEnterprise,
+    },
+    "[Free Credits] Processing free credit grant on subscription renewal"
+  );
+
+  let creditAmountMicroUsd: number;
+
+  const programmaticConfig =
+    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+  if (
+    programmaticConfig &&
+    programmaticConfig.freeCreditMicroUsd !== null &&
+    customerPaymentStatus === "paying"
+  ) {
+    creditAmountMicroUsd = programmaticConfig.freeCreditMicroUsd;
+    logger.info(
+      {
+        workspaceId,
+        creditAmountMicroUsd,
+      },
+      "[Free Credits] Using ProgrammaticUsageConfiguration override amount"
+    );
+  } else {
+    switch (customerPaymentStatus) {
+      case "not_paying":
+        logger.warn(
+          {
+            workspaceId,
+            subscriptionId: stripeSubscription.id,
+          },
+          "[Free Credits] Pro subscription not eligible for free credits (subscription payment too old or missing)"
+        );
+        return new Err(
+          new Error("Pro subscription not eligible for free credits")
+        );
+      case "trialing":
+        creditAmountMicroUsd = TRIAL_CREDIT_MICRO_USD;
+        break;
+      case "paying":
+        const userCount = await countEligibleUsersForFreeCredits(workspace);
+        creditAmountMicroUsd = calculateFreeCreditAmountMicroUsd(userCount);
+        logger.info(
+          {
+            workspaceId,
+            userCount,
+            creditAmountMicroUsd,
+            customerPaymentStatus,
+          },
+          "[Free Credits] Calculated credit amount using brackets system"
+        );
+        break;
+      default:
+        assertNever(customerPaymentStatus);
+    }
+
+    assert(
+      creditAmountMicroUsd > 0,
+      "Unexpected programmatic usage free credit amount equal to zero"
+    );
+  }
+
+  const periodStart = new Date(stripeSubscription.current_period_start * 1000);
+  const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
+
+  const { credit, created } =
+    await CreditResource.makeNewOrFetchByInvoiceOrLineItemId(auth, {
+      type: "free",
+      initialAmountMicroUsd: creditAmountMicroUsd,
+      consumedAmountMicroUsd: 0,
+      discount: null,
+      invoiceOrLineItemId: idempotencyKey,
+    });
+
+  if (!created) {
+    logger.info(
+      {
+        workspaceId,
+        creditId: credit.id,
+        subscriptionId: stripeSubscription.id,
+      },
+      "[Free Credits] Credit already exists for this billing cycle, skipping"
+    );
+    return new Ok(undefined);
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      creditId: credit.id,
+      creditAmountMicroUsd,
+      periodStart,
+      periodEnd,
+    },
+    "[Free Credits] Created credit, now starting"
+  );
+
+  // Start the credit at beginning of billing cycle.
+  const startResult = await credit.start(auth, {
+    startDate: periodStart,
+    expirationDate: periodEnd,
+  });
+  if (startResult.isErr()) {
+    logger.error(
+      {
+        panic: true,
+        workspaceId,
+        creditId: credit.id,
+        error: startResult.error,
+      },
+      "[Free Credits] Error starting credit"
+    );
+    getStatsDClient().increment("credits.top_up.error", 1, [
+      `workspace_id:${workspaceId}`,
+      "type:free",
+      `customer:${isEnterprise ? "enterprise" : "pro"}`,
+    ]);
+    return new Err(startResult.error);
+  }
+
+  getStatsDClient().increment("credits.top_up.success", 1, [
+    `workspace_id:${workspaceId}`,
+    "type:free",
+    `customer:${isEnterprise ? "enterprise" : "pro"}`,
+  ]);
+  logger.info(
+    {
+      workspaceId,
+      creditId: credit.id,
+      creditAmountMicroUsd,
+      periodStart,
+      periodEnd,
+    },
+    "[Free Credits] Successfully granted and activated free credit on renewal"
+  );
+
+  await linkAndSyncMetronomeRecurringCredit({
+    workspace,
+    credit,
+    amountMicroUsd: creditAmountMicroUsd,
+  });
+
+  return new Ok(undefined);
+}
+
+/**
+ * Yearly variant of {@link grantFreeCreditsFromSubscriptionStateChange}: the
+ * credit spans the full year and the bracket amount is multiplied by 12.
+ */
+export async function grantFreeCreditFromSubscriptionStateChangeYearly({
+  auth,
+  stripeSubscription,
+}: {
+  auth: Authenticator;
+  stripeSubscription: Stripe.Subscription;
+}): Promise<Result<undefined, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const workspaceId = workspace.sId;
+
+  // Check if credit already exists for this billing cycle (idempotency)
+  const idempotencyKey = `free-renewal-yearly-${stripeSubscription.id}-${stripeSubscription.current_period_start}`;
+  const existingCredit = await CreditResource.fetchByInvoiceOrLineItemId(
+    auth,
+    idempotencyKey
+  );
+
+  if (existingCredit) {
+    logger.info(
+      {
+        workspaceId,
+        creditId: existingCredit.id,
+        subscriptionId: stripeSubscription.id,
+      },
+      "[Free Credits Yearly] Credit already exists for this billing cycle, skipping"
+    );
+    return new Ok(undefined);
+  }
+
+  const isEnterprise = isEnterpriseSubscription(stripeSubscription);
+  const customerPaymentStatus: CustomerPaymentStatus =
+    await getCustomerPaymentStatus(stripeSubscription);
+
+  logger.info(
+    {
+      workspaceId,
+      subscriptionId: stripeSubscription.id,
+      isEnterprise,
+    },
+    "[Free Credits Yearly] Processing free credit grant on yearly subscription renewal"
+  );
+
+  // Yearly subscriptions don't have trials - must be paying
+  if (customerPaymentStatus !== "paying") {
+    logger.warn(
+      {
+        workspaceId,
+        subscriptionId: stripeSubscription.id,
+        customerPaymentStatus,
+      },
+      "[Free Credits Yearly] Yearly subscription not eligible for free credits (not paying)"
+    );
+    return new Err(
+      new Error("Yearly subscription not eligible for free credits")
+    );
+  }
+
+  let creditAmountMicroUsd: number;
+
+  const programmaticConfig =
+    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+  if (programmaticConfig && programmaticConfig.freeCreditMicroUsd !== null) {
+    // For yearly subscriptions, the configured amount is assumed to be yearly
+    creditAmountMicroUsd = programmaticConfig.freeCreditMicroUsd;
+    logger.info(
+      {
+        workspaceId,
+        creditAmountMicroUsd,
+      },
+      "[Free Credits Yearly] Using ProgrammaticUsageConfiguration override amount (yearly)"
+    );
+  } else {
+    // Calculate monthly amount and multiply by 12 for yearly
+    const userCount = await countEligibleUsersForFreeCredits(workspace);
+    const monthlyAmountMicroUsd = calculateFreeCreditAmountMicroUsd(userCount);
+    creditAmountMicroUsd = monthlyAmountMicroUsd * YEARLY_MULTIPLIER;
+    logger.info(
+      {
+        workspaceId,
+        userCount,
+        monthlyAmountMicroUsd,
+        creditAmountMicroUsd,
+      },
+      "[Free Credits Yearly] Calculated credit amount using brackets system x 12"
+    );
+  }
+
+  assert(
+    creditAmountMicroUsd > 0,
+    "Unexpected programmatic usage free credit amount equal to zero"
+  );
+
+  const periodStart = new Date(stripeSubscription.current_period_start * 1000);
+  const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
+
+  const { credit, created } =
+    await CreditResource.makeNewOrFetchByInvoiceOrLineItemId(auth, {
+      type: "free",
+      initialAmountMicroUsd: creditAmountMicroUsd,
+      consumedAmountMicroUsd: 0,
+      discount: null,
+      invoiceOrLineItemId: idempotencyKey,
+    });
+
+  if (!created) {
+    logger.info(
+      {
+        workspaceId,
+        creditId: credit.id,
+        subscriptionId: stripeSubscription.id,
+      },
+      "[Free Credits Yearly] Credit already exists for this billing cycle, skipping"
+    );
+    return new Ok(undefined);
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      creditId: credit.id,
+      creditAmountMicroUsd,
+      periodStart,
+      periodEnd,
+    },
+    "[Free Credits Yearly] Created credit, now starting"
+  );
+
+  // Start the credit at beginning of billing cycle (spans the full year).
+  const startResult = await credit.start(auth, {
+    startDate: periodStart,
+    expirationDate: periodEnd,
+  });
+  if (startResult.isErr()) {
+    logger.error(
+      {
+        panic: true,
+        workspaceId,
+        creditId: credit.id,
+        error: startResult.error,
+      },
+      "[Free Credits Yearly] Error starting credit"
+    );
+    getStatsDClient().increment("credits.top_up.error", 1, [
+      `workspace_id:${workspaceId}`,
+      "type:free_yearly",
+      `customer:${isEnterprise ? "enterprise" : "pro"}`,
+    ]);
+    return new Err(startResult.error);
+  }
+
+  getStatsDClient().increment("credits.top_up.success", 1, [
+    `workspace_id:${workspaceId}`,
+    "type:free_yearly",
+    `customer:${isEnterprise ? "enterprise" : "pro"}`,
+  ]);
+  logger.info(
+    {
+      workspaceId,
+      creditId: credit.id,
+      creditAmountMicroUsd,
+      periodStart,
+      periodEnd,
+    },
+    "[Free Credits Yearly] Successfully granted and activated free credit on yearly renewal"
+  );
+
+  await linkAndSyncMetronomeRecurringCredit({
+    workspace,
+    credit,
+    amountMicroUsd: creditAmountMicroUsd,
+  });
+
+  return new Ok(undefined);
+}
+
+function isYearlySubscription(
+  stripeSubscription: Stripe.Subscription
+): boolean {
+  const firstItem = stripeSubscription.items.data[0];
+  return firstItem?.price?.recurring?.interval === "year";
+}
+
+/**
+ * Grant the free programmatic-usage credit for a Stripe subscription,
+ * dispatching to the monthly or yearly variant based on the billing interval.
+ */
+export async function grantFreeCreditsForSubscription({
+  auth,
+  stripeSubscription,
+}: {
+  auth: Authenticator;
+  stripeSubscription: Stripe.Subscription;
+}): Promise<Result<undefined, Error>> {
+  if (isYearlySubscription(stripeSubscription)) {
+    return grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription,
+    });
+  }
+  return grantFreeCreditsFromSubscriptionStateChange({
+    auth,
+    stripeSubscription,
+  });
 }


### PR DESCRIPTION
## Description

Enterprise shadow contracts (#28234) and their packages (#28319) were removed, so the Metronome `credit.segment.start` recurring-credit path no longer fires for enterprise workspaces — they stopped receiving their monthly/yearly free programmatic-usage credits.

This reverts to the pre-#25129 mechanism **for all plans**: grant the free credit on the Stripe `customer.subscription.updated` / `customer.subscription.created` webhook, anchored to the Stripe billing period. Simpler, no shadow contracts, no reprovisioning script.

### Changes
- **`lib/credits/free.ts`**: restore `grantFreeCreditsFromSubscriptionStateChange` / `grantFreeCreditFromSubscriptionStateChangeYearly` (from git `5631abb557~1`) and add a `grantFreeCreditsForSubscription` dispatcher (monthly vs yearly). Idempotent per billing cycle via `free-renewal-{sub}-{periodStart}`.
- **`linkAndSyncMetronomeRecurringCredit`**: best-effort pushes the granted amount into the workspace's Metronome recurring free credit (`updateMetronomeCreditSegmentAmount`) and stamps `metronomeCreditId`, so Metronome-billed plans (legacy pro/business) keep their invoice offset **in sync**. No-op for enterprise / non-Metronome workspaces. DB credit is committed first, so a Metronome hiccup only affects invoice offset (reconciled by the sync script).
- **`lib/api/stripe/webhook_handler.ts`**: wire the grant into `customer.subscription.updated` and `customer.subscription.created`.
- **`lib/api/metronome/process_webhook.ts`**: remove the automatic free-credit grant on `credit.segment.start`. Kept `handleFreeCreditSegmentGrant` (poke plugin) and `grantFreeCreditFromMetronomeSegment` (fix script).
- **`lib/credits/free.test.ts`**: restore the grant unit tests.

## Tests

- `npx tsgo --noEmit` clean.
- `free.test.ts` → 42 passed (includes restored monthly + yearly grant suites).
- `npm run format:changed` clean.

## Risk

Low–medium (billing). No double-grant: legacy pro/business Metronome contracts still fire `credit.segment.start`, but that path no longer creates a DB credit — the Stripe path is the sole grantor and syncs the Metronome amount. Residual: the poke plugin can still be invoked manually (now effectively obsolete).

## Deploy Plan

Standard deploy. Grants happen on the next `customer.subscription.updated` per workspace; no backfill/reprovisioning required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)