### PR TITLE
[front] Normalize sub-cent unit prices on Metronome-pushed Stripe invoices

### DIFF
--- a/front/lib/plans/stripe.test.ts
+++ b/front/lib/plans/stripe.test.ts
@@ -1,4 +1,5 @@
 import {
+  cleanAndFinalizeMetronomeDraftInvoice,
   createCreditPurchaseCoupon,
   finalizeInvoice,
   getCreditAmountFromInvoice,
@@ -30,10 +31,13 @@ const {
     retrieve: vi.fn(),
     voidInvoice: vi.fn(),
     update: vi.fn(),
+    listLineItems: vi.fn(),
   };
 
   const mockInvoiceItems = {
     create: vi.fn(),
+    del: vi.fn(),
+    update: vi.fn(),
   };
 
   const mockCoupons = {
@@ -106,6 +110,16 @@ vi.mock("stripe", () => {
     ),
   };
 });
+
+vi.mock("@app/lib/resources/workspace_resource", () => ({
+  WorkspaceResource: { fetchById: vi.fn(async () => null) },
+}));
+
+vi.mock("@app/lib/resources/credit_usage_configuration_resource", () => ({
+  CreditUsageConfigurationResource: {
+    fetchByWorkspaceModelId: vi.fn(async () => null),
+  },
+}));
 
 const NOV_2024_START_SECONDS = 1730419200; // 2024-11-01
 const DEC_2024_START_SECONDS = 1733011200; // 2024-12-01
@@ -841,5 +855,228 @@ describe("getStripePricingData", () => {
         gbp: { unitAmount: 0 },
       },
     });
+  });
+});
+
+describe("cleanAndFinalizeMetronomeDraftInvoice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeMetronomeLine({
+    id,
+    amountCents,
+    quantity = 1,
+    unitAmountDecimalCents = null,
+    currency = "eur",
+    description = "Pro Seat",
+  }: {
+    id: string;
+    amountCents: number;
+    quantity?: number;
+    unitAmountDecimalCents?: string | null;
+    currency?: string;
+    description?: string;
+  }): Stripe.InvoiceLineItem {
+    return {
+      id,
+      amount: amountCents,
+      quantity,
+      currency,
+      description,
+      invoice_item: `ii_${id}`,
+      price:
+        unitAmountDecimalCents !== null
+          ? { unit_amount_decimal: unitAmountDecimalCents }
+          : null,
+    } as unknown as Stripe.InvoiceLineItem;
+  }
+
+  function setupMetronomeDraftInvoice({
+    lines,
+    totalCents,
+  }: {
+    lines: Stripe.InvoiceLineItem[];
+    totalCents: number;
+  }) {
+    const invoice = makeInvoice({
+      metadata: { metronome_customer_id: "mc_1" },
+      total: totalCents,
+      currency: "eur",
+    });
+    mockInvoices.retrieve.mockResolvedValue(invoice);
+    mockInvoices.update.mockResolvedValue(invoice);
+    mockInvoices.finalizeInvoice.mockResolvedValue({
+      ...invoice,
+      status: "open",
+    });
+    mockInvoices.listLineItems.mockReturnValue(
+      (async function* () {
+        yield* lines;
+      })()
+    );
+    mockInvoiceItems.del.mockResolvedValue({});
+    mockInvoiceItems.update.mockResolvedValue({});
+  }
+
+  it("should normalize a sub-cent unit price, keeping quantity when the total divides evenly", async () => {
+    setupMetronomeDraftInvoice({
+      lines: [
+        makeMetronomeLine({
+          id: "l1",
+          amountCents: 1965,
+          quantity: 1,
+          unitAmountDecimalCents: "1964.516129032258",
+        }),
+      ],
+      totalCents: 1965,
+    });
+
+    const result = await cleanAndFinalizeMetronomeDraftInvoice({
+      invoiceId: "in_test",
+      workspaceId: "w_test",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.outcome).toBe("cleaned");
+    }
+    expect(mockInvoiceItems.update).toHaveBeenCalledWith("ii_l1", {
+      quantity: 1,
+      unit_amount: 1965,
+    });
+    expect(mockInvoiceItems.del).not.toHaveBeenCalled();
+    expect(mockInvoices.finalizeInvoice).toHaveBeenCalledWith("in_test");
+  });
+
+  it("should keep a quantity > 1 when the total divides evenly by it", async () => {
+    setupMetronomeDraftInvoice({
+      lines: [
+        makeMetronomeLine({
+          id: "l1",
+          amountCents: 3930,
+          quantity: 2,
+          unitAmountDecimalCents: "1964.9",
+        }),
+      ],
+      totalCents: 3930,
+    });
+
+    const result = await cleanAndFinalizeMetronomeDraftInvoice({
+      invoiceId: "in_test",
+      workspaceId: "w_test",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockInvoiceItems.update).toHaveBeenCalledWith("ii_l1", {
+      quantity: 2,
+      unit_amount: 1965,
+    });
+  });
+
+  it("should keep the quantity and use the fewest sub-cent decimals when the total does not divide evenly", async () => {
+    setupMetronomeDraftInvoice({
+      lines: [
+        makeMetronomeLine({
+          id: "l1",
+          amountCents: 5894,
+          quantity: 3,
+          unitAmountDecimalCents: "1964.666666666667",
+        }),
+      ],
+      totalCents: 5894,
+    });
+
+    const result = await cleanAndFinalizeMetronomeDraftInvoice({
+      invoiceId: "in_test",
+      workspaceId: "w_test",
+    });
+
+    expect(result.isOk()).toBe(true);
+    // 1964.7 cents × 3 = 5894.1 cents, which rounds back to the exact total.
+    expect(mockInvoiceItems.update).toHaveBeenCalledWith("ii_l1", {
+      quantity: 3,
+      unit_amount_decimal: "1964.7",
+    });
+  });
+
+  it("should keep adding decimals until the total reconstructs exactly, even for large quantities", async () => {
+    setupMetronomeDraftInvoice({
+      lines: [
+        makeMetronomeLine({
+          id: "l1",
+          amountCents: 1001,
+          quantity: 1000,
+          unitAmountDecimalCents: "1.001000000000",
+        }),
+      ],
+      totalCents: 1001,
+    });
+
+    const result = await cleanAndFinalizeMetronomeDraftInvoice({
+      invoiceId: "in_test",
+      workspaceId: "w_test",
+    });
+
+    expect(result.isOk()).toBe(true);
+    // 1 and 2 decimals round the total to 1000 cents; 3 decimals are exact.
+    expect(mockInvoiceItems.update).toHaveBeenCalledWith("ii_l1", {
+      quantity: 1000,
+      unit_amount_decimal: "1.001",
+    });
+  });
+
+  it("should leave whole-cent unit prices and price-less lines untouched", async () => {
+    setupMetronomeDraftInvoice({
+      lines: [
+        makeMetronomeLine({
+          id: "l1",
+          amountCents: 1900,
+          unitAmountDecimalCents: "1900",
+        }),
+        makeMetronomeLine({
+          id: "l2",
+          amountCents: 500,
+          unitAmountDecimalCents: null,
+        }),
+      ],
+      totalCents: 2400,
+    });
+
+    const result = await cleanAndFinalizeMetronomeDraftInvoice({
+      invoiceId: "in_test",
+      workspaceId: "w_test",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockInvoiceItems.update).not.toHaveBeenCalled();
+    expect(mockInvoices.finalizeInvoice).toHaveBeenCalledWith("in_test");
+  });
+
+  it("should delete negative lines without normalizing them", async () => {
+    setupMetronomeDraftInvoice({
+      lines: [
+        makeMetronomeLine({
+          id: "l1",
+          amountCents: -1965,
+          unitAmountDecimalCents: "-1964.516129032258",
+        }),
+        makeMetronomeLine({
+          id: "l2",
+          amountCents: 1900,
+          unitAmountDecimalCents: "1900",
+        }),
+      ],
+      totalCents: 1900,
+    });
+
+    const result = await cleanAndFinalizeMetronomeDraftInvoice({
+      invoiceId: "in_test",
+      workspaceId: "w_test",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockInvoiceItems.del).toHaveBeenCalledWith("ii_l1");
+    expect(mockInvoiceItems.update).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1705,6 +1705,127 @@ function findCommitAppliedLineIds(
 }
 
 /**
+ * Stripe accepts at most 12 decimal places on `unit_amount_decimal`.
+ */
+const STRIPE_MAX_UNIT_AMOUNT_DECIMAL_PLACES = 12;
+
+/**
+ * Round-half-up integer division for positive bigints — the bigint equivalent
+ * of Math.round(numerator / denominator), which is also how Stripe rounds
+ * recomputed line totals. Bigint `/` truncates, so rounding is expressed as
+ * floor((2a + b) / 2b).
+ */
+function divideRoundHalfUp(numerator: bigint, denominator: bigint): bigint {
+  const two = BigInt(2);
+  return (two * numerator + denominator) / (two * denominator);
+}
+
+/**
+ * Metronome pushes invoice items with `unit_amount_decimal` (Stripe's
+ * sub-cent-precision unit price), e.g. "1964.516129032258" cents for a
+ * prorated seat. Stripe renders that unit price verbatim on the
+ * customer-facing invoice, showing a long tail of decimals. Rewrites the
+ * backing invoice item to the shortest unit price — whole cents first, then
+ * increasing sub-cent decimals — that multiplies back (by the unchanged
+ * quantity) to the exact line total (`amount`, integer cents), so both the
+ * displayed quantity and the invoice total are preserved. Any precision with
+ * more than log10(quantity) sub-cent decimals reconstructs the total exactly,
+ * so a match is always found well within Stripe's 12-decimal maximum.
+ */
+async function normalizeSubCentUnitAmount(
+  stripe: Stripe,
+  invoice: Stripe.Invoice,
+  line: Stripe.InvoiceLineItem
+): Promise<void> {
+  const unitAmountDecimalCents = line.price?.unit_amount_decimal;
+  if (
+    unitAmountDecimalCents == null ||
+    Number.isInteger(Number(unitAmountDecimalCents))
+  ) {
+    return;
+  }
+
+  const invoiceItemId =
+    typeof line.invoice_item === "string"
+      ? line.invoice_item
+      : line.invoice_item?.id;
+
+  if (!invoiceItemId) {
+    logger.warn(
+      { stripeInvoiceId: invoice.id, lineId: line.id },
+      "[Stripe] Cannot normalize sub-cent unit price: line not backed by an invoice item"
+    );
+    return;
+  }
+
+  const quantity = line.quantity ?? 1;
+  const amountCents = line.amount;
+  if (quantity <= 0) {
+    return;
+  }
+
+  // BigInt throughout: at 12 decimal places the scaled values exceed Number's
+  // safe integer range.
+  const amountBig = BigInt(amountCents);
+  const quantityBig = BigInt(quantity);
+
+  for (
+    let decimalPlaces = 0;
+    decimalPlaces <= STRIPE_MAX_UNIT_AMOUNT_DECIMAL_PLACES;
+    decimalPlaces++
+  ) {
+    // 10^12 is well within Number's safe integer range, so the Number
+    // exponentiation is exact.
+    const scale = BigInt(10 ** decimalPlaces);
+    const scaledUnit = divideRoundHalfUp(amountBig * scale, quantityBig);
+    // Stripe recomputes the line total as round(unit price × quantity); only
+    // keep this precision if that lands back on the exact original total.
+    const reconstructed = divideRoundHalfUp(scaledUnit * quantityBig, scale);
+    if (reconstructed !== amountBig) {
+      continue;
+    }
+
+    const update: Stripe.InvoiceItemUpdateParams =
+      decimalPlaces === 0
+        ? { quantity, unit_amount: Number(scaledUnit) }
+        : {
+            quantity,
+            unit_amount_decimal: `${scaledUnit / scale}.${String(
+              scaledUnit % scale
+            ).padStart(decimalPlaces, "0")}`,
+          };
+
+    logger.info(
+      {
+        stripeInvoiceId: invoice.id,
+        lineId: line.id,
+        invoiceItemId,
+        unitAmountDecimalCents,
+        amountCents,
+        quantity,
+        update,
+      },
+      "[Stripe] Normalizing sub-cent unit price on Metronome invoice line"
+    );
+
+    await stripe.invoiceItems.update(invoiceItemId, update);
+    return;
+  }
+
+  logger.warn(
+    {
+      stripeInvoiceId: invoice.id,
+      lineId: line.id,
+      invoiceItemId,
+      unitAmountDecimalCents,
+      amountCents,
+      quantity,
+    },
+    "[Stripe] Could not shorten sub-cent unit price without changing the line total, leaving line as-is"
+  );
+}
+
+/**
  * Removes from a Metronome-pushed Stripe draft invoice the line items that
  * should not appear on the customer-facing invoice:
  *
@@ -1713,6 +1834,9 @@ function findCommitAppliedLineIds(
  *    `findCommitAppliedLineIds` (see its doc comment).
  * 3. Wrong-currency lines — non-fiat lines (e.g. AWU-priced) that Metronome may
  *    not transfer to Stripe; guard retained for safety.
+ *
+ * Lines that are kept get their unit price shortened via
+ * `normalizeSubCentUnitAmount`. Quantity and total are preserved, so the totals safety check below is unaffected.
  *
  * Filters 1 and 2 cancel each other out: the negative "applied" line and the
  * positive line it offsets have equal and opposite amounts, so removing both
@@ -1769,6 +1893,7 @@ async function cleanMetronomeInvoiceLines(
     );
 
     if (!shouldRemove) {
+      await normalizeSubCentUnitAmount(stripe, invoice, line);
       continue;
     }
 

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1745,10 +1745,9 @@ async function normalizeSubCentUnitAmount(
     return;
   }
 
-  const invoiceItemId =
-    typeof line.invoice_item === "string"
-      ? line.invoice_item
-      : line.invoice_item?.id;
+  const invoiceItemId = isString(line.invoice_item)
+    ? line.invoice_item
+    : line.invoice_item?.id;
 
   if (!invoiceItemId) {
     logger.warn(


### PR DESCRIPTION
closes https://github.com/dust-tt/tasks/issues/9401

## Description

Metronome pushes invoice items with unit_amount_decimal (sub-cent precision), which Stripe renders verbatim on the customer-facing invoice (e.g. "€19.6451612903"). When cleaning a Metronome draft invoice, rewrite each kept line's unit price to the shortest decimal that multiplies back (by the unchanged quantity) to the exact line total, preserving both the displayed quantity and the invoice total.

Checking the unit test help understand the behaviour if needed

## Tests

added unit tests

## Risk

break some amounts displayed on the invoice.
Should not happen as we have acheck for that.

## Deploy Plan

deploy front
