### PR TITLE
Block selection of non available models and prevent save.

### DIFF
--- a/front-api/routes/w/[wId]/models.ts
+++ b/front-api/routes/w/[wId]/models.ts
@@ -1,10 +1,6 @@
-import { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
-import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
-import { config as regionConfig } from "@app/lib/api/regions/config";
-import { filterEnabledModels } from "@app/lib/assistant";
-import { getFeatureFlags } from "@app/lib/auth";
+import { withModelSelectability } from "@app/lib/advanced_models/enabled_models";
+import { getAvailableModelsForWorkspace } from "@app/lib/api/assistant/workspace_capabilities";
 import type { GetEnabledModelsResponseType } from "@app/types/api/assistant/models";
-import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
@@ -15,20 +11,10 @@ const app = workspaceApp();
 app.get("/", async (ctx): HandlerResult<GetEnabledModelsResponseType> => {
   const auth = ctx.get("auth");
 
-  const featureFlags = await getFeatureFlags(auth);
-  const owner = auth.getNonNullableWorkspace();
-  const plan = auth.plan();
-  const region = regionConfig.getCurrentRegion();
-  const whitelistedProviders = getWhitelistedProviders(auth);
+  const availableModels = await getAvailableModelsForWorkspace(auth);
 
-  // Include both standard models and custom models (from GCS at build time).
-  const allUsedModels = [...USED_MODEL_CONFIGS, ...CUSTOM_MODEL_CONFIGS];
-  const models = filterEnabledModels(allUsedModels, {
-    featureFlags,
-    plan,
-    regionalModelsOnly: owner.regionalModelsOnly,
-    region,
-    whitelistedProviders,
+  const models = await withModelSelectability(auth, {
+    models: availableModels,
   });
 
   return ctx.json({ models });

--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -8,8 +8,8 @@ import { RegionalFlag } from "@app/components/shared/RegionalFlag";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
+import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import { getProviderDisplayName } from "@app/types/assistant/models/providers";
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { RegionType } from "@app/types/region";
 import {
   DropdownMenuLabel,
@@ -24,19 +24,24 @@ import type React from "react";
 import { useController } from "react-hook-form";
 
 interface ModelSelectionSubmenuProps {
-  models: ModelConfigurationType[];
+  models: EnabledModelConfigurationType[];
 }
 
+const NOT_SELECTABLE_MODEL_DESCRIPTION =
+  "Not enabled for you. Choose another model to save.";
+
 interface ModelRadioItemProps {
-  modelConfig: ModelConfigurationType;
+  modelConfig: EnabledModelConfigurationType;
   isDark: boolean;
-  onModelSelection: (modelConfig: ModelConfigurationType) => void;
+  isSelected: boolean;
+  onModelSelection: (modelConfig: EnabledModelConfigurationType) => void;
   regionalComponent?: React.ReactNode | null;
 }
 
 function ModelRadioItem({
   modelConfig,
   isDark,
+  isSelected,
   onModelSelection,
   regionalComponent,
 }: ModelRadioItemProps) {
@@ -44,9 +49,16 @@ function ModelRadioItem({
     <DropdownMenuRadioItem
       value={modelConfig.modelId}
       icon={getModelProviderLogo(modelConfig.providerId, isDark)}
-      description={modelConfig.shortDescription}
+      description={
+        !modelConfig.isSelectable && isSelected
+          ? NOT_SELECTABLE_MODEL_DESCRIPTION
+          : modelConfig.shortDescription
+      }
       label={modelConfig.displayName}
-      onClick={() => onModelSelection(modelConfig)}
+      disabled={!modelConfig.isSelectable}
+      onClick={() => {
+        onModelSelection(modelConfig);
+      }}
       endComponent={regionalComponent}
     />
   );
@@ -90,14 +102,23 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
   const currentModelKey = modelField.value.modelId;
 
   const selectedModel = models.find(
-    (model) => model.modelId === currentModelKey
+    (model) =>
+      model.modelId === modelField.value.modelId &&
+      model.providerId === modelField.value.providerId
   );
 
   const isSelectedModelNotInBest =
     selectedModel &&
     !bestGeneralModels.some((model) => model.modelId === selectedModel.modelId);
 
-  const handleModelSelection = (modelConfig: ModelConfigurationType) => {
+  const showSelectedModelSection =
+    selectedModel && (!selectedModel.isSelectable || isSelectedModelNotInBest);
+
+  const handleModelSelection = (modelConfig: EnabledModelConfigurationType) => {
+    if (!modelConfig.isSelectable) {
+      return;
+    }
+
     modelField.onChange({
       modelId: modelConfig.modelId,
       providerId: modelConfig.providerId,
@@ -106,12 +127,16 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
     reasoningEffortField.onChange(modelConfig.defaultReasoningEffort);
   };
 
+  const isModelSelected = (modelConfig: EnabledModelConfigurationType) =>
+    modelConfig.modelId === modelField.value.modelId &&
+    modelConfig.providerId === modelField.value.providerId;
+
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger label="Model selection" />
       <DropdownMenuPortal>
         <DropdownMenuSubContent className="w-80">
-          {isSelectedModelNotInBest && selectedModel && (
+          {showSelectedModelSection && selectedModel && (
             <>
               <DropdownMenuLabel label="Selected model" />
               <DropdownMenuRadioGroup value={currentModelKey}>
@@ -119,6 +144,7 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                   key={getModelKey(selectedModel)}
                   modelConfig={selectedModel}
                   isDark={isDark}
+                  isSelected={true}
                   onModelSelection={handleModelSelection}
                   regionalComponent={
                     selectedModel.regionalAvailability[regionInfo.name]
@@ -137,6 +163,7 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                 key={getModelKey(modelConfig)}
                 modelConfig={modelConfig}
                 isDark={isDark}
+                isSelected={isModelSelected(modelConfig)}
                 onModelSelection={handleModelSelection}
                 regionalComponent={
                   modelConfig.regionalAvailability[regionInfo.name]
@@ -167,6 +194,7 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                               key={getModelKey(modelConfig)}
                               modelConfig={modelConfig}
                               isDark={isDark}
+                              isSelected={isModelSelected(modelConfig)}
                               onModelSelection={handleModelSelection}
                               regionalComponent={
                                 modelConfig.regionalAvailability[
@@ -193,6 +221,7 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                               key={getModelKey(modelConfig)}
                               modelConfig={modelConfig}
                               isDark={isDark}
+                              isSelected={isModelSelected(modelConfig)}
                               onModelSelection={handleModelSelection}
                               regionalComponent={
                                 modelConfig.regionalAvailability[

--- a/front/components/agent_builder/instructions/ReasoningEffortSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ReasoningEffortSubmenu.tsx
@@ -1,7 +1,7 @@
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import {
   getAvailableReasoningEfforts,
-  type ModelConfigurationType,
   type ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
@@ -27,7 +27,7 @@ const REASONING_EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
 };
 
 interface ReasoningEffortSubmenuProps {
-  models: ModelConfigurationType[];
+  models: EnabledModelConfigurationType[];
 }
 
 export function ReasoningEffortSubmenu({
@@ -70,7 +70,7 @@ export function ReasoningEffortSubmenu({
     }
   }, [modelConfig, field]);
 
-  if (!modelConfig) {
+  if (!modelConfig || !modelConfig.isSelectable) {
     return null;
   }
 

--- a/front/components/agent_builder/instructions/utils.ts
+++ b/front/components/agent_builder/instructions/utils.ts
@@ -23,12 +23,14 @@ export function isBestPerformingModel(modelId: ModelIdType): boolean {
   return BEST_PERFORMING_MODELS_ID.includes(modelId);
 }
 
-export function categorizeModels(models: ModelConfigurationType[]): {
-  bestPerformingModelConfigs: ModelConfigurationType[];
-  otherModelConfigs: ModelConfigurationType[];
+export function categorizeModels<T extends ModelConfigurationType>(
+  models: T[]
+): {
+  bestPerformingModelConfigs: T[];
+  otherModelConfigs: T[];
 } {
-  const bestPerformingModelConfigs: ModelConfigurationType[] = [];
-  const otherModelConfigs: ModelConfigurationType[] = [];
+  const bestPerformingModelConfigs: T[] = [];
+  const otherModelConfigs: T[] = [];
 
   for (const modelConfig of models) {
     if (isBestPerformingModel(modelConfig.modelId)) {
@@ -41,25 +43,29 @@ export function categorizeModels(models: ModelConfigurationType[]): {
   return { bestPerformingModelConfigs, otherModelConfigs };
 }
 
-export function getModelKey(modelConfig: ModelConfigurationType): string {
+export function getModelKey(
+  modelConfig: Pick<ModelConfigurationType, "modelId">
+): ModelIdType {
   return modelConfig.modelId;
 }
 
 // Enhanced categorization for new UI structure
-export interface ModelCategories {
-  bestGeneralModels: ModelConfigurationType[];
+export interface ModelCategories<
+  T extends ModelConfigurationType = ModelConfigurationType,
+> {
+  bestGeneralModels: T[];
   providerGroups: Map<
     ModelProviderIdType,
     {
-      recent: ModelConfigurationType[];
-      older: ModelConfigurationType[];
+      recent: T[];
+      older: T[];
     }
   >;
 }
 
-export function getModelsCategorization(
-  models: ModelConfigurationType[]
-): ModelCategories {
+export function getModelsCategorization<T extends ModelConfigurationType>(
+  models: T[]
+): ModelCategories<T> {
   // Use existing categorization to separate best performing models
   const { bestPerformingModelConfigs, otherModelConfigs } =
     categorizeModels(models);
@@ -68,8 +74,8 @@ export function getModelsCategorization(
   const providerGroups = new Map<
     ModelProviderIdType,
     {
-      recent: ModelConfigurationType[];
-      older: ModelConfigurationType[];
+      recent: T[];
+      older: T[];
     }
   >();
 

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -1,6 +1,7 @@
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder/types";
 import type { FetchAgentTemplateResponse } from "@app/lib/resources/template_resource";
+import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/types/assistant/creativity";
 import {
@@ -10,10 +11,7 @@ import {
 import { GEMINI_3_1_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { MISTRAL_MEDIUM_3_5_MODEL_ID } from "@app/types/assistant/models/mistral";
 import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
-import type {
-  ModelConfigurationType,
-  ModelIdType,
-} from "@app/types/assistant/models/types";
+import type { ModelIdType } from "@app/types/assistant/models/types";
 import { GROK_4_MODEL_ID } from "@app/types/assistant/models/xai";
 import type { UserType } from "@app/types/user";
 import uniqueId from "lodash/uniqueId";
@@ -75,20 +73,27 @@ const PREFERRED_LARGE_MODEL_IDS: ModelIdType[] = [
  * then a hardcoded default.
  */
 export function getDefaultModel(
-  availableModels: ModelConfigurationType[]
-): ModelConfigurationType {
+  availableModels: EnabledModelConfigurationType[]
+): EnabledModelConfigurationType {
+  const selectableModels = availableModels.filter((m) => m.isSelectable);
+
   for (const modelId of PREFERRED_LARGE_MODEL_IDS) {
-    const model = availableModels.find((m) => m.modelId === modelId);
+    const model = selectableModels.find((m) => m.modelId === modelId);
     if (model) {
       return model;
     }
   }
 
   const fallbackModel =
-    availableModels.find((m) => m.largeModel) ??
-    availableModels.find((m) => !m.largeModel);
+    selectableModels.find((m) => m.largeModel) ??
+    selectableModels.find((m) => !m.largeModel);
 
-  return fallbackModel ?? CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
+  return (
+    fallbackModel ?? {
+      ...CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+      isSelectable: true,
+    }
+  );
 }
 
 export function getDefaultAgentFormData({

--- a/front/lib/advanced_models/enabled_models.test.ts
+++ b/front/lib/advanced_models/enabled_models.test.ts
@@ -1,0 +1,114 @@
+import { withModelSelectability } from "@app/lib/advanced_models/enabled_models";
+import { Authenticator } from "@app/lib/auth";
+import { AdvancedModelResource } from "@app/lib/resources/advanced_model_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import {
+  CLAUDE_OPUS_4_6_MODEL_ID,
+  CLAUDE_SONNET_4_6_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
+import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
+import { describe, expect, it } from "vitest";
+
+const opusModel = SUPPORTED_MODEL_CONFIGS.find(
+  (m) => m.modelId === CLAUDE_OPUS_4_6_MODEL_ID
+)!;
+const sonnetModel = SUPPORTED_MODEL_CONFIGS.find(
+  (m) => m.modelId === CLAUDE_SONNET_4_6_MODEL_ID
+)!;
+
+function getModelSelectability(
+  models: Awaited<ReturnType<typeof withModelSelectability>>,
+  modelId: string
+): boolean | undefined {
+  return models.find((model) => model.modelId === modelId)?.isSelectable;
+}
+
+describe("withModelSelectability", () => {
+  it("marks every model as selectable when models_picker is disabled", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const result = await withModelSelectability(auth, {
+      models: [opusModel, sonnetModel],
+    });
+
+    expect(getModelSelectability(result, opusModel.modelId)).toBe(true);
+    expect(getModelSelectability(result, sonnetModel.modelId)).toBe(true);
+  });
+
+  it("marks non-advanced models as selectable when models_picker is enabled", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "models_picker");
+
+    const result = await withModelSelectability(auth, {
+      models: [sonnetModel],
+    });
+
+    expect(getModelSelectability(result, sonnetModel.modelId)).toBe(true);
+  });
+
+  it("marks advanced models as not selectable when they are not allowed", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "models_picker");
+
+    await AdvancedModelResource.removeWorkspaceAllowedAdvancedModel(adminAuth, {
+      providerId: opusModel.providerId,
+      modelId: opusModel.modelId,
+    });
+
+    const result = await withModelSelectability(auth, {
+      models: [opusModel],
+    });
+
+    expect(getModelSelectability(result, opusModel.modelId)).toBe(false);
+  });
+
+  it("marks advanced models as selectable when they are allowed", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(userAuth, "models_picker");
+
+    await AdvancedModelResource.addWorkspaceAllowedAdvancedModel(adminAuth, {
+      providerId: "anthropic",
+      modelId: CLAUDE_OPUS_4_6_MODEL_ID,
+    });
+
+    const result = await withModelSelectability(userAuth, {
+      models: [opusModel, sonnetModel],
+    });
+
+    expect(getModelSelectability(result, opusModel.modelId)).toBe(true);
+    expect(getModelSelectability(result, sonnetModel.modelId)).toBe(true);
+  });
+});

--- a/front/lib/advanced_models/enabled_models.ts
+++ b/front/lib/advanced_models/enabled_models.ts
@@ -1,0 +1,37 @@
+import { advancedModelKey } from "@app/lib/advanced_models/resolve_allowed";
+import { isAdvancedModel } from "@app/lib/assistant";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { AdvancedModelResource } from "@app/lib/resources/advanced_model_resource";
+import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+
+export async function withModelSelectability(
+  auth: Authenticator,
+  { models }: { models: ModelConfigurationType[] }
+): Promise<EnabledModelConfigurationType[]> {
+  const featureFlags = await getFeatureFlags(auth);
+
+  if (!featureFlags.includes("models_picker")) {
+    return models.map((model) => ({
+      ...model,
+      isSelectable: true,
+    }));
+  }
+
+  const { models: allowedAdvancedModels } =
+    await AdvancedModelResource.resolveAllowedAdvancedModels(auth, {
+      user: auth.user(),
+    });
+
+  const allowedAdvancedModelKeys = new Set(
+    allowedAdvancedModels.map(advancedModelKey)
+  );
+
+  return models.map((model) => ({
+    ...model,
+    isSelectable:
+      !isAdvancedModel(model) ||
+      allowedAdvancedModelKeys.has(advancedModelKey(model)),
+  }));
+}

--- a/front/lib/api/assistant/configuration/create_or_upgrade.ts
+++ b/front/lib/api/assistant/configuration/create_or_upgrade.ts
@@ -3,6 +3,7 @@ import type {
   MCPServerConfigurationType,
   ServerSideMCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
+import { getAdvancedModelAccessErrorForAgentConfiguration } from "@app/lib/advanced_models/access";
 import { pruneSuggestionsForAgent } from "@app/lib/api/assistant/agent_suggestion_pruning";
 import { createAgentActionConfiguration } from "@app/lib/api/assistant/configuration/actions";
 import {
@@ -12,6 +13,8 @@ import {
 } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
@@ -142,6 +145,22 @@ export async function createOrUpgradeAgentConfiguration({
     return new Err(
       new Error("An author must be provided when no user is authenticated.")
     );
+  }
+
+  const featureFlags = await getFeatureFlags(auth);
+  const modelConfig = getSupportedModelConfig(assistant.model);
+  if (modelConfig) {
+    const accessError = await getAdvancedModelAccessErrorForAgentConfiguration(
+      auth,
+      {
+        agentName: assistant.name,
+        model: modelConfig,
+        featureFlags,
+      }
+    );
+    if (accessError) {
+      return new Err(new Error(accessError.message));
+    }
   }
 
   const agentConfigurationRes = await createAgentConfiguration(auth, {

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -252,6 +252,25 @@ describe("isModelAvailable", () => {
     ).toBe(false);
   });
 
+  it("should return true for advanced models when models_picker is enabled without plan access", () => {
+    const model = createMockModel({
+      availableIfOneOf: { plansWithAdvancedModels: true },
+      largeModel: false,
+    });
+    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE, {
+      hasAdvancedModelAccess: false,
+    });
+
+    expect(
+      isModelAvailable(model, {
+        featureFlags: ["models_picker"],
+        plan,
+        regionalModelsOnly: owner.regionalModelsOnly,
+        region: TEST_REGION,
+      })
+    ).toBe(true);
+  });
+
   it("should return true when both plansWithAdvancedModels and featureFlag are set, with advanced model access", () => {
     const model = createMockModel({
       availableIfOneOf: {
@@ -316,6 +335,26 @@ describe("isModelAvailable", () => {
 });
 
 describe("filterEnabledModels", () => {
+  it("includes advanced models when models_picker is enabled without plan access", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const model = createMockModel({
+      availableIfOneOf: { plansWithAdvancedModels: true },
+      largeModel: false,
+      providerId: "anthropic",
+    });
+
+    const result = filterEnabledModels([model], {
+      featureFlags: ["models_picker"],
+      plan: { ...auth.plan()!, hasAdvancedModelAccess: false },
+      regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
+      region: TEST_REGION,
+      whitelistedProviders: getWhitelistedProviders(auth),
+    });
+
+    expect(result).toEqual([model]);
+  });
+
   it("should include model when available and provider is whitelisted", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -32,7 +32,11 @@ export function isModelAvailable(
     region: RegionType;
   }
 ) {
-  if (m.largeModel && !isUpgraded(plan)) {
+  // Otherwise, we filter too early.
+  const includeAdvancedModelInPicker =
+    featureFlags.includes("models_picker") && isAdvancedModel(m);
+
+  if (m.largeModel && !isUpgraded(plan) && !includeAdvancedModelInPicker) {
     return false;
   }
 
@@ -50,7 +54,10 @@ export function isModelAvailable(
 
   const { plansWithAdvancedModels, featureFlag } = m.availableIfOneOf;
 
-  if (plansWithAdvancedModels === true && plan?.hasAdvancedModelAccess) {
+  if (
+    plansWithAdvancedModels === true &&
+    (plan?.hasAdvancedModelAccess || includeAdvancedModelInPicker)
+  ) {
     return true;
   }
 

--- a/front/types/api/assistant/models.ts
+++ b/front/types/api/assistant/models.ts
@@ -1,5 +1,9 @@
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 
+export type EnabledModelConfigurationType = ModelConfigurationType & {
+  isSelectable: boolean;
+};
+
 export type GetEnabledModelsResponseType = {
-  models: ModelConfigurationType[];
+  models: EnabledModelConfigurationType[];
 };


### PR DESCRIPTION
## Description

Adds model selectability enforcement for the `models_picker` feature flag. When the FF is on, advanced models are shown in the agent builder picker but disabled (`isSelectable: false`) if the user/workspace hasn't been granted access via `AdvancedModelResource.resolveAllowedAdvancedModels`. A new `EnabledModelConfigurationType` (= `ModelConfigurationType & { isSelectable: boolean }`) threads through the UI. The currently-selected model — if now restricted — stays visible in `ModelSelectionSubmenu` with a "Not enabled for you. Choose another model to save." warning. `createOrUpgradeAgentConfiguration` enforces access server-side via `getAdvancedModelAccessErrorForAgentConfiguration` and returns an `Err` on save if the model isn't allowed. `getDefaultModel` filters to selectable models only.

<img width="583" height="700" alt="file-31dc8a74f7a9bc1d32f63ee0f938ec9d" src="https://github.com/user-attachments/assets/89cc82ad-5612-41b6-9b4c-275058475ac5" />

<img width="372" height="174" alt="image" src="https://github.com/user-attachments/assets/e8f2e9d9-7333-4ae3-9c55-895feb15e486" />

## Tests

- New Vitest suite for `withModelSelectability` in `front/lib/advanced_models/enabled_models.test.ts` covering: FF off (all selectable), non-advanced (always selectable), advanced + disallowed (not selectable), advanced + allowed (selectable).
- Updated `isModelAvailable` and `filterEnabledModels` tests in `front/lib/assistant.test.ts` for `models_picker` + no plan `hasAdvancedModelAccess` cases.
- Tested manually in the agent builder UI.

## Risk

All changes are gated behind the `models_picker` FF. When the FF is off, `withModelSelectability` marks every model selectable and behaviour is unchanged. Low risk, trivially rollback-safe.

## Deploy Plan

Deploy front.
