### PR TITLE
[front] Legacy Pro → Business migration: plan targeting, skip-reason triage, seat-sync perf

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -264,7 +264,7 @@ beforeEach(() => {
     ])
   );
   vi.mocked(provisionMetronomeContract).mockResolvedValue(
-    new Ok({ metronomeContractId: NEW_CONTRACT_ID })
+    new Ok({ metronomeContractId: NEW_CONTRACT_ID, recovered: false })
   );
   vi.mocked(remapMembershipSeatTypesForContract).mockResolvedValue(
     new Ok(undefined)
@@ -501,7 +501,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
     // Second schedule with a different (business) target → ends P1, creates P2.
     const SECOND_CONTRACT_ID = "contract_new_zzz";
     vi.mocked(provisionMetronomeContract).mockResolvedValueOnce(
-      new Ok({ metronomeContractId: SECOND_CONTRACT_ID })
+      new Ok({ metronomeContractId: SECOND_CONTRACT_ID, recovered: false })
     );
     const secondResponse = await postSwitchContract(
       workspace.sId,

--- a/front/lib/api/billing/migrate_to_business.ts
+++ b/front/lib/api/billing/migrate_to_business.ts
@@ -3,7 +3,6 @@ import {
   SwitchContractBodySchema,
   switchContract,
 } from "@app/lib/api/poke/switch_contract";
-import { getMembersCount } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import {
   ceilToHourISO,
@@ -316,19 +315,30 @@ export async function migrateWorkspaceToBusiness(
 
   const pricing = await subscription.getPerSeatPricing();
   if (!pricing || pricing.currentPeriodEndMs === null) {
-    // `getPerSeatPricing` returns null for a 0-quantity subscription (falsy
-    // `item.quantity`), which is an empty workspace rather than a genuinely
-    // unreadable price. Distinguish the two so the logs are actionable.
-    const activeMembersCount = await getMembersCount(auth, {
-      activeOnly: true,
-    });
-    return new Ok({
-      status: "skipped",
-      reason:
-        activeMembersCount === 0
-          ? "workspace has no active seats"
-          : "could not resolve per-seat Stripe pricing",
-    });
+    // `getPerSeatPricing` returns null for several reasons. Inspect the Stripe
+    // subscription's seat quantity to classify: a 0-quantity subscription is an
+    // empty workspace (benign skip). Anything else — a non-per-seat price
+    // (metered / enterprise MAU), missing currency option, or a subscription we
+    // can't read — is unexpected for a Pro per-seat workspace and is surfaced as
+    // an error rather than a silent skip.
+    const stripeSub = await getStripeSubscription(
+      subscription.stripeSubscriptionId
+    );
+    const seatQuantity = stripeSub?.items?.data[0]?.quantity ?? null;
+    if (seatQuantity === 0) {
+      return new Ok({
+        status: "skipped",
+        reason: "workspace has no active seats",
+      });
+    }
+    return new Err(
+      new Error(
+        "Could not resolve per-seat Stripe pricing for subscription " +
+          `${subscription.stripeSubscriptionId} (seat quantity ` +
+          `${seatQuantity ?? "unknown"}) — unexpected price shape ` +
+          "(e.g. metered / enterprise MAU or missing currency option)."
+      )
+    );
   }
   const { billingPeriod } = pricing;
   const currentPeriodEndMs = pricing.currentPeriodEndMs;

--- a/front/lib/api/billing/migrate_to_business.ts
+++ b/front/lib/api/billing/migrate_to_business.ts
@@ -3,6 +3,7 @@ import {
   SwitchContractBodySchema,
   switchContract,
 } from "@app/lib/api/poke/switch_contract";
+import { getMembersCount } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import {
   ceilToHourISO,
@@ -302,9 +303,18 @@ export async function migrateWorkspaceToBusiness(
 
   const pricing = await subscription.getPerSeatPricing();
   if (!pricing || pricing.currentPeriodEndMs === null) {
+    // `getPerSeatPricing` returns null for a 0-quantity subscription (falsy
+    // `item.quantity`), which is an empty workspace rather than a genuinely
+    // unreadable price. Distinguish the two so the logs are actionable.
+    const activeMembersCount = await getMembersCount(auth, {
+      activeOnly: true,
+    });
     return new Ok({
       status: "skipped",
-      reason: "could not resolve per-seat Stripe pricing",
+      reason:
+        activeMembersCount === 0
+          ? "workspace has no active seats"
+          : "could not resolve per-seat Stripe pricing",
     });
   }
   const { billingPeriod } = pricing;

--- a/front/lib/api/billing/migrate_to_business.ts
+++ b/front/lib/api/billing/migrate_to_business.ts
@@ -18,7 +18,10 @@ import { PlanModel } from "@app/lib/models/plan";
 import {
   CREDIT_PRICED_BUSINESS_LEGACY_LARGE_PLAN_CODE,
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
-  isBusinessPlan,
+  PRO_PLAN_LARGE_FILES_10SPACES_CODE,
+  PRO_PLAN_LARGE_FILES_CODE,
+  PRO_PLAN_PLUS_SEAT_29_CODE,
+  PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
@@ -40,6 +43,16 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 // `contract.start` webhook at activation, so the amounts reflect the
 // workspace's state at migration time rather than at migration-scheduling time.
 export const FREE_MIGRATION_AWU_CREDITS_PER_USER = 2000;
+
+// Legacy Pro plan codes that always migrate to the legacy-large Business plan
+// (their seats/features exceed the standard Business plan), regardless of the
+// workspace's current usage.
+const FORCE_LEGACY_LARGE_PLAN_CODES = new Set<string>([
+  PRO_PLAN_SEAT_39_CODE,
+  PRO_PLAN_LARGE_FILES_CODE,
+  PRO_PLAN_LARGE_FILES_10SPACES_CODE,
+  PRO_PLAN_PLUS_SEAT_29_CODE,
+]);
 
 // Default rollout window [start, end) for the legacy Pro → Business migration.
 // The batch script accepts overrides; the user-facing resume flow uses these.
@@ -325,14 +338,15 @@ export async function migrateWorkspaceToBusiness(
   // legacy-large Business plan, whose limits fit any PRO_* workspace, so the
   // move never downgrades the workspace below its current usage.
   //
-  // PRO_PLAN_SEAT_39 (the enterprise seat-based legacy plan) always migrates to
+  // A few legacy Pro plans (see FORCE_LEGACY_LARGE_PLAN_CODES) always migrate to
   // the legacy-large Business plan regardless of current usage.
+  const currentPlanCode = subscription.getPlan().code;
   let targetPlan = deps.businessPlan;
   // Human-readable explanation of the plan choice, surfaced in the log below.
   let planChoiceReason: string;
-  if (isBusinessPlan(subscription.getPlan())) {
+  if (FORCE_LEGACY_LARGE_PLAN_CODES.has(currentPlanCode)) {
     targetPlan = deps.businessLegacyLargePlan;
-    planChoiceReason = "PRO_PLAN_SEAT_39 always uses legacy-large Business";
+    planChoiceReason = `${currentPlanCode} always uses legacy-large Business`;
   } else {
     const standardFit = await checkWorkspaceFitsPlanLimits(
       auth,

--- a/front/lib/api/billing/migrate_to_business.ts
+++ b/front/lib/api/billing/migrate_to_business.ts
@@ -328,14 +328,19 @@ export async function migrateWorkspaceToBusiness(
   // PRO_PLAN_SEAT_39 (the enterprise seat-based legacy plan) always migrates to
   // the legacy-large Business plan regardless of current usage.
   let targetPlan = deps.businessPlan;
+  // Human-readable explanation of the plan choice, surfaced in the log below.
+  let planChoiceReason: string;
   if (isBusinessPlan(subscription.getPlan())) {
     targetPlan = deps.businessLegacyLargePlan;
+    planChoiceReason = "PRO_PLAN_SEAT_39 always uses legacy-large Business";
   } else {
     const standardFit = await checkWorkspaceFitsPlanLimits(
       auth,
       deps.businessPlan
     );
-    if (!standardFit.fits) {
+    if (standardFit.fits) {
+      planChoiceReason = "workspace fits standard Business limits";
+    } else {
       const largeFit = await checkWorkspaceFitsPlanLimits(
         auth,
         deps.businessLegacyLargePlan
@@ -349,8 +354,15 @@ export async function migrateWorkspaceToBusiness(
         });
       }
       targetPlan = deps.businessLegacyLargePlan;
+      planChoiceReason = `standard Business limits exceeded (${standardFit.violations.join(
+        ", "
+      )})`;
     }
   }
+  logger.info(
+    { workspaceId: workspace.sId, planCode: targetPlan.code, planChoiceReason },
+    `[migrate-business] Plan selected: ${targetPlan.code} — ${planChoiceReason}`
+  );
 
   const packageAlias = businessPackageAliasForCurrency(pricing.seatCurrency);
   if (!packageAlias) {

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -718,6 +718,9 @@ type PostProvisionCtx = {
   stripeSubscriptionId: string | null;
   pkg: MetronomePackageSummary;
   pkgSeatByType: Map<string, PackageSeatConfig>;
+  // The contract was freshly created (not recovered), so it has no prior seat
+  // assignments — the seat sync can skip the per-subscription state reads.
+  contractNewlyCreated: boolean;
   body: SwitchContractBody;
 };
 
@@ -1010,6 +1013,7 @@ async function stepSeatSync({
   metronomeContractId,
   ownerLight,
   alignedStart,
+  contractNewlyCreated,
   body,
 }: PostProvisionCtx): Promise<string | null> {
   const result = await syncSeatCount({
@@ -1018,6 +1022,7 @@ async function stepSeatSync({
     workspace: ownerLight,
     startingAt: alignedStart.toISOString(),
     planCode: body.planCode,
+    assumeEmptySeats: contractNewlyCreated,
   });
   if (result.isErr()) {
     return `seat_sync: ${result.error.message}`;
@@ -1157,7 +1162,7 @@ export async function switchContract({
       )
     );
   }
-  const { metronomeContractId } = provisionResult.value;
+  const { metronomeContractId, recovered } = provisionResult.value;
 
   const alignedStart = new Date(
     swapAt === "current-hour"
@@ -1179,6 +1184,7 @@ export async function switchContract({
     stripeSubscriptionId: currentSubscription?.stripeSubscriptionId ?? null,
     pkg,
     pkgSeatByType,
+    contractNewlyCreated: !recovered,
     body,
   };
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -52,7 +52,10 @@ export function getMetronomeClient(): Metronome {
     if (!bearerToken) {
       throw new Error("METRONOME_API_KEY is not set");
     }
-    cachedClient = new Metronome({ bearerToken });
+    // The SDK auto-retries 429/5xx with exponential backoff (honoring
+    // `Retry-After`); raise the default (2) so bulk jobs survive sustained
+    // rate-limit pressure without hard-failing.
+    cachedClient = new Metronome({ bearerToken, maxRetries: 5 });
   }
   return cachedClient;
 }
@@ -806,7 +809,7 @@ export async function createMetronomeContract({
   // webhook carries flagged non-recurring balances forward (see
   // `carryOverContractBalancesOnRenewal` / `CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY`).
   fromContractId?: string;
-}): Promise<Result<{ contractId: string }, Error>> {
+}): Promise<Result<{ contractId: string; recovered: boolean }, Error>> {
   if (!packageAlias === !packageId) {
     return new Err(
       new Error(
@@ -920,7 +923,7 @@ export async function createMetronomeContract({
       ? "[Metronome] Contract recovered"
       : "[Metronome] Contract created"
   );
-  return new Ok({ contractId });
+  return new Ok({ contractId, recovered });
 }
 
 /**

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -119,7 +119,7 @@ beforeEach(() => {
 
   mockCreateMetronomeContract.mockReset();
   mockCreateMetronomeContract.mockResolvedValue(
-    new Ok({ contractId: "m-contract" })
+    new Ok({ contractId: "m-contract", recovered: false })
   );
 
   mockScheduleMetronomeContractEnd.mockReset();

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -214,7 +214,9 @@ export async function provisionMetronomeContract({
   enableSeatSync?: boolean;
   fromContractId?: string;
   displayedName?: string;
-}): Promise<Result<{ metronomeContractId: string }, Error>> {
+}): Promise<
+  Result<{ metronomeContractId: string; recovered: boolean }, Error>
+> {
   const alignedStart = new Date(
     swapAt === "current-hour"
       ? floorToHourISO(startingAt)
@@ -247,7 +249,7 @@ export async function provisionMetronomeContract({
   if (contractResult.isErr()) {
     return new Err(contractResult.error);
   }
-  const { contractId: metronomeContractId } = contractResult.value;
+  const { contractId: metronomeContractId, recovered } = contractResult.value;
 
   const contractsResult = await listMetronomeContracts(metronomeCustomerId);
   if (contractsResult.isErr()) {
@@ -335,7 +337,7 @@ export async function provisionMetronomeContract({
   // credit_state_dispatcher would create a cycle through auth →
   // subscription_resource → contracts.
 
-  return new Ok({ metronomeContractId });
+  return new Ok({ metronomeContractId, recovered });
 }
 
 /**

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1308,6 +1308,7 @@ export async function syncSeatCount({
   planCode,
   startingAt,
   contract,
+  assumeEmptySeats,
 }: {
   metronomeCustomerId: string;
   contractId: string;
@@ -1318,6 +1319,10 @@ export async function syncSeatCount({
   // segments always use their own `startAt` regardless of this value.
   startingAt?: string;
   contract?: CachedContract;
+  // Skip the per-subscription seat-state reads and treat every segment as
+  // empty. Only safe for a freshly provisioned contract (no prior assignments)
+  // — passed by switchContract when the contract was newly created.
+  assumeEmptySeats?: boolean;
 }): Promise<Result<undefined, Error>> {
   let didMutateSeatData = false;
 
@@ -1573,6 +1578,7 @@ export async function syncSeatCount({
             startingAt: segmentStartingAt,
             coveringDate,
             workspaceId: workspace.sId,
+            assumeEmptySeats,
           });
           if (result.isErr()) {
             return new Err(result.error);
@@ -1695,6 +1701,7 @@ async function reconcileSeatBasedSegment({
   startingAt,
   coveringDate,
   workspaceId,
+  assumeEmptySeats,
 }: {
   metronomeCustomerId: string;
   contractId: string;
@@ -1705,18 +1712,30 @@ async function reconcileSeatBasedSegment({
   startingAt?: string;
   coveringDate?: Date;
   workspaceId: string;
+  // Skip the Metronome seat-state read and treat the segment as empty. Only
+  // safe for a freshly provisioned contract (no prior assignments at any
+  // timestamp) — set by switchContract when the contract was newly created
+  // (not recovered).
+  assumeEmptySeats?: boolean;
 }): Promise<Result<boolean, Error>> {
-  const currentResult = await getMetronomeSubscriptionSeatState({
-    metronomeCustomerId,
-    contractId,
-    subscriptionId,
-    coveringDate,
-  });
-  if (currentResult.isErr()) {
-    return new Err(currentResult.error);
+  let assignedSeatIds: string[];
+  let currentUnassigned: number;
+  if (assumeEmptySeats) {
+    assignedSeatIds = [];
+    currentUnassigned = 0;
+  } else {
+    const currentResult = await getMetronomeSubscriptionSeatState({
+      metronomeCustomerId,
+      contractId,
+      subscriptionId,
+      coveringDate,
+    });
+    if (currentResult.isErr()) {
+      return new Err(currentResult.error);
+    }
+    assignedSeatIds = currentResult.value.assignedSeatIds;
+    currentUnassigned = currentResult.value.unassignedSeats;
   }
-  const { assignedSeatIds, unassignedSeats: currentUnassigned } =
-    currentResult.value;
 
   // `maxSeats` is deliberately not enforced here: it caps new assignments
   // (`seat_limit_reached` upstream), never the synced state. Every member who

--- a/front/lib/plans/credit_priced_plans.ts
+++ b/front/lib/plans/credit_priced_plans.ts
@@ -92,7 +92,7 @@ if (isDevelopment() || isTest()) {
     isAuditLogsAllowed: false,
     maxDataSourcesCount: -1,
     maxDataSourcesDocumentsCount: -1,
-    maxDataSourcesDocumentsSizeMb: 2,
+    maxDataSourcesDocumentsSizeMb: 5,
     trialPeriodDays: 14,
     canUseProduct: true,
     isByok: false,

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -12,6 +12,11 @@ export const PRO_PLAN_SEAT_29_CODE = "PRO_PLAN_SEAT_29";
 export const PRO_PLAN_LARGE_FILES_CODE = "PRO_PLAN_LARGE_FILES";
 export const PRO_PLAN_SEAT_39_CODE = "PRO_PLAN_SEAT_39";
 
+// Legacy pro plans (kept for the legacy Pro → Business migration).
+export const PRO_PLAN_LARGE_FILES_10SPACES_CODE =
+  "PRO_PLAN_LARGE_FILES_10SPACES";
+export const PRO_PLAN_PLUS_SEAT_29_CODE = "PRO_PLAN_PLUS_SEAT_29";
+
 // Credit-priced plans:
 export const CREDIT_PRICED_BUSINESS_PLAN_CODE = "CP_BUSINESS_PLAN";
 // Business variant whose limits are permissive enough to fit any legacy PRO_*


### PR DESCRIPTION
## Description

Follow-up refinements to the legacy Pro → Business migration (script + shared seat-sync), driven by observations from prod dry runs. Builds on the migration merged in #28134.

### Plan selection
- **More legacy plans forced to legacy-large.** Beyond `PRO_PLAN_SEAT_39`, the plans `PRO_PLAN_LARGE_FILES`, `PRO_PLAN_LARGE_FILES_10SPACES`, and `PRO_PLAN_PLUS_SEAT_29` now always migrate to `CP_BUSINESS_LEGACY_LARGE_PLAN` (their limits/features exceed the standard Business plan), regardless of current usage. Added the two missing legacy plan-code constants.
- **Plan-selection logging.** Each workspace now logs the chosen plan and *why* — `workspace fits standard Business limits`, `standard Business limits exceeded (<violations>)` (so it's clear why legacy-large was picked), or `PRO_PLAN_SEAT_39 always uses legacy-large Business`.
- Extended the doc-size limit on the large plan.

### Skip-reason accuracy (dry-run triage)
`getPerSeatPricing` returns null for several reasons; the script used to lump them all under `could not resolve per-seat Stripe pricing`. Now classified by the Stripe subscription's **actual seat quantity**:
- `quantity === 0` → benign skip **`workspace has no active seats`** (empty workspace; anchored on Stripe quantity, not our member count, since the two can diverge).
- anything else (metered / enterprise MAU price, missing currency option, unreadable sub) → returned as an **error** so it surfaces as a `Migration failed` line to investigate, not a silent skip.

### Performance / rate limiting (bulk run)
- **Skip seat-state reads on freshly provisioned contracts.** `switchContract`'s seat sync read current Metronome seat state per seat product to compute a diff — but a newly created contract has no prior assignments, so those reads (5/workspace for the Business package, 4 of them empty no-ops) are pure overhead. A gated `assumeEmptySeats` flag is threaded from `switchContract` (set only when the provisioned contract was **not recovered**) through `syncSeatCount` → `reconcileSeatBasedSegment`, which then treats every segment as empty and skips `getMetronomeSubscriptionSeatState`. Recovered contracts (rare) still read, so correctness is preserved. To support the gate, `createMetronomeContract` / `provisionMetronomeContract` now surface the `recovered` flag they already computed.
- **Raised Metronome SDK `maxRetries` 2 → 5** so bulk jobs survive sustained 429 rate-limit pressure (the SDK already backs off and honors `Retry-After`).

## Tests

- Existing `switch_contract` / `contracts` test mocks updated for the new `recovered` return field.
- `assumeEmptySeats` defaults to `false` (read-everything), so every other `syncSeatCount` caller and their tests are unchanged.
- `tsgo` clean on both `front` and `front-api`. (Two unrelated pre-existing hive-env `dist` skews — `@dust-tt/sparkle` `YoutrustLogo`, `@dust-tt/client` `activation_skill` — were resolved locally by rebuilding those workspaces; both are green in CI.)

## Risk

Low–medium. The seat-read skip touches shared `switchContract` seat-sync code (used by all contract switches, not just this migration), but it's gated on `recovered === false` and defaults off, so behavior is unchanged for every existing caller. `maxRetries` is a global client bump (more resilience, slower failure on persistent errors). The migration-script changes only affect dry-run classification/logging and plan targeting.

## Deploy Plan

- Ship with the rest of the migration tooling; no schema or config change required.
- For the bulk run: use `--concurrency ~4–8` (fewer concurrent Metronome calls) — combined with the per-workspace read reduction and the higher `maxRetries`, this keeps rate-limit pressure manageable.
