### PR TITLE
feat(sandbox): pod egress allowlist — audit logging

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.test.ts
@@ -7,9 +7,20 @@ import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockWritePodPolicy } = vi.hoisted(() => ({
+const { mockEmitAuditLogEvent, mockWritePodPolicy } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn(),
   mockWritePodPolicy: vi.fn(),
 }));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+
+  return {
+    ...actual,
+    emitAuditLogEvent: mockEmitAuditLogEvent,
+  };
+});
 
 // Stub the GCS projection so we can assert it fires without a real bucket.
 vi.mock("@app/lib/api/sandbox/egress_policy", async (importOriginal) => {
@@ -91,6 +102,20 @@ describe("GET/PUT /api/w/:wId/spaces/:spaceId/sandbox/egress-policy", () => {
     expect(await getResponse.json()).toEqual({
       policy: { allowedDomains: ["api.github.com", "*.github.com"] },
     });
+
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "pod_egress_policy.updated",
+        metadata: {
+          allowed_domain_count: "2",
+          allowed_domains: "api.github.com,*.github.com",
+        },
+        targets: [
+          expect.objectContaining({ type: "workspace", id: workspace.sId }),
+          expect.objectContaining({ type: "space", id: pod.sId }),
+        ],
+      })
+    );
   });
 
   it("projects the allowlist onto a live pod sandbox", async () => {
@@ -131,6 +156,10 @@ describe("GET/PUT /api/w/:wId/spaces/:spaceId/sandbox/egress-policy", () => {
     });
 
     expect(response.status).toBe(400);
+    // withSpace may emit `space.accessed`, but the policy-update event must not fire.
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "pod_egress_policy.updated" })
+    );
 
     // The invalid write must not have been persisted.
     const getResponse = await getPolicy(workspace.sId, pod.sId);

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
@@ -1,4 +1,9 @@
 import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import {
   getPodEgressDomains,
   setPodEgressDomains,
 } from "@app/lib/api/sandbox/pod_egress_policy";
@@ -83,6 +88,20 @@ app.put(
         },
       });
     }
+
+    void emitAuditLogEvent({
+      auth,
+      action: "pod_egress_policy.updated",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("space", space),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        allowed_domain_count: String(result.value.allowedDomains.length),
+        allowed_domains: result.value.allowedDomains.join(","),
+      },
+    });
 
     return ctx.json({ policy: result.value });
   }

--- a/front/admin/audit_log_schemas/pod_egress_policy.updated.json
+++ b/front/admin/audit_log_schemas/pod_egress_policy.updated.json
@@ -1,0 +1,16 @@
+{
+  "action": "pod_egress_policy.updated",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "space"
+    }
+  ],
+  "metadata": {
+    "allowed_domain_count": "string",
+    "allowed_domains": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -49,6 +49,7 @@
   "oauth.authorized": 3,
   "oauth.initiated": 3,
   "oauth.revoked": 2,
+  "pod_egress_policy.updated": 1,
   "project.joined": 3,
   "project.left": 3,
   "sandbox_egress_policy.agent_requests_setting_updated": 1,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -77,6 +77,7 @@ export const AUDIT_ACTIONS = [
   "sandbox_egress_policy.agent_requests_setting_updated",
   "sandbox_egress_policy.sandbox_updated",
   "sandbox_egress_policy.updated",
+  "pod_egress_policy.updated",
   "sandbox_env_var.allowed_domains_updated",
   "sandbox_env_var.created",
   "sandbox_env_var.deleted",


### PR DESCRIPTION
> **Superseded** by the owner-keyed egress policy re-layout stack (`egress-relayout-*` branches, PRs `28652`–`28655`). Branch kept for reference.

## Pod egress allowlist — audit logging

Emit `pod_egress_policy.updated` when an admin updates a Pod's egress allowlist. Fire-and-forget at the mutation site, logging the resulting full list (`allowed_domain_count`, `allowed_domains`) — same shape as the workspace-level `sandbox_egress_policy.updated`. Schema includes `actor_type`, matching the primary emit functions.

Kept as its own PR so it can be dropped while we decide whether this action should be audited.

### Stack

Pod-level network egress allowlist, split for review:

1. #28352 — data layer (this stack's base)
2. #28512 — egress policy backend
3. #28513 — admin API route
4. #28514 — audit logging (droppable)
5. #28515 — settings UI

### Risk

Worst case, a noisy audit event. Safe to rollback.

### Deploy plan

- [ ] Register the schema with WorkOS before deploy: `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`