### PR TITLE
[front] chore: log missing replayed tools

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -135,7 +135,7 @@ function getReplayedToolNames(
     }
   }
 
-  return Array.from(toolNames);
+  return [...toolNames];
 }
 
 // This method is used by the multi-actions execution loop to pick the next action to execute and

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -74,7 +74,10 @@ import type {
   AgentMessageType,
   UserMessageOrigin,
 } from "@app/types/assistant/conversation";
-import { isTextContent } from "@app/types/assistant/generation";
+import {
+  isTextContent,
+  type ModelConversationTypeMultiActions,
+} from "@app/types/assistant/generation";
 import { isByokProviderId } from "@app/types/assistant/models/providers";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -107,6 +110,20 @@ function concatWithNewlineBoundary(
     return previous + "\n" + current;
   }
   return previous + current;
+}
+
+function getReplayedToolNames(
+  modelConversation: ModelConversationTypeMultiActions
+): string[] {
+  return Array.from(
+    new Set(
+      modelConversation.messages
+        .filter((message) => message.role === "assistant")
+        .flatMap((message) => message.contents)
+        .filter((content) => content.type === "function_call")
+        .map((content) => content.value.name)
+    )
+  );
 }
 
 // This method is used by the multi-actions execution loop to pick the next action to execute and
@@ -415,14 +432,14 @@ export async function runModel(
   // deferred behind tool search is an Anthropic-specific policy applied in the
   // Anthropic client, gated on `toolSearchEnabled` (threaded through below).
   const toolSearchEnabled = featureFlags.includes("anthropic_tool_search");
-  const specifications: AgentActionSpecification[] = availableActions.map((a) =>
-    buildToolSpecification(a)
+  const baseSpecifications: AgentActionSpecification[] = availableActions.map(
+    (a) => buildToolSpecification(a)
   );
 
   // Count the number of tokens used by the functions presented to the model.
   // This is a rough estimate of the number of tokens.
   const tools = JSON.stringify(
-    specifications.map((s) => ({
+    baseSpecifications.map((s) => ({
       name: s.name,
       description: s.description,
       inputSchema: s.inputSchema,
@@ -472,6 +489,45 @@ export async function runModel(
 
     return null;
   }
+
+  const replayedToolNames = getReplayedToolNames(
+    modelConversationRes.value.modelConversation
+  );
+  const currentToolNames = new Set(baseSpecifications.map((spec) => spec.name));
+  const missingReplayedToolNames = replayedToolNames.filter(
+    (name) => !currentToolNames.has(name)
+  );
+
+  if (missingReplayedToolNames.length > 0) {
+    localLogger.info(
+      {
+        missingReplayedToolNames,
+        replayedToolNames,
+      },
+      "Replayed tools missing from current specifications"
+    );
+  }
+
+  const specifications = baseSpecifications;
+  // TODO(2026-07-06 aubin): uncomment once we confirm we need this.
+  // const specifications = [
+  //   ...baseSpecifications.map((spec) =>
+  //     replayedToolNames.includes(spec.name) ? { ...spec, eager: true } : spec
+  //   ),
+  //   ...missingReplayedToolNames.map((name) => ({
+  //     name,
+  //     description:
+  //       "Replay-only placeholder for a historical tool call. " +
+  //       "This tool is not available for new calls.",
+  //     inputSchema: {
+  //       type: "object",
+  //       properties: {},
+  //       required: [],
+  //       additionalProperties: true,
+  //     },
+  //     eager: true,
+  //   })),
+  // ];
 
   // Temporarily adding this to check if we can consider contents property only in llms
   const unexpectedMessage =

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -33,6 +33,8 @@ import {
   emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
 import { getStreamLLM } from "@app/lib/api/llm";
+import { ANTHROPIC_PROVIDER_ID } from "@app/lib/api/llm/clients/anthropic/types";
+import { parseAnthropicToolSearchBlock } from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import {
   getByokUserFacingLLMErrorMessage,
@@ -123,6 +125,21 @@ function getReplayedToolNames(
         for (const content of message.contents) {
           if (content.type === "function_call") {
             toolNames.add(content.value.name);
+          }
+          if (
+            content.type === "provider_passthrough" &&
+            content.value.provider === ANTHROPIC_PROVIDER_ID
+          ) {
+            const block = parseAnthropicToolSearchBlock(content.value.block);
+
+            if (
+              block?.type === "tool_search_tool_result" &&
+              block.content.type === "tool_search_tool_search_result"
+            ) {
+              for (const ref of block.content.tool_references) {
+                toolNames.add(ref.tool_name);
+              }
+            }
           }
         }
         break;

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -115,15 +115,27 @@ function concatWithNewlineBoundary(
 function getReplayedToolNames(
   modelConversation: ModelConversationTypeMultiActions
 ): string[] {
-  return Array.from(
-    new Set(
-      modelConversation.messages
-        .filter((message) => message.role === "assistant")
-        .flatMap((message) => message.contents)
-        .filter((content) => content.type === "function_call")
-        .map((content) => content.value.name)
-    )
-  );
+  const toolNames = new Set<string>();
+
+  for (const message of modelConversation.messages) {
+    switch (message.role) {
+      case "assistant":
+        for (const content of message.contents) {
+          if (content.type === "function_call") {
+            toolNames.add(content.value.name);
+          }
+        }
+        break;
+      case "function":
+      case "compaction":
+      case "user":
+        break;
+      default:
+        assertNever(message);
+    }
+  }
+
+  return Array.from(toolNames);
 }
 
 // This method is used by the multi-actions execution loop to pick the next action to execute and


### PR DESCRIPTION
## Description

This PR adds logging in the agent loop for replayed tools that are missing from the current action specifications. Replayed tools are collected from conversation-history function calls and Anthropic `tool_search_tool_result` passthrough references.

Next step is to analyze these logs, and potentially add dummy tool specifications for these.
End goal is to make sure the list of tools is append-only.

One issue we face when removing tool specifications is that a replayed `tool_search_tool_result` whose `tool_reference` points to a missing tool errors with 400: `Tool reference 'archived_lookup_tool' not found in available tools`.

Tested Anthropic tool-search replay behavior locally with the API: adding a dummy tool with the same name and dummy description/schema is accepted by Anthropic.

## Tests

- Tested locally.

## Risk

- Low. Logging only.

## Deploy Plan

- Deploy front.
