### PR TITLE
Pricing: Add a new 'top-ups history' tab in usage page

### DIFF
--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -15,6 +15,7 @@ import membersUsage from "./members-usage";
 import myUsage from "./my-usage";
 import myUsageAnalytics from "./my-usage-analytics";
 import purchase from "./purchase";
+import topUps from "./top-ups";
 import upgradeRequests from "./upgrade-requests";
 import usageConfiguration from "./usage-configuration";
 
@@ -27,6 +28,7 @@ app.route("/members-usage", membersUsage);
 app.route("/my-usage", myUsage);
 app.route("/my-usage-analytics", myUsageAnalytics);
 app.route("/purchase", purchase);
+app.route("/top-ups", topUps);
 app.route("/upgrade-requests", upgradeRequests);
 app.route("/usage-configuration", usageConfiguration);
 

--- a/front-api/routes/w/[wId]/credits/top-ups.test.ts
+++ b/front-api/routes/w/[wId]/credits/top-ups.test.ts
@@ -1,0 +1,180 @@
+import * as metronomeClient from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import type { MetronomeBalance } from "@app/lib/metronome/types";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<typeof metronomeClient>(
+    "@app/lib/metronome/client"
+  );
+  return {
+    ...actual,
+    listMetronomeBalances: vi.fn(),
+  };
+});
+
+// The seat-product filter goes through Redis-cached Metronome lookups that
+// are unavailable in tests; with no active contract the filter is a no-op.
+vi.mock("@app/lib/metronome/plan_type", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/plan_type")
+  >("@app/lib/metronome/plan_type");
+  return {
+    ...actual,
+    getActiveContract: vi.fn().mockResolvedValue(null),
+  };
+});
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/seat_types")
+  >("@app/lib/metronome/seat_types");
+  return {
+    ...actual,
+    getProductSeatTypes: vi.fn().mockResolvedValue(new Map()),
+  };
+});
+
+function topUpsUrl(wId: string) {
+  return `/api/w/${wId}/credits/top-ups`;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW_MS = Date.now();
+const TWO_MONTHS_AGO = new Date(NOW_MS - 60 * DAY_MS).toISOString();
+const ONE_MONTH_AGO = new Date(NOW_MS - 30 * DAY_MS).toISOString();
+const ONE_WEEK_AGO = new Date(NOW_MS - 7 * DAY_MS).toISOString();
+const NEXT_MONTH = new Date(NOW_MS + 30 * DAY_MS).toISOString();
+const NEXT_YEAR = new Date(NOW_MS + 365 * DAY_MS).toISOString();
+
+function makeAwuCredit({
+  name,
+  scheduleItems,
+  contractId,
+}: {
+  name: string;
+  scheduleItems: { amount: number; startingAt: string; endingBefore: string }[];
+  contractId?: string;
+}): MetronomeBalance {
+  return {
+    id: `credit-${name}`,
+    type: "CREDIT",
+    product: { id: "product-pool", name: "Credits" },
+    ...(contractId ? { contract: { id: contractId } } : {}),
+    access_schedule: {
+      credit_type: { id: getCreditTypeAwuId(), name: "AWU" },
+      schedule_items: scheduleItems.map((item, i) => ({
+        id: `item-${name}-${i}`,
+        amount: item.amount,
+        starting_at: item.startingAt,
+        ending_before: item.endingBefore,
+      })),
+    },
+    name,
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(metronomeClient.listMetronomeBalances).mockResolvedValue(
+    new Ok([])
+  );
+});
+
+describe("GET /api/w/[wId]/credits/top-ups", () => {
+  it("returns 403 when the caller is a user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(topUpsUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+    expect(metronomeClient.listMetronomeBalances).not.toHaveBeenCalled();
+  });
+
+  it("returns the granted top-ups, most recent first, excluding future grants", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+      workspace,
+    });
+
+    vi.mocked(metronomeClient.listMetronomeBalances).mockResolvedValue(
+      new Ok([
+        makeAwuCredit({
+          name: "Coupon: WELCOME100",
+          scheduleItems: [
+            {
+              amount: 1000,
+              startingAt: TWO_MONTHS_AGO,
+              endingBefore: NEXT_MONTH,
+            },
+          ],
+        }),
+        // Recurring free credits: the future period is not a top-up yet.
+        makeAwuCredit({
+          name: "Free Monthly Credits",
+          scheduleItems: [
+            {
+              amount: 500,
+              startingAt: ONE_MONTH_AGO,
+              endingBefore: NEXT_MONTH,
+            },
+            { amount: 500, startingAt: NEXT_MONTH, endingBefore: NEXT_YEAR },
+          ],
+        }),
+        makeAwuCredit({
+          name: "Credit top-up: 5,000 credits",
+          scheduleItems: [
+            { amount: 5000, startingAt: ONE_WEEK_AGO, endingBefore: NEXT_YEAR },
+          ],
+          contractId: "test-metronome-contract-id",
+        }),
+        // Grant on another contract: excluded.
+        makeAwuCredit({
+          name: "Other contract grant",
+          scheduleItems: [
+            {
+              amount: 42,
+              startingAt: TWO_MONTHS_AGO,
+              endingBefore: NEXT_MONTH,
+            },
+          ],
+          contractId: "some-other-contract-id",
+        }),
+      ])
+    );
+
+    const response = await honoApp.request(topUpsUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.topUps).toEqual([
+      {
+        name: "Credit top-up: 5,000 credits",
+        amountCredits: 5000,
+        grantedAtMs: new Date(ONE_WEEK_AGO).getTime(),
+        expiresAtMs: new Date(NEXT_YEAR).getTime(),
+      },
+      {
+        name: "Free Monthly Credits",
+        amountCredits: 500,
+        grantedAtMs: new Date(ONE_MONTH_AGO).getTime(),
+        expiresAtMs: new Date(NEXT_MONTH).getTime(),
+      },
+      {
+        name: "Coupon: WELCOME100",
+        amountCredits: 1000,
+        grantedAtMs: new Date(TWO_MONTHS_AGO).getTime(),
+        expiresAtMs: new Date(NEXT_MONTH).getTime(),
+      },
+    ]);
+  });
+});

--- a/front-api/routes/w/[wId]/credits/top-ups.ts
+++ b/front-api/routes/w/[wId]/credits/top-ups.ts
@@ -1,0 +1,52 @@
+import type { AwuTopUpsHistoryError } from "@app/lib/api/credits/top_ups_history";
+import { getAwuTopUpsHistory } from "@app/lib/api/credits/top_ups_history";
+import type { GetAwuTopUpsHistoryResponseBody } from "@app/types/api/credits/top_ups_history";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+function topUpsErrorToApi(ctx: Context, err: AwuTopUpsHistoryError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/w/:wId/credits/top-ups.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsBusinessAdmin(),
+  async (ctx): HandlerResult<GetAwuTopUpsHistoryResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const result = await getAwuTopUpsHistory(auth);
+    if (result.isErr()) {
+      return topUpsErrorToApi(ctx, result.error);
+    }
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -19,6 +19,7 @@ import { GroupsUsageTable } from "@app/components/workspace/GroupsUsageTable";
 import { MembersSelectionBanner } from "@app/components/workspace/MembersSelectionBanner";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
+import { TopUpsHistoryTable } from "@app/components/workspace/TopUpsHistoryTable";
 import { UpgradeRequestsTable } from "@app/components/workspace/UpgradeRequestsTable";
 import { AdvancedModelsSettingsCard } from "@app/components/workspace/usage/AdvancedModelsSettingsCard";
 import { LockedSection } from "@app/components/workspace/usage/LockedSection";
@@ -983,6 +984,9 @@ export function UsagePage() {
             {isWorkspaceAdmin && pricingGroupsEnabled && (
               <TabsTrigger value="groups" label="Groups" />
             )}
+            {isWorkspaceAdmin && isCreditPriced && (
+              <TabsTrigger value="top-ups" label="Top-ups history" />
+            )}
             {isWorkspaceAdmin && (
               <TabsTrigger value="settings" label="Settings" />
             )}
@@ -1053,6 +1057,12 @@ export function UsagePage() {
           {isWorkspaceAdmin && pricingGroupsEnabled && (
             <TabsContent value="groups">
               <GroupsUsageTable owner={owner} readOnly={isReadOnly} />
+            </TabsContent>
+          )}
+
+          {isWorkspaceAdmin && isCreditPriced && (
+            <TabsContent value="top-ups">
+              <TopUpsHistoryTable owner={owner} />
             </TabsContent>
           )}
 

--- a/front/components/workspace/TopUpsHistoryTable.tsx
+++ b/front/components/workspace/TopUpsHistoryTable.tsx
@@ -1,0 +1,111 @@
+import { formatCredits } from "@app/lib/client/credits";
+import { useAwuTopUpsHistory } from "@app/lib/swr/credits";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  AlertCircle,
+  ContentMessage,
+  DataTable,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
+
+interface TopUpsHistoryTableProps {
+  owner: LightWorkspaceType;
+}
+
+type TopUpRowData = {
+  date: string;
+  name: string;
+  credits: string;
+  expiration: string;
+  onClick?: () => void;
+};
+
+const COLUMNS: ColumnDef<TopUpRowData, string>[] = [
+  {
+    accessorKey: "date",
+    header: "Date",
+    enableSorting: false,
+    meta: { className: "w-[18%]" },
+    cell: ({ row }) => <span className="text-sm">{row.original.date}</span>,
+  },
+  {
+    accessorKey: "name",
+    header: "Top-up",
+    enableSorting: false,
+    meta: { className: "w-[44%]" },
+    cell: ({ row }) => <span className="text-sm">{row.original.name}</span>,
+  },
+  {
+    accessorKey: "credits",
+    header: "Credits",
+    enableSorting: false,
+    meta: { headerAlign: "right", className: "w-[18%]" },
+    cell: ({ row }) => (
+      <span className="block text-right text-sm">{row.original.credits}</span>
+    ),
+  },
+  {
+    accessorKey: "expiration",
+    header: "Expiration",
+    enableSorting: false,
+    meta: { headerAlign: "right", className: "w-[20%]" },
+    cell: ({ row }) => (
+      <span className="block text-right text-sm text-muted-foreground">
+        {row.original.expiration}
+      </span>
+    ),
+  },
+];
+
+export function TopUpsHistoryTable({ owner }: TopUpsHistoryTableProps) {
+  const { topUps, isTopUpsHistoryLoading, isTopUpsHistoryError } =
+    useAwuTopUpsHistory({ workspaceId: owner.sId });
+
+  const rows: TopUpRowData[] = useMemo(() => {
+    const nowMs = Date.now();
+    return topUps.map((topUp) => ({
+      date: formatTimestampToFriendlyDate(topUp.grantedAtMs, "compactWithDay"),
+      name: topUp.name,
+      credits: formatCredits(topUp.amountCredits),
+      expiration:
+        topUp.expiresAtMs <= nowMs
+          ? `Expired ${formatTimestampToFriendlyDate(topUp.expiresAtMs, "compactWithDay")}`
+          : formatTimestampToFriendlyDate(topUp.expiresAtMs, "compactWithDay"),
+    }));
+  }, [topUps]);
+
+  if (isTopUpsHistoryError) {
+    return (
+      <ContentMessage
+        title="Failed to load top-ups history"
+        icon={AlertCircle}
+        variant="warning"
+      >
+        An error occurred while loading the top-ups history. Please refresh the
+        page or contact support if the issue persists.
+      </ContentMessage>
+    );
+  }
+
+  if (isTopUpsHistoryLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <span className="copy-sm text-muted-foreground">
+        No top-ups yet: credits you buy, free credits and coupon credits will
+        appear here.
+      </span>
+    );
+  }
+
+  return <DataTable data={rows} columns={COLUMNS} hideRowDivider={false} />;
+}

--- a/front/lib/api/credits/top_ups_history.ts
+++ b/front/lib/api/credits/top_ups_history.ts
@@ -1,0 +1,100 @@
+import type { Authenticator } from "@app/lib/auth";
+import { listMetronomeBalances } from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import {
+  getProductSeatTypes,
+  getSeatTypesByProductIdFromContract,
+} from "@app/lib/metronome/seat_types";
+import type {
+  AwuTopUpData,
+  GetAwuTopUpsHistoryResponseBody,
+} from "@app/types/api/credits/top_ups_history";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export class AwuTopUpsHistoryError extends Error {
+  constructor(
+    readonly type: "not_configured" | "balances_fetch_failed",
+    readonly cause?: Error
+  ) {
+    super(type);
+  }
+}
+
+/**
+ * List every top-up of the workspace AWU credit pool that has happened so
+ * far: purchased credits, free recurring credits, coupon credits and manual
+ * grants. Each schedule item of a Metronome pool commit/credit is one
+ * top-up, dated by its access start.
+ */
+export async function getAwuTopUpsHistory(
+  auth: Authenticator
+): Promise<Result<GetAwuTopUpsHistoryResponseBody, AwuTopUpsHistoryError>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription();
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId || !subscription?.metronomeContractId) {
+    return new Err(new AwuTopUpsHistoryError("not_configured"));
+  }
+  const { metronomeContractId } = subscription;
+
+  const now = new Date();
+
+  // Unlike the pool summary, this is a history: drop the covering-date
+  // filter so expired grants are returned, and hide future-dated balances.
+  const balancesResult = await listMetronomeBalances(metronomeCustomerId, {
+    coveringDate: null,
+    effectiveBefore: now,
+  });
+  if (balancesResult.isErr()) {
+    return new Err(
+      new AwuTopUpsHistoryError("balances_fetch_failed", balancesResult.error)
+    );
+  }
+
+  // Filter to non-seat AWU pool credits and commits — same filter as the
+  // pool summary (`getAwuPoolSummary`). The seat product IDs come from the
+  // contract's tagged subscriptions, and the contract filter prevents
+  // grants on other contracts from leaking into the history.
+  const awuCreditTypeId = getCreditTypeAwuId();
+  const activeContract = await getActiveContract(workspace.sId);
+  const productSeatTypes = await getProductSeatTypes();
+  const seatProductIds = activeContract
+    ? new Set(
+        getSeatTypesByProductIdFromContract(
+          activeContract,
+          productSeatTypes
+        ).keys()
+      )
+    : new Set<string>();
+  const awuBalances = balancesResult.value.filter(
+    (entry) =>
+      entry.access_schedule?.credit_type?.id === awuCreditTypeId &&
+      !seatProductIds.has(entry.product.id) &&
+      (entry.contract?.id === metronomeContractId || !entry.contract)
+  );
+
+  const nowMs = now.getTime();
+  const topUps: AwuTopUpData[] = [];
+  for (const entry of awuBalances) {
+    for (const item of entry.access_schedule?.schedule_items ?? []) {
+      const grantedAtMs = new Date(item.starting_at).getTime();
+      // A recurring credit carries one schedule item per period; items
+      // starting in the future are grants that have not happened yet.
+      if (grantedAtMs > nowMs) {
+        continue;
+      }
+      topUps.push({
+        name: entry.name ?? entry.product.name,
+        amountCredits: item.amount,
+        grantedAtMs,
+        expiresAtMs: new Date(item.ending_before).getTime(),
+      });
+    }
+  }
+
+  return new Ok({
+    topUps: topUps.sort((a, b) => b.grantedAtMs - a.grantedAtMs),
+  });
+}

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -7,6 +7,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
 import type { GetMembersSeatsResponseBody } from "@app/types/api/credits/members_seats";
+import type { GetAwuTopUpsHistoryResponseBody } from "@app/types/api/credits/top_ups_history";
 import type {
   GetCreditsResponseBody,
   PendingCreditData,
@@ -255,6 +256,30 @@ export function useAwuPoolSummary({
     isAwuPoolSummaryError: error,
     isAwuPoolSummaryValidating: isValidating,
     mutateAwuPoolSummary: mutate,
+  };
+}
+
+export function useAwuTopUpsHistory({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const topUpsFetcher: Fetcher<GetAwuTopUpsHistoryResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/credits/top-ups`,
+    topUpsFetcher,
+    { disabled }
+  );
+
+  return {
+    topUps: data?.topUps ?? emptyArray(),
+    isTopUpsHistoryLoading: !error && !data && !disabled,
+    isTopUpsHistoryError: error,
+    mutateTopUpsHistory: mutate,
   };
 }
 

--- a/front/types/api/credits/top_ups_history.ts
+++ b/front/types/api/credits/top_ups_history.ts
@@ -1,0 +1,16 @@
+export type AwuTopUpData = {
+  /**
+   * Metronome grant name — self-describing, e.g. "Credit top-up: 5,000
+   * credits", "Free Monthly Credits", "Coupon: WELCOME100".
+   */
+  name: string;
+  amountCredits: number;
+  /** When the credits were granted to the workspace pool. */
+  grantedAtMs: number;
+  /** Exclusive end of the grant's validity period. */
+  expiresAtMs: number;
+};
+
+export type GetAwuTopUpsHistoryResponseBody = {
+  topUps: AwuTopUpData[];
+};


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8837

There is currently no way to see the top-ups contributing to the pool.
This PRs pull the information for metronome and displays it as a new tab in the "Usage" page.

<img width="1714" height="683" alt="Screenshot 2026-07-06 at 16 10 05" src="https://github.com/user-attachments/assets/3b262c3c-8661-439d-b60e-fb9ea4760695" />

There is a question of where to place this between the "Usage" page and the "Billing" page. IMHO it is more adapted to be in the Usage page because it is the only place where we talk about the credit pool, and it is the place where you can actually top up the pool, so where you will want to see the history.

## Tests

Tested locally + unit tests

## Risk

low, easy to revert

## Deploy Plan

deploy front