### PR TITLE
Add HubSpot leads support (create and search)

### DIFF
--- a/front/lib/api/actions/servers/hubspot/client.ts
+++ b/front/lib/api/actions/servers/hubspot/client.ts
@@ -942,7 +942,7 @@ export const createLead = async ({
     for (const assoc of associations) {
       const associationTypeId = await getAssociationTypeId(
         accessToken,
-        "deals",
+        "leads",
         assoc.toObjectType
       );
       builtAssociations.push({
@@ -963,7 +963,7 @@ export const createLead = async ({
     associations: builtAssociations,
   };
 
-  return hubspotClient.crm.deals.basicApi.create(leadData);
+  return hubspotClient.crm.objects.basicApi.create("leads", leadData);
 };
 
 export const createTask = async ({
@@ -1390,7 +1390,8 @@ export const searchCrmObjects = async ({
     | "quotes"
     | "feedback_submissions"
     | "products"
-    | "tickets";
+    | "tickets"
+    | "leads";
   filters?: Array<HubspotFilter>;
   query?: string;
   propertiesToReturn?: string[];
@@ -1500,6 +1501,12 @@ export const searchCrmObjects = async ({
       case "tickets":
         searchResponse =
           await hubspotClient.crm.tickets.searchApi.doSearch(searchRequest);
+        break;
+      case "leads":
+        searchResponse =
+          await hubspotClient.crm.objects.leads.searchApi.doSearch(
+            searchRequest
+          );
         break;
       default:
         throw new Error(

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -23,6 +23,7 @@ const searchableObjectTypes = [
   "quotes",
   "feedback_submissions",
   "tickets",
+  "leads",
 ] as const;
 
 const filterSchema = z.object({
@@ -237,7 +238,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   search_crm_objects: {
     description:
-      "Find HubSpot contacts, companies, deals, and activity records when " +
+      "Find HubSpot contacts, companies, deals, leads, and activity records when " +
       "you do not know the object ID. " +
       "Use this to find contacts at a company, search deals by close date, " +
       "or locate tasks, notes, meetings, calls, and emails. " +
@@ -622,14 +623,11 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_lead: {
-    description:
-      "Create a new lead in Hubspot (as a Deal), with optional associations. Ensure properties correctly define it as a lead.",
+    description: "Create a new lead in Hubspot, with optional associations.",
     schema: {
       properties: z
         .record(z.string())
-        .describe(
-          "Properties for the lead (deal), including those that identify it as a lead."
-        ),
+        .describe("An object containing the properties for the lead."),
       associations: z
         .array(associationSchema)
         .optional()

--- a/front/lib/api/actions/servers/hubspot/tools/index.ts
+++ b/front/lib/api/actions/servers/hubspot/tools/index.ts
@@ -744,7 +744,7 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
         associations,
       });
       return new Ok([
-        { type: "text" as const, text: "Lead (as Deal) created successfully." },
+        { type: "text" as const, text: "Lead created successfully." },
         { type: "text" as const, text: JSON.stringify(result, null, 2) },
       ]);
     });

--- a/front/lib/api/oauth/providers/hubspot.ts
+++ b/front/lib/api/oauth/providers/hubspot.ts
@@ -39,6 +39,8 @@ export class HubspotOAuthProvider implements BaseOAuthStrategyProvider {
       "crm.objects.deals.read",
       "crm.objects.deals.write",
       "crm.schemas.deals.read",
+      "crm.objects.leads.read",
+      "crm.objects.leads.write",
       "crm.objects.owners.read",
       "crm.schemas.custom.read",
       "crm.objects.custom.read",


### PR DESCRIPTION
## Description

 The HubSpot MCP server had a `create_lead` tool that actually created a Deal (there is no `crm.leads` typed API in the SDK, so it fell back to `crm.deals`) This PR fixes both:

   - `create_lead` now creates a real Lead via `crm.objects.basicApi.create("leads", …)` (same generic-objects pattern already used by `create_note`/`create_meeting`), with associations resolved against `"leads"` instead of `"deals"`.
   - Leads are now searchable : added a `"leads"` case to `searchCrmObjects` (via the typed `crm.objects.leads.searchApi`) and to `searchableObjectTypes`

## Tests

Tested locally after enabling the leads.read and leads.write scopes in the dev test account. 

## Risk

Low

## Deploy Plan

Need to add the scopes `crm.objects.leads.read` and `crm.objects.leads.write`in the prod Hubspot account before deploying. 
