### PR TITLE
[Admin Gov] Phase 0.3a — GroupPermissionResource core (instance grants + reads)

### DIFF
--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -29,7 +29,7 @@ describe("GroupPermissionResource", () => {
       });
 
       const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupIds: [groupA.id],
+        groupModelIds: [groupA.id],
       });
       expect(grants).toHaveLength(1);
       expect(grants[0].permissionType).toBe("read");
@@ -48,7 +48,7 @@ describe("GroupPermissionResource", () => {
       await GroupPermissionResource.grant(auth, spec);
 
       const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupIds: [groupA.id],
+        groupModelIds: [groupA.id],
       });
       expect(grants).toHaveLength(1);
     });
@@ -107,7 +107,7 @@ describe("GroupPermissionResource", () => {
       });
 
       const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupIds: [groupA.id, groupB.id],
+        groupModelIds: [groupA.id, groupB.id],
         resourceType: "space",
         resourceId: 1,
       });
@@ -119,7 +119,7 @@ describe("GroupPermissionResource", () => {
 
     it("returns [] for no groups without querying", async () => {
       const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupIds: [],
+        groupModelIds: [],
       });
       expect(grants).toEqual([]);
     });
@@ -148,7 +148,7 @@ describe("GroupPermissionResource", () => {
       });
 
       const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupIds: [groupA.id],
+        groupModelIds: [groupA.id],
       });
       expect(grants).toHaveLength(1);
       expect(grants[0].permissionType).toBe("write");
@@ -184,7 +184,7 @@ describe("GroupPermissionResource", () => {
       expect(deleted).toBe(2);
 
       const remaining = await GroupPermissionResource.listForGroups(auth, {
-        groupIds: [groupA.id, groupB.id],
+        groupModelIds: [groupA.id, groupB.id],
       });
       expect(remaining).toHaveLength(1);
       expect(remaining[0].resourceId).toBe(100);

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -1,0 +1,202 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import type { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("GroupPermissionResource", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let auth: Authenticator;
+  let groupA: GroupResource;
+  let groupB: GroupResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+    groupA = await GroupFactory.regular(workspace, "A");
+    groupB = await GroupFactory.regular(workspace, "B");
+    auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  });
+
+  describe("grant", () => {
+    it("creates an instance-level grant that is readable", async () => {
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 42,
+      });
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupIds: [groupA.id],
+      });
+      expect(grants).toHaveLength(1);
+      expect(grants[0].permissionType).toBe("read");
+      expect(grants[0].resourceType).toBe("space");
+      expect(grants[0].resourceId).toBe(42);
+    });
+
+    it("is idempotent (unique index dedupes)", async () => {
+      const spec = {
+        group: groupA,
+        permissionType: "write" as const,
+        resourceType: "agent" as const,
+        resourceId: 7,
+      };
+      await GroupPermissionResource.grant(auth, spec);
+      await GroupPermissionResource.grant(auth, spec);
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupIds: [groupA.id],
+      });
+      expect(grants).toHaveLength(1);
+    });
+
+    it("rejects a type-wide grant (resourceId = -1)", async () => {
+      await expect(
+        GroupPermissionResource.grant(auth, {
+          group: groupA,
+          permissionType: "read",
+          resourceType: "space",
+          resourceId: -1,
+        })
+      ).rejects.toThrow(/instance-level/);
+    });
+
+    it("rejects a grant that violates the registry", async () => {
+      await expect(
+        GroupPermissionResource.grant(auth, {
+          group: groupA,
+          permissionType: "invite",
+          resourceType: "space",
+          resourceId: 5,
+        })
+      ).rejects.toThrow(/not allowed/);
+    });
+
+    it("rejects a group from another workspace", async () => {
+      const otherWorkspace = await WorkspaceFactory.basic();
+      await GroupFactory.defaults(otherWorkspace);
+      const otherGroup = await GroupFactory.regular(otherWorkspace, "other");
+
+      await expect(
+        GroupPermissionResource.grant(auth, {
+          group: otherGroup,
+          permissionType: "read",
+          resourceType: "space",
+          resourceId: 5,
+        })
+      ).rejects.toThrow(/does not belong/);
+    });
+  });
+
+  describe("additivity across groups", () => {
+    it("returns grants from every requested group", async () => {
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 1,
+      });
+      await GroupPermissionResource.grant(auth, {
+        group: groupB,
+        permissionType: "write",
+        resourceType: "space",
+        resourceId: 1,
+      });
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupIds: [groupA.id, groupB.id],
+        resourceType: "space",
+        resourceId: 1,
+      });
+      expect(grants).toHaveLength(2);
+      expect(new Set(grants.map((g) => g.groupId))).toEqual(
+        new Set([groupA.id, groupB.id])
+      );
+    });
+
+    it("returns [] for no groups without querying", async () => {
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupIds: [],
+      });
+      expect(grants).toEqual([]);
+    });
+  });
+
+  describe("revoke", () => {
+    it("removes a specific grant only", async () => {
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 1,
+      });
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        permissionType: "write",
+        resourceType: "space",
+        resourceId: 1,
+      });
+
+      await GroupPermissionResource.revoke(auth, {
+        group: groupA,
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 1,
+      });
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupIds: [groupA.id],
+      });
+      expect(grants).toHaveLength(1);
+      expect(grants[0].permissionType).toBe("write");
+    });
+  });
+
+  describe("deleteAllForResource", () => {
+    it("drops every group's grants for one resource", async () => {
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        permissionType: "read",
+        resourceType: "agent",
+        resourceId: 99,
+      });
+      await GroupPermissionResource.grant(auth, {
+        group: groupB,
+        permissionType: "write",
+        resourceType: "agent",
+        resourceId: 99,
+      });
+      // A grant on a different resource must survive.
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        permissionType: "read",
+        resourceType: "agent",
+        resourceId: 100,
+      });
+
+      const deleted = await GroupPermissionResource.deleteAllForResource(auth, {
+        resourceType: "agent",
+        resourceId: 99,
+      });
+      expect(deleted).toBe(2);
+
+      const remaining = await GroupPermissionResource.listForGroups(auth, {
+        groupIds: [groupA.id, groupB.id],
+      });
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].resourceId).toBe(100);
+    });
+
+    it("refuses to clear type-wide grants", async () => {
+      await expect(
+        GroupPermissionResource.deleteAllForResource(auth, {
+          resourceType: "agent",
+          resourceId: -1,
+        })
+      ).rejects.toThrow(/type-wide/);
+    });
+  });
+});

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -1,0 +1,196 @@
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { assertValidGrant } from "@app/lib/resources/group_permission_registry";
+import type { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type {
+  GroupPermissionResourceType,
+  PermissionType,
+} from "@app/types/group_permissions";
+import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import assert from "assert";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+/**
+ * All writes to `group_permissions` go through this resource — never a raw model write elsewhere.
+ * This file covers instance-level grants and reads; wildcard / type-level writes (resourceId = -1,
+ * "*") land through dedicated named methods in a follow-up so a defaulted -1 can never silently
+ * grant a whole type.
+ */
+
+interface InstanceGrantSpec {
+  group: GroupResource;
+  permissionType: PermissionType;
+  resourceType: GroupPermissionResourceType;
+  resourceId: number;
+  transaction?: Transaction;
+}
+
+interface ListForGroupsSpec {
+  groupIds: ModelId[];
+  permissionType?: PermissionType;
+  resourceType?: GroupPermissionResourceType;
+  resourceId?: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface GroupPermissionResource
+  extends ReadonlyAttributesType<GroupPermissionModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class GroupPermissionResource extends BaseResource<GroupPermissionModel> {
+  static model: ModelStatic<GroupPermissionModel> = GroupPermissionModel;
+
+  constructor(
+    model: ModelStatic<GroupPermissionModel>,
+    blob: Attributes<GroupPermissionModel>
+  ) {
+    super(GroupPermissionModel, blob);
+  }
+
+  // A group is scoped to a single workspace, and every grant is scoped to the caller's workspace.
+  // The DB only FKs groupId to groups.id (not to the workspace), so we enforce the match here to
+  // keep a group from workspace B out of workspace A's grants.
+  private static assertGroupInWorkspace(
+    auth: Authenticator,
+    group: GroupResource
+  ): void {
+    assert(
+      group.workspaceId === auth.getNonNullableWorkspace().id,
+      "Group does not belong to the authenticated workspace."
+    );
+  }
+
+  // Grant an instance-level permission (a specific resource). Idempotent: the unique index dedupes,
+  // so granting twice is a no-op. Type-wide grants (resourceId = -1) go through dedicated methods.
+  static async grant(
+    auth: Authenticator,
+    {
+      group,
+      permissionType,
+      resourceType,
+      resourceId,
+      transaction,
+    }: InstanceGrantSpec
+  ): Promise<GroupPermissionResource> {
+    assert(
+      resourceId > 0,
+      "grant() is instance-level; use a dedicated wildcard method for type-wide grants."
+    );
+    this.assertGroupInWorkspace(auth, group);
+    assertValidGrant({ permissionType, resourceType, resourceId });
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const [row] = await GroupPermissionModel.findOrCreate({
+      where: {
+        workspaceId,
+        groupId: group.id,
+        permissionType,
+        resourceType,
+        resourceId,
+      },
+      transaction,
+    });
+
+    return new this(GroupPermissionModel, row.get());
+  }
+
+  // Revoke a single instance-level grant. No-op if absent. Type-wide (-1) grants are removed via
+  // revokeOnAllResourcesOfType, mirroring the instance-only contract of grant().
+  static async revoke(
+    auth: Authenticator,
+    {
+      group,
+      permissionType,
+      resourceType,
+      resourceId,
+      transaction,
+    }: InstanceGrantSpec
+  ): Promise<void> {
+    assert(
+      resourceId > 0,
+      "revoke() is instance-level; use revokeOnAllResourcesOfType for type-wide grants."
+    );
+    await GroupPermissionModel.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        groupId: group.id,
+        permissionType,
+        resourceType,
+        resourceId,
+      },
+      transaction,
+    });
+  }
+
+  // Read grants for the given groups, optionally narrowed by verb / type / resource. The
+  // (workspaceId, resourceType, resourceId) index backs type/resource-scoped reads.
+  static async listForGroups(
+    auth: Authenticator,
+    { groupIds, permissionType, resourceType, resourceId }: ListForGroupsSpec
+  ): Promise<GroupPermissionResource[]> {
+    if (groupIds.length === 0) {
+      return [];
+    }
+
+    const rows = await GroupPermissionModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        groupId: groupIds,
+        ...(permissionType !== undefined ? { permissionType } : {}),
+        ...(resourceType !== undefined ? { resourceType } : {}),
+        ...(resourceId !== undefined ? { resourceId } : {}),
+      },
+    });
+
+    return rows.map((row) => new this(GroupPermissionModel, row.get()));
+  }
+
+  // Deletion-integrity hook: drop every grant (across all groups) targeting one resource. There is
+  // no FK on the resource side, so callers invoke this when a resource is deleted. Guards against
+  // wiping the type-wide wildcard rows.
+  static async deleteAllForResource(
+    auth: Authenticator,
+    {
+      resourceType,
+      resourceId,
+      transaction,
+    }: {
+      resourceType: GroupPermissionResourceType;
+      resourceId: number;
+      transaction?: Transaction;
+    }
+  ): Promise<number> {
+    assert(
+      resourceId > 0 && resourceId !== WHOLE_TYPE_RESOURCE_ID,
+      "deleteAllForResource targets a concrete resource; it must not clear type-wide grants."
+    );
+
+    return GroupPermissionModel.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        resourceType,
+        resourceId,
+      },
+      transaction,
+    });
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+}

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -31,7 +31,7 @@ interface InstanceGrantSpec {
 }
 
 interface ListForGroupsSpec {
-  groupIds: ModelId[];
+  groupModelIds: ModelId[];
   permissionType?: PermissionType;
   resourceType?: GroupPermissionResourceType;
   resourceId?: number;
@@ -130,16 +130,21 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
   // (workspaceId, resourceType, resourceId) index backs type/resource-scoped reads.
   static async listForGroups(
     auth: Authenticator,
-    { groupIds, permissionType, resourceType, resourceId }: ListForGroupsSpec
+    {
+      groupModelIds,
+      permissionType,
+      resourceType,
+      resourceId,
+    }: ListForGroupsSpec
   ): Promise<GroupPermissionResource[]> {
-    if (groupIds.length === 0) {
+    if (groupModelIds.length === 0) {
       return [];
     }
 
     const rows = await GroupPermissionModel.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
-        groupId: groupIds,
+        groupId: groupModelIds,
         ...(permissionType !== undefined ? { permissionType } : {}),
         ...(resourceType !== undefined ? { resourceType } : {}),
         ...(resourceId !== undefined ? { resourceId } : {}),


### PR DESCRIPTION
## Description

Admin Governance — Phase 0, PR 3a/9. Follows #28484.

The `GroupPermissionResource` scaffold and the everyday write/read surface (all `group_permissions` writes go through this resource):
- `grant(...)` — instance-level only: asserts `resourceId > 0` so a stray `-1` can't grant a whole type through the general method; registry-validated; idempotent (`findOrCreate`).
- `revoke(...)` — deletes one precise grant; no-op if absent.
- `listForGroups(...)` — scoped read; returns `[]` for no groups without hitting the DB.
- `deleteAllForResource(...)` — resource-deletion-integrity hook (no FK on the resource side); refuses to clear type-wide (`-1`) rows.

Type-wide / batch writes come in PR 3b; the workspace-scrub hook is a follow-up PR. No call sites — no behavior change.

Context: [Design Doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48) · [Implementation Plan](https://app.notion.com/p/dust-tt/Implementation-Plan-Admin-Governance-39528599d9418153aa9bf3dd69d5448d)

## Risks

Blast radius: new resource, not yet called from existing code.
Risk: none

## Deploy Plan
- pmrr
- deploy front
