### PR TITLE
Tool outputs: resolve DustFileSystem from tool context

### DIFF
--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -83,17 +83,38 @@ async function setupTest() {
     retryPolicy: "no_retry",
   };
 
-  const { action } = await ConversationFactory.createAgentMessage(auth, {
-    workspace,
-    conversation,
-    agentConfig,
-    mcpAction: { toolConfiguration },
-  });
+  const { action, agentMessage } = await ConversationFactory.createAgentMessage(
+    auth,
+    {
+      workspace,
+      conversation,
+      agentConfig,
+      mcpAction: { toolConfiguration },
+    }
+  );
   assert(action, "MCP action should be created");
 
-  const toolContext = {
-    runContext: { contextType: "agent_loop", conversation },
-  } as unknown as ToolContextType;
+  // The agent message above is created with rank 0, use rank 1 for the user message.
+  const { userMessage } = await ConversationFactory.createUserMessage({
+    auth,
+    workspace,
+    conversation,
+    content: "Test message",
+    rank: 1,
+  });
+
+  const toolContext: ToolContextType = {
+    runContext: {
+      contextType: "agent_loop",
+      agentConfiguration: agentConfig,
+      agentMessage,
+      currentAction: action.toJSON(),
+      conversation,
+      stepContext: action.stepContext,
+      toolConfiguration,
+      userMessage,
+    },
+  };
 
   return { auth, conversation, action, toolConfiguration, toolContext };
 }

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -12,6 +12,7 @@ import {
   processToolResults,
 } from "@app/lib/actions/mcp_execution";
 import type { DataSourceNodeContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -90,7 +91,11 @@ async function setupTest() {
   });
   assert(action, "MCP action should be created");
 
-  return { auth, conversation, action, toolConfiguration };
+  const toolContext = {
+    runContext: { contextType: "agent_loop", conversation },
+  } as unknown as ToolContextType;
+
+  return { auth, conversation, action, toolConfiguration, toolContext };
 }
 
 async function setupAuth() {
@@ -214,7 +219,8 @@ describe("getAugmentedInputs", () => {
 
 describe("processToolResults", () => {
   it("should store snippet in DB when text exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES", async () => {
-    const { auth, conversation, action, toolConfiguration } = await setupTest();
+    const { auth, conversation, action, toolConfiguration, toolContext } =
+      await setupTest();
 
     // Generate text that exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES (20KB).
     const largeText = "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
@@ -223,6 +229,7 @@ describe("processToolResults", () => {
       action,
       conversation,
       localLogger: logger.child({ test: true }),
+      toolContext,
       toolCallResultContent: [{ type: "text", text: largeText }],
       toolConfiguration,
     });
@@ -244,7 +251,8 @@ describe("processToolResults", () => {
   });
 
   it("should store snippet for large resource text", async () => {
-    const { auth, conversation, action, toolConfiguration } = await setupTest();
+    const { auth, conversation, action, toolConfiguration, toolContext } =
+      await setupTest();
 
     // Generate resource text that exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES (20KB).
     const largeResourceText = "y".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
@@ -253,6 +261,7 @@ describe("processToolResults", () => {
       action,
       conversation,
       localLogger: logger.child({ test: true }),
+      toolContext,
       toolCallResultContent: [
         {
           type: "resource",
@@ -278,7 +287,8 @@ describe("processToolResults", () => {
   });
 
   it("should keep small text content as-is", async () => {
-    const { auth, conversation, action, toolConfiguration } = await setupTest();
+    const { auth, conversation, action, toolConfiguration, toolContext } =
+      await setupTest();
 
     const smallText = "hello world";
 
@@ -286,6 +296,7 @@ describe("processToolResults", () => {
       action,
       conversation,
       localLogger: logger.child({ test: true }),
+      toolContext,
       toolCallResultContent: [{ type: "text", text: smallText }],
       toolConfiguration,
     });
@@ -300,7 +311,8 @@ describe("processToolResults", () => {
   });
 
   it("should keep large sandbox text content as-is", async () => {
-    const { auth, conversation, action, toolConfiguration } = await setupTest();
+    const { auth, conversation, action, toolConfiguration, toolContext } =
+      await setupTest();
 
     const largeText = "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
 
@@ -308,6 +320,7 @@ describe("processToolResults", () => {
       action,
       conversation,
       localLogger: logger.child({ test: true }),
+      toolContext,
       toolCallResultContent: [{ type: "text", text: largeText }],
       toolConfiguration: {
         ...toolConfiguration,
@@ -325,7 +338,8 @@ describe("processToolResults", () => {
   });
 
   it("should keep small resource text as-is", async () => {
-    const { auth, conversation, action, toolConfiguration } = await setupTest();
+    const { auth, conversation, action, toolConfiguration, toolContext } =
+      await setupTest();
 
     const smallText = "small resource text";
 
@@ -333,6 +347,7 @@ describe("processToolResults", () => {
       action,
       conversation,
       localLogger: logger.child({ test: true }),
+      toolContext,
       toolCallResultContent: [
         {
           type: "resource",
@@ -352,7 +367,8 @@ describe("processToolResults", () => {
   });
 
   it(`should persist DATA_SOURCE_NODE_CONTENT block to ${TOOL_OUTPUTS_FOLDER_NAME}/`, async () => {
-    const { auth, conversation, action, toolConfiguration } = await setupTest();
+    const { auth, conversation, action, toolConfiguration, toolContext } =
+      await setupTest();
 
     fileStorageMock.reset();
 
@@ -377,6 +393,7 @@ describe("processToolResults", () => {
       action,
       conversation,
       localLogger: logger.child({ test: true }),
+      toolContext,
       toolCallResultContent: [
         {
           type: "resource",
@@ -399,7 +416,8 @@ describe("processToolResults", () => {
   });
 
   it(`should persist large plain text block to ${TOOL_OUTPUTS_FOLDER_NAME}/ as .txt`, async () => {
-    const { auth, conversation, action, toolConfiguration } = await setupTest();
+    const { auth, conversation, action, toolConfiguration, toolContext } =
+      await setupTest();
 
     fileStorageMock.reset();
 
@@ -409,6 +427,7 @@ describe("processToolResults", () => {
       action,
       conversation,
       localLogger: logger.child({ test: true }),
+      toolContext,
       toolCallResultContent: [{ type: "text", text: largeText }],
       toolConfiguration,
     });
@@ -424,7 +443,8 @@ describe("processToolResults", () => {
   });
 
   it(`should persist large JSON text block to ${TOOL_OUTPUTS_FOLDER_NAME}/ as .json`, async () => {
-    const { auth, conversation, action, toolConfiguration } = await setupTest();
+    const { auth, conversation, action, toolConfiguration, toolContext } =
+      await setupTest();
 
     fileStorageMock.reset();
 
@@ -436,6 +456,7 @@ describe("processToolResults", () => {
       action,
       conversation,
       localLogger: logger.child({ test: true }),
+      toolContext,
       toolCallResultContent: [{ type: "text", text: largeJson }],
       toolConfiguration,
     });

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -39,7 +39,11 @@ vi.mock("@app/lib/api/files/processing", async (importOriginal) => {
   };
 });
 
-async function setupTest() {
+async function setupTest({
+  mcpServerName = "test_server",
+}: {
+  mcpServerName?: string;
+} = {}) {
   const user = await UserFactory.basic();
   const workspace = await WorkspaceFactory.basic();
   await MembershipFactory.associate(workspace, user, { role: "admin" });
@@ -65,7 +69,7 @@ async function setupTest() {
     type: "mcp_configuration",
     name: "test_tool",
     originalName: "test_tool",
-    mcpServerName: "test_server",
+    mcpServerName,
     dataSources: null,
     tables: null,
     childAgentId: null,
@@ -116,7 +120,7 @@ async function setupTest() {
     },
   };
 
-  return { auth, conversation, action, toolConfiguration, toolContext };
+  return { auth, conversation, action, toolContext };
 }
 
 async function setupAuth() {
@@ -240,8 +244,7 @@ describe("getAugmentedInputs", () => {
 
 describe("processToolResults", () => {
   it("should store snippet in DB when text exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES", async () => {
-    const { auth, conversation, action, toolConfiguration, toolContext } =
-      await setupTest();
+    const { auth, conversation, action, toolContext } = await setupTest();
 
     // Generate text that exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES (20KB).
     const largeText = "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
@@ -252,7 +255,6 @@ describe("processToolResults", () => {
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [{ type: "text", text: largeText }],
-      toolConfiguration,
     });
 
     expect(outputItems).toHaveLength(1);
@@ -272,8 +274,7 @@ describe("processToolResults", () => {
   });
 
   it("should store snippet for large resource text", async () => {
-    const { auth, conversation, action, toolConfiguration, toolContext } =
-      await setupTest();
+    const { auth, conversation, action, toolContext } = await setupTest();
 
     // Generate resource text that exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES (20KB).
     const largeResourceText = "y".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
@@ -289,7 +290,6 @@ describe("processToolResults", () => {
           resource: { uri: "file://test.txt", text: largeResourceText },
         },
       ],
-      toolConfiguration,
     });
 
     expect(outputItems).toHaveLength(1);
@@ -308,8 +308,7 @@ describe("processToolResults", () => {
   });
 
   it("should keep small text content as-is", async () => {
-    const { auth, conversation, action, toolConfiguration, toolContext } =
-      await setupTest();
+    const { auth, conversation, action, toolContext } = await setupTest();
 
     const smallText = "hello world";
 
@@ -319,7 +318,6 @@ describe("processToolResults", () => {
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [{ type: "text", text: smallText }],
-      toolConfiguration,
     });
 
     expect(outputItems).toHaveLength(1);
@@ -332,8 +330,9 @@ describe("processToolResults", () => {
   });
 
   it("should keep large sandbox text content as-is", async () => {
-    const { auth, conversation, action, toolConfiguration, toolContext } =
-      await setupTest();
+    const { auth, conversation, action, toolContext } = await setupTest({
+      mcpServerName: "sandbox",
+    });
 
     const largeText = "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
 
@@ -343,10 +342,6 @@ describe("processToolResults", () => {
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [{ type: "text", text: largeText }],
-      toolConfiguration: {
-        ...toolConfiguration,
-        mcpServerName: "sandbox",
-      },
     });
 
     expect(outputItems).toHaveLength(1);
@@ -359,8 +354,7 @@ describe("processToolResults", () => {
   });
 
   it("should keep small resource text as-is", async () => {
-    const { auth, conversation, action, toolConfiguration, toolContext } =
-      await setupTest();
+    const { auth, conversation, action, toolContext } = await setupTest();
 
     const smallText = "small resource text";
 
@@ -375,7 +369,6 @@ describe("processToolResults", () => {
           resource: { uri: "file://small.txt", text: smallText },
         },
       ],
-      toolConfiguration,
     });
 
     expect(outputItems).toHaveLength(1);
@@ -388,8 +381,7 @@ describe("processToolResults", () => {
   });
 
   it(`should persist DATA_SOURCE_NODE_CONTENT block to ${TOOL_OUTPUTS_FOLDER_NAME}/`, async () => {
-    const { auth, conversation, action, toolConfiguration, toolContext } =
-      await setupTest();
+    const { auth, conversation, action, toolContext } = await setupTest();
 
     fileStorageMock.reset();
 
@@ -421,7 +413,6 @@ describe("processToolResults", () => {
           resource: dataSourceNodeResult,
         },
       ],
-      toolConfiguration,
     });
 
     const toolOutputWrite = fileStorageMock.saveFileCalls.find((call) =>
@@ -437,8 +428,7 @@ describe("processToolResults", () => {
   });
 
   it(`should persist large plain text block to ${TOOL_OUTPUTS_FOLDER_NAME}/ as .txt`, async () => {
-    const { auth, conversation, action, toolConfiguration, toolContext } =
-      await setupTest();
+    const { auth, conversation, action, toolContext } = await setupTest();
 
     fileStorageMock.reset();
 
@@ -450,7 +440,6 @@ describe("processToolResults", () => {
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [{ type: "text", text: largeText }],
-      toolConfiguration,
     });
 
     const toolOutputWrite = fileStorageMock.saveFileCalls.find((call) =>
@@ -464,8 +453,7 @@ describe("processToolResults", () => {
   });
 
   it(`should persist large JSON text block to ${TOOL_OUTPUTS_FOLDER_NAME}/ as .json`, async () => {
-    const { auth, conversation, action, toolConfiguration, toolContext } =
-      await setupTest();
+    const { auth, conversation, action, toolContext } = await setupTest();
 
     fileStorageMock.reset();
 
@@ -479,7 +467,6 @@ describe("processToolResults", () => {
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [{ type: "text", text: largeJson }],
-      toolConfiguration,
     });
 
     const toolOutputWrite = fileStorageMock.saveFileCalls.find((call) =>

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -16,7 +16,10 @@ import {
   isToolGeneratedFilePath,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { handleBase64Upload } from "@app/lib/actions/mcp_utils";
-import type { ActionGeneratedFileType } from "@app/lib/actions/types";
+import type {
+  ActionGeneratedFileType,
+  ToolContextType,
+} from "@app/lib/actions/types";
 import { isInternalServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { persistToolOutput } from "@app/lib/api/files/action_output_fs";
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
@@ -146,12 +149,14 @@ export async function processToolResults(
     localLogger,
     toolCallResultContent,
     toolConfiguration,
+    toolContext,
   }: {
     action: AgentMCPActionResource;
     conversation: ConversationType;
     localLogger: Logger;
     toolCallResultContent: CallToolResult["content"];
     toolConfiguration: LightMCPToolConfigurationType;
+    toolContext: ToolContextType;
   }
 ): Promise<{
   outputItems: AgentMCPActionOutputItemModel[];
@@ -169,7 +174,7 @@ export async function processToolResults(
   }[] = await concurrentExecutor(
     toolCallResultContent,
     async (block, idx) => {
-      const res = await persistToolOutput(auth, conversation, block, {
+      const res = await persistToolOutput(auth, toolContext, block, {
         toolName: toolConfiguration.name,
         serverName: toolConfiguration.mcpServerName,
       });

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -1,7 +1,6 @@
 import { uploadFileToConversationDataSource } from "@app/lib/actions/action_file_helpers";
 import { FILE_OFFLOAD_SNIPPET_LENGTH } from "@app/lib/actions/action_output_limits";
 import type {
-  LightMCPToolConfigurationType,
   MCPToolConfigurationType,
   ToolNotificationEvent,
 } from "@app/lib/actions/mcp";
@@ -49,6 +48,7 @@ import {
   toWellFormed,
 } from "@app/types/shared/utils/string_utils";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import assert from "assert";
 import { extname } from "path";
 import type { Logger } from "pino";
 
@@ -148,20 +148,24 @@ export async function processToolResults(
     conversation,
     localLogger,
     toolCallResultContent,
-    toolConfiguration,
     toolContext,
   }: {
     action: AgentMCPActionResource;
     conversation: ConversationType;
     localLogger: Logger;
     toolCallResultContent: CallToolResult["content"];
-    toolConfiguration: LightMCPToolConfigurationType;
     toolContext: ToolContextType;
   }
 ): Promise<{
   outputItems: AgentMCPActionOutputItemModel[];
   generatedFiles: ActionGeneratedFileType[];
 }> {
+  assert(
+    toolContext.runContext,
+    "processToolResults requires a tool run context."
+  );
+  const { toolConfiguration } = toolContext.runContext;
+
   const fileUseCase: FileUseCase = "conversation";
   const fileUseCaseMetadata: FileUseCaseMetadata = {
     conversationId: conversation.sId,

--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -1,5 +1,6 @@
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import type { CoreDataSourceSearchCriteria } from "@app/lib/api/assistant/process_data_sources";
 import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
@@ -133,14 +134,14 @@ const EXTRACT_RESULT_SNIPPET_MAX_LENGTH = 1000;
 
 export async function generateProcessToolOutput({
   auth,
-  conversation,
+  toolContext,
   outputs,
   jsonSchema,
   timeFrame,
   objective,
 }: {
   auth: Authenticator;
-  conversation: ConversationType;
+  toolContext: ToolContextType;
   outputs: ProcessActionOutputsType | null;
   jsonSchema: JSONSchema;
   timeFrame: TimeFrame | null;
@@ -161,7 +162,7 @@ export async function generateProcessToolOutput({
   const fileName = makeFileName({ name: stem, ext: ".json" });
   const content = JSON.stringify(outputs?.data ?? [], null, 2);
 
-  const writeResult = await writeToToolOutputsFolder(auth, conversation, {
+  const writeResult = await writeToToolOutputsFolder(auth, toolContext, {
     fileName,
     content,
     contentType: "application/json",

--- a/front/lib/api/actions/servers/extract_data/tools/index.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.ts
@@ -199,7 +199,7 @@ export function createExtractDataTools(
 
     const result = await generateProcessToolOutput({
       auth,
-      conversation,
+      toolContext,
       outputs,
       jsonSchema: jsonSchemaForExtraction,
       timeFrame: timeFrameForExtraction ?? null,

--- a/front/lib/api/actions/servers/run_dust_app/helpers.ts
+++ b/front/lib/api/actions/servers/run_dust_app/helpers.ts
@@ -11,7 +11,10 @@ import type {
   ToolGeneratedFilePathType,
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type {
+  AgentLoopRunContextType,
+  ToolContextType,
+} from "@app/lib/actions/types";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { getDatasetSchema } from "@app/lib/api/datasets";
 import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
@@ -157,6 +160,7 @@ export async function prepareAppContext(
 
 export async function processDustFileOutput(
   auth: Authenticator,
+  toolContext: ToolContextType,
   sanitizedOutput: DustFileOutput,
   conversation: ConversationWithoutContentType,
   appName: string
@@ -253,7 +257,7 @@ export async function processDustFileOutput(
       fileName = makeFileName({ name: appName, ext: ".txt" });
     }
 
-    const result = await writeToToolOutputsFolder(auth, conversation, {
+    const result = await writeToToolOutputsFolder(auth, toolContext, {
       fileName,
       content: fileContent,
       contentType,

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -207,6 +207,7 @@ export default async function createServer(
         if (containsFileOutput(sanitizedOutput) && runContext.conversation) {
           const fileContentResult = await processDustFileOutput(
             auth,
+            toolContext,
             sanitizedOutput,
             runContext.conversation,
             app.name

--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -239,11 +239,11 @@ async function handleWebbrowser(
           ext: ".txt",
         });
 
-        const writeResult = await writeToToolOutputsFolder(
-          auth,
-          runCtx.conversation,
-          { fileName, content: fileContent, contentType: "text/plain" }
-        );
+        const writeResult = await writeToToolOutputsFolder(auth, toolContext, {
+          fileName,
+          content: fileContent,
+          contentType: "text/plain",
+        });
 
         if (writeResult.isErr()) {
           throw writeResult.error;

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -1,7 +1,12 @@
 import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
 import { isResourceContentWithText } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system/types";
+import {
+  conversationScopedPath,
+  podScopedPath,
+  SCOPED_PREFIX_CONVERSATION,
+} from "@app/lib/api/file_system/types";
 import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
 import {
   resolveResourceOutput,
@@ -12,6 +17,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { slugify } from "@app/types/shared/utils/string_utils";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -19,6 +25,64 @@ export interface PersistedToolOutput {
   contentType: AllSupportedFileContentType;
   fileName: string;
   scopedPath: string;
+}
+
+/**
+ * Builds the DustFileSystem associated with a tool context: the conversation file system when
+ * running in an agent loop, the pod (project space) file system when running in a sandbox
+ * function invocation.
+ */
+async function getDustFileSystemForToolContext(
+  auth: Authenticator,
+  toolContext: ToolContextType
+): Promise<Result<DustFileSystem, Error>> {
+  const { runContext } = toolContext;
+  if (!runContext) {
+    return new Err(
+      new Error("Tool outputs can only be persisted from a tool run context.")
+    );
+  }
+
+  switch (runContext.contextType) {
+    case "agent_loop":
+      return DustFileSystem.forConversation(auth, runContext.conversation);
+    case "sandbox_function":
+      return DustFileSystem.forPod(
+        auth,
+        runContext.invocation.sandboxFunction.space
+      );
+    default:
+      return assertNever(runContext);
+  }
+}
+
+function getToolOutputsScopedPath(
+  toolContext: ToolContextType,
+  fileName: string
+): Result<string, Error> {
+  const { runContext } = toolContext;
+  if (!runContext) {
+    return new Err(
+      new Error("Tool outputs can only be persisted from a tool run context.")
+    );
+  }
+
+  const rel = `${TOOL_OUTPUTS_FOLDER_NAME}/${fileName}`;
+  switch (runContext.contextType) {
+    case "agent_loop":
+      return new Ok(
+        conversationScopedPath({
+          conversationId: runContext.conversation.sId,
+          rel,
+        })
+      );
+    case "sandbox_function":
+      return new Ok(
+        podScopedPath(runContext.invocation.sandboxFunction.space.sId, rel)
+      );
+    default:
+      return assertNever(runContext);
+  }
 }
 
 /**
@@ -59,12 +123,14 @@ export async function writeToConversationFolder(
 }
 
 /**
- * Writes content to the conversation's .tool_outputs folder via DustFileSystem.
- * Returns the scoped path (e.g. "conversation-{cId}/.tool_outputs/{fileName}") on success.
+ * Writes content to the .tool_outputs folder of the file system associated with the tool context
+ * (conversation in an agent loop, pod in a sandbox function invocation) via DustFileSystem.
+ * Returns the scoped path (e.g. "conversation-{cId}/.tool_outputs/{fileName}" or
+ * "pod-{pId}/.tool_outputs/{fileName}") on success.
  */
 export async function writeToToolOutputsFolder(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType,
+  toolContext: ToolContextType,
   {
     fileName,
     content,
@@ -75,12 +141,17 @@ export async function writeToToolOutputsFolder(
     contentType: AllSupportedFileContentType;
   }
 ): Promise<Result<string, Error>> {
-  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  const fsResult = await getDustFileSystemForToolContext(auth, toolContext);
   if (fsResult.isErr()) {
     return new Err(new Error(fsResult.error.message));
   }
 
-  const scopedPath = `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/${TOOL_OUTPUTS_FOLDER_NAME}/${fileName}`;
+  const scopedPathResult = getToolOutputsScopedPath(toolContext, fileName);
+  if (scopedPathResult.isErr()) {
+    return scopedPathResult;
+  }
+  const scopedPath = scopedPathResult.value;
+
   const writeResult = await fsResult.value.write(
     scopedPath,
     content,
@@ -94,14 +165,14 @@ export async function writeToToolOutputsFolder(
 }
 
 /**
- * Attempts to persist a tool output block to the conversation's .tool_outputs folder via
+ * Attempts to persist a tool output block to the tool context's .tool_outputs folder via
  * DustFileSystem. Returns null if the block does not qualify for persistence.
  *
  * Call this as a side effect from processToolResults.
  */
 export async function persistToolOutput(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType,
+  toolContext: ToolContextType,
   block: CallToolResult["content"][number],
   { toolName, serverName }: { toolName: string; serverName: string }
 ): Promise<Result<PersistedToolOutput | null, Error>> {
@@ -112,7 +183,7 @@ export async function persistToolOutput(
     const ext = storageContentType === "application/json" ? ".json" : ".md";
     const fileName = makeFileName({ name: rawName, ext });
 
-    const result = await writeToToolOutputsFolder(auth, conversation, {
+    const result = await writeToToolOutputsFolder(auth, toolContext, {
       fileName,
       content,
       contentType: storageContentType,
@@ -135,7 +206,7 @@ export async function persistToolOutput(
       toolName
     );
 
-    const result = await writeToToolOutputsFolder(auth, conversation, {
+    const result = await writeToToolOutputsFolder(auth, toolContext, {
       fileName,
       content: block.text,
       contentType,
@@ -156,7 +227,7 @@ export async function persistToolOutput(
     const text = block.resource.text;
     const { fileName, contentType } = inferTextFileMetadata(text, toolName);
 
-    const result = await writeToToolOutputsFolder(auth, conversation, {
+    const result = await writeToToolOutputsFolder(auth, toolContext, {
       fileName,
       content: text,
       contentType,

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -148,7 +148,6 @@ export async function* runToolWithStreaming(
         conversation,
         localLogger,
         toolCallResultContent: toolCallResult.content,
-        toolConfiguration,
         toolContext: { runContext: agentLoopRunContext },
       }),
     {

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -149,6 +149,7 @@ export async function* runToolWithStreaming(
         localLogger,
         toolCallResultContent: toolCallResult.content,
         toolConfiguration,
+        toolContext: { runContext: agentLoopRunContext },
       }),
     {
       intervalMs: TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS,

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -68,6 +68,7 @@ to dynamically express that a server is not usable.
 ### TODOs:
 
 - [x] run_tool/mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
+- [ ] make runToolWithStreaming conversation-free
 - [ ] data_warehouse: flow to tool_outputs if in sandbox function
 - [ ] image_generation: flow to tool_outputs if in sandbox function
 - [ ] query_tables_v2: flow to tool_outputs if in sandbox function

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -5,56 +5,58 @@
 - means should be filtered (some are libs so all callers should be filtered)
 
 [-]     4  front/lib/actions/mcp_internal_actions/utils/file_utils.ts:109
-[+]     3  front/lib/actions/mcp_internal_actions/wrappers.ts:141
 [-]     5  front/lib/api/actions/servers/agent_memory/tools/index.ts:53
 [-]     1  front/lib/api/actions/servers/ask_user_question/tools/index.ts:18
-[+]     1  front/lib/api/actions/servers/common_utilities/tools/index.ts:100
 [-]     1  front/lib/api/actions/servers/conversation_files/index.ts:19
 [-]     4  front/lib/api/actions/servers/conversation_files/tools/index.ts:98
-[+]     1  front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts:169
-[+]     1  front/lib/api/actions/servers/data_sources_file_system/tools/search.ts:55
+[-]     2  front/lib/api/actions/servers/extract_data/tools/index.ts:56
+[-]     1  front/lib/api/actions/servers/files/tools/agent_loop_fs.ts:15
+[-]     3  front/lib/api/actions/servers/plan_mode/tools/index.ts:28
+[-]     6  front/lib/api/actions/servers/run_agent/index.ts:224
+           // Deeply tied to main conversation for now :/
+[-]     7  front/lib/api/actions/servers/sandbox/tools/index.ts:231
+[-]     4  front/lib/api/actions/servers/schedules_management/tools/index.ts:35
+           // Agent specific
+[-]     4  front/lib/api/actions/servers/skill_management/tools/index.ts:103
+[-]     4  front/lib/api/actions/servers/toolsets/tools/index.ts:25
+[-]     5  front/lib/api/actions/servers/wakeups/tools/index.ts:92
+[-]     1  front/lib/api/actions/servers/helpers.ts:44
+           // TODO: sidekick should be removed from list
+
 [~]     1  front/lib/api/actions/servers/data_warehouses/tools/index.ts:262
            // TODO: end state is a migration of the whole system here but today it relies on table
                     query. To re-enable likely different path when sandbox function that writes to
                     the pod tool outputs. Will need to change the tool return (currently returns a
                     file should now be a path for that flow). See TODOs below.
-[-]     2  front/lib/api/actions/servers/extract_data/tools/index.ts:56
-[-]     1  front/lib/api/actions/servers/files/tools/agent_loop_fs.ts:15
-[+]     1  front/lib/api/actions/servers/google_calendar/helpers.ts:176
-           // TODO: user timezone for calendar, once we have it in invocations
-[+]     2  front/lib/api/actions/servers/google_drive/tools/index.ts:300
-[+]     1  front/lib/api/actions/servers/helpers.ts:44
-           // TODO: sidekick should be removed from list
 [~]     1  front/lib/api/actions/servers/image_generation/helpers.ts:217
            // TODO: similar to data_warehouse, we need a specific flow to write to the pod
                     tool_outputs when in sandbox function. See TODOs below.
-[+]     4  front/lib/api/actions/servers/include_data/tools/index.ts:33
 [~]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
            // We don't know how to create frames directly in pods for now.
            // Create still conversation tied. Will have to skip for now the server.
+[~]     1  front/lib/api/actions/servers/query_tables_v2/tools/index.ts:284
+           // TODO: similar to data_warehouse, relies on generateCSVFileAndSnippet.
+
+[+]     1  front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts:169
+[+]     1  front/lib/api/actions/servers/data_sources_file_system/tools/search.ts:55
+[+]     1  front/lib/api/actions/servers/common_utilities/tools/index.ts:100
+[+]     3  front/lib/actions/mcp_internal_actions/wrappers.ts:141
+[+]     1  front/lib/api/actions/servers/google_calendar/helpers.ts:176
+           // TODO: user timezone for calendar, once we have it in invocations
+[+]     2  front/lib/api/actions/servers/google_drive/tools/index.ts:300
+[+]     4  front/lib/api/actions/servers/include_data/tools/index.ts:33
 [+]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
 [+]     2  front/lib/api/actions/servers/notion/tools/index.ts:118
-[-]     3  front/lib/api/actions/servers/plan_mode/tools/index.ts:28
 [+]     2  front/lib/api/actions/servers/pod_manager/helpers.ts:147
 [+]    11  front/lib/api/actions/servers/pod_manager/tools/index.ts:986
            // TODO: create_conversation should have timezone
                     origin defaults to "web" which is fine for now
 [+]     3  front/lib/api/actions/servers/pod_tasks/tools/index.ts:303
-[~]     1  front/lib/api/actions/servers/query_tables_v2/tools/index.ts:284
-           // TODO: similar to data_warehouse, relies on generateCSVFileAndSnippet.
-[-]     6  front/lib/api/actions/servers/run_agent/index.ts:224
-           // Deeply tied to main conversation for now :/
 [+]     3  front/lib/api/actions/servers/run_dust_app/index.ts:141
-[-]     7  front/lib/api/actions/servers/sandbox/tools/index.ts:231
-[-]     4  front/lib/api/actions/servers/schedules_management/tools/index.ts:35
-           // Agent specific
 [+]     2  front/lib/api/actions/servers/search/tools/index.ts:65
-[-]     4  front/lib/api/actions/servers/skill_management/tools/index.ts:103
 [+]     3  front/lib/api/actions/servers/slack_personal/tools/index.ts:449
 [+]     2  front/lib/api/actions/servers/snowflake/tools/index.ts:42
-[-]     4  front/lib/api/actions/servers/toolsets/tools/index.ts:25
 [+]     1  front/lib/api/actions/servers/user_mentions/tools/index.ts:44
-[-]     5  front/lib/api/actions/servers/wakeups/tools/index.ts:92
 [+]     4  front/lib/api/actions/servers/web_search_browse/tools/index.ts:59
 [+]     1  front/lib/api/mcp/run_tool.ts:91
 
@@ -65,7 +67,7 @@ to dynamically express that a server is not usable.
 
 ### TODOs:
 
-- [ ] run_tool/mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
+- [x] run_tool/mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
 - [ ] data_warehouse: flow to tool_outputs if in sandbox function
 - [ ] image_generation: flow to tool_outputs if in sandbox function
 - [ ] query_tables_v2: flow to tool_outputs if in sandbox function


### PR DESCRIPTION
## Description

`writeToToolOutputsFolder` / `persistToolOutput` now take a `ToolContextType` instead of a conversation. The file system is resolved inside `action_output_fs`: conversation file system for agent loop run contexts, pod file system for sandbox function run contexts (`invocation.sandboxFunction.space`). Outputs land in `conversation-{cId}/.tool_outputs/...` or `pod-{pId}/.tool_outputs/...` accordingly.

Call sites (`processToolResults`, `web_search_browse`, `run_dust_app`, `extract_data`) thread their existing `toolContext` through. No behavior change for the agent loop path.

This is plumbing for now we still need to get rid of `conversation` in `front/lib/actions/mcp_execution.ts`

## Tests

Updated `mcp_execution.test.ts` setup to pass a tool context; existing offload tests pass.

## Risk

Low. Pod path is not exercised yet (no caller runs tools in a sandbox function context); agent loop path is unchanged.

## Deploy Plan

- deploy `front`
