### PR TITLE
Tool notifications: make processToolNotification tool-context dependent

### DIFF
--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -1,6 +1,6 @@
 import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import type { InputBarContainerProps } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
-import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
+import type { AgentLoopToolNotificationEvent } from "@app/lib/actions/mcp";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
@@ -98,7 +98,7 @@ export type ConversationForkNotice = {
 
 export type AgentMessageStateEvent = (
   | AgentMessageEvents
-  | ToolNotificationEvent
+  | AgentLoopToolNotificationEvent
 ) & { step: number };
 
 export type AgentMessageStateWithControlEvent =

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -239,20 +239,42 @@ export type MCPErrorEvent = {
   };
 };
 
-export type ToolNotificationEvent = {
+type ToolNotificationEventBase = {
   type: "tool_notification";
   created: number;
-  configurationId: string;
-  conversationId: string;
-  messageId: string;
   action: AgentMCPActionWithOutputType;
   notification: ProgressNotificationContentType;
 };
 
+// Tool notification emitted when running a tool within an agent loop. Published on the
+// conversation message channel, hence the conversation-scoped identifiers.
+export type AgentLoopToolNotificationEvent = ToolNotificationEventBase & {
+  configurationId: string;
+  conversationId: string;
+  messageId: string;
+};
+
+// Tool notification emitted when running a tool within a sandbox function invocation.
+export type SandboxFunctionToolNotificationEvent = ToolNotificationEventBase & {
+  sandboxFunctionId: string;
+  invocationId: string;
+};
+
+export type ToolNotificationEvent =
+  | AgentLoopToolNotificationEvent
+  | SandboxFunctionToolNotificationEvent;
+
+export function isAgentLoopToolNotificationEvent(
+  event: ToolNotificationEvent
+): event is AgentLoopToolNotificationEvent {
+  return "messageId" in event;
+}
+
+// AgentActionRunningEvents are events related action execution within an agent loop.
 export type AgentActionRunningEvents =
   | MCPParamsEvent
   | MCPApproveExecutionEvent
-  | ToolNotificationEvent;
+  | AgentLoopToolNotificationEvent;
 
 const MAX_DESCRIPTION_LENGTH = 1024;
 

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -27,11 +27,7 @@ import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/action
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type {
-  AgentMessageType,
-  ConversationType,
-} from "@app/types/assistant/conversation";
+import type { ConversationType } from "@app/types/assistant/conversation";
 import type {
   FileUseCase,
   FileUseCaseMetadata,
@@ -79,19 +75,18 @@ export async function processToolNotification(
   notification: MCPProgressNotificationType,
   {
     action,
-    agentConfiguration,
-    conversation,
-    agentMessage,
+    toolContext,
   }: {
     action: AgentMCPActionResource;
-    agentConfiguration: AgentConfigurationType;
-    conversation: ConversationType;
-    agentMessage: AgentMessageType;
+    toolContext: ToolContextType;
   }
 ): Promise<{
   event: ToolNotificationEvent;
   storedItems: AgentMCPActionOutputItemModel[];
 }> {
+  const { runContext } = toolContext;
+  assert(runContext, "processToolNotification requires a tool run context.");
+
   const output = notification.params._meta.data.output;
 
   let storedItems: AgentMCPActionOutputItemModel[] = [];
@@ -118,23 +113,43 @@ export async function processToolNotification(
     });
   }
 
-  // Regular notifications, we yield them as is with the type "tool_notification".
-  return {
-    event: {
-      type: "tool_notification",
-      created: Date.now(),
-      configurationId: agentConfiguration.sId,
-      conversationId: conversation.sId,
-      messageId: agentMessage.sId,
-      action: {
-        ...action.toJSON(),
-        output: null,
-        generatedFiles: [],
-      },
-      notification: notification.params,
-    },
-    storedItems,
+  const actionWithOutput = {
+    ...action.toJSON(),
+    output: null,
+    generatedFiles: [],
   };
+
+  // Regular notifications, we yield them as is with the type "tool_notification", scoped to the
+  // run context they were emitted from.
+  switch (runContext.contextType) {
+    case "agent_loop":
+      return {
+        event: {
+          type: "tool_notification",
+          created: Date.now(),
+          configurationId: runContext.agentConfiguration.sId,
+          conversationId: runContext.conversation.sId,
+          messageId: runContext.agentMessage.sId,
+          action: actionWithOutput,
+          notification: notification.params,
+        },
+        storedItems,
+      };
+    case "sandbox_function":
+      return {
+        event: {
+          type: "tool_notification",
+          created: Date.now(),
+          sandboxFunctionId: runContext.invocation.sandboxFunction.sId,
+          invocationId: runContext.invocation.sId,
+          action: actionWithOutput,
+          notification: notification.params,
+        },
+        storedItems,
+      };
+    default:
+      return assertNever(runContext);
+  }
 }
 
 /**

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -114,7 +114,7 @@ export async function* runToolWithStreaming(
         const { event, storedItems } = await processToolNotification(
           auth,
           notification,
-          { action, agentConfiguration, conversation, agentMessage }
+          { action, toolContext: { runContext: agentLoopRunContext } }
         );
         intermediateOutputItems.push(...storedItems);
         return event;

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,3 +1,4 @@
+import { isAgentLoopToolNotificationEvent } from "@app/lib/actions/mcp";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { isLightClientSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
@@ -464,7 +465,21 @@ async function executeToolStreaming(
         });
         break;
       case "tool_params":
+        await handleNonDeferredEvents(auth, {
+          event,
+          agentMessage,
+          conversation,
+          step,
+        });
+        break;
+
       case "tool_notification":
+        // Tools executed from the agent loop activity always run with an agent loop context, so
+        // sandbox function notification events cannot surface here.
+        assert(
+          isAgentLoopToolNotificationEvent(event),
+          "Unexpected sandbox function tool notification in the agent loop."
+        );
         await handleNonDeferredEvents(auth, {
           event,
           agentMessage,

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -68,16 +68,15 @@ to dynamically express that a server is not usable.
 ### TODOs:
 
 - [x] run_tool/mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
-- [ ] make runToolWithStreaming conversation-free
+- [x] make runToolWithStreaming conversation-free
 - [ ] data_warehouse: flow to tool_outputs if in sandbox function
 - [ ] image_generation: flow to tool_outputs if in sandbox function
 - [ ] query_tables_v2: flow to tool_outputs if in sandbox function
-- [ ] interactive_content: allow converstaion less create and publish (big one, flavien has context)
+- [ ] interactive_content: allow conversation-less create and publish (big one, flavien has context)
 - [ ] pod_manager: filter add_message_to_conversation tool when in sandbox function 
 - [ ] timezone on invocation for:
       - google_calendar
       - pod_manager/create_conversation
-- [ ] runToolWithStreaming is highly conversation centric, maybe dsbx does not use it.
 
 ### files server
 

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -68,7 +68,10 @@ to dynamically express that a server is not usable.
 ### TODOs:
 
 - [x] run_tool/mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
-- [x] make runToolWithStreaming conversation-free
+- [ ] make runToolWithStreaming conversation-free
+  - [x] make processToolNotification conversation-free
+  - [ ] make processToolResults conversation-free
+  - [ ] make getExitOrPauseEvents conversation-free
 - [ ] data_warehouse: flow to tool_outputs if in sandbox function
 - [ ] image_generation: flow to tool_outputs if in sandbox function
 - [ ] query_tables_v2: flow to tool_outputs if in sandbox function


### PR DESCRIPTION
## Description

Step towards conversation-free tool execution (sandbox function invocations).

- `processToolNotification` now takes a `ToolContextType` instead of `agentConfiguration` / `conversation` / `agentMessage`, and builds the notification event from the run context.
- `ToolNotificationEvent` is split into `AgentLoopToolNotificationEvent` (`configurationId` / `conversationId` / `messageId`, wire shape unchanged) and `SandboxFunctionToolNotificationEvent` (`sandboxFunctionId` / `invocationId`, not emitted yet).
- The conversation publish path (`AgentActionRunningEvents` / `AgentMessageEvents`) only carries the agent loop variant; the agent loop activity asserts it.

Audited all `tool_notification` readers (front publish path, web client, Slack connector, public SDK schema, private swagger schema): the agent loop event payload is unchanged.

## Tests

- `lib/actions/mcp_execution.test.ts` ✅ 
- `lib/actions/mcp_actions.test.ts` ✅ 
- `lib/actions/mcp_internal_actions/exit_events.test.ts` ✅ 
- `temporal/agent_loop/activities/common.test.ts` ✅ 

## Risk

Low. Agent loop notification events are byte-identical; the sandbox function variant has no emitter yet.

## Deploy Plan

- deploy `front`

r? @flvndvd cc @PopDaph 