### PR TITLE
Add contract lookup fallback

### DIFF
--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -519,9 +519,28 @@ async function fetchBillingPeriodRecordForWorkspace(
   if (!ids) {
     return null;
   }
-  const periodResult = await fetchMetronomeCurrentBillingPeriod(ids);
+  let periodResult = await fetchMetronomeCurrentBillingPeriod(ids);
   if (periodResult.isErr()) {
-    throw periodResult.error;
+    // The DB-resolved "active" contract can be momentarily stale right after
+    // a contract switch: the new contract is already live on Metronome, but
+    // the subscription row isn't swapped onto it until later in the
+    // `contract.start` webhook handler. If the (still DB-active) old
+    // contract has since ended, ask Metronome directly which contract
+    // actually covers today instead of failing outright.
+    const coveringResult = await listMetronomeContracts(
+      ids.metronomeCustomerId,
+      { coveringDate: new Date() }
+    );
+    const coveringContract = coveringResult.isOk()
+      ? coveringResult.value.find((c) => billingPeriodFromContract(c).isOk())
+      : undefined;
+    if (!coveringContract) {
+      throw periodResult.error;
+    }
+    periodResult = billingPeriodFromContract(coveringContract);
+    if (periodResult.isErr()) {
+      throw periodResult.error;
+    }
   }
   if (!periodResult.value) {
     return null;


### PR DESCRIPTION
## Description

in fetchBillingPeriodRecordForWorkspace , if the DB-resolved "active" contract has no current billing period, it asks Metronome directly via listMetronomeContracts(metronomeCustomerId, { coveringDate: new Date() }) and retries billingPeriodFromContract on whichever contract that returns.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front
