### PR TITLE
[Admin Gov] Phase 0.6 — shadow-compare helper + feature flag

### DIFF
--- a/front/lib/api/permissions/shadow.test.ts
+++ b/front/lib/api/permissions/shadow.test.ts
@@ -1,0 +1,91 @@
+import { shadowCompare } from "@app/lib/api/permissions/shadow";
+
+import { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("shadowCompare", () => {
+  let auth: Authenticator;
+
+  beforeEach(async () => {
+    const workspace = await WorkspaceFactory.basic();
+    auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  });
+
+  it("does not evaluate the candidate when the flag is off", async () => {
+    const candidate = vi.fn(async () => "candidate");
+
+    const result = await shadowCompare({
+      auth,
+      legacy: "legacy",
+      candidate,
+      context: { check: "test" },
+    });
+
+    expect(result).toBe("legacy");
+    expect(candidate).not.toHaveBeenCalled();
+  });
+
+  it("evaluates the candidate but does not log when results match", async () => {
+    await FeatureFlagFactory.basic(auth, "group_permissions_shadow");
+    const warn = vi.spyOn(logger, "warn");
+    const candidate = vi.fn(async () => "same");
+
+    const result = await shadowCompare({
+      auth,
+      legacy: "same",
+      candidate,
+      context: { check: "test" },
+    });
+
+    expect(result).toBe("same");
+    expect(candidate).toHaveBeenCalledOnce();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("logs one stable line on mismatch and still serves the legacy result", async () => {
+    await FeatureFlagFactory.basic(auth, "group_permissions_shadow");
+    const warn = vi.spyOn(logger, "warn");
+
+    const result = await shadowCompare({
+      auth,
+      legacy: true,
+      candidate: async () => false,
+      context: { check: "can_create_agent", workspaceId: 42 },
+    });
+
+    expect(result).toBe(true);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        check: "can_create_agent",
+        workspaceId: 42,
+        legacyResult: true,
+        candidateResult: false,
+      }),
+      "group_permissions_shadow_mismatch"
+    );
+  });
+
+  it("serves the legacy result when the candidate throws", async () => {
+    await FeatureFlagFactory.basic(auth, "group_permissions_shadow");
+    const error = vi.spyOn(logger, "error");
+
+    const result = await shadowCompare({
+      auth,
+      legacy: "legacy",
+      candidate: async () => {
+        throw new Error("candidate boom");
+      },
+      context: { check: "test" },
+    });
+
+    expect(result).toBe("legacy");
+    expect(error).toHaveBeenCalledWith(
+      expect.objectContaining({ check: "test" }),
+      "group_permissions_shadow_candidate_error"
+    );
+  });
+});

--- a/front/lib/api/permissions/shadow.ts
+++ b/front/lib/api/permissions/shadow.ts
@@ -1,0 +1,72 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+/**
+ * Shadow-compare machinery for the group_permissions rollout.
+ *
+ * Every later phase runs the legacy permission check and the new group_permissions check side by
+ * side, serves the legacy result, and logs mismatches so a Datadog monitor can confirm parity
+ * before we flip. The candidate is only evaluated when the feature flag is enabled for the
+ * workspace, so shadowing is per-workspace and reverts instantly by toggling the flag off.
+ */
+
+// The literal message is the Datadog monitor key — keep it stable.
+const SHADOW_MISMATCH_MESSAGE = "group_permissions_shadow_mismatch";
+
+// Logged when the candidate check itself throws (it must never break the served legacy path).
+const SHADOW_CANDIDATE_ERROR_MESSAGE =
+  "group_permissions_shadow_candidate_error";
+
+const SHADOW_FEATURE_FLAG: WhitelistableFeature = "group_permissions_shadow";
+
+type ShadowContext = Record<string, string | number | boolean | null>;
+
+interface ShadowCompareArgs<T> {
+  auth: Authenticator;
+  // The result actually served — already computed on the legacy path.
+  legacy: T;
+  // The new check, evaluated lazily and only while shadowing is enabled.
+  candidate: () => Promise<T>;
+  // Structured fields identifying the call site, logged on mismatch.
+  context: ShadowContext;
+  // Custom equality when T is not comparable with ===.
+  equals?: (legacy: T, candidate: T) => boolean;
+}
+
+export async function shadowCompare<T>({
+  auth,
+  legacy,
+  candidate,
+  context,
+  equals,
+}: ShadowCompareArgs<T>): Promise<T> {
+  const flags = await getFeatureFlags(auth);
+  if (!flags.includes(SHADOW_FEATURE_FLAG)) {
+    return legacy;
+  }
+
+  // Shadowing must never break the served path: any failure computing or comparing the candidate is
+  // logged and swallowed, and the legacy result is still returned.
+  try {
+    const candidateResult = await candidate();
+    const matches = equals
+      ? equals(legacy, candidateResult)
+      : legacy === candidateResult;
+    if (!matches) {
+      logger.warn(
+        { ...context, legacyResult: legacy, candidateResult },
+        SHADOW_MISMATCH_MESSAGE
+      );
+    }
+  } catch (err) {
+    logger.error(
+      { ...context, err: normalizeError(err) },
+      SHADOW_CANDIDATE_ERROR_MESSAGE
+    );
+  }
+
+  return legacy;
+}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -320,6 +320,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable the Activation skill for agentic user activation pods",
     stage: "dust_only",
   },
+  group_permissions_shadow: {
+    description:
+      "Admin Governance: evaluate the new group_permissions checks alongside the legacy ones and log mismatches (shadow mode). Serves the legacy result; safe to toggle.",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -719,6 +719,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dust_internal_global_agents"
   | "fireworks_new_model_feature"
   | "google_sheets_tool"
+  | "group_permissions_shadow"
   | "http_client_tool"
   | "index_private_slack_channel"
   | "labs_mcp_actions_dashboard"


### PR DESCRIPTION
## Description

Admin Governance — Phase 0, PR 6/9. Based on #28481 (model) — independent of the resource chain.

The reusable strangler machinery every later phase uses to prove parity before flipping a check. `shadowCompare({ auth, legacy, candidate, context, equals? })` (`front/lib/api/permissions/shadow.ts`) serves the legacy result, and **only when the `group_permissions_shadow` feature flag is on for the workspace** evaluates the candidate and logs one stable line on mismatch. The literal message `group_permissions_shadow_mismatch` is the Datadog monitor key. Also adds the `group_permissions_shadow` feature flag (per-workspace toggle, instant rollback).

Logically independent of the resource PRs (touches only a new helper + the feature-flag list); stacked here for cohesive review. Nothing calls it yet — no behavior change.

### How it will be used

Concrete example: gating **agent publishing**. Today the check lives in `lib/api/assistant/publishing_restrictions.ts` (role + feature flag); the group_permissions equivalent is the `publish:agent` capability via `auth.hasWorkspacePermission` (PR 5). During rollout, a call site keeps serving the legacy answer while comparing the new one in the background:

```ts
// Legacy — publishing is gated by role + feature flag.
const level = getPublishingRestrictionLevel(featureFlags);
const legacy = level === null || canPublishForAuth(auth, level);

// Serve `legacy`; while the shadow flag is on for this workspace, evaluate the
// group_permissions capability too and log a stable line on any divergence.
const canPublish = await shadowCompare({
  auth,
  legacy,
  candidate: () => auth.hasWorkspacePermission("publish", "agent"),
  context: { check: "publish_agent", workspaceId: owner.sId },
});
// ...use `canPublish` exactly as before — behavior is unchanged until we flip.
```

A Datadog monitor on `group_permissions_shadow_mismatch` then confirms parity per workspace before we swap `legacy` out for the candidate and drop the shadow.

Context: [Design Doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48) · [Implementation Plan](https://app.notion.com/p/dust-tt/Implementation-Plan-Admin-Governance-39528599d9418153aa9bf3dd69d5448d)

## Risks

Blast radius: new helper + one new feature flag (off by default); not yet called.
Risk: none

## Deploy Plan

- deploy front