### PR TITLE
Strip unreplayable Anthropic tool search blocks at request build

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -27,6 +27,7 @@ import {
   handleInvalidToolJsonAnthropicError,
   isAnthropicErrorUnableToParseToolParam,
 } from "@app/lib/api/llm/clients/anthropic/utils/errors";
+import { stripUnreplayableToolSearchBlocks } from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
 import {
   getInferenceClient,
   getModel,
@@ -292,7 +293,9 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       model: this.modelId,
       ...thinkingConfig,
       system,
-      messages,
+      messages: stripUnreplayableToolSearchBlocks(messages, {
+        toolSearchInRequest: includesToolSearchTool(tools),
+      }),
       temperature: this.temperature ?? undefined,
       tools,
       max_tokens: this.modelConfig.generationTokensCount,

--- a/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.test.ts
@@ -1,9 +1,14 @@
 import type {
+  ContentBlockParam,
+  MessageParam,
   ServerToolUseBlockParam,
   ToolSearchToolResultBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
 import type { AnthropicToolSearchBlock } from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
-import { parseAnthropicToolSearchBlock } from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
+import {
+  parseAnthropicToolSearchBlock,
+  stripUnreplayableToolSearchBlocks,
+} from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
 import { describe, expect, expectTypeOf, it } from "vitest";
 
 describe("parseAnthropicToolSearchBlock", () => {
@@ -55,6 +60,180 @@ describe("parseAnthropicToolSearchBlock", () => {
       null
     );
     expect(parseAnthropicToolSearchBlock(null)).toBe(null);
+  });
+});
+
+// -- stripUnreplayableToolSearchBlocks fixtures --
+
+function search(id: string): ContentBlockParam {
+  return {
+    type: "server_tool_use",
+    id,
+    name: "tool_search_tool_bm25",
+    input: { query: "calendar" },
+  };
+}
+
+function searchResult(id: string): ContentBlockParam {
+  return {
+    type: "tool_search_tool_result",
+    tool_use_id: id,
+    content: {
+      type: "tool_search_tool_search_result",
+      tool_references: [{ type: "tool_reference", tool_name: "list_events" }],
+    },
+  };
+}
+
+function thinking(): ContentBlockParam {
+  return { type: "thinking", thinking: "reasoning", signature: "sig" };
+}
+
+function text(value: string): ContentBlockParam {
+  return { type: "text", text: value };
+}
+
+function toolUse(id: string): ContentBlockParam {
+  return { type: "tool_use", id, name: "enable_skill", input: {} };
+}
+
+function toolResult(id: string): ContentBlockParam {
+  return {
+    type: "tool_result",
+    tool_use_id: id,
+    content: [{ type: "text", text: "Skill enabled." }],
+  };
+}
+
+function assistant(...content: ContentBlockParam[]): MessageParam {
+  return { role: "assistant", content };
+}
+
+function user(...content: ContentBlockParam[]): MessageParam {
+  return { role: "user", content };
+}
+
+function blockTypes(message: MessageParam): string[] {
+  if (typeof message.content === "string") {
+    throw new Error("expected block content");
+  }
+  return message.content.map((block) => block.type);
+}
+
+describe("stripUnreplayableToolSearchBlocks", () => {
+  it("returns the input array untouched when every block is replayable", () => {
+    const messages = [
+      user(text("Find my meetings.")),
+      assistant(search("srv_1"), searchResult("srv_1"), toolUse("tool_1")),
+      user(toolResult("tool_1")),
+    ];
+
+    expect(
+      stripUnreplayableToolSearchBlocks(messages, { toolSearchInRequest: true })
+    ).toBe(messages);
+  });
+
+  it("keeps a dangling search on the final assistant message when the continuation is exclusively tool_result blocks", () => {
+    const messages = [
+      user(text("Find my meetings.")),
+      assistant(thinking(), search("srv_1"), toolUse("tool_1")),
+      user(toolResult("tool_1")),
+    ];
+
+    expect(
+      stripUnreplayableToolSearchBlocks(messages, { toolSearchInRequest: true })
+    ).toBe(messages);
+  });
+
+  it("strips a dangling search when the continuation carries a non tool_result block", () => {
+    const messages = [
+      user(text("Find my meetings.")),
+      assistant(thinking(), search("srv_1"), toolUse("tool_1")),
+      user(
+        toolResult("tool_1"),
+        text("<dust_system>skill instructions</dust_system>")
+      ),
+    ];
+
+    const sanitized = stripUnreplayableToolSearchBlocks(messages, {
+      toolSearchInRequest: true,
+    });
+
+    expect(blockTypes(sanitized[1])).toEqual(["thinking", "tool_use"]);
+    expect(blockTypes(sanitized[2])).toEqual(["tool_result", "text"]);
+  });
+
+  it("strips a dangling search sitting in the middle of the history", () => {
+    const messages = [
+      user(text("Find my meetings.")),
+      assistant(search("srv_1"), toolUse("tool_1")),
+      user(toolResult("tool_1")),
+      assistant(text("Done.")),
+      user(text("Thanks, now summarize.")),
+    ];
+
+    const sanitized = stripUnreplayableToolSearchBlocks(messages, {
+      toolSearchInRequest: true,
+    });
+
+    expect(blockTypes(sanitized[1])).toEqual(["tool_use"]);
+  });
+
+  it("keeps completed pairs verbatim while stripping the dangling sibling", () => {
+    const messages = [
+      user(text("Find my meetings.")),
+      assistant(
+        search("srv_1"),
+        searchResult("srv_1"),
+        search("srv_2"),
+        toolUse("tool_1")
+      ),
+      user(toolResult("tool_1"), text("steering text")),
+    ];
+
+    const sanitized = stripUnreplayableToolSearchBlocks(messages, {
+      toolSearchInRequest: true,
+    });
+
+    expect(blockTypes(sanitized[1])).toEqual([
+      "server_tool_use",
+      "tool_search_tool_result",
+      "tool_use",
+    ]);
+  });
+
+  it("strips every tool search block when the request has no tool search tool", () => {
+    const messages = [
+      user(text("Find my meetings.")),
+      assistant(
+        text("Searching."),
+        search("srv_1"),
+        searchResult("srv_1"),
+        toolUse("tool_1")
+      ),
+      user(toolResult("tool_1")),
+    ];
+
+    const sanitized = stripUnreplayableToolSearchBlocks(messages, {
+      toolSearchInRequest: false,
+    });
+
+    expect(blockTypes(sanitized[1])).toEqual(["text", "tool_use"]);
+  });
+
+  it("drops a message emptied by stripping and merges its same-role neighbors", () => {
+    const messages = [
+      user(text("Find my meetings.")),
+      assistant(search("srv_1"), searchResult("srv_1")),
+      user(text("Thanks, now summarize.")),
+    ];
+
+    const sanitized = stripUnreplayableToolSearchBlocks(messages, {
+      toolSearchInRequest: false,
+    });
+
+    expect(sanitized.map((m) => m.role)).toEqual(["user"]);
+    expect(blockTypes(sanitized[0])).toEqual(["text", "text"]);
   });
 });
 

--- a/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.ts
@@ -1,9 +1,16 @@
 import type {
+  ContentBlockParam,
+  MessageParam,
   ServerToolUseBlockParam,
   ToolSearchToolResultBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
 import logger from "@app/logger/logger";
 import { z } from "zod";
+
+const TOOL_SEARCH_SERVER_TOOL_NAMES = [
+  "tool_search_tool_bm25",
+  "tool_search_tool_regex",
+] as const;
 
 // Anthropic runs tool search server-side inside a single assistant turn, emitting
 // `server_tool_use` and `tool_search_tool_result` blocks interleaved with the
@@ -23,7 +30,7 @@ const toolReferenceSchema = z.object({
 const serverToolUseSchema = z.object({
   type: z.literal("server_tool_use"),
   id: z.string(),
-  name: z.enum(["tool_search_tool_bm25", "tool_search_tool_regex"]),
+  name: z.enum(TOOL_SEARCH_SERVER_TOOL_NAMES),
   input: z.unknown(),
 });
 
@@ -93,4 +100,200 @@ export function parseAnthropicToolSearchBlock(
     tool_use_id: r.data.tool_use_id,
     content: r.data.content,
   };
+}
+
+// -- Replay sanitation --
+//
+// The API constrains how tool search blocks can be replayed, and rejects the whole request with a
+// 400 when a constraint is violated:
+//
+//   - Without the tool search tool in the request (auxiliary calls such as title generation), no
+//     tool search block is valid at all: the results carry tool_reference blocks the API cannot
+//     expand.
+//   - With it, completed pairs (a server_tool_use with its tool_search_tool_result) must be
+//     replayed verbatim.
+//   - A dangling server_tool_use (a search the API never ran, e.g. because the turn ended on a
+//     client tool call or was interrupted) is valid only on the final assistant message when the
+//     continuation is exclusively tool_result blocks. The API then resumes the search.
+//
+// This sanitizer keeps the replayable blocks and strips the rest, unbricking conversations that
+// captured a pending search. The model simply searches again when it needs the tools. Stripping is
+// verified safe next to signed thinking blocks: signatures cover the thinking blocks themselves,
+// not their siblings (see scripts/debug_tool_search_steering_pending_search.ts).
+
+function isToolSearchServerToolUseBlock(
+  block: ContentBlockParam
+): block is ServerToolUseBlockParam {
+  return (
+    block.type === "server_tool_use" &&
+    TOOL_SEARCH_SERVER_TOOL_NAMES.some((name) => name === block.name)
+  );
+}
+
+function isToolSearchToolResultBlock(
+  block: ContentBlockParam
+): block is ToolSearchToolResultBlockParam {
+  return block.type === "tool_search_tool_result";
+}
+
+function getDanglingServerToolUseIds(
+  content: ContentBlockParam[]
+): Set<string> {
+  const resultIds = new Set(
+    content.filter(isToolSearchToolResultBlock).map((b) => b.tool_use_id)
+  );
+
+  return new Set(
+    content
+      .filter(isToolSearchServerToolUseBlock)
+      .filter((b) => !resultIds.has(b.id))
+      .map((b) => b.id)
+  );
+}
+
+function isToolResultOnlyUserMessage(message: MessageParam): boolean {
+  return (
+    message.role === "user" &&
+    Array.isArray(message.content) &&
+    message.content.length > 0 &&
+    message.content.every((block) => block.type === "tool_result")
+  );
+}
+
+// Index of the final assistant message when its dangling searches are still resumable, meaning
+// every message after it carries exclusively tool_result blocks. -1 when there is no such message.
+function findResumableAssistantIndex(messages: MessageParam[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role !== "assistant") {
+      continue;
+    }
+
+    for (let j = i + 1; j < messages.length; j++) {
+      if (!isToolResultOnlyUserMessage(messages[j])) {
+        return -1;
+      }
+    }
+    return i;
+  }
+
+  return -1;
+}
+
+function toContentBlocks(
+  content: MessageParam["content"]
+): ContentBlockParam[] {
+  return typeof content === "string"
+    ? [{ type: "text", text: content }]
+    : content;
+}
+
+// Anthropic rejects consecutive same-role messages, so re-merge neighbors after a message was
+// dropped entirely. O(n) in messages. Merging a run of same-role messages re-copies the merged
+// content at each step, but the input arrives with no same-role neighbors (the renderers already
+// merged them), so runs only form around dropped messages and stay short.
+function mergeConsecutiveSameRoleMessages(
+  messages: MessageParam[]
+): MessageParam[] {
+  const merged: MessageParam[] = [];
+  for (const message of messages) {
+    const previous = merged[merged.length - 1];
+    if (previous && previous.role === message.role) {
+      merged[merged.length - 1] = {
+        ...previous,
+        content: [
+          ...toContentBlocks(previous.content),
+          ...toContentBlocks(message.content),
+        ],
+      };
+    } else {
+      merged.push(message);
+    }
+  }
+
+  return merged;
+}
+
+interface StripUnreplayableToolSearchBlocksOptions {
+  // Whether the request being built carries the tool search server tool.
+  toolSearchInRequest: boolean;
+}
+
+// Strips the tool search blocks the API would reject, per the rules above.
+// Returns the input array untouched when nothing needs stripping, so the common path is allocation
+// free and byte identical for prompt caching.
+export function stripUnreplayableToolSearchBlocks(
+  messages: MessageParam[],
+  { toolSearchInRequest }: StripUnreplayableToolSearchBlocksOptions
+): MessageParam[] {
+  const resumableAssistantIndex = findResumableAssistantIndex(messages);
+
+  let strippedServerToolUseCount = 0;
+  let strippedResultCount = 0;
+  let droppedMessageCount = 0;
+
+  const sanitized: MessageParam[] = [];
+  for (const [index, message] of messages.entries()) {
+    if (message.role !== "assistant" || typeof message.content === "string") {
+      sanitized.push(message);
+      continue;
+    }
+
+    const danglingIds = getDanglingServerToolUseIds(message.content);
+    const danglingIsResumable =
+      toolSearchInRequest && index === resumableAssistantIndex;
+
+    const content = message.content.filter((block) => {
+      if (isToolSearchServerToolUseBlock(block)) {
+        const keep =
+          toolSearchInRequest &&
+          (!danglingIds.has(block.id) || danglingIsResumable);
+        if (!keep) {
+          strippedServerToolUseCount++;
+        }
+
+        return keep;
+      }
+
+      if (isToolSearchToolResultBlock(block)) {
+        if (!toolSearchInRequest) {
+          strippedResultCount++;
+
+          return false;
+        }
+
+        return true;
+      }
+
+      return true;
+    });
+
+    if (content.length === 0) {
+      droppedMessageCount++;
+      continue;
+    }
+
+    sanitized.push(
+      content.length === message.content.length
+        ? message
+        : { ...message, content }
+    );
+  }
+
+  if (strippedServerToolUseCount + strippedResultCount === 0) {
+    return messages;
+  }
+
+  logger.warn(
+    {
+      toolSearchInRequest,
+      strippedServerToolUseCount,
+      strippedResultCount,
+      droppedMessageCount,
+    },
+    "[tool-search] Stripped unreplayable tool search blocks from replay"
+  );
+
+  return droppedMessageCount > 0
+    ? mergeConsecutiveSameRoleMessages(sanitized)
+    : sanitized;
 }

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
@@ -4,6 +4,7 @@ import type {
   Model,
   TextBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages";
+import { stripUnreplayableToolSearchBlocks } from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
 import type { Client } from "@app/lib/model_constructors/client";
 import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import {
@@ -101,10 +102,15 @@ export function WithAnthropicAIInputConverter<
 
       const system = this.systemMessagesToSystemParam(conversation.system);
 
+      const renderedMessages = await this.conversationToMessages(conversation);
+      const messages = stripUnreplayableToolSearchBlocks(renderedMessages, {
+        toolSearchInRequest: includesToolSearchTool(anthropicTools),
+      });
+
       return {
         model: this.modelIdToApiModelId(this.constructor.modelId),
         max_tokens: this.constructor.maxOutputTokens,
-        messages: await this.conversationToMessages(conversation),
+        messages,
         system: includesToolSearchTool(anthropicTools)
           ? [...system, { type: "text", text: TOOL_SEARCH_INSTRUCTION }]
           : system,

--- a/front/lib/model_constructors/sdk/anthropic_ai/tool_search_dangling_server_tool_use.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/tool_search_dangling_server_tool_use.test.ts
@@ -1,0 +1,365 @@
+import type {
+  MessageParam,
+  RawMessageStartEvent,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import {
+  parseAnthropicToolSearchBlock,
+  stripUnreplayableToolSearchBlocks,
+} from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
+import type { MessageBlockConverters } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
+import {
+  assistantProviderPassthroughMessageToBlocks,
+  assistantReasoningMessageToThinkingBlocks,
+  assistantTextMessageToTextBlock,
+  assistantToolCallRequestToToolUseBlock,
+  conversationToMessages,
+  imageUrlToImageBlock,
+  systemMessageToTextBlock,
+  userTextMessageToTextBlock,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
+import type { OutputEventConverters } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/utils";
+import {
+  accumulatedReasoningToReasoningEvent,
+  accumulatedTextToTextEvent,
+  accumulatedToolCallToToolCallEvent,
+  inputJsonDeltaToToolCallDeltaEvent,
+  invalidJsonToolCallToToolCallEvent,
+  messageDeltaUsageToTokenUsageEvent,
+  messageStartToResponseIdEvent,
+  rawOutputToEvents,
+  reasoningDeltaToReasoningDeltaEvent,
+  serverToolBlockToProviderPassthroughEvent,
+  stopReasonToErrorEvent,
+  streamErrorToErrorEvent,
+  textDeltaToTextDeltaEvent,
+  toolUseBlockStartToToolCallStartedEvent,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/utils";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type {
+  BaseMessage,
+  ToolCallResultPart,
+} from "@app/lib/model_constructors/types/input/messages";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { describe, expect, it } from "vitest";
+
+/* Reproduction of the production 400:
+ *
+ *   messages.1: `tool_search_tool_bm25` tool use with id `srvtoolu_...` was
+ *   found without a corresponding `tool_search_tool_bm25_tool_result` block
+ *
+ * Observed incident shape: when the model calls tool search AND a client tool
+ * in the same turn, the API can end the turn (stop_reason "tool_use") without
+ * executing the searches. The response carries server_tool_use blocks with no
+ * tool_search_tool_result blocks. We persist those blocks verbatim and replay
+ * them verbatim on the next step. The API resumes the pending searches only
+ * when the continuation user message is exclusively tool_result blocks and
+ * rejects every other replay shape.
+ *
+ * These tests cover the incident end to end: stream -> unified events (what we
+ * persist) -> replayed request, sanitized by stripUnreplayableToolSearchBlocks
+ * at request build time. The resumable shape keeps the dangling blocks, the
+ * unresumable one (a text block appended after the tool_result, as enable_skill
+ * does with skill instructions) gets them stripped.
+ */
+
+const metadata: EndpointMetadata = {
+  providerId: "anthropic",
+  api: "anthropic",
+  region: "us",
+  modelId: "claude-opus-4-8",
+};
+
+const outputConverters: OutputEventConverters = {
+  messageStartToResponseIdEvent,
+  textDeltaToTextDeltaEvent,
+  reasoningDeltaToReasoningDeltaEvent,
+  accumulatedTextToTextEvent,
+  accumulatedReasoningToReasoningEvent,
+  toolUseBlockStartToToolCallStartedEvent,
+  inputJsonDeltaToToolCallDeltaEvent,
+  accumulatedToolCallToToolCallEvent,
+  invalidJsonToolCallToToolCallEvent,
+  serverToolBlockToProviderPassthroughEvent,
+  messageDeltaUsageToTokenUsageEvent,
+  stopReasonToErrorEvent,
+  streamErrorToErrorEvent,
+};
+
+const inputConverters: MessageBlockConverters = {
+  systemMessageToTextBlock,
+  userTextMessageToTextBlock,
+  imageUrlToImageBlock,
+  assistantTextMessageToTextBlock,
+  assistantReasoningMessageToThinkingBlocks,
+  assistantToolCallRequestToToolUseBlock,
+  assistantProviderPassthroughMessageToBlocks,
+};
+
+// The incident stream: two tool searches and a client tool call in one burst,
+// ending on stop_reason "tool_use" with NO tool_search_tool_result blocks.
+function incidentStreamEvents(): RawMessageStreamEvent[] {
+  return [
+    {
+      type: "message_start",
+      message: { id: "msg_incident" },
+    } as RawMessageStartEvent,
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "", citations: [] },
+    } as RawMessageStreamEvent,
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: {
+        type: "text_delta",
+        text: "Let me find the right tools and enable Go Deep.",
+      },
+    } as RawMessageStreamEvent,
+    { type: "content_block_stop", index: 0 } as RawMessageStreamEvent,
+    {
+      type: "content_block_start",
+      index: 1,
+      content_block: {
+        type: "server_tool_use",
+        id: "srvtoolu_01HYMiK87QN76JLMFWMfRcha",
+        name: "tool_search_tool_bm25",
+        input: {},
+      },
+    } as RawMessageStreamEvent,
+    {
+      type: "content_block_delta",
+      index: 1,
+      delta: {
+        type: "input_json_delta",
+        partial_json: '{"limit":10,"query":"search retrieve documents"}',
+      },
+    } as RawMessageStreamEvent,
+    { type: "content_block_stop", index: 1 } as RawMessageStreamEvent,
+    {
+      type: "content_block_start",
+      index: 2,
+      content_block: {
+        type: "server_tool_use",
+        id: "srvtoolu_012AkyEMoNfiXjN9W6r2SiWJ",
+        name: "tool_search_tool_bm25",
+        input: {},
+      },
+    } as RawMessageStreamEvent,
+    {
+      type: "content_block_delta",
+      index: 2,
+      delta: {
+        type: "input_json_delta",
+        partial_json: '{"limit":10,"query":"Google Calendar list events"}',
+      },
+    } as RawMessageStreamEvent,
+    { type: "content_block_stop", index: 2 } as RawMessageStreamEvent,
+    {
+      type: "content_block_start",
+      index: 3,
+      content_block: {
+        type: "tool_use",
+        id: "toolu_015T894z6exFvubKtC8hCZaf",
+        name: "skill_management__enable_skill",
+        input: {},
+      },
+    } as RawMessageStreamEvent,
+    {
+      type: "content_block_delta",
+      index: 3,
+      delta: {
+        type: "input_json_delta",
+        partial_json: '{"skillName":"Go Deep"}',
+      },
+    } as RawMessageStreamEvent,
+    { type: "content_block_stop", index: 3 } as RawMessageStreamEvent,
+    {
+      type: "message_delta",
+      delta: { stop_reason: "tool_use", stop_sequence: null },
+      usage: {
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        input_tokens: 100,
+        output_tokens: 50,
+        output_tokens_details: null,
+        server_tool_use: null,
+      },
+    } as RawMessageStreamEvent,
+    { type: "message_stop" } as RawMessageStreamEvent,
+  ];
+}
+
+async function* streamOf(
+  events: RawMessageStreamEvent[]
+): AsyncGenerator<RawMessageStreamEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+async function collect(
+  generator: AsyncGenerator<ModelResponseEvent>
+): Promise<ModelResponseEvent[]> {
+  const out: ModelResponseEvent[] = [];
+  for await (const event of generator) {
+    out.push(event);
+  }
+  return out;
+}
+
+describe("tool search alongside client tool_use without search results", () => {
+  it("persists the dangling server_tool_use blocks exactly as streamed", async () => {
+    const events = await collect(
+      rawOutputToEvents(
+        streamOf(incidentStreamEvents()),
+        metadata,
+        outputConverters
+      )
+    );
+
+    // The two searches surface as passthrough blocks (what we persist and
+    // replay), with no result blocks anywhere in the stream.
+    const passthroughBlocks = events
+      .filter((e) => e.type === "provider_passthrough")
+      .map((e) => parseAnthropicToolSearchBlock(e.content.block));
+    expect(passthroughBlocks.map((b) => b?.type)).toEqual([
+      "server_tool_use",
+      "server_tool_use",
+    ]);
+
+    const toolCalls = events.filter((e) => e.type === "tool_call");
+    expect(toolCalls).toHaveLength(1);
+  });
+
+  it("keeps the dangling blocks in the resumable shape and strips them from the unresumable one", async () => {
+    // What we persist from the incident stream, replayed on the next step
+    // alongside the client tool's result, mirroring the agent loop.
+    const events = await collect(
+      rawOutputToEvents(
+        streamOf(incidentStreamEvents()),
+        metadata,
+        outputConverters
+      )
+    );
+
+    const replayedAssistantMessages: BaseMessage[] = events.flatMap(
+      (event): BaseMessage[] => {
+        switch (event.type) {
+          case "text":
+            return [
+              {
+                role: "assistant",
+                type: "text",
+                content: { value: event.content.value },
+              },
+            ];
+          case "provider_passthrough":
+            return [
+              {
+                role: "assistant",
+                type: "provider_passthrough",
+                content: event.content,
+              },
+            ];
+          case "tool_call":
+            return [
+              {
+                role: "assistant",
+                type: "tool_call_request",
+                content: {
+                  callId: event.content.id,
+                  toolName: event.content.name,
+                  arguments: JSON.stringify(event.content.arguments),
+                },
+              },
+            ];
+          default:
+            return [];
+        }
+      }
+    );
+
+    const toolResultParts: ToolCallResultPart[] = [
+      { type: "text", text: "Skill enabled." },
+    ];
+
+    const messages = await conversationToMessages(
+      {
+        system: [],
+        messages: [
+          {
+            role: "user",
+            type: "text",
+            content: { value: "Summarize the meeting." },
+          },
+          ...replayedAssistantMessages,
+          {
+            role: "user",
+            type: "tool_call_result",
+            content: {
+              callId: "toolu_015T894z6exFvubKtC8hCZaf",
+              toolName: "skill_management__enable_skill",
+              parts: toolResultParts,
+              isError: false,
+            },
+          },
+        ],
+      },
+      inputConverters
+    );
+
+    // messages[1] is the assistant message, the `messages.1` the API error
+    // pointed at. The renderer stays faithful: it replays the dangling blocks
+    // exactly as persisted.
+    expect(messages.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+
+    const assistantBlockTypes = (message: MessageParam): string[] => {
+      if (typeof message.content === "string") {
+        throw new Error("expected block content");
+      }
+      return message.content.map((b) => b.type);
+    };
+
+    expect(assistantBlockTypes(messages[1])).toEqual([
+      "text",
+      "server_tool_use",
+      "server_tool_use",
+      "tool_use",
+    ]);
+
+    // The continuation is exclusively tool_result blocks, so the shape is
+    // resumable: the sanitizer keeps the dangling blocks and the API runs the
+    // pending searches on the next request.
+    expect(
+      stripUnreplayableToolSearchBlocks(messages, { toolSearchInRequest: true })
+    ).toBe(messages);
+
+    // With a text block appended after the tool_result (what enable_skill does
+    // with skill instructions), the shape is unresumable and the dangling
+    // blocks are stripped, avoiding the 400.
+    const lastMessage = messages[messages.length - 1];
+    if (typeof lastMessage.content === "string") {
+      throw new Error("expected block content");
+    }
+    const unresumableMessages: MessageParam[] = [
+      ...messages.slice(0, -1),
+      {
+        ...lastMessage,
+        content: [
+          ...lastMessage.content,
+          {
+            type: "text",
+            text: "<dust_system>skill instructions</dust_system>",
+          },
+        ],
+      },
+    ];
+
+    const sanitized = stripUnreplayableToolSearchBlocks(unresumableMessages, {
+      toolSearchInRequest: true,
+    });
+    expect(assistantBlockTypes(sanitized[1])).toEqual(["text", "tool_use"]);
+  });
+});


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
With Anthropic tool search enabled, assistant turns carry server side search blocks that we persist opaquely and replay verbatim on later requests. The API validates those blocks on every request and rejects the whole request with a 400 when the replayed shape is not one it can honor. In production this bricked conversations: once the bad shape was persisted, every subsequent step failed deterministically with the same error, and retries could not help.

Live probing and a [chat](https://dust4ai.slack.com/archives/C0735P3JH9T/p1783006234708799?thread_ts=1782917065.661639&cid=C0735P3JH9T) with Anthropic established the exact contract, which the public documentation does not cover. A search the API never ran, which happens when the model issues searches and a client tool call in the same turn and the turn ends on the client call, or when a turn is interrupted, is accepted in exactly one shape: it must sit on the final assistant message and the continuation must consist exclusively of tool results, in which case the API resumes the search on the follow up request. Every other replay is rejected: a text block appended to the continuation, which is what enabling a skill does with its instructions and was the trigger observed in production, a pending search sitting in the middle of history after the conversation moved on, or a stopped or errored turn followed by a new user message. Separately, requests that carry no tool search tool at all, such as title generation and other auxiliary calls that replay conversation history without tools, reject any tool search block because the tool references inside the results cannot be expanded.

The fix is a single pure sanitation step where the provider request is assembled, applied in both the new router and the legacy client and therefore covering streaming and batch. It keeps everything the API accepts and strips only what it would reject. Completed search pairs are never touched. A pending search in the resumable shape is kept so the API can still run it, which is strictly better than stripping since the search is not lost. Every other pending search is removed, as are all tool search blocks on requests that do not carry the search tool. When stripping empties a message entirely the message is dropped and its same role neighbors are re merged, since the API also rejects consecutive same role messages. When nothing needs stripping the input is returned untouched, so the common path allocates nothing and stays byte identical for prompt caching.

> [!NOTE]
> The main risk assessed was the interaction with signed thinking blocks, since the same assistant message can interleave reasoning with searches and the API rejects modified thinking. Both the documentation and live probes confirm the signature covers the thinking blocks themselves and not their siblings: removing a pending search from the middle of a message that carries signed thinking is accepted, including with an unresumable continuation and with tool choice steering on the follow up request.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
