### PR TITLE
[front] fix: inject placeholder specifications for historic tool references

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.test.ts
@@ -30,6 +30,20 @@ const baseSpec: AgentActionSpecification = {
   inputSchema: { type: "object", properties: {} },
 };
 
+const replayOnlySpec: AgentActionSpecification = {
+  name: "github__create_issue",
+  description:
+    "Replay-only placeholder for a historical tool call. " +
+    "This tool is not available for new calls.",
+  inputSchema: {
+    type: "object",
+    properties: {},
+    required: [],
+    additionalProperties: true,
+  },
+  eager: true,
+};
+
 describe("toTool", () => {
   it("defers a non-eager tool when tool search is enabled", () => {
     const tool = toTool(baseSpec, { toolSearchEnabled: true });
@@ -114,6 +128,39 @@ describe("toToolsParam", () => {
     expect(forced && "defer_loading" in forced && forced.defer_loading).toBe(
       false
     );
+  });
+
+  it("keeps a replay-only placeholder specification eager", () => {
+    const tools = toToolsParam([replayOnlySpec], undefined, {
+      toolSearchEnabled: true,
+    });
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({
+      name: "github__create_issue",
+      description: replayOnlySpec.description,
+      eager_input_streaming: true,
+      input_schema: replayOnlySpec.inputSchema,
+    });
+    expect(tools[0]).not.toHaveProperty("defer_loading");
+  });
+
+  it("does not defer a replay-only placeholder when other tools are deferred", () => {
+    const tools = toToolsParam([replayOnlySpec, coldSpec], undefined, {
+      toolSearchEnabled: true,
+    });
+
+    expect(tools[0].type).toBe(TOOL_SEARCH_TYPE);
+
+    const replayTool = tools.find((tool) => tool.name === replayOnlySpec.name);
+    expect(replayTool).toMatchObject({
+      name: "github__create_issue",
+      input_schema: replayOnlySpec.inputSchema,
+    });
+    expect(replayTool).not.toHaveProperty("defer_loading");
+
+    const deferredTool = tools.find((tool) => tool.name === coldSpec.name);
+    expect(deferredTool).toHaveProperty("defer_loading", true);
   });
 });
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -169,6 +169,24 @@ function getReplayedToolNames(
   return [...toolNames];
 }
 
+function buildReplayOnlyToolSpecification(
+  name: string
+): AgentActionSpecification {
+  return {
+    name,
+    description:
+      "Replay-only placeholder for a historical tool call. " +
+      "This tool is not available for new calls.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: true,
+    },
+    eager: true,
+  };
+}
+
 // This method is used by the multi-actions execution loop to pick the next action to execute and
 // generate its inputs.
 export async function runModel(
@@ -527,6 +545,7 @@ export async function runModel(
   const replayedToolNames = getReplayedToolNames(
     modelConversationRes.value.modelConversation
   );
+  const replayedToolNameSet = new Set(replayedToolNames);
   const currentToolNames = new Set(baseSpecifications.map((spec) => spec.name));
   const missingReplayedToolNames = replayedToolNames.filter(
     (name) => !currentToolNames.has(name)
@@ -542,26 +561,14 @@ export async function runModel(
     );
   }
 
-  const specifications = baseSpecifications;
-  // TODO(2026-07-06 aubin): uncomment once we confirm we need this.
-  // const specifications = [
-  //   ...baseSpecifications.map((spec) =>
-  //     replayedToolNames.includes(spec.name) ? { ...spec, eager: true } : spec
-  //   ),
-  //   ...missingReplayedToolNames.map((name) => ({
-  //     name,
-  //     description:
-  //       "Replay-only placeholder for a historical tool call. " +
-  //       "This tool is not available for new calls.",
-  //     inputSchema: {
-  //       type: "object",
-  //       properties: {},
-  //       required: [],
-  //       additionalProperties: true,
-  //     },
-  //     eager: true,
-  //   })),
-  // ];
+  const specifications: AgentActionSpecification[] = [
+    ...baseSpecifications.map((spec) =>
+      replayedToolNameSet.has(spec.name) ? { ...spec, eager: true } : spec
+    ),
+    ...missingReplayedToolNames.map((name) =>
+      buildReplayOnlyToolSpecification(name)
+    ),
+  ];
 
   // Temporarily adding this to check if we can consider contents property only in llms
   const unexpectedMessage =


### PR DESCRIPTION
## Description

Follow up on https://github.com/dust-tt/dust/pull/28479.
Injects tool specifications for tools that are found in the convo history (either `tool_references` from tool search or previous tool calls) but not in the current specifications.

This is a little more exhaustive than only Anthropic tool search uses, for regular tool calls this comes in addition to the `missing_action_catcher` and also allows detecting issues due to tools having been removed vs the model inventing a one from scratch.

## Tests

- Updated existing Anthropic converter tests.
- Tested locally with a direct Anthropic API smoke using `DUST_MANAGED_ANTHROPIC_API_KEY`.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
