### PR TITLE
[Admin Gov] Phase 0.2 — group_permissions validity registry

### DIFF
--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -1,0 +1,109 @@
+import { assertValidGrant } from "@app/lib/resources/group_permission_registry";
+import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
+import { describe, expect, it } from "vitest";
+
+describe("assertValidGrant", () => {
+  describe("accepts valid combinations", () => {
+    it("instance-level grant with a real resourceId", () => {
+      expect(() =>
+        assertValidGrant({
+          permissionType: "read",
+          resourceType: "space",
+          resourceId: 5,
+        })
+      ).not.toThrow();
+    });
+
+    it("instance-level verb with -1 (all resources of the type)", () => {
+      expect(() =>
+        assertValidGrant({
+          permissionType: "write",
+          resourceType: "agent",
+          resourceId: WHOLE_TYPE_RESOURCE_ID,
+        })
+      ).not.toThrow();
+    });
+
+    it("type-level verb (create) with -1", () => {
+      expect(() =>
+        assertValidGrant({
+          permissionType: "create",
+          resourceType: "skill",
+          resourceId: WHOLE_TYPE_RESOURCE_ID,
+        })
+      ).not.toThrow();
+    });
+
+    it("instance-less domain with -1", () => {
+      expect(() =>
+        assertValidGrant({
+          permissionType: "admin",
+          resourceType: "billing",
+          resourceId: WHOLE_TYPE_RESOURCE_ID,
+        })
+      ).not.toThrow();
+    });
+
+    it("full wildcard with -1", () => {
+      expect(() =>
+        assertValidGrant({
+          permissionType: "*",
+          resourceType: "*",
+          resourceId: WHOLE_TYPE_RESOURCE_ID,
+        })
+      ).not.toThrow();
+    });
+  });
+
+  describe("rejects invalid combinations", () => {
+    it("verb not allowed on the resource type", () => {
+      expect(() =>
+        assertValidGrant({
+          permissionType: "invite",
+          resourceType: "space",
+          resourceId: 5,
+        })
+      ).toThrow(/not allowed/);
+    });
+
+    it("real resourceId on an instance-less domain", () => {
+      expect(() =>
+        assertValidGrant({
+          permissionType: "admin",
+          resourceType: "billing",
+          resourceId: 5,
+        })
+      ).toThrow(/type-level/);
+    });
+
+    it("real resourceId on a type-level verb (create)", () => {
+      expect(() =>
+        assertValidGrant({
+          permissionType: "create",
+          resourceType: "agent",
+          resourceId: 5,
+        })
+      ).toThrow(/type-level/);
+    });
+
+    it("wildcard permission with a real resourceId", () => {
+      expect(() =>
+        assertValidGrant({
+          permissionType: "*",
+          resourceType: "agent",
+          resourceId: 5,
+        })
+      ).toThrow(/Wildcard/);
+    });
+
+    it("zero resourceId (neither a real id nor the sentinel)", () => {
+      expect(() =>
+        assertValidGrant({
+          permissionType: "read",
+          resourceType: "space",
+          resourceId: 0,
+        })
+      ).toThrow(/positive resourceId/);
+    });
+  });
+});

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -1,0 +1,115 @@
+import type {
+  GroupPermissionResourceType,
+  PermissionType,
+} from "@app/types/group_permissions";
+import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
+import assert from "assert";
+
+/**
+ * Static source of truth for `group_permissions` validity.
+ *
+ * The table is polymorphic, so its representable space is larger than its valid space. Every write
+ * path in `GroupPermissionResource` validates against this registry and throws on violation — invalid
+ * writes are programmer errors, so we fail fast rather than returning a `Result`. The DB CHECK only
+ * covers the coarse instance-less-domain rule; finer per-verb rules (e.g. `create` ⇒ `-1` only) live
+ * here.
+ *
+ * The `"*"` wildcards in the vocabulary are intentionally not part of the per-type table: a wildcard
+ * grant applies to the whole type (or all types) and is only ever a type-level (`-1`) grant.
+ */
+
+// Concrete (non-wildcard) vocabulary — the registry describes these.
+type ConcreteResourceType = Exclude<GroupPermissionResourceType, "*">;
+type ConcretePermissionType = Exclude<PermissionType, "*">;
+
+interface ResourceTypeRule {
+  // Verbs grantable on a specific instance (resourceId > 0).
+  instanceLevelPermissions: ConcretePermissionType[];
+  // Verbs grantable type-wide (resourceId = -1). For types with instances this includes the
+  // instance verbs (a -1 grant covers all resources) plus type-only verbs like "create"; the two
+  // lists therefore overlap. Instance-less domains have an empty instanceLevelPermissions and list
+  // their verbs here only.
+  typeLevelPermissions: ConcretePermissionType[];
+}
+
+const REGISTRY: Record<ConcreteResourceType, ResourceTypeRule> = {
+  space: {
+    instanceLevelPermissions: ["read", "write", "admin"],
+    typeLevelPermissions: ["read", "write", "admin"],
+  },
+  agent: {
+    instanceLevelPermissions: ["read", "write", "publish"],
+    typeLevelPermissions: ["read", "write", "publish", "create"],
+  },
+  skill: {
+    instanceLevelPermissions: ["read", "write", "publish"],
+    typeLevelPermissions: ["read", "write", "publish", "create"],
+  },
+  frame: {
+    instanceLevelPermissions: [],
+    typeLevelPermissions: ["invite", "publish"],
+  },
+  billing: {
+    instanceLevelPermissions: [],
+    typeLevelPermissions: ["admin"],
+  },
+  identity: {
+    instanceLevelPermissions: [],
+    typeLevelPermissions: ["admin"],
+  },
+  audit_log: {
+    instanceLevelPermissions: [],
+    typeLevelPermissions: ["read"],
+  },
+};
+
+interface GrantSpec {
+  permissionType: PermissionType;
+  resourceType: GroupPermissionResourceType;
+  resourceId: number;
+}
+
+// Throws when the (permissionType, resourceType, resourceId) combination is not representable in the
+// governance model. Fail-fast: callers pass programmatic values, not user input.
+export function assertValidGrant({
+  permissionType,
+  resourceType,
+  resourceId,
+}: GrantSpec): void {
+  // A wildcard on either axis applies to the whole type / all types and is always type-level.
+  if (permissionType === "*" || resourceType === "*") {
+    assert(
+      resourceId === WHOLE_TYPE_RESOURCE_ID,
+      `Wildcard grant (${permissionType} on ${resourceType}) requires resourceId = ${WHOLE_TYPE_RESOURCE_ID}.`
+    );
+    return;
+  }
+
+  const rule = REGISTRY[resourceType];
+  const allowedOnInstance =
+    rule.instanceLevelPermissions.includes(permissionType);
+  const allowedTypeWide = rule.typeLevelPermissions.includes(permissionType);
+  assert(
+    allowedOnInstance || allowedTypeWide,
+    `Permission "${permissionType}" is not allowed on resource type "${resourceType}".`
+  );
+
+  // Type-wide grant (all resources of the type / an instance-less domain).
+  if (resourceId === WHOLE_TYPE_RESOURCE_ID) {
+    assert(
+      allowedTypeWide,
+      `Permission "${permissionType}" cannot be granted type-wide on "${resourceType}".`
+    );
+    return;
+  }
+
+  // Instance-level grant: a real resource id.
+  assert(
+    resourceId > 0,
+    `Instance-level grant on "${resourceType}" requires a positive resourceId or ${WHOLE_TYPE_RESOURCE_ID}, got ${resourceId}.`
+  );
+  assert(
+    allowedOnInstance,
+    `Permission "${permissionType}" on "${resourceType}" is type-level and requires resourceId = ${WHOLE_TYPE_RESOURCE_ID}.`
+  );
+}


### PR DESCRIPTION
## Description

Admin Governance — Phase 0, PR 2/9. Follows #28481.

Adds the static validity registry (`front/lib/resources/group_permission_registry.ts`) — the single source of truth for which `(permissionType, resourceType, resourceId)` combinations are representable. `assertValidGrant(...)` **fails fast** (throws) on invalid combinations; invalid writes are programmer errors, so no `Result`. Encodes the validity table: `space` (read/write/admin), `agent`/`skill` (read/write/create/publish, with `create` type-level only), `frame` (invite/publish, instance-less), `billing`/`identity` (admin, instance-less), `audit_log` (read, instance-less). `"*"` wildcards are always type-level (`-1`).

Not wired into any write path yet (that's PR 3) — no behavior change.

Context: [Design Doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48) · [Implementation Plan](https://app.notion.com/p/dust-tt/Implementation-Plan-Admin-Governance-39528599d9418153aa9bf3dd69d5448d)

## Risks

Blast radius: new pure-function module, not yet called.
Risk: none

## Deploy Plan
- pmrr
- deploy front
