### PR TITLE
[LLM] Add OpenAI Responses EU endpoints for GPT-5 models

### DIFF
--- a/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five.ts
+++ b/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveConfig } from "@app/lib/llms/providers/openai/models/gpt_five";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIResponsesEuropeGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five";
+
+export class DustOpenAIResponsesEuropeGptFiveStream extends WithDustGptFiveConfig(
+  OpenAIResponsesEuropeGptFiveStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIResponsesEuropeGptFiveStream);

--- a/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_five.ts
+++ b/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_five.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveDotFiveConfig } from "@app/lib/llms/providers/openai/models/gpt_five_dot_five";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIResponsesEuropeGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_five";
+
+export class DustOpenAIResponsesEuropeGptFiveDotFiveStream extends WithDustGptFiveDotFiveConfig(
+  OpenAIResponsesEuropeGptFiveDotFiveStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIResponsesEuropeGptFiveDotFiveStream);

--- a/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_four.ts
+++ b/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_four.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveDotFourConfig } from "@app/lib/llms/providers/openai/models/gpt_five_dot_four";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIResponsesEuropeGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four";
+
+export class DustOpenAIResponsesEuropeGptFiveDotFourStream extends WithDustGptFiveDotFourConfig(
+  OpenAIResponsesEuropeGptFiveDotFourStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIResponsesEuropeGptFiveDotFourStream);

--- a/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_four_mini.ts
+++ b/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_four_mini.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveDotFourMiniConfig } from "@app/lib/llms/providers/openai/models/gpt_five_dot_four_mini";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIResponsesEuropeGptFiveDotFourMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_mini";
+
+export class DustOpenAIResponsesEuropeGptFiveDotFourMiniStream extends WithDustGptFiveDotFourMiniConfig(
+  OpenAIResponsesEuropeGptFiveDotFourMiniStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIResponsesEuropeGptFiveDotFourMiniStream);

--- a/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_four_nano.ts
+++ b/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_four_nano.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveDotFourNanoConfig } from "@app/lib/llms/providers/openai/models/gpt_five_dot_four_nano";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIResponsesEuropeGptFiveDotFourNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_nano";
+
+export class DustOpenAIResponsesEuropeGptFiveDotFourNanoStream extends WithDustGptFiveDotFourNanoConfig(
+  OpenAIResponsesEuropeGptFiveDotFourNanoStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIResponsesEuropeGptFiveDotFourNanoStream);

--- a/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_one.ts
+++ b/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_one.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveDotOneConfig } from "@app/lib/llms/providers/openai/models/gpt_five_dot_one";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIResponsesEuropeGptFiveDotOneStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_one";
+
+export class DustOpenAIResponsesEuropeGptFiveDotOneStream extends WithDustGptFiveDotOneConfig(
+  OpenAIResponsesEuropeGptFiveDotOneStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIResponsesEuropeGptFiveDotOneStream);

--- a/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_two.ts
+++ b/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_two.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveDotTwoConfig } from "@app/lib/llms/providers/openai/models/gpt_five_dot_two";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIResponsesEuropeGptFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_two";
+
+export class DustOpenAIResponsesEuropeGptFiveDotTwoStream extends WithDustGptFiveDotTwoConfig(
+  OpenAIResponsesEuropeGptFiveDotTwoStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIResponsesEuropeGptFiveDotTwoStream);

--- a/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_mini.ts
+++ b/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_mini.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveMiniConfig } from "@app/lib/llms/providers/openai/models/gpt_five_mini";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIResponsesEuropeGptFiveMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_mini";
+
+export class DustOpenAIResponsesEuropeGptFiveMiniStream extends WithDustGptFiveMiniConfig(
+  OpenAIResponsesEuropeGptFiveMiniStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIResponsesEuropeGptFiveMiniStream);

--- a/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_nano.ts
+++ b/front/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_nano.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveNanoConfig } from "@app/lib/llms/providers/openai/models/gpt_five_nano";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIResponsesEuropeGptFiveNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_nano";
+
+export class DustOpenAIResponsesEuropeGptFiveNanoStream extends WithDustGptFiveNanoConfig(
+  OpenAIResponsesEuropeGptFiveNanoStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIResponsesEuropeGptFiveNanoStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -18,6 +18,15 @@ import { DustMistralEuropeCodestralStream } from "@app/lib/llms/stream/endpoints
 import { DustMistralEuropeMistralLargeStream } from "@app/lib/llms/stream/endpoints/mistral_eu_mistral_large";
 import { DustMistralEuropeMistralMedium35Stream } from "@app/lib/llms/stream/endpoints/mistral_eu_mistral_medium_3_5";
 import { DustMistralEuropeMistralSmallStream } from "@app/lib/llms/stream/endpoints/mistral_eu_mistral_small";
+import { DustOpenAIResponsesEuropeGptFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_eu_gpt_five";
+import { DustOpenAIResponsesEuropeGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_five";
+import { DustOpenAIResponsesEuropeGptFiveDotFourStream } from "@app/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_four";
+import { DustOpenAIResponsesEuropeGptFiveDotFourMiniStream } from "@app/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_four_mini";
+import { DustOpenAIResponsesEuropeGptFiveDotFourNanoStream } from "@app/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_four_nano";
+import { DustOpenAIResponsesEuropeGptFiveDotOneStream } from "@app/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_one";
+import { DustOpenAIResponsesEuropeGptFiveDotTwoStream } from "@app/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_dot_two";
+import { DustOpenAIResponsesEuropeGptFiveMiniStream } from "@app/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_mini";
+import { DustOpenAIResponsesEuropeGptFiveNanoStream } from "@app/lib/llms/stream/endpoints/openai_responses_eu_gpt_five_nano";
 import { DustOpenAIResponsesGlobalGptFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 import { DustOpenAIResponsesGlobalGptFiveDotFourStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_four";
@@ -37,12 +46,16 @@ import type {
 import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
 
 export const DUST_STREAM_ENDPOINTS = {
+  [DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
+    DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream,
+  [DustAgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
+    DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
+  [DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]:
+    DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream,
+  [DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]:
+    DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream,
   [DustAnthropicGlobalClaudeFableFiveStream.id]:
     DustAnthropicGlobalClaudeFableFiveStream,
-  [DustAnthropicGlobalClaudeSonnetFiveStream.id]:
-    DustAnthropicGlobalClaudeSonnetFiveStream,
-  [DustAnthropicGlobalClaudeSonnetFourDotSixStream.id]:
-    DustAnthropicGlobalClaudeSonnetFourDotSixStream,
   [DustAnthropicGlobalClaudeHaikuFourDotFiveStream.id]:
     DustAnthropicGlobalClaudeHaikuFourDotFiveStream,
   [DustAnthropicGlobalClaudeOpusFourDotEightStream.id]:
@@ -51,46 +64,60 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAnthropicGlobalClaudeOpusFourDotSevenStream,
   [DustAnthropicGlobalClaudeOpusFourDotSixStream.id]:
     DustAnthropicGlobalClaudeOpusFourDotSixStream,
-  [DustAgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
-    DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
-  [DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]:
-    DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream,
-  [DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]:
-    DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream,
-  [DustGoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
-    DustGoogleAiStudioGlobalGeminiThreeDotOneProStream,
-  [DustOpenAIResponsesGlobalGptFiveDotFiveStream.id]:
-    DustOpenAIResponsesGlobalGptFiveDotFiveStream,
-  [DustOpenAIResponsesGlobalGptFiveDotFourStream.id]:
-    DustOpenAIResponsesGlobalGptFiveDotFourStream,
-  [DustOpenAIResponsesGlobalGptFiveDotTwoStream.id]:
-    DustOpenAIResponsesGlobalGptFiveDotTwoStream,
-  [DustOpenAIResponsesGlobalGptFiveStream.id]:
-    DustOpenAIResponsesGlobalGptFiveStream,
-  [DustOpenAIResponsesGlobalGptFiveDotOneStream.id]:
-    DustOpenAIResponsesGlobalGptFiveDotOneStream,
-  [DustOpenAIResponsesGlobalGptFiveDotFourMiniStream.id]:
-    DustOpenAIResponsesGlobalGptFiveDotFourMiniStream,
-  [DustOpenAIResponsesGlobalGptFiveDotFourNanoStream.id]:
-    DustOpenAIResponsesGlobalGptFiveDotFourNanoStream,
-  [DustOpenAIResponsesGlobalGptFiveMiniStream.id]:
-    DustOpenAIResponsesGlobalGptFiveMiniStream,
-  [DustOpenAIResponsesGlobalGptFiveNanoStream.id]:
-    DustOpenAIResponsesGlobalGptFiveNanoStream,
-  [DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
-    DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream,
-  [DustFireworksGlobalGlmFiveDotTwoStream.id]:
-    DustFireworksGlobalGlmFiveDotTwoStream,
+  [DustAnthropicGlobalClaudeSonnetFiveStream.id]:
+    DustAnthropicGlobalClaudeSonnetFiveStream,
+  [DustAnthropicGlobalClaudeSonnetFourDotSixStream.id]:
+    DustAnthropicGlobalClaudeSonnetFourDotSixStream,
   [DustFireworksGlobalDeepSeekV4ProStream.id]:
     DustFireworksGlobalDeepSeekV4ProStream,
+  [DustFireworksGlobalGlmFiveDotTwoStream.id]:
+    DustFireworksGlobalGlmFiveDotTwoStream,
   [DustFireworksGlobalKimiK2Dot5Stream.id]: DustFireworksGlobalKimiK2Dot5Stream,
-  [DustTogetheraiGlobalLlama3370BInstructTurboStream.id]:
-    DustTogetheraiGlobalLlama3370BInstructTurboStream,
+  [DustGoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
+    DustGoogleAiStudioGlobalGeminiThreeDotOneProStream,
+  [DustMistralEuropeCodestralStream.id]: DustMistralEuropeCodestralStream,
   [DustMistralEuropeMistralLargeStream.id]: DustMistralEuropeMistralLargeStream,
   [DustMistralEuropeMistralMedium35Stream.id]:
     DustMistralEuropeMistralMedium35Stream,
   [DustMistralEuropeMistralSmallStream.id]: DustMistralEuropeMistralSmallStream,
-  [DustMistralEuropeCodestralStream.id]: DustMistralEuropeCodestralStream,
+  [DustOpenAIResponsesEuropeGptFiveDotFiveStream.id]:
+    DustOpenAIResponsesEuropeGptFiveDotFiveStream,
+  [DustOpenAIResponsesEuropeGptFiveDotFourMiniStream.id]:
+    DustOpenAIResponsesEuropeGptFiveDotFourMiniStream,
+  [DustOpenAIResponsesEuropeGptFiveDotFourNanoStream.id]:
+    DustOpenAIResponsesEuropeGptFiveDotFourNanoStream,
+  [DustOpenAIResponsesEuropeGptFiveDotFourStream.id]:
+    DustOpenAIResponsesEuropeGptFiveDotFourStream,
+  [DustOpenAIResponsesEuropeGptFiveDotOneStream.id]:
+    DustOpenAIResponsesEuropeGptFiveDotOneStream,
+  [DustOpenAIResponsesEuropeGptFiveDotTwoStream.id]:
+    DustOpenAIResponsesEuropeGptFiveDotTwoStream,
+  [DustOpenAIResponsesEuropeGptFiveMiniStream.id]:
+    DustOpenAIResponsesEuropeGptFiveMiniStream,
+  [DustOpenAIResponsesEuropeGptFiveNanoStream.id]:
+    DustOpenAIResponsesEuropeGptFiveNanoStream,
+  [DustOpenAIResponsesEuropeGptFiveStream.id]:
+    DustOpenAIResponsesEuropeGptFiveStream,
+  [DustOpenAIResponsesGlobalGptFiveDotFiveStream.id]:
+    DustOpenAIResponsesGlobalGptFiveDotFiveStream,
+  [DustOpenAIResponsesGlobalGptFiveDotFourMiniStream.id]:
+    DustOpenAIResponsesGlobalGptFiveDotFourMiniStream,
+  [DustOpenAIResponsesGlobalGptFiveDotFourNanoStream.id]:
+    DustOpenAIResponsesGlobalGptFiveDotFourNanoStream,
+  [DustOpenAIResponsesGlobalGptFiveDotFourStream.id]:
+    DustOpenAIResponsesGlobalGptFiveDotFourStream,
+  [DustOpenAIResponsesGlobalGptFiveDotOneStream.id]:
+    DustOpenAIResponsesGlobalGptFiveDotOneStream,
+  [DustOpenAIResponsesGlobalGptFiveDotTwoStream.id]:
+    DustOpenAIResponsesGlobalGptFiveDotTwoStream,
+  [DustOpenAIResponsesGlobalGptFiveMiniStream.id]:
+    DustOpenAIResponsesGlobalGptFiveMiniStream,
+  [DustOpenAIResponsesGlobalGptFiveNanoStream.id]:
+    DustOpenAIResponsesGlobalGptFiveNanoStream,
+  [DustOpenAIResponsesGlobalGptFiveStream.id]:
+    DustOpenAIResponsesGlobalGptFiveStream,
+  [DustTogetheraiGlobalLlama3370BInstructTurboStream.id]:
+    DustTogetheraiGlobalLlama3370BInstructTurboStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
 
 export function getStreamEndpoints(

--- a/front/lib/model_constructors/providers/openai/base_url.ts
+++ b/front/lib/model_constructors/providers/openai/base_url.ts
@@ -1,0 +1,3 @@
+export const OPENAI_GLOBAL_BASE_URL = "https://api.openai.com/v1";
+
+export const OPENAI_EU_BASE_URL = "https://eu.api.openai.com/v1/";

--- a/front/lib/model_constructors/stream/clients/anthropic_agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic_agent_platform.ts
@@ -43,7 +43,7 @@ const MODEL_MAPPING: Partial<Record<ModelId, Model>> = {
   [CLAUDE_HAIKU_4_5_MODEL_ID]: "claude-haiku-4-5@20251001",
 };
 
-export abstract class AgentPlatformStream extends WithAnthropicAIInputConverter(
+export abstract class AnthropicAgentPlatformStream extends WithAnthropicAIInputConverter(
   WithAnthropicAIOutputConverter(
     StreamEndpoint<
       MessageCreateParamsNonStreaming,

--- a/front/lib/model_constructors/stream/clients/google_agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/google_agent_platform.ts
@@ -24,13 +24,13 @@ import { GoogleGenAI } from "@google/genai";
 // the same place — it passes no location, so `@google/genai` defaults to
 // `global`. Extend with a specific region (e.g. `europe-west1`) once these
 // models become available there.
-export type AgentPlatformGoogleLocation = "global";
+export type GoogleAgentPlatformLocation = "global";
 
 // Gemini-on-Vertex transport. Same @google/genai SDK and converters as the AI
 // Studio client; only the client construction differs (Vertex project +
 // location instead of an API key). Mirrors the legacy `useVertex` branch and is
 // the path non-BYOK plans depend on.
-export abstract class AgentPlatformGoogleStream extends WithGoogleGenAIInputConverter(
+export abstract class GoogleAgentPlatformStream extends WithGoogleGenAIInputConverter(
   WithGoogleGenAIOutputConverter(
     StreamEndpoint<
       GenerateContentParameters,
@@ -41,13 +41,13 @@ export abstract class AgentPlatformGoogleStream extends WithGoogleGenAIInputConv
 ) {
   // Narrow `this.constructor` so the per-endpoint static below is visible.
   declare ["constructor"]: BaseEndpointConfiguration<GoogleAiStudioInputConfig> & {
-    regionalEndpoint: AgentPlatformGoogleLocation;
+    regionalEndpoint: GoogleAgentPlatformLocation;
   };
 
   static readonly providerId = GOOGLE_AI_STUDIO_PROVIDER_ID;
   static readonly api = AGENT_PLATFORM_API;
 
-  static readonly regionalEndpoint: AgentPlatformGoogleLocation;
+  static readonly regionalEndpoint: GoogleAgentPlatformLocation;
 
   static readonly configSchema = googleAiStudioConfigSchema;
 

--- a/front/lib/model_constructors/stream/clients/openai_responses.ts
+++ b/front/lib/model_constructors/stream/clients/openai_responses.ts
@@ -36,14 +36,23 @@ export abstract class OpenAIResponsesStream extends WithOpenAIResponsesInputConv
 
   static readonly configSchema: z.ZodType<OpenAIInputConfig> = configSchema;
 
-  private readonly client: OpenAI;
+  protected abstract readonly baseUrl: string;
 
-  constructor({ OPENAI_API_KEY, OPENAI_BASE_URL }: Credentials) {
+  private readonly apiKey: string | undefined;
+  private _client: OpenAI | undefined;
+
+  constructor({ OPENAI_API_KEY }: Credentials) {
     super();
-    this.client = new OpenAI({
-      apiKey: OPENAI_API_KEY,
-      baseURL: OPENAI_BASE_URL,
+    this.apiKey = OPENAI_API_KEY;
+  }
+
+  // Lazy: `baseUrl` is an abstract field, only set after subclass initializers run.
+  private get client(): OpenAI {
+    this._client ??= new OpenAI({
+      apiKey: this.apiKey,
+      baseURL: this.baseUrl,
     });
+    return this._client;
   }
 
   async *streamRaw(

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five.ts
@@ -1,9 +1,9 @@
 import { WithAnthropicClaudeHaikuFourDotFiveConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five";
-import { AgentPlatformStream } from "@app/lib/model_constructors/stream/clients/agent_platform";
+import { AnthropicAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/anthropic_agent_platform";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 
 export class AgentPlatformEuropeClaudeHaikuFourDotFiveStream extends WithAnthropicClaudeHaikuFourDotFiveConfig(
-  AgentPlatformStream
+  AnthropicAgentPlatformStream
 ) {
   // Vertex regional/multi-region endpoints add a 10% premium over global.
   // https://platform.claude.com/docs/en/about-claude/pricing

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
@@ -1,9 +1,9 @@
 import { WithAnthropicClaudeSonnetFourDotSixConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six";
-import { AgentPlatformStream } from "@app/lib/model_constructors/stream/clients/agent_platform";
+import { AnthropicAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/anthropic_agent_platform";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 
 export class AgentPlatformEuropeClaudeSonnetFourDotSixStream extends WithAnthropicClaudeSonnetFourDotSixConfig(
-  AgentPlatformStream
+  AnthropicAgentPlatformStream
 ) {
   // https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing#europe-west1
   static readonly tokenPricing = {

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite.ts
@@ -1,10 +1,10 @@
 import { WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite";
-import { AgentPlatformGoogleStream } from "@app/lib/model_constructors/stream/clients/agent_platform_google";
+import { GoogleAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/google_agent_platform";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { EUROPE } from "@app/lib/model_constructors/types/regions";
 
 export class AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream extends WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig(
-  AgentPlatformGoogleStream
+  GoogleAgentPlatformStream
 ) {
   static readonly tokenPricing = {
     cacheCreated: 1.0,

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash.ts
@@ -1,10 +1,10 @@
 import { WithGoogleAiStudioGeminiThreeDotFiveFlashConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash";
-import { AgentPlatformGoogleStream } from "@app/lib/model_constructors/stream/clients/agent_platform_google";
+import { GoogleAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/google_agent_platform";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { EUROPE } from "@app/lib/model_constructors/types/regions";
 
 export class AgentPlatformEuropeGeminiThreeDotFiveFlashStream extends WithGoogleAiStudioGeminiThreeDotFiveFlashConfig(
-  AgentPlatformGoogleStream
+  GoogleAgentPlatformStream
 ) {
   static readonly tokenPricing = {
     cacheCreated: 1.0,

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five.ts
@@ -1,0 +1,24 @@
+import { OPENAI_EU_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
+import { WithOpenAIGptFiveConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesEuropeGptFiveStream extends WithOpenAIGptFiveConfig(
+  OpenAIResponsesStream
+) {
+  // https://developers.openai.com/api/docs/models/gpt-5
+  static readonly tokenPricing = {
+    cacheHit: 0.125,
+    standardInput: 1.25,
+    standardOutput: 10.0,
+  };
+
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_EU_BASE_URL;
+}
+
+OpenAIResponsesEuropeGptFiveStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_five.ts
@@ -1,0 +1,24 @@
+import { OPENAI_EU_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
+import { WithOpenAIGptFiveDotFiveConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_five";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesEuropeGptFiveDotFiveStream extends WithOpenAIGptFiveDotFiveConfig(
+  OpenAIResponsesStream
+) {
+  // https://developers.openai.com/api/docs/models/gpt-5.5
+  static readonly tokenPricing = {
+    cacheHit: 0.5,
+    standardInput: 5.0,
+    standardOutput: 30.0,
+  };
+
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_EU_BASE_URL;
+}
+
+OpenAIResponsesEuropeGptFiveDotFiveStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_five.ts
@@ -8,10 +8,12 @@ export class OpenAIResponsesEuropeGptFiveDotFiveStream extends WithOpenAIGptFive
   OpenAIResponsesStream
 ) {
   // https://developers.openai.com/api/docs/models/gpt-5.5
+  // Regional (data residency) endpoints are charged a 10% uplift for models
+  // released on or after March 5, 2026.
   static readonly tokenPricing = {
-    cacheHit: 0.5,
-    standardInput: 5.0,
-    standardOutput: 30.0,
+    cacheHit: 0.55,
+    standardInput: 5.5,
+    standardOutput: 33.0,
   };
 
   static readonly region = EUROPE;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four.ts
@@ -1,0 +1,24 @@
+import { OPENAI_EU_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
+import { WithOpenAIGptFiveDotFourConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_four";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesEuropeGptFiveDotFourStream extends WithOpenAIGptFiveDotFourConfig(
+  OpenAIResponsesStream
+) {
+  // https://developers.openai.com/api/docs/models/gpt-5.4
+  static readonly tokenPricing = {
+    cacheHit: 0.25,
+    standardInput: 2.5,
+    standardOutput: 15.0,
+  };
+
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_EU_BASE_URL;
+}
+
+OpenAIResponsesEuropeGptFiveDotFourStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four.ts
@@ -8,10 +8,12 @@ export class OpenAIResponsesEuropeGptFiveDotFourStream extends WithOpenAIGptFive
   OpenAIResponsesStream
 ) {
   // https://developers.openai.com/api/docs/models/gpt-5.4
+  // Regional (data residency) endpoints are charged a 10% uplift for models
+  // released on or after March 5, 2026.
   static readonly tokenPricing = {
-    cacheHit: 0.25,
-    standardInput: 2.5,
-    standardOutput: 15.0,
+    cacheHit: 0.275,
+    standardInput: 2.75,
+    standardOutput: 16.5,
   };
 
   static readonly region = EUROPE;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_mini.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_mini.ts
@@ -1,0 +1,24 @@
+import { OPENAI_EU_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
+import { WithOpenAIGptFiveDotFourMiniConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesEuropeGptFiveDotFourMiniStream extends WithOpenAIGptFiveDotFourMiniConfig(
+  OpenAIResponsesStream
+) {
+  // https://developers.openai.com/api/docs/models/gpt-5.4-mini
+  static readonly tokenPricing = {
+    cacheHit: 0.075,
+    standardInput: 0.75,
+    standardOutput: 4.5,
+  };
+
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_EU_BASE_URL;
+}
+
+OpenAIResponsesEuropeGptFiveDotFourMiniStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_mini.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_mini.ts
@@ -8,10 +8,12 @@ export class OpenAIResponsesEuropeGptFiveDotFourMiniStream extends WithOpenAIGpt
   OpenAIResponsesStream
 ) {
   // https://developers.openai.com/api/docs/models/gpt-5.4-mini
+  // Regional (data residency) endpoints are charged a 10% uplift for models
+  // released on or after March 5, 2026.
   static readonly tokenPricing = {
-    cacheHit: 0.075,
-    standardInput: 0.75,
-    standardOutput: 4.5,
+    cacheHit: 0.0825,
+    standardInput: 0.825,
+    standardOutput: 4.95,
   };
 
   static readonly region = EUROPE;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_nano.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_nano.ts
@@ -1,0 +1,24 @@
+import { OPENAI_EU_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
+import { WithOpenAIGptFiveDotFourNanoConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_four_nano";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesEuropeGptFiveDotFourNanoStream extends WithOpenAIGptFiveDotFourNanoConfig(
+  OpenAIResponsesStream
+) {
+  // https://developers.openai.com/api/docs/models/gpt-5.4-nano
+  static readonly tokenPricing = {
+    cacheHit: 0.02,
+    standardInput: 0.2,
+    standardOutput: 1.25,
+  };
+
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_EU_BASE_URL;
+}
+
+OpenAIResponsesEuropeGptFiveDotFourNanoStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_nano.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_nano.ts
@@ -8,10 +8,12 @@ export class OpenAIResponsesEuropeGptFiveDotFourNanoStream extends WithOpenAIGpt
   OpenAIResponsesStream
 ) {
   // https://developers.openai.com/api/docs/models/gpt-5.4-nano
+  // Regional (data residency) endpoints are charged a 10% uplift for models
+  // released on or after March 5, 2026.
   static readonly tokenPricing = {
-    cacheHit: 0.02,
-    standardInput: 0.2,
-    standardOutput: 1.25,
+    cacheHit: 0.022,
+    standardInput: 0.22,
+    standardOutput: 1.375,
   };
 
   static readonly region = EUROPE;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_one.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_one.ts
@@ -1,0 +1,24 @@
+import { OPENAI_EU_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
+import { WithOpenAIGptFiveDotOneConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_one";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesEuropeGptFiveDotOneStream extends WithOpenAIGptFiveDotOneConfig(
+  OpenAIResponsesStream
+) {
+  // https://developers.openai.com/api/docs/models/gpt-5.1
+  static readonly tokenPricing = {
+    cacheHit: 0.125,
+    standardInput: 1.25,
+    standardOutput: 10.0,
+  };
+
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_EU_BASE_URL;
+}
+
+OpenAIResponsesEuropeGptFiveDotOneStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_two.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_two.ts
@@ -1,0 +1,24 @@
+import { OPENAI_EU_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
+import { WithOpenAIGptFiveDotTwoConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_two";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesEuropeGptFiveDotTwoStream extends WithOpenAIGptFiveDotTwoConfig(
+  OpenAIResponsesStream
+) {
+  // https://developers.openai.com/api/docs/models/gpt-5.2
+  static readonly tokenPricing = {
+    cacheHit: 0.175,
+    standardInput: 1.75,
+    standardOutput: 14.0,
+  };
+
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_EU_BASE_URL;
+}
+
+OpenAIResponsesEuropeGptFiveDotTwoStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_mini.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_mini.ts
@@ -1,0 +1,24 @@
+import { OPENAI_EU_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
+import { WithOpenAIGptFiveMiniConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_mini";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesEuropeGptFiveMiniStream extends WithOpenAIGptFiveMiniConfig(
+  OpenAIResponsesStream
+) {
+  // https://developers.openai.com/api/docs/models/gpt-5-mini
+  static readonly tokenPricing = {
+    cacheHit: 0.025,
+    standardInput: 0.25,
+    standardOutput: 2.0,
+  };
+
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_EU_BASE_URL;
+}
+
+OpenAIResponsesEuropeGptFiveMiniStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_nano.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_nano.ts
@@ -1,0 +1,24 @@
+import { OPENAI_EU_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
+import { WithOpenAIGptFiveNanoConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_nano";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesEuropeGptFiveNanoStream extends WithOpenAIGptFiveNanoConfig(
+  OpenAIResponsesStream
+) {
+  // https://developers.openai.com/api/docs/models/gpt-5-nano
+  static readonly tokenPricing = {
+    cacheHit: 0.005,
+    standardInput: 0.05,
+    standardOutput: 0.4,
+  };
+
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_EU_BASE_URL;
+}
+
+OpenAIResponsesEuropeGptFiveNanoStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five.ts
@@ -1,3 +1,4 @@
+import { OPENAI_GLOBAL_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
 import { WithOpenAIGptFiveConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five";
 import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
@@ -16,6 +17,8 @@ export class OpenAIResponsesGlobalGptFiveStream extends WithOpenAIGptFiveConfig(
   static readonly region = GLOBAL;
 
   static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_GLOBAL_BASE_URL;
 }
 
 OpenAIResponsesGlobalGptFiveStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five.ts
@@ -1,3 +1,4 @@
+import { OPENAI_GLOBAL_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
 import { WithOpenAIGptFiveDotFiveConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_five";
 import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
@@ -16,6 +17,8 @@ export class OpenAIResponsesGlobalGptFiveDotFiveStream extends WithOpenAIGptFive
   static readonly region = GLOBAL;
 
   static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_GLOBAL_BASE_URL;
 }
 
 OpenAIResponsesGlobalGptFiveDotFiveStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four.ts
@@ -1,3 +1,4 @@
+import { OPENAI_GLOBAL_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
 import { WithOpenAIGptFiveDotFourConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_four";
 import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
@@ -16,6 +17,8 @@ export class OpenAIResponsesGlobalGptFiveDotFourStream extends WithOpenAIGptFive
   static readonly region = GLOBAL;
 
   static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_GLOBAL_BASE_URL;
 }
 
 OpenAIResponsesGlobalGptFiveDotFourStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini.ts
@@ -1,3 +1,4 @@
+import { OPENAI_GLOBAL_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
 import { WithOpenAIGptFiveDotFourMiniConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini";
 import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
@@ -16,6 +17,8 @@ export class OpenAIResponsesGlobalGptFiveDotFourMiniStream extends WithOpenAIGpt
   static readonly region = GLOBAL;
 
   static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_GLOBAL_BASE_URL;
 }
 
 OpenAIResponsesGlobalGptFiveDotFourMiniStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_nano.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_nano.ts
@@ -1,3 +1,4 @@
+import { OPENAI_GLOBAL_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
 import { WithOpenAIGptFiveDotFourNanoConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_four_nano";
 import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
@@ -16,6 +17,8 @@ export class OpenAIResponsesGlobalGptFiveDotFourNanoStream extends WithOpenAIGpt
   static readonly region = GLOBAL;
 
   static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_GLOBAL_BASE_URL;
 }
 
 OpenAIResponsesGlobalGptFiveDotFourNanoStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_one.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_one.ts
@@ -1,3 +1,4 @@
+import { OPENAI_GLOBAL_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
 import { WithOpenAIGptFiveDotOneConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_one";
 import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
@@ -16,6 +17,8 @@ export class OpenAIResponsesGlobalGptFiveDotOneStream extends WithOpenAIGptFiveD
   static readonly region = GLOBAL;
 
   static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_GLOBAL_BASE_URL;
 }
 
 OpenAIResponsesGlobalGptFiveDotOneStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_two.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_two.ts
@@ -1,3 +1,4 @@
+import { OPENAI_GLOBAL_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
 import { WithOpenAIGptFiveDotTwoConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_two";
 import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
@@ -16,6 +17,8 @@ export class OpenAIResponsesGlobalGptFiveDotTwoStream extends WithOpenAIGptFiveD
   static readonly region = GLOBAL;
 
   static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_GLOBAL_BASE_URL;
 }
 
 OpenAIResponsesGlobalGptFiveDotTwoStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_mini.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_mini.ts
@@ -1,3 +1,4 @@
+import { OPENAI_GLOBAL_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
 import { WithOpenAIGptFiveMiniConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_mini";
 import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
@@ -16,6 +17,8 @@ export class OpenAIResponsesGlobalGptFiveMiniStream extends WithOpenAIGptFiveMin
   static readonly region = GLOBAL;
 
   static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_GLOBAL_BASE_URL;
 }
 
 OpenAIResponsesGlobalGptFiveMiniStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_nano.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_nano.ts
@@ -1,3 +1,4 @@
+import { OPENAI_GLOBAL_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
 import { WithOpenAIGptFiveNanoConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_nano";
 import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
@@ -16,6 +17,8 @@ export class OpenAIResponsesGlobalGptFiveNanoStream extends WithOpenAIGptFiveNan
   static readonly region = GLOBAL;
 
   static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_GLOBAL_BASE_URL;
 }
 
 OpenAIResponsesGlobalGptFiveNanoStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -18,6 +18,15 @@ import { MistralEuropeCodestralStream } from "@app/lib/model_constructors/stream
 import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
 import { MistralEuropeMistralMedium35Stream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5";
 import { MistralEuropeMistralSmallStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_small";
+import { OpenAIResponsesEuropeGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five";
+import { OpenAIResponsesEuropeGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_five";
+import { OpenAIResponsesEuropeGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four";
+import { OpenAIResponsesEuropeGptFiveDotFourMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_mini";
+import { OpenAIResponsesEuropeGptFiveDotFourNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_nano";
+import { OpenAIResponsesEuropeGptFiveDotOneStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_one";
+import { OpenAIResponsesEuropeGptFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_two";
+import { OpenAIResponsesEuropeGptFiveMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_mini";
+import { OpenAIResponsesEuropeGptFiveNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_nano";
 import { OpenAIResponsesGlobalGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 import { OpenAIResponsesGlobalGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four";
@@ -30,12 +39,16 @@ import { OpenAIResponsesGlobalGptFiveNanoStream } from "@app/lib/model_construct
 import { TogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/model_constructors/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo";
 
 export const STREAM_ENDPOINTS = {
+  [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
+    AgentPlatformEuropeClaudeHaikuFourDotFiveStream,
+  [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
+    AgentPlatformEuropeClaudeSonnetFourDotSixStream,
+  [AgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]:
+    AgentPlatformEuropeGeminiThreeDotFiveFlashStream,
+  [AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]:
+    AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream,
   [AnthropicGlobalClaudeFableFiveStream.id]:
     AnthropicGlobalClaudeFableFiveStream,
-  [AnthropicGlobalClaudeSonnetFiveStream.id]:
-    AnthropicGlobalClaudeSonnetFiveStream,
-  [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:
-    AnthropicGlobalClaudeSonnetFourDotSixStream,
   [AnthropicGlobalClaudeHaikuFourDotFiveStream.id]:
     AnthropicGlobalClaudeHaikuFourDotFiveStream,
   [AnthropicGlobalClaudeOpusFourDotEightStream.id]:
@@ -44,42 +57,55 @@ export const STREAM_ENDPOINTS = {
     AnthropicGlobalClaudeOpusFourDotSevenStream,
   [AnthropicGlobalClaudeOpusFourDotSixStream.id]:
     AnthropicGlobalClaudeOpusFourDotSixStream,
-  [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
-    AgentPlatformEuropeClaudeSonnetFourDotSixStream,
-  [AgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]:
-    AgentPlatformEuropeGeminiThreeDotFiveFlashStream,
-  [AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]:
-    AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream,
+  [AnthropicGlobalClaudeSonnetFiveStream.id]:
+    AnthropicGlobalClaudeSonnetFiveStream,
+  [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:
+    AnthropicGlobalClaudeSonnetFourDotSixStream,
+  [FireworksGlobalDeepSeekV4ProStream.id]: FireworksGlobalDeepSeekV4ProStream,
+  [FireworksGlobalGlmFiveDotTwoStream.id]: FireworksGlobalGlmFiveDotTwoStream,
+  [FireworksGlobalKimiK2Dot5Stream.id]: FireworksGlobalKimiK2Dot5Stream,
   [GoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
     GoogleAiStudioGlobalGeminiThreeDotOneProStream,
+  [MistralEuropeCodestralStream.id]: MistralEuropeCodestralStream,
+  [MistralEuropeMistralLargeStream.id]: MistralEuropeMistralLargeStream,
+  [MistralEuropeMistralMedium35Stream.id]: MistralEuropeMistralMedium35Stream,
+  [MistralEuropeMistralSmallStream.id]: MistralEuropeMistralSmallStream,
+  [OpenAIResponsesEuropeGptFiveDotFiveStream.id]:
+    OpenAIResponsesEuropeGptFiveDotFiveStream,
+  [OpenAIResponsesEuropeGptFiveDotFourMiniStream.id]:
+    OpenAIResponsesEuropeGptFiveDotFourMiniStream,
+  [OpenAIResponsesEuropeGptFiveDotFourNanoStream.id]:
+    OpenAIResponsesEuropeGptFiveDotFourNanoStream,
+  [OpenAIResponsesEuropeGptFiveDotFourStream.id]:
+    OpenAIResponsesEuropeGptFiveDotFourStream,
+  [OpenAIResponsesEuropeGptFiveDotOneStream.id]:
+    OpenAIResponsesEuropeGptFiveDotOneStream,
+  [OpenAIResponsesEuropeGptFiveDotTwoStream.id]:
+    OpenAIResponsesEuropeGptFiveDotTwoStream,
+  [OpenAIResponsesEuropeGptFiveMiniStream.id]:
+    OpenAIResponsesEuropeGptFiveMiniStream,
+  [OpenAIResponsesEuropeGptFiveNanoStream.id]:
+    OpenAIResponsesEuropeGptFiveNanoStream,
+  [OpenAIResponsesEuropeGptFiveStream.id]: OpenAIResponsesEuropeGptFiveStream,
   [OpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     OpenAIResponsesGlobalGptFiveDotFiveStream,
-  [OpenAIResponsesGlobalGptFiveDotFourStream.id]:
-    OpenAIResponsesGlobalGptFiveDotFourStream,
-  [OpenAIResponsesGlobalGptFiveDotTwoStream.id]:
-    OpenAIResponsesGlobalGptFiveDotTwoStream,
-  [OpenAIResponsesGlobalGptFiveStream.id]: OpenAIResponsesGlobalGptFiveStream,
-  [OpenAIResponsesGlobalGptFiveDotOneStream.id]:
-    OpenAIResponsesGlobalGptFiveDotOneStream,
   [OpenAIResponsesGlobalGptFiveDotFourMiniStream.id]:
     OpenAIResponsesGlobalGptFiveDotFourMiniStream,
   [OpenAIResponsesGlobalGptFiveDotFourNanoStream.id]:
     OpenAIResponsesGlobalGptFiveDotFourNanoStream,
+  [OpenAIResponsesGlobalGptFiveDotFourStream.id]:
+    OpenAIResponsesGlobalGptFiveDotFourStream,
+  [OpenAIResponsesGlobalGptFiveDotOneStream.id]:
+    OpenAIResponsesGlobalGptFiveDotOneStream,
+  [OpenAIResponsesGlobalGptFiveDotTwoStream.id]:
+    OpenAIResponsesGlobalGptFiveDotTwoStream,
   [OpenAIResponsesGlobalGptFiveMiniStream.id]:
     OpenAIResponsesGlobalGptFiveMiniStream,
   [OpenAIResponsesGlobalGptFiveNanoStream.id]:
     OpenAIResponsesGlobalGptFiveNanoStream,
-  [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
-    AgentPlatformEuropeClaudeHaikuFourDotFiveStream,
-  [FireworksGlobalGlmFiveDotTwoStream.id]: FireworksGlobalGlmFiveDotTwoStream,
-  [FireworksGlobalDeepSeekV4ProStream.id]: FireworksGlobalDeepSeekV4ProStream,
-  [FireworksGlobalKimiK2Dot5Stream.id]: FireworksGlobalKimiK2Dot5Stream,
+  [OpenAIResponsesGlobalGptFiveStream.id]: OpenAIResponsesGlobalGptFiveStream,
   [TogetheraiGlobalLlama3370BInstructTurboStream.id]:
     TogetheraiGlobalLlama3370BInstructTurboStream,
-  [MistralEuropeMistralLargeStream.id]: MistralEuropeMistralLargeStream,
-  [MistralEuropeMistralMedium35Stream.id]: MistralEuropeMistralMedium35Stream,
-  [MistralEuropeMistralSmallStream.id]: MistralEuropeMistralSmallStream,
-  [MistralEuropeCodestralStream.id]: MistralEuropeCodestralStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;
 
 export type StreamEndpointId = keyof typeof STREAM_ENDPOINTS;

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test.ts
@@ -5,65 +5,69 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-export const AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup: StreamSetup = {
-  createInstance: () =>
-    new AgentPlatformEuropeClaudeHaikuFourDotFiveStream({
-      AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
-    }),
-  // `null` runs the case with its default checkers; a checker array overrides
-  // them. Every case always runs.
-  tests: {
-    // Only low/medium/high reasoning efforts are supported by the model.
-    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    // When forcing tool use, reasoning must be set to none.
-    "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
+export const AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new AgentPlatformEuropeClaudeHaikuFourDotFiveStream({
+        AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+      }),
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    tests: {
+      // Only low/medium/high reasoning efforts are supported by the model.
+      "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      // When forcing tool use, reasoning must be set to none.
+      "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
 
-    "simple/no-tools/t-default/r-default": null,
-    "simple/no-tools/t-default/r-none": null,
-    "simple/no-tools/t-default/r-low": null,
-    "simple/no-tools/t-default/r-medium": null,
-    "simple/no-tools/t-default/r-high": null,
-    "simple/no-tools/t-0/r-default": null,
-    "simple/no-tools/t-0/r-none": null,
-    "simple/no-tools/t-0/r-low": null,
-    "simple/no-tools/t-0/r-medium": null,
-    "simple/no-tools/t-0/r-high": null,
-    "simple/no-tools/t-0.1/r-default": null,
-    "simple/no-tools/t-0.1/r-none": null,
-    "simple/no-tools/t-0.1/r-low": null,
-    "simple/no-tools/t-0.1/r-medium": null,
-    "simple/no-tools/t-0.1/r-high": null,
-    "simple/no-tools/t-1/r-default": null,
-    "simple/no-tools/t-1/r-none": null,
-    "simple/no-tools/t-1/r-low": null,
-    "simple/no-tools/t-1/r-medium": null,
-    "simple/no-tools/t-1/r-high": null,
+      "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-none": null,
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-0/r-default": null,
+      "simple/no-tools/t-0/r-none": null,
+      "simple/no-tools/t-0/r-low": null,
+      "simple/no-tools/t-0/r-medium": null,
+      "simple/no-tools/t-0/r-high": null,
+      "simple/no-tools/t-0.1/r-default": null,
+      "simple/no-tools/t-0.1/r-none": null,
+      "simple/no-tools/t-0.1/r-low": null,
+      "simple/no-tools/t-0.1/r-medium": null,
+      "simple/no-tools/t-0.1/r-high": null,
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-none": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
 
-    "calc/calc/t-default/r-medium": null,
-    "calc/calc/t-0.1/r-default": null,
-    "calc/calc/t-0.1/r-medium": null,
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": null,
+      "calc/calc/t-0.1/r-medium": null,
 
-    "calc/calc/t-default/r-default/force-tool-default": null,
-    "calc/calc/t-default/r-none/force-tool": null,
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-none/force-tool": null,
 
-    "reasoning/no-tools/t-default/r-none": null,
-    "reasoning/no-tools/t-default/r-low": null,
+      "reasoning/no-tools/t-default/r-none": null,
+      "reasoning/no-tools/t-default/r-low": null,
 
-    "output-format/json-schema/t-default/r-none": null,
-    "output-format/json-schema/t-default/r-high": null,
+      "output-format/json-schema/t-default/r-none": null,
+      "output-format/json-schema/t-default/r-high": null,
 
-    "following/no-tools/t-default/r-default": null,
+      "following/no-tools/t-default/r-default": null,
 
-    "cache/no-tools/t-default/r-default": null,
-  },
-};
+      "cache/no-tools/t-default/r-default": null,
+    },
+  };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test.ts
-runStreamEndpointTests(AgentPlatformEuropeClaudeHaikuFourDotFiveStream, AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup);
+runStreamEndpointTests(
+  AgentPlatformEuropeClaudeHaikuFourDotFiveStream,
+  AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup: StreamSetup = {
   createInstance: () =>
     new AgentPlatformEuropeClaudeHaikuFourDotFiveStream({
       AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
@@ -66,4 +66,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test.ts
-runStreamEndpointTests(AgentPlatformEuropeClaudeHaikuFourDotFiveStream, setup);
+runStreamEndpointTests(AgentPlatformEuropeClaudeHaikuFourDotFiveStream, AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup: StreamSetup = {
   createInstance: () =>
     new AgentPlatformEuropeClaudeSonnetFourDotSixStream({
       AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
@@ -67,4 +67,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test.ts
-runStreamEndpointTests(AgentPlatformEuropeClaudeSonnetFourDotSixStream, setup);
+runStreamEndpointTests(AgentPlatformEuropeClaudeSonnetFourDotSixStream, AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test.ts
@@ -5,66 +5,70 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-export const AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup: StreamSetup = {
-  createInstance: () =>
-    new AgentPlatformEuropeClaudeSonnetFourDotSixStream({
-      AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
-    }),
-  // `null` runs the case with its default checkers; a checker array overrides
-  // them. Every case always runs.
-  tests: {
-    // Minimal reasoning effort is not supported by the model.
-    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    // When forcing tool use, reasoning must be set to none.
-    "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
+export const AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new AgentPlatformEuropeClaudeSonnetFourDotSixStream({
+        AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+      }),
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    tests: {
+      // Minimal reasoning effort is not supported by the model.
+      "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      // When forcing tool use, reasoning must be set to none.
+      "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
 
-    "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-default": null,
 
-    "simple/no-tools/t-default/r-none": null,
-    "simple/no-tools/t-default/r-low": null,
-    "simple/no-tools/t-default/r-medium": null,
-    "simple/no-tools/t-default/r-high": null,
-    "simple/no-tools/t-default/r-maximal": null,
-    "simple/no-tools/t-0/r-default": null,
-    "simple/no-tools/t-0/r-none": null,
-    "simple/no-tools/t-0/r-low": null,
-    "simple/no-tools/t-0/r-medium": null,
-    "simple/no-tools/t-0/r-high": null,
-    "simple/no-tools/t-0/r-maximal": null,
-    "simple/no-tools/t-0.1/r-default": null,
-    "simple/no-tools/t-0.1/r-none": null,
-    "simple/no-tools/t-0.1/r-low": null,
-    "simple/no-tools/t-0.1/r-medium": null,
-    "simple/no-tools/t-0.1/r-high": null,
-    "simple/no-tools/t-0.1/r-maximal": null,
-    "simple/no-tools/t-1/r-default": null,
-    "simple/no-tools/t-1/r-none": null,
-    "simple/no-tools/t-1/r-low": null,
-    "simple/no-tools/t-1/r-medium": null,
-    "simple/no-tools/t-1/r-high": null,
-    "simple/no-tools/t-1/r-maximal": null,
+      "simple/no-tools/t-default/r-none": null,
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-default/r-maximal": null,
+      "simple/no-tools/t-0/r-default": null,
+      "simple/no-tools/t-0/r-none": null,
+      "simple/no-tools/t-0/r-low": null,
+      "simple/no-tools/t-0/r-medium": null,
+      "simple/no-tools/t-0/r-high": null,
+      "simple/no-tools/t-0/r-maximal": null,
+      "simple/no-tools/t-0.1/r-default": null,
+      "simple/no-tools/t-0.1/r-none": null,
+      "simple/no-tools/t-0.1/r-low": null,
+      "simple/no-tools/t-0.1/r-medium": null,
+      "simple/no-tools/t-0.1/r-high": null,
+      "simple/no-tools/t-0.1/r-maximal": null,
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-none": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
+      "simple/no-tools/t-1/r-maximal": null,
 
-    "calc/calc/t-default/r-medium": null,
-    "calc/calc/t-0.1/r-default": null,
-    "calc/calc/t-0.1/r-medium": null,
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": null,
+      "calc/calc/t-0.1/r-medium": null,
 
-    "calc/calc/t-default/r-default/force-tool-default": null,
-    "calc/calc/t-default/r-none/force-tool": null,
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-none/force-tool": null,
 
-    "reasoning/no-tools/t-default/r-none": null,
-    "reasoning/no-tools/t-default/r-low": null,
+      "reasoning/no-tools/t-default/r-none": null,
+      "reasoning/no-tools/t-default/r-low": null,
 
-    "output-format/json-schema/t-default/r-none": null,
-    "output-format/json-schema/t-default/r-high": null,
+      "output-format/json-schema/t-default/r-none": null,
+      "output-format/json-schema/t-default/r-high": null,
 
-    "following/no-tools/t-default/r-default": null,
+      "following/no-tools/t-default/r-default": null,
 
-    "cache/no-tools/t-default/r-default": null,
-  },
-};
+      "cache/no-tools/t-default/r-default": null,
+    },
+  };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test.ts
-runStreamEndpointTests(AgentPlatformEuropeClaudeSonnetFourDotSixStream, AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup);
+runStreamEndpointTests(
+  AgentPlatformEuropeClaudeSonnetFourDotSixStream,
+  AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test.ts
@@ -8,72 +8,73 @@ import {
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-export const AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup: StreamSetup = {
-  createInstance: () =>
-    new AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream({
-      AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
-    }),
-  // `null` runs the case with its default checkers; a checker array overrides
-  // them. Every case always runs.
-  tests: {
-    // Flash-Lite supports none/minimal/low/medium/high. `maximal` is
-    // unsupported and rejected by the config schema. `none` maps to the minimum
-    // thinking budget with thoughts hidden (legacy parity).
-    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+export const AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream({
+        AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+      }),
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    tests: {
+      // Flash-Lite supports none/minimal/low/medium/high. `maximal` is
+      // unsupported and rejected by the config schema. `none` maps to the minimum
+      // thinking budget with thoughts hidden (legacy parity).
+      "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
 
-    "simple/no-tools/t-default/r-none": null,
-    "simple/no-tools/t-0/r-none": null,
-    "simple/no-tools/t-0.1/r-none": null,
-    "simple/no-tools/t-1/r-none": null,
-    "calc/calc/t-default/r-none/force-tool": null,
-    "reasoning/no-tools/t-default/r-none": null,
-    "output-format/json-schema/t-default/r-none": null,
+      "simple/no-tools/t-default/r-none": null,
+      "simple/no-tools/t-0/r-none": null,
+      "simple/no-tools/t-0.1/r-none": null,
+      "simple/no-tools/t-1/r-none": null,
+      "calc/calc/t-default/r-none/force-tool": null,
+      "reasoning/no-tools/t-default/r-none": null,
+      "output-format/json-schema/t-default/r-none": null,
 
-    "simple/no-tools/t-default/r-minimal": null,
-    "simple/no-tools/t-0/r-minimal": null,
-    "simple/no-tools/t-0.1/r-minimal": null,
-    "simple/no-tools/t-1/r-minimal": null,
+      "simple/no-tools/t-default/r-minimal": null,
+      "simple/no-tools/t-0/r-minimal": null,
+      "simple/no-tools/t-0.1/r-minimal": null,
+      "simple/no-tools/t-1/r-minimal": null,
 
-    "simple/no-tools/t-default/r-default": null,
-    "simple/no-tools/t-default/r-low": null,
-    "simple/no-tools/t-default/r-medium": null,
-    "simple/no-tools/t-default/r-high": null,
-    "simple/no-tools/t-0/r-default": null,
-    "simple/no-tools/t-0/r-low": null,
-    "simple/no-tools/t-0/r-medium": null,
-    "simple/no-tools/t-0/r-high": null,
-    "simple/no-tools/t-0.1/r-default": null,
-    "simple/no-tools/t-0.1/r-low": null,
-    "simple/no-tools/t-0.1/r-medium": null,
-    "simple/no-tools/t-0.1/r-high": null,
-    "simple/no-tools/t-1/r-default": null,
-    "simple/no-tools/t-1/r-low": null,
-    "simple/no-tools/t-1/r-medium": null,
-    "simple/no-tools/t-1/r-high": null,
+      "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-0/r-default": null,
+      "simple/no-tools/t-0/r-low": null,
+      "simple/no-tools/t-0/r-medium": null,
+      "simple/no-tools/t-0/r-high": null,
+      "simple/no-tools/t-0.1/r-default": null,
+      "simple/no-tools/t-0.1/r-low": null,
+      "simple/no-tools/t-0.1/r-medium": null,
+      "simple/no-tools/t-0.1/r-high": null,
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
 
-    // Gemini ignores the Anthropic-style cache markers (it uses implicit
-    // caching), so this behaves like a plain "say Hi" prompt.
-    "cache/no-tools/t-default/r-default": null,
+      // Gemini ignores the Anthropic-style cache markers (it uses implicit
+      // caching), so this behaves like a plain "say Hi" prompt.
+      "cache/no-tools/t-default/r-default": null,
 
-    "calc/calc/t-default/r-medium": null,
-    "calc/calc/t-0.1/r-default": null,
-    "calc/calc/t-0.1/r-medium": null,
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": null,
+      "calc/calc/t-0.1/r-medium": null,
 
-    "calc/calc/t-default/r-default/force-tool-default": null,
-    "calc/calc/t-default/r-default/force-tool": null,
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-default/force-tool": null,
 
-    // Unlike Pro/Flash, this lightweight model does not reliably surface thought
-    // content at `low` effort, so we only assert the stream completes.
-    "reasoning/no-tools/t-default/r-low": [SUCCESS],
+      // Unlike Pro/Flash, this lightweight model does not reliably surface thought
+      // content at `low` effort, so we only assert the stream completes.
+      "reasoning/no-tools/t-default/r-low": [SUCCESS],
 
-    "output-format/json-schema/t-default/r-high": null,
+      "output-format/json-schema/t-default/r-high": null,
 
-    "following/no-tools/t-default/r-default": null,
-  },
-};
+      "following/no-tools/t-default/r-default": null,
+    },
+  };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test.ts
 runStreamEndpointTests(

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test.ts
@@ -8,7 +8,7 @@ import {
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup: StreamSetup = {
   createInstance: () =>
     new AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream({
       AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
@@ -78,5 +78,5 @@ const setup: StreamSetup = {
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test.ts
 runStreamEndpointTests(
   AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream,
-  setup
+  AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup
 );

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test.ts
@@ -5,67 +5,71 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-export const AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup: StreamSetup = {
-  createInstance: () =>
-    new AgentPlatformEuropeGeminiThreeDotFiveFlashStream({
-      AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
-    }),
-  // `null` runs the case with its default checkers; a checker array overrides
-  // them. Every case always runs.
-  tests: {
-    // Flash supports minimal/low/medium/high. `none` and `maximal` are
-    // unsupported and rejected by the config schema.
-    "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
-    "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
-    "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+export const AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new AgentPlatformEuropeGeminiThreeDotFiveFlashStream({
+        AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+      }),
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    tests: {
+      // Flash supports minimal/low/medium/high. `none` and `maximal` are
+      // unsupported and rejected by the config schema.
+      "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
+      "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+      "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
 
-    "simple/no-tools/t-default/r-default": null,
-    "simple/no-tools/t-default/r-minimal": null,
-    "simple/no-tools/t-default/r-low": null,
-    "simple/no-tools/t-default/r-medium": null,
-    "simple/no-tools/t-default/r-high": null,
-    "simple/no-tools/t-0/r-default": null,
-    "simple/no-tools/t-0/r-minimal": null,
-    "simple/no-tools/t-0/r-low": null,
-    "simple/no-tools/t-0/r-medium": null,
-    "simple/no-tools/t-0/r-high": null,
-    "simple/no-tools/t-0.1/r-default": null,
-    "simple/no-tools/t-0.1/r-minimal": null,
-    "simple/no-tools/t-0.1/r-low": null,
-    "simple/no-tools/t-0.1/r-medium": null,
-    "simple/no-tools/t-0.1/r-high": null,
-    "simple/no-tools/t-1/r-default": null,
-    "simple/no-tools/t-1/r-minimal": null,
-    "simple/no-tools/t-1/r-low": null,
-    "simple/no-tools/t-1/r-medium": null,
-    "simple/no-tools/t-1/r-high": null,
+      "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-minimal": null,
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-0/r-default": null,
+      "simple/no-tools/t-0/r-minimal": null,
+      "simple/no-tools/t-0/r-low": null,
+      "simple/no-tools/t-0/r-medium": null,
+      "simple/no-tools/t-0/r-high": null,
+      "simple/no-tools/t-0.1/r-default": null,
+      "simple/no-tools/t-0.1/r-minimal": null,
+      "simple/no-tools/t-0.1/r-low": null,
+      "simple/no-tools/t-0.1/r-medium": null,
+      "simple/no-tools/t-0.1/r-high": null,
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-minimal": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
 
-    // Gemini ignores the Anthropic-style cache markers (it uses implicit
-    // caching), so this behaves like a plain "say Hi" prompt.
-    "cache/no-tools/t-default/r-default": null,
+      // Gemini ignores the Anthropic-style cache markers (it uses implicit
+      // caching), so this behaves like a plain "say Hi" prompt.
+      "cache/no-tools/t-default/r-default": null,
 
-    "calc/calc/t-default/r-medium": null,
-    "calc/calc/t-0.1/r-default": null,
-    "calc/calc/t-0.1/r-medium": null,
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": null,
+      "calc/calc/t-0.1/r-medium": null,
 
-    "calc/calc/t-default/r-default/force-tool-default": null,
-    "calc/calc/t-default/r-default/force-tool": null,
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-default/force-tool": null,
 
-    "reasoning/no-tools/t-default/r-low": null,
+      "reasoning/no-tools/t-default/r-low": null,
 
-    "output-format/json-schema/t-default/r-high": null,
+      "output-format/json-schema/t-default/r-high": null,
 
-    "following/no-tools/t-default/r-default": null,
-  },
-};
+      "following/no-tools/t-default/r-default": null,
+    },
+  };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test.ts
-runStreamEndpointTests(AgentPlatformEuropeGeminiThreeDotFiveFlashStream, AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup);
+runStreamEndpointTests(
+  AgentPlatformEuropeGeminiThreeDotFiveFlashStream,
+  AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup: StreamSetup = {
   createInstance: () =>
     new AgentPlatformEuropeGeminiThreeDotFiveFlashStream({
       AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
@@ -68,4 +68,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test.ts
-runStreamEndpointTests(AgentPlatformEuropeGeminiThreeDotFiveFlashStream, setup);
+runStreamEndpointTests(AgentPlatformEuropeGeminiThreeDotFiveFlashStream, AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test.ts
@@ -8,7 +8,7 @@ import {
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const AnthropicGlobalClaudeFableFiveStreamSetup: StreamSetup = {
   createInstance: () =>
     new AnthropicGlobalClaudeFableFiveStream({
       ANTHROPIC_API_KEY:
@@ -72,4 +72,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeFableFiveStream, setup);
+runStreamEndpointTests(AnthropicGlobalClaudeFableFiveStream, AnthropicGlobalClaudeFableFiveStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test.ts
@@ -72,4 +72,7 @@ export const AnthropicGlobalClaudeFableFiveStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeFableFiveStream, AnthropicGlobalClaudeFableFiveStreamSetup);
+runStreamEndpointTests(
+  AnthropicGlobalClaudeFableFiveStream,
+  AnthropicGlobalClaudeFableFiveStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test.ts
@@ -66,4 +66,7 @@ export const AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeHaikuFourDotFiveStream, AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup);
+runStreamEndpointTests(
+  AnthropicGlobalClaudeHaikuFourDotFiveStream,
+  AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup: StreamSetup = {
   createInstance: () =>
     new AnthropicGlobalClaudeHaikuFourDotFiveStream({
       ANTHROPIC_API_KEY: process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
@@ -66,4 +66,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeHaikuFourDotFiveStream, setup);
+runStreamEndpointTests(AnthropicGlobalClaudeHaikuFourDotFiveStream, AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const AnthropicGlobalClaudeOpusFourDotEightStreamSetup: StreamSetup = {
   createInstance: () =>
     new AnthropicGlobalClaudeOpusFourDotEightStream({
       ANTHROPIC_API_KEY: process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
@@ -66,4 +66,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeOpusFourDotEightStream, setup);
+runStreamEndpointTests(AnthropicGlobalClaudeOpusFourDotEightStream, AnthropicGlobalClaudeOpusFourDotEightStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test.ts
@@ -66,4 +66,7 @@ export const AnthropicGlobalClaudeOpusFourDotEightStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeOpusFourDotEightStream, AnthropicGlobalClaudeOpusFourDotEightStreamSetup);
+runStreamEndpointTests(
+  AnthropicGlobalClaudeOpusFourDotEightStream,
+  AnthropicGlobalClaudeOpusFourDotEightStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_seven.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_seven.test.ts
@@ -71,4 +71,7 @@ export const AnthropicGlobalClaudeOpusFourDotSevenStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_seven.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeOpusFourDotSevenStream, AnthropicGlobalClaudeOpusFourDotSevenStreamSetup);
+runStreamEndpointTests(
+  AnthropicGlobalClaudeOpusFourDotSevenStream,
+  AnthropicGlobalClaudeOpusFourDotSevenStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_seven.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_seven.test.ts
@@ -8,7 +8,7 @@ import {
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const AnthropicGlobalClaudeOpusFourDotSevenStreamSetup: StreamSetup = {
   createInstance: () =>
     new AnthropicGlobalClaudeOpusFourDotSevenStream({
       ANTHROPIC_API_KEY: process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
@@ -71,4 +71,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_seven.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeOpusFourDotSevenStream, setup);
+runStreamEndpointTests(AnthropicGlobalClaudeOpusFourDotSevenStream, AnthropicGlobalClaudeOpusFourDotSevenStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_six.test.ts
@@ -8,7 +8,7 @@ import {
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const AnthropicGlobalClaudeOpusFourDotSixStreamSetup: StreamSetup = {
   createInstance: () =>
     new AnthropicGlobalClaudeOpusFourDotSixStream({
       ANTHROPIC_API_KEY: process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
@@ -71,4 +71,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_six.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeOpusFourDotSixStream, setup);
+runStreamEndpointTests(AnthropicGlobalClaudeOpusFourDotSixStream, AnthropicGlobalClaudeOpusFourDotSixStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_six.test.ts
@@ -71,4 +71,7 @@ export const AnthropicGlobalClaudeOpusFourDotSixStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_six.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeOpusFourDotSixStream, AnthropicGlobalClaudeOpusFourDotSixStreamSetup);
+runStreamEndpointTests(
+  AnthropicGlobalClaudeOpusFourDotSixStream,
+  AnthropicGlobalClaudeOpusFourDotSixStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_five.test.ts
@@ -66,4 +66,7 @@ export const AnthropicGlobalClaudeSonnetFiveStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_sonnet_five.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeSonnetFiveStream, AnthropicGlobalClaudeSonnetFiveStreamSetup);
+runStreamEndpointTests(
+  AnthropicGlobalClaudeSonnetFiveStream,
+  AnthropicGlobalClaudeSonnetFiveStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_five.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const AnthropicGlobalClaudeSonnetFiveStreamSetup: StreamSetup = {
   createInstance: () =>
     new AnthropicGlobalClaudeSonnetFiveStream({
       ANTHROPIC_API_KEY: process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
@@ -66,4 +66,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_sonnet_five.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeSonnetFiveStream, setup);
+runStreamEndpointTests(AnthropicGlobalClaudeSonnetFiveStream, AnthropicGlobalClaudeSonnetFiveStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_four_dot_six.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const AnthropicGlobalClaudeSonnetFourDotSixStreamSetup: StreamSetup = {
   createInstance: () =>
     new AnthropicGlobalClaudeSonnetFourDotSixStream({
       ANTHROPIC_API_KEY: process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
@@ -66,4 +66,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_sonnet_four_dot_six.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeSonnetFourDotSixStream, setup);
+runStreamEndpointTests(AnthropicGlobalClaudeSonnetFourDotSixStream, AnthropicGlobalClaudeSonnetFourDotSixStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_four_dot_six.test.ts
@@ -66,4 +66,7 @@ export const AnthropicGlobalClaudeSonnetFourDotSixStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_sonnet_four_dot_six.test.ts
-runStreamEndpointTests(AnthropicGlobalClaudeSonnetFourDotSixStream, AnthropicGlobalClaudeSonnetFourDotSixStreamSetup);
+runStreamEndpointTests(
+  AnthropicGlobalClaudeSonnetFourDotSixStream,
+  AnthropicGlobalClaudeSonnetFourDotSixStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/fireworks_global_deepseek_v4_pro.test.ts
+++ b/front/lib/model_constructors/test/endpoints/fireworks_global_deepseek_v4_pro.test.ts
@@ -65,4 +65,7 @@ export const FireworksGlobalDeepSeekV4ProStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/fireworks_global_deepseek_v4_pro.test.ts
-runStreamEndpointTests(FireworksGlobalDeepSeekV4ProStream, FireworksGlobalDeepSeekV4ProStreamSetup);
+runStreamEndpointTests(
+  FireworksGlobalDeepSeekV4ProStream,
+  FireworksGlobalDeepSeekV4ProStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/fireworks_global_deepseek_v4_pro.test.ts
+++ b/front/lib/model_constructors/test/endpoints/fireworks_global_deepseek_v4_pro.test.ts
@@ -8,7 +8,7 @@ import {
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const FireworksGlobalDeepSeekV4ProStreamSetup: StreamSetup = {
   createInstance: () =>
     new FireworksGlobalDeepSeekV4ProStream({
       FIREWORKS_API_KEY: process.env.DUST_MANAGED_FIREWORKS_API_KEY ?? "",
@@ -65,4 +65,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/fireworks_global_deepseek_v4_pro.test.ts
-runStreamEndpointTests(FireworksGlobalDeepSeekV4ProStream, setup);
+runStreamEndpointTests(FireworksGlobalDeepSeekV4ProStream, FireworksGlobalDeepSeekV4ProStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/fireworks_global_glm_five_dot_two.test.ts
+++ b/front/lib/model_constructors/test/endpoints/fireworks_global_glm_five_dot_two.test.ts
@@ -8,7 +8,7 @@ import {
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const FireworksGlobalGlmFiveDotTwoStreamSetup: StreamSetup = {
   createInstance: () =>
     new FireworksGlobalGlmFiveDotTwoStream({
       FIREWORKS_API_KEY: process.env.DUST_MANAGED_FIREWORKS_API_KEY ?? "",
@@ -65,4 +65,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/fireworks_global_glm_five_dot_two.test.ts
-runStreamEndpointTests(FireworksGlobalGlmFiveDotTwoStream, setup);
+runStreamEndpointTests(FireworksGlobalGlmFiveDotTwoStream, FireworksGlobalGlmFiveDotTwoStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/fireworks_global_glm_five_dot_two.test.ts
+++ b/front/lib/model_constructors/test/endpoints/fireworks_global_glm_five_dot_two.test.ts
@@ -65,4 +65,7 @@ export const FireworksGlobalGlmFiveDotTwoStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/fireworks_global_glm_five_dot_two.test.ts
-runStreamEndpointTests(FireworksGlobalGlmFiveDotTwoStream, FireworksGlobalGlmFiveDotTwoStreamSetup);
+runStreamEndpointTests(
+  FireworksGlobalGlmFiveDotTwoStream,
+  FireworksGlobalGlmFiveDotTwoStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_five.test.ts
@@ -65,4 +65,7 @@ export const FireworksGlobalKimiK2Dot5StreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_five.test.ts
-runStreamEndpointTests(FireworksGlobalKimiK2Dot5Stream, FireworksGlobalKimiK2Dot5StreamSetup);
+runStreamEndpointTests(
+  FireworksGlobalKimiK2Dot5Stream,
+  FireworksGlobalKimiK2Dot5StreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_five.test.ts
@@ -8,7 +8,7 @@ import {
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const FireworksGlobalKimiK2Dot5StreamSetup: StreamSetup = {
   createInstance: () =>
     new FireworksGlobalKimiK2Dot5Stream({
       FIREWORKS_API_KEY: process.env.DUST_MANAGED_FIREWORKS_API_KEY ?? "",
@@ -65,4 +65,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_five.test.ts
-runStreamEndpointTests(FireworksGlobalKimiK2Dot5Stream, setup);
+runStreamEndpointTests(FireworksGlobalKimiK2Dot5Stream, FireworksGlobalKimiK2Dot5StreamSetup);

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup: StreamSetup = {
   createInstance: () =>
     new GoogleAiStudioGlobalGeminiThreeDotOneProStream({
       GOOGLE_AI_STUDIO_API_KEY:
@@ -69,4 +69,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
-runStreamEndpointTests(GoogleAiStudioGlobalGeminiThreeDotOneProStream, setup);
+runStreamEndpointTests(GoogleAiStudioGlobalGeminiThreeDotOneProStream, GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
@@ -5,68 +5,72 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-export const GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup: StreamSetup = {
-  createInstance: () =>
-    new GoogleAiStudioGlobalGeminiThreeDotOneProStream({
-      GOOGLE_AI_STUDIO_API_KEY:
-        process.env.DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY ?? "",
-    }),
-  // `null` runs the case with its default checkers; a checker array overrides
-  // them. Every case always runs.
-  tests: {
-    // Pro supports none/low/medium/high; `minimal` and `maximal` are rejected.
-    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+export const GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new GoogleAiStudioGlobalGeminiThreeDotOneProStream({
+        GOOGLE_AI_STUDIO_API_KEY:
+          process.env.DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY ?? "",
+      }),
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    tests: {
+      // Pro supports none/low/medium/high; `minimal` and `maximal` are rejected.
+      "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
 
-    "simple/no-tools/t-default/r-none": null,
-    "simple/no-tools/t-0/r-none": null,
-    "simple/no-tools/t-0.1/r-none": null,
-    "simple/no-tools/t-1/r-none": null,
-    "calc/calc/t-default/r-none/force-tool": null,
-    "reasoning/no-tools/t-default/r-none": null,
-    "output-format/json-schema/t-default/r-none": null,
+      "simple/no-tools/t-default/r-none": null,
+      "simple/no-tools/t-0/r-none": null,
+      "simple/no-tools/t-0.1/r-none": null,
+      "simple/no-tools/t-1/r-none": null,
+      "calc/calc/t-default/r-none/force-tool": null,
+      "reasoning/no-tools/t-default/r-none": null,
+      "output-format/json-schema/t-default/r-none": null,
 
-    "simple/no-tools/t-default/r-default": null,
-    "simple/no-tools/t-default/r-low": null,
-    "simple/no-tools/t-default/r-medium": null,
-    "simple/no-tools/t-default/r-high": null,
-    "simple/no-tools/t-0/r-default": null,
-    "simple/no-tools/t-0/r-low": null,
-    "simple/no-tools/t-0/r-medium": null,
-    "simple/no-tools/t-0/r-high": null,
-    "simple/no-tools/t-0.1/r-default": null,
-    "simple/no-tools/t-0.1/r-low": null,
-    "simple/no-tools/t-0.1/r-medium": null,
-    "simple/no-tools/t-0.1/r-high": null,
-    "simple/no-tools/t-1/r-default": null,
-    "simple/no-tools/t-1/r-low": null,
-    "simple/no-tools/t-1/r-medium": null,
-    "simple/no-tools/t-1/r-high": null,
+      "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-0/r-default": null,
+      "simple/no-tools/t-0/r-low": null,
+      "simple/no-tools/t-0/r-medium": null,
+      "simple/no-tools/t-0/r-high": null,
+      "simple/no-tools/t-0.1/r-default": null,
+      "simple/no-tools/t-0.1/r-low": null,
+      "simple/no-tools/t-0.1/r-medium": null,
+      "simple/no-tools/t-0.1/r-high": null,
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
 
-    // Gemini ignores the Anthropic-style cache markers (it uses implicit
-    // caching), so this behaves like a plain "say Hi" prompt.
-    "cache/no-tools/t-default/r-default": null,
+      // Gemini ignores the Anthropic-style cache markers (it uses implicit
+      // caching), so this behaves like a plain "say Hi" prompt.
+      "cache/no-tools/t-default/r-default": null,
 
-    "calc/calc/t-default/r-medium": null,
-    "calc/calc/t-0.1/r-default": null,
-    "calc/calc/t-0.1/r-medium": null,
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": null,
+      "calc/calc/t-0.1/r-medium": null,
 
-    "calc/calc/t-default/r-default/force-tool-default": null,
-    "calc/calc/t-default/r-default/force-tool": null,
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-default/force-tool": null,
 
-    "reasoning/no-tools/t-default/r-low": null,
+      "reasoning/no-tools/t-default/r-low": null,
 
-    "output-format/json-schema/t-default/r-high": null,
+      "output-format/json-schema/t-default/r-high": null,
 
-    "following/no-tools/t-default/r-default": null,
-  },
-};
+      "following/no-tools/t-default/r-default": null,
+    },
+  };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
-runStreamEndpointTests(GoogleAiStudioGlobalGeminiThreeDotOneProStream, GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup);
+runStreamEndpointTests(
+  GoogleAiStudioGlobalGeminiThreeDotOneProStream,
+  GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_codestral.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_codestral.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const MistralEuropeCodestralStreamSetup: StreamSetup = {
   createInstance: () =>
     new MistralEuropeCodestralStream({
       MISTRAL_API_KEY: process.env.DUST_MANAGED_MISTRAL_API_KEY ?? "",
@@ -64,4 +64,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_codestral.test.ts
-runStreamEndpointTests(MistralEuropeCodestralStream, setup);
+runStreamEndpointTests(MistralEuropeCodestralStream, MistralEuropeCodestralStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_codestral.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_codestral.test.ts
@@ -64,4 +64,7 @@ export const MistralEuropeCodestralStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_codestral.test.ts
-runStreamEndpointTests(MistralEuropeCodestralStream, MistralEuropeCodestralStreamSetup);
+runStreamEndpointTests(
+  MistralEuropeCodestralStream,
+  MistralEuropeCodestralStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test.ts
@@ -64,4 +64,7 @@ export const MistralEuropeMistralLargeStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test.ts
-runStreamEndpointTests(MistralEuropeMistralLargeStream, MistralEuropeMistralLargeStreamSetup);
+runStreamEndpointTests(
+  MistralEuropeMistralLargeStream,
+  MistralEuropeMistralLargeStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const MistralEuropeMistralLargeStreamSetup: StreamSetup = {
   createInstance: () =>
     new MistralEuropeMistralLargeStream({
       MISTRAL_API_KEY: process.env.DUST_MANAGED_MISTRAL_API_KEY ?? "",
@@ -64,4 +64,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test.ts
-runStreamEndpointTests(MistralEuropeMistralLargeStream, setup);
+runStreamEndpointTests(MistralEuropeMistralLargeStream, MistralEuropeMistralLargeStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const MistralEuropeMistralMedium35StreamSetup: StreamSetup = {
   createInstance: () =>
     new MistralEuropeMistralMedium35Stream({
       MISTRAL_API_KEY: process.env.DUST_MANAGED_MISTRAL_API_KEY ?? "",
@@ -64,4 +64,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test.ts
-runStreamEndpointTests(MistralEuropeMistralMedium35Stream, setup);
+runStreamEndpointTests(MistralEuropeMistralMedium35Stream, MistralEuropeMistralMedium35StreamSetup);

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test.ts
@@ -64,4 +64,7 @@ export const MistralEuropeMistralMedium35StreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test.ts
-runStreamEndpointTests(MistralEuropeMistralMedium35Stream, MistralEuropeMistralMedium35StreamSetup);
+runStreamEndpointTests(
+  MistralEuropeMistralMedium35Stream,
+  MistralEuropeMistralMedium35StreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const MistralEuropeMistralSmallStreamSetup: StreamSetup = {
   createInstance: () =>
     new MistralEuropeMistralSmallStream({
       MISTRAL_API_KEY: process.env.DUST_MANAGED_MISTRAL_API_KEY ?? "",
@@ -64,4 +64,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test.ts
-runStreamEndpointTests(MistralEuropeMistralSmallStream, setup);
+runStreamEndpointTests(MistralEuropeMistralSmallStream, MistralEuropeMistralSmallStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test.ts
@@ -64,4 +64,7 @@ export const MistralEuropeMistralSmallStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test.ts
-runStreamEndpointTests(MistralEuropeMistralSmallStream, MistralEuropeMistralSmallStreamSetup);
+runStreamEndpointTests(
+  MistralEuropeMistralSmallStream,
+  MistralEuropeMistralSmallStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five.test.ts
@@ -69,4 +69,7 @@ export const OpenAIResponsesEuropeGptFiveStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five.test.ts
-runStreamEndpointTests(OpenAIResponsesEuropeGptFiveStream, OpenAIResponsesEuropeGptFiveStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesEuropeGptFiveStream,
+  OpenAIResponsesEuropeGptFiveStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+
+import { OpenAIResponsesEuropeGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const OpenAIResponsesEuropeGptFiveStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesEuropeGptFiveStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // gpt-5 maps reasoning "none" to "minimal", so it runs normally. The
+    // universal "maximal" (mapped to the unsupported "xhigh") remains an input
+    // config error.
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-none/force-tool": null,
+    "reasoning/no-tools/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-none": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-minimal": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    // gpt-5 rejects an explicit temperature; the schema strips it, so these
+    // succeed with the model default.
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-minimal": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-minimal": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-minimal": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five.test.ts
+runStreamEndpointTests(OpenAIResponsesEuropeGptFiveStream, OpenAIResponsesEuropeGptFiveStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_five.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import { OpenAIResponsesEuropeGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_five";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const OpenAIResponsesEuropeGptFiveDotFiveStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesEuropeGptFiveDotFiveStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // "minimal" and "maximal" reasoning efforts are not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    // Unlike Anthropic, the Responses API accepts a forced tool without
+    // requiring reasoning "none", so this is a normal tool call.
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_five.test.ts
+runStreamEndpointTests(OpenAIResponsesEuropeGptFiveDotFiveStream, OpenAIResponsesEuropeGptFiveDotFiveStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_five.test.ts
@@ -67,4 +67,7 @@ export const OpenAIResponsesEuropeGptFiveDotFiveStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_five.test.ts
-runStreamEndpointTests(OpenAIResponsesEuropeGptFiveDotFiveStream, OpenAIResponsesEuropeGptFiveDotFiveStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesEuropeGptFiveDotFiveStream,
+  OpenAIResponsesEuropeGptFiveDotFiveStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four.test.ts
@@ -67,4 +67,7 @@ export const OpenAIResponsesEuropeGptFiveDotFourStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four.test.ts
-runStreamEndpointTests(OpenAIResponsesEuropeGptFiveDotFourStream, OpenAIResponsesEuropeGptFiveDotFourStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesEuropeGptFiveDotFourStream,
+  OpenAIResponsesEuropeGptFiveDotFourStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import { OpenAIResponsesEuropeGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const OpenAIResponsesEuropeGptFiveDotFourStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesEuropeGptFiveDotFourStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // "minimal" and "maximal" reasoning efforts are not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    // Unlike Anthropic, the Responses API accepts a forced tool without
+    // requiring reasoning "none", so this is a normal tool call.
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four.test.ts
+runStreamEndpointTests(OpenAIResponsesEuropeGptFiveDotFourStream, OpenAIResponsesEuropeGptFiveDotFourStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_mini.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_mini.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { OpenAIResponsesEuropeGptFiveDotFourMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_mini";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const OpenAIResponsesEuropeGptFiveDotFourMiniStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesEuropeGptFiveDotFourMiniStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // "minimal" and "maximal" reasoning efforts are not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_mini.test.ts
+runStreamEndpointTests(OpenAIResponsesEuropeGptFiveDotFourMiniStream, OpenAIResponsesEuropeGptFiveDotFourMiniStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_mini.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_mini.test.ts
@@ -65,4 +65,7 @@ export const OpenAIResponsesEuropeGptFiveDotFourMiniStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_mini.test.ts
-runStreamEndpointTests(OpenAIResponsesEuropeGptFiveDotFourMiniStream, OpenAIResponsesEuropeGptFiveDotFourMiniStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesEuropeGptFiveDotFourMiniStream,
+  OpenAIResponsesEuropeGptFiveDotFourMiniStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_nano.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_nano.test.ts
@@ -67,4 +67,7 @@ export const OpenAIResponsesEuropeGptFiveDotFourNanoStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_nano.test.ts
-runStreamEndpointTests(OpenAIResponsesEuropeGptFiveDotFourNanoStream, OpenAIResponsesEuropeGptFiveDotFourNanoStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesEuropeGptFiveDotFourNanoStream,
+  OpenAIResponsesEuropeGptFiveDotFourNanoStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_nano.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_nano.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import { OpenAIResponsesEuropeGptFiveDotFourNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_nano";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const OpenAIResponsesEuropeGptFiveDotFourNanoStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesEuropeGptFiveDotFourNanoStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // "minimal" and "maximal" reasoning efforts are not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    // Unlike Anthropic, the Responses API accepts a forced tool without
+    // requiring reasoning "none", so this is a normal tool call.
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_nano.test.ts
+runStreamEndpointTests(OpenAIResponsesEuropeGptFiveDotFourNanoStream, OpenAIResponsesEuropeGptFiveDotFourNanoStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_one.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_one.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import { OpenAIResponsesEuropeGptFiveDotOneStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_one";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const OpenAIResponsesEuropeGptFiveDotOneStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesEuropeGptFiveDotOneStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // "minimal" and "maximal" reasoning efforts are not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    // Unlike Anthropic, the Responses API accepts a forced tool without
+    // requiring reasoning "none", so this is a normal tool call.
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_one.test.ts
+runStreamEndpointTests(OpenAIResponsesEuropeGptFiveDotOneStream, OpenAIResponsesEuropeGptFiveDotOneStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_one.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_one.test.ts
@@ -67,4 +67,7 @@ export const OpenAIResponsesEuropeGptFiveDotOneStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_one.test.ts
-runStreamEndpointTests(OpenAIResponsesEuropeGptFiveDotOneStream, OpenAIResponsesEuropeGptFiveDotOneStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesEuropeGptFiveDotOneStream,
+  OpenAIResponsesEuropeGptFiveDotOneStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_two.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_two.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import { OpenAIResponsesEuropeGptFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_two";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const OpenAIResponsesEuropeGptFiveDotTwoStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesEuropeGptFiveDotTwoStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // "minimal" and "maximal" reasoning efforts are not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    // Unlike Anthropic, the Responses API accepts a forced tool without
+    // requiring reasoning "none", so this is a normal tool call.
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_two.test.ts
+runStreamEndpointTests(OpenAIResponsesEuropeGptFiveDotTwoStream, OpenAIResponsesEuropeGptFiveDotTwoStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_two.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_two.test.ts
@@ -67,4 +67,7 @@ export const OpenAIResponsesEuropeGptFiveDotTwoStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_two.test.ts
-runStreamEndpointTests(OpenAIResponsesEuropeGptFiveDotTwoStream, OpenAIResponsesEuropeGptFiveDotTwoStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesEuropeGptFiveDotTwoStream,
+  OpenAIResponsesEuropeGptFiveDotTwoStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_mini.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_mini.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+
+import { OpenAIResponsesEuropeGptFiveMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_mini";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const OpenAIResponsesEuropeGptFiveMiniStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesEuropeGptFiveMiniStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // gpt-5-mini maps reasoning "none" to "minimal", so it runs normally. The
+    // universal "maximal" (mapped to the unsupported "xhigh") remains an input
+    // config error.
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-minimal": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-minimal": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-minimal": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-minimal": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    // Reasoning "none" maps to "minimal", so the forced tool call runs normally.
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_mini.test.ts
+runStreamEndpointTests(OpenAIResponsesEuropeGptFiveMiniStream, OpenAIResponsesEuropeGptFiveMiniStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_mini.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_mini.test.ts
@@ -68,4 +68,7 @@ export const OpenAIResponsesEuropeGptFiveMiniStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_mini.test.ts
-runStreamEndpointTests(OpenAIResponsesEuropeGptFiveMiniStream, OpenAIResponsesEuropeGptFiveMiniStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesEuropeGptFiveMiniStream,
+  OpenAIResponsesEuropeGptFiveMiniStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_nano.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_nano.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+
+import { OpenAIResponsesEuropeGptFiveNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_nano";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const OpenAIResponsesEuropeGptFiveNanoStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesEuropeGptFiveNanoStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // gpt-5-nano supports "minimal" reasoning (unlike gpt-5.5), so these pass.
+    "simple/no-tools/t-default/r-minimal": null,
+    "simple/no-tools/t-0/r-minimal": null,
+    "simple/no-tools/t-0.1/r-minimal": null,
+    "simple/no-tools/t-1/r-minimal": null,
+    // "none" maps to "minimal", so it runs normally. "maximal" (→ xhigh) is
+    // unsupported and rejected locally.
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    // The Responses API accepts a forced tool without requiring reasoning
+    // "none", so this is a normal tool call.
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_nano.test.ts
+runStreamEndpointTests(OpenAIResponsesEuropeGptFiveNanoStream, OpenAIResponsesEuropeGptFiveNanoStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_nano.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_nano.test.ts
@@ -69,4 +69,7 @@ export const OpenAIResponsesEuropeGptFiveNanoStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_nano.test.ts
-runStreamEndpointTests(OpenAIResponsesEuropeGptFiveNanoStream, OpenAIResponsesEuropeGptFiveNanoStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesEuropeGptFiveNanoStream,
+  OpenAIResponsesEuropeGptFiveNanoStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const OpenAIResponsesGlobalGptFiveStreamSetup: StreamSetup = {
   createInstance: () =>
     new OpenAIResponsesGlobalGptFiveStream({
       OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
@@ -69,4 +69,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveStream, setup);
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveStream, OpenAIResponsesGlobalGptFiveStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test.ts
@@ -69,4 +69,7 @@ export const OpenAIResponsesGlobalGptFiveStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveStream, OpenAIResponsesGlobalGptFiveStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesGlobalGptFiveStream,
+  OpenAIResponsesGlobalGptFiveStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_five.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const OpenAIResponsesGlobalGptFiveDotFiveStreamSetup: StreamSetup = {
   createInstance: () =>
     new OpenAIResponsesGlobalGptFiveDotFiveStream({
       OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
@@ -67,4 +67,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_five.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFiveStream, setup);
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFiveStream, OpenAIResponsesGlobalGptFiveDotFiveStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_five.test.ts
@@ -67,4 +67,7 @@ export const OpenAIResponsesGlobalGptFiveDotFiveStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_five.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFiveStream, OpenAIResponsesGlobalGptFiveDotFiveStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesGlobalGptFiveDotFiveStream,
+  OpenAIResponsesGlobalGptFiveDotFiveStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const OpenAIResponsesGlobalGptFiveDotFourStreamSetup: StreamSetup = {
   createInstance: () =>
     new OpenAIResponsesGlobalGptFiveDotFourStream({
       OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
@@ -67,4 +67,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFourStream, setup);
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFourStream, OpenAIResponsesGlobalGptFiveDotFourStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test.ts
@@ -67,4 +67,7 @@ export const OpenAIResponsesGlobalGptFiveDotFourStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFourStream, OpenAIResponsesGlobalGptFiveDotFourStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesGlobalGptFiveDotFourStream,
+  OpenAIResponsesGlobalGptFiveDotFourStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_mini.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_mini.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup: StreamSetup = {
   createInstance: () =>
     new OpenAIResponsesGlobalGptFiveDotFourMiniStream({
       OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
@@ -65,4 +65,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_mini.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFourMiniStream, setup);
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFourMiniStream, OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_mini.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_mini.test.ts
@@ -65,4 +65,7 @@ export const OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_mini.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFourMiniStream, OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesGlobalGptFiveDotFourMiniStream,
+  OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_nano.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_nano.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup: StreamSetup = {
   createInstance: () =>
     new OpenAIResponsesGlobalGptFiveDotFourNanoStream({
       OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
@@ -67,4 +67,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_nano.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFourNanoStream, setup);
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFourNanoStream, OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_nano.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_nano.test.ts
@@ -67,4 +67,7 @@ export const OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_nano.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFourNanoStream, OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesGlobalGptFiveDotFourNanoStream,
+  OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_one.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_one.test.ts
@@ -67,4 +67,7 @@ export const OpenAIResponsesGlobalGptFiveDotOneStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_one.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotOneStream, OpenAIResponsesGlobalGptFiveDotOneStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesGlobalGptFiveDotOneStream,
+  OpenAIResponsesGlobalGptFiveDotOneStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_one.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_one.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const OpenAIResponsesGlobalGptFiveDotOneStreamSetup: StreamSetup = {
   createInstance: () =>
     new OpenAIResponsesGlobalGptFiveDotOneStream({
       OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
@@ -67,4 +67,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_one.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotOneStream, setup);
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotOneStream, OpenAIResponsesGlobalGptFiveDotOneStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_two.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_two.test.ts
@@ -67,4 +67,7 @@ export const OpenAIResponsesGlobalGptFiveDotTwoStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_two.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotTwoStream, OpenAIResponsesGlobalGptFiveDotTwoStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesGlobalGptFiveDotTwoStream,
+  OpenAIResponsesGlobalGptFiveDotTwoStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_two.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_two.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const OpenAIResponsesGlobalGptFiveDotTwoStreamSetup: StreamSetup = {
   createInstance: () =>
     new OpenAIResponsesGlobalGptFiveDotTwoStream({
       OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
@@ -67,4 +67,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_two.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotTwoStream, setup);
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotTwoStream, OpenAIResponsesGlobalGptFiveDotTwoStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_mini.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_mini.test.ts
@@ -68,4 +68,7 @@ export const OpenAIResponsesGlobalGptFiveMiniStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_mini.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveMiniStream, OpenAIResponsesGlobalGptFiveMiniStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesGlobalGptFiveMiniStream,
+  OpenAIResponsesGlobalGptFiveMiniStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_mini.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_mini.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const OpenAIResponsesGlobalGptFiveMiniStreamSetup: StreamSetup = {
   createInstance: () =>
     new OpenAIResponsesGlobalGptFiveMiniStream({
       OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
@@ -68,4 +68,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_mini.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveMiniStream, setup);
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveMiniStream, OpenAIResponsesGlobalGptFiveMiniStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_nano.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_nano.test.ts
@@ -5,7 +5,7 @@ import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/case
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const OpenAIResponsesGlobalGptFiveNanoStreamSetup: StreamSetup = {
   createInstance: () =>
     new OpenAIResponsesGlobalGptFiveNanoStream({
       OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
@@ -69,4 +69,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_nano.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveNanoStream, setup);
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveNanoStream, OpenAIResponsesGlobalGptFiveNanoStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_nano.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_nano.test.ts
@@ -69,4 +69,7 @@ export const OpenAIResponsesGlobalGptFiveNanoStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_nano.test.ts
-runStreamEndpointTests(OpenAIResponsesGlobalGptFiveNanoStream, OpenAIResponsesGlobalGptFiveNanoStreamSetup);
+runStreamEndpointTests(
+  OpenAIResponsesGlobalGptFiveNanoStream,
+  OpenAIResponsesGlobalGptFiveNanoStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/setups.ts
+++ b/front/lib/model_constructors/test/endpoints/setups.ts
@@ -1,0 +1,121 @@
+// Completeness map: every stream endpoint must have a corresponding test
+// setup here. The `satisfies Record<StreamEndpointId, StreamSetup>` fails to
+// type-check when a new endpoint is added to `STREAM_ENDPOINTS` without a
+// matching test file exporting its `setup`, forcing the test to be written.
+import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
+import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
+import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
+import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
+import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
+import { AnthropicGlobalClaudeFableFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_fable_five";
+import { AnthropicGlobalClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five";
+import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
+import { AnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
+import { AnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
+import { AnthropicGlobalClaudeSonnetFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_five";
+import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { FireworksGlobalDeepSeekV4ProStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_deepseek_v4_pro";
+import { FireworksGlobalGlmFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_glm_five_dot_two";
+import { FireworksGlobalKimiK2Dot5Stream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_kimi_k2_dot_five";
+import { GoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { MistralEuropeCodestralStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_codestral";
+import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
+import { MistralEuropeMistralMedium35Stream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5";
+import { MistralEuropeMistralSmallStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_small";
+import { OpenAIResponsesGlobalGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five";
+import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
+import { OpenAIResponsesGlobalGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four";
+import { OpenAIResponsesGlobalGptFiveDotFourMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini";
+import { OpenAIResponsesGlobalGptFiveDotFourNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_nano";
+import { OpenAIResponsesGlobalGptFiveDotOneStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_one";
+import { OpenAIResponsesGlobalGptFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_two";
+import { OpenAIResponsesGlobalGptFiveMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_mini";
+import { OpenAIResponsesGlobalGptFiveNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_nano";
+import { TogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/model_constructors/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo";
+import { AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test";
+import { AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test";
+import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test";
+import { AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test";
+import { AnthropicGlobalClaudeFableFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test";
+import { AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test";
+import { AnthropicGlobalClaudeOpusFourDotEightStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test";
+import { AnthropicGlobalClaudeOpusFourDotSevenStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_seven.test";
+import { AnthropicGlobalClaudeOpusFourDotSixStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_six.test";
+import { AnthropicGlobalClaudeSonnetFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_five.test";
+import { AnthropicGlobalClaudeSonnetFourDotSixStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_four_dot_six.test";
+import { FireworksGlobalDeepSeekV4ProStreamSetup } from "@app/lib/model_constructors/test/endpoints/fireworks_global_deepseek_v4_pro.test";
+import { FireworksGlobalGlmFiveDotTwoStreamSetup } from "@app/lib/model_constructors/test/endpoints/fireworks_global_glm_five_dot_two.test";
+import { FireworksGlobalKimiK2Dot5StreamSetup } from "@app/lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_five.test";
+import { GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test";
+import { MistralEuropeCodestralStreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_codestral.test";
+import { MistralEuropeMistralLargeStreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test";
+import { MistralEuropeMistralMedium35StreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test";
+import { MistralEuropeMistralSmallStreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test";
+import { OpenAIResponsesGlobalGptFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test";
+import { OpenAIResponsesGlobalGptFiveDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_five.test";
+import { OpenAIResponsesGlobalGptFiveDotFourStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test";
+import { OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_mini.test";
+import { OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_nano.test";
+import { OpenAIResponsesGlobalGptFiveDotOneStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_one.test";
+import { OpenAIResponsesGlobalGptFiveDotTwoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_two.test";
+import { OpenAIResponsesGlobalGptFiveMiniStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_mini.test";
+import { OpenAIResponsesGlobalGptFiveNanoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_nano.test";
+import { TogetheraiGlobalLlama3370BInstructTurboStreamSetup } from "@app/lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const STREAM_ENDPOINT_SETUPS = {
+  [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
+    AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup,
+  [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
+    AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup,
+  [AgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]:
+    AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup,
+  [AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]:
+    AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup,
+  [AnthropicGlobalClaudeFableFiveStream.id]:
+    AnthropicGlobalClaudeFableFiveStreamSetup,
+  [AnthropicGlobalClaudeHaikuFourDotFiveStream.id]:
+    AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup,
+  [AnthropicGlobalClaudeOpusFourDotEightStream.id]:
+    AnthropicGlobalClaudeOpusFourDotEightStreamSetup,
+  [AnthropicGlobalClaudeOpusFourDotSevenStream.id]:
+    AnthropicGlobalClaudeOpusFourDotSevenStreamSetup,
+  [AnthropicGlobalClaudeOpusFourDotSixStream.id]:
+    AnthropicGlobalClaudeOpusFourDotSixStreamSetup,
+  [AnthropicGlobalClaudeSonnetFiveStream.id]:
+    AnthropicGlobalClaudeSonnetFiveStreamSetup,
+  [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:
+    AnthropicGlobalClaudeSonnetFourDotSixStreamSetup,
+  [FireworksGlobalDeepSeekV4ProStream.id]:
+    FireworksGlobalDeepSeekV4ProStreamSetup,
+  [FireworksGlobalGlmFiveDotTwoStream.id]:
+    FireworksGlobalGlmFiveDotTwoStreamSetup,
+  [FireworksGlobalKimiK2Dot5Stream.id]: FireworksGlobalKimiK2Dot5StreamSetup,
+  [GoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
+    GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup,
+  [MistralEuropeCodestralStream.id]: MistralEuropeCodestralStreamSetup,
+  [MistralEuropeMistralLargeStream.id]: MistralEuropeMistralLargeStreamSetup,
+  [MistralEuropeMistralMedium35Stream.id]:
+    MistralEuropeMistralMedium35StreamSetup,
+  [MistralEuropeMistralSmallStream.id]: MistralEuropeMistralSmallStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotFiveStream.id]:
+    OpenAIResponsesGlobalGptFiveDotFiveStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotFourMiniStream.id]:
+    OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotFourNanoStream.id]:
+    OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotFourStream.id]:
+    OpenAIResponsesGlobalGptFiveDotFourStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotOneStream.id]:
+    OpenAIResponsesGlobalGptFiveDotOneStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotTwoStream.id]:
+    OpenAIResponsesGlobalGptFiveDotTwoStreamSetup,
+  [OpenAIResponsesGlobalGptFiveMiniStream.id]:
+    OpenAIResponsesGlobalGptFiveMiniStreamSetup,
+  [OpenAIResponsesGlobalGptFiveNanoStream.id]:
+    OpenAIResponsesGlobalGptFiveNanoStreamSetup,
+  [OpenAIResponsesGlobalGptFiveStream.id]:
+    OpenAIResponsesGlobalGptFiveStreamSetup,
+  [TogetheraiGlobalLlama3370BInstructTurboStream.id]:
+    TogetheraiGlobalLlama3370BInstructTurboStreamSetup,
+} satisfies Record<StreamEndpointId, StreamSetup>;

--- a/front/lib/model_constructors/test/endpoints/setups.ts
+++ b/front/lib/model_constructors/test/endpoints/setups.ts
@@ -3,10 +3,11 @@
 // type-check when a new endpoint is added to `STREAM_ENDPOINTS` without a
 // matching test file exporting its `setup`, forcing the test to be written.
 import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
-import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
 import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
+import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
 import { AnthropicGlobalClaudeFableFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_fable_five";
 import { AnthropicGlobalClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five";
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
@@ -22,20 +23,29 @@ import { MistralEuropeCodestralStream } from "@app/lib/model_constructors/stream
 import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
 import { MistralEuropeMistralMedium35Stream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5";
 import { MistralEuropeMistralSmallStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_small";
-import { OpenAIResponsesGlobalGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five";
+import { OpenAIResponsesEuropeGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_five";
+import { OpenAIResponsesEuropeGptFiveDotFourMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_mini";
+import { OpenAIResponsesEuropeGptFiveDotFourNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_nano";
+import { OpenAIResponsesEuropeGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four";
+import { OpenAIResponsesEuropeGptFiveDotOneStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_one";
+import { OpenAIResponsesEuropeGptFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_two";
+import { OpenAIResponsesEuropeGptFiveMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_mini";
+import { OpenAIResponsesEuropeGptFiveNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_nano";
+import { OpenAIResponsesEuropeGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
-import { OpenAIResponsesGlobalGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four";
 import { OpenAIResponsesGlobalGptFiveDotFourMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini";
 import { OpenAIResponsesGlobalGptFiveDotFourNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_nano";
+import { OpenAIResponsesGlobalGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four";
 import { OpenAIResponsesGlobalGptFiveDotOneStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_one";
 import { OpenAIResponsesGlobalGptFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_two";
 import { OpenAIResponsesGlobalGptFiveMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_mini";
 import { OpenAIResponsesGlobalGptFiveNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_nano";
+import { OpenAIResponsesGlobalGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five";
 import { TogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/model_constructors/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo";
 import { AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test";
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test";
-import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test";
 import { AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test";
+import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test";
 import { AnthropicGlobalClaudeFableFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test";
 import { AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test";
 import { AnthropicGlobalClaudeOpusFourDotEightStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test";
@@ -51,71 +61,63 @@ import { MistralEuropeCodestralStreamSetup } from "@app/lib/model_constructors/t
 import { MistralEuropeMistralLargeStreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test";
 import { MistralEuropeMistralMedium35StreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test";
 import { MistralEuropeMistralSmallStreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test";
-import { OpenAIResponsesGlobalGptFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test";
+import { OpenAIResponsesEuropeGptFiveDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_five.test";
+import { OpenAIResponsesEuropeGptFiveDotFourMiniStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_mini.test";
+import { OpenAIResponsesEuropeGptFiveDotFourNanoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_nano.test";
+import { OpenAIResponsesEuropeGptFiveDotFourStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four.test";
+import { OpenAIResponsesEuropeGptFiveDotOneStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_one.test";
+import { OpenAIResponsesEuropeGptFiveDotTwoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_two.test";
+import { OpenAIResponsesEuropeGptFiveMiniStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_mini.test";
+import { OpenAIResponsesEuropeGptFiveNanoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_nano.test";
+import { OpenAIResponsesEuropeGptFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five.test";
 import { OpenAIResponsesGlobalGptFiveDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_five.test";
-import { OpenAIResponsesGlobalGptFiveDotFourStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test";
 import { OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_mini.test";
 import { OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_nano.test";
+import { OpenAIResponsesGlobalGptFiveDotFourStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test";
 import { OpenAIResponsesGlobalGptFiveDotOneStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_one.test";
 import { OpenAIResponsesGlobalGptFiveDotTwoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_two.test";
 import { OpenAIResponsesGlobalGptFiveMiniStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_mini.test";
 import { OpenAIResponsesGlobalGptFiveNanoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_nano.test";
+import { OpenAIResponsesGlobalGptFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test";
 import { TogetheraiGlobalLlama3370BInstructTurboStreamSetup } from "@app/lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test";
-import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
 export const STREAM_ENDPOINT_SETUPS = {
-  [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
-    AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup,
-  [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
-    AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup,
-  [AgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]:
-    AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup,
-  [AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]:
-    AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup,
-  [AnthropicGlobalClaudeFableFiveStream.id]:
-    AnthropicGlobalClaudeFableFiveStreamSetup,
-  [AnthropicGlobalClaudeHaikuFourDotFiveStream.id]:
-    AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup,
-  [AnthropicGlobalClaudeOpusFourDotEightStream.id]:
-    AnthropicGlobalClaudeOpusFourDotEightStreamSetup,
-  [AnthropicGlobalClaudeOpusFourDotSevenStream.id]:
-    AnthropicGlobalClaudeOpusFourDotSevenStreamSetup,
-  [AnthropicGlobalClaudeOpusFourDotSixStream.id]:
-    AnthropicGlobalClaudeOpusFourDotSixStreamSetup,
-  [AnthropicGlobalClaudeSonnetFiveStream.id]:
-    AnthropicGlobalClaudeSonnetFiveStreamSetup,
-  [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:
-    AnthropicGlobalClaudeSonnetFourDotSixStreamSetup,
-  [FireworksGlobalDeepSeekV4ProStream.id]:
-    FireworksGlobalDeepSeekV4ProStreamSetup,
-  [FireworksGlobalGlmFiveDotTwoStream.id]:
-    FireworksGlobalGlmFiveDotTwoStreamSetup,
+  [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]: AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup,
+  [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]: AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup,
+  [AgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]: AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup,
+  [AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]: AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup,
+  [AnthropicGlobalClaudeFableFiveStream.id]: AnthropicGlobalClaudeFableFiveStreamSetup,
+  [AnthropicGlobalClaudeHaikuFourDotFiveStream.id]: AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup,
+  [AnthropicGlobalClaudeOpusFourDotEightStream.id]: AnthropicGlobalClaudeOpusFourDotEightStreamSetup,
+  [AnthropicGlobalClaudeOpusFourDotSevenStream.id]: AnthropicGlobalClaudeOpusFourDotSevenStreamSetup,
+  [AnthropicGlobalClaudeOpusFourDotSixStream.id]: AnthropicGlobalClaudeOpusFourDotSixStreamSetup,
+  [AnthropicGlobalClaudeSonnetFiveStream.id]: AnthropicGlobalClaudeSonnetFiveStreamSetup,
+  [AnthropicGlobalClaudeSonnetFourDotSixStream.id]: AnthropicGlobalClaudeSonnetFourDotSixStreamSetup,
+  [FireworksGlobalDeepSeekV4ProStream.id]: FireworksGlobalDeepSeekV4ProStreamSetup,
+  [FireworksGlobalGlmFiveDotTwoStream.id]: FireworksGlobalGlmFiveDotTwoStreamSetup,
   [FireworksGlobalKimiK2Dot5Stream.id]: FireworksGlobalKimiK2Dot5StreamSetup,
-  [GoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
-    GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup,
+  [GoogleAiStudioGlobalGeminiThreeDotOneProStream.id]: GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup,
   [MistralEuropeCodestralStream.id]: MistralEuropeCodestralStreamSetup,
   [MistralEuropeMistralLargeStream.id]: MistralEuropeMistralLargeStreamSetup,
-  [MistralEuropeMistralMedium35Stream.id]:
-    MistralEuropeMistralMedium35StreamSetup,
+  [MistralEuropeMistralMedium35Stream.id]: MistralEuropeMistralMedium35StreamSetup,
   [MistralEuropeMistralSmallStream.id]: MistralEuropeMistralSmallStreamSetup,
-  [OpenAIResponsesGlobalGptFiveDotFiveStream.id]:
-    OpenAIResponsesGlobalGptFiveDotFiveStreamSetup,
-  [OpenAIResponsesGlobalGptFiveDotFourMiniStream.id]:
-    OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup,
-  [OpenAIResponsesGlobalGptFiveDotFourNanoStream.id]:
-    OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup,
-  [OpenAIResponsesGlobalGptFiveDotFourStream.id]:
-    OpenAIResponsesGlobalGptFiveDotFourStreamSetup,
-  [OpenAIResponsesGlobalGptFiveDotOneStream.id]:
-    OpenAIResponsesGlobalGptFiveDotOneStreamSetup,
-  [OpenAIResponsesGlobalGptFiveDotTwoStream.id]:
-    OpenAIResponsesGlobalGptFiveDotTwoStreamSetup,
-  [OpenAIResponsesGlobalGptFiveMiniStream.id]:
-    OpenAIResponsesGlobalGptFiveMiniStreamSetup,
-  [OpenAIResponsesGlobalGptFiveNanoStream.id]:
-    OpenAIResponsesGlobalGptFiveNanoStreamSetup,
-  [OpenAIResponsesGlobalGptFiveStream.id]:
-    OpenAIResponsesGlobalGptFiveStreamSetup,
-  [TogetheraiGlobalLlama3370BInstructTurboStream.id]:
-    TogetheraiGlobalLlama3370BInstructTurboStreamSetup,
+  [OpenAIResponsesEuropeGptFiveDotFiveStream.id]: OpenAIResponsesEuropeGptFiveDotFiveStreamSetup,
+  [OpenAIResponsesEuropeGptFiveDotFourMiniStream.id]: OpenAIResponsesEuropeGptFiveDotFourMiniStreamSetup,
+  [OpenAIResponsesEuropeGptFiveDotFourNanoStream.id]: OpenAIResponsesEuropeGptFiveDotFourNanoStreamSetup,
+  [OpenAIResponsesEuropeGptFiveDotFourStream.id]: OpenAIResponsesEuropeGptFiveDotFourStreamSetup,
+  [OpenAIResponsesEuropeGptFiveDotOneStream.id]: OpenAIResponsesEuropeGptFiveDotOneStreamSetup,
+  [OpenAIResponsesEuropeGptFiveDotTwoStream.id]: OpenAIResponsesEuropeGptFiveDotTwoStreamSetup,
+  [OpenAIResponsesEuropeGptFiveMiniStream.id]: OpenAIResponsesEuropeGptFiveMiniStreamSetup,
+  [OpenAIResponsesEuropeGptFiveNanoStream.id]: OpenAIResponsesEuropeGptFiveNanoStreamSetup,
+  [OpenAIResponsesEuropeGptFiveStream.id]: OpenAIResponsesEuropeGptFiveStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotFiveStream.id]: OpenAIResponsesGlobalGptFiveDotFiveStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotFourMiniStream.id]: OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotFourNanoStream.id]: OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotFourStream.id]: OpenAIResponsesGlobalGptFiveDotFourStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotOneStream.id]: OpenAIResponsesGlobalGptFiveDotOneStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotTwoStream.id]: OpenAIResponsesGlobalGptFiveDotTwoStreamSetup,
+  [OpenAIResponsesGlobalGptFiveMiniStream.id]: OpenAIResponsesGlobalGptFiveMiniStreamSetup,
+  [OpenAIResponsesGlobalGptFiveNanoStream.id]: OpenAIResponsesGlobalGptFiveNanoStreamSetup,
+  [OpenAIResponsesGlobalGptFiveStream.id]: OpenAIResponsesGlobalGptFiveStreamSetup,
+  [TogetheraiGlobalLlama3370BInstructTurboStream.id]: TogetheraiGlobalLlama3370BInstructTurboStreamSetup,
 } satisfies Record<StreamEndpointId, StreamSetup>;

--- a/front/lib/model_constructors/test/endpoints/setups.ts
+++ b/front/lib/model_constructors/test/endpoints/setups.ts
@@ -3,11 +3,10 @@
 // type-check when a new endpoint is added to `STREAM_ENDPOINTS` without a
 // matching test file exporting its `setup`, forcing the test to be written.
 import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
-import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
-import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
 import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
+import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
 import { AnthropicGlobalClaudeFableFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_fable_five";
 import { AnthropicGlobalClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five";
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
@@ -23,29 +22,29 @@ import { MistralEuropeCodestralStream } from "@app/lib/model_constructors/stream
 import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
 import { MistralEuropeMistralMedium35Stream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5";
 import { MistralEuropeMistralSmallStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_small";
+import { OpenAIResponsesEuropeGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five";
 import { OpenAIResponsesEuropeGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_five";
+import { OpenAIResponsesEuropeGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four";
 import { OpenAIResponsesEuropeGptFiveDotFourMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_mini";
 import { OpenAIResponsesEuropeGptFiveDotFourNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four_nano";
-import { OpenAIResponsesEuropeGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_four";
 import { OpenAIResponsesEuropeGptFiveDotOneStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_one";
 import { OpenAIResponsesEuropeGptFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_dot_two";
 import { OpenAIResponsesEuropeGptFiveMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_mini";
 import { OpenAIResponsesEuropeGptFiveNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five_nano";
-import { OpenAIResponsesEuropeGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_eu_gpt_five";
+import { OpenAIResponsesGlobalGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
+import { OpenAIResponsesGlobalGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four";
 import { OpenAIResponsesGlobalGptFiveDotFourMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini";
 import { OpenAIResponsesGlobalGptFiveDotFourNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_nano";
-import { OpenAIResponsesGlobalGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four";
 import { OpenAIResponsesGlobalGptFiveDotOneStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_one";
 import { OpenAIResponsesGlobalGptFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_two";
 import { OpenAIResponsesGlobalGptFiveMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_mini";
 import { OpenAIResponsesGlobalGptFiveNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_nano";
-import { OpenAIResponsesGlobalGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five";
 import { TogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/model_constructors/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo";
 import { AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test";
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test";
-import { AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test";
 import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test";
+import { AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test";
 import { AnthropicGlobalClaudeFableFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test";
 import { AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test";
 import { AnthropicGlobalClaudeOpusFourDotEightStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test";
@@ -61,63 +60,98 @@ import { MistralEuropeCodestralStreamSetup } from "@app/lib/model_constructors/t
 import { MistralEuropeMistralLargeStreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test";
 import { MistralEuropeMistralMedium35StreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test";
 import { MistralEuropeMistralSmallStreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test";
+import { OpenAIResponsesEuropeGptFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five.test";
 import { OpenAIResponsesEuropeGptFiveDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_five.test";
+import { OpenAIResponsesEuropeGptFiveDotFourStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four.test";
 import { OpenAIResponsesEuropeGptFiveDotFourMiniStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_mini.test";
 import { OpenAIResponsesEuropeGptFiveDotFourNanoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four_nano.test";
-import { OpenAIResponsesEuropeGptFiveDotFourStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_four.test";
 import { OpenAIResponsesEuropeGptFiveDotOneStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_one.test";
 import { OpenAIResponsesEuropeGptFiveDotTwoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_dot_two.test";
 import { OpenAIResponsesEuropeGptFiveMiniStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_mini.test";
 import { OpenAIResponsesEuropeGptFiveNanoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five_nano.test";
-import { OpenAIResponsesEuropeGptFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_eu_gpt_five.test";
+import { OpenAIResponsesGlobalGptFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test";
 import { OpenAIResponsesGlobalGptFiveDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_five.test";
+import { OpenAIResponsesGlobalGptFiveDotFourStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test";
 import { OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_mini.test";
 import { OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_nano.test";
-import { OpenAIResponsesGlobalGptFiveDotFourStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test";
 import { OpenAIResponsesGlobalGptFiveDotOneStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_one.test";
 import { OpenAIResponsesGlobalGptFiveDotTwoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_two.test";
 import { OpenAIResponsesGlobalGptFiveMiniStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_mini.test";
 import { OpenAIResponsesGlobalGptFiveNanoStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_nano.test";
-import { OpenAIResponsesGlobalGptFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five.test";
 import { TogetheraiGlobalLlama3370BInstructTurboStreamSetup } from "@app/lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
 export const STREAM_ENDPOINT_SETUPS = {
-  [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]: AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup,
-  [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]: AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup,
-  [AgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]: AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup,
-  [AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]: AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup,
-  [AnthropicGlobalClaudeFableFiveStream.id]: AnthropicGlobalClaudeFableFiveStreamSetup,
-  [AnthropicGlobalClaudeHaikuFourDotFiveStream.id]: AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup,
-  [AnthropicGlobalClaudeOpusFourDotEightStream.id]: AnthropicGlobalClaudeOpusFourDotEightStreamSetup,
-  [AnthropicGlobalClaudeOpusFourDotSevenStream.id]: AnthropicGlobalClaudeOpusFourDotSevenStreamSetup,
-  [AnthropicGlobalClaudeOpusFourDotSixStream.id]: AnthropicGlobalClaudeOpusFourDotSixStreamSetup,
-  [AnthropicGlobalClaudeSonnetFiveStream.id]: AnthropicGlobalClaudeSonnetFiveStreamSetup,
-  [AnthropicGlobalClaudeSonnetFourDotSixStream.id]: AnthropicGlobalClaudeSonnetFourDotSixStreamSetup,
-  [FireworksGlobalDeepSeekV4ProStream.id]: FireworksGlobalDeepSeekV4ProStreamSetup,
-  [FireworksGlobalGlmFiveDotTwoStream.id]: FireworksGlobalGlmFiveDotTwoStreamSetup,
+  [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
+    AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup,
+  [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
+    AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup,
+  [AgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]:
+    AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup,
+  [AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]:
+    AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup,
+  [AnthropicGlobalClaudeFableFiveStream.id]:
+    AnthropicGlobalClaudeFableFiveStreamSetup,
+  [AnthropicGlobalClaudeHaikuFourDotFiveStream.id]:
+    AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup,
+  [AnthropicGlobalClaudeOpusFourDotEightStream.id]:
+    AnthropicGlobalClaudeOpusFourDotEightStreamSetup,
+  [AnthropicGlobalClaudeOpusFourDotSevenStream.id]:
+    AnthropicGlobalClaudeOpusFourDotSevenStreamSetup,
+  [AnthropicGlobalClaudeOpusFourDotSixStream.id]:
+    AnthropicGlobalClaudeOpusFourDotSixStreamSetup,
+  [AnthropicGlobalClaudeSonnetFiveStream.id]:
+    AnthropicGlobalClaudeSonnetFiveStreamSetup,
+  [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:
+    AnthropicGlobalClaudeSonnetFourDotSixStreamSetup,
+  [FireworksGlobalDeepSeekV4ProStream.id]:
+    FireworksGlobalDeepSeekV4ProStreamSetup,
+  [FireworksGlobalGlmFiveDotTwoStream.id]:
+    FireworksGlobalGlmFiveDotTwoStreamSetup,
   [FireworksGlobalKimiK2Dot5Stream.id]: FireworksGlobalKimiK2Dot5StreamSetup,
-  [GoogleAiStudioGlobalGeminiThreeDotOneProStream.id]: GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup,
+  [GoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
+    GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup,
   [MistralEuropeCodestralStream.id]: MistralEuropeCodestralStreamSetup,
   [MistralEuropeMistralLargeStream.id]: MistralEuropeMistralLargeStreamSetup,
-  [MistralEuropeMistralMedium35Stream.id]: MistralEuropeMistralMedium35StreamSetup,
+  [MistralEuropeMistralMedium35Stream.id]:
+    MistralEuropeMistralMedium35StreamSetup,
   [MistralEuropeMistralSmallStream.id]: MistralEuropeMistralSmallStreamSetup,
-  [OpenAIResponsesEuropeGptFiveDotFiveStream.id]: OpenAIResponsesEuropeGptFiveDotFiveStreamSetup,
-  [OpenAIResponsesEuropeGptFiveDotFourMiniStream.id]: OpenAIResponsesEuropeGptFiveDotFourMiniStreamSetup,
-  [OpenAIResponsesEuropeGptFiveDotFourNanoStream.id]: OpenAIResponsesEuropeGptFiveDotFourNanoStreamSetup,
-  [OpenAIResponsesEuropeGptFiveDotFourStream.id]: OpenAIResponsesEuropeGptFiveDotFourStreamSetup,
-  [OpenAIResponsesEuropeGptFiveDotOneStream.id]: OpenAIResponsesEuropeGptFiveDotOneStreamSetup,
-  [OpenAIResponsesEuropeGptFiveDotTwoStream.id]: OpenAIResponsesEuropeGptFiveDotTwoStreamSetup,
-  [OpenAIResponsesEuropeGptFiveMiniStream.id]: OpenAIResponsesEuropeGptFiveMiniStreamSetup,
-  [OpenAIResponsesEuropeGptFiveNanoStream.id]: OpenAIResponsesEuropeGptFiveNanoStreamSetup,
-  [OpenAIResponsesEuropeGptFiveStream.id]: OpenAIResponsesEuropeGptFiveStreamSetup,
-  [OpenAIResponsesGlobalGptFiveDotFiveStream.id]: OpenAIResponsesGlobalGptFiveDotFiveStreamSetup,
-  [OpenAIResponsesGlobalGptFiveDotFourMiniStream.id]: OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup,
-  [OpenAIResponsesGlobalGptFiveDotFourNanoStream.id]: OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup,
-  [OpenAIResponsesGlobalGptFiveDotFourStream.id]: OpenAIResponsesGlobalGptFiveDotFourStreamSetup,
-  [OpenAIResponsesGlobalGptFiveDotOneStream.id]: OpenAIResponsesGlobalGptFiveDotOneStreamSetup,
-  [OpenAIResponsesGlobalGptFiveDotTwoStream.id]: OpenAIResponsesGlobalGptFiveDotTwoStreamSetup,
-  [OpenAIResponsesGlobalGptFiveMiniStream.id]: OpenAIResponsesGlobalGptFiveMiniStreamSetup,
-  [OpenAIResponsesGlobalGptFiveNanoStream.id]: OpenAIResponsesGlobalGptFiveNanoStreamSetup,
-  [OpenAIResponsesGlobalGptFiveStream.id]: OpenAIResponsesGlobalGptFiveStreamSetup,
-  [TogetheraiGlobalLlama3370BInstructTurboStream.id]: TogetheraiGlobalLlama3370BInstructTurboStreamSetup,
+  [OpenAIResponsesEuropeGptFiveDotFiveStream.id]:
+    OpenAIResponsesEuropeGptFiveDotFiveStreamSetup,
+  [OpenAIResponsesEuropeGptFiveDotFourMiniStream.id]:
+    OpenAIResponsesEuropeGptFiveDotFourMiniStreamSetup,
+  [OpenAIResponsesEuropeGptFiveDotFourNanoStream.id]:
+    OpenAIResponsesEuropeGptFiveDotFourNanoStreamSetup,
+  [OpenAIResponsesEuropeGptFiveDotFourStream.id]:
+    OpenAIResponsesEuropeGptFiveDotFourStreamSetup,
+  [OpenAIResponsesEuropeGptFiveDotOneStream.id]:
+    OpenAIResponsesEuropeGptFiveDotOneStreamSetup,
+  [OpenAIResponsesEuropeGptFiveDotTwoStream.id]:
+    OpenAIResponsesEuropeGptFiveDotTwoStreamSetup,
+  [OpenAIResponsesEuropeGptFiveMiniStream.id]:
+    OpenAIResponsesEuropeGptFiveMiniStreamSetup,
+  [OpenAIResponsesEuropeGptFiveNanoStream.id]:
+    OpenAIResponsesEuropeGptFiveNanoStreamSetup,
+  [OpenAIResponsesEuropeGptFiveStream.id]:
+    OpenAIResponsesEuropeGptFiveStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotFiveStream.id]:
+    OpenAIResponsesGlobalGptFiveDotFiveStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotFourMiniStream.id]:
+    OpenAIResponsesGlobalGptFiveDotFourMiniStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotFourNanoStream.id]:
+    OpenAIResponsesGlobalGptFiveDotFourNanoStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotFourStream.id]:
+    OpenAIResponsesGlobalGptFiveDotFourStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotOneStream.id]:
+    OpenAIResponsesGlobalGptFiveDotOneStreamSetup,
+  [OpenAIResponsesGlobalGptFiveDotTwoStream.id]:
+    OpenAIResponsesGlobalGptFiveDotTwoStreamSetup,
+  [OpenAIResponsesGlobalGptFiveMiniStream.id]:
+    OpenAIResponsesGlobalGptFiveMiniStreamSetup,
+  [OpenAIResponsesGlobalGptFiveNanoStream.id]:
+    OpenAIResponsesGlobalGptFiveNanoStreamSetup,
+  [OpenAIResponsesGlobalGptFiveStream.id]:
+    OpenAIResponsesGlobalGptFiveStreamSetup,
+  [TogetheraiGlobalLlama3370BInstructTurboStream.id]:
+    TogetheraiGlobalLlama3370BInstructTurboStreamSetup,
 } satisfies Record<StreamEndpointId, StreamSetup>;

--- a/front/lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test.ts
+++ b/front/lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test.ts
@@ -5,7 +5,7 @@ import { HAS_NO_REASONING } from "@app/lib/model_constructors/test/cases";
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
-const setup: StreamSetup = {
+export const TogetheraiGlobalLlama3370BInstructTurboStreamSetup: StreamSetup = {
   createInstance: () =>
     new TogetheraiGlobalLlama3370BInstructTurboStream({
       TOGETHERAI_API_KEY: process.env.DUST_MANAGED_TOGETHERAI_API_KEY ?? "",
@@ -66,4 +66,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test.ts
-runStreamEndpointTests(TogetheraiGlobalLlama3370BInstructTurboStream, setup);
+runStreamEndpointTests(TogetheraiGlobalLlama3370BInstructTurboStream, TogetheraiGlobalLlama3370BInstructTurboStreamSetup);

--- a/front/lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test.ts
+++ b/front/lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test.ts
@@ -66,4 +66,7 @@ export const TogetheraiGlobalLlama3370BInstructTurboStreamSetup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test.ts
-runStreamEndpointTests(TogetheraiGlobalLlama3370BInstructTurboStream, TogetheraiGlobalLlama3370BInstructTurboStreamSetup);
+runStreamEndpointTests(
+  TogetheraiGlobalLlama3370BInstructTurboStream,
+  TogetheraiGlobalLlama3370BInstructTurboStreamSetup
+);


### PR DESCRIPTION
## Description

Register OpenAI Responses EU stream endpoints for the GPT-5 model family, with a per-endpoint base URL and a 10% regional pricing uplift for GPT-5.4+.

## Tests

Added stream endpoint tests for each new EU endpoint; every stream endpoint is now mapped to its test setup for type-checked coverage.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`