### PR TITLE
[front] Metronome seat sync: count only active (used) memberships

### DIFF
--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1382,10 +1382,16 @@ export async function syncSeatCount({
     const legacy = !isCreditPricedPlanPrefix(planCode);
 
     // userSId → current seat type (the seat they are on right now).
+    //
+    // Only count memberships that are active in the same sense as the Stripe
+    // seat count (`getMembersCountForWorkspace({ activeOnly: true })`): the seat
+    // window is open AND `firstUsedAt` is set. This excludes provisioned members
+    // who have never used the workspace, so Metronome and Stripe bill the same
+    // set of seats.
     const currentSeatByUserSId = new Map<string, MembershipSeatType>();
     for (const m of activeMemberships) {
       const userSId = m.user?.sId;
-      if (userSId) {
+      if (userSId && m.firstUsedAt !== null) {
         currentSeatByUserSId.set(userSId, m.seatType);
       }
     }
@@ -1398,7 +1404,12 @@ export async function syncSeatCount({
     const scheduledChanges: ScheduledChange[] = [];
     for (const m of futureMemberships) {
       const userSId = m.user?.sId;
-      if (userSId) {
+      // Same `firstUsedAt` filter as the current-seat map above: a scheduled
+      // change carries the current row's `firstUsedAt` (see `scheduleSeatChange`),
+      // so provisioned-but-never-used members (SCIM on enterprise contracts) are
+      // scheduled by contract switches / migrations yet must stay uncounted, just
+      // like Stripe. Without this the future segment would re-introduce them.
+      if (userSId && m.firstUsedAt !== null) {
         scheduledChanges.push({
           userSId,
           newSeatType: m.seatType,


### PR DESCRIPTION
## Problem

`syncSeatCount` (Metronome) counted **every** membership within the open seat window (`startAt <= now`, `endAt` null/future). Stripe's seat count uses `MembershipResource.getMembersCountForWorkspace({ activeOnly: true })`, which *additionally* requires `firstUsedAt != null`.

As a result, provisioned members who never used the workspace were billed on Metronome but **not** on Stripe — the two systems disagreed on the billable seat set.

## Fix

Apply the same `firstUsedAt != null` filter as Stripe in `syncSeatCount`, on **both**:

1. **The current-seat map** (`currentSeatByUserSId`, from `getActiveMemberships`).
2. **The scheduled-change list** (`scheduledChanges`, from `getScheduledFutureMemberships`).

### Why the scheduled path matters (enterprise + SCIM)

Pro plans can't provision, so they were never affected. But on enterprise contracts with SCIM, provisioned members have `firstUsedAt === null`. A contract switch / legacy Pro→Business migration (`switchContract`, `migrate_legacy_pro_monthly_to_business`) schedules seat changes for **all** members, and `scheduleSeatChange` creates the future row copying the current `firstUsedAt` (i.e. `null`).

Without filtering the scheduled path too, such a never-used member would be excluded at "now" but **re-introduced and counted from the scheduled instant forward** — re-creating the divergence. Filtering both paths keeps Metronome and Stripe consistent everywhere: immediate, remap, and contract switch.

## Notes

- A membership can carry a `seatType` in the table but stays uncounted until `firstUsedAt` is populated (user actually uses the workspace).
- The remap machinery itself is unchanged — only the inputs are filtered.

## Test

- `lib/metronome/seats_sync.test.ts` passes (6/6). Existing mocks omit `firstUsedAt`, so `undefined !== null` keeps them counted.
- `npx tsgo --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)