### PR TITLE
[Admin Gov] Phase 0.1 — group_permissions model + migration

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -98,6 +98,7 @@ import {
   SharingGrantModel,
 } from "@app/lib/resources/storage/models/files";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
@@ -185,6 +186,7 @@ export function loadAllModels() {
     ExternalViewerSessionModel,
     DustAppSecretModel,
     GroupSpaceModel,
+    GroupPermissionModel,
     WebhookSourceModel,
     WebhookSourcesViewModel,
     TriggerModel,

--- a/front/lib/resources/storage/models/group_permissions.ts
+++ b/front/lib/resources/storage/models/group_permissions.ts
@@ -1,0 +1,100 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type {
+  GroupPermissionResourceType,
+  PermissionType,
+} from "@app/types/group_permissions";
+import type { CreationOptional, ForeignKey } from "sequelize";
+
+// Single table backing all Admin Governance permission grants (design doc §1A). See
+// `@app/types/group_permissions` for the vocabulary and `group_permission_registry` for validity.
+export class GroupPermissionModel extends WorkspaceAwareModel<GroupPermissionModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare groupId: ForeignKey<GroupModel["id"]>;
+  declare permissionType: PermissionType;
+  declare resourceType: GroupPermissionResourceType;
+  // Resource ModelId, or -1 (WHOLE_TYPE_RESOURCE_ID) for "the type as a whole".
+  declare resourceId: number;
+  // workspaceId is inherited from WorkspaceAwareModel.
+}
+
+GroupPermissionModel.init(
+  {
+    id: {
+      type: DataTypes.BIGINT,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    groupId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    permissionType: {
+      type: DataTypes.STRING(256),
+      allowNull: false,
+    },
+    resourceType: {
+      type: DataTypes.STRING(256),
+      allowNull: false,
+    },
+    resourceId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    // workspaceId is automatically added by WorkspaceAwareModel.init.
+  },
+  {
+    modelName: "group_permissions",
+    sequelize: frontSequelize,
+    indexes: [
+      // Dedupes grants and covers the "does this group have this grant" direction.
+      // Explicit name kept in sync with the migration so schema diffing stays clean.
+      {
+        name: "group_permissions_ws_group_ptype_rtype_rid_unique",
+        unique: true,
+        fields: [
+          "workspaceId",
+          "groupId",
+          "permissionType",
+          "resourceType",
+          "resourceId",
+        ],
+      },
+      // "who can act on resource X" direction.
+      {
+        name: "group_permissions_ws_rtype_rid",
+        fields: ["workspaceId", "resourceType", "resourceId"],
+      },
+      // FK index (BACK13): groups are deletable, avoid a table scan on group deletion.
+      {
+        name: "group_permissions_group_id",
+        fields: ["groupId"],
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+GroupPermissionModel.belongsTo(GroupModel, {
+  foreignKey: { name: "groupId", allowNull: false },
+  targetKey: "id",
+});
+GroupModel.hasMany(GroupPermissionModel, {
+  foreignKey: { name: "groupId", allowNull: false },
+  sourceKey: "id",
+});

--- a/front/lib/resources/storage/models/group_permissions.ts
+++ b/front/lib/resources/storage/models/group_permissions.ts
@@ -62,29 +62,19 @@ GroupPermissionModel.init(
     modelName: "group_permissions",
     sequelize: frontSequelize,
     indexes: [
-      // Dedupes grants and covers the "does this group have this grant" direction.
+      // Dedupes grants and covers the "does this group have this grant" direction. A group belongs
+      // to a single workspace, so groupId already scopes the workspace — no need for workspaceId
+      // here. Its leading groupId also serves as the FK index (BACK13) for group deletion.
       // Explicit name kept in sync with the migration so schema diffing stays clean.
       {
-        name: "group_permissions_ws_group_ptype_rtype_rid_unique",
+        name: "group_permissions_group_ptype_rtype_rid_unique",
         unique: true,
-        fields: [
-          "workspaceId",
-          "groupId",
-          "permissionType",
-          "resourceType",
-          "resourceId",
-        ],
+        fields: ["groupId", "permissionType", "resourceType", "resourceId"],
       },
       // "who can act on resource X" direction.
       {
         name: "group_permissions_ws_rtype_rid",
         fields: ["workspaceId", "resourceType", "resourceId"],
-      },
-      // FK index (BACK13): groups are deletable, avoid a table scan on group deletion.
-      {
-        name: "group_permissions_group_id",
-        fields: ["groupId"],
-        concurrently: true,
       },
     ],
   }

--- a/front/migrations/pre-deploy/20260706113819_create_group_permissions.sql
+++ b/front/migrations/pre-deploy/20260706113819_create_group_permissions.sql
@@ -1,0 +1,34 @@
+-- Admin Governance §1A: single table backing all group permission grants (resource-level access
+-- and workspace-level capabilities). See front/types/group_permissions.ts for the vocabulary and
+-- lib/resources/group_permission_registry.ts for validity rules.
+SET lock_timeout = '5s';
+
+CREATE TABLE "public"."group_permissions"
+(
+  "createdAt"      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedAt"      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "workspaceId"    BIGINT       NOT NULL REFERENCES "public"."workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "groupId"        BIGINT       NOT NULL REFERENCES "public"."groups" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "permissionType" VARCHAR(256) NOT NULL,
+  "resourceType"   VARCHAR(256) NOT NULL,
+  -- Resource ModelId, or -1 for "the type as a whole" (no NULL: one meaning, one representation).
+  "resourceId"     BIGINT       NOT NULL,
+  "id"             BIGSERIAL,
+  PRIMARY KEY ("id"),
+  -- Instance-less domains and the "all types" wildcard only make sense at the type level.
+  -- Finer per-verb rules (e.g. "create" ⇒ -1) live in the code registry, not here.
+  CONSTRAINT "group_permissions_instanceless_resource_id_check"
+    CHECK ("resourceId" = -1 OR "resourceType" NOT IN ('billing', 'identity', 'audit_log', '*'))
+);
+
+-- Dedupes grants and covers the "does this group have this grant" direction.
+CREATE UNIQUE INDEX CONCURRENTLY "group_permissions_ws_group_ptype_rtype_rid_unique"
+  ON "public"."group_permissions" ("workspaceId", "groupId", "permissionType", "resourceType", "resourceId");
+
+-- "who can act on resource X" direction.
+CREATE INDEX CONCURRENTLY "group_permissions_ws_rtype_rid"
+  ON "public"."group_permissions" ("workspaceId", "resourceType", "resourceId");
+
+-- FK index (BACK13): groups are deletable, avoid a table scan on group deletion.
+CREATE INDEX CONCURRENTLY "group_permissions_group_id"
+  ON "public"."group_permissions" ("groupId");

--- a/front/migrations/pre-deploy/20260706113819_create_group_permissions.sql
+++ b/front/migrations/pre-deploy/20260706113819_create_group_permissions.sql
@@ -21,14 +21,12 @@ CREATE TABLE "public"."group_permissions"
     CHECK ("resourceId" = -1 OR "resourceType" NOT IN ('billing', 'identity', 'audit_log', '*'))
 );
 
--- Dedupes grants and covers the "does this group have this grant" direction.
-CREATE UNIQUE INDEX CONCURRENTLY "group_permissions_ws_group_ptype_rtype_rid_unique"
-  ON "public"."group_permissions" ("workspaceId", "groupId", "permissionType", "resourceType", "resourceId");
+-- Dedupes grants and covers the "does this group have this grant" direction. groupId already
+-- scopes the workspace (a group belongs to one workspace), so workspaceId is omitted; the leading
+-- groupId also serves as the FK index (BACK13) for group deletion.
+CREATE UNIQUE INDEX CONCURRENTLY "group_permissions_group_ptype_rtype_rid_unique"
+  ON "public"."group_permissions" ("groupId", "permissionType", "resourceType", "resourceId");
 
 -- "who can act on resource X" direction.
 CREATE INDEX CONCURRENTLY "group_permissions_ws_rtype_rid"
   ON "public"."group_permissions" ("workspaceId", "resourceType", "resourceId");
-
--- FK index (BACK13): groups are deletable, avoid a table scan on group deletion.
-CREATE INDEX CONCURRENTLY "group_permissions_group_id"
-  ON "public"."group_permissions" ("groupId");

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -1,0 +1,53 @@
+/**
+ * Vocabulary for the `group_permissions` table (Admin Governance §1A).
+ *
+ * All permission grants — resource-level access (spaces, agents, skills) and workspace-level
+ * capabilities (billing, identity, …) — live in a single table keyed by a plain-verb
+ * `permissionType`, a `resourceType`, and a numeric `resourceId`. The validity of a given
+ * (permissionType, resourceType, resourceId) combination is enforced by the registry in
+ * `@app/lib/resources/group_permission_registry`; this file only defines the raw vocabulary and
+ * the "whole type" sentinel.
+ */
+
+// Plain verbs. "*" means "all verbs".
+export const PERMISSION_TYPES = [
+  "read",
+  "write",
+  "admin",
+  "create",
+  "publish",
+  "invite",
+  "*",
+] as const;
+export type PermissionType = (typeof PERMISSION_TYPES)[number];
+
+// Resource domains. "*" means "all resource types".
+export const GROUP_PERMISSION_RESOURCE_TYPES = [
+  "space",
+  "agent",
+  "skill",
+  "frame",
+  "billing",
+  "identity",
+  "audit_log",
+  "*",
+] as const;
+export type GroupPermissionResourceType =
+  (typeof GROUP_PERMISSION_RESOURCE_TYPES)[number];
+
+// `resourceId = -1` means "the type as a whole": for instance-level verbs, all resources of the
+// type; for type-level verbs (e.g. "create"), the only sensible value. There is deliberately no
+// NULL anywhere — one meaning, one representation — and the unique index dedupes wildcard rows.
+export const WHOLE_TYPE_RESOURCE_ID = -1;
+
+export function isPermissionType(value: unknown): value is PermissionType {
+  return PERMISSION_TYPES.includes(value as PermissionType);
+}
+
+export function isGroupPermissionResourceType(
+  value: unknown
+): value is GroupPermissionResourceType {
+  return GROUP_PERMISSION_RESOURCE_TYPES.includes(
+    value as GroupPermissionResourceType
+  );
+}

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -41,13 +41,13 @@ export type GroupPermissionResourceType =
 export const WHOLE_TYPE_RESOURCE_ID = -1;
 
 export function isPermissionType(value: unknown): value is PermissionType {
-  return PERMISSION_TYPES.includes(value as PermissionType);
+  return PERMISSION_TYPES.some((permission) => permission === value);
 }
 
 export function isGroupPermissionResourceType(
   value: unknown
 ): value is GroupPermissionResourceType {
-  return GROUP_PERMISSION_RESOURCE_TYPES.includes(
-    value as GroupPermissionResourceType
+  return GROUP_PERMISSION_RESOURCE_TYPES.some(
+    (resourceType) => resourceType === value
   );
 }


### PR DESCRIPTION
## Description

Admin Governance — Phase 0, PR 1/9. Foundations of the single `group_permissions` table: the Sequelize model (`WorkspaceAwareModel`), the permission/resource vocabulary types (`front/types/group_permissions.ts`), and the pre-deploy migration. Nothing is wired into existing code, so there is **zero production behavior change**.

Schema: unique index `(groupId, permissionType, resourceType, resourceId)` — `groupId` already scopes the workspace and doubles as the FK index (BACK13); a `(workspaceId, resourceType, resourceId)` index for the "who can act on X" direction; and a CHECK that the instance-less domains (`billing`/`identity`/`audit_log`) and the `*` wildcard require `resourceId = -1`.

First of a git-spice stack (registry → resource → governance toggle → auth check → shadow helper → seeding hook).

Context: [Design Doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48) · [Implementation Plan](https://app.notion.com/p/dust-tt/Implementation-Plan-Admin-Governance-39528599d9418153aa9bf3dd69d5448d)

## Risks

Blast radius: adds an unused table + model; no reads or writes from existing code.
Risk: none

## Deploy Plan

- run migration `20260706113819_create_group_permissions.sql` (pre-deploy, additive)
- deploy front
