### PR TITLE
fix(sidekick): exempt free origins from credit-state cap gate

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -67,6 +67,7 @@ import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
 import { isApiKeyCapped } from "@app/lib/metronome/api_key_block";
+import { isFreeOrigin } from "@app/lib/metronome/events";
 import {
   getWorkspaceCreditPoolStatus,
   getWorkspaceProgrammaticCreditStatus,
@@ -2510,40 +2511,47 @@ async function checkMessagesLimit(
         },
       });
     }
-    if (blockedReason === "user_cap_reached") {
-      return new Err({
-        status_code: 403,
-        api_error: {
-          type: "user_cap_reached",
-          message: "You have reached your personal usage cap.",
-        },
-      });
-    }
-    if (blockedReason === "credits_exhausted") {
-      return new Err({
-        status_code: 403,
-        api_error: {
-          type: "credits_exhausted",
-          message: "Your workspace has run out of credits.",
-        },
-      });
-    }
+    // Free origins (e.g. Sidekick) produce only free, non-billable usage, so
+    // the credit-state caps and pool-balance concurrency limit don't apply — a
+    // capped user or a credit-exhausted workspace can still use them. The
+    // `no_seat` gate above is intentionally left outside this exemption since
+    // it reflects membership, not credit state.
+    if (!isFreeOrigin(context.origin)) {
+      if (blockedReason === "user_cap_reached") {
+        return new Err({
+          status_code: 403,
+          api_error: {
+            type: "user_cap_reached",
+            message: "You have reached your personal usage cap.",
+          },
+        });
+      }
+      if (blockedReason === "credits_exhausted") {
+        return new Err({
+          status_code: 403,
+          api_error: {
+            type: "credits_exhausted",
+            message: "Your workspace has run out of credits.",
+          },
+        });
+      }
 
-    // Pre-emptive concurrency limit based on pool credit state. Prevents
-    // close-to-0 attacks where many requests are sent simultaneously before
-    // Metronome debits settle.
-    const poolLimit = await checkPoolCreditConcurrencyLimit(auth);
-    if (poolLimit.isLimitReached && poolLimit.limitType) {
-      return new Err({
-        status_code: 429,
-        api_error: {
-          type: poolLimit.limitType,
-          message: getMessageLimitErrorMessage({
-            limitType: poolLimit.limitType,
-            message: poolLimit.message,
-          }),
-        },
-      });
+      // Pre-emptive concurrency limit based on pool credit state. Prevents
+      // close-to-0 attacks where many requests are sent simultaneously before
+      // Metronome debits settle.
+      const poolLimit = await checkPoolCreditConcurrencyLimit(auth);
+      if (poolLimit.isLimitReached && poolLimit.limitType) {
+        return new Err({
+          status_code: 429,
+          api_error: {
+            type: poolLimit.limitType,
+            message: getMessageLimitErrorMessage({
+              limitType: poolLimit.limitType,
+              message: poolLimit.message,
+            }),
+          },
+        });
+      }
     }
 
     // Programmatic monthly cap: block programmatic calls when the cap is reached.

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -99,7 +99,7 @@ export function getToolBillingInfo(
 export const FREE_ORIGINS: ReadonlySet<UserMessageOrigin> =
   new Set<UserMessageOrigin>(["agent_sidekick"]);
 
-function isFreeOrigin(origin: UserMessageOrigin | null): boolean {
+export function isFreeOrigin(origin: UserMessageOrigin | null): boolean {
   if (origin == null) {
     return false;
   }


### PR DESCRIPTION
## Problem

When a user is capped (`user_cap_reached`) or the workspace is out of credits (`credits_exhausted`), opening Sidekick fails with *"There was an issue starting the Sidekick session. Please try again later."*

The credit-state gate in `checkMessagesLimit` (`front/lib/api/assistant/conversation.ts`) is **origin-blind**: it rejects the request based on the Redis-cached user/workspace block state *before* any free-origin classification comes into play. Sidekick's origin (`agent_sidekick`) is in `FREE_ORIGINS`, so a Sidekick message is billed as free usage if it gets through — but the gate rejects it outright first.

This contrasts with the programmatic cap check right below it, which already gates on `context.origin` before applying its block.

## Fix

Exempt free origins from the credit-state rejections in the credit-priced branch:
- `user_cap_reached`
- `credits_exhausted`
- pool-balance concurrency limit (`checkPoolCreditConcurrencyLimit`)

All three are needed: a credit-exhausted workspace drives the pool near zero, so the concurrency limit would have blocked Sidekick even after exempting the first two.

The `no_seat` gate is intentionally left **outside** the exemption — it reflects membership, not credit state.

No change was needed to the programmatic block or legacy branch: `agent_sidekick` is classified `"user"` and Sidekick uses session (not API-key) auth, so `isProgrammaticUsage` is already `false` for it.

## Notes

- Exported the existing `isFreeOrigin` helper from `front/lib/metronome/events.ts`.
- `tsgo --noEmit` and `format:changed` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)