### PR TITLE
[sparkle] Use Geist in Storybook

### DIFF
--- a/sparkle/.storybook/manager-head.html
+++ b/sparkle/.storybook/manager-head.html
@@ -1,0 +1,28 @@
+<!-- Geist for the Storybook manager UI (sidebar, toolbar). The preview loads
+     these faces via src/styles/fonts.css; the manager needs its own copy.
+     Served from front/public/static via the /static staticDir in main.ts. -->
+<style>
+  @font-face {
+    font-family: "Geist";
+    src: url("/static/fonts/GeistVariable.woff2") format("woff2");
+    font-weight: 100 900;
+    font-style: normal;
+    font-display: swap;
+  }
+
+  @font-face {
+    font-family: "Geist";
+    src: url("/static/fonts/GeistVariable-Italic.woff2") format("woff2");
+    font-weight: 100 900;
+    font-style: italic;
+    font-display: swap;
+  }
+
+  @font-face {
+    font-family: "Geist Mono";
+    src: url("/static/fonts/GeistMonoVariable.woff2") format("woff2");
+    font-weight: 100 900;
+    font-style: normal;
+    font-display: swap;
+  }
+</style>

--- a/sparkle/.storybook/manager.ts
+++ b/sparkle/.storybook/manager.ts
@@ -8,6 +8,10 @@ const dustTheme = create({
   brandUrl: "https://dust.tt",
   brandImage: "/brand/dust.svg",
   brandTarget: "_self",
+  // Geist is loaded in the manager via manager-head.html (the manager does
+  // not load the preview's fonts.css).
+  fontBase: "Geist, sans-serif",
+  fontCode: "'Geist Mono', monospace",
 });
 
 addons.setConfig({ theme: dustTheme });

--- a/sparkle/.storybook/preview.ts
+++ b/sparkle/.storybook/preview.ts
@@ -3,9 +3,18 @@ import "../src/styles/tailwind.css";
 
 import { withThemeByClassName } from "@storybook/addon-themes";
 import type { Preview } from "@storybook/react";
+import { create } from "storybook/theming/create";
 
 const preview: Preview = {
   parameters: {
+    docs: {
+      // Render docs pages in the system fonts (Geist is loaded by fonts.css).
+      theme: create({
+        base: "light",
+        fontBase: "Geist, sans-serif",
+        fontCode: "'Geist Mono', monospace",
+      }),
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,


### PR DESCRIPTION
## Description

Sets Geist / Geist Mono as the font for the entire Storybook UI — both the docs theme (`preview.ts`) and the manager sidebar/toolbar theme (`manager.ts`). The manager doesn't import the preview's `fonts.css`, so the font faces are loaded separately via a new `manager-head.html` that references the woff2 files already served from `front/public/static`.

## Tests

Verified manually: Geist renders in the sidebar, toolbar, and docs pages.

## Risk

_None — Storybook configuration only._

## Deploy Plan

Deploy sparkle.