### PR TITLE
[front] Fix programmatic credit state depleting when no cap is configured

### DIFF
--- a/front/components/poke/credits/ReconcileCreditStateButton.tsx
+++ b/front/components/poke/credits/ReconcileCreditStateButton.tsx
@@ -12,6 +12,8 @@ interface ReconcileCreditStateButtonProps {
   target: ReconcileCreditStateTarget;
   // Required when target is "user".
   userId?: string;
+  // Required when target is "api_key".
+  keyName?: string;
   label?: string;
   // Called after a successful reconcile so callers can refresh their data.
   onReconciled?: () => void;
@@ -21,6 +23,7 @@ export function ReconcileCreditStateButton({
   owner,
   target,
   userId,
+  keyName,
   label = "Reconcile",
   onReconciled,
 }: ReconcileCreditStateButtonProps) {
@@ -38,10 +41,14 @@ export function ReconcileCreditStateButton({
 
   const handleClick = async () => {
     setIsRunning(true);
+    // The plugin's arg schema requires every string arg to be present (the
+    // `dependsOn` conditions only drive rendering, not validation), so send the
+    // conditional userId/keyName as empty strings when they don't apply.
     const result = await doRunPlugin({
       target: [target],
       mode: ["execute"],
       userId: userId ?? "",
+      keyName: keyName ?? "",
     });
     setIsRunning(false);
 

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -293,26 +293,41 @@ export async function reconcileProgrammatic({
   const config = await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
     workspace.id
   );
-  const monthlyCapCredits = config?.programmaticMonthlyCapAwuCredits ?? 0;
+  // Distinguish "no cap configured" (null) from an explicit hard cap of 0:
+  // null means programmatic usage is unrestricted at the cap level, whereas 0
+  // is an explicit block. Collapsing both to 0 would wrongly deplete workspaces
+  // that never set a programmatic cap.
+  const monthlyCapCredits = config?.programmaticMonthlyCapAwuCredits ?? null;
 
   const previousState = workspace.programmaticCreditState;
 
-  // Cap of 0/null → always depleted; no spend to read.
-  if (monthlyCapCredits === 0 || !metronomeContractId) {
+  // States that don't require reading live spend:
+  //  - explicit hard cap of 0 → always depleted (programmatic API blocked).
+  //  - no cap configured (null), or no contract to meter spend against →
+  //    programmatic usage is unrestricted at the cap level; stay "active" and
+  //    let the pool gate (isApiBlocked) decide. This keeps PAYG programmatic
+  //    usage running when the pool is in overage and no programmatic cap is set.
+  if (
+    monthlyCapCredits === null ||
+    monthlyCapCredits === 0 ||
+    !metronomeContractId
+  ) {
+    const expectedState: WorkspaceProgrammaticCreditState =
+      monthlyCapCredits === 0 ? "depleted" : "active";
     if (execute) {
-      await setProgrammaticCreditStateReconciled(workspace, "depleted");
+      await setProgrammaticCreditStateReconciled(workspace, expectedState);
       void clearWorkspaceProgrammaticWarningReached(workspace.sId);
     }
     const newState = workspace.programmaticCreditState;
     return new Ok({
       target: "programmatic",
       previousState,
-      expectedState: "depleted",
+      expectedState,
       newState,
-      wasInvalid: previousState !== "depleted",
+      wasInvalid: previousState !== expectedState,
       corrected: previousState !== newState,
       executed: execute,
-      monthlyCapCredits,
+      monthlyCapCredits: monthlyCapCredits ?? 0,
       spentAwuCredits: null,
     });
   }


### PR DESCRIPTION
## Problem

Programmatic (API) usage was being marked `depleted` for workspaces that never configured a programmatic monthly cap, which blocks all programmatic API calls via `isProgrammaticApiBlocked`. This was **not** PAYG-related — it hit every capless workspace.

Root cause in `reconcileProgrammatic()`:

```ts
const monthlyCapCredits = config?.programmaticMonthlyCapAwuCredits ?? 0;
if (monthlyCapCredits === 0 || !metronomeContractId) → "depleted"
```

The DB column deliberately distinguishes **`null` = no cap configured** from **`0` = explicit hard block** (see `syncProgrammaticUsageLimit`). The `?? 0` collapsed both into `0` and forced `depleted` in both cases. This also contradicted the rest of the system: the workspace default is `active`, `expectedProgrammaticCreditStateFromAlerts` returns `active` when no cap is configured, and the per-API-key path returns `on_pool` (not blocked) when uncapped.

## Fix

- **`reconcileProgrammatic`**: preserve `null` and only deplete on an explicit `0`.
  - `null` (no cap) or no contract → `active` — unrestricted at the cap level; the pool gate (`isApiBlocked`) governs, so PAYG programmatic usage keeps running while the pool is in `overage`.
  - `0` (hard cap) → `depleted` (unchanged).
  - `> 0` → read spend and compute the band (unchanged).

  Side effect: an admin **removing** a programmatic cap now un-blocks programmatic usage immediately instead of leaving it depleted.

- **Poke "Reconcile" button (Usage tab)**: `createZodSchemaFromArgs` makes every string arg required (`dependsOn` only drives rendering), but `ReconcileCreditStateButton` never sent `keyName`, so the pool/programmatic buttons failed validation with "keyName required". Now sends `keyName: ""` like `userId`, plus an optional `keyName` prop for future `api_key` reconciles.

## Note on existing data

Because this affected every capless workspace, some workspaces may currently be persisted at `programmaticCreditState = "depleted"` that should be `active`. This fix stops it recurring; existing rows self-heal on the next reconcile (poke button, manage-cap flow, or backfill). Happy to add a bulk backfill if wanted.

## Validation

- `npx tsgo --noEmit`: clean
- `programmatic_credit_state_machine.test.ts`: 19 passed
- DB-backed suites can't run in this worktree (`@dust-tt/client` build is broken here, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)