### PR TITLE
[Admin Gov] Phase 0.3b — type-wide and batch group_permission writes

### DIFF
--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -223,4 +223,114 @@ describe("GroupPermissionResource", () => {
       expect(remaining).toEqual([]);
     });
   });
+
+  describe("grantOnAllResourcesOfType", () => {
+    it("writes a type-wide (-1) grant and dedupes on repeat", async () => {
+      await GroupPermissionResource.grantOnAllResourcesOfType(auth, {
+        group: groupA,
+        permissionType: "create",
+        resourceType: "agent",
+      });
+      await GroupPermissionResource.grantOnAllResourcesOfType(auth, {
+        group: groupA,
+        permissionType: "create",
+        resourceType: "agent",
+      });
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupIds: [groupA.id],
+      });
+      expect(grants).toHaveLength(1);
+      expect(grants[0].resourceId).toBe(-1);
+    });
+
+    it("rejects a verb the registry does not allow", async () => {
+      await expect(
+        GroupPermissionResource.grantOnAllResourcesOfType(auth, {
+          group: groupA,
+          permissionType: "read",
+          resourceType: "billing",
+        })
+      ).rejects.toThrow(/not allowed/);
+    });
+
+    it("revokeOnAllResourcesOfType removes the -1 row", async () => {
+      await GroupPermissionResource.grantOnAllResourcesOfType(auth, {
+        group: groupA,
+        permissionType: "admin",
+        resourceType: "billing",
+      });
+      await GroupPermissionResource.revokeOnAllResourcesOfType(auth, {
+        group: groupA,
+        permissionType: "admin",
+        resourceType: "billing",
+      });
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupIds: [groupA.id],
+      });
+      expect(grants).toHaveLength(0);
+    });
+  });
+
+  describe("batch writes", () => {
+    it("grantOnAllResourcesOfTypeForGroups writes one -1 row per group", async () => {
+      await GroupPermissionResource.grantOnAllResourcesOfTypeForGroups(auth, {
+        groups: [groupA, groupB],
+        permissionType: "create",
+        resourceType: "skill",
+      });
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupIds: [groupA.id, groupB.id],
+      });
+      expect(grants).toHaveLength(2);
+      expect(grants.every((g) => g.resourceId === -1)).toBe(true);
+    });
+
+    it("grantMany dedupes duplicate instance grants via the unique index", async () => {
+      await GroupPermissionResource.grantMany(auth, {
+        grants: [
+          {
+            group: groupA,
+            permissionType: "read",
+            resourceType: "space",
+            resourceId: 1,
+          },
+          {
+            group: groupA,
+            permissionType: "read",
+            resourceType: "space",
+            resourceId: 1,
+          },
+          {
+            group: groupA,
+            permissionType: "read",
+            resourceType: "space",
+            resourceId: 2,
+          },
+        ],
+      });
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupIds: [groupA.id],
+      });
+      expect(grants).toHaveLength(2);
+    });
+
+    it("grantMany rejects a -1 grant", async () => {
+      await expect(
+        GroupPermissionResource.grantMany(auth, {
+          grants: [
+            {
+              group: groupA,
+              permissionType: "read",
+              resourceType: "space",
+              resourceId: -1,
+            },
+          ],
+        })
+      ).rejects.toThrow(/instance-level/);
+    });
+  });
 });

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -224,14 +224,14 @@ describe("GroupPermissionResource", () => {
     });
   });
 
-  describe("grantOnAllResourcesOfType", () => {
+  describe("grantTypeWide", () => {
     it("writes a type-wide (-1) grant and dedupes on repeat", async () => {
-      await GroupPermissionResource.grantOnAllResourcesOfType(auth, {
+      await GroupPermissionResource.grantTypeWide(auth, {
         group: groupA,
         permissionType: "create",
         resourceType: "agent",
       });
-      await GroupPermissionResource.grantOnAllResourcesOfType(auth, {
+      await GroupPermissionResource.grantTypeWide(auth, {
         group: groupA,
         permissionType: "create",
         resourceType: "agent",
@@ -246,7 +246,7 @@ describe("GroupPermissionResource", () => {
 
     it("rejects a verb the registry does not allow", async () => {
       await expect(
-        GroupPermissionResource.grantOnAllResourcesOfType(auth, {
+        GroupPermissionResource.grantTypeWide(auth, {
           group: groupA,
           permissionType: "read",
           resourceType: "billing",
@@ -254,13 +254,13 @@ describe("GroupPermissionResource", () => {
       ).rejects.toThrow(/not allowed/);
     });
 
-    it("revokeOnAllResourcesOfType removes the -1 row", async () => {
-      await GroupPermissionResource.grantOnAllResourcesOfType(auth, {
+    it("revokeTypeWide removes the -1 row", async () => {
+      await GroupPermissionResource.grantTypeWide(auth, {
         group: groupA,
         permissionType: "admin",
         resourceType: "billing",
       });
-      await GroupPermissionResource.revokeOnAllResourcesOfType(auth, {
+      await GroupPermissionResource.revokeTypeWide(auth, {
         group: groupA,
         permissionType: "admin",
         resourceType: "billing",
@@ -274,8 +274,8 @@ describe("GroupPermissionResource", () => {
   });
 
   describe("batch writes", () => {
-    it("grantOnAllResourcesOfTypeForGroups writes one -1 row per group", async () => {
-      await GroupPermissionResource.grantOnAllResourcesOfTypeForGroups(auth, {
+    it("grantTypeWideForGroups writes one -1 row per group", async () => {
+      await GroupPermissionResource.grantTypeWideForGroups(auth, {
         groups: [groupA, groupB],
         permissionType: "create",
         resourceType: "skill",

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -238,7 +238,7 @@ describe("GroupPermissionResource", () => {
       });
 
       const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupIds: [groupA.id],
+        groupModelIds: [groupA.id],
       });
       expect(grants).toHaveLength(1);
       expect(grants[0].resourceId).toBe(-1);
@@ -267,7 +267,7 @@ describe("GroupPermissionResource", () => {
       });
 
       const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupIds: [groupA.id],
+        groupModelIds: [groupA.id],
       });
       expect(grants).toHaveLength(0);
     });
@@ -282,7 +282,7 @@ describe("GroupPermissionResource", () => {
       });
 
       const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupIds: [groupA.id, groupB.id],
+        groupModelIds: [groupA.id, groupB.id],
       });
       expect(grants).toHaveLength(2);
       expect(grants.every((g) => g.resourceId === -1)).toBe(true);
@@ -313,7 +313,7 @@ describe("GroupPermissionResource", () => {
       });
 
       const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupIds: [groupA.id],
+        groupModelIds: [groupA.id],
       });
       expect(grants).toHaveLength(2);
     });

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -30,6 +30,13 @@ interface InstanceGrantSpec {
   transaction?: Transaction;
 }
 
+interface TypeWideGrantSpec {
+  group: GroupResource;
+  permissionType: PermissionType;
+  resourceType: GroupPermissionResourceType;
+  transaction?: Transaction;
+}
+
 interface ListForGroupsSpec {
   groupModelIds: ModelId[];
   permissionType?: PermissionType;
@@ -190,6 +197,133 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     await GroupPermissionModel.destroy({
       where: { workspaceId: auth.getNonNullableWorkspace().id },
     });
+  }
+
+  // Grant a type-wide permission (resourceId = -1: the whole type). Dedicated, explicitly named so a
+  // defaulted -1 can never silently reach `grant`. Idempotent. Used for type-level verbs (e.g.
+  // "create") and for governance capabilities (see the governance-toggle methods).
+  static async grantOnAllResourcesOfType(
+    auth: Authenticator,
+    { group, permissionType, resourceType, transaction }: TypeWideGrantSpec
+  ): Promise<GroupPermissionResource> {
+    this.assertGroupInWorkspace(auth, group);
+    assertValidGrant({
+      permissionType,
+      resourceType,
+      resourceId: WHOLE_TYPE_RESOURCE_ID,
+    });
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const [row] = await GroupPermissionModel.findOrCreate({
+      where: {
+        workspaceId,
+        groupId: group.id,
+        permissionType,
+        resourceType,
+        resourceId: WHOLE_TYPE_RESOURCE_ID,
+      },
+      transaction,
+    });
+
+    return new this(GroupPermissionModel, row.get());
+  }
+
+  // Batch of grantOnAllResourcesOfType across groups (one INSERT, unique index dedupes). Backs the
+  // governance setGroups transition without an N+1.
+  static async grantOnAllResourcesOfTypeForGroups(
+    auth: Authenticator,
+    {
+      groups,
+      permissionType,
+      resourceType,
+      transaction,
+    }: {
+      groups: GroupResource[];
+      permissionType: PermissionType;
+      resourceType: GroupPermissionResourceType;
+      transaction?: Transaction;
+    }
+  ): Promise<void> {
+    assertValidGrant({
+      permissionType,
+      resourceType,
+      resourceId: WHOLE_TYPE_RESOURCE_ID,
+    });
+    groups.forEach((group) => this.assertGroupInWorkspace(auth, group));
+    if (groups.length === 0) {
+      return;
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    await GroupPermissionModel.bulkCreate(
+      groups.map((group) => ({
+        workspaceId,
+        groupId: group.id,
+        permissionType,
+        resourceType,
+        resourceId: WHOLE_TYPE_RESOURCE_ID,
+      })),
+      { ignoreDuplicates: true, transaction }
+    );
+  }
+
+  // Revoke a group's type-wide grant. No-op if absent.
+  static async revokeOnAllResourcesOfType(
+    auth: Authenticator,
+    { group, permissionType, resourceType, transaction }: TypeWideGrantSpec
+  ): Promise<void> {
+    await GroupPermissionModel.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        groupId: group.id,
+        permissionType,
+        resourceType,
+        resourceId: WHOLE_TYPE_RESOURCE_ID,
+      },
+      transaction,
+    });
+  }
+
+  // Batch of instance-level grants (one INSERT, unique index dedupes). Each is validated; -1 is
+  // rejected here as in `grant` — type-wide grants use the dedicated methods above.
+  static async grantMany(
+    auth: Authenticator,
+    {
+      grants,
+      transaction,
+    }: {
+      grants: Array<{
+        group: GroupResource;
+        permissionType: PermissionType;
+        resourceType: GroupPermissionResourceType;
+        resourceId: number;
+      }>;
+      transaction?: Transaction;
+    }
+  ): Promise<void> {
+    if (grants.length === 0) {
+      return;
+    }
+    for (const { group, permissionType, resourceType, resourceId } of grants) {
+      assert(
+        resourceId > 0,
+        "grantMany is instance-level; use the dedicated type-wide methods for -1 grants."
+      );
+      this.assertGroupInWorkspace(auth, group);
+      assertValidGrant({ permissionType, resourceType, resourceId });
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    await GroupPermissionModel.bulkCreate(
+      grants.map(({ group, permissionType, resourceType, resourceId }) => ({
+        workspaceId,
+        groupId: group.id,
+        permissionType,
+        resourceType,
+        resourceId,
+      })),
+      { ignoreDuplicates: true, transaction }
+    );
   }
 
   async delete(

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -106,7 +106,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
   }
 
   // Revoke a single instance-level grant. No-op if absent. Type-wide (-1) grants are removed via
-  // revokeOnAllResourcesOfType, mirroring the instance-only contract of grant().
+  // revokeTypeWide, mirroring the instance-only contract of grant().
   static async revoke(
     auth: Authenticator,
     {
@@ -119,7 +119,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
   ): Promise<void> {
     assert(
       resourceId > 0,
-      "revoke() is instance-level; use revokeOnAllResourcesOfType for type-wide grants."
+      "revoke() is instance-level; use revokeTypeWide for type-wide grants."
     );
     await GroupPermissionModel.destroy({
       where: {
@@ -199,38 +199,24 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     });
   }
 
-  // Grant a type-wide permission (resourceId = -1: the whole type). Dedicated, explicitly named so a
-  // defaulted -1 can never silently reach `grant`. Idempotent. Used for type-level verbs (e.g.
-  // "create") and for governance capabilities (see the governance-toggle methods).
-  static async grantOnAllResourcesOfType(
+  // Grant a permission for the whole resource type (resourceId = -1). Single-group convenience over
+  // grantTypeWideForGroups. Dedicated, explicitly named so a defaulted -1 can never silently reach
+  // `grant`. Idempotent. Used for type-level verbs (e.g. "create") and governance capabilities.
+  static async grantTypeWide(
     auth: Authenticator,
     { group, permissionType, resourceType, transaction }: TypeWideGrantSpec
-  ): Promise<GroupPermissionResource> {
-    this.assertGroupInWorkspace(auth, group);
-    assertValidGrant({
+  ): Promise<void> {
+    await this.grantTypeWideForGroups(auth, {
+      groups: [group],
       permissionType,
       resourceType,
-      resourceId: WHOLE_TYPE_RESOURCE_ID,
-    });
-
-    const workspaceId = auth.getNonNullableWorkspace().id;
-    const [row] = await GroupPermissionModel.findOrCreate({
-      where: {
-        workspaceId,
-        groupId: group.id,
-        permissionType,
-        resourceType,
-        resourceId: WHOLE_TYPE_RESOURCE_ID,
-      },
       transaction,
     });
-
-    return new this(GroupPermissionModel, row.get());
   }
 
-  // Batch of grantOnAllResourcesOfType across groups (one INSERT, unique index dedupes). Backs the
+  // Batch of grantTypeWide across groups (one INSERT, unique index dedupes). Backs the
   // governance setGroups transition without an N+1.
-  static async grantOnAllResourcesOfTypeForGroups(
+  static async grantTypeWideForGroups(
     auth: Authenticator,
     {
       groups,
@@ -268,7 +254,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
   }
 
   // Revoke a group's type-wide grant. No-op if absent.
-  static async revokeOnAllResourcesOfType(
+  static async revokeTypeWide(
     auth: Authenticator,
     { group, permissionType, resourceType, transaction }: TypeWideGrantSpec
   ): Promise<void> {


### PR DESCRIPTION
## Description

Admin Governance — Phase 0, PR 3b/9. Follows #28485.

Adds the dedicated type-wide (`resourceId = -1`) writers to `GroupPermissionResource`, kept separate from the instance CRUD so the "grant the whole type" path is explicit and reviewable:
- `grantTypeWide(...)` — single-group convenience over `grantTypeWideForGroups`; the only sanctioned way to write a `-1` row (never a defaulted param). Idempotent, registry-validated.
- `grantTypeWideForGroups(...)` — batch of the above (one INSERT, unique index dedupes); backs the governance `setGroups` transition without an N+1.
- `revokeTypeWide(...)` — removes a group's `-1` row.
- `grantMany(...)` — batch instance grants; each validated, `-1` rejected as in `grant`.

No call sites — no behavior change.

Context: [Design Doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48) · [Implementation Plan](https://app.notion.com/p/dust-tt/Implementation-Plan-Admin-Governance-39528599d9418153aa9bf3dd69d5448d)

## Risks

Blast radius: new resource methods, not yet called from existing code.
Risk: none

## Deploy Plan

- deploy front