### PR TITLE
[front/viz] enable callFunction for shared frames for authenticated members

### DIFF
--- a/front-api/routes/v1/public/frames/[token]/index.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.ts
@@ -226,6 +226,9 @@ app.get(
       // Only return the project URL if the user can read the project.
       projectUrl:
         canRead && spaceId ? getPodRoute(workspace.sId, spaceId) : null,
+      // Lets the frame enable member-only tools (e.g. callFunction) client-side;
+      // real authorization still happens server-side on invocation.
+      isAuthenticatedMember: !!user,
     });
   }
 );

--- a/front-api/routes/v1/viz/content.test.ts
+++ b/front-api/routes/v1/viz/content.test.ts
@@ -86,6 +86,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
       metadata: {
         conversationId: "conversation-A",
       },
+      isAuthenticatedMember: false,
     });
   });
 
@@ -270,6 +271,48 @@ describe("/api/v1/viz/content endpoint tests", () => {
       metadata: {
         conversationId: "conversation-A",
       },
+      isAuthenticatedMember: false,
+    });
+  });
+  
+  it("should return isAuthenticatedMember: true when the token carries a userId", async () => {
+    const frameFile = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "frame.html",
+      fileSize: 1000,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: "conversation-A" },
+    });
+
+    const frameShareInfo = await frameFile.getShareInfo();
+    const fileToken = frameShareInfo?.shareUrl.split("/").at(-1);
+    if (!fileToken) {
+      throw new Error("No file token found");
+    }
+
+    const accessToken = generateVizAccessToken({
+      contentType: frameContentType,
+      fileToken,
+      workspaceId: workspace.sId,
+      shareScope: "public",
+      userId: "user-123",
+    });
+
+    mockFetchByShareToken(frameFile);
+
+    const response = await request({
+      authorization: `Bearer ${accessToken}`,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      content: "<html><h1>Interactive Frame</h1></html>",
+      contentType: frameContentType,
+      metadata: {
+        conversationId: "conversation-A",
+      },
+      isAuthenticatedMember: true,
     });
   });
 });

--- a/front-api/routes/v1/viz/content.test.ts
+++ b/front-api/routes/v1/viz/content.test.ts
@@ -274,7 +274,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
       isAuthenticatedMember: false,
     });
   });
-  
+
   it("should return isAuthenticatedMember: true when the token carries a userId", async () => {
     const frameFile = await FileFactory.create(auth, null, {
       contentType: frameContentType,

--- a/front-api/routes/v1/viz/content.ts
+++ b/front-api/routes/v1/viz/content.ts
@@ -30,7 +30,7 @@ app.get("/", async (ctx): HandlerResult<PublicVizContentResponseBodyType> => {
     });
   }
   const tokenPayload = tokenRes.value;
-  const { fileToken } = tokenPayload;
+  const { fileToken, userId } = tokenPayload;
 
   const result = await FileResource.fetchByShareTokenWithContent(fileToken);
   if (!result) {
@@ -126,6 +126,7 @@ app.get("/", async (ctx): HandlerResult<PublicVizContentResponseBodyType> => {
       conversationId: result.file.useCaseMetadata?.conversationId,
       spaceId: result.file.useCaseMetadata?.spaceId,
     },
+    isAuthenticatedMember: !!userId,
   });
 });
 

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -627,9 +627,7 @@ export const VisualizationActionIframe = forwardRef<
     ): Promise<Result<SandboxFunctionInvocationType, Error>> => {
       try {
         if (frameAccess === "public-anonymous") {
-          throw new Error(
-            "Pod functions are not supported in shared frames."
-          );
+          throw new Error("Pod functions are not supported in shared frames.");
         }
 
         const body: PostSandboxFunctionInvocationRequestBody = {

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -721,12 +721,8 @@ export const VisualizationActionIframe = forwardRef<
       params.set("editable", "true");
     }
 
-    if (frameAccess === "public-member") {
-      params.set("isAuthenticated", "true");
-    }
-
     return `${props.vizUrl.replace(/\/$/, "")}/content?${params.toString()}`;
-  }, [visualization, isInDrawer, isEditable, props.vizUrl, frameAccess]);
+  }, [visualization, isInDrawer, isEditable, props.vizUrl]);
 
   return (
     <div className={cn("relative flex flex-col", isInDrawer && "h-full")}>

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -71,6 +71,8 @@ type ProtectedVisualization = BaseVisualization & {
 
 export type Visualization = PublicVisualization | ProtectedVisualization;
 
+export type FrameAccess = "conversation" | "public-anonymous" | "public-member";
+
 const sendResponseToIframe = <T extends VisualizationRPCCommand>(
   request: { command: T } & VisualizationRPCRequest,
   response: CommandResultMap[T],
@@ -484,8 +486,8 @@ interface VisualizationActionIframeProps {
   conversationId: string | null;
   isEditable?: boolean;
   isInDrawer?: boolean;
-  isPublic?: boolean;
   onEditText?: EditTextFn;
+  frameAccess?: FrameAccess;
   spaceId?: string;
   visualization: Visualization;
   vizUrl: string;
@@ -567,12 +569,14 @@ export const VisualizationActionIframe = forwardRef<
     conversationId,
     isEditable = false,
     isInDrawer = false,
-    isPublic = false,
     onEditText,
     spaceId,
     visualization,
     workspaceId,
+    frameAccess = "conversation",
   } = props;
+
+  const isPublic = frameAccess !== "conversation";
 
   const getFileBlob = useCallback(
     async (fileId: string) => {
@@ -622,8 +626,10 @@ export const VisualizationActionIframe = forwardRef<
       input?: unknown
     ): Promise<Result<SandboxFunctionInvocationType, Error>> => {
       try {
-        if (isPublic) {
-          throw new Error("Pod functions are not supported in shared frames.");
+        if (frameAccess === "public-anonymous") {
+          throw new Error(
+            "Pod functions are not supported in shared frames."
+          );
         }
 
         const body: PostSandboxFunctionInvocationRequestBody = {
@@ -655,7 +661,7 @@ export const VisualizationActionIframe = forwardRef<
         return new Err(normalizeError(error));
       }
     },
-    [isPublic, workspaceId]
+    [frameAccess, workspaceId]
   );
 
   useVisualizationDataHandler({
@@ -715,8 +721,12 @@ export const VisualizationActionIframe = forwardRef<
       params.set("editable", "true");
     }
 
+    if (frameAccess === "public-member") {
+      params.set("isAuthenticated", "true");
+    }
+
     return `${props.vizUrl.replace(/\/$/, "")}/content?${params.toString()}`;
-  }, [visualization, isInDrawer, isEditable, props.vizUrl]);
+  }, [visualization, isInDrawer, isEditable, props.vizUrl, frameAccess]);
 
   return (
     <div className={cn("relative flex flex-col", isInDrawer && "h-full")}>

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -31,10 +31,20 @@ export function PublicFrameRenderer({
   workspaceId,
   vizUrl,
 }: PublicFrameRendererProps) {
-  const { conversationUrl, projectUrl, isFrameLoading, error, accessToken } =
-    usePublicFrame({
-      shareToken,
-    });
+  const {
+    conversationUrl,
+    projectUrl,
+    isFrameLoading,
+    error,
+    accessToken,
+    isAuthenticatedMember,
+  } = usePublicFrame({
+    shareToken,
+  });
+
+  // Members can call functions on shared frames; anonymous viewers cannot.
+  // Real authorization still happens server-side on invocation.
+  const access = isAuthenticatedMember ? "public-member" : "public-anonymous";
 
   const [cookies] = useCookies([DUST_HAS_SESSION]);
   const hasSession = hasSessionIndicator(cookies[DUST_HAS_SESSION]);
@@ -89,8 +99,8 @@ export function PublicFrameRenderer({
               identifier: `viz-${fileId}`,
             }}
             key={`viz-${fileId}`}
+            frameAccess={access}
             isInDrawer
-            isPublic
           />
         </div>
       </div>

--- a/front/lib/swr/frames.ts
+++ b/front/lib/swr/frames.ts
@@ -35,6 +35,7 @@ export function usePublicFrame({ shareToken }: { shareToken: string | null }) {
     projectUrl: data?.projectUrl ?? null,
     accessToken: data?.accessToken ?? null,
     isFrameLoading: !error && !data,
+    isAuthenticatedMember: data?.isAuthenticatedMember ?? false,
     error,
     mutateFrame: mutate,
   };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3186,6 +3186,7 @@ export const PublicVizContentResponseBodySchema = z.object({
   content: z.string(),
   contentType: z.string(),
   metadata: z.record(z.unknown()).optional(),
+  isAuthenticatedMember: z.boolean().optional(),
 });
 
 export type PublicVizContentResponseBodyType = z.infer<

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3175,6 +3175,7 @@ export const PublicFrameResponseBodySchema = z.object({
   conversationUrl: z.string().nullable(),
   projectUrl: z.string().nullable(),
   file: FileTypeSchema,
+  isAuthenticatedMember: z.boolean().optional(),
 });
 
 export type PublicFrameResponseBodyType = z.infer<

--- a/viz/app/content/ServerVisualizationWrapper.tsx
+++ b/viz/app/content/ServerVisualizationWrapper.tsx
@@ -97,6 +97,7 @@ interface ServerSideVisualizationWrapperProps {
   identifier: string;
   isFullHeight?: boolean;
   isPdfMode?: boolean;
+  isAuthenticatedMember?: boolean;
 }
 
 /**
@@ -116,6 +117,7 @@ export async function ServerSideVisualizationWrapper({
   identifier,
   isFullHeight = false,
   isPdfMode = false,
+  isAuthenticatedMember = false,
 }: ServerSideVisualizationWrapperProps) {
   let prefetchedCode: string | undefined;
   let preFetchedFiles: PreFetchedFile[] = [];
@@ -168,6 +170,7 @@ export async function ServerSideVisualizationWrapper({
       isPdfMode={isPdfMode}
       prefetchedCode={prefetchedCode}
       prefetchedFiles={preFetchedFiles}
+      isAuthenticatedMember={isAuthenticatedMember}
     />
   );
 }

--- a/viz/app/content/ServerVisualizationWrapper.tsx
+++ b/viz/app/content/ServerVisualizationWrapper.tsx
@@ -97,7 +97,6 @@ interface ServerSideVisualizationWrapperProps {
   identifier: string;
   isFullHeight?: boolean;
   isPdfMode?: boolean;
-  isAuthenticatedMember?: boolean;
 }
 
 /**
@@ -117,10 +116,10 @@ export async function ServerSideVisualizationWrapper({
   identifier,
   isFullHeight = false,
   isPdfMode = false,
-  isAuthenticatedMember = false,
 }: ServerSideVisualizationWrapperProps) {
   let prefetchedCode: string | undefined;
   let preFetchedFiles: PreFetchedFile[] = [];
+  let isAuthenticatedMember = false;
 
   try {
     const headers: Record<string, string> = {};
@@ -137,6 +136,7 @@ export async function ServerSideVisualizationWrapper({
     if (codeResponse.ok) {
       const responseData = await codeResponse.json();
       prefetchedCode = responseData.content;
+      isAuthenticatedMember = responseData.isAuthenticatedMember ?? false;
 
       if (!prefetchedCode) {
         logger.warn({ identifier }, "No code content found for visualization");

--- a/viz/app/content/ServerVisualizationWrapperClient.tsx
+++ b/viz/app/content/ServerVisualizationWrapperClient.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import { NavigationProvider } from "@viz/app/components/NavigationProvider";
-import { VisualizationWrapperWithErrorBoundary } from "@viz/app/components/VisualizationWrapper";
+import {
+  makeSendCrossDocumentMessage,
+  VisualizationWrapperWithErrorBoundary,
+} from "@viz/app/components/VisualizationWrapper";
 import {
   CacheDataAPI,
   type PreFetchedFile,
 } from "@viz/app/lib/data-apis/cache-data-api";
+import { HybridDataAPI } from "@viz/app/lib/data-apis/hybrid-data-api";
+import { RPCDataAPI } from "@viz/app/lib/data-apis/rpc-data-api";
 import type { VisualizationConfig } from "@viz/app/lib/visualization-api";
 import { useMemo } from "react";
 
@@ -16,6 +21,7 @@ const TRUSTED_NAVIGATION_DOMAINS = ["dust.tt", "eu.dust.tt"];
 interface ServerVisualizationWrapperClientProps {
   allowedOrigins: string[];
   identifier: string;
+  isAuthenticatedMember?: boolean;
   isFullHeight?: boolean;
   isPdfMode?: boolean;
   prefetchedCode?: string;
@@ -37,15 +43,32 @@ interface ServerVisualizationWrapperClientProps {
 export function ServerVisualizationWrapperClient({
   identifier,
   allowedOrigins,
+  isAuthenticatedMember = false,
   isFullHeight = false,
   isPdfMode = false,
   prefetchedCode,
   prefetchedFiles = [],
 }: ServerVisualizationWrapperClientProps) {
   const dataAPI = useMemo(() => {
-    // Create cache-based API with pre-fetched data.
-    return new CacheDataAPI(prefetchedFiles, prefetchedCode);
-  }, [prefetchedCode, prefetchedFiles]);
+    const cache = new CacheDataAPI(prefetchedFiles, prefetchedCode);
+    if (!isAuthenticatedMember) {
+      return cache;
+    }
+
+    // Authenticated member on a public frame: keep SSR reads from the cache,
+    // route callFunction over RPC.
+    const sendMessage = makeSendCrossDocumentMessage({
+      allowedOrigins,
+      identifier,
+    });
+    return new HybridDataAPI(cache, new RPCDataAPI(sendMessage));
+  }, [
+    prefetchedCode,
+    prefetchedFiles,
+    isAuthenticatedMember,
+    allowedOrigins,
+    identifier,
+  ]);
 
   const config: VisualizationConfig = {
     allowedOrigins,

--- a/viz/app/content/page.tsx
+++ b/viz/app/content/page.tsx
@@ -7,7 +7,6 @@ interface RenderVisualizationSearchParams {
   fullHeight?: string;
   identifier?: string;
   pdfMode?: string;
-  isAuthenticated?: string;
 }
 
 const { ALLOWED_VISUALIZATION_ORIGIN } = process.env;
@@ -21,14 +20,8 @@ export default function RenderVisualization({
     ? ALLOWED_VISUALIZATION_ORIGIN.split(",").map((s) => s.trim())
     : [];
 
-  const {
-    accessToken,
-    editable,
-    fullHeight,
-    identifier,
-    pdfMode,
-    isAuthenticated,
-  } = searchParams;
+  const { accessToken, editable, fullHeight, identifier, pdfMode } =
+    searchParams;
 
   const isEditable = editable === "true";
   const isFullHeight = fullHeight === "true";
@@ -44,7 +37,6 @@ export default function RenderVisualization({
         identifier={identifier!}
         isFullHeight={isFullHeight}
         isPdfMode={isPdfMode}
-        isAuthenticatedMember={isAuthenticated === "true"}
       />
     );
   }

--- a/viz/app/content/page.tsx
+++ b/viz/app/content/page.tsx
@@ -7,6 +7,7 @@ interface RenderVisualizationSearchParams {
   fullHeight?: string;
   identifier?: string;
   pdfMode?: string;
+  isAuthenticated?: string;
 }
 
 const { ALLOWED_VISUALIZATION_ORIGIN } = process.env;
@@ -20,8 +21,14 @@ export default function RenderVisualization({
     ? ALLOWED_VISUALIZATION_ORIGIN.split(",").map((s) => s.trim())
     : [];
 
-  const { accessToken, editable, fullHeight, identifier, pdfMode } =
-    searchParams;
+  const {
+    accessToken,
+    editable,
+    fullHeight,
+    identifier,
+    pdfMode,
+    isAuthenticated,
+  } = searchParams;
 
   const isEditable = editable === "true";
   const isFullHeight = fullHeight === "true";
@@ -37,6 +44,7 @@ export default function RenderVisualization({
         identifier={identifier!}
         isFullHeight={isFullHeight}
         isPdfMode={isPdfMode}
+        isAuthenticatedMember={isAuthenticated === "true"}
       />
     );
   }

--- a/viz/app/lib/data-apis/hybrid-data-api.ts
+++ b/viz/app/lib/data-apis/hybrid-data-api.ts
@@ -1,0 +1,26 @@
+import type { CacheDataAPI } from "@viz/app/lib/data-apis/cache-data-api";
+import type { RPCDataAPI } from "@viz/app/lib/data-apis/rpc-data-api";
+import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
+
+/**
+ * Data API for public frames viewed by an authenticated workspace member:
+ * code and files are served from the SSR cache, callFunction goes over RPC.
+ */
+export class HybridDataAPI implements VisualizationDataAPI {
+  constructor(
+    private readonly cache: CacheDataAPI,
+    private readonly rpc: RPCDataAPI
+  ) {}
+
+  async callFunction(functionId: string, input?: unknown) {
+    return this.rpc.callFunction(functionId, input);
+  }
+
+  async fetchFile(fileId: string): Promise<File | null> {
+    return this.cache.fetchFile(fileId);
+  }
+
+  async fetchCode(): Promise<string | null> {
+    return this.cache.fetchCode();
+  }
+}


### PR DESCRIPTION
## Description

Enables `callFunction` (sandbox function RPC) on shared/public frames when the
viewer is an authenticated workspace member. Previously it was hard-blocked for
everyone on shared frames.

The authenticated-member status is passed **explicitly** instead of being decoded
from the viz access token client-side.

- **front-api `/public/frames`**: `resolveOptionalAuth` resolves the viewer from
  the session cookie; the response returns `isAuthenticatedMember` (`!!user`).
  Front uses it to derive `frameAccess` → the host-side guard.
- **front-api `/viz/content`**: this endpoint already verifies the access token to
  serve the frame code; it now also returns `isAuthenticatedMember`
  (`!!tokenPayload.userId`) in the same response.
- **viz**: `ServerSideVisualizationWrapper` (server component) reads
  `isAuthenticatedMember` from the `/viz/content` fetch it already makes
  (server-to-server), and passes it to `ServerVisualizationWrapperClient`, which
  selects `HybridDataAPI` (SSR cache for reads, `callFunction` over RPC) instead
  of `CacheDataAPI`. No URL param, no token decode.

Both fields (optional, append-only) are added to the SDK schemas. The flag is a
UI hint only; real authorization stays server-side (session cookie + pod access)
at invocation.

## Tests

- Authenticated member on a shared frame: `callFunction` executes end-to-end.
- Anonymous / non-member (private window / other Google session): returns
  "Sandbox function <id> is not supported in public frames."

## Risk

**Low.**

- Anonymous/non-member behavior unchanged (safe default `false`).
- The `isAuthenticated` URL param is only a UX hint (unverified, tamper-able);
  actual authorization is server-side (cookie + pod access), untouched. Tampering
  the URL at worst exposes `callFunction` in viz, but the invocation is still
  rejected by the host guard (server-authoritative `frameAccess`) and the
  authenticated endpoint (401/404).
- A member without pod access gets 404.
- safe to revert

## Deploy Plan

Standard deploy.