### PR TITLE
Automate deletion of old draft agents

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1665,6 +1665,74 @@ export async function batchHardDeletePendingAgentConfigurations(
 }
 
 /**
+ * Batch-deletes draft agent configurations and their related resources.
+ * Only call with drafts that are not referenced by any mention, since
+ * conversation rendering relies on the mentioned configuration.
+ */
+export async function batchHardDeleteDraftAgentConfigurations(
+  agents: AgentConfigurationModel[],
+  workspaceId: number
+) {
+  const agentIds = agents.map((a) => a.id);
+
+  const mcpConfigs = await AgentMCPServerConfigurationModel.findAll({
+    where: { agentConfigurationId: agentIds, workspaceId },
+    attributes: ["id"],
+  });
+  const mcpIds = mcpConfigs.map((c) => c.id);
+
+  await withTransaction(async (t) => {
+    if (mcpIds.length > 0) {
+      await AgentDataSourceConfigurationModel.destroy({
+        where: { mcpServerConfigurationId: { [Op.in]: mcpIds }, workspaceId },
+        transaction: t,
+      });
+
+      await AgentTablesQueryConfigurationTableModel.destroy({
+        where: { mcpServerConfigurationId: { [Op.in]: mcpIds }, workspaceId },
+        transaction: t,
+      });
+
+      await AgentChildAgentConfigurationModel.destroy({
+        where: { mcpServerConfigurationId: { [Op.in]: mcpIds }, workspaceId },
+        transaction: t,
+      });
+
+      await AgentMCPServerConfigurationModel.destroy({
+        where: { id: { [Op.in]: mcpIds }, workspaceId },
+        transaction: t,
+      });
+    }
+
+    await TagAgentModel.destroy({
+      where: { agentConfigurationId: agentIds, workspaceId },
+      transaction: t,
+    });
+
+    // Drafts do not get editor groups, but unlink defensively.
+    await GroupAgentModel.destroy({
+      where: { agentConfigurationId: agentIds, workspaceId },
+      transaction: t,
+    });
+
+    await AgentSkillModel.destroy({
+      where: { agentConfigurationId: agentIds, workspaceId },
+      transaction: t,
+    });
+
+    await AgentSuggestionModel.destroy({
+      where: { agentConfigurationId: agentIds, workspaceId },
+      transaction: t,
+    });
+
+    await AgentConfigurationModel.destroy({
+      where: { id: agentIds, workspaceId },
+      transaction: t,
+    });
+  });
+}
+
+/**
  * Updates the permissions (editors) for an agent configuration.
  */
 export async function updateAgentPermissions(

--- a/front/temporal/hard_delete/activities.test.ts
+++ b/front/temporal/hard_delete/activities.test.ts
@@ -1,17 +1,24 @@
 import { createPendingAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import {
+  MentionModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import {
+  purgeExpiredDraftAgentsActivity,
   purgeExpiredPendingAgentsActivity,
   purgeExpiredSyntheticSkillSuggestionsActivity,
 } from "@app/temporal/hard_delete/activities";
 import {
+  DRAFT_AGENTS_RETENTION_DAYS,
   PENDING_AGENTS_RETENTION_HOURS,
   SYNTHETIC_SUGGESTIONS_RETENTION_DAYS,
 } from "@app/temporal/hard_delete/utils";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
@@ -225,6 +232,150 @@ describe("purgeExpiredPendingAgentsActivity", () => {
     expect(
       await GroupResource.fetchByModelIds(authenticator, [activeGroupId])
     ).toHaveLength(1);
+  });
+});
+
+const PAST_DRAFT_THRESHOLD_MS =
+  (DRAFT_AGENTS_RETENTION_DAYS + 1) * 24 * 3600 * 1000;
+
+describe("purgeExpiredDraftAgentsActivity", () => {
+  it("deletes draft agents older than threshold", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const draft = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Old Draft", status: "draft" }
+    );
+
+    vi.advanceTimersByTime(PAST_DRAFT_THRESHOLD_MS);
+
+    await purgeExpiredDraftAgentsActivity();
+
+    const draftAfter = await AgentConfigurationModel.findOne({
+      where: { sId: draft.sId, workspaceId: workspace.id },
+    });
+    expect(draftAfter).toBeNull();
+  });
+
+  it("does not delete draft agents younger than threshold", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const draft = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Fresh Draft", status: "draft" }
+    );
+
+    await purgeExpiredDraftAgentsActivity();
+
+    const draftAfter = await AgentConfigurationModel.findOne({
+      where: { sId: draft.sId, workspaceId: workspace.id },
+    });
+    expect(draftAfter).not.toBeNull();
+    expect(draftAfter!.status).toBe("draft");
+  });
+
+  it("does not delete draft agents referenced by a mention", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const draft = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Used Draft", status: "draft" }
+    );
+
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: draft.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    const message = await MessageModel.findOne({
+      where: { conversationId: conversation.id, workspaceId: workspace.id },
+    });
+    expect(message).not.toBeNull();
+    await MentionModel.create({
+      workspaceId: workspace.id,
+      messageId: message!.id,
+      agentConfigurationId: draft.sId,
+      status: "approved",
+    });
+
+    vi.advanceTimersByTime(PAST_DRAFT_THRESHOLD_MS);
+
+    await purgeExpiredDraftAgentsActivity();
+
+    const draftAfter = await AgentConfigurationModel.findOne({
+      where: { sId: draft.sId, workspaceId: workspace.id },
+    });
+    expect(draftAfter).not.toBeNull();
+  });
+
+  it("does not delete active agents", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    await AgentConfigurationFactory.createTestAgent(authenticator, {
+      name: "Active Survivor",
+    });
+
+    vi.advanceTimersByTime(PAST_DRAFT_THRESHOLD_MS);
+
+    await purgeExpiredDraftAgentsActivity();
+
+    const agents = await AgentConfigurationModel.findAll({
+      where: { name: "Active Survivor", workspaceId: workspace.id },
+    });
+    expect(agents).toHaveLength(1);
+    expect(agents[0].status).toBe("active");
+  });
+
+  it("deletes all expired drafts across multiple batches, skipping mentioned ones", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const drafts = [];
+    for (let i = 0; i < 3; i++) {
+      drafts.push(
+        await AgentConfigurationFactory.createTestAgent(authenticator, {
+          name: `Draft ${i}`,
+          status: "draft",
+        })
+      );
+    }
+
+    // Mention the middle draft so it must survive.
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: drafts[1].sId,
+      messagesCreatedAt: [new Date()],
+    });
+    const message = await MessageModel.findOne({
+      where: { conversationId: conversation.id, workspaceId: workspace.id },
+    });
+    await MentionModel.create({
+      workspaceId: workspace.id,
+      messageId: message!.id,
+      agentConfigurationId: drafts[1].sId,
+      status: "approved",
+    });
+
+    vi.advanceTimersByTime(PAST_DRAFT_THRESHOLD_MS);
+
+    // Use batchSize=1 to force multiple pagination loops.
+    await purgeExpiredDraftAgentsActivity(1);
+
+    const remaining = await AgentConfigurationModel.findAll({
+      where: {
+        sId: drafts.map((d) => d.sId),
+        workspaceId: workspace.id,
+      },
+    });
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].sId).toBe(drafts[1].sId);
   });
 });
 

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -1,6 +1,10 @@
 // biome-ignore-all lint/plugin/noRawSql: hard delete activities require raw SQL for cascade deletions
-import { batchHardDeletePendingAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import {
+  batchHardDeleteDraftAgentConfigurations,
+  batchHardDeletePendingAgentConfigurations,
+} from "@app/lib/api/assistant/configuration/agent";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { MentionModel } from "@app/lib/models/agent/conversation";
 import { REINFORCEMENT_EXCLUDED_PLAN_CODES } from "@app/lib/plans/plan_codes";
 import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
@@ -12,6 +16,7 @@ import type {
   RunsJoinsRow,
 } from "@app/temporal/hard_delete/types";
 import {
+  getDraftAgentsDeletionCutoffDate,
   getPendingAgentsDeletionCutoffDate,
   getRunExecutionsDeletionCutoffDate,
   getSyntheticSuggestionsDeletionCutoffDate,
@@ -177,6 +182,86 @@ export async function purgeExpiredPendingAgentsActivity(
   logger.info(
     { totalDeleted },
     "Done purging expired pending agent configurations."
+  );
+}
+
+export async function purgeExpiredDraftAgentsActivity(
+  batchSize: number = BATCH_SIZE
+) {
+  const cutoffDate = getDraftAgentsDeletionCutoffDate();
+
+  logger.info(
+    {},
+    `About to purge draft agents created before ${cutoffDate.toISOString()}.`
+  );
+
+  const workspaces = await WorkspaceResource.listAll();
+
+  const deletedCounts = await concurrentExecutor(
+    workspaces,
+    async (workspace) => {
+      let deleted = 0;
+      let hasMore = true;
+      // Keyset pagination: mentioned drafts are skipped (not deleted), so
+      // re-querying from the start would loop on them forever.
+      let lastId = 0;
+
+      do {
+        const batch = await AgentConfigurationModel.findAll({
+          where: {
+            status: "draft",
+            createdAt: { [Op.lt]: cutoffDate },
+            workspaceId: workspace.id,
+            id: { [Op.gt]: lastId },
+          },
+          limit: batchSize,
+          order: [["id", "ASC"]],
+        });
+
+        hasMore = batch.length === batchSize;
+
+        if (batch.length > 0) {
+          lastId = batch[batch.length - 1].id;
+
+          // Drafts referenced by a mention were used in a conversation and
+          // must be kept: rendering the conversation needs their
+          // configuration.
+          const mentions = await MentionModel.findAll({
+            where: {
+              workspaceId: workspace.id,
+              agentConfigurationId: batch.map((a) => a.sId),
+            },
+            attributes: ["agentConfigurationId"],
+          });
+          const mentionedAgentIds = new Set(
+            mentions.map((m) => m.agentConfigurationId)
+          );
+
+          const deletableAgents = batch.filter(
+            (a) => !mentionedAgentIds.has(a.sId)
+          );
+          if (deletableAgents.length > 0) {
+            await batchHardDeleteDraftAgentConfigurations(
+              deletableAgents,
+              workspace.id
+            );
+            deleted += deletableAgents.length;
+          }
+        }
+
+        Context.current().heartbeat();
+      } while (hasMore);
+
+      return deleted;
+    },
+    { concurrency: WORKSPACE_CONCURRENCY }
+  );
+
+  const totalDeleted = deletedCounts.reduce((sum, count) => sum + count, 0);
+
+  logger.info(
+    { totalDeleted },
+    "Done purging expired draft agent configurations."
   );
 }
 

--- a/front/temporal/hard_delete/utils.ts
+++ b/front/temporal/hard_delete/utils.ts
@@ -37,6 +37,19 @@ export function getPendingAgentsDeletionCutoffDate(): Date {
 }
 
 /**
+ * Purge draft agents logic.
+ */
+
+export const DRAFT_AGENTS_RETENTION_DAYS = 7;
+
+export function getDraftAgentsDeletionCutoffDate(): Date {
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - DRAFT_AGENTS_RETENTION_DAYS);
+
+  return cutoffDate;
+}
+
+/**
  * Purge synthetic agent suggestions logic.
  */
 

--- a/front/temporal/hard_delete/workflows.ts
+++ b/front/temporal/hard_delete/workflows.ts
@@ -5,6 +5,7 @@ import { proxyActivities } from "@temporalio/workflow";
 const {
   purgeExpiredRunExecutionsActivity,
   purgeExpiredPendingAgentsActivity,
+  purgeExpiredDraftAgentsActivity,
   purgeExpiredSyntheticSkillSuggestionsActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "60 minutes",
@@ -13,5 +14,6 @@ const {
 export async function hardDeleteCronWorkflow(): Promise<void> {
   await purgeExpiredRunExecutionsActivity();
   await purgeExpiredPendingAgentsActivity();
+  await purgeExpiredDraftAgentsActivity();
   await purgeExpiredSyntheticSkillSuggestionsActivity();
 }

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -1,6 +1,9 @@
 import { createAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  AgentConfigurationType,
+  AgentStatus,
+} from "@app/types/assistant/agent";
 import type {
   ModelIdType,
   ModelProviderIdType,
@@ -15,6 +18,7 @@ export class AgentConfigurationFactory {
       name: string;
       description: string;
       scope: Exclude<AgentConfigurationType["scope"], "global">;
+      status: AgentStatus;
       model: {
         providerId: ModelProviderIdType;
         modelId: ModelIdType;
@@ -26,6 +30,7 @@ export class AgentConfigurationFactory {
     const name = overrides.name ?? "Test Agent";
     const description = overrides.description ?? "Test Agent Description";
     const scope = overrides.scope ?? "visible";
+    const status = overrides.status ?? "active";
     const providerId = overrides.model?.providerId ?? "openai";
     const modelId = overrides.model?.modelId ?? "gpt-4-turbo";
     const temperature = overrides.model?.temperature ?? 0.7;
@@ -40,7 +45,7 @@ export class AgentConfigurationFactory {
       instructions: "Test Instructions",
       instructionsHtml: null,
       pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
-      status: "active",
+      status,
       scope,
       model: {
         providerId,


### PR DESCRIPTION
## Description

We currently have ~600K draft agents in the US
This PR adds a workflow running daily to delete the draft agents older than 7 days and have no mention (the mentionned one are required to render the conversation).

This will delete ~500K draft agents which are older than 7 days and have no mention.

## Tests

added unit tests

## Risk

may accidentally delete unwanted agents

## Deploy Plan

deploy front
