### PR TITLE
fix(labs-transcripts): don't delete retrieval schedule on transient errors

### DIFF
--- a/front/admin/check_transcripts_connections.ts
+++ b/front/admin/check_transcripts_connections.ts
@@ -1,0 +1,215 @@
+import config from "@app/lib/api/config";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
+import { Authenticator } from "@app/lib/auth";
+import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import type { ScheduleClient } from "@temporalio/client";
+import { ScheduleNotFoundError } from "@temporalio/client";
+import parseArgs from "minimist";
+
+const REQUIRED_SCOPE = "https://www.googleapis.com/auth/drive.meet.readonly";
+
+type ConnectionVerdict =
+  | "VALID"
+  | "VALID_WRONG_SCOPE"
+  | "INVALID"
+  | "MISSING"
+  | "N/A";
+
+type ScheduleStatus =
+  | { exists: false }
+  | {
+      exists: true;
+      paused: boolean;
+      lastRun: string | null;
+      nextRun: string | null;
+    };
+
+function extractScope(rawJson: unknown): string | null {
+  if (
+    rawJson &&
+    typeof rawJson === "object" &&
+    "scope" in rawJson &&
+    typeof rawJson.scope === "string"
+  ) {
+    return rawJson.scope;
+  }
+  return null;
+}
+
+async function describeSchedule(
+  scheduleClient: ScheduleClient,
+  scheduleId: string
+): Promise<ScheduleStatus> {
+  try {
+    const desc = await scheduleClient.getHandle(scheduleId).describe();
+    const recent = desc.info.recentActions;
+    const next = desc.info.nextActionTimes;
+    return {
+      exists: true,
+      paused: desc.state.paused,
+      lastRun: recent.length
+        ? recent[recent.length - 1].takenAt.toISOString()
+        : null,
+      nextRun: next.length ? next[0].toISOString() : null,
+    };
+  } catch (err) {
+    if (err instanceof ScheduleNotFoundError) {
+      return { exists: false };
+    }
+    throw err;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.wId) {
+    throw new Error("Missing --wId argument (workspace sId)");
+  }
+
+  const auth = await Authenticator.internalAdminForWorkspace(args.wId);
+  const workspace = auth.getNonNullableWorkspace();
+
+  const configurations =
+    await LabsTranscriptsConfigurationResource.findByWorkspaceId(workspace.id);
+
+  const filtered = args.cId
+    ? configurations.filter((c) => c.sId === args.cId)
+    : configurations;
+
+  if (filtered.length === 0) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "No transcript configurations found."
+    );
+    return;
+  }
+
+  const { schedule: scheduleClient } =
+    await getTemporalClientForFrontNamespace();
+
+  const revokedGoogleDrive: string[] = [];
+  const wrongScopeGoogleDrive: string[] = [];
+  const validWithLiveSchedule: string[] = [];
+  const validDisabledWithHistory: string[] = [];
+  const validDisabledNoHistory: string[] = [];
+
+  for (const configuration of filtered) {
+    const user = await configuration.getUser();
+    const userEmail = user?.email ?? "unknown";
+    const hasHistory = await configuration.hasAnyHistory();
+    const lastHistoryDate = await configuration.getMostRecentHistoryDate();
+
+    const scheduleId = `retrieve-transcripts-${configuration.workspaceId}-${configuration.id}`;
+    const schedule = await describeSchedule(scheduleClient, scheduleId);
+    const hasLiveSchedule = schedule.exists && !schedule.paused;
+
+    let verdict: ConnectionVerdict = "N/A";
+    let scope: string | null = null;
+    let accessTokenExpiry: string | null = null;
+
+    if (configuration.provider === "google_drive") {
+      if (!configuration.connectionId) {
+        verdict = "MISSING";
+      } else {
+        const tokRes = await getOAuthConnectionAccessToken({
+          config: config.getOAuthAPIConfig(),
+          logger,
+          connectionId: configuration.connectionId,
+        });
+
+        if (tokRes.isErr()) {
+          verdict = "INVALID";
+        } else {
+          scope = extractScope(tokRes.value.scrubbed_raw_json);
+          verdict = scope?.includes(REQUIRED_SCOPE)
+            ? "VALID"
+            : "VALID_WRONG_SCOPE";
+          accessTokenExpiry = tokRes.value.access_token_expiry
+            ? new Date(tokRes.value.access_token_expiry).toISOString()
+            : null;
+        }
+      }
+
+      switch (verdict) {
+        case "INVALID":
+          revokedGoogleDrive.push(userEmail);
+          break;
+        case "VALID_WRONG_SCOPE":
+          wrongScopeGoogleDrive.push(userEmail);
+          break;
+        case "VALID":
+          if (hasLiveSchedule) {
+            validWithLiveSchedule.push(userEmail);
+          } else if (hasHistory) {
+            validDisabledWithHistory.push(userEmail);
+          } else {
+            validDisabledNoHistory.push(userEmail);
+          }
+          break;
+        default:
+          break;
+      }
+    }
+
+    logger.info(
+      {
+        configId: configuration.sId,
+        userEmail: userEmail,
+        provider: configuration.provider,
+        status: configuration.status,
+        dataSourceViewId: configuration.dataSourceViewId,
+        agentConfigurationId: configuration.agentConfigurationId,
+        connectionId: configuration.connectionId,
+        connection: verdict,
+        scope,
+        accessTokenExpiry,
+        hasHistory,
+        lastHistoryDate: lastHistoryDate ? lastHistoryDate.toISOString() : null,
+        schedule,
+        hasLiveSchedule,
+      },
+      "[transcripts:check] configuration"
+    );
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      totalConfigurations: filtered.length,
+      googleDrive: {
+        revokedToken: {
+          count: revokedGoogleDrive.length,
+          users: revokedGoogleDrive,
+        },
+        wrongScope: {
+          count: wrongScopeGoogleDrive.length,
+          users: wrongScopeGoogleDrive,
+        },
+        validWithLiveSchedule: {
+          count: validWithLiveSchedule.length,
+          users: validWithLiveSchedule,
+        },
+        validDisabledWithHistory: {
+          count: validDisabledWithHistory.length,
+          users: validDisabledWithHistory,
+        },
+        validDisabledNoHistory: {
+          count: validDisabledNoHistory.length,
+          users: validDisabledNoHistory,
+        },
+      },
+    },
+    "[transcripts:check] SUMMARY"
+  );
+}
+
+void main().then(
+  () => process.exit(0),
+  (err) => {
+    logger.error({ err }, "[transcripts:check] failed");
+    process.exit(1);
+  }
+);

--- a/front/admin/check_transcripts_pending.ts
+++ b/front/admin/check_transcripts_pending.ts
@@ -1,0 +1,100 @@
+import { Authenticator } from "@app/lib/auth";
+import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
+import logger from "@app/logger/logger";
+import { retrieveGoogleTranscripts } from "@app/temporal/labs/transcripts/utils/google";
+import parseArgs from "minimist";
+
+// Previews what a config's next scheduled run would pick up: runs the same
+// last-24h Drive query + history dedup and reports the file ids it would process
+// (and therefore email once the config is active). It does not process, store,
+// email, or record history. It does call getTranscriptsGoogleAuth, which disables
+// a config whose token is revoked, so run it on valid-token configs.
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.wId) {
+    throw new Error("Missing --wId argument (workspace sId)");
+  }
+  if (!args.cIds) {
+    throw new Error("Missing --cIds argument (comma-separated config sIds)");
+  }
+
+  const cIds = String(args.cIds)
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  const adminAuth = await Authenticator.internalAdminForWorkspace(args.wId);
+
+  let totalPending = 0;
+
+  for (const cId of cIds) {
+    const configuration = await LabsTranscriptsConfigurationResource.fetchById(
+      adminAuth,
+      cId
+    );
+
+    if (!configuration) {
+      logger.warn({ cId }, "[transcripts:pending] configuration not found");
+      continue;
+    }
+
+    const user = await configuration.getUser();
+    const userEmail = user?.email ?? "unknown";
+
+    if (!user) {
+      logger.warn(
+        { cId, userEmail },
+        "[transcripts:pending] user not found; skipping"
+      );
+      continue;
+    }
+
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      args.wId
+    );
+
+    const res = await retrieveGoogleTranscripts(
+      userAuth,
+      configuration,
+      logger
+    );
+
+    if (res.isErr()) {
+      logger.error(
+        { cId, userEmail, error: res.error.message },
+        "[transcripts:pending] retrieval failed"
+      );
+      continue;
+    }
+
+    const pendingCount = res.value.length;
+    totalPending += pendingCount;
+
+    logger.info(
+      {
+        configId: configuration.sId,
+        userEmail,
+        status: configuration.status,
+        pendingCount,
+        pendingFileIds: res.value,
+      },
+      "[transcripts:pending] would-be-processed on next run"
+    );
+  }
+
+  logger.info(
+    { workspaceId: args.wId, configsChecked: cIds.length, totalPending },
+    "[transcripts:pending] SUMMARY"
+  );
+}
+
+void main().then(
+  () => process.exit(0),
+  (err) => {
+    logger.error({ err }, "[transcripts:pending] failed");
+    process.exit(1);
+  }
+);

--- a/front/lib/labs/transcripts/utils/helpers.ts
+++ b/front/lib/labs/transcripts/utils/helpers.ts
@@ -43,7 +43,9 @@ export async function getTranscriptsGoogleAuth(
       { connectionId, error: tokRes.error, provider },
       "Error retrieving access token"
     );
-    await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
+    if (tokRes.error.code === "token_revoked_error") {
+      await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
+    }
     throw new Error(`Error retrieving access token from ${provider}`);
   }
 

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -110,7 +110,6 @@ export async function retrieveNewTranscriptsActivity(
         localLogger
       );
       if (googleTranscriptsRes.isErr()) {
-        await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
         throw new TranscriptNonRetryableError(
           `Error retrieving Google transcripts: ${googleTranscriptsRes.error.message}`
         );


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9004

Meeting Transcript Processing silently stops for users when a transient error deletes their Temporal retrieval schedule with no auto-recovery. A Temporal schedule keeps firing regardless of whether individual runs fail, so the only reason a momentary failure becomes permanent is the explicit stopRetrieveTranscriptsWorkflow() teardown.

This PR removes the teardown from the two every-5-min external-call paths:

- getTranscriptsGoogleAuth: only tear down when the token is genuinely revoked (token_revoked_error). Transient OAuth/network errors now throw without deleting the schedule, which self-heals on the next tick.
- retrieveNewTranscriptsActivity: the Drive files.list failure path no longer deletes the schedule. It fails the run (schedule survives).

Also adds two read-only admin diagnostics for on-call:
- check_transcripts_connections.ts: per-config token validity, scope, history recency, and live-schedule status, bucketed in a summary.
- check_transcripts_pending.ts: previews the retrieval query (Drive listing + history dedup, no processing) to count transcripts a config would pick up on its next run.

## Tests

Local

## Risk

Low

## Deploy Plan

Front