### PR TITLE
[Admin Gov] Phase 0.5 — auth.hasWorkspacePermission

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1110,7 +1110,7 @@ export class Authenticator {
     }
 
     const grants = await GroupPermissionResource.listForGroups(this, {
-      groupIds: this._groupModelIds,
+      groupModelIds: this._groupModelIds,
       resourceId: WHOLE_TYPE_RESOURCE_ID,
     });
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -16,6 +16,8 @@ import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
+import { assertValidGrant } from "@app/lib/resources/group_permission_registry";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { KeyAuthType } from "@app/lib/resources/key_resource";
 import {
@@ -37,6 +39,11 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import type {
+  GroupPermissionResourceType,
+  PermissionType as GroupPermissionType,
+} from "@app/types/group_permissions";
+import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
 import type { ProvidersHealth } from "@app/types/provider_credential";
 import type {
@@ -1073,6 +1080,46 @@ export class Authenticator {
 
   isAdmin(): boolean {
     return isAdmin(this.workspace());
+  }
+
+  /**
+   * Whether the caller holds a workspace-level capability. A capability is a
+   * (permissionType, resourceType) pair whose grants live on the type-wide (-1) group_permissions
+   * rows. Admins bypass unconditionally (billing/security are admin-by-default). Otherwise we look
+   * for a -1 grant on any of the caller's groups; "*" grants match any verb / type.
+   *
+   * Cold path: a query per check is fine — no caching yet (pending auth-resolution decision).
+   */
+  async hasWorkspacePermission(
+    permissionType: GroupPermissionType,
+    resourceType: GroupPermissionResourceType
+  ): Promise<boolean> {
+    // Reject invalid capability queries (e.g. write/billing) up front, so a "*" grant can't satisfy
+    // a pair the registry forbids, and so callers fail fast on a programmer error.
+    assertValidGrant({
+      permissionType,
+      resourceType,
+      resourceId: WHOLE_TYPE_RESOURCE_ID,
+    });
+
+    if (this.isAdmin()) {
+      return true;
+    }
+    if (!this.workspace()) {
+      return false;
+    }
+
+    const grants = await GroupPermissionResource.listForGroups(this, {
+      groupIds: this._groupModelIds,
+      resourceId: WHOLE_TYPE_RESOURCE_ID,
+    });
+
+    return grants.some(
+      (grant) =>
+        (grant.resourceType === resourceType || grant.resourceType === "*") &&
+        (grant.permissionType === permissionType ||
+          grant.permissionType === "*")
+    );
   }
 
   isSystemKey(): boolean {

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -1,0 +1,119 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { beforeEach, describe, expect, it } from "vitest";
+
+const CAPABILITY = { permissionType: "create", resourceType: "agent" } as const;
+
+describe("Authenticator.hasWorkspacePermission", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let adminAuth: Authenticator;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+
+    const admin = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, admin, { role: "admin" });
+    adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      admin.sId,
+      workspace.sId
+    );
+  });
+
+  // Build a non-admin member of `group` (if given) and return their authenticator.
+  async function memberAuthInGroup(
+    group?: Awaited<ReturnType<typeof GroupFactory.regular>>
+  ): Promise<Authenticator> {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    if (group) {
+      await GroupFactory.withMembers(adminAuth, group, [user]);
+    }
+    return Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+  }
+
+  it("returns true for admins unconditionally (no grant needed)", async () => {
+    expect(adminAuth.isAdmin()).toBe(true);
+    expect(
+      await adminAuth.hasWorkspacePermission(
+        CAPABILITY.permissionType,
+        CAPABILITY.resourceType
+      )
+    ).toBe(true);
+  });
+
+  it("returns false for a non-admin without any grant", async () => {
+    const auth = await memberAuthInGroup();
+    expect(auth.isAdmin()).toBe(false);
+    expect(
+      await auth.hasWorkspacePermission(
+        CAPABILITY.permissionType,
+        CAPABILITY.resourceType
+      )
+    ).toBe(false);
+  });
+
+  it("returns true when one of the caller's groups holds the -1 grant", async () => {
+    const group = await GroupFactory.regular(workspace, "eng");
+    await GroupPermissionResource.grantOnAllResourcesOfType(adminAuth, {
+      group,
+      ...CAPABILITY,
+    });
+    const auth = await memberAuthInGroup(group);
+
+    expect(
+      await auth.hasWorkspacePermission(
+        CAPABILITY.permissionType,
+        CAPABILITY.resourceType
+      )
+    ).toBe(true);
+    // A different verb on the same type is not granted.
+    expect(await auth.hasWorkspacePermission("publish", "agent")).toBe(false);
+  });
+
+  it("returns true for everybody when the global group holds the grant", async () => {
+    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
+      workspace.id
+    );
+    if (!globalGroup) {
+      throw new Error("global group should exist");
+    }
+    await GroupPermissionResource.grantOnAllResourcesOfType(adminAuth, {
+      group: globalGroup,
+      ...CAPABILITY,
+    });
+    const auth = await memberAuthInGroup();
+
+    expect(
+      await auth.hasWorkspacePermission(
+        CAPABILITY.permissionType,
+        CAPABILITY.resourceType
+      )
+    ).toBe(true);
+  });
+
+  it("matches a wildcard grant against any capability", async () => {
+    const group = await GroupFactory.regular(workspace, "superadmins");
+    await GroupPermissionResource.grantOnAllResourcesOfType(adminAuth, {
+      group,
+      permissionType: "*",
+      resourceType: "*",
+    });
+    const auth = await memberAuthInGroup(group);
+
+    expect(await auth.hasWorkspacePermission("admin", "billing")).toBe(true);
+    expect(await auth.hasWorkspacePermission("read", "audit_log")).toBe(true);
+  });
+
+  it("rejects an invalid capability query, even for admins", async () => {
+    // `write` is not a valid verb on `billing`; a wildcard grant must not satisfy it.
+    await expect(
+      adminAuth.hasWorkspacePermission("write", "billing")
+    ).rejects.toThrow(/not allowed/);
+  });
+});

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -60,7 +60,7 @@ describe("Authenticator.hasWorkspacePermission", () => {
 
   it("returns true when one of the caller's groups holds the -1 grant", async () => {
     const group = await GroupFactory.regular(workspace, "eng");
-    await GroupPermissionResource.grantOnAllResourcesOfType(adminAuth, {
+    await GroupPermissionResource.grantTypeWide(adminAuth, {
       group,
       ...CAPABILITY,
     });
@@ -83,7 +83,7 @@ describe("Authenticator.hasWorkspacePermission", () => {
     if (!globalGroup) {
       throw new Error("global group should exist");
     }
-    await GroupPermissionResource.grantOnAllResourcesOfType(adminAuth, {
+    await GroupPermissionResource.grantTypeWide(adminAuth, {
       group: globalGroup,
       ...CAPABILITY,
     });
@@ -99,7 +99,7 @@ describe("Authenticator.hasWorkspacePermission", () => {
 
   it("matches a wildcard grant against any capability", async () => {
     const group = await GroupFactory.regular(workspace, "superadmins");
-    await GroupPermissionResource.grantOnAllResourcesOfType(adminAuth, {
+    await GroupPermissionResource.grantTypeWide(adminAuth, {
       group,
       permissionType: "*",
       resourceType: "*",


### PR DESCRIPTION
## Description

Admin Governance — Phase 0, PR 5/9. Follows #28486 (3b) — sits on 3b because its test uses the type-wide grant helper to create the -1 capability rows that `hasWorkspacePermission` reads.

Adds `Authenticator.hasWorkspacePermission(permissionType, resourceType)`:
- **Admin role bypass** — returns `true` unconditionally (billing/security are admin-by-default; consistent here).
- Otherwise resolves the type-wide (`-1`) grants for the caller's groups (`_groupModelIds`, which already excludes system groups). `"*"` grants match any verb / type.
- **No caching** — the auth-resolution strategy is a pending decision (scheduled before the space migration); capabilities are cold paths, so a query per check is fine.

Nothing calls it yet — no behavior change.

Context: [Design Doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48) · [Implementation Plan](https://app.notion.com/p/dust-tt/Implementation-Plan-Admin-Governance-39528599d9418153aa9bf3dd69d5448d)

## Risks

Blast radius: new `Authenticator` method, not yet called from existing code.
Risk: none

## Deploy Plan

- deploy front
