### PR TITLE
feat(sandbox): pod egress allowlist — backend

### DIFF
--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -44,6 +44,7 @@ import {
   parseExactEgressDomain,
   readSandboxPolicy,
   readWorkspacePolicy,
+  writePodPolicy,
   writeWorkspacePolicy,
 } from "./egress_policy";
 
@@ -316,5 +317,89 @@ describe("sandbox egress policy storage", () => {
     );
     expect(parseExactEgressDomain("127.0.0.1").isErr()).toBe(true);
     expect(parseExactEgressDomain("*.github.com").isErr()).toBe(true);
+  });
+});
+
+describe("pod egress policy storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGetEgressPolicyBucket.mockReturnValue("egress-policy-bucket");
+    mockGetEgressProxyInternalUrl.mockReturnValue("https://egress-proxy");
+    mockMintEgressInvalidationJwt.mockReturnValue("invalidation-token");
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetchFileContent.mockResolvedValue(
+      JSON.stringify({ allowedDomains: ["API.GitHub.COM"] })
+    );
+    mockUploadRawContentToBucket.mockResolvedValue(undefined);
+    mockDelete.mockResolvedValue(undefined);
+    mockGetBucketInstance.mockReturnValue({
+      delete: mockDelete,
+      fetchFileContent: mockFetchFileContent,
+      uploadRawContentToBucket: mockUploadRawContentToBucket,
+    });
+  });
+
+  it("writes normalized pod domains and supports wildcards", async () => {
+    const result = await writePodPolicy("pod-provider-id", [
+      "API.GitHub.COM",
+      "*.GitHub.COM",
+    ]);
+
+    expect(result).toEqual(
+      new Ok({ allowedDomains: ["api.github.com", "*.github.com"] })
+    );
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
+      content: JSON.stringify({
+        allowedDomains: ["api.github.com", "*.github.com"],
+      }),
+      contentType: "application/json",
+      filePath: "sandboxes/pod-provider-id.json",
+    });
+  });
+
+  it("writes an empty pod policy when no domains are configured", async () => {
+    const result = await writePodPolicy("pod-provider-id", []);
+
+    expect(result).toEqual(new Ok({ allowedDomains: [] }));
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
+      content: JSON.stringify({ allowedDomains: [] }),
+      contentType: "application/json",
+      filePath: "sandboxes/pod-provider-id.json",
+    });
+  });
+
+  it("does not write invalid pod domains", async () => {
+    const result = await writePodPolicy("pod-provider-id", ["127.0.0.1"]);
+
+    expect(result.isErr()).toBe(true);
+    expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
+  });
+
+  it("rejects pod policies over the domain cap", async () => {
+    const domains = Array.from(
+      { length: 101 },
+      (_, i) => `domain-${i}.example.com`
+    );
+
+    const result = await writePodPolicy("pod-provider-id", domains);
+
+    expect(result.isErr()).toBe(true);
+    expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the pod sandbox policy cache after writes", async () => {
+    await writePodPolicy("pod-provider-id", ["example.org"]);
+
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://egress-proxy/invalidate-policy",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+    expect(mockMintEgressInvalidationJwt).toHaveBeenCalledWith({
+      sandboxId: "pod-provider-id",
+    });
   });
 });

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -9,13 +9,14 @@ import {
   EMPTY_EGRESS_POLICY,
   normalizeEgressPolicy,
   normalizeEgressPolicyDomain,
+  normalizeEgressPolicyDomains,
   parseEgressPolicy,
 } from "@app/types/sandbox/egress_policy";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const INVALIDATION_TIMEOUT_MS = 5_000;
-const SANDBOX_POLICY_MAX_DOMAINS = 100;
+export const SANDBOX_POLICY_MAX_DOMAINS = 100;
 
 function getWorkspacePolicyPath(auth: Authenticator): string {
   return `workspaces/${auth.getNonNullableWorkspace().sId}.json`;
@@ -194,6 +195,64 @@ export async function deleteSandboxPolicy(
     void invalidateSandboxPolicyCache(sandboxProviderId);
 
     return new Ok(undefined);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pod egress policy
+//
+// A Pod's Shared Computer runs on one persistent sandbox owned by
+// `PodSandboxAdapter`. Its pod-level allowlist is stored as that sandbox's
+// policy file (`sandboxes/{providerId}.json`) — the same GCS path used by
+// conversation sandboxes, but with different semantics: for conversation
+// sandboxes the file is ephemeral and user-editable via the `add_egress_domain`
+// tool; for pod sandboxes it is admin-configured, sourced from
+// `ProjectMetadata.podNetworkAllowedDomains`, and (re)written by the pod policy
+// manager at sandbox activation. The egress proxy reads it and unions it with
+// the workspace-level allowlist, so no proxy changes are needed.
+// ---------------------------------------------------------------------------
+
+function getPodPolicyPath(podSandboxProviderId: string): string {
+  // Same path as the sandbox policy, different semantics (see block comment).
+  return getSandboxPolicyPath(podSandboxProviderId);
+}
+
+// Writes the pod's configured domains to the pod sandbox's policy file and
+// invalidates the proxy cache. Unlike `addSandboxPolicyDomain` (the user-facing
+// tool, which appends exact domains), this replaces the whole policy with the
+// admin-configured allowlist and — like the workspace-level policy — supports
+// wildcard domains such as `*.github.com`.
+export async function writePodPolicy(
+  podSandboxProviderId: string,
+  domains: string[]
+): Promise<Result<EgressPolicy, Error>> {
+  const normalizedDomains = normalizeEgressPolicyDomains(domains);
+  if (normalizedDomains.isErr()) {
+    return new Err(normalizedDomains.error);
+  }
+
+  if (normalizedDomains.value.length > SANDBOX_POLICY_MAX_DOMAINS) {
+    return new Err(
+      new Error(
+        `Pod egress policy cannot exceed ${SANDBOX_POLICY_MAX_DOMAINS} domains.`
+      )
+    );
+  }
+
+  const policy: EgressPolicy = { allowedDomains: normalizedDomains.value };
+
+  try {
+    await getPolicyBucket().uploadRawContentToBucket({
+      content: JSON.stringify(policy),
+      contentType: "application/json",
+      filePath: getPodPolicyPath(podSandboxProviderId),
+    });
+
+    void invalidateSandboxPolicyCache(podSandboxProviderId);
+
+    return new Ok(policy);
   } catch (error) {
     return new Err(normalizeError(error));
   }

--- a/front/lib/api/sandbox/pod_egress_policy.ts
+++ b/front/lib/api/sandbox/pod_egress_policy.ts
@@ -1,0 +1,115 @@
+import {
+  SANDBOX_POLICY_MAX_DOMAINS,
+  writePodPolicy,
+} from "@app/lib/api/sandbox/egress_policy";
+import type { Authenticator } from "@app/lib/auth";
+import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+import { normalizeEgressPolicyDomains } from "@app/types/sandbox/egress_policy";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+
+// The source of truth for a Pod's egress allowlist is
+// `ProjectMetadata.podNetworkAllowedDomains` (DB). The GCS sandbox policy file
+// is a projection of it: written lazily on the pod sandbox's next activation
+// (see `PodSandboxAdapter`), and kept in sync eagerly on updates when a pod
+// sandbox already exists.
+
+export async function getPodEgressDomains(
+  auth: Authenticator,
+  pod: SpaceResource
+): Promise<string[]> {
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+  return metadata?.podNetworkAllowedDomains ?? [];
+}
+
+// Validates and normalizes the requested domains, persists them to the pod's
+// metadata (source of truth), then projects them onto the pod sandbox's policy
+// file if a sandbox currently exists. Returns the normalized policy.
+//
+// The GCS projection is best-effort: if it fails we log and still succeed,
+// because the DB value is authoritative and the next sandbox activation
+// re-syncs the file. When no sandbox exists yet there is nothing to sync (and
+// nothing cached to invalidate) — the domains are written at first activation.
+export async function setPodEgressDomains(
+  auth: Authenticator,
+  pod: SpaceResource,
+  requestedDomains: string[]
+): Promise<Result<EgressPolicy, Error>> {
+  const normalizedDomains = normalizeEgressPolicyDomains(requestedDomains);
+  if (normalizedDomains.isErr()) {
+    return new Err(normalizedDomains.error);
+  }
+
+  if (normalizedDomains.value.length > SANDBOX_POLICY_MAX_DOMAINS) {
+    return new Err(
+      new Error(
+        `Pod egress policy cannot exceed ${SANDBOX_POLICY_MAX_DOMAINS} domains.`
+      )
+    );
+  }
+
+  const domains = normalizedDomains.value;
+
+  // Upsert the pod metadata: the allowlist lives on the pod even before a
+  // sandbox has ever been created.
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+  if (metadata) {
+    await metadata.updatePodNetworkAllowedDomains(domains);
+  } else {
+    await ProjectMetadataResource.makeNew(auth, pod, {
+      podNetworkAllowedDomains: domains,
+    });
+  }
+
+  // Project onto the sandbox policy file if a pod sandbox exists. A deleted
+  // record has no live policy file (it is removed on destroy) and gets the
+  // domains at next activation.
+  const sandbox = await PodSandboxAdapter.fetchSandbox(auth, pod);
+  if (sandbox && sandbox.status !== "deleted") {
+    const writeResult = await writePodPolicy(sandbox.providerId, domains);
+    if (writeResult.isErr()) {
+      logger.warn(
+        {
+          err: writeResult.error,
+          spaceId: pod.sId,
+          sandboxProviderId: sandbox.providerId,
+        },
+        "Failed to sync pod egress policy to sandbox — DB value is authoritative and will re-sync at next activation."
+      );
+    }
+  }
+
+  return new Ok({ allowedDomains: domains });
+}
+
+// Idempotent single-domain append. Reads the current allowlist from the pod's
+// metadata, normalizes the incoming domain, no-ops if already present, then
+// delegates to setPodEgressDomains. Used by the Category G (manifest-declared
+// domain) approve path so callers don't have to re-implement the
+// read-normalize-merge-write sequence.
+export async function addPodEgressDomain(
+  auth: Authenticator,
+  pod: SpaceResource,
+  domain: string
+): Promise<Result<{ allowedDomains: string[] }, Error>> {
+  const normalized = normalizeEgressPolicyDomains([domain]);
+  if (normalized.isErr()) {
+    return new Err(normalized.error);
+  }
+
+  if (normalized.value.length === 0) {
+    return new Err(new Error(`Invalid domain: ${domain}`));
+  }
+
+  const current = await getPodEgressDomains(auth, pod);
+  const normalizedDomain = normalized.value[0];
+
+  if (current.includes(normalizedDomain)) {
+    return new Ok({ allowedDomains: current });
+  }
+
+  return setPodEgressDomains(auth, pod, [...current, normalizedDomain]);
+}

--- a/front/lib/resources/pod_sandbox_adapter.ts
+++ b/front/lib/resources/pod_sandbox_adapter.ts
@@ -1,4 +1,6 @@
+import { writePodPolicy } from "@app/lib/api/sandbox/egress_policy";
 import type { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import {
   type EnsureSandboxResult,
   type SandboxCreateBlob,
@@ -10,6 +12,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import assert from "assert";
@@ -122,13 +125,58 @@ export class PodSandboxAdapter {
   ): Promise<Result<EnsureSandboxResult, Error>> {
     this.assertPod(pod);
 
-    return SandboxResource.ensureActive(auth, {
+    const result = await SandboxResource.ensureActive(auth, {
       lockKey: pod.sId,
       envVars: { SPACE_ID: pod.sId },
       logLabel: "pod",
       fetchSandbox: () => this.fetchSandboxByPod(auth, pod),
       createSandbox: (blob) => this.createSandboxRecordForPod(auth, pod, blob),
     });
+
+    // Write the pod's egress allowlist to the (new) sandbox's policy file. Only
+    // needed when the sandbox was freshly created/recreated (new provider id,
+    // no policy file) or woke from sleep (a persisted file may be stale if the
+    // admin changed the allowlist while it slept). An already-running sandbox
+    // keeps the file written at its last create/wake, and admin updates on a
+    // live sandbox are synced by the API path.
+    //
+    // This runs outside the lifecycle lock (ensureActive released it). That is
+    // safe: pod domains are additive over the workspace allowlist, so the worst
+    // case of a racing/late write is a domain briefly denied until the file and
+    // the proxy's 60s cache catch up — fail-closed. Concurrent writers converge
+    // (last-writer-wins on the same DB-sourced value).
+    if (
+      result.isOk() &&
+      (result.value.freshlyCreated || result.value.wokeFromSleep)
+    ) {
+      await this.writePodEgressPolicy(auth, pod, result.value.sandbox);
+    }
+
+    return result;
+  }
+
+  // Best-effort: failing to write the allowlist falls back to the
+  // workspace-level policy only, which is strictly more restrictive, so we log
+  // rather than block sandbox activation.
+  private static async writePodEgressPolicy(
+    auth: Authenticator,
+    pod: SpaceResource,
+    sandbox: SandboxResource
+  ): Promise<void> {
+    const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+    const domains = metadata?.podNetworkAllowedDomains ?? [];
+
+    const writeResult = await writePodPolicy(sandbox.providerId, domains);
+    if (writeResult.isErr()) {
+      logger.warn(
+        {
+          err: writeResult.error,
+          spaceId: pod.sId,
+          sandboxProviderId: sandbox.providerId,
+        },
+        "Failed to write pod egress policy at sandbox activation."
+      );
+    }
   }
 
   static async pauseSandboxForApproval(


### PR DESCRIPTION
> **Superseded** by the owner-keyed egress policy re-layout stack (`egress-relayout-*` branches, PRs `28652`–`28655`). Branch kept for reference.

## Pod egress allowlist — backend

GCS + orchestration layer. No egress-proxy (Rust) changes anywhere in this stack: the proxy already reads both `workspaces/{wId}.json` and `sandboxes/{providerId}.json` and takes the union, so writing the Pod's domains into its persistent sandbox's policy file is picked up automatically.

- **DB is the source of truth** (`podNetworkAllowedDomains`, from #28352); the GCS policy file is a projection of it.
- `writePodPolicy` replaces a pod sandbox's policy file (wildcards allowed, 100-domain cap) and invalidates the proxy cache. Same GCS path as conversation-sandbox policies, different semantics — see the block comment.
- `pod_egress_policy.ts`: `getPodEgressDomains` / `setPodEgressDomains` (persist to DB, then best-effort projection onto a live sandbox — failures log and re-sync at next activation), plus `addPodEgressDomain`, an idempotent single-domain append for the upcoming manifest-declared-domain approve path.
- `PodSandboxAdapter` projects the allowlist at activation (fresh create or wake), outside the lifecycle lock — safe because pod domains are additive over the workspace allowlist (fail-closed, last-writer-wins).

Merging this alone is inert-but-safe: pod sandboxes start projecting an empty allowlist. The admin API to set domains is #28513.

### Stack

Pod-level network egress allowlist, split for review:

1. #28352 — data layer (this stack's base)
2. #28512 — egress policy backend
3. #28513 — admin API route
4. #28514 — audit logging (droppable)
5. #28515 — settings UI

### Risk

Worst case, pod domains don't apply until the next sandbox activation; the workspace allowlist still enforces. Safe to rollback.