### PR TITLE
fix(llm): don't route regionally-unavailable Anthropic models to Vertex

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -197,7 +197,16 @@ export async function getLegacyLLM(
       featureFlags.includes("use_vertex_for_supported_models"));
 
   if (isAnthropicWhitelistedModelId(modelId)) {
-    const useEapKey = getModelConfigByModelId(modelId)?.useEapKey ?? false;
+    const modelConfig = getModelConfigByModelId(modelId);
+    const useEapKey = modelConfig?.useEapKey ?? false;
+
+    // Vertex serves models from regional deployments, so only route to Vertex
+    // when the model actually has quota in the current region. A model that is
+    // not regionally available (e.g. Sonnet 5 in europe-west1) must fall back to
+    // the direct Anthropic API rather than hit a non-existent regional endpoint.
+    const regionallyAvailable =
+      modelConfig?.regionalAvailability[regionConfig.getCurrentRegion()] ===
+      true;
 
     // EAP models must hit the Anthropic API directly with the EAP key. Vertex
     // authenticates via GCP project creds and ignores ANTHROPIC_API_KEY, so
@@ -205,7 +214,8 @@ export async function getLegacyLLM(
     const useVertex =
       !useEapKey &&
       useVertexPrerequisite &&
-      isAnthropicVertexWhitelistedModelId(modelId);
+      isAnthropicVertexWhitelistedModelId(modelId) &&
+      regionallyAvailable;
 
     const anthropicCredentials = useEapKey
       ? withEapAnthropicKey(modelId, credentials)


### PR DESCRIPTION
## Problem

In an EU (`europe-west1`) workspace with **"EU-hosted models only" _disabled_**, the `claude-sonnet` agent resolves to **Claude Sonnet 5** and then fails: the request is routed to EU Vertex, where Sonnet 5 has no quota / deployment.

Two layers are involved:

- **Selection** (`isModelAvailable`, `lib/assistant.ts`) only filters out regionally-unavailable models when `regionalModelsOnly` (the "EU-hosted models only" setting) is **on**. With the setting **off**, Sonnet 5 (`regionalAvailability["europe-west1"]: false`) stays selectable, so the `claude-sonnet` agent picks it. (With the setting on, #28415 makes the agent fall back to Sonnet 4.6, which works — so the bug surfaces specifically when the setting is off.)
- **Runtime routing** — the **legacy** router (`getLegacyLLM`, used when `use_new_llm_router` is off) decides `useVertex` from deployment region + credit pricing + membership in `VERTEX_MODEL_ID_MAP`, but **never consults `regionalAvailability`**. Sonnet 5 is Vertex-whitelisted, so it gets routed to EU Vertex and fails. The legacy path does not look at `regionalModelsOnly` at all.

The new router already handles this correctly (with no region restriction it selects Sonnet 5's global/US endpoint), which is why the bug only reproduces with `use_new_llm_router` off.

Note: this also affects any custom agent explicitly pinned to `claude-sonnet-5`, independent of the "EU-hosted models only" setting, since a pinned model isn't re-filtered through selection.

## Fix

Gate `useVertex` on the model being regionally available in the current region. A Vertex-whitelisted model with no regional quota now falls back to the direct Anthropic API — the same global/US endpoint the new router selects.

| Model (EU deployment) | `regionalAvailability["europe-west1"]` | Before | After |
|---|---|---|---|
| Sonnet 4.6 | `true` | EU Vertex ✓ | EU Vertex ✓ (unchanged) |
| Sonnet 5 | `false` | EU Vertex → fails | direct Anthropic API (US) ✓ |

EAP models, US workspaces, and BYOK are unaffected (they short-circuit before this check).

## Testing

Type-check + biome clean. The legacy `useVertex` decision isn't reachable from a functional/endpoint test without a live Anthropic call (private field on `AnthropicLLM`; existing `llm.test.ts` is a live integration harness), consistent with the workspace testing rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)