### PR TITLE
[Admin Gov] Phase 0.4b — governance capability transitions

### DIFF
--- a/front/lib/resources/group_permission_governance.test.ts
+++ b/front/lib/resources/group_permission_governance.test.ts
@@ -2,8 +2,10 @@ import { Authenticator } from "@app/lib/auth";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { getNamespace } from "@app/tests/utils/test_cls";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import assert from "assert";
+import type { Transaction } from "sequelize";
 import { beforeEach, describe, expect, it } from "vitest";
 
 // A concrete capability used across the governance-state tests.
@@ -93,5 +95,95 @@ describe("GroupPermissionResource — governance state (reads)", () => {
     const groupsState = states.get("create:skill");
     assert(groupsState?.scope === "groups", "expected groups scope");
     expect(groupsState.groups.map((g) => g.id)).toEqual([groupA.id]);
+  });
+
+  describe("transitions", () => {
+    // The test harness wraps each test in an (uncommitted) CLS transaction, so the multi-step
+    // transitions must run inside it to see the groups created above. Production callers pass no
+    // transaction and the methods open their own.
+    let transaction: Transaction | undefined;
+    beforeEach(() => {
+      transaction = getNamespace("test-namespace")?.get("transaction");
+    });
+
+    it("setForEverybody clears specific groups (mutual exclusivity)", async () => {
+      await GroupPermissionResource.setGroups(auth, CAPABILITY, [groupA], {
+        transaction,
+      });
+      await GroupPermissionResource.setForEverybody(auth, CAPABILITY, {
+        transaction,
+      });
+
+      expect(await stateOf(CAPABILITY)).toEqual({ scope: "everyone" });
+    });
+
+    it("setGroups clears the everybody row (mutual exclusivity)", async () => {
+      await GroupPermissionResource.setForEverybody(auth, CAPABILITY, {
+        transaction,
+      });
+      await GroupPermissionResource.setGroups(
+        auth,
+        CAPABILITY,
+        [groupA, groupB],
+        { transaction }
+      );
+
+      const state = await stateOf(CAPABILITY);
+      assert(state?.scope === "groups", "expected groups scope");
+      expect(new Set(state.groups.map((g) => g.id))).toEqual(
+        new Set([groupA.id, groupB.id])
+      );
+    });
+
+    it("setGroups replaces the previous set of groups", async () => {
+      await GroupPermissionResource.setGroups(
+        auth,
+        CAPABILITY,
+        [groupA, groupB],
+        { transaction }
+      );
+      await GroupPermissionResource.setGroups(auth, CAPABILITY, [groupB], {
+        transaction,
+      });
+
+      const state = await stateOf(CAPABILITY);
+      assert(state?.scope === "groups", "expected groups scope");
+      expect(state.groups.map((g) => g.id)).toEqual([groupB.id]);
+    });
+
+    it("disable removes all -1 rows", async () => {
+      await GroupPermissionResource.setForEverybody(auth, CAPABILITY, {
+        transaction,
+      });
+      await GroupPermissionResource.disable(auth, CAPABILITY, { transaction });
+
+      expect(await stateOf(CAPABILITY)).toEqual({ scope: "disabled" });
+    });
+
+    it("setGroups([]) disables the capability", async () => {
+      await GroupPermissionResource.setForEverybody(auth, CAPABILITY, {
+        transaction,
+      });
+      await GroupPermissionResource.setGroups(auth, CAPABILITY, [], {
+        transaction,
+      });
+
+      expect(await stateOf(CAPABILITY)).toEqual({ scope: "disabled" });
+    });
+
+    it("setGroups rejects the system group", async () => {
+      const systemGroup = await GroupResource.internalFetchWorkspaceSystemGroup(
+        workspace.id
+      );
+      await expect(
+        GroupPermissionResource.setGroups(auth, CAPABILITY, [systemGroup])
+      ).rejects.toThrow(/system group/);
+    });
+
+    it("setGroups rejects the global group", async () => {
+      await expect(
+        GroupPermissionResource.setGroups(auth, CAPABILITY, [globalGroup])
+      ).rejects.toThrow(/setForEverybody/);
+    });
   });
 });

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -5,6 +5,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   GroupPermissionResourceType,
   PermissionType,
@@ -443,29 +444,16 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     });
   }
 
-  // Run `fn` in `transaction` if provided, otherwise in a fresh one. Transitions need atomicity so
-  // a state switch never leaves the capability half-updated; callers already inside a transaction
-  // pass it so the whole thing commits together.
-  private static async inTransaction(
-    transaction: Transaction | undefined,
-    fn: (transaction: Transaction) => Promise<void>
-  ): Promise<void> {
-    if (transaction) {
-      await fn(transaction);
-      return;
-    }
-    await frontSequelize.transaction(fn);
-  }
-
   // Serialize concurrent transitions for the same capability. Without this, two transactions can
   // each clear the -1 rows and then insert, leaving both the everybody row and specific-group rows
   // (overgranting). The transaction-scoped advisory lock releases on commit/rollback.
-  private static async lockCapability(
+  private static async getCapabilityLock(
     auth: Authenticator,
     { permissionType, resourceType }: CapabilitySpec,
     transaction: Transaction
   ): Promise<void> {
     const key = `group_permissions:${auth.getNonNullableWorkspace().id}:${resourceType}:${permissionType}`;
+    // biome-ignore lint/plugin/noRawSql: advisory lock requires raw SQL
     await frontSequelize.query("SELECT pg_advisory_xact_lock(hashtext(:key))", {
       replacements: { key },
       transaction,
@@ -483,15 +471,15 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     );
     assert(globalGroup, "Workspace is missing its global group.");
 
-    await this.inTransaction(transaction, async (t) => {
-      await this.lockCapability(auth, capability, t);
+    await withTransaction(async (t) => {
+      await this.getCapabilityLock(auth, capability, t);
       await this.disable(auth, capability, { transaction: t });
       await this.grantTypeWide(auth, {
         group: globalGroup,
         ...capability,
         transaction: t,
       });
-    });
+    }, transaction);
   }
 
   // Grant the capability to exactly `groups`, clearing the everybody row and any other specific
@@ -514,15 +502,15 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       );
     }
 
-    await this.inTransaction(transaction, async (t) => {
-      await this.lockCapability(auth, capability, t);
+    await withTransaction(async (t) => {
+      await this.getCapabilityLock(auth, capability, t);
       await this.disable(auth, capability, { transaction: t });
       await this.grantTypeWideForGroups(auth, {
         groups,
         ...capability,
         transaction: t,
       });
-    });
+    }, transaction);
   }
 
   async delete(

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -486,7 +486,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     await this.inTransaction(transaction, async (t) => {
       await this.lockCapability(auth, capability, t);
       await this.disable(auth, capability, { transaction: t });
-      await this.grantOnAllResourcesOfType(auth, {
+      await this.grantTypeWide(auth, {
         group: globalGroup,
         ...capability,
         transaction: t,
@@ -517,7 +517,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     await this.inTransaction(transaction, async (t) => {
       await this.lockCapability(auth, capability, t);
       await this.disable(auth, capability, { transaction: t });
-      await this.grantOnAllResourcesOfTypeForGroups(auth, {
+      await this.grantTypeWideForGroups(auth, {
         groups,
         ...capability,
         transaction: t,

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -2,6 +2,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { assertValidGrant } from "@app/lib/resources/group_permission_registry";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type {
@@ -416,6 +417,112 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     }
 
     return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Governance-toggle state (write side).
+  //
+  // The three states are mutually exclusive, so each transition first clears every -1 row for the
+  // capability, then writes the new state — atomically, in a transaction.
+  // ---------------------------------------------------------------------------
+
+  // Remove every -1 row for the capability => disabled.
+  static async disable(
+    auth: Authenticator,
+    { permissionType, resourceType }: CapabilitySpec,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    await GroupPermissionModel.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        permissionType,
+        resourceType,
+        resourceId: WHOLE_TYPE_RESOURCE_ID,
+      },
+      transaction,
+    });
+  }
+
+  // Run `fn` in `transaction` if provided, otherwise in a fresh one. Transitions need atomicity so
+  // a state switch never leaves the capability half-updated; callers already inside a transaction
+  // pass it so the whole thing commits together.
+  private static async inTransaction(
+    transaction: Transaction | undefined,
+    fn: (transaction: Transaction) => Promise<void>
+  ): Promise<void> {
+    if (transaction) {
+      await fn(transaction);
+      return;
+    }
+    await frontSequelize.transaction(fn);
+  }
+
+  // Serialize concurrent transitions for the same capability. Without this, two transactions can
+  // each clear the -1 rows and then insert, leaving both the everybody row and specific-group rows
+  // (overgranting). The transaction-scoped advisory lock releases on commit/rollback.
+  private static async lockCapability(
+    auth: Authenticator,
+    { permissionType, resourceType }: CapabilitySpec,
+    transaction: Transaction
+  ): Promise<void> {
+    const key = `group_permissions:${auth.getNonNullableWorkspace().id}:${resourceType}:${permissionType}`;
+    await frontSequelize.query("SELECT pg_advisory_xact_lock(hashtext(:key))", {
+      replacements: { key },
+      transaction,
+    });
+  }
+
+  // Grant the capability to the whole workspace (the global group), clearing any specific-group rows.
+  static async setForEverybody(
+    auth: Authenticator,
+    capability: CapabilitySpec,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
+      auth.getNonNullableWorkspace().id
+    );
+    assert(globalGroup, "Workspace is missing its global group.");
+
+    await this.inTransaction(transaction, async (t) => {
+      await this.lockCapability(auth, capability, t);
+      await this.disable(auth, capability, { transaction: t });
+      await this.grantOnAllResourcesOfType(auth, {
+        group: globalGroup,
+        ...capability,
+        transaction: t,
+      });
+    });
+  }
+
+  // Grant the capability to exactly `groups`, clearing the everybody row and any other specific
+  // rows. System and global groups are rejected: system is internal, and "everybody" goes through
+  // setForEverybody so the states stay unambiguous.
+  static async setGroups(
+    auth: Authenticator,
+    capability: CapabilitySpec,
+    groups: GroupResource[],
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    for (const group of groups) {
+      assert(
+        !group.isSystem(),
+        "Cannot grant a governance capability to the system group."
+      );
+      assert(
+        !group.isGlobal(),
+        "Use setForEverybody to grant a capability to the whole workspace."
+      );
+    }
+
+    await this.inTransaction(transaction, async (t) => {
+      await this.lockCapability(auth, capability, t);
+      await this.disable(auth, capability, { transaction: t });
+      await this.grantOnAllResourcesOfTypeForGroups(auth, {
+        groups,
+        ...capability,
+        transaction: t,
+      });
+    });
   }
 
   async delete(


### PR DESCRIPTION
## Description

Admin Governance — Phase 0, PR 4b/9. Follows #28487.

The write side of the governance toggle (the trickiest logic in Phase 0). Adds to `GroupPermissionResource`:
- `disable(capability)` — removes every `-1` row for the capability.
- `setForEverybody(capability)` — grants the global group's `-1` row, **atomically clearing** specific-group rows.
- `setGroups(capability, groups)` — grants exactly `groups`, **atomically clearing** the everybody row and stale specifics. Rejects the **system** group (internal) and the **global** group (that's `setForEverybody`).

Each transition clears all `-1` rows then writes the new state, in a transaction, so a switch never leaves the capability half-updated. Methods accept an optional `transaction` (caller-owned atomicity) and open their own otherwise. No behavior change.

Context: [Design Doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48) · [Implementation Plan](https://app.notion.com/p/dust-tt/Implementation-Plan-Admin-Governance-39528599d9418153aa9bf3dd69d5448d)

## Risks

Blast radius: new resource methods, not yet called from existing code.
Risk: none

## Deploy Plan

- deploy front
