### PR TITLE
[front-api] Add early startup "signs of life" logging

### DIFF
--- a/front-api/lib/instrumentation-config.ts
+++ b/front-api/lib/instrumentation-config.ts
@@ -1,4 +1,5 @@
 import { initializeOpenTelemetryInstrumentation } from "@app/lib/api/instrumentation/init";
+import logger from "@app/logger/logger";
 
 // Initialize OpenTelemetry / Langfuse instrumentation for the front-api process.
 // Without this, any `startActiveObservation` created while handling an HTTP
@@ -6,3 +7,7 @@ import { initializeOpenTelemetryInstrumentation } from "@app/lib/api/instrumenta
 // dropped and Langfuse traces only "begin" once they reach the agent-loop
 // worker (which initializes its own instrumentation).
 initializeOpenTelemetryInstrumentation({ serviceName: "dust-front" });
+
+// Startup checkpoint: reaching this line means instrumentation setup completed
+// and the app module graph is about to be imported (see server.ts).
+logger.info("front-api instrumentation initialized");

--- a/front-api/lib/startup-log.ts
+++ b/front-api/lib/startup-log.ts
@@ -1,0 +1,17 @@
+import { performance } from "node:perf_hooks";
+
+import logger from "@app/logger/logger";
+
+// Emitted as early as possible in the process lifecycle. This module is
+// intentionally imported first in server.ts — before the OpenTelemetry
+// instrumentation setup and the (heavy) app module graph — and only depends on
+// pino, so it runs even when a later boot step hangs or crashes. Startup probe
+// failures on front / front-sse otherwise leave no log at all to work from
+// (the previous earliest log fired only once the server was already listening).
+//
+// `performance.now()` is measured from process start, so it captures how long
+// Node's own bootstrap plus the dd-trace/init preload took to reach this line.
+logger.info(
+  { elapsedMs: Math.round(performance.now()) },
+  "front-api process starting up"
+);

--- a/front-api/server.ts
+++ b/front-api/server.ts
@@ -1,3 +1,6 @@
+// Imported first: logs a "sign of life" before instrumentation and the app
+// module graph load, so startup probe failures leave a trace in the logs.
+import "./lib/startup-log";
 import "./lib/tracer-config";
 import "./lib/instrumentation-config";
 
@@ -16,6 +19,10 @@ setupGlobalErrorHandler(logger);
 const dev = isDevelopment();
 const port = parseInt(process.env.PORT ?? "3000", 10);
 const hostname = process.env.HOSTNAME ?? "localhost";
+
+// The app module graph is fully imported by this point; log before binding the
+// socket so a hang between here and "listening" isolates the bind step.
+logger.info({ port, hostname, dev }, "front-api starting HTTP server");
 
 const server = serve({ fetch: honoApp.fetch, port, hostname }, () => {
   // performance.nodeTiming is measured from process start, so we can split


### PR DESCRIPTION
## Problem

We sometimes get startup probe failures when `front` / `front-sse` boot:

```
Startup probe failed: Get "http://.../api/healthz/startup": dial tcp ...:3000: connect: connection refused
```

When that happens we see **no log whatsoever** for the process in Datadog.

Both `front` and `front-sse` run the same binary — the esbuild-bundled Hono server `front-api/dist/server.js` (from `front-api/server.ts`). The only existing startup log, `"front-api server listening"`, fires inside the `serve()` callback — i.e. **after** OpenTelemetry init and the entire `./app` module graph have loaded. Because ESM imports are hoisted, no statement in `server.ts` runs before `./app` is fully imported, so a hang or crash during module init produces zero logs.

## Change

Add a boot checkpoint ladder (each fires once per process start). The **last** log seen localizes where a stuck/crashing boot died:

| Log | Where | Fires when |
|---|---|---|
| `front-api process starting up` (`elapsedMs` since process start) | new `lib/startup-log.ts`, imported **first** | before OTEL setup + app graph — only depends on pino |
| `front-api instrumentation initialized` | end of `lib/instrumentation-config.ts` | OTEL init done, app graph about to load |
| `front-api starting HTTP server` | `server.ts`, right before `serve()` | full app graph imported OK, about to bind |
| `front-api server listening` (existing) | `serve()` callback | socket bound |

Interpretation:
- **none** → died before/at Node bootstrap, the dd-trace preload, or pino import
- **only (1)** → tracer/OTEL instrumentation init hung or threw
- **(1) + (2)** → the `./app` route/module graph import hung or threw
- **(1)–(3), no (4)** → socket bind stalled

No Dockerfile/CMD changes needed — these are plain in-bundle log statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)