### PR TITLE
[front] poke: support usage coupons in apply_coupon plugin

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/apply_coupon.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_coupon.test.ts
@@ -134,6 +134,7 @@ describe("applyCouponPlugin.execute", () => {
     if (result.isOk()) {
       expect(result.value.display).toBe("text");
       expect(result.value.value).toContain(coupon.code);
+      expect(result.value.value).toContain("seat discount");
     }
 
     const redemptions = await CouponRedemptionResource.listAllByCoupon(coupon);
@@ -143,6 +144,53 @@ describe("applyCouponPlugin.execute", () => {
     expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({ action: "coupon.redeemed" })
     );
+  });
+
+  it("applies a valid credit_pool_top_up coupon → active redemption, type shown in output, audit event emitted", async () => {
+    const { auth } = await makeWorkspaceWithMetronome();
+    const coupon = await CouponFactory.create({
+      discountType: "credit_pool_top_up",
+      amount: 5000,
+    });
+    mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "awu-credit-1" }));
+
+    const result = await applyCouponPlugin.execute(auth, null, {
+      couponCode: coupon.code,
+      confirm: true,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.display).toBe("text");
+      expect(result.value.value).toContain(coupon.code);
+      expect(result.value.value).toContain("usage credit top-up");
+    }
+
+    const redemptions = await CouponRedemptionResource.listAllByCoupon(coupon);
+    expect(redemptions).toHaveLength(1);
+    expect(redemptions[0].status).toBe("active");
+
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "coupon.redeemed" })
+    );
+  });
+
+  it("returns Err with workspace_not_on_metronome message for credit_pool_top_up coupon when no Metronome customer ID", async () => {
+    const { auth } = await makeWorkspaceNoMetronome();
+    const coupon = await CouponFactory.create({
+      discountType: "credit_pool_top_up",
+      amount: 5000,
+    });
+
+    const result = await applyCouponPlugin.execute(auth, null, {
+      couponCode: coupon.code,
+      confirm: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(/not provisioned on Metronome/i);
+    }
   });
 
   it("returns Err when coupon code is not found", async () => {

--- a/front/lib/api/poke/plugins/workspaces/apply_coupon.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_coupon.ts
@@ -54,12 +54,17 @@ export const applyCouponPlugin = createPlugin({
 
     const { discountType } = coupon;
 
-    const result =
-      discountType === "seat"
-        ? await redeemCoupon(auth, { coupon })
-        : discountType === "credit_pool_top_up"
-          ? await redeemCreditsCoupon(auth, { coupon })
-          : assertNever(discountType); // exhaustive check — compile-time safety for future types
+    let result;
+    switch (discountType) {
+      case "seat":
+        result = await redeemCoupon(auth, { coupon });
+        break;
+      case "credit_pool_top_up":
+        result = await redeemCreditsCoupon(auth, { coupon });
+        break;
+      default:
+        return assertNever(discountType);
+    }
 
     if (result.isErr()) {
       const err = result.error;
@@ -70,10 +75,18 @@ export const applyCouponPlugin = createPlugin({
     }
 
     const redemption = result.value;
-    const typeLabel =
-      discountType === "seat"
-        ? "seat discount (subscription)"
-        : "usage credit top-up (AWU)";
+
+    let typeLabel;
+    switch (discountType) {
+      case "seat":
+        typeLabel = "seat discount (subscription)";
+        break;
+      case "credit_pool_top_up":
+        typeLabel = "usage credit top-up (AWU)";
+        break;
+      default:
+        return assertNever(discountType);
+    }
 
     return new Ok({
       display: "text",

--- a/front/lib/api/poke/plugins/workspaces/apply_coupon.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_coupon.ts
@@ -1,5 +1,6 @@
 import { createPlugin } from "@app/lib/api/poke/types";
-import { redeemCoupon } from "@app/lib/metronome/coupons";
+import { redeemCoupon, redeemCreditsCoupon } from "@app/lib/metronome/coupons";
+import type { CouponValidationError } from "@app/lib/resources/coupon_resource";
 import { CouponResource } from "@app/lib/resources/coupon_resource";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -20,7 +21,9 @@ export const applyCouponPlugin = createPlugin({
     id: "apply-coupon",
     name: "Apply Coupon",
     description:
-      "Apply a coupon to this workspace on behalf of the customer. The workspace must already be provisioned on Metronome.",
+      "Apply a coupon to this workspace on behalf of the customer. " +
+      "Supports both seat coupons (subscription discount) and usage coupons (AWU credit top-up). " +
+      "The workspace must already be provisioned on Metronome.",
     resourceTypes: ["workspaces"],
     args: {
       couponCode: {
@@ -49,59 +52,78 @@ export const applyCouponPlugin = createPlugin({
       return new Err(new Error(`Coupon not found: "${couponCode}".`));
     }
 
-    const result = await redeemCoupon(auth, { coupon });
+    const { discountType } = coupon;
+
+    const result =
+      discountType === "seat"
+        ? await redeemCoupon(auth, { coupon })
+        : discountType === "credit_pool_top_up"
+          ? await redeemCreditsCoupon(auth, { coupon })
+          : assertNever(discountType); // exhaustive check — compile-time safety for future types
+
     if (result.isErr()) {
       const err = result.error;
       if (err instanceof Error) {
         return new Err(err);
       }
-      switch (err.code) {
-        case "workspace_not_on_metronome":
-          return new Err(
-            new Error(
-              "Workspace is not provisioned on Metronome. Provision it first using the 'Switch to Metronome Billing' plugin."
-            )
-          );
-        case "coupon_validation_failed":
-          switch (err.reason.code) {
-            case "expired":
-              return new Err(
-                new Error(
-                  `Coupon "${couponCode}" expired on ${err.reason.expirationDate.toISOString()}.`
-                )
-              );
-            case "exhausted":
-              return new Err(
-                new Error(
-                  `Coupon "${couponCode}" has reached its limit of ${err.reason.maxRedemptions} redemption(s).`
-                )
-              );
-            case "archived":
-              return new Err(new Error(`Coupon "${couponCode}" is archived.`));
-            case "already_redeemed":
-              return new Err(
-                new Error(
-                  `Coupon "${couponCode}" has already been redeemed by this workspace.`
-                )
-              );
-            case "wrong_coupon_type":
-              return new Err(
-                new Error(
-                  `Coupon "${couponCode}" cannot be applied as a subscription discount.`
-                )
-              );
-            default:
-              return assertNever(err.reason);
-          }
-        default:
-          return assertNever(err);
-      }
+      return handleRedeemError(couponCode, err);
     }
 
     const redemption = result.value;
+    const typeLabel =
+      discountType === "seat"
+        ? "seat discount (subscription)"
+        : "usage credit top-up (AWU)";
+
     return new Ok({
       display: "text",
-      value: `Coupon "${couponCode}" applied successfully. Redemption ID: ${redemption.sId}.`,
+      value: `Coupon "${couponCode}" applied successfully.\nType: ${typeLabel}\nRedemption ID: ${redemption.sId}.`,
     });
   },
 });
+
+function handleRedeemError(
+  couponCode: string,
+  err:
+    | { code: "workspace_not_on_metronome" }
+    | { code: "coupon_validation_failed"; reason: CouponValidationError }
+): Err<Error> {
+  switch (err.code) {
+    case "workspace_not_on_metronome":
+      return new Err(new Error("Workspace is not provisioned on Metronome."));
+    case "coupon_validation_failed":
+      switch (err.reason.code) {
+        case "expired":
+          return new Err(
+            new Error(
+              `Coupon "${couponCode}" expired on ${err.reason.expirationDate.toISOString()}.`
+            )
+          );
+        case "exhausted":
+          return new Err(
+            new Error(
+              `Coupon "${couponCode}" has reached its limit of ${err.reason.maxRedemptions} redemption(s).`
+            )
+          );
+        case "archived":
+          return new Err(new Error(`Coupon "${couponCode}" is archived.`));
+        case "already_redeemed":
+          return new Err(
+            new Error(
+              `Coupon "${couponCode}" has already been redeemed by this workspace.`
+            )
+          );
+        case "wrong_coupon_type":
+          // Defensive fallback — should not be reached with proper discountType routing.
+          return new Err(
+            new Error(
+              `Coupon "${couponCode}" is not valid for its detected coupon type.`
+            )
+          );
+        default:
+          return assertNever(err.reason);
+      }
+    default:
+      return assertNever(err);
+  }
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9416
=> handle both types of coupons in Apply Coupon poke plugin

Branch on discountType to redeem seat coupons via redeemCoupon and credit_pool_top_up coupons via redeemCreditsCoupon, and surface the applied coupon type in the plugin's success output.

## Tests

Tested locally => applied coupons for seat and usage using the plugin

## Risk

Low, poke plugin only

## Deploy Plan

Deploy front