### PR TITLE
refactor(front): move agent deselect into AgentPicker selected section

### DIFF
--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -35,8 +35,6 @@ interface AgentPickerProps {
   disabled?: boolean;
   mountPortal?: boolean;
   onOpenChange?: (open: boolean) => void;
-  // When set, the matching agent is pinned at the top of the list under
-  // "Selected" with a toggle to deselect it (via `onDeselect`).
   selectedAgentId?: string | null;
   onDeselect?: () => void;
 }

--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -7,13 +7,16 @@ import type { LightWorkspaceType } from "@app/types/user";
 import {
   Avatar,
   Button,
+  Check,
   DotsHorizontal,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Icon,
   Robot,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -32,6 +35,10 @@ interface AgentPickerProps {
   disabled?: boolean;
   mountPortal?: boolean;
   onOpenChange?: (open: boolean) => void;
+  // When set, the matching agent is pinned at the top of the list under
+  // "Selected" with a toggle to deselect it (via `onDeselect`).
+  selectedAgentId?: string | null;
+  onDeselect?: () => void;
 }
 
 export function AgentPicker({
@@ -47,13 +54,22 @@ export function AgentPicker({
   isLoading = false,
   disabled = false,
   onOpenChange,
+  selectedAgentId,
+  onDeselect,
 }: AgentPickerProps) {
   const clientType = useClientType();
   const isMobile = useIsMobile();
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  const searchedAgents = filterAndSortAgents(agents, searchText);
+  const selectedAgent = selectedAgentId
+    ? (agents.find((a) => a.sId === selectedAgentId) ?? null)
+    : null;
+  // The selected agent is pinned separately at the top, so keep it out of the
+  // searchable list below to avoid showing it twice.
+  const searchedAgents = filterAndSortAgents(agents, searchText).filter(
+    (a) => a.sId !== selectedAgent?.sId
+  );
 
   return (
     <DropdownMenu
@@ -113,42 +129,82 @@ export function AgentPicker({
           </>
         }
       >
-        {searchedAgents.length > 0 ? (
-          searchedAgents.map((c) => (
+        {selectedAgent && (
+          <>
+            <DropdownMenuLabel label="Selected" />
             <DropdownMenuItem
-              key={`agent-picker-${c.sId}`}
-              icon={() => <Avatar size="xs" visual={c.pictureUrl} />}
-              label={c.name}
+              key={`agent-picker-selected-${selectedAgent.sId}`}
+              icon={() => (
+                <Avatar size="xs" visual={selectedAgent.pictureUrl} />
+              )}
+              label={selectedAgent.name}
               truncateText
               className="group py-1 notranslate"
               endComponent={
-                onAgentDetailsClick && clientType !== "extension" ? (
-                  <Button
-                    icon={DotsHorizontal}
-                    variant="outline"
-                    size="mini"
-                    className="opacity-0 group-hover:opacity-100"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      e.preventDefault();
-                      onAgentDetailsClick(c.sId);
-                      setIsOpen(false);
-                    }}
-                  />
-                ) : undefined
+                <div className="flex items-center gap-1">
+                  <Icon visual={Check} size="sm" />
+                  {onAgentDetailsClick && clientType !== "extension" ? (
+                    <Button
+                      icon={DotsHorizontal}
+                      variant="outline"
+                      size="mini"
+                      className="opacity-0 group-hover:opacity-100"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        onAgentDetailsClick(selectedAgent.sId);
+                        setIsOpen(false);
+                      }}
+                    />
+                  ) : undefined}
+                </div>
               }
-              onClick={() => {
-                onItemClick(c);
-                setSearchText("");
-                setIsOpen(false);
-              }}
+              // Clicking the row deselects the agent; keep the picker open so a
+              // different agent can be chosen right away.
+              onClick={() => onDeselect?.()}
+              onSelect={(e) => e.preventDefault()}
             />
-          ))
-        ) : (
-          <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-            No results found
-          </div>
+            <DropdownMenuSeparator />
+          </>
         )}
+        {searchedAgents.length > 0
+          ? searchedAgents.map((c) => (
+              <DropdownMenuItem
+                key={`agent-picker-${c.sId}`}
+                icon={() => <Avatar size="xs" visual={c.pictureUrl} />}
+                label={c.name}
+                truncateText
+                className="group py-1 notranslate"
+                endComponent={
+                  onAgentDetailsClick && clientType !== "extension" ? (
+                    <Button
+                      icon={DotsHorizontal}
+                      variant="outline"
+                      size="mini"
+                      className="opacity-0 group-hover:opacity-100"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        onAgentDetailsClick(c.sId);
+                        setIsOpen(false);
+                      }}
+                    />
+                  ) : undefined
+                }
+                onClick={() => {
+                  onItemClick(c);
+                  setSearchText("");
+                  setIsOpen(false);
+                }}
+              />
+            ))
+          : // Skip the empty state when a selected agent is pinned and the user
+            // isn't actively searching (the pinned row is the only content).
+            (searchText.trim() !== "" || !selectedAgent) && (
+              <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+                No results found
+              </div>
+            )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
   Icon,
   Robot,
+  X,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -130,10 +131,27 @@ export function AgentPicker({
                 icon={() => <Avatar size="xs" visual={c.pictureUrl} />}
                 label={c.name}
                 truncateText
-                className="group py-1 notranslate"
+                className={`group py-1 notranslate ${
+                  isSelected ? "bg-primary-100" : ""
+                }`}
                 endComponent={
                   <div className="flex items-center gap-1">
-                    {isSelected && <Icon visual={Check} size="sm" />}
+                    {isSelected && (
+                      // Show a tick by default; on hover swap it for an X to
+                      // signal that clicking will deselect the agent.
+                      <>
+                        <Icon
+                          visual={Check}
+                          size="sm"
+                          className="group-hover:hidden"
+                        />
+                        <Icon
+                          visual={X}
+                          size="sm"
+                          className="hidden group-hover:block"
+                        />
+                      </>
+                    )}
                     {onAgentDetailsClick && clientType !== "extension" ? (
                       <Button
                         icon={DotsHorizontal}

--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -12,7 +12,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -60,14 +59,9 @@ export function AgentPicker({
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  const selectedAgent = selectedAgentId
-    ? (agents.find((a) => a.sId === selectedAgentId) ?? null)
-    : null;
-  // The selected agent is pinned separately at the top, so keep it out of the
-  // searchable list below to avoid showing it twice.
-  const searchedAgents = filterAndSortAgents(agents, searchText).filter(
-    (a) => a.sId !== selectedAgent?.sId
-  );
+  const searchedAgents = filterAndSortAgents(agents, searchText, {
+    selectedAgentId,
+  });
 
   return (
     <DropdownMenu
@@ -127,46 +121,10 @@ export function AgentPicker({
           </>
         }
       >
-        {selectedAgent && (
-          <>
-            <DropdownMenuLabel label="Selected" />
-            <DropdownMenuItem
-              key={`agent-picker-selected-${selectedAgent.sId}`}
-              icon={() => (
-                <Avatar size="xs" visual={selectedAgent.pictureUrl} />
-              )}
-              label={selectedAgent.name}
-              truncateText
-              className="group py-1 notranslate"
-              endComponent={
-                <div className="flex items-center gap-1">
-                  <Icon visual={Check} size="sm" />
-                  {onAgentDetailsClick && clientType !== "extension" ? (
-                    <Button
-                      icon={DotsHorizontal}
-                      variant="outline"
-                      size="mini"
-                      className="opacity-0 group-hover:opacity-100"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        onAgentDetailsClick(selectedAgent.sId);
-                        setIsOpen(false);
-                      }}
-                    />
-                  ) : undefined}
-                </div>
-              }
-              // Clicking the row deselects the agent; keep the picker open so a
-              // different agent can be chosen right away.
-              onClick={() => onDeselect?.()}
-              onSelect={(e) => e.preventDefault()}
-            />
-            <DropdownMenuSeparator />
-          </>
-        )}
-        {searchedAgents.length > 0
-          ? searchedAgents.map((c) => (
+        {searchedAgents.length > 0 ? (
+          searchedAgents.map((c) => {
+            const isSelected = c.sId === selectedAgentId;
+            return (
               <DropdownMenuItem
                 key={`agent-picker-${c.sId}`}
                 icon={() => <Avatar size="xs" visual={c.pictureUrl} />}
@@ -174,35 +132,44 @@ export function AgentPicker({
                 truncateText
                 className="group py-1 notranslate"
                 endComponent={
-                  onAgentDetailsClick && clientType !== "extension" ? (
-                    <Button
-                      icon={DotsHorizontal}
-                      variant="outline"
-                      size="mini"
-                      className="opacity-0 group-hover:opacity-100"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        onAgentDetailsClick(c.sId);
-                        setIsOpen(false);
-                      }}
-                    />
-                  ) : undefined
+                  <div className="flex items-center gap-1">
+                    {isSelected && <Icon visual={Check} size="sm" />}
+                    {onAgentDetailsClick && clientType !== "extension" ? (
+                      <Button
+                        icon={DotsHorizontal}
+                        variant="outline"
+                        size="mini"
+                        className="opacity-0 group-hover:opacity-100"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          e.preventDefault();
+                          onAgentDetailsClick(c.sId);
+                          setIsOpen(false);
+                        }}
+                      />
+                    ) : undefined}
+                  </div>
                 }
                 onClick={() => {
+                  // Clicking the selected agent deselects it; keep the picker
+                  // open so a different agent can be chosen right away.
+                  if (isSelected) {
+                    onDeselect?.();
+                    return;
+                  }
                   onItemClick(c);
                   setSearchText("");
                   setIsOpen(false);
                 }}
+                onSelect={isSelected ? (e) => e.preventDefault() : undefined}
               />
-            ))
-          : // Skip the empty state when a selected agent is pinned and the user
-            // isn't actively searching (the pinned row is the only content).
-            (searchText.trim() !== "" || !selectedAgent) && (
-              <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-                No results found
-              </div>
-            )}
+            );
+          })
+        ) : (
+          <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+            No results found
+          </div>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -6,6 +6,7 @@ import type useCustomEditor from "@app/components/editor/input_bar/useCustomEdit
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useAppRouter } from "@app/lib/platform";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { setQueryParam } from "@app/lib/utils/router";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -28,7 +29,6 @@ import {
   InfoCircle,
   Robot,
   Tooltip,
-  XClose,
 } from "@dust-tt/sparkle";
 import React from "react";
 
@@ -97,6 +97,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   onAttachmentsPickerOpenChange,
 }: InputBarButtonsProps) {
   const router = useAppRouter();
+  const isMobile = useIsMobile();
   // Current space is taken from the conversation (if already set) or from the space prop (if provided).
   const spaceId = conversation?.spaceId ?? space?.sId ?? undefined;
 
@@ -120,6 +121,8 @@ export const InputBarButtons = React.memo(function InputBarButtons({
         handleSingleAgentSelect(toRichAgentMentionType(c));
       }}
       agents={allAgents}
+      selectedAgentId={selectedAgent?.id}
+      onDeselect={onAgentRemove}
       showDropdownArrow={false}
       side={conversation ? "top" : "bottom"}
       showFooterButtons={
@@ -141,9 +144,11 @@ export const InputBarButtons = React.memo(function InputBarButtons({
             )}
           >
             <Avatar size="xxs" visual={selectedAgent.pictureUrl} />
-            <span className="grow truncate notranslate">
-              {selectedAgent.label}
-            </span>
+            {!isMobile && (
+              <span className="grow truncate notranslate">
+                {selectedAgent.label}
+              </span>
+            )}
             {isDefaultAgentUnavailable && (
               <Tooltip
                 tooltipTriggerAsChild
@@ -165,22 +170,6 @@ export const InputBarButtons = React.memo(function InputBarButtons({
                 label={defaultAgentUnavailableLabel}
               />
             )}
-            <button
-              type="button"
-              aria-label="Remove agent"
-              className="p-0.5 text-faint hover:text-foreground transition-colors duration-200"
-              onPointerDown={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-              }}
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                onAgentRemove();
-              }}
-            >
-              <XClose className="h-3 w-3" />
-            </button>
           </div>
         ) : (
           <Button
@@ -245,6 +234,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
         />
       </>
     );
+
   return (
     <>
       {agentButton}

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -302,7 +302,8 @@ export function compareForFuzzySort(query: string, a: string, b: string) {
 
 export function filterAndSortAgents(
   agents: LightAgentConfigurationType[],
-  searchText: string
+  searchText: string,
+  { selectedAgentId }: { selectedAgentId?: string | null } = {}
 ) {
   const lowerCaseSearchText = searchText.toLowerCase();
 
@@ -316,6 +317,19 @@ export function filterAndSortAgents(
         compareForFuzzySort(lowerCaseSearchText, a.name, b.name) ||
         compareAgentsForSort(a, b)
     );
+  }
+
+  // Pin the selected agent to the front so it always displays first.
+  if (selectedAgentId) {
+    filtered.sort((a, b) => {
+      if (a.sId === selectedAgentId) {
+        return -1;
+      }
+      if (b.sId === selectedAgentId) {
+        return 1;
+      }
+      return 0;
+    });
   }
 
   return filtered;


### PR DESCRIPTION
## Description

After
<img width="954" height="636" alt="Screenshot 2026-07-06 at 13 34 24" src="https://github.com/user-attachments/assets/b0e94246-31b3-4677-90bd-42ebae247085" />

Before
<img width="822" height="506" alt="image" src="https://github.com/user-attachments/assets/5ad217a7-fa9c-47da-8086-a55a5b59225a" />

Reworks the agent chip in the conversation input bar to move deselection into the `AgentPicker` dropdown, in preparation for the model picker that sits next to it in the stack.

- The currently selected agent is pinned at the top of the `AgentPicker` list under a **Selected** label, with an inline toggle to deselect it.
- Drops the separate `XClose` button that used to sit on the agent chip — deselection now happens from inside the picker. **Only 3% of convos did not ping a user as the first message and anyway when you @ someone, the agent deselects.**
- On mobile, the agent label is hidden so the chip shows only the avatar, leaving room for the other input-bar buttons.
<img width="380" height="791" alt="Screenshot 2026-07-06 at 13 36 42" src="https://github.com/user-attachments/assets/1c02fc7d-a6d0-4039-a1bb-dd624fd0b442" />


Part of the model-picker stack (bottom → top): #28344 → #28346 → **#28488 (this)** → #28489 → #28049.

## Tests

Manual: open the input bar, select an agent, reopen the picker and confirm it appears under "Selected" with a working deselect toggle. Check the chip renders avatar-only at mobile widths and full-label on desktop.

## Risk

Low, but user-facing and **not** feature-flagged: the agent-chip interaction changes for everyone. Purely presentational, safe to roll back by reverting.

## Deploy Plan

None.
