### PR TITLE
fix(email): parse form-encoded body in email validate-action endpoint

### DIFF
--- a/front-api/routes/email/validate-action.test.ts
+++ b/front-api/routes/email/validate-action.test.ts
@@ -1,0 +1,49 @@
+import { generateValidationToken } from "@app/lib/api/email/validation_token";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+process.env.EMAIL_VALIDATION_SECRET ||= "test-email-validation-secret";
+
+const VALIDATE_ACTION_PATH = "/api/email/validate-action";
+
+describe("POST /api/email/validate-action", () => {
+  it("returns 400 when the token is missing", async () => {
+    const res = await honoApp.request(VALIDATE_ACTION_PATH, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toBe("Missing or invalid token parameter.");
+  });
+
+  it("accepts a form-encoded token (the validation page posts a plain HTML form)", async () => {
+    const token = generateValidationToken("bogus-action-id", "approved");
+
+    const res = await honoApp.request(VALIDATE_ACTION_PATH, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ token }).toString(),
+    });
+
+    // The token is read from the form body: the request gets past the 400
+    // token check and redirects to the validation result page.
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/email/validation?status=");
+  });
+
+  it("accepts a JSON-encoded token", async () => {
+    const token = generateValidationToken("bogus-action-id", "approved");
+
+    const res = await honoApp.request(VALIDATE_ACTION_PATH, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/email/validation?status=");
+  });
+});

--- a/front-api/routes/email/validate-action.ts
+++ b/front-api/routes/email/validate-action.ts
@@ -15,8 +15,17 @@ const app = createHono();
 
 /** @ignoreswagger */
 app.post("/", async (ctx) => {
-  const body = await ctx.req.json().catch(() => ({}));
-  const { token } = body ?? {};
+  // The validation page auto-submits a plain HTML form, which posts as
+  // `application/x-www-form-urlencoded` (Next's body parser decoded it
+  // transparently; Hono's `ctx.req.json()` does not). Parse form bodies when
+  // the header says so, and default to JSON otherwise.
+  const contentType = ctx.req.header("content-type") ?? "";
+  const body: Record<string, unknown> = contentType.includes(
+    "application/x-www-form-urlencoded"
+  )
+    ? await ctx.req.parseBody().catch(() => ({}))
+    : await ctx.req.json().catch(() => ({}));
+  const { token } = body;
   if (!isString(token)) {
     return apiError(ctx, {
       status_code: 400,


### PR DESCRIPTION
## Problem

Clicking an Allow/Decline link in an agent tool-validation email fails in the browser with:

```
{"error":{"type":"invalid_request_error","message":"Missing or invalid token parameter."}}
```

Reported in dust-tt/tasks#9410.

## Root cause

The validation page (`ValidationPage.tsx`) auto-submits a plain HTML `<form method="POST">`, which sends `application/x-www-form-urlencoded`. The old Next.js handler worked because Next's body parser transparently decodes form bodies. The Hono migration (#25903) replaced it with `ctx.req.json().catch(() => ({}))`, which fails on form-encoded bodies, silently falls back to `{}`, and 400s. Every email validation link click has been broken since.

## Fix

Parse the body according to content-type (`parseBody()` for form-encoded, JSON otherwise), matching the existing pattern in `front-api/routes/workos/[action].ts` which fixed the same migration bug for the Chrome extension token endpoint.

Adds functional tests covering form-encoded, JSON, and missing-token cases.

Fixes dust-tt/tasks#9410