### PR TITLE
[front] chore: allow `ask_user_question` for all origins consumed via webapp

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -84,11 +84,26 @@ import { startActiveObservation } from "@langfuse/tracing";
 import { Context, heartbeat } from "@temporalio/activity";
 import assert from "assert";
 
-const ASK_USER_QUESTION_ALLOWED_ORIGINS: UserMessageOrigin[] = [
-  "web",
-  "slack",
-  "extension",
-  "agent_sidekick",
+const ASK_USER_QUESTION_BLOCKED_ORIGINS: readonly UserMessageOrigin[] = [
+  "api",
+  "cli",
+  "cli_programmatic",
+  "email",
+  "excel",
+  "gsheet",
+  "make",
+  "n8n",
+  "powerpoint",
+  "raycast",
+  "slack_workflow",
+  "teams",
+  "transcript",
+  "zapier",
+  "zendesk",
+  "onboarding_conversation",
+  "reinforced_skill_notification",
+  "reinforcement",
+  "branch_anchor",
 ];
 
 // Concatenate two content strings, ensuring at least one whitespace character
@@ -311,11 +326,11 @@ export async function runModel(
     );
   }
 
-  // Filter out ask_user_question when no human is available to answer: origins that don't
-  // support interactive questions, or sub-agent runs (conversation depth > 0) where the
+  // Filter out ask_user_question when no human is available to answer: origins with no
+  // interactive reply surface, or sub-agent runs (conversation depth > 0) where the
   // "user" is the parent agent rather than a human.
   const supportsInteractiveQuestions =
-    ASK_USER_QUESTION_ALLOWED_ORIGINS.includes(userMessage.context.origin) &&
+    !ASK_USER_QUESTION_BLOCKED_ORIGINS.includes(userMessage.context.origin) &&
     conversation.depth === 0;
 
   const filteredMcpActions = supportsInteractiveQuestions


### PR DESCRIPTION
## Description

This PR allows using the `ask_user_question` tool from user message origins that are consumed via the webapp.
Goal is to reduce entropy on the list of tools available, which causes errors notably when using tool search.
Also turns the allow-list into a blacklist to prevent getting similar issues when a new origin is added.

## Tests

- Checked locally (wakeup)

## Risk

- Low.

## Deploy Plan

- Deploy front.
