### PR TITLE
fix(google-calendar): normalize event-carried timezones in formatEventAsText

### DIFF
--- a/front/lib/api/actions/servers/google_calendar/helpers.test.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.test.ts
@@ -141,4 +141,31 @@ describe("formatEventAsText - timezone handling", () => {
     const text = formatEventAsText(enriched);
     expect(text).toContain("Start: Tuesday, June 30, 2026 at 12:00 PM");
   });
+
+  it("keeps the raw timestamp when the event timeZone cannot be resolved", () => {
+    const enriched = enrichEventWithDayOfWeek(
+      {
+        summary: "Timed meeting",
+        start: {
+          dateTime: "2026-06-30T10:00:00Z",
+          timeZone: "Romance Standard Time",
+        },
+        end: {
+          dateTime: "2026-06-30T11:00:00Z",
+          timeZone: "Romance Standard Time",
+        },
+      },
+      normalizeTimezone("GMT+02:00")
+    );
+
+    expect(() => formatEventAsText(enriched)).not.toThrow();
+
+    const text = formatEventAsText(enriched);
+    // The raw ISO timestamp (whose offset is authoritative) is preserved
+    // rather than silently reformatted in the server's local timezone.
+    expect(text).toContain(
+      "Start: Tuesday, 2026-06-30T10:00:00Z (Romance Standard Time)"
+    );
+    expect(text).not.toContain("at 12:00 PM");
+  });
 });

--- a/front/lib/api/actions/servers/google_calendar/helpers.test.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.test.ts
@@ -109,3 +109,36 @@ describe("enrichEventWithDayOfWeek - timezone handling", () => {
     expect(enriched.start?.eventDayOfWeek).toBe("Tuesday");
   });
 });
+
+describe("formatEventAsText - timezone handling", () => {
+  it("does not throw when the event carries a UTC offset timeZone", () => {
+    const enriched = enrichEventWithDayOfWeek(
+      {
+        summary: "Timed meeting",
+        start: { dateTime: "2026-06-30T10:00:00Z", timeZone: "GMT+02:00" },
+        end: { dateTime: "2026-06-30T11:00:00Z", timeZone: "GMT+02:00" },
+      },
+      normalizeTimezone("GMT+02:00")
+    );
+
+    expect(() => formatEventAsText(enriched)).not.toThrow();
+
+    const text = formatEventAsText(enriched);
+    expect(text).toContain("Start: Tuesday, June 30, 2026 at 12:00 PM");
+    expect(text).toContain("End: Tuesday, June 30, 2026 at 1:00 PM");
+  });
+
+  it("still formats correctly when the event timeZone is a valid IANA name", () => {
+    const enriched = enrichEventWithDayOfWeek(
+      {
+        summary: "Timed meeting",
+        start: { dateTime: "2026-06-30T10:00:00Z", timeZone: "Europe/Paris" },
+        end: { dateTime: "2026-06-30T11:00:00Z", timeZone: "Europe/Paris" },
+      },
+      "Europe/Paris"
+    );
+
+    const text = formatEventAsText(enriched);
+    expect(text).toContain("Start: Tuesday, June 30, 2026 at 12:00 PM");
+  });
+});

--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -211,7 +211,7 @@ export function isGoogleCalendarEvent(
 function formatDayOfWeek(date: Date, timezone?: string): string {
   return date.toLocaleDateString("en-US", {
     weekday: "long",
-    timeZone: normalizeTimezone(timezone) ?? undefined,
+    timeZone: timezone,
   });
 }
 
@@ -220,7 +220,7 @@ function formatDate(date: Date, timezone?: string): string {
     month: "long",
     day: "numeric",
     year: "numeric",
-    timeZone: normalizeTimezone(timezone) ?? undefined,
+    timeZone: timezone,
   });
 }
 
@@ -228,8 +228,20 @@ function formatTime(date: Date, timezone?: string): string {
   return date.toLocaleTimeString("en-US", {
     hour: "numeric",
     minute: "2-digit",
-    timeZone: normalizeTimezone(timezone) ?? undefined,
+    timeZone: timezone,
   });
+}
+
+function formatTimedEventDateTime(dateTime: string, timeZone?: string): string {
+  const date = new Date(dateTime);
+  const normalizedZone = normalizeTimezone(timeZone);
+
+  if (timeZone && !normalizedZone) {
+    return dateTime;
+  }
+
+  const zone = normalizedZone ?? undefined;
+  return `${formatDate(date, zone)} at ${formatTime(date, zone)}`;
 }
 
 export function enrichEventWithDayOfWeek(
@@ -288,12 +300,12 @@ export function formatEventAsText(event: EnrichedGoogleCalendarEvent): string {
         lines.push(`Date: ${start.eventDayOfWeek}, ${start.date}`);
       } else {
         if (start.dateTime) {
-          const startDate = new Date(start.dateTime);
-          const timezone = start.timeZone ?? undefined;
-          const timeStr = formatTime(startDate, timezone);
-          const dateStr = formatDate(startDate, timezone);
+          const formatted = formatTimedEventDateTime(
+            start.dateTime,
+            start.timeZone
+          );
           lines.push(
-            `Start: ${start.eventDayOfWeek}, ${dateStr} at ${timeStr}${start.timeZone ? ` (${start.timeZone})` : ""}`
+            `Start: ${start.eventDayOfWeek}, ${formatted}${start.timeZone ? ` (${start.timeZone})` : ""}`
           );
         }
       }
@@ -311,12 +323,12 @@ export function formatEventAsText(event: EnrichedGoogleCalendarEvent): string {
         lines.push(`End: ${end.eventDayOfWeek}, ${end.date}`);
       } else {
         if (end.dateTime) {
-          const endDate = new Date(end.dateTime);
-          const timezone = end.timeZone ?? undefined;
-          const timeStr = formatTime(endDate, timezone);
-          const dateStr = formatDate(endDate, timezone);
+          const formatted = formatTimedEventDateTime(
+            end.dateTime,
+            end.timeZone
+          );
           lines.push(
-            `End: ${end.eventDayOfWeek}, ${dateStr} at ${timeStr}${end.timeZone ? ` (${end.timeZone})` : ""}`
+            `End: ${end.eventDayOfWeek}, ${formatted}${end.timeZone ? ` (${end.timeZone})` : ""}`
           );
         }
       }

--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -211,7 +211,7 @@ export function isGoogleCalendarEvent(
 function formatDayOfWeek(date: Date, timezone?: string): string {
   return date.toLocaleDateString("en-US", {
     weekday: "long",
-    timeZone: timezone,
+    timeZone: normalizeTimezone(timezone) ?? undefined,
   });
 }
 
@@ -220,7 +220,7 @@ function formatDate(date: Date, timezone?: string): string {
     month: "long",
     day: "numeric",
     year: "numeric",
-    timeZone: timezone,
+    timeZone: normalizeTimezone(timezone) ?? undefined,
   });
 }
 
@@ -228,7 +228,7 @@ function formatTime(date: Date, timezone?: string): string {
   return date.toLocaleTimeString("en-US", {
     hour: "numeric",
     minute: "2-digit",
-    timeZone: timezone,
+    timeZone: normalizeTimezone(timezone) ?? undefined,
   });
 }
 


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9230

PR #28254 normalized only the user-context timezone (getUserTimezone -> enrichEventWithDayOfWeek). formatEventAsText still passed the event's own start.timeZone/end.timeZone (e.g. "GMT+02:00" from Exchange/Outlook/ICS sourced events) straight to Intl, so list_events kept crashing with "Invalid time zone specified: GMT+02:00" once the first path was unblocked.

Normalize inside the toLocale* sink functions (formatDayOfWeek, formatDate, formatTime) so no timezone string can reach Intl unnormalized, regardless of source. Add regression tests covering an event whose own timeZone is a UTC offset string.

## Tests

Unit

## Risk

Low
## Deploy Plan

Front