### PR TITLE
feat: business admins usage limit increase

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -149,7 +149,7 @@ interface UsageSectionProps {
 }
 
 function UsageSection({ owner, onClose, visible }: UsageSectionProps) {
-  const { isAdmin, subscription } = useAuth();
+  const { isAdmin, isBusinessAdmin, subscription } = useAuth();
 
   const isCreditBased = isCreditPricedPlan(subscription.plan);
 
@@ -164,7 +164,7 @@ function UsageSection({ owner, onClose, visible }: UsageSectionProps) {
 
   const { hasPendingUpgradeRequest } = useWorkspaceUsageStatus({
     owner,
-    disabled: isAdmin || !isCreditBased,
+    disabled: isBusinessAdmin || !isCreditBased,
   });
 
   const seatName =
@@ -197,8 +197,8 @@ function UsageSection({ owner, onClose, visible }: UsageSectionProps) {
               owner={owner}
               hasPendingUpgradeRequest={hasPendingUpgradeRequest}
               variant="button"
-              isAdmin={isAdmin}
-              onAdminNavigate={onClose}
+              isBusinessAdmin={isBusinessAdmin}
+              onBusinessAdminNavigate={onClose}
             />
           </div>
           <Separator />

--- a/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
@@ -9,7 +9,7 @@ interface InputBarUsageBannerProps {
 }
 
 export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
-  const { isAdmin } = useAuth();
+  const { isBusinessAdmin } = useAuth();
   const {
     userNearCreditLimit,
     canRequestUpgrade,
@@ -20,7 +20,8 @@ export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
     owner,
   });
 
-  const showUpgradeCta = !willAutoUpgrade && (canRequestUpgrade || isAdmin);
+  const showUpgradeCta =
+    !willAutoUpgrade && (canRequestUpgrade || isBusinessAdmin);
 
   if (userBlockedReason === "no_seat") {
     return (
@@ -38,7 +39,7 @@ export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
             <UsageUpgradeButton
               owner={owner}
               hasPendingUpgradeRequest={hasPendingUpgradeRequest}
-              isAdmin={isAdmin}
+              isBusinessAdmin={isBusinessAdmin}
             />
           </div>
         )}
@@ -82,7 +83,7 @@ export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
           <UsageUpgradeButton
             owner={owner}
             hasPendingUpgradeRequest={hasPendingUpgradeRequest}
-            isAdmin={isAdmin}
+            isBusinessAdmin={isBusinessAdmin}
           />
         </div>
       )}

--- a/front/components/credits/UsageUpgradeButton.tsx
+++ b/front/components/credits/UsageUpgradeButton.tsx
@@ -1,3 +1,4 @@
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRequestUpgrade } from "@app/lib/swr/upgrade_requests";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -18,8 +19,8 @@ interface UsageUpgradeButtonProps {
   owner: LightWorkspaceType;
   hasPendingUpgradeRequest: boolean;
   variant?: UsageUpgradeButtonVariant;
-  isAdmin?: boolean;
-  onAdminNavigate?: () => void;
+  isBusinessAdmin?: boolean;
+  onBusinessAdminNavigate?: () => void;
 }
 
 // Member-initiated upgrade-request CTA. Opens a confirmation dialog and posts
@@ -29,9 +30,11 @@ export function UsageUpgradeButton({
   owner,
   hasPendingUpgradeRequest,
   variant = "link",
-  isAdmin = false,
-  onAdminNavigate,
+  isBusinessAdmin = false,
+  onBusinessAdminNavigate,
 }: UsageUpgradeButtonProps) {
+  const { hasFeature } = useFeatureFlags();
+  const isAdminGovernanceEnabled = hasFeature("admin_governance");
   const { doRequestUpgrade } = useRequestUpgrade({ workspaceId: owner.sId });
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -53,7 +56,7 @@ export function UsageUpgradeButton({
   }
 
   function renderTrigger() {
-    if (isAdmin) {
+    if (isBusinessAdmin) {
       const usageHref = `/w/${owner.sId}/usage`;
 
       if (variant === "button") {
@@ -63,7 +66,7 @@ export function UsageUpgradeButton({
             size="xs"
             label="Go to workspace usage"
             href={usageHref}
-            onClick={onAdminNavigate}
+            onClick={onBusinessAdminNavigate}
           />
         );
       }
@@ -73,7 +76,7 @@ export function UsageUpgradeButton({
           variant="primary"
           className="copy-sm underline underline-offset-2"
           href={usageHref}
-          onClick={onAdminNavigate}
+          onClick={onBusinessAdminNavigate}
         >
           Go to workspace usage
         </Hoverable>
@@ -122,8 +125,12 @@ export function UsageUpgradeButton({
           </DialogHeader>
           <DialogContainer>
             <p className="text-sm text-muted-foreground">
-              Your workspace admins will be notified that you'd like your usage
-              limit increased. They'll review your request and get back to you.
+              Your workspace{" "}
+              {isAdminGovernanceEnabled
+                ? "admins and business admins"
+                : "admins"}{" "}
+              will be notified that you'd like your usage limit increased.
+              They'll review your request and get back to you.
             </p>
           </DialogContainer>
           <DialogFooter

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -1,3 +1,4 @@
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   useUpdateUsageNotifications,
   useUsageNotifications,
@@ -19,6 +20,8 @@ export function UsageNotificationsCard({
   workspaceId,
   readOnly,
 }: UsageNotificationsCardProps) {
+  const { hasFeature } = useFeatureFlags();
+  const isAdminGovernanceEnabled = hasFeature("admin_governance");
   const { usageNotifications, isUsageNotificationsLoading } =
     useUsageNotifications({ workspaceId });
   const { doUpdateUsageNotifications } = useUpdateUsageNotifications({
@@ -108,7 +111,9 @@ export function UsageNotificationsCard({
         />
         <SettingsList.Row
           title="Upgrade request emails"
-          description="Email all workspace admins when a member requests a spend-limit upgrade."
+          description={`Email all workspace ${
+            isAdminGovernanceEnabled ? "admins and business admins" : "admins"
+          } when a member requests a spend-limit upgrade.`}
           action={
             <SliderToggle
               selected={usageNotifications.upgradeRequestEmail}

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -1,4 +1,5 @@
 import { LockedSection } from "@app/components/workspace/usage/LockedSection";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   useDefaultUserSpendLimit,
   useUpdateDefaultUserSpendLimit,
@@ -28,6 +29,8 @@ export function UsageSettingsCard({
   readOnly,
   hasPool,
 }: UsageSettingsCardProps) {
+  const { hasFeature } = useFeatureFlags();
+  const isAdminGovernanceEnabled = hasFeature("admin_governance");
   const { defaultUserSpendLimit, isDefaultUserSpendLimitLoading } =
     useDefaultUserSpendLimit({ workspaceId });
   const { doUpdateDefaultUserSpendLimit } = useUpdateDefaultUserSpendLimit({
@@ -129,7 +132,7 @@ export function UsageSettingsCard({
         </LockedSection>
         <SettingsList.Row
           title="Upgrade request"
-          description="Allow members who reach their limit to request an upgrade. Workspace admins review requests on the this page."
+          description={`Allow members who reach their limit to request an upgrade. Workspace ${isAdminGovernanceEnabled ? "admins and business admins" : "admins"} review requests on the this page.`}
           action={
             <SliderToggle
               selected={usageSettings.allowUpgradeRequest}

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -6,7 +6,7 @@ import { isEligibleForAutoSeatUpgrade } from "@app/lib/api/credits/auto_seat_upg
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
-import { notifyAdminsUpgradeRequested } from "@app/lib/notifications/workflows/upgrade-request-created";
+import { notifyUpgradeRequested } from "@app/lib/notifications/workflows/upgrade-request-created";
 import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -51,7 +51,7 @@ async function isUpgradeRequestEmailEnabled(
   return config?.upgradeRequestEmailEnabled ?? true;
 }
 
-async function notifyAdminsOfUpgradeRequest(
+async function notifyBusinessAdminsAndAdminsOfUpgradeRequest(
   auth: Authenticator,
   { request }: { request: MembershipUpgradeRequestResource }
 ): Promise<void> {
@@ -62,14 +62,14 @@ async function notifyAdminsOfUpgradeRequest(
     }
 
     const workspace = auth.getNonNullableWorkspace();
-    const { members: admins } = await getMembers(auth, {
-      roles: ["admin"],
+    const { members: usersToNotify } = await getMembers(auth, {
+      roles: ["admin", "business_admin"],
       activeOnly: true,
     });
 
     const requester = request.requester;
-    notifyAdminsUpgradeRequested({
-      admins: admins.map((admin) => ({
+    notifyUpgradeRequested({
+      users: usersToNotify.map((admin) => ({
         sId: admin.sId,
         email: admin.email,
         firstName: admin.firstName,
@@ -164,7 +164,7 @@ export async function createUpgradeRequest(
     metadata: { request_sid: request.sId },
   });
 
-  void notifyAdminsOfUpgradeRequest(auth, { request });
+  void notifyBusinessAdminsAndAdminsOfUpgradeRequest(auth, { request });
 
   return new Ok(request.toJSON());
 }
@@ -198,7 +198,7 @@ export async function getUpgradeRequestAvailabilityForUser(
     };
   }
 
-  if (auth.isAdmin()) {
+  if (auth.isBusinessAdmin()) {
     return unavailable;
   }
 

--- a/front/lib/notifications/workflows/upgrade-request-created.ts
+++ b/front/lib/notifications/workflows/upgrade-request-created.ts
@@ -107,20 +107,20 @@ export const upgradeRequestCreatedWorkflow = workflow(
 );
 
 /**
- * Email a workspace's admins that a member requested a spend-limit upgrade. One
- * Novu event is triggered per admin (subscribed by their Dust user sId), deduped
- * via a `transactionId` keyed on the upgrade-request sId so redeliveries don't
+ * Email a workspace's admins and business admins that a member requested a spend-limit
+ * upgrade. One Novu event is triggered per admin (subscribed by their Dust user sId),
+ * deduped via a `transactionId` keyed on the upgrade-request sId so redeliveries don't
  * re-send. Fire-and-forget — errors are logged but don't block the caller.
  */
-export function notifyAdminsUpgradeRequested({
-  admins,
+export function notifyUpgradeRequested({
+  users,
   workspaceId,
   workspaceName,
   requestId,
   requesterName,
   requesterEmail,
 }: {
-  admins: Array<{
+  users: Array<{
     sId: string;
     email: string;
     firstName: string | null;
@@ -132,7 +132,7 @@ export function notifyAdminsUpgradeRequested({
   requesterName: string;
   requesterEmail: string | null;
 }): void {
-  if (admins.length === 0) {
+  if (users.length === 0) {
     return;
   }
 
@@ -146,7 +146,7 @@ export function notifyAdminsUpgradeRequested({
   void getNovuClient()
     .then((novuClient) =>
       novuClient.triggerBulk({
-        events: admins.map((admin) => ({
+        events: users.map((admin) => ({
           workflowId: UPGRADE_REQUEST_CREATED_TRIGGER_ID,
           to: {
             subscriberId: admin.sId,


### PR DESCRIPTION
## Description

This PR extends the usage limit increase flow to  fully support business admins, ensuring they are notified when a member requests a spend-limit upgrade and that they see the appropriate admin UI for managing usage.

- Business admins receive emails when a seat upgrade is requested
- Business admins can auto upgrade, so they do not see the components to request a seat upgrade in the personal settings.

## Tests

Manually.

## Risks

Low. The change scopes the admin-level upgrade UI to business admins and expands notification recipients.

## Deploy Plan

Standard deployment.

