### PR TITLE
Ignore h1-pentest test connectors in last-sync production check

### DIFF
--- a/front/lib/production_checks/checks/check_connectors_last_sync_success.ts
+++ b/front/lib/production_checks/checks/check_connectors_last_sync_success.ts
@@ -8,6 +8,9 @@ import type { ConnectorProvider } from "@app/types/data_source";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
 import { QueryTypes } from "sequelize";
 
+// Connectors in the h1-pentest workspace, which is a test we don't want to alert on.
+const IGNORED_CONNECTOR_IDS = [55901, 55902];
+
 interface ConnectorBlob {
   id: number;
   type: ConnectorProvider;
@@ -71,7 +74,9 @@ export const checkConnectorsLastSyncSuccess: CheckFunction = async (
       // Ignore webhook-based connectors, webcrawlers, and bot-type connectors
       !isWebhookBasedProvider(connector.type) &&
       !isBotTypeProvider(connector.type) &&
-      connector.type !== "webcrawler"
+      connector.type !== "webcrawler" &&
+      // Ignore test connectors
+      !IGNORED_CONNECTOR_IDS.includes(connector.id)
   );
   heartbeat();
 


### PR DESCRIPTION
## Summary

The "Connectors have not synced in the last week" production check was alerting on connectors `55901` and `55902`, which belong to the **h1-pentest** workspace — a test we don't want to alert on.

This adds an `IGNORED_CONNECTOR_IDS` list and filters those connectors out before the freshness check.

## Test plan

- Typecheck / biome pass via pre-commit hooks.
- The two connectors will no longer be considered by `checkConnectorsLastSyncSuccess`, so they can't trigger the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)