### PR TITLE
[Email] Add context to webhook error logs

### DIFF
--- a/front-api/routes/email/webhook.ts
+++ b/front-api/routes/email/webhook.ts
@@ -211,6 +211,12 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
       }
 
       const { user, workspace } = userRes.value;
+      const errorLogContext = {
+        userId: user.sId,
+        userEmail: user.email,
+        workspaceId: workspace.sId,
+        workspaceName: workspace.name,
+      };
 
       const targetEmails = [
         ...(email.envelope.to ?? []),
@@ -219,12 +225,16 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
       ].filter((e) => e.endsWith(`@${ASSISTANT_EMAIL_SUBDOMAIN}`));
 
       if (targetEmails.length === 0) {
-        await replyToError(email, {
-          type: "invalid_email_error",
-          message:
-            `Failed to match any valid agent email. ` +
-            `Expected agent email format: {ASSISTANT_NAME}@${ASSISTANT_EMAIL_SUBDOMAIN}.`,
-        });
+        await replyToError(
+          email,
+          {
+            type: "invalid_email_error",
+            message:
+              `Failed to match any valid agent email. ` +
+              `Expected agent email format: {ASSISTANT_NAME}@${ASSISTANT_EMAIL_SUBDOMAIN}.`,
+          },
+          errorLogContext
+        );
         return;
       }
 
@@ -234,18 +244,26 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
       );
 
       if (workspace.metadata?.allowEmailAgents !== true) {
-        await replyToError(email, {
-          type: "invalid_email_error",
-          message:
-            "Email interactions with agents are not enabled for your workspace.",
-        });
+        await replyToError(
+          email,
+          {
+            type: "invalid_email_error",
+            message:
+              "Email interactions with agents are not enabled for your workspace.",
+          },
+          errorLogContext
+        );
         return;
       }
 
       const emailBlacklistedAgentIdsRes =
         getEmailBlacklistedAgentIds(workspace);
       if (emailBlacklistedAgentIdsRes.isErr()) {
-        await replyToError(email, emailBlacklistedAgentIdsRes.error);
+        await replyToError(
+          email,
+          emailBlacklistedAgentIdsRes.error,
+          errorLogContext
+        );
         return;
       }
 
@@ -265,7 +283,7 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
           targetEmail,
         });
         if (matchResult.isErr()) {
-          await replyToError(email, matchResult.error);
+          await replyToError(email, matchResult.error, errorLogContext);
           continue;
         }
         agentConfigurations.push(matchResult.value.agentConfiguration);
@@ -281,7 +299,7 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
       });
 
       if (triggerRes.isErr()) {
-        await replyToError(email, triggerRes.error);
+        await replyToError(email, triggerRes.error, errorLogContext);
         return;
       }
 

--- a/front/lib/api/assistant/email/webhook_helpers.ts
+++ b/front/lib/api/assistant/email/webhook_helpers.ts
@@ -244,6 +244,13 @@ export function parseThreadingHeaders(rawHeaders: string | null) {
   };
 }
 
+type EmailWebhookErrorLogContext = {
+  userId: string;
+  userEmail: string;
+  workspaceId: string;
+  workspaceName: string;
+};
+
 // Parses the Sendgrid webhook form data and validates it returning a fully formed InboundEmail.
 export const parseSendgridWebhookContent = async (
   rawBody: Buffer,
@@ -368,10 +375,15 @@ export const parseSendgridWebhookContent = async (
 
 export const replyToError = async (
   email: InboundEmail,
-  error: EmailTriggerError
+  error: EmailTriggerError,
+  context?: EmailWebhookErrorLogContext
 ): Promise<void> => {
   logger.error(
-    { error, envelope: email.envelope },
+    {
+      error,
+      envelope: email.envelope,
+      ...(context ?? {}),
+    },
     "[email] Error handling email."
   );
   const htmlContent =


### PR DESCRIPTION
## Description
Adds user and workspace structured fields to the email webhook error logs once the sender user and workspace have been resolved. Pre-lookup errors keep the existing log shape because that context is not available yet.

Local validation: Biome passed on the touched files. `npm run tsgo --workspace @dust-tt/front-api` is currently blocked by existing unrelated type errors outside this change, and `NODE_ENV=test npm run test --workspace @dust-tt/front-api -- routes/email/webhook.test.ts` fails before executing tests on an existing Sparkle runtime issue.

## Risks
Blast radius: email webhook error logging only.
Risk: low

## Deploy Plan
- pmrr (minor, not urgent)
- deploy front-api