### PR TITLE
[sparkle] Foundations stories as token reference tables

### DIFF
--- a/sparkle/src/stories/Borders.stories.tsx
+++ b/sparkle/src/stories/Borders.stories.tsx
@@ -1,0 +1,232 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { cn } from "@sparkle/lib/utils";
+
+import {
+  TokenChip,
+  useComputedStyle,
+  withThemedSurface,
+} from "./foundations-helpers";
+
+const meta = {
+  title: "Foundations/Borders",
+  tags: ["autodocs"],
+  decorators: [withThemedSurface],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `The border scale: corner radii (\`rounded-*\`) and stroke widths (\`border-*\`). Each token is shown as a reference row: live specimen, a click-to-copy class chip, its computed value (read from the compiled CSS), and a description of intended use. Border *colors* are structural color tokens — see the Surface & Structural table in **Foundations/Colors** (\`border\`, \`border-dark\`, \`border-focus\`, \`border-warning\`).`,
+      },
+    },
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type BorderRow = {
+  // Utility class documented by the row; the chip copies it.
+  name: string;
+  // Classes applied to the specimen (defaults to `name`).
+  specimenClassName?: string;
+  description?: React.ReactNode;
+};
+
+type BorderKind = "radius" | "width";
+
+const RADIUS_MEASURED = ["border-radius"] as const;
+const WIDTH_MEASURED = ["border-top-width"] as const;
+
+const BorderTableRow = ({
+  row,
+  kind,
+  withDescription,
+}: {
+  row: BorderRow;
+  kind: BorderKind;
+  withDescription: boolean;
+}) => {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const measured = useComputedStyle(
+    ref,
+    kind === "radius" ? RADIUS_MEASURED : WIDTH_MEASURED
+  );
+  const value =
+    kind === "radius"
+      ? measured["border-radius"]
+      : measured["border-top-width"];
+
+  const specimen =
+    kind === "radius" ? (
+      <div
+        ref={ref}
+        className={cn(
+          "h-14 w-14 bg-foreground",
+          row.specimenClassName ?? row.name
+        )}
+      />
+    ) : (
+      <div className="flex h-14 w-44 items-center">
+        <div
+          ref={ref}
+          className={cn(
+            "w-full border-foreground",
+            row.specimenClassName ?? row.name
+          )}
+        />
+      </div>
+    );
+
+  return (
+    <tr className="border-b border-border last:border-b-0">
+      <td className="w-52 py-3 pr-4 align-middle">{specimen}</td>
+      <td className="py-3 pr-4 align-middle">
+        <TokenChip value={row.name} />
+      </td>
+      <td className="whitespace-nowrap py-3 pr-4 align-middle font-mono text-xs text-muted-foreground">
+        {value || "—"}
+      </td>
+      {withDescription && (
+        <td className="py-3 align-middle text-sm text-muted-foreground">
+          {row.description ?? "—"}
+        </td>
+      )}
+    </tr>
+  );
+};
+
+// Mirrors the Colors TokenTable: specimen · copyable chip · live value ·
+// optional description, so every Foundations page reads the same way.
+const BorderTable = ({
+  rows,
+  kind,
+}: {
+  rows: BorderRow[];
+  kind: BorderKind;
+}) => {
+  const withDescription = rows.some((row) => row.description != null);
+  return (
+    <table className="w-full border-collapse text-left">
+      <thead>
+        <tr className="border-b border-border text-xs uppercase tracking-wide text-muted-foreground">
+          <th className="py-2 pr-4 font-medium">Preview</th>
+          <th className="py-2 pr-4 font-medium">Name</th>
+          <th className="py-2 pr-4 font-medium">Value</th>
+          {withDescription && <th className="py-2 font-medium">Description</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <BorderTableRow
+            key={row.name}
+            row={row}
+            kind={kind}
+            withDescription={withDescription}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+const Section = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-2">
+      <h2 className="text-xl font-semibold">{title}</h2>
+      {description}
+    </div>
+    {children}
+  </div>
+);
+
+export const BorderRadius: Story = {
+  render: () => (
+    <Section
+      title="Border Radius"
+      description={
+        <p className="text-sm text-primary-600">
+          The corner scale. Radius grows with the surface: small controls take
+          small radii, floating surfaces take larger ones.
+        </p>
+      }
+    >
+      <BorderTable
+        kind="radius"
+        rows={[
+          { name: "rounded-none" },
+          { name: "rounded-xs" },
+          { name: "rounded-sm" },
+          {
+            name: "rounded-md",
+            description: "Small controls: checkboxes, inline chips.",
+          },
+          {
+            name: "rounded-lg",
+            description: "Menu and list items, small buttons.",
+          },
+          {
+            name: "rounded-xl",
+            description: "Buttons, dropdown and popover containers.",
+          },
+          {
+            name: "rounded-2xl",
+            description: "Dialogs, cards, and input surfaces.",
+          },
+          { name: "rounded-3xl" },
+          { name: "rounded-4xl", description: "The largest hero surfaces." },
+          {
+            name: "rounded-full",
+            description: "Avatars, pills, and status dots.",
+          },
+        ]}
+      />
+    </Section>
+  ),
+};
+
+export const BorderWidth: Story = {
+  render: () => (
+    <Section
+      title="Border Width"
+      description={
+        <p className="text-sm text-primary-600">
+          Stroke widths. Nearly everything uses the 1px default; heavier strokes
+          are for emphasis like focus rings and selected states.
+        </p>
+      }
+    >
+      <BorderTable
+        kind="width"
+        rows={[
+          {
+            name: "border-0",
+            specimenClassName: "border-t-0",
+            description: "Removes a border.",
+          },
+          {
+            name: "border",
+            specimenClassName: "border-t",
+            description: "The default hairline for containers and dividers.",
+          },
+          {
+            name: "border-2",
+            specimenClassName: "border-t-2",
+            description: "Emphasis: focus and selected states.",
+          },
+          { name: "border-4", specimenClassName: "border-t-4" },
+          { name: "border-8", specimenClassName: "border-t-8" },
+        ]}
+      />
+    </Section>
+  ),
+};

--- a/sparkle/src/stories/Motion.stories.tsx
+++ b/sparkle/src/stories/Motion.stories.tsx
@@ -1,17 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useState } from "react";
 
-import { Play } from "../index_with_tw_base";
-import { Copyable, useCssVar, withThemedSurface } from "./foundations-helpers";
+import { TokenChip, useCssVar, withThemedSurface } from "./foundations-helpers";
 
 const meta = {
   title: "Foundations/Motion",
+  tags: ["autodocs"],
   decorators: [withThemedSurface],
   parameters: {
-    layout: "centered",
+    layout: "padded",
     docs: {
       description: {
-        component: `Motion tokens as Tailwind utilities. Two decisions: **easing** (entering/exiting → ease-out, moving on screen → ease-in-out) and **duration** (bigger element → longer). Prefer the semantic aliases (\`ease-enter\`, \`duration-enter\`, …).`,
+        component: `Motion tokens as Tailwind utilities. Two decisions: **easing** (entering/exiting → ease-out, moving on screen → ease-in-out) and **duration** (bigger element → longer). Prefer the semantic aliases (\`ease-enter\`, \`duration-enter\`, …). Each token is shown as a reference row: a continuously looping specimen (a ball tracing the curve, a square spinning at the duration), a click-to-copy class chip, its resolved value, and a description of intended use.`,
       },
     },
   },
@@ -20,301 +20,361 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-interface MotionToken {
-  label: string;
-  easingClass?: string;
-  // Raw CSS value for curves that have no token on purpose (ease-in demo).
-  easingStyle?: string;
-  durationClass?: string;
-  circleClass?: string;
-  note?: string;
-}
+const SLIDE_KEYFRAMES = "sb-motion-slide";
+const SPIN_KEYFRAMES = "sb-motion-spin";
 
-interface MotionGroup {
-  group: string;
-  description: string;
-  items: MotionToken[];
-}
+// Keyframes for the looping specimens. The slide moves during the first 65%
+// and holds the rest, so each loop reads as one gesture with a beat between.
+const MotionKeyframes = () => (
+  <style>{`
+    @keyframes ${SLIDE_KEYFRAMES} {
+      0% { transform: translateX(0); }
+      65% { transform: translateX(8.25rem); }
+      100% { transform: translateX(8.25rem); }
+    }
+    @keyframes ${SPIN_KEYFRAMES} {
+      to { transform: rotate(360deg); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .sb-motion-specimen {
+        /* The specimens animate via inline style; only !important wins here. */
+        animation: none !important;
+      }
+    }
+  `}</style>
+);
 
-const EASING_GROUPS: MotionGroup[] = [
-  {
-    group: "Ease Out",
-    description:
-      "For anything entering or exiting the screen. The fast start feels responsive. Sorted weak → strong: bigger elements take stronger curves.",
-    items: [
-      {
-        label: "out-quad",
-        easingClass: "ease-out-quad",
-        note: "subtle: button press, small fades",
-      },
-      {
-        label: "out-cubic",
-        easingClass: "ease-out-cubic",
-        note: "the everyday default",
-      },
-      { label: "out-quart", easingClass: "ease-out-quart" },
-      {
-        label: "out-quint",
-        easingClass: "ease-out-quint",
-        note: "pronounced settle: modals, drawers",
-      },
-      {
-        label: "out-expo",
-        easingClass: "ease-out-expo",
-        note: "very snappy: large surfaces, sheets",
-      },
-    ],
-  },
-  {
-    group: "Ease In-Out",
-    description:
-      "For elements already on screen that move or morph. Never for enter/exit — the slow start delays feedback.",
-    items: [
-      {
-        label: "in-out-quad",
-        easingClass: "ease-in-out-quad",
-        note: "gentle: small position shifts",
-      },
-      {
-        label: "in-out-cubic",
-        easingClass: "ease-in-out-cubic",
-        note: "standard on-screen movement",
-      },
-      {
-        label: "in-out-quint",
-        easingClass: "ease-in-out-quint",
-        note: "dramatic: full-screen morphs",
-      },
-    ],
-  },
-  {
-    group: "Semantic aliases",
-    description:
-      "Prefer these in components so you can retune the whole system from one place.",
-    items: [
-      {
-        label: "enter",
-        easingClass: "ease-enter",
-        note: "= out-cubic — tooltips, dropdowns, popovers",
-      },
-      {
-        label: "emphasized",
-        easingClass: "ease-emphasized",
-        note: "= out-quint — modals, drawers",
-      },
-      {
-        label: "move",
-        easingClass: "ease-move",
-        note: "= in-out-quad — tab indicators, reorder",
-      },
-    ],
-  },
-];
-
-const EASE_IN_COMPARISON: MotionGroup = {
-  group: "Why there is no ease-in",
-  description:
-    "Ease-in starts slow and accelerates into the stop — the UI feels sluggish, so there are no ease-in tokens. For hovers use the default ease; ease-linear is for progress and marquees only.",
-  items: [
-    {
-      label: "out-cubic",
-      easingClass: "ease-out-cubic",
-      circleClass: "bg-green-500",
-      note: "responds instantly, settles naturally",
-    },
-    {
-      label: "ease-in",
-      easingStyle: "cubic-bezier(0.55, 0.085, 0.68, 0.53)",
-      circleClass: "bg-red-500",
-      note: "sluggish start, abrupt stop — avoid",
-    },
-  ],
+type MotionRow = {
+  // Utility class documented by the row; the chip copies it.
+  name: string;
+  // Raw CSS easing for curves that have no token on purpose (ease-in demo).
+  rawEasing?: string;
+  description?: React.ReactNode;
 };
 
-const DURATION_GROUPS: MotionGroup[] = [
-  {
-    group: "Primitives",
-    description:
-      "300ms is the ceiling for product UI. Anything used 100+ times a day: no animation at all.",
-    items: [
-      {
-        label: "duration-100",
-        durationClass: "duration-100",
-        note: "micro-interactions (press, toggle)",
-      },
-      {
-        label: "duration-150",
-        durationClass: "duration-150",
-        note: "hover & color transitions",
-      },
-      {
-        label: "duration-200",
-        durationClass: "duration-200",
-        note: "standard UI (tooltips, dropdowns)",
-      },
-      {
-        label: "duration-300",
-        durationClass: "duration-300",
-        note: "modals & drawers — the ceiling",
-      },
-    ],
-  },
-  {
-    group: "Semantic durations",
-    description:
-      "Exits run ~20% faster than entrances — these names encode the rule for you.",
-    items: [
-      {
-        label: "duration-enter",
-        durationClass: "duration-enter",
-        note: "200ms — standard UI appearing",
-      },
-      {
-        label: "duration-exit",
-        durationClass: "duration-exit",
-        note: "160ms — same element leaving",
-      },
-      {
-        label: "duration-modal-enter",
-        durationClass: "duration-modal-enter",
-        note: "300ms — largest surfaces",
-      },
-      {
-        label: "duration-modal-exit",
-        durationClass: "duration-modal-exit",
-        note: "240ms — largest surfaces leaving",
-      },
-    ],
-  },
-];
+type MotionKind = "easing" | "duration";
 
-function MotionRow({
-  label,
-  easingClass,
-  easingStyle,
-  durationClass,
-  circleClass = "bg-foreground",
-  note,
-  playSignal,
-}: MotionToken & { playSignal?: number }) {
-  const effectiveEasing = easingStyle ? "" : (easingClass ?? "ease-out-cubic");
-  const effectiveDuration = durationClass ?? "duration-1000";
+// The duration utilities: numeric ones (duration-200) resolve to a literal,
+// semantic ones (duration-enter) to their --transition-duration-* variable.
+const durationSuffix = (name: string) =>
+  name.startsWith("duration-") ? name.slice("duration-".length) : "";
 
-  // A row demoes either an easing or a duration. The other axis is a default.
-  const isDurationSubject =
-    durationClass !== undefined && easingClass === undefined && !easingStyle;
-  const copyValue = isDurationSubject ? durationClass : (easingClass ?? "");
+const MotionTableRow = ({
+  row,
+  kind,
+  withDescription,
+}: {
+  row: MotionRow;
+  kind: MotionKind;
+  withDescription: boolean;
+}) => {
+  const suffix = durationSuffix(row.name);
+  const isNumericDuration = /^\d+$/.test(suffix);
 
-  // Resolve the token's live value: cubic-bezier for easings, ms for durations.
-  const easingValue = useCssVar(easingClass ? `--${easingClass}` : "");
-  const durationSuffix = durationClass?.startsWith("duration-")
-    ? durationClass.slice("duration-".length)
-    : "";
-  const durationIsNumeric = /^\d+$/.test(durationSuffix);
-  const durationVarValue = useCssVar(
-    durationIsNumeric ? "" : `--transition-duration-${durationSuffix}`
-  );
-  const resolvedValue = easingStyle
-    ? easingStyle
-    : isDurationSubject
-      ? durationIsNumeric
-        ? `${durationSuffix}ms`
-        : durationVarValue
-      : easingValue;
+  const cssVarName =
+    kind === "easing"
+      ? row.rawEasing
+        ? ""
+        : `--${row.name}`
+      : isNumericDuration
+        ? ""
+        : `--transition-duration-${suffix}`;
+  const varValue = useCssVar(cssVarName);
+  const resolvedValue =
+    row.rawEasing ?? (isNumericDuration ? `${suffix}ms` : varValue);
 
-  const [animate, setAnimate] = useState(false);
-  // Replay needs the box to snap back to the start without animating,
-  // so the transition is disabled for the reset frame.
-  const [resetting, setResetting] = useState(false);
-
-  const play = useCallback(() => {
-    setResetting(true);
-    setAnimate(false);
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        setResetting(false);
-        setAnimate(true);
-      });
-    });
-  }, []);
-
-  useEffect(() => {
-    if (playSignal !== undefined && playSignal > 0) {
-      play();
-    }
-  }, [playSignal, play]);
-
-  return (
-    <div className="flex items-center gap-2">
-      <button
-        onClick={play}
-        aria-label={`Play ${label}`}
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-primary-100 hover:text-foreground"
-      >
-        <Play className="h-4 w-4" />
-      </button>
-      <div className="w-44 shrink-0">
-        {copyValue ? (
-          <Copyable value={copyValue}>
-            <div className="font-mono text-xs text-foreground">{label}</div>
-            {resolvedValue && (
-              <div className="break-all font-mono text-[10px] text-muted-foreground">
-                {resolvedValue}
-              </div>
-            )}
-          </Copyable>
-        ) : (
-          <>
-            <div className="font-mono text-xs text-foreground">{label}</div>
-            {resolvedValue && (
-              <div className="break-all font-mono text-[10px] text-muted-foreground">
-                {resolvedValue}
-              </div>
-            )}
-          </>
-        )}
-        {note && <div className="text-xs text-muted-foreground">{note}</div>}
-      </div>
-      <div className="relative h-10 w-full rounded-full bg-primary-100">
+  const specimen =
+    kind === "easing" ? (
+      <div className="relative h-8 w-44 rounded-full bg-primary-100">
         <div
-          className={`absolute top-2 h-6 w-6 rounded-full ${circleClass} ${
-            resetting
-              ? "transition-none"
-              : `transition-all ${effectiveEasing} ${effectiveDuration}`
-          }`}
+          className="sb-motion-specimen absolute left-1.5 top-1.5 h-5 w-5 rounded-full bg-foreground"
           style={{
-            left: animate ? "calc(100% - 2rem)" : "0.5rem",
-            transitionTimingFunction: resetting ? undefined : easingStyle,
+            animation: `${SLIDE_KEYFRAMES} 1400ms infinite`,
+            animationTimingFunction: row.rawEasing ?? `var(--${row.name})`,
           }}
         />
       </div>
-    </div>
-  );
-}
-
-function MotionGroupSection({ group, description, items }: MotionGroup) {
-  const [playSignal, setPlaySignal] = useState(0);
+    ) : (
+      <div className="flex h-8 w-44 items-center">
+        <div
+          className="sb-motion-specimen h-6 w-6 rounded bg-foreground"
+          style={{
+            animation: `${SPIN_KEYFRAMES} linear infinite`,
+            animationDuration: isNumericDuration
+              ? `${suffix}ms`
+              : `var(--transition-duration-${suffix})`,
+          }}
+        />
+      </div>
+    );
 
   return (
-    <div className="flex flex-col gap-3">
-      <div>
-        <div className="flex items-center gap-3">
-          <h3 className="text-lg font-semibold">{group}</h3>
-          <button
-            onClick={() => setPlaySignal((n) => n + 1)}
-            className="rounded border border-border px-3 py-1 text-xs font-medium text-muted-foreground hover:bg-primary-100"
-          >
-            Play all
-          </button>
-        </div>
-        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
-      </div>
-      {items.map((item) => (
-        <MotionRow key={item.label} {...item} playSignal={playSignal} />
-      ))}
-    </div>
+    <tr className="border-b border-border last:border-b-0">
+      <td className="w-52 py-3 pr-4 align-middle">{specimen}</td>
+      <td className="py-3 pr-4 align-middle">
+        {row.rawEasing ? (
+          // No token on purpose — show a plain label instead of a copy chip.
+          <span className="font-mono text-xs text-muted-foreground">
+            {row.name}
+          </span>
+        ) : (
+          <TokenChip value={row.name} />
+        )}
+      </td>
+      <td className="whitespace-nowrap py-3 pr-4 align-middle font-mono text-xs text-muted-foreground">
+        {resolvedValue || "—"}
+      </td>
+      {withDescription && (
+        <td className="py-3 align-middle text-sm text-muted-foreground">
+          {row.description ?? "—"}
+        </td>
+      )}
+    </tr>
   );
-}
+};
+
+// Mirrors the Colors TokenTable: specimen · copyable chip · live value ·
+// optional description, so every Foundations page reads the same way.
+const MotionTable = ({
+  rows,
+  kind,
+}: {
+  rows: MotionRow[];
+  kind: MotionKind;
+}) => {
+  const withDescription = rows.some((row) => row.description != null);
+  return (
+    <table className="w-full border-collapse text-left">
+      <thead>
+        <tr className="border-b border-border text-xs uppercase tracking-wide text-muted-foreground">
+          <th className="py-2 pr-4 font-medium">Preview</th>
+          <th className="py-2 pr-4 font-medium">Name</th>
+          <th className="py-2 pr-4 font-medium">Value</th>
+          {withDescription && <th className="py-2 font-medium">Description</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <MotionTableRow
+            key={row.name}
+            row={row}
+            kind={kind}
+            withDescription={withDescription}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+const Section = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-2">
+      <h2 className="text-xl font-semibold">{title}</h2>
+      {description}
+    </div>
+    {children}
+  </div>
+);
+
+export const Easing: Story = {
+  render: () => (
+    <div className="flex flex-col gap-12">
+      <MotionKeyframes />
+      <Section
+        title="Ease Out"
+        description={
+          <p className="text-sm text-primary-600">
+            For anything entering or exiting the screen — the fast start feels
+            responsive. Sorted weak → strong: bigger elements take stronger
+            curves.
+          </p>
+        }
+      >
+        <MotionTable
+          kind="easing"
+          rows={[
+            {
+              name: "ease-out-quad",
+              description: "Subtle: button press, small fades.",
+            },
+            {
+              name: "ease-out-cubic",
+              description: "The everyday default.",
+            },
+            { name: "ease-out-quart" },
+            {
+              name: "ease-out-quint",
+              description: "Pronounced settle: modals, drawers.",
+            },
+            {
+              name: "ease-out-expo",
+              description: "Very snappy: large surfaces, sheets.",
+            },
+          ]}
+        />
+      </Section>
+      <Section
+        title="Ease In-Out"
+        description={
+          <p className="text-sm text-primary-600">
+            For elements already on screen that move or morph. Never for
+            enter/exit — the slow start delays feedback.
+          </p>
+        }
+      >
+        <MotionTable
+          kind="easing"
+          rows={[
+            {
+              name: "ease-in-out-quad",
+              description: "Gentle: small position shifts.",
+            },
+            {
+              name: "ease-in-out-cubic",
+              description: "Standard on-screen movement.",
+            },
+            {
+              name: "ease-in-out-quint",
+              description: "Dramatic: full-screen morphs.",
+            },
+          ]}
+        />
+      </Section>
+      <Section
+        title="Semantic aliases"
+        description={
+          <p className="text-sm text-primary-600">
+            Prefer these in components so the whole system can be retuned from
+            one place.
+          </p>
+        }
+      >
+        <MotionTable
+          kind="easing"
+          rows={[
+            {
+              name: "ease-enter",
+              description: "= out-cubic — tooltips, dropdowns, popovers.",
+            },
+            {
+              name: "ease-emphasized",
+              description: "= out-quint — modals, drawers.",
+            },
+            {
+              name: "ease-move",
+              description: "= in-out-quad — tab indicators, reorder.",
+            },
+          ]}
+        />
+      </Section>
+      <Section
+        title="Why there is no ease-in"
+        description={
+          <p className="text-sm text-primary-600">
+            Ease-in starts slow and accelerates into the stop — the UI feels
+            sluggish, so there are no ease-in tokens. For hovers use the default
+            ease; ease-linear is for progress and marquees only.
+          </p>
+        }
+      >
+        <MotionTable
+          kind="easing"
+          rows={[
+            {
+              name: "ease-out-cubic",
+              description: "Responds instantly, settles naturally.",
+            },
+            {
+              name: "ease-in",
+              rawEasing: "cubic-bezier(0.55, 0.085, 0.68, 0.53)",
+              description: "Sluggish start, abrupt stop — avoid.",
+            },
+          ]}
+        />
+      </Section>
+    </div>
+  ),
+};
+
+export const Durations: Story = {
+  render: () => (
+    <div className="flex flex-col gap-12">
+      <MotionKeyframes />
+      <Section
+        title="Durations"
+        description={
+          <p className="text-sm text-primary-600">
+            Bigger elements need more time; each square completes one turn per
+            token duration. 300ms is the ceiling for product UI — anything used
+            100+ times a day gets no animation at all.
+          </p>
+        }
+      >
+        <MotionTable
+          kind="duration"
+          rows={[
+            {
+              name: "duration-100",
+              description: "Micro-interactions (press, toggle).",
+            },
+            {
+              name: "duration-150",
+              description: "Hover & color transitions.",
+            },
+            {
+              name: "duration-200",
+              description: "Standard UI (tooltips, dropdowns).",
+            },
+            {
+              name: "duration-300",
+              description: "Modals & drawers — the ceiling.",
+            },
+          ]}
+        />
+      </Section>
+      <Section
+        title="Semantic durations"
+        description={
+          <p className="text-sm text-primary-600">
+            Exits run ~20% faster than entrances — these names encode the rule
+            for you.
+          </p>
+        }
+      >
+        <MotionTable
+          kind="duration"
+          rows={[
+            {
+              name: "duration-enter",
+              description: "Standard UI appearing.",
+            },
+            {
+              name: "duration-exit",
+              description: "The same element leaving.",
+            },
+            {
+              name: "duration-modal-enter",
+              description: "The largest surfaces appearing.",
+            },
+            {
+              name: "duration-modal-exit",
+              description: "The largest surfaces leaving.",
+            },
+          ]}
+        />
+      </Section>
+    </div>
+  ),
+};
 
 interface EnterExitDemoProps {
   label: string;
@@ -362,48 +422,13 @@ function EnterExitDemo({
   );
 }
 
-export const Easing: Story = {
-  render: () => (
-    <div className="flex w-[640px] flex-col gap-8 p-8">
-      <div>
-        <h2 className="text-xl font-semibold">Easing</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Entering or exiting the screen → ease-out. Moving while on screen →
-          ease-in-out.
-        </p>
-      </div>
-      {EASING_GROUPS.map((group) => (
-        <MotionGroupSection key={group.group} {...group} />
-      ))}
-      <MotionGroupSection {...EASE_IN_COMPARISON} />
-    </div>
-  ),
-};
-
-export const Durations: Story = {
-  render: () => (
-    <div className="flex w-[640px] flex-col gap-8 p-8">
-      <div>
-        <h2 className="text-xl font-semibold">Durations</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Bigger elements need more time. Use “Play all” to compare (all rows
-          use ease-out-cubic).
-        </p>
-      </div>
-      {DURATION_GROUPS.map((group) => (
-        <MotionGroupSection key={group.group} {...group} />
-      ))}
-    </div>
-  ),
-};
-
 export const EnterExitPairing: Story = {
   render: () => (
-    <div className="flex w-[640px] flex-col gap-8 p-8">
+    <div className="flex max-w-2xl flex-col gap-8">
       <div>
         <h2 className="text-xl font-semibold">Pairing the tokens</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          Pick the pair that matches the element’s size. The exit is quicker
+          Pick the pair that matches the element's size. The exit is quicker
           than the entrance.
         </p>
       </div>

--- a/sparkle/src/stories/Shadows.stories.tsx
+++ b/sparkle/src/stories/Shadows.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
+import { cn } from "@sparkle/lib/utils";
+
 import {
-  Copyable,
+  TokenChip,
   useComputedStyle,
   withThemedSurface,
 } from "./foundations-helpers";
@@ -12,10 +14,10 @@ const meta = {
   tags: ["autodocs"],
   decorators: [withThemedSurface],
   parameters: {
-    layout: "centered",
+    layout: "padded",
     docs: {
       description: {
-        component: `The elevation scale: box shadows (\`shadow\` through \`shadow-2xl\`) for surfaces and drop shadows (\`drop-shadow-*\`) for irregular shapes. Apply these Tailwind utilities to convey elevation consistently, reserving larger shadows for higher, more transient surfaces like popovers and dialogs. In dark mode the surface tokens \`bg-panel-background\`, \`bg-overlay-background\`, and \`bg-modal-background\` carry built-in elevation shadows that override these utilities — see Surface Elevation below. Click a specimen to copy its class; the caption shows the live computed value. Specimens sit on a \`muted-background\` surface so elevation reads in both light and dark themes.`,
+        component: `The elevation scale: box shadows (\`shadow\` through \`shadow-2xl\`) for surfaces and drop shadows (\`drop-shadow-*\`) for irregular shapes. Apply these Tailwind utilities to convey elevation consistently, reserving larger shadows for higher, more transient surfaces like popovers and dialogs. In dark mode the surface tokens \`bg-panel-background\`, \`bg-overlay-background\`, and \`bg-modal-background\` carry built-in elevation shadows that override these utilities — see Surface Elevation below. Each token is shown as a reference row: live specimen on a \`muted-background\` plate, a click-to-copy class chip, its computed value (read from the compiled CSS), and a description of intended use.`,
       },
     },
   },
@@ -24,21 +26,28 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+type ShadowRow = {
+  // Utility class documented by the row; the chip copies this.
+  name: string;
+  // Classes applied to the specimen box (defaults to `bg-background ${name}`).
+  boxClassName?: string;
+  description?: React.ReactNode;
+};
+
+// Which computed property carries the value for this kind of shadow.
+type MeasureKind = "box-shadow" | "filter";
+
 const BOX_MEASURED = ["box-shadow"] as const;
 const FILTER_MEASURED = ["filter"] as const;
 
-const ShadowBox = ({
-  label,
-  shadowClass,
+const ShadowTableRow = ({
+  row,
   measure,
-  surface = "bg-background",
+  withDescription,
 }: {
-  label: string;
-  shadowClass: string;
-  // Which computed property carries the value for this kind of shadow.
-  measure: "box-shadow" | "filter";
-  // The fill of the specimen box; surface-token specimens supply their own.
-  surface?: string;
+  row: ShadowRow;
+  measure: MeasureKind;
+  withDescription: boolean;
 }) => {
   const ref = React.useRef<HTMLDivElement>(null);
   const measured = useComputedStyle(
@@ -48,104 +57,177 @@ const ShadowBox = ({
   const value = measured[measure];
 
   return (
-    <Copyable value={shadowClass} className="flex flex-col items-center gap-2">
-      <div
-        className={`h-24 w-24 rounded-lg ${surface} ${shadowClass}`}
-        ref={ref}
-      />
-      <div className="flex flex-col items-center">
-        <span className="font-mono text-sm text-primary-600">
-          {shadowClass}
-        </span>
-        <span className="max-w-40 truncate font-mono text-[10px] text-muted-foreground">
-          {value && value !== "none" ? value : "—"}
-        </span>
-      </div>
-    </Copyable>
+    <tr className="border-b border-border last:border-b-0">
+      <td className="w-48 py-3 pr-4 align-middle">
+        {/* A muted plate under each specimen so elevation reads in both
+            themes, like the swatch column in the Colors tables. */}
+        <div className="rounded-lg bg-muted-background p-4">
+          <div
+            ref={ref}
+            className={cn(
+              "h-14 w-full rounded-lg",
+              row.boxClassName ?? `bg-background ${row.name}`
+            )}
+          />
+        </div>
+      </td>
+      <td className="py-3 pr-4 align-middle">
+        <TokenChip value={row.name} />
+      </td>
+      <td className="max-w-md py-3 pr-4 align-middle font-mono text-xs text-muted-foreground">
+        {value && value !== "none" ? value : "—"}
+      </td>
+      {withDescription && (
+        <td className="py-3 align-middle text-sm text-muted-foreground">
+          {row.description ?? "—"}
+        </td>
+      )}
+    </tr>
   );
 };
 
-const boxShadows = [
-  "shadow",
-  "shadow-md",
-  "shadow-lg",
-  "shadow-xl",
-  "shadow-2xl",
-] as const;
+// Mirrors the Colors TokenTable: specimen · copyable chip · live value ·
+// optional description, so every Foundations page reads the same way.
+const ShadowTable = ({
+  rows,
+  measure = "box-shadow",
+}: {
+  rows: ShadowRow[];
+  measure?: MeasureKind;
+}) => {
+  const withDescription = rows.some((row) => row.description != null);
+  return (
+    <table className="w-full border-collapse text-left">
+      <thead>
+        <tr className="border-b border-border text-xs uppercase tracking-wide text-muted-foreground">
+          <th className="py-2 pr-4 font-medium">Preview</th>
+          <th className="py-2 pr-4 font-medium">Name</th>
+          <th className="py-2 pr-4 font-medium">Value</th>
+          {withDescription && <th className="py-2 font-medium">Description</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <ShadowTableRow
+            key={row.name}
+            row={row}
+            measure={measure}
+            withDescription={withDescription}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
+};
 
-const dropShadows = [
-  "drop-shadow",
-  "drop-shadow-sm",
-  "drop-shadow-md",
-  "drop-shadow-lg",
-  "drop-shadow-xl",
-  "drop-shadow-2xl",
-] as const;
+const Section = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-2">
+      <h2 className="text-xl font-semibold">{title}</h2>
+      {description}
+    </div>
+    {children}
+  </div>
+);
 
 export const BoxShadows: Story = {
   render: () => (
-    <div className="rounded-xl bg-muted-background p-8">
-      <h2 className="mb-6 text-xl font-semibold">Box Shadows</h2>
-      <div className="flex flex-wrap gap-8">
-        {boxShadows.map((shadowClass) => (
-          <ShadowBox
-            key={shadowClass}
-            label={shadowClass}
-            shadowClass={shadowClass}
-            measure="box-shadow"
-          />
-        ))}
-      </div>
-    </div>
+    <Section
+      title="Box Shadows"
+      description={
+        <p className="text-sm text-primary-600">
+          The elevation ladder for rectangular surfaces. Bigger shadows mean
+          higher, more transient surfaces.
+        </p>
+      }
+    >
+      <ShadowTable
+        rows={[
+          { name: "shadow", description: "Subtle lift: cards at rest." },
+          { name: "shadow-md", description: "Raised cards and hover states." },
+          {
+            name: "shadow-lg",
+            description: "Dropdowns, popovers, and tooltips.",
+          },
+          { name: "shadow-xl", description: "Dialogs and sheets." },
+          {
+            name: "shadow-2xl",
+            description: "The highest, most transient surfaces.",
+          },
+        ]}
+      />
+    </Section>
   ),
 };
 
-const elevatedSurfaces = [
-  "bg-panel-background",
-  "bg-overlay-background",
-  "bg-modal-background",
-] as const;
-
 export const SurfaceElevation: Story = {
   render: () => (
-    <div className="rounded-xl bg-app-background p-8">
-      <h2 className="mb-2 text-xl font-semibold">Surface Elevation</h2>
-      <p className="mb-6 max-w-lg text-sm text-muted-foreground">
-        In dark mode these surface tokens carry built-in shadows (panel &lt;
-        overlay &lt; modal) that override shadow-* utilities on the same
-        element, and a surface nested inside the same surface casts none. In
-        light mode they are flat — pair them with the box shadows above. Toggle
-        the theme to compare.
-      </p>
-      <div className="flex flex-wrap gap-8">
-        {elevatedSurfaces.map((surfaceClass) => (
-          <ShadowBox
-            key={surfaceClass}
-            label={surfaceClass}
-            shadowClass={surfaceClass}
-            surface=""
-            measure="box-shadow"
-          />
-        ))}
-      </div>
-    </div>
+    <Section
+      title="Surface Elevation"
+      description={
+        <p className="text-sm text-primary-600">
+          In dark mode these surface tokens carry built-in shadows (panel &lt;
+          overlay &lt; modal) that override shadow-* utilities on the same
+          element, and a surface nested inside the same surface casts none. In
+          light mode they are flat — pair them with the box shadows above.
+          Toggle the theme to compare.
+        </p>
+      }
+    >
+      <ShadowTable
+        rows={[
+          {
+            name: "bg-panel-background",
+            boxClassName: "bg-panel-background",
+            description: "Panels and cards — the lowest elevation step.",
+          },
+          {
+            name: "bg-overlay-background",
+            boxClassName: "bg-overlay-background",
+            description: "Dropdowns, popovers, and tooltips.",
+          },
+          {
+            name: "bg-modal-background",
+            boxClassName: "bg-modal-background",
+            description: "Dialogs and sheets — the highest elevation.",
+          },
+        ]}
+      />
+    </Section>
   ),
 };
 
 export const DropShadows: Story = {
   render: () => (
-    <div className="rounded-xl bg-muted-background p-8">
-      <h2 className="mb-6 text-xl font-semibold">Drop Shadows</h2>
-      <div className="flex flex-wrap gap-8">
-        {dropShadows.map((shadowClass) => (
-          <ShadowBox
-            key={shadowClass}
-            label={shadowClass}
-            shadowClass={shadowClass}
-            measure="filter"
-          />
-        ))}
-      </div>
-    </div>
+    <Section
+      title="Drop Shadows"
+      description={
+        <p className="text-sm text-primary-600">
+          Filter-based shadows that follow an element's rendered silhouette —
+          use for irregular shapes (icons, images with transparency) where a box
+          shadow would draw a rectangle.
+        </p>
+      }
+    >
+      <ShadowTable
+        measure="filter"
+        rows={[
+          { name: "drop-shadow" },
+          { name: "drop-shadow-sm" },
+          { name: "drop-shadow-md" },
+          { name: "drop-shadow-lg" },
+          { name: "drop-shadow-xl" },
+          { name: "drop-shadow-2xl" },
+        ]}
+      />
+    </Section>
   ),
 };

--- a/sparkle/src/stories/Spacing.stories.tsx
+++ b/sparkle/src/stories/Spacing.stories.tsx
@@ -1,0 +1,213 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import {
+  TokenChip,
+  useComputedStyle,
+  withThemedSurface,
+} from "./foundations-helpers";
+
+const meta = {
+  title: "Foundations/Spacing",
+  tags: ["autodocs"],
+  decorators: [withThemedSurface],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `The spacing scale: a 4px-based ramp shared by every spacing utility — \`p-*\`, \`m-*\`, \`gap-*\`, \`space-*\`, \`size-*\`, \`w-*\`/\`h-*\`. Rows are named with \`gap-*\` as the canonical example; swap the prefix for the property you need (\`gap-2\` ↔ \`p-2\` ↔ \`m-2\`). Each token is shown as a reference row: a live specimen (two dots separated by the token's gap), a click-to-copy class chip, its computed value, and a description of intended use. Stick to the scale — arbitrary values like \`p-[13px]\` break the rhythm.`,
+      },
+    },
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type SpacingRow = {
+  // Canonical example class documented by the row; the chip copies it.
+  name: string;
+  // Static width class for the specimen spacer (Tailwind needs literal class
+  // names at build time, so it cannot be derived from `name`).
+  widthClass: string;
+  description?: React.ReactNode;
+};
+
+const SPACING_MEASURED = ["width"] as const;
+
+const SpacingTableRow = ({
+  row,
+  withDescription,
+}: {
+  row: SpacingRow;
+  withDescription: boolean;
+}) => {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const measured = useComputedStyle(ref, SPACING_MEASURED);
+
+  return (
+    <tr className="border-b border-border last:border-b-0">
+      <td className="w-52 py-3 pr-4 align-middle">
+        <div className="flex h-12 items-center">
+          <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-foreground" />
+          <div
+            ref={ref}
+            className={`h-9 shrink-0 bg-primary-100 ${row.widthClass}`}
+          />
+          <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-foreground" />
+        </div>
+      </td>
+      <td className="py-3 pr-4 align-middle">
+        <TokenChip value={row.name} />
+      </td>
+      <td className="whitespace-nowrap py-3 pr-4 align-middle font-mono text-xs text-muted-foreground">
+        {measured["width"] || "—"}
+      </td>
+      {withDescription && (
+        <td className="py-3 align-middle text-sm text-muted-foreground">
+          {row.description ?? "—"}
+        </td>
+      )}
+    </tr>
+  );
+};
+
+// Mirrors the Colors TokenTable: specimen · copyable chip · live value ·
+// optional description, so every Foundations page reads the same way.
+const SpacingTable = ({ rows }: { rows: SpacingRow[] }) => {
+  const withDescription = rows.some((row) => row.description != null);
+  return (
+    <table className="w-full border-collapse text-left">
+      <thead>
+        <tr className="border-b border-border text-xs uppercase tracking-wide text-muted-foreground">
+          <th className="py-2 pr-4 font-medium">Preview</th>
+          <th className="py-2 pr-4 font-medium">Name</th>
+          <th className="py-2 pr-4 font-medium">Value</th>
+          {withDescription && <th className="py-2 font-medium">Description</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <SpacingTableRow
+            key={row.name}
+            row={row}
+            withDescription={withDescription}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+const Section = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-2">
+      <h2 className="text-xl font-semibold">{title}</h2>
+      {description}
+    </div>
+    {children}
+  </div>
+);
+
+export const Scale: Story = {
+  render: () => (
+    <Section
+      title="Spacing Scale"
+      description={
+        <p className="text-sm text-primary-600">
+          The 4px-based ramp. Small steps separate related elements inside a
+          component; big steps separate sections of a page.
+        </p>
+      }
+    >
+      <SpacingTable
+        rows={[
+          {
+            name: "gap-0.5",
+            widthClass: "w-0.5",
+            description: "Hairline separation: stacked list items.",
+          },
+          {
+            name: "gap-1",
+            widthClass: "w-1",
+            description: "Tightly related: icon to its label.",
+          },
+          { name: "gap-1.5", widthClass: "w-1.5" },
+          {
+            name: "gap-2",
+            widthClass: "w-2",
+            description: "The default gap inside components.",
+          },
+          { name: "gap-2.5", widthClass: "w-2.5" },
+          {
+            name: "gap-3",
+            widthClass: "w-3",
+            description: "Between sibling controls (button rows).",
+          },
+          {
+            name: "gap-4",
+            widthClass: "w-4",
+            description: "Between form fields and card content blocks.",
+          },
+          { name: "gap-5", widthClass: "w-5" },
+          {
+            name: "gap-6",
+            widthClass: "w-6",
+            description: "Between groups inside a panel.",
+          },
+          {
+            name: "gap-8",
+            widthClass: "w-8",
+            description: "Between sections of a page.",
+          },
+          { name: "gap-10", widthClass: "w-10" },
+          {
+            name: "gap-12",
+            widthClass: "w-12",
+            description: "Major page sections and empty states.",
+          },
+          { name: "gap-16", widthClass: "w-16" },
+          { name: "gap-20", widthClass: "w-20" },
+          {
+            name: "gap-24",
+            widthClass: "w-24",
+            description: "Marketing / hero rhythm.",
+          },
+        ]}
+      />
+    </Section>
+  ),
+};
+
+export const NamedSpacing: Story = {
+  render: () => (
+    <Section
+      title="Named Spacing"
+      description={
+        <p className="text-sm text-primary-600">
+          Semantic spacing tokens with a fixed meaning, usable with any spacing
+          prefix.
+        </p>
+      }
+    >
+      <SpacingTable
+        rows={[
+          {
+            name: "mx-sidebar-side-spacing",
+            widthClass: "w-sidebar-side-spacing",
+            description:
+              "Horizontal inset of sidebar content, so nav items, headers, and footers align.",
+          },
+        ]}
+      />
+    </Section>
+  ),
+};

--- a/sparkle/src/stories/Typography.stories.tsx
+++ b/sparkle/src/stories/Typography.stories.tsx
@@ -1,273 +1,408 @@
-// Typography.stories.tsx
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
 import { cn } from "@sparkle/lib/utils";
 
 import {
-  Copyable,
+  TokenChip,
   useComputedStyle,
   withThemedSurface,
 } from "./foundations-helpers";
 
-// Define the text sizes and weights
-const textSizes = {
-  xs: "text-xs",
-  sm: "text-sm",
-  md: "text-base",
-  lg: "text-lg",
-  xl: "text-xl",
-};
-
-const copySizes = {
-  xs: "copy-xs",
-  sm: "copy-sm",
-  base: "copy-base",
-  lg: "copy-lg",
-  xl: "copy-xl",
-};
-
-const extraTextSizes = {
-  "2xl": "text-2xl",
-  "3xl": "text-3xl",
-  "4xl": "text-4xl",
-  "5xl": "text-5xl",
-  "6xl": "text-6xl",
-  "7xl": "text-7xl",
-  "8xl": "text-8xl",
-  "9xl": "text-9xl",
-};
-
-const headingSizes = {
-  base: "heading-base",
-  lg: "heading-lg",
-  xl: "heading-xl",
-  "2xl": "heading-2xl",
-  "3xl": "heading-3xl",
-  "4xl": "heading-4xl",
-  "5xl": "heading-5xl",
-  "6xl": "heading-6xl",
-  "7xl": "heading-7xl",
-  "8xl": "heading-8xl",
-  "9xl": "heading-9xl",
-};
-
-const headingMonoSizes = {
-  lg: "heading-mono-lg",
-  xl: "heading-mono-xl",
-  "2xl": "heading-mono-2xl",
-  "3xl": "heading-mono-3xl",
-  "4xl": "heading-mono-4xl",
-  "5xl": "heading-mono-5xl",
-  "6xl": "heading-mono-6xl",
-  "7xl": "heading-mono-7xl",
-  "8xl": "heading-mono-8xl",
-  "9xl": "heading-mono-9xl",
-};
-
-const fontWeights = {
-  normal: "font-normal",
-  medium: "font-medium",
-  semibold: "font-semibold",
-  bold: "font-bold",
-};
-
-// Readable line length per copy size, keyed by size token.
-const copyMaxWidth: Record<string, string> = {
-  xs: "20rem",
-  sm: "24rem",
-  base: "32rem",
-  lg: "40rem",
-  xl: "48rem",
-};
-
-const loremIpsum =
-  "Geist. Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
-
-const copyLoremIpsum = `Geist. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
-
-const MEASURED = ["font-size", "line-height", "font-weight"] as const;
-
-// One type specimen: click the label to copy its utility class(es), and read
-// the live computed size / line-height / weight so the numbers never drift from
-// the compiled CSS.
-const TypeSpecimen = ({
-  label,
-  className,
-  sample,
-  style,
-}: {
-  label: string;
-  className: string;
-  sample: string;
-  style?: React.CSSProperties;
-}) => {
-  const ref = React.useRef<HTMLParagraphElement>(null);
-  const measured = useComputedStyle(ref, MEASURED);
-
-  return (
-    <div className="space-y-1">
-      <div className="flex flex-wrap items-baseline gap-2">
-        <Copyable value={className}>
-          <span className="font-mono text-xs text-foreground">{label}</span>
-        </Copyable>
-        {measured["font-size"] && (
-          <span className="font-mono text-[10px] text-muted-foreground">
-            {measured["font-size"]} / {measured["line-height"]} ·{" "}
-            {measured["font-weight"]}
-          </span>
-        )}
-      </div>
-      <p ref={ref} className={className} style={style}>
-        {sample}
-      </p>
-    </div>
-  );
-};
-
-interface TypographyProps {
-  variant: "font-size" | "heading" | "heading-mono" | "copy";
-}
-
-const Typography: React.FC<TypographyProps> = ({ variant }) => {
-  if (variant === "font-size") {
-    return (
-      <div>
-        <div
-          className="grid gap-4 bg-repeat py-8"
-          style={{
-            gridTemplateColumns: `repeat(${Object.keys(fontWeights).length}, minmax(0, 1fr))`,
-          }}
-        >
-          {Object.entries(textSizes).map(([sizeKey, sizeClass]) =>
-            Object.entries(fontWeights).map(([weightKey, weightClass]) => (
-              <TypeSpecimen
-                key={`${sizeKey}-${weightKey}`}
-                label={`${sizeKey} ${weightKey}`}
-                className={cn(sizeClass, weightClass)}
-                sample={loremIpsum}
-              />
-            ))
-          )}
-        </div>
-        <div className="mt-6 grid gap-16 bg-repeat py-8">
-          {Object.entries(extraTextSizes).map(([sizeKey, sizeClass]) => (
-            <TypeSpecimen
-              key={sizeKey}
-              label={`${sizeKey} medium`}
-              className={cn(sizeClass, "font-medium")}
-              sample={loremIpsum}
-            />
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  if (variant === "copy") {
-    return (
-      <div className="space-y-12 bg-repeat py-8">
-        {Object.entries(copySizes).map(([sizeKey, copyClass]) => {
-          const maxWidth = copyMaxWidth[sizeKey] ?? "48rem";
-          return (
-            <div key={sizeKey} className="space-y-4">
-              {[
-                { suffix: "", modifier: "" },
-                { suffix: " Italic", modifier: "italic" },
-                { suffix: " Mono", modifier: "font-mono" },
-              ].map(({ suffix, modifier }) => (
-                <TypeSpecimen
-                  key={suffix || "regular"}
-                  label={`Copy ${sizeKey}${suffix}`}
-                  className={cn(copyClass, modifier)}
-                  sample={copyLoremIpsum}
-                  style={{ maxWidth }}
-                />
-              ))}
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
-
-  if (variant === "heading-mono") {
-    return (
-      <div className="space-y-8 bg-repeat py-8">
-        {Object.entries(headingMonoSizes).map(([sizeKey, headingClass]) => (
-          <TypeSpecimen
-            key={sizeKey}
-            label={`Heading Mono ${sizeKey}`}
-            className={headingClass}
-            sample={loremIpsum}
-          />
-        ))}
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-8 bg-repeat py-8">
-      {Object.entries(headingSizes).map(([sizeKey, headingClass]) => (
-        <TypeSpecimen
-          key={sizeKey}
-          label={`Heading ${sizeKey}`}
-          className={headingClass}
-          sample={loremIpsum}
-        />
-      ))}
-    </div>
-  );
-};
-
-const meta: Meta<typeof Typography> = {
+const meta = {
   title: "Foundations/Typography",
-  component: Typography,
   tags: ["autodocs"],
   decorators: [withThemedSurface],
   parameters: {
     layout: "padded",
     docs: {
       description: {
-        component: `The Sparkle type scale, rendered in Geist. Covers font sizes (\`text-xs\` to \`text-9xl\`) with weights, heading styles (\`heading-*\` and monospace \`heading-mono-*\`), and copy/body styles (\`copy-*\`, including italic and mono). Use the **variant** control to switch between the font-size, heading, heading-mono, and copy specimens. Click any label to copy its utility class; the caption shows the live computed size / line-height / weight. Reach for these utilities instead of ad-hoc font sizing.`,
+        component: `The Sparkle type system, rendered in Geist. Prefer the composite utilities — \`heading-*\`, \`copy-*\`, \`label-*\` (and monospace \`heading-mono-*\`) — over ad-hoc \`text-*\` + \`font-*\` combinations so weight, line-height, and letter-spacing stay consistent. Each token is shown as a reference row: live specimen, a click-to-copy class chip, its computed value (size / line-height · weight, read from the compiled CSS), and a description of intended use. Compose modifiers like \`italic\` or \`font-mono\` on top of the copy styles when needed.`,
       },
     },
   },
-  args: {
-    variant: "font-size",
-  },
-};
+} satisfies Meta;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// Add a Default story that matches the expected ID
-export const Default: Story = {
-  args: {
-    variant: "font-size",
-  },
+const MEASURED = [
+  "font-size",
+  "line-height",
+  "font-weight",
+  "font-family",
+] as const;
+
+type TypeRow = {
+  // Utility class documented by the row; the chip copies this.
+  name: string;
+  // Classes applied to the specimen (defaults to `name`).
+  className?: string;
+  sample: string;
+  description?: React.ReactNode;
 };
 
-export const FontSize: Story = {
-  args: {
-    variant: "font-size",
-  },
+// Which computed properties the Value column shows.
+type ValueKind = "metrics" | "family";
+
+const TypeTableRow = ({
+  row,
+  valueKind,
+  withDescription,
+}: {
+  row: TypeRow;
+  valueKind: ValueKind;
+  withDescription: boolean;
+}) => {
+  const ref = React.useRef<HTMLParagraphElement>(null);
+  const measured = useComputedStyle(ref, MEASURED);
+  const value =
+    valueKind === "family"
+      ? measured["font-family"]
+      : measured["font-size"] &&
+        `${measured["font-size"]} / ${measured["line-height"]} · ${measured["font-weight"]}`;
+
+  return (
+    <tr className="border-b border-border last:border-b-0">
+      <td className="w-2/5 py-3 pr-4 align-middle">
+        <p
+          ref={ref}
+          className={cn(
+            row.className ?? row.name,
+            "overflow-hidden text-ellipsis whitespace-nowrap"
+          )}
+        >
+          {row.sample}
+        </p>
+      </td>
+      <td className="py-3 pr-4 align-middle">
+        <TokenChip value={row.name} />
+      </td>
+      <td className="whitespace-nowrap py-3 pr-4 align-middle font-mono text-xs text-muted-foreground">
+        {value || "—"}
+      </td>
+      {withDescription && (
+        <td className="py-3 align-middle text-sm text-muted-foreground">
+          {row.description ?? "—"}
+        </td>
+      )}
+    </tr>
+  );
 };
 
-export const Heading: Story = {
-  args: {
-    variant: "heading",
-  },
+// Mirrors the Colors TokenTable: specimen · copyable chip · live value ·
+// optional description, so every Foundations page reads the same way.
+const TypeTable = ({
+  rows,
+  valueKind = "metrics",
+}: {
+  rows: TypeRow[];
+  valueKind?: ValueKind;
+}) => {
+  const withDescription = rows.some((row) => row.description != null);
+  return (
+    <table className="w-full border-collapse text-left">
+      <thead>
+        <tr className="border-b border-border text-xs uppercase tracking-wide text-muted-foreground">
+          <th className="py-2 pr-4 font-medium">Preview</th>
+          <th className="py-2 pr-4 font-medium">Name</th>
+          <th className="py-2 pr-4 font-medium">Value</th>
+          {withDescription && <th className="py-2 font-medium">Description</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <TypeTableRow
+            key={row.name}
+            row={row}
+            valueKind={valueKind}
+            withDescription={withDescription}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
 };
 
-export const HeadingMono: Story = {
-  args: {
-    variant: "heading-mono",
-  },
+const Section = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-2">
+      <h2 className="text-xl font-semibold">{title}</h2>
+      {description}
+    </div>
+    {children}
+  </div>
+);
+
+const copySentence =
+  "The quick brown fox jumps over the lazy dog and settles in.";
+
+export const FontFamilies: Story = {
+  render: () => (
+    <Section
+      title="Font Families"
+      description={
+        <p className="text-sm text-primary-600">
+          The two families of the system. Everything defaults to Geist; use mono
+          for code, identifiers, and technical values.
+        </p>
+      }
+    >
+      <TypeTable
+        valueKind="family"
+        rows={[
+          {
+            name: "font-sans",
+            className: "font-sans text-xl",
+            sample: "Sparkle",
+            description: "Geist — the default for all product UI.",
+          },
+          {
+            name: "font-mono",
+            className: "font-mono text-xl",
+            sample: "Sparkle",
+            description: "Geist Mono — code, tokens, and technical values.",
+          },
+        ]}
+      />
+    </Section>
+  ),
 };
+
+const rawSizes = [
+  "xs",
+  "sm",
+  "base",
+  "lg",
+  "xl",
+  "2xl",
+  "3xl",
+  "4xl",
+  "5xl",
+  "6xl",
+  "7xl",
+  "8xl",
+  "9xl",
+] as const;
+
+export const FontSizes: Story = {
+  render: () => (
+    <Section
+      title="Font Sizes"
+      description={
+        <p className="text-sm text-primary-600">
+          The raw size scale with its paired line-heights. Prefer the semantic
+          heading / copy / label utilities below; reach for raw sizes only when
+          composing something the semantic styles don't cover.
+        </p>
+      }
+    >
+      <TypeTable
+        rows={rawSizes.map((size) => ({
+          name: `text-${size}`,
+          sample: "Aa",
+        }))}
+      />
+    </Section>
+  ),
+};
+
+export const FontWeights: Story = {
+  render: () => (
+    <Section
+      title="Font Weights"
+      description={
+        <p className="text-sm text-primary-600">
+          Geist is tuned slightly lighter than the usual scale — medium is 450
+          and semibold 550. The semantic utilities already pick the right
+          weight; these are for manual composition.
+        </p>
+      }
+    >
+      <TypeTable
+        rows={[
+          {
+            name: "font-normal",
+            className: "text-xl font-normal",
+            sample: "Aa",
+            description: "400 — body text (what copy-* uses).",
+          },
+          {
+            name: "font-medium",
+            className: "text-xl font-medium",
+            sample: "Aa",
+            description: "450 — labels and buttons (what label-* uses).",
+          },
+          {
+            name: "font-semibold",
+            className: "text-xl font-semibold",
+            sample: "Aa",
+            description: "550 — headings (what heading-* uses).",
+          },
+          {
+            name: "font-bold",
+            className: "text-xl font-bold",
+            sample: "Aa",
+            description: "700 — strong emphasis; use sparingly.",
+          },
+        ]}
+      />
+    </Section>
+  ),
+};
+
+const headingDescriptions: Record<string, string> = {
+  "heading-xs": "Tiny headers: menu group labels, overlines.",
+  "heading-sm": "Menu items, compact card titles.",
+  "heading-base": "Default component heading: dialog sections, list titles.",
+  "heading-lg": "Section titles in pages and panels.",
+  "heading-xl": "Dialog and page titles.",
+  "heading-2xl": "Large page titles.",
+  "heading-3xl": "Hero / marketing headings.",
+};
+
+const headingSizes = [
+  "xs",
+  "sm",
+  "base",
+  "lg",
+  "xl",
+  "2xl",
+  "3xl",
+  "4xl",
+  "5xl",
+  "6xl",
+  "7xl",
+  "8xl",
+  "9xl",
+] as const;
+
+export const Headings: Story = {
+  render: () => (
+    <Section
+      title="Headings"
+      description={
+        <p className="text-sm text-primary-600">
+          Semibold (550) headings across the scale — size, line-height, and
+          letter-spacing are packaged together. Sizes above 3xl are for
+          marketing surfaces.
+        </p>
+      }
+    >
+      <TypeTable
+        rows={headingSizes.map((size) => ({
+          name: `heading-${size}`,
+          sample: "Sparkle",
+          description: headingDescriptions[`heading-${size}`],
+        }))}
+      />
+    </Section>
+  ),
+};
+
+const headingMonoSizes = [
+  "lg",
+  "xl",
+  "2xl",
+  "3xl",
+  "4xl",
+  "5xl",
+  "6xl",
+  "7xl",
+  "8xl",
+  "9xl",
+] as const;
+
+export const HeadingsMono: Story = {
+  render: () => (
+    <Section
+      title="Headings Mono"
+      description={
+        <p className="text-sm text-primary-600">
+          The heading scale in Geist Mono, for technical or editorial accents.
+        </p>
+      }
+    >
+      <TypeTable
+        rows={headingMonoSizes.map((size) => ({
+          name: `heading-mono-${size}`,
+          sample: "Sparkle",
+        }))}
+      />
+    </Section>
+  ),
+};
+
+const copyDescriptions: Record<string, string> = {
+  "copy-xs": "Captions, hints, and metadata.",
+  "copy-sm": "Dense product body text.",
+  "copy-base": "Default body text.",
+  "copy-lg": "Comfortable long-form reading.",
+  "copy-xl": "Intro paragraphs, marketing copy.",
+  "copy-2xl": "Large editorial / marketing copy.",
+};
+
+const copySizes = ["xs", "sm", "base", "lg", "xl", "2xl"] as const;
 
 export const Copy: Story = {
-  args: {
-    variant: "copy",
-  },
+  render: () => (
+    <Section
+      title="Copy"
+      description={
+        <p className="text-sm text-primary-600">
+          Regular-weight (400) body styles. Compose <code>italic</code> or{" "}
+          <code>font-mono</code> on top when a passage needs it.
+        </p>
+      }
+    >
+      <TypeTable
+        rows={copySizes.map((size) => ({
+          name: `copy-${size}`,
+          sample: copySentence,
+          description: copyDescriptions[`copy-${size}`],
+        }))}
+      />
+    </Section>
+  ),
+};
+
+export const Labels: Story = {
+  render: () => (
+    <Section
+      title="Labels"
+      description={
+        <p className="text-sm text-primary-600">
+          Medium-weight (450) styles for interactive and compact UI text.
+        </p>
+      }
+    >
+      <TypeTable
+        rows={[
+          {
+            name: "label-xs",
+            sample: "Label",
+            description: "Chips, counters, and the smallest buttons.",
+          },
+          {
+            name: "label-sm",
+            sample: "Label",
+            description: "Buttons and form labels.",
+          },
+          {
+            name: "label-base",
+            sample: "Label",
+            description: "Larger buttons and prominent labels.",
+          },
+        ]}
+      />
+    </Section>
+  ),
 };

--- a/sparkle/src/stories/foundations-helpers.tsx
+++ b/sparkle/src/stories/foundations-helpers.tsx
@@ -354,7 +354,7 @@ export function TokenChip({
         "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
       )}
     >
-      <span>{label ?? value}</span>
+      <span className="whitespace-nowrap">{label ?? value}</span>
       {isCopied ? (
         <Check className="h-3 w-3 shrink-0 text-success-500" />
       ) : (


### PR DESCRIPTION
## Description

Reworks the Sparkle Foundations Storybook stories (Typography, Shadows, Motion) to match the existing Colors reference-table layout — each token row now shows a live specimen, a click-to-copy class chip, its computed CSS value, and a description of intended use. Two new pages are added: **Borders** (corner radii and stroke widths) and **Spacing**. Motion previews loop continuously — an easing ball traces the curve and a duration square spins one turn per token. `TokenChip` labels no longer wrap.

## Tests

Verified manually in Storybook: all six Foundations pages render correctly, tokens are copyable, specimens loop, and computed values resolve from the compiled CSS.

## Risk

_None — Storybook stories only, no production code changed._

## Deploy Plan

Deploy Storybook.