### PR TITLE
[Admin Gov] Phase 0.7 — workspace capability seeding hook

### DIFF
--- a/front/lib/api/permissions/governance_seeding.test.ts
+++ b/front/lib/api/permissions/governance_seeding.test.ts
@@ -1,0 +1,16 @@
+import { seedWorkspaceCapabilities } from "@app/lib/api/permissions/governance_seeding";
+import { Authenticator } from "@app/lib/auth";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it } from "vitest";
+
+describe("seedWorkspaceCapabilities", () => {
+  it("is a safe no-op with the empty Phase 0 seeder list", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    // Empty registry: resolves without touching the database.
+    await expect(seedWorkspaceCapabilities(auth)).resolves.toBeUndefined();
+  });
+});

--- a/front/lib/api/permissions/governance_seeding.ts
+++ b/front/lib/api/permissions/governance_seeding.ts
@@ -1,0 +1,27 @@
+import type { Authenticator } from "@app/lib/auth";
+
+/**
+ * Workspace-creation entry point for governance capability seeding.
+ *
+ * A capability seeder sets up the default state of a workspace-level governance capability (which
+ * groups get it, or "everybody"/"disabled") for a freshly created workspace. Phase 2 capabilities
+ * register their seeder here; Phase 0 ships the hook with an empty list, so it is a no-op.
+ */
+
+export interface CapabilitySeeder {
+  // Stable identifier for logs / debugging (e.g. "create:agent").
+  name: string;
+  seed: (auth: Authenticator) => Promise<void>;
+}
+
+const CAPABILITY_SEEDERS: CapabilitySeeder[] = [];
+
+// Seed default governance state for a newly created workspace. Called once from workspace
+// provisioning. Runs seeders sequentially — the list is a small, static registry, not user data.
+export async function seedWorkspaceCapabilities(
+  auth: Authenticator
+): Promise<void> {
+  for (const seeder of CAPABILITY_SEEDERS) {
+    await seeder.seed(auth);
+  }
+}

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -1,3 +1,4 @@
+import { seedWorkspaceCapabilities } from "@app/lib/api/permissions/governance_seeding";
 import { activateCreditPricedFreePlanForWorkspace } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { Authenticator } from "@app/lib/auth";
@@ -95,6 +96,9 @@ export async function createWorkspaceInternal({
     systemGroup,
     globalGroup,
   });
+
+  // Seed default governance capability state (no-op until Phase 2 capabilities register seeders).
+  await seedWorkspaceCapabilities(auth);
 
   // Ensure all auto MCP server views are created for the workspace
   await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);


### PR DESCRIPTION
## Description

Admin Governance — Phase 0, PR 7/9 (final). Based on #28481 (model) — independent of the resource chain.

Adds the workspace-creation seeding entry point. `seedWorkspaceCapabilities(auth)` (`front/lib/api/permissions/governance_seeding.ts`) iterates a static `CAPABILITY_SEEDERS` registry (empty in Phase 0) and is wired into `createWorkspaceInternal` right after the default groups/spaces are created. Phase 2 capabilities register their default-state seeders here; today it is a no-op.

Deletion integrity (`deleteAllForResource`) already exists on the resource (PR 3a) and is intentionally not wired into delete flows yet — that happens per-domain in later phases. No behavior change.

Context: [Design Doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48) · [Implementation Plan](https://app.notion.com/p/dust-tt/Implementation-Plan-Admin-Governance-39528599d9418153aa9bf3dd69d5448d)

## Risks

Blast radius: one no-op call added to the workspace-creation path.
Risk: none

## Deploy Plan
- deploy front
