### PR TITLE
[LLM] retire legacy o1/o3 OpenAI global agents

### DIFF
--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -1441,7 +1441,11 @@ const RETIRED_GLOBAL_AGENTS_SID = [
   GLOBAL_AGENTS_SID.MISTRAL_MEDIUM,
   GLOBAL_AGENTS_SID.MISTRAL_SMALL,
   GLOBAL_AGENTS_SID.NOTION,
+  GLOBAL_AGENTS_SID.O1,
+  GLOBAL_AGENTS_SID.O1_HIGH_REASONING,
   GLOBAL_AGENTS_SID.O1_MINI,
+  GLOBAL_AGENTS_SID.O3,
+  GLOBAL_AGENTS_SID.O3_MINI,
   GLOBAL_AGENTS_SID.GPT4,
   GLOBAL_AGENTS_SID.SLACK,
   // Hidden helper sub-agent, only invoked via run_agent by deep-dive
@@ -1532,19 +1536,6 @@ export async function getGlobalAgents(
 
   const flags = await getFeatureFlags(auth);
 
-  if (!flags.includes("openai_o1_feature")) {
-    agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.O1
-    );
-    agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.O3
-    );
-  }
-  if (!flags.includes("openai_o1_high_reasoning_feature")) {
-    agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.O1_HIGH_REASONING
-    );
-  }
   if (!flags.includes("workspace_analytics")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) => sId !== GLOBAL_AGENTS_SID.ANALYST

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -126,10 +126,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to OpenAI o1 model",
     stage: "on_demand",
   },
-  openai_o1_high_reasoning_feature: {
-    description: "Access to OpenAI o1 high reasoning model",
-    stage: "on_demand",
-  },
   openai_usage_mcp: {
     description: "OpenAI tool for tracking API consumption and costs",
     stage: "on_demand",


### PR DESCRIPTION
## Description

Retire the legacy o1/o3 OpenAI global agents (`o1`, `o1-high-reasoning`, `o1-mini`, `o3`, `o3-mini`) by moving them to `RETIRED_GLOBAL_AGENTS_SID` — they drop off default/user agent lists but stay callable in past conversations — and remove the now-redundant `openai_o1_feature`/`openai_o1_high_reasoning_feature` gate blocks plus the unused `openai_o1_high_reasoning_feature` flag.

## Tests

Type-checked locally (`tsgo --noEmit`); no behavioral tests needed.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`