### PR TITLE
fix(conversations): don't 500 on userless auth when listing private-by-default conversations

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1811,6 +1811,75 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     );
   });
 
+  it("should not throw and should filter participant-restricted conversations for a userless sandbox token when private conversation URLs are private by default", async () => {
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+    const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminAuth.getNonNullableUser().sId,
+      workspace.sId
+    );
+
+    // Top-level conversation subject to the participants_only restriction.
+    const participantRequiredConversation = await ConversationFactory.create(
+      refreshedAdminAuth,
+      {
+        agentConfigurationId: agents[0].sId,
+        requestedSpaceIds: [globalSpace.id],
+        messagesCreatedAt: [dateFromDaysAgo(2)],
+      }
+    );
+
+    // Sub-conversation (depth 1) is exempt from the restriction and stays
+    // visible, proving the userless auth filters selectively rather than
+    // returning nothing.
+    const subConversation = await ConversationFactory.create(
+      refreshedAdminAuth,
+      {
+        agentConfigurationId: agents[0].sId,
+        requestedSpaceIds: [globalSpace.id],
+        messagesCreatedAt: [dateFromDaysAgo(2)],
+      }
+    );
+    await ConversationModel.update(
+      { depth: 1 },
+      { where: { workspaceId: workspace.id, sId: subConversation.sId } }
+    );
+
+    // Userless sandbox token: conversation driven by a non-human actor (no uId).
+    const userlessSandboxAuthRes = await Authenticator.fromSandboxToken(
+      {
+        wId: workspace.sId,
+        cId: participantRequiredConversation.sId,
+        aId: agents[0].sId,
+        mId: "test-message-id-userless",
+        sbId: "test-sandbox-id-userless",
+        execId: "test-exec-id-userless",
+        actionId: "test-action-id-userless",
+      },
+      workspace.sId
+    );
+    assert(
+      userlessSandboxAuthRes.isOk(),
+      "Failed to create userless sandbox authenticator"
+    );
+    const userlessSandboxAuth = userlessSandboxAuthRes.value;
+    expect(userlessSandboxAuth.authMethod()).toBe("sandbox_token");
+    expect(userlessSandboxAuth.user()).toBeNull();
+
+    // Must not throw (previously threw "User not found while auth method is not
+    // api key, system api key, or internal"). A userless actor is never a
+    // participant, so the participants_only conversation is excluded while the
+    // exempt sub-conversation remains visible.
+    const conversations =
+      await ConversationResource.listAll(userlessSandboxAuth);
+    const conversationIds = conversations.map((c) => c.sId);
+    expect(conversationIds).not.toContain(participantRequiredConversation.sId);
+    expect(conversationIds).toContain(subConversation.sId);
+  });
+
   it("should allow API key auth to fetch a conversation it created when private URLs are enabled by default", async () => {
     const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
       privateConversationUrlsByDefault: true,

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -966,13 +966,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return spaceBasedAccessible;
     }
 
-    const user = auth.user();
-    if (!user) {
-      throw new Error(
-        "User not found while auth method is not api key, system api key, or internal"
-      );
-    }
-
     const participantRestrictedConversations = spaceBasedAccessible.filter(
       (conversation) =>
         this.shouldApplyPrivateByDefaultUrlRestriction(conversation) &&
@@ -985,17 +978,23 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return spaceBasedAccessible;
     }
 
-    // For all participant-restricted conversations, check if the user is a participant.
-    const participations = await ConversationParticipantModel.findAll({
-      where: {
-        workspaceId: workspace.id,
-        userId: user.id,
-        conversationId: {
-          [Op.in]: participantRestrictedConversations.map((c) => c.id),
-        },
-      },
-      attributes: ["conversationId"],
-    });
+    // For all participant-restricted conversations, check if the user is a participant. A userless
+    // authenticator (e.g. a userless sandbox token driven by a non-human actor, or a session/oauth
+    // request with no matching Dust user) can never be a participant, so it sees none of them. This
+    // mirrors the null-user handling in canUserAccessPrivateByDefaultConversation.
+    const user = auth.user();
+    const participations = user
+      ? await ConversationParticipantModel.findAll({
+          where: {
+            workspaceId: workspace.id,
+            userId: user.id,
+            conversationId: {
+              [Op.in]: participantRestrictedConversations.map((c) => c.id),
+            },
+          },
+          attributes: ["conversationId"],
+        })
+      : [];
 
     const participantConversationIds = new Set(
       participations.map((p) => p.conversationId)


### PR DESCRIPTION
## Problem

Workspaces with **"Private conversation URLs by default"** enabled were emitting `User not found while auth method is not api key, system api key, or internal` errors (500s).

`ConversationResource.baseFetchWithAuthorization` — the central path behind nearly all conversation list/fetch calls — throws whenever a **non-bypassed** authenticator (`session`, `oauth`, or `sandbox_token`) has a `null` user while the workspace flag is on.

A null user reaches that point in three legitimate ways:

1. **Userless sandbox token** (`Authenticator.fromSandboxToken`) — a conversation driven by a non-human actor (e.g. a Slack bot / triggered conversation). Most likely culprit for bot-active workspaces.
2. **`session`** — a valid WorkOS session with no matching Dust `User` row (deleted user, mid-onboarding, cross-region/stale session).
3. **Bearer `oauth` via `fromSession`** — same missing-Dust-user case (`fromWorkOSToken` guards this, but the `fromSession` bearer branch does not).

## Fix

The sibling single-access path, `canUserAccessPrivateByDefaultConversation`, already handles a null user **gracefully by denying access** (returns `false`, no throw). The list path was simply inconsistent — it threw a 500 instead of filtering.

This change aligns the two: a userless authenticator can never be a conversation participant, so it sees **none** of the participant-restricted conversations instead of crashing.

**No capability change** — userless auth was already denied these conversations via `canAccess`; this only stops the 500 on the list path.

## Test plan

- [x] `npx tsgo --noEmit` passes
- [x] `biome check` clean
- [ ] Reviewer: confirm behavior via a workspace with the flag on + a bot/triggered conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)