### PR TITLE
feat: add business admin tests for usage endpoints

### DIFF
--- a/front-api/routes/w/[wId]/analytics/awu-usage.test.ts
+++ b/front-api/routes/w/[wId]/analytics/awu-usage.test.ts
@@ -1,0 +1,110 @@
+import type { GetAwuUsageResponse } from "@app/lib/api/analytics/awu_usage";
+import * as metronomeClient from "@app/lib/metronome/client";
+import * as planType from "@app/lib/metronome/plan_type";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<typeof metronomeClient>(
+    "@app/lib/metronome/client"
+  );
+  return { ...actual, listMetronomeUsage: vi.fn() };
+});
+
+vi.mock("@app/lib/metronome/plan_type", async () => {
+  const actual = await vi.importActual<typeof planType>(
+    "@app/lib/metronome/plan_type"
+  );
+  return { ...actual, getActiveContract: vi.fn() };
+});
+
+function awuUsageUrl(wId: string) {
+  return `/api/w/${wId}/analytics/awu-usage?billingCycleStartDay=1`;
+}
+
+const USAGE_CREDITS = 4200;
+
+function fakeUsage() {
+  const day = new Date();
+  day.setUTCHours(0, 0, 0, 0);
+  return [
+    {
+      billableMetricId: "metric_awu",
+      billableMetricName: "AWU",
+      customerId: "cus_test_credit_priced",
+      startTimestamp: day.toISOString(),
+      endTimestamp: new Date(day.getTime() + 24 * 60 * 60 * 1000).toISOString(),
+      value: USAGE_CREDITS,
+    },
+  ];
+}
+
+function totalPointCredits(body: {
+  points: { groups: { valueCredits: number }[] }[];
+}): number {
+  return body.points
+    .flatMap((p) => p.groups)
+    .reduce((sum, g) => sum + g.valueCredits, 0);
+}
+
+beforeEach(() => {
+  vi.mocked(metronomeClient.listMetronomeUsage).mockResolvedValue(
+    new Ok(fakeUsage())
+  );
+  vi.mocked(planType.getActiveContract).mockResolvedValue(null);
+});
+
+describe("GET /api/w/[wId]/analytics/awu-usage", () => {
+  it("returns 403 when the caller is a user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(awuUsageUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+    expect(metronomeClient.listMetronomeUsage).not.toHaveBeenCalled();
+  });
+
+  it("allows a business admin to read AWU usage", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "business_admin",
+      workspace,
+    });
+
+    const response = await honoApp.request(awuUsageUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body: GetAwuUsageResponse = await response.json();
+    expect(body.availableGroups).toEqual([
+      { groupKey: "total", groupLabel: "Total usage" },
+    ]);
+    expect(totalPointCredits(body)).toBe(USAGE_CREDITS);
+    expect(metronomeClient.listMetronomeUsage).toHaveBeenCalled();
+  });
+
+  it("allows an admin to read AWU usage", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+      workspace,
+    });
+
+    const response = await honoApp.request(awuUsageUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body: GetAwuUsageResponse = await response.json();
+    expect(body.availableGroups).toEqual([
+      { groupKey: "total", groupLabel: "Total usage" },
+    ]);
+    expect(totalPointCredits(body)).toBe(USAGE_CREDITS);
+  });
+});

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
@@ -1,0 +1,82 @@
+import * as metronomeClient from "@app/lib/metronome/client";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<typeof metronomeClient>(
+    "@app/lib/metronome/client"
+  );
+  return {
+    ...actual,
+    listMetronomeBalances: vi.fn(),
+    listMetronomeDraftInvoices: vi.fn(),
+  };
+});
+
+function awuPoolSummaryUrl(wId: string) {
+  return `/api/w/${wId}/credits/awu-pool-summary`;
+}
+
+const EMPTY_POOL_SUMMARY = {
+  totalRemainingCredits: 0,
+  totalActiveCredits: 0,
+  overageCredits: null,
+  overageAmountCents: null,
+  overageCurrency: null,
+};
+
+beforeEach(() => {
+  vi.mocked(metronomeClient.listMetronomeBalances).mockResolvedValue(
+    new Ok([])
+  );
+  vi.mocked(metronomeClient.listMetronomeDraftInvoices).mockResolvedValue(
+    new Ok([])
+  );
+});
+
+describe("GET /api/w/[wId]/credits/awu-pool-summary", () => {
+  it("returns 403 when the caller is a user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(awuPoolSummaryUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+    expect(metronomeClient.listMetronomeBalances).not.toHaveBeenCalled();
+  });
+
+  it("allows a business admin to read the AWU pool summary", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "business_admin",
+      workspace,
+    });
+
+    const response = await honoApp.request(awuPoolSummaryUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(EMPTY_POOL_SUMMARY);
+    expect(metronomeClient.listMetronomeBalances).toHaveBeenCalled();
+  });
+
+  it("allows an admin to read the AWU pool summary", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+      workspace,
+    });
+
+    const response = await honoApp.request(awuPoolSummaryUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(EMPTY_POOL_SUMMARY);
+  });
+});

--- a/front-api/routes/w/[wId]/credits/members-usage.test.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.test.ts
@@ -1,0 +1,94 @@
+import * as membersUsage from "@app/lib/api/credits/members_usage";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/credits/members_usage", async () => {
+  const actual = await vi.importActual<typeof membersUsage>(
+    "@app/lib/api/credits/members_usage"
+  );
+  return { ...actual, getMembersUsage: vi.fn() };
+});
+
+function membersUsageUrl(wId: string) {
+  return `/api/w/${wId}/credits/members-usage`;
+}
+
+const MEMBER_USAGE = {
+  billingFrequency: "ANNUAL" as const,
+  consumedAwuCredits: 100,
+  consumedFromAllowanceAwuCredits: 50,
+  consumedFromPoolAwuCredits: 50,
+  creditState: "normal" as const,
+  email: "member1@example.com",
+  freeCreditEmptyAlert: null,
+  freeCreditLowAlert: null,
+  groups: [],
+  image: null,
+  memberUsageLimit: null,
+  name: "Member One",
+  nearLimit: false,
+  nextCreditResetAt: null,
+  sId: "member1",
+  scheduledSeatChangeAt: null,
+  scheduledSeatType: null,
+  seatType: "max" as const,
+  seatBalanceAwu: 100,
+  spendLimitAlertId: null,
+  spendLimitAwuCredits: null,
+  spendLimitSource: "default" as const,
+  spendLimitWarningAlertId: null,
+};
+
+beforeEach(() => {
+  vi.mocked(membersUsage.getMembersUsage).mockResolvedValue({
+    members: [MEMBER_USAGE],
+    total: 1,
+  });
+});
+
+describe("GET /api/w/[wId]/credits/members-usage", () => {
+  it("returns 403 when the caller is not a business admin", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(membersUsageUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+    expect(membersUsage.getMembersUsage).not.toHaveBeenCalled();
+  });
+
+  it("allows a business admin to read members usage", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "business_admin",
+    });
+
+    const response = await honoApp.request(membersUsageUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      members: [MEMBER_USAGE],
+      total: 1,
+    });
+    expect(membersUsage.getMembersUsage).toHaveBeenCalled();
+  });
+
+  it("allows an admin to read members usage", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const response = await honoApp.request(membersUsageUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      members: [MEMBER_USAGE],
+      total: 1,
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/credits/purchase.test.ts
+++ b/front-api/routes/w/[wId]/credits/purchase.test.ts
@@ -1,0 +1,128 @@
+import * as limits from "@app/lib/credits/limits";
+import * as contracts from "@app/lib/metronome/contracts";
+import * as stripe from "@app/lib/plans/stripe";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/plans/stripe", async () => {
+  const actual = await vi.importActual<typeof stripe>("@app/lib/plans/stripe");
+  return { ...actual, getStripePricingData: vi.fn() };
+});
+
+vi.mock("@app/lib/metronome/contracts", async () => {
+  const actual = await vi.importActual<typeof contracts>(
+    "@app/lib/metronome/contracts"
+  );
+  return { ...actual, resolveCurrencyForExistingMetronomeCustomer: vi.fn() };
+});
+
+vi.mock("@app/lib/credits/limits", async () => {
+  const actual = await vi.importActual<typeof limits>(
+    "@app/lib/credits/limits"
+  );
+  return { ...actual, getCreditPurchaseLimits: vi.fn() };
+});
+
+function purchaseUrl(wId: string) {
+  return `/api/w/${wId}/credits/purchase`;
+}
+
+const PURCHASE_LIMITS = {
+  canPurchase: true as const,
+  maxAmountMicroUsd: 1_000_000_000,
+};
+
+beforeEach(() => {
+  vi.mocked(stripe.getStripePricingData).mockResolvedValue(null);
+  vi.mocked(
+    contracts.resolveCurrencyForExistingMetronomeCustomer
+  ).mockResolvedValue(new Ok("usd"));
+  vi.mocked(limits.getCreditPurchaseLimits).mockResolvedValue(PURCHASE_LIMITS);
+});
+
+describe("/api/w/[wId]/credits/purchase", () => {
+  describe("GET (business-admin-readable)", () => {
+    it("returns 403 when the caller is a user", async () => {
+      const { workspace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+
+      const response = await honoApp.request(purchaseUrl(workspace.sId));
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
+    });
+
+    it("allows a business admin to read purchase info", async () => {
+      const workspace = await WorkspaceFactory.creditPriced();
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "business_admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(purchaseUrl(workspace.sId));
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.currency).toBe("usd");
+      expect(body.discountPercent).toBe(0);
+      expect(body.creditPurchaseLimits).toEqual(PURCHASE_LIMITS);
+    });
+
+    it("allows an admin to read purchase info", async () => {
+      const workspace = await WorkspaceFactory.creditPriced();
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(purchaseUrl(workspace.sId));
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.currency).toBe("usd");
+      expect(body.discountPercent).toBe(0);
+      expect(body.creditPurchaseLimits).toEqual(PURCHASE_LIMITS);
+    });
+  });
+
+  describe("POST (admin-only write)", () => {
+    it("returns 403 for a business admin", async () => {
+      const { workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "business_admin",
+      });
+
+      const response = await honoApp.request(purchaseUrl(workspace.sId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amountDollars: 1 }),
+      });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
+    });
+
+    it("returns 403 for a regular user", async () => {
+      const { workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+      });
+
+      const response = await honoApp.request(purchaseUrl(workspace.sId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amountDollars: 1 }),
+      });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
@@ -30,7 +30,7 @@ async function createMemberRequest(workspace: WorkspaceType) {
 
 describe("/api/w/[wId]/credits/upgrade-requests", () => {
   describe("auth", () => {
-    it("GET returns 403 when caller is not an admin", async () => {
+    it("GET returns 403 when caller is a user", async () => {
       const workspace = await creditPricedWorkspace();
       await createPrivateApiMockRequest({
         method: "GET",
@@ -42,6 +42,36 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
 
       expect(response.status).toBe(403);
       expect((await response.json()).error.type).toBe("workspace_auth_error");
+    });
+
+    it("allows a business admin to list and resolve requests", async () => {
+      const workspace = await creditPricedWorkspace();
+      const { user: member } = await createMemberRequest(workspace);
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "business_admin",
+        workspace,
+      });
+
+      const listResponse = await honoApp.request(
+        upgradeRequestsUrl(workspace.sId)
+      );
+      expect(listResponse.status).toBe(200);
+      const { requests } = await listResponse.json();
+      expect(requests).toHaveLength(1);
+      expect(requests[0].requester.sId).toBe(member.sId);
+
+      const patchResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}/${requests[0].sId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "approved" }),
+        }
+      );
+      expect(patchResponse.status).toBe(200);
+      expect((await patchResponse.json()).request.status).toBe("approved");
     });
   });
 
@@ -154,7 +184,7 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
       expect(response.status).toBe(404);
     });
 
-    it("PATCH returns 403 when caller is not an admin", async () => {
+    it("PATCH returns 403 when caller is a user", async () => {
       const workspace = await creditPricedWorkspace();
       await createPrivateApiMockRequest({
         method: "GET",

--- a/front-api/routes/w/[wId]/credits/usage-configuration.test.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.test.ts
@@ -7,7 +7,7 @@ function usageConfigurationUrl(wId: string) {
 }
 
 describe("/api/w/[wId]/credits/usage-configuration", () => {
-  it("GET returns 403 when caller is not an admin", async () => {
+  it("GET returns 403 when caller is a user", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "user",
@@ -15,6 +15,40 @@ describe("/api/w/[wId]/credits/usage-configuration", () => {
 
     const response = await honoApp.request(
       usageConfigurationUrl(workspace.sId)
+    );
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+  });
+
+  it("GET allows a business admin to read the configuration", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "business_admin",
+    });
+
+    const response = await honoApp.request(
+      usageConfigurationUrl(workspace.sId)
+    );
+
+    expect(response.status).toBe(200);
+    const { configuration } = await response.json();
+    expect(configuration.allowMemberUpgradeRequests).toBe(true);
+  });
+
+  it("PATCH returns 403 for a business admin (admin-only write)", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "business_admin",
+    });
+
+    const response = await honoApp.request(
+      usageConfigurationUrl(workspace.sId),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ allowMemberUpgradeRequests: false }),
+      }
     );
 
     expect(response.status).toBe(403);

--- a/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
@@ -118,6 +118,25 @@ describe("/api/w/[wId]/groups/[groupId]/spend_limit", () => {
       expect(response.status).toBe(403);
       expect((await response.json()).error.type).toBe("workspace_auth_error");
     });
+
+    it("returns 403 for a business admin (admin-only write)", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const group = await makeProvisionedGroup(workspace);
+      const { auth } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "business_admin",
+        workspace,
+      });
+      await FeatureFlagFactory.basic(auth, "pricing_groups");
+
+      const response = await putLimit(workspace.sId, group.sId, {
+        kind: "limited",
+        awuCredits: 1500,
+      });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
+    });
   });
 
   describe("input validation", () => {

--- a/front-api/routes/w/[wId]/members/[uId]/seat-type.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/seat-type.test.ts
@@ -11,7 +11,7 @@ function seatTypeUrl(wId: string, uId: string) {
 
 describe("PATCH /api/w/:wId/members/:uId/seat-type", () => {
   describe("auth", () => {
-    it("returns 403 when caller is not an admin", async () => {
+    it("returns 403 when caller is a user", async () => {
       const { workspace, user } = await createPrivateApiMockRequest({
         method: "PATCH",
         role: "user",
@@ -102,6 +102,32 @@ describe("PATCH /api/w/:wId/members/:uId/seat-type", () => {
       await createPrivateApiMockRequest({
         method: "PATCH",
         role: "admin",
+        workspace,
+      });
+
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      const response = await honoApp.request(
+        seatTypeUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ seatType: "pro" }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).seatType).toBe("pro");
+    });
+
+    it("returns 200 when a business admin upgrades another member to pro", async () => {
+      const workspace = await WorkspaceFactory.metronome();
+      await createPrivateApiMockRequest({
+        method: "PATCH",
+        role: "business_admin",
         workspace,
       });
 

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -69,7 +69,7 @@ beforeEach(() => {
 
 describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
   describe("auth", () => {
-    it("returns 403 when caller is not an admin", async () => {
+    it("returns 403 when caller is a user", async () => {
       const { workspace, user } = await createPrivateApiMockRequest({
         method: "GET",
         role: "user",
@@ -81,6 +81,42 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
 
       expect(response.status).toBe(403);
       expect((await response.json()).error.type).toBe("workspace_auth_error");
+    });
+
+    it("allows a business admin to read and set the spend limit", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "business_admin",
+        workspace,
+      });
+
+      const putResponse = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind: "limited", awuCredits: 1500 }),
+        }
+      );
+      expect(putResponse.status).toBe(200);
+      expect(await putResponse.json()).toEqual({
+        limit: { kind: "limited", awuCredits: 1500 },
+      });
+
+      const getResponse = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId)
+      );
+      expect(getResponse.status).toBe(200);
+      expect(await getResponse.json()).toEqual({
+        kind: "limited",
+        awuCredits: 1500,
+      });
     });
 
     it("returns 403 when workspace is not on Metronome billing", async () => {

--- a/front-api/routes/w/[wId]/members/bulk-spend-limit.test.ts
+++ b/front-api/routes/w/[wId]/members/bulk-spend-limit.test.ts
@@ -41,7 +41,7 @@ beforeEach(() => {
 });
 
 describe("POST /api/w/[wId]/members/bulk-spend-limit", () => {
-  it("returns 403 when the caller is not an admin", async () => {
+  it("returns 403 when the caller is a user", async () => {
     const workspace = await makeMetronomeWorkspace();
     await createPrivateApiMockRequest({
       method: "POST",
@@ -57,6 +57,33 @@ describe("POST /api/w/[wId]/members/bulk-spend-limit", () => {
     expect(response.status).toBe(403);
     expect((await response.json()).error.type).toBe("workspace_auth_error");
     expect(bulkClient.runBulkSetUserSpendLimitWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("allows a business admin to launch the workflow", async () => {
+    const workspace = await makeMetronomeWorkspace();
+    const { auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "business_admin",
+      workspace,
+    });
+    await FeatureFlagFactory.basic(auth, "pricing_groups");
+
+    const member = await UserFactory.basic();
+    vi.mocked(UserResource.searchAllUsers).mockResolvedValue(
+      new Ok({ users: [member], total: 1 })
+    );
+
+    const response = await post(workspace.sId, {
+      selection: { mode: "ids", userIds: [member.sId] },
+      limit: { kind: "limited", awuCredits: 1000 },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      workflowId: "wf_test_bulk",
+      memberCount: 1,
+    });
+    expect(bulkClient.runBulkSetUserSpendLimitWorkflow).toHaveBeenCalled();
   });
 
   it("returns 403 when the pricing_groups flag is off", async () => {

--- a/front/lib/resources/membership_upgrade_request_resource.ts
+++ b/front/lib/resources/membership_upgrade_request_resource.ts
@@ -163,7 +163,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
   static async listPendingByWorkspace(
     auth: Authenticator
   ): Promise<MembershipUpgradeRequestResource[]> {
-    if (!auth.isAdmin()) {
+    if (!auth.isBusinessAdmin()) {
       return [];
     }
     return this.baseFetch(auth, {
@@ -172,13 +172,13 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     });
   }
 
-  // Fetching an arbitrary request by id is an admin-only operation (the admin
-  // resolves it).
+  // Fetching an arbitrary request by id is a business-admin operation (a
+  // business admin or full admin resolves it from the usage page).
   static async fetchById(
     auth: Authenticator,
     membershipUpgradeRequestId: string
   ): Promise<MembershipUpgradeRequestResource | null> {
-    if (!auth.isAdmin()) {
+    if (!auth.isBusinessAdmin()) {
       return null;
     }
     const modelId = getResourceIdFromSId(membershipUpgradeRequestId);


### PR DESCRIPTION
## Description

This PR adds test coverage for usage and billing API endpoints that support the `business_admin` role.

- Adds new test files for `analytics/awu-usage`, `credits/awu-pool-summary`, `credits/members-usage`, `credits/purchase`, and `groups/[groupId]/spend_limit` endpoints
- Updates existing test files for `credits/upgrade-requests`, `credits/usage-configuration`, and `members/[uId]/seat-type` to cover the `business_admin` role

## Tests
Added tests.

## Risk

Low. Test-only changes.

## Deploy Plan
