### PR TITLE
Pricing: Display coupon negative amount in next bill preview

### DIFF
--- a/front-api/routes/w/[wId]/metronome/invoice.test.ts
+++ b/front-api/routes/w/[wId]/metronome/invoice.test.ts
@@ -1,0 +1,286 @@
+import {
+  CREDIT_TYPE_EUR_ID,
+  getCreditTypeAwuId,
+} from "@app/lib/metronome/constants";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import type { Invoice } from "@metronome/sdk/resources/v1/customers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", () => ({
+  listMetronomeDraftInvoices: vi.fn(),
+}));
+
+import { listMetronomeDraftInvoices } from "@app/lib/metronome/client";
+
+function invoiceLinesUrl(wId: string) {
+  return `/api/w/${wId}/metronome/invoice/lines`;
+}
+
+async function setActiveSubscriptionBilling({
+  workspaceId,
+  metronomeContractId,
+}: {
+  workspaceId: number;
+  metronomeContractId: string;
+}) {
+  const currentSubscription =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspaceId);
+
+  if (!currentSubscription) {
+    throw new Error("Expected an active subscription.");
+  }
+
+  await currentSubscription.markAsEnded("ended");
+
+  await SubscriptionResource.makeNew(
+    {
+      sId: generateRandomModelSId(),
+      workspaceId,
+      planId: currentSubscription.planId,
+      status: "active",
+      trialing: false,
+      startDate: new Date(),
+      endDate: null,
+      stripeSubscriptionId: null,
+      metronomeContractId,
+    },
+    currentSubscription.getPlan()
+  );
+
+  const updateResult = await WorkspaceResource.updateMetronomeCustomerId(
+    workspaceId,
+    "m-customer"
+  );
+
+  if (updateResult.isErr()) {
+    throw updateResult.error;
+  }
+}
+
+function makeCurrentDraftInvoice({
+  contractId,
+  lineItems,
+}: {
+  contractId: string;
+  lineItems: Invoice.LineItem[];
+}): Invoice {
+  const nowMs = Date.now();
+
+  return {
+    id: "inv-1",
+    type: "USAGE",
+    status: "DRAFT",
+    customer_id: "m-customer",
+    contract_id: contractId,
+    start_timestamp: new Date(nowMs - 60_000).toISOString(),
+    end_timestamp: new Date(nowMs + 60_000).toISOString(),
+    credit_type: { id: CREDIT_TYPE_EUR_ID, name: "EUR" },
+    total: 0,
+    line_items: lineItems,
+  };
+}
+
+describe("/api/w/[wId]/metronome/invoice/lines", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns charge lines and applied credit lines for a discounted invoice", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await setActiveSubscriptionBilling({
+      workspaceId: workspace.id,
+      metronomeContractId: "m-contract-lines",
+    });
+
+    vi.mocked(listMetronomeDraftInvoices).mockResolvedValue(
+      new Ok([
+        makeCurrentDraftInvoice({
+          contractId: "m-contract-lines",
+          lineItems: [
+            {
+              name: "Pro Seat",
+              type: "subscription",
+              credit_type: { id: CREDIT_TYPE_EUR_ID, name: "EUR" },
+              quantity: 3,
+              unit_price: 29,
+              total: 87,
+              is_prorated: false,
+            },
+            {
+              name: "Coupon: WELCOME100 applied",
+              type: "applied_commit_or_credit",
+              credit_type: { id: CREDIT_TYPE_EUR_ID, name: "EUR" },
+              total: -87,
+              applied_commit_or_credit: { id: "credit-1", type: "CREDIT" },
+            },
+            // Sub-cent noise: dropped.
+            {
+              name: "Rounding artifact",
+              type: "usage",
+              credit_type: { id: CREDIT_TYPE_EUR_ID, name: "EUR" },
+              total: 0.001,
+            },
+            // Non-fiat (AWU) line: dropped by the currency filter.
+            {
+              name: "Credits (AWU)",
+              type: "usage",
+              credit_type: { id: getCreditTypeAwuId(), name: "AWU" },
+              total: 500,
+            },
+          ],
+        }),
+      ])
+    );
+
+    const response = await honoApp.request(invoiceLinesUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.currency).toBe("eur");
+    expect(body.lineItems).toHaveLength(2);
+    expect(body.lineItems[0]).toMatchObject({
+      name: "Pro Seat",
+      type: "subscription",
+      quantity: 3,
+      unitPriceCents: 2900,
+      totalCents: 8700,
+    });
+    expect(body.lineItems[1]).toMatchObject({
+      name: "Coupon: WELCOME100 applied",
+      type: "applied_commit_or_credit",
+      totalCents: -8700,
+    });
+  });
+
+  it("merges charge lines split by credit application and credit lines sharing a coupon", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await setActiveSubscriptionBilling({
+      workspaceId: workspace.id,
+      metronomeContractId: "m-contract-merge",
+    });
+
+    const periodStart = "2026-08-01T00:00:00.000Z";
+    const periodEnd = "2026-09-01T00:00:00.000Z";
+
+    vi.mocked(listMetronomeDraftInvoices).mockResolvedValue(
+      new Ok([
+        makeCurrentDraftInvoice({
+          contractId: "m-contract-merge",
+          lineItems: [
+            // A single Max Seat split by Metronome into the portion covered
+            // by the coupon credit and the uncovered remainder.
+            {
+              name: "Max Seat",
+              type: "subscription",
+              credit_type: { id: CREDIT_TYPE_EUR_ID, name: "EUR" },
+              quantity: 1 / 3,
+              unit_price: 150,
+              total: 50,
+              is_prorated: false,
+              starting_at: periodStart,
+              ending_before: periodEnd,
+              applied_commit_or_credit: { id: "credit-1", type: "CREDIT" },
+            },
+            {
+              name: "Max Seat",
+              type: "subscription",
+              credit_type: { id: CREDIT_TYPE_EUR_ID, name: "EUR" },
+              quantity: 2 / 3,
+              unit_price: 150,
+              total: 100,
+              is_prorated: false,
+              starting_at: periodStart,
+              ending_before: periodEnd,
+            },
+            // A prorated Max Seat line over a different period: not merged.
+            {
+              name: "Max Seat",
+              type: "subscription",
+              credit_type: { id: CREDIT_TYPE_EUR_ID, name: "EUR" },
+              quantity: 1,
+              unit_price: 145.97,
+              total: 145.97,
+              is_prorated: true,
+              starting_at: "2026-07-02T00:00:00.000Z",
+              ending_before: periodEnd,
+            },
+            // The same coupon applied to two products: one applied line each.
+            {
+              name: "Coupon: SEAT50 applied",
+              type: "applied_commit_or_credit",
+              credit_type: { id: CREDIT_TYPE_EUR_ID, name: "EUR" },
+              total: -50,
+              starting_at: periodStart,
+              ending_before: periodEnd,
+              applied_commit_or_credit: { id: "credit-1", type: "CREDIT" },
+            },
+            {
+              name: "Coupon: SEAT50 applied",
+              type: "applied_commit_or_credit",
+              credit_type: { id: CREDIT_TYPE_EUR_ID, name: "EUR" },
+              total: -30,
+              starting_at: periodStart,
+              ending_before: periodEnd,
+              applied_commit_or_credit: { id: "credit-1", type: "CREDIT" },
+            },
+            // The same coupon applied over a different period: not merged.
+            {
+              name: "Coupon: SEAT50 applied",
+              type: "applied_commit_or_credit",
+              credit_type: { id: CREDIT_TYPE_EUR_ID, name: "EUR" },
+              total: -10,
+              starting_at: "2026-07-02T00:00:00.000Z",
+              ending_before: periodStart,
+              applied_commit_or_credit: { id: "credit-1", type: "CREDIT" },
+            },
+          ],
+        }),
+      ])
+    );
+
+    const response = await honoApp.request(invoiceLinesUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.currency).toBe("eur");
+    expect(body.lineItems).toHaveLength(4);
+    expect(body.lineItems[0]).toMatchObject({
+      name: "Max Seat",
+      unitPriceCents: 15000,
+      totalCents: 15000,
+      periodStartMs: new Date(periodStart).getTime(),
+      periodEndMs: new Date(periodEnd).getTime(),
+    });
+    expect(body.lineItems[0].quantity).toBeCloseTo(1, 6);
+    expect(body.lineItems[1]).toMatchObject({
+      name: "Max Seat",
+      isProrated: true,
+      totalCents: 14597,
+    });
+    expect(body.lineItems[2]).toMatchObject({
+      name: "Coupon: SEAT50 applied",
+      totalCents: -8000,
+      periodStartMs: new Date(periodStart).getTime(),
+      periodEndMs: new Date(periodEnd).getTime(),
+    });
+    expect(body.lineItems[3]).toMatchObject({
+      name: "Coupon: SEAT50 applied",
+      totalCents: -1000,
+      periodStartMs: new Date("2026-07-02T00:00:00.000Z").getTime(),
+      periodEndMs: new Date(periodStart).getTime(),
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/metronome/invoice.test.ts
+++ b/front-api/routes/w/[wId]/metronome/invoice.test.ts
@@ -22,14 +22,14 @@ function invoiceLinesUrl(wId: string) {
 }
 
 async function setActiveSubscriptionBilling({
-  workspaceId,
+  workspaceModelId,
   metronomeContractId,
 }: {
-  workspaceId: number;
+  workspaceModelId: number;
   metronomeContractId: string;
 }) {
   const currentSubscription =
-    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspaceId);
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspaceModelId);
 
   if (!currentSubscription) {
     throw new Error("Expected an active subscription.");
@@ -40,7 +40,7 @@ async function setActiveSubscriptionBilling({
   await SubscriptionResource.makeNew(
     {
       sId: generateRandomModelSId(),
-      workspaceId,
+      workspaceId: workspaceModelId,
       planId: currentSubscription.planId,
       status: "active",
       trialing: false,
@@ -53,7 +53,7 @@ async function setActiveSubscriptionBilling({
   );
 
   const updateResult = await WorkspaceResource.updateMetronomeCustomerId(
-    workspaceId,
+    workspaceModelId,
     "m-customer"
   );
 
@@ -97,7 +97,7 @@ describe("/api/w/[wId]/metronome/invoice/lines", () => {
     });
 
     await setActiveSubscriptionBilling({
-      workspaceId: workspace.id,
+      workspaceModelId: workspace.id,
       metronomeContractId: "m-contract-lines",
     });
 
@@ -168,7 +168,7 @@ describe("/api/w/[wId]/metronome/invoice/lines", () => {
     });
 
     await setActiveSubscriptionBilling({
-      workspaceId: workspace.id,
+      workspaceModelId: workspace.id,
       metronomeContractId: "m-contract-merge",
     });
 

--- a/front-api/routes/w/[wId]/metronome/invoice.ts
+++ b/front-api/routes/w/[wId]/metronome/invoice.ts
@@ -8,6 +8,7 @@ import {
 import type {
   GetMetronomeInvoiceLinesResponseBody,
   GetMetronomeInvoiceResponseBody,
+  MetronomeInvoiceLineItem,
   MetronomeInvoiceSummary,
 } from "@app/lib/metronome/invoice";
 import type { SupportedCurrency } from "@app/types/currency";
@@ -58,6 +59,48 @@ async function findCurrentInvoice(
     return startMs <= nowMs && nowMs < endMs;
   });
   return new Ok(invoice);
+}
+
+// When a credit partially covers a charge, Metronome splits the charge line
+// into a covered portion (fractional quantity, carrying
+// applied_commit_or_credit) and the uncovered remainder. Similarly, a single
+// coupon applied to several products yields one applied-credit line per
+// product. Merge those splits back so the invoice reads as one line per
+// charge and one line per coupon/credit.
+function mergeLineItems(
+  lineItems: MetronomeInvoiceLineItem[]
+): MetronomeInvoiceLineItem[] {
+  const merged: MetronomeInvoiceLineItem[] = [];
+  const indexByKey = new Map<string, number>();
+  for (const item of lineItems) {
+    // Lines merge only when everything but the quantity/total matches (for
+    // applied-credit lines, unit price and quantity are always null, so this
+    // amounts to merging by coupon/credit name and period).
+    const key = JSON.stringify([
+      item.name,
+      item.type,
+      item.unitPriceCents,
+      item.isProrated,
+      item.periodStartMs,
+      item.periodEndMs,
+    ]);
+    const index = indexByKey.get(key);
+    if (index === undefined) {
+      indexByKey.set(key, merged.length);
+      merged.push(item);
+      continue;
+    }
+    const existing = merged[index];
+    merged[index] = {
+      ...existing,
+      quantity:
+        existing.quantity !== null && item.quantity !== null
+          ? existing.quantity + item.quantity
+          : null,
+      totalCents: existing.totalCents + item.totalCents,
+    };
+  }
+  return merged;
 }
 
 // Mounted at /api/w/:wId/metronome/invoice.
@@ -181,13 +224,15 @@ app.get(
 
     const currency = creditTypeIdToCurrency(invoice.credit_type.id);
 
-    const lineItems = invoice.line_items
+    const mappedLineItems = invoice.line_items
       .filter((item) => {
         const itemCurrency = creditTypeIdToCurrency(item.credit_type.id);
         return !!currency && !!itemCurrency && itemCurrency === currency;
       })
-      .filter((item) => item.total >= 0.01)
-      .filter((item) => !item.applied_commit_or_credit)
+      // Keep negative lines: applied commits/credits (coupons, free credits,
+      // commitments) explain why the invoice total is lower than the sum of
+      // the charge lines. Only drop sub-cent noise.
+      .filter((item) => Math.abs(item.total) >= 0.01)
       .map((item) => {
         const itemCurrency = creditTypeIdToCurrency(item.credit_type.id);
         return {
@@ -212,7 +257,7 @@ app.get(
         };
       });
 
-    return ctx.json({ currency, lineItems });
+    return ctx.json({ currency, lineItems: mergeLineItems(mappedLineItems) });
   }
 );
 

--- a/front/components/workspace/billing/NextInvoicePreview.tsx
+++ b/front/components/workspace/billing/NextInvoicePreview.tsx
@@ -5,6 +5,7 @@ import {
 } from "@app/components/workspace/billing/seatTypeUtils";
 import { SEAT_PRODUCT_YEARLY_SUFFIX } from "@app/lib/metronome/constants";
 import type { MetronomeInvoiceLineItem } from "@app/lib/metronome/invoice";
+import { isAppliedCreditLineItem } from "@app/lib/metronome/invoice";
 import {
   FREE_SEAT_PRODUCT_NAME,
   MAX_SEAT_PRODUCT_NAME,
@@ -223,9 +224,19 @@ export function NextInvoicePreview() {
     });
   };
 
-  // Group items by name, preserving insertion order.
+  // Applied commits/credits (coupons, free credits, commitments) are negative
+  // lines rendered after the charges, so a discounted — possibly 0.00 — total
+  // remains understandable.
+  const chargeItems = invoiceLines.lineItems.filter(
+    (item) => !isAppliedCreditLineItem(item)
+  );
+  const creditItems = invoiceLines.lineItems.filter((item) =>
+    isAppliedCreditLineItem(item)
+  );
+
+  // Group charge items by name, preserving insertion order.
   const groups = new Map<string, MetronomeInvoiceLineItem[]>();
-  for (const item of invoiceLines.lineItems) {
+  for (const item of chargeItems) {
     const existing = groups.get(item.name);
     if (existing) {
       existing.push(item);
@@ -261,16 +272,34 @@ export function NextInvoicePreview() {
     }
   }
 
-  const totalCents = invoiceLines.lineItems.reduce(
+  const chargesTotalCents = chargeItems.reduce(
     (sum, item) => sum + item.totalCents,
     0
   );
+  const creditsTotalCents = creditItems.reduce(
+    (sum, item) => sum + item.totalCents,
+    0
+  );
+
+  if (creditItems.length > 0) {
+    rows.push({
+      name: "Subtotal",
+      period: null,
+      quantity: "",
+      cost: "",
+      subtotal: formatAmount(chargesTotalCents, currency),
+    });
+    for (const item of creditItems) {
+      rows.push(formatLineItem(item, currency));
+    }
+  }
+
   rows.push({
     name: "Total",
     period: null,
     quantity: "",
     cost: "",
-    subtotal: formatAmount(totalCents, currency),
+    subtotal: formatAmount(chargesTotalCents + creditsTotalCents, currency),
     isBold: true,
   });
 

--- a/front/lib/metronome/invoice.ts
+++ b/front/lib/metronome/invoice.ts
@@ -15,6 +15,19 @@ export type GetMetronomeInvoiceResponseBody = {
   invoice: MetronomeInvoiceSummary | null;
 };
 
+/**
+ * Metronome line item type for an applied commit or credit (coupon, free
+ * credits, commitment): a negative line that offsets the charge lines above
+ * it and explains a discounted invoice total.
+ */
+export const APPLIED_COMMIT_OR_CREDIT_LINE_TYPE = "applied_commit_or_credit";
+
+export function isAppliedCreditLineItem(
+  item: MetronomeInvoiceLineItem
+): boolean {
+  return item.type === APPLIED_COMMIT_OR_CREDIT_LINE_TYPE;
+}
+
 export type MetronomeInvoiceLineItem = {
   name: string;
   type: string;


### PR DESCRIPTION
## Description

<img width="2328" height="1522" alt="image" src="https://github.com/user-attachments/assets/dcc11c92-44fd-43f8-8e5b-3b16707b7691" />

 - Merge lines when they are about the same product and same period (for instance, if you have a 50$ coupon, you max seat can be split between 100$ and 50$ for the same entry).
 - Display the coupon to explain why the amount is lower 

## Tests

 - unit tests added
 - tested locally with coupon

## Risk

low

## Deploy Plan

deploy front
