### PR TITLE
Pricing: Add contract id to pool credits coupon 

### DIFF
--- a/front-api/routes/w/[wId]/coupon/redeem.ts
+++ b/front-api/routes/w/[wId]/coupon/redeem.ts
@@ -1,4 +1,4 @@
-import { redeemCreditsCoupon } from "@app/lib/metronome/coupons";
+import { redeemPoolTopupCoupon } from "@app/lib/metronome/coupons";
 import { CouponResource } from "@app/lib/resources/coupon_resource";
 import type { CouponType } from "@app/types/coupon";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -44,7 +44,7 @@ app.post(
       });
     }
 
-    const result = await redeemCreditsCoupon(auth, { coupon });
+    const result = await redeemPoolTopupCoupon(auth, { coupon });
     if (result.isErr()) {
       const err = result.error;
       if (err instanceof Error) {

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -16,7 +16,7 @@ import {
 } from "@app/lib/metronome/amounts";
 import {
   useAwuPurchaseStatus,
-  useRedeemCreditsCoupon,
+  useRedeemPoolTopupCoupon,
 } from "@app/lib/swr/credits";
 import { useValidateCoupon } from "@app/lib/swr/workspaces";
 import type { CouponType } from "@app/types/coupon";
@@ -132,7 +132,7 @@ function UseCouponTab({
   const [couponError, setCouponError] = useState<string>("");
   const [isCheckingCoupon, setIsCheckingCoupon] = useState(false);
   const { validateCoupon } = useValidateCoupon({ workspaceId });
-  const { redeemCreditsCoupon } = useRedeemCreditsCoupon({ workspaceId });
+  const { redeemPoolTopupCoupon } = useRedeemPoolTopupCoupon({ workspaceId });
 
   // For a "credits" coupon, `amount` is the number of bonus AWU credits granted.
   const bonusCredits = checkedCoupon?.amount ?? 0;
@@ -167,7 +167,7 @@ function UseCouponTab({
       return;
     }
     setCouponState("redeeming");
-    const result = await redeemCreditsCoupon(checkedCoupon.code);
+    const result = await redeemPoolTopupCoupon(checkedCoupon.code);
     switch (result.status) {
       case "success":
         setCouponState("success");
@@ -180,7 +180,7 @@ function UseCouponTab({
       default:
         assertNeverAndIgnore(result);
     }
-  }, [checkedCoupon, redeemCreditsCoupon, onSuccess]);
+  }, [checkedCoupon, redeemPoolTopupCoupon, onSuccess]);
 
   const resetCouponInput = useCallback(() => {
     setCheckedCoupon(null);

--- a/front/lib/api/checkout/business_activation.test.ts
+++ b/front/lib/api/checkout/business_activation.test.ts
@@ -168,7 +168,7 @@ vi.mock("@app/lib/metronome/amounts", () => ({
 }));
 
 vi.mock("@app/lib/metronome/coupons", () => ({
-  createCouponCredit: vi.fn(),
+  createSeatCouponCredit: vi.fn(),
   getCreditTypeFromPackage: vi.fn(),
 }));
 

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -36,7 +36,7 @@ import {
   provisionPaymentGatedActivationContract,
 } from "@app/lib/metronome/contracts";
 import {
-  createCouponCredit,
+  createSeatCouponCredit,
   getCreditTypeFromPackage,
 } from "@app/lib/metronome/coupons";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
@@ -457,7 +457,7 @@ export async function handleSubscriptionActivationSuccess({
       );
       if (creditTypeResult.isOk()) {
         const { creditTypeId, currency } = creditTypeResult.value;
-        const creditResult = await createCouponCredit({
+        const creditResult = await createSeatCouponCredit({
           metronomeCustomerId: workspace.metronomeCustomerId!,
           metronomeContractId: contractId,
           coupon,

--- a/front/lib/api/poke/plugins/workspaces/apply_coupon.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_coupon.test.ts
@@ -2,7 +2,7 @@ import { applyCouponPlugin } from "@app/lib/api/poke/plugins/workspaces/apply_co
 import { revokeCouponPlugin } from "@app/lib/api/poke/plugins/workspaces/revoke_coupon";
 import { Authenticator } from "@app/lib/auth";
 import { CREDIT_TYPE_USD_ID } from "@app/lib/metronome/constants";
-import { redeemCoupon } from "@app/lib/metronome/coupons";
+import { redeemSeatCoupon } from "@app/lib/metronome/coupons";
 import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { CouponFactory } from "@app/tests/utils/CouponFactory";
@@ -243,7 +243,7 @@ describe("revokeCouponPlugin.execute", () => {
     const { auth } = await makeWorkspaceWithMetronome();
     const coupon = await CouponFactory.create();
 
-    const redeemResult = await redeemCoupon(auth, { coupon });
+    const redeemResult = await redeemSeatCoupon(auth, { coupon });
     expect(redeemResult.isOk()).toBe(true);
     if (!redeemResult.isOk()) {
       return;
@@ -289,7 +289,7 @@ describe("revokeCouponPlugin.execute", () => {
     const { auth: authB } = await makeWorkspaceWithMetronome();
     const coupon = await CouponFactory.create();
 
-    const redeemResult = await redeemCoupon(authA, { coupon });
+    const redeemResult = await redeemSeatCoupon(authA, { coupon });
     expect(redeemResult.isOk()).toBe(true);
     if (!redeemResult.isOk()) {
       return;
@@ -309,7 +309,7 @@ describe("revokeCouponPlugin.execute", () => {
     const { auth } = await makeWorkspaceWithMetronome();
     const coupon = await CouponFactory.create();
 
-    const redeemResult = await redeemCoupon(auth, { coupon });
+    const redeemResult = await redeemSeatCoupon(auth, { coupon });
     expect(redeemResult.isOk()).toBe(true);
     if (!redeemResult.isOk()) {
       return;
@@ -336,7 +336,7 @@ describe("revokeCouponPlugin.execute", () => {
     const { auth } = await makeWorkspaceWithMetronome();
     const coupon = await CouponFactory.create();
 
-    const redeemResult = await redeemCoupon(auth, { coupon });
+    const redeemResult = await redeemSeatCoupon(auth, { coupon });
     expect(redeemResult.isOk()).toBe(true);
     if (!redeemResult.isOk()) {
       return;

--- a/front/lib/api/poke/plugins/workspaces/apply_coupon.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_coupon.ts
@@ -1,5 +1,8 @@
 import { createPlugin } from "@app/lib/api/poke/types";
-import { redeemSeatCoupon, redeemPoolTopupCoupon } from "@app/lib/metronome/coupons";
+import {
+  redeemPoolTopupCoupon,
+  redeemSeatCoupon,
+} from "@app/lib/metronome/coupons";
 import type { CouponValidationError } from "@app/lib/resources/coupon_resource";
 import { CouponResource } from "@app/lib/resources/coupon_resource";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/api/poke/plugins/workspaces/apply_coupon.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_coupon.ts
@@ -1,5 +1,5 @@
 import { createPlugin } from "@app/lib/api/poke/types";
-import { redeemCoupon, redeemCreditsCoupon } from "@app/lib/metronome/coupons";
+import { redeemSeatCoupon, redeemPoolTopupCoupon } from "@app/lib/metronome/coupons";
 import type { CouponValidationError } from "@app/lib/resources/coupon_resource";
 import { CouponResource } from "@app/lib/resources/coupon_resource";
 import { Err, Ok } from "@app/types/shared/result";
@@ -57,10 +57,10 @@ export const applyCouponPlugin = createPlugin({
     let result;
     switch (discountType) {
       case "seat":
-        result = await redeemCoupon(auth, { coupon });
+        result = await redeemSeatCoupon(auth, { coupon });
         break;
       case "credit_pool_top_up":
-        result = await redeemCreditsCoupon(auth, { coupon });
+        result = await redeemPoolTopupCoupon(auth, { coupon });
         break;
       default:
         return assertNever(discountType);

--- a/front/lib/metronome/coupons.test.ts
+++ b/front/lib/metronome/coupons.test.ts
@@ -8,8 +8,8 @@ import {
   endCouponCredit,
   getCreditTypeFromContract,
   getCreditTypeFromPackage,
-  redeemSeatCoupon,
   redeemPoolTopupCoupon,
+  redeemSeatCoupon,
   revokeCouponRedemption,
 } from "@app/lib/metronome/coupons";
 import { SEAT_TAG } from "@app/lib/metronome/setup_common";

--- a/front/lib/metronome/coupons.test.ts
+++ b/front/lib/metronome/coupons.test.ts
@@ -8,7 +8,7 @@ import {
   endCouponCredit,
   getCreditTypeFromContract,
   getCreditTypeFromPackage,
-  redeemCoupon,
+  redeemSeatCoupon,
   redeemPoolTopupCoupon,
   revokeCouponRedemption,
 } from "@app/lib/metronome/coupons";
@@ -547,16 +547,18 @@ describe("endCouponCredit", () => {
 });
 
 // ---------------------------------------------------------------------------
-// redeemCoupon
+// redeemSeatCoupon
 // ---------------------------------------------------------------------------
 
-describe("redeemCoupon", () => {
+describe("redeemSeatCoupon", () => {
   it("happy path: seat/once coupon → active redemption, 1 credit ID, count incremented, audit emitted", async () => {
     const { auth } = await makeWorkspaceWithUserAuth();
     const coupon = await CouponFactory.create({ durationMonths: null });
-    mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "credit-abc" }));
+    mockAddCreditToContract.mockResolvedValue(
+      new Ok({ creditId: "credit-abc" })
+    );
 
-    const result = await redeemCoupon(auth, { coupon });
+    const result = await redeemSeatCoupon(auth, { coupon });
 
     expect(result.isOk()).toBe(true);
     if (!result.isOk()) {
@@ -566,6 +568,12 @@ describe("redeemCoupon", () => {
     const redemption = result.value;
     expect(redemption.status).toBe("active");
     expect(redemption.metronomeCreditIds).toEqual(["credit-abc"]);
+
+    // Attached to the active contract, not the customer.
+    expect(mockAddCreditToContract).toHaveBeenCalledWith(
+      expect.objectContaining({ metronomeContractId: "contract-1" })
+    );
+    expect(mockCreateMetronomeCredit).not.toHaveBeenCalled();
 
     const updated = await CouponResourceClass.fetchByCouponId(coupon.sId);
     expect(updated?.redemptionCount).toBe(1);
@@ -581,7 +589,7 @@ describe("redeemCoupon", () => {
     const coupon = await CouponFactory.create();
     mockGetActiveContract.mockResolvedValueOnce(null);
 
-    const result = await redeemCoupon(auth, { coupon });
+    const result = await redeemSeatCoupon(auth, { coupon });
 
     expect(result.isErr()).toBe(true);
     expect(mockCreateMetronomeCredit).not.toHaveBeenCalled();
@@ -591,7 +599,7 @@ describe("redeemCoupon", () => {
     const { auth } = await makeWorkspaceWithUserAuthNoMetronome();
     const coupon = await CouponFactory.create();
 
-    const result = await redeemCoupon(auth, { coupon });
+    const result = await redeemSeatCoupon(auth, { coupon });
 
     expect(result.isErr()).toBe(true);
     if (!result.isErr()) {
@@ -606,7 +614,7 @@ describe("redeemCoupon", () => {
       expirationDate: new Date(Date.now() - 1000),
     });
 
-    const result = await redeemCoupon(auth, { coupon });
+    const result = await redeemSeatCoupon(auth, { coupon });
 
     expect(result.isErr()).toBe(true);
     if (!result.isErr()) {
@@ -625,7 +633,7 @@ describe("redeemCoupon", () => {
       redemptionCount: 2,
     });
 
-    const result = await redeemCoupon(auth, { coupon });
+    const result = await redeemSeatCoupon(auth, { coupon });
 
     expect(result.isErr()).toBe(true);
     if (!result.isErr()) {
@@ -642,12 +650,12 @@ describe("redeemCoupon", () => {
     const coupon = await CouponFactory.create();
     mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "credit-xyz" }));
 
-    const first = await redeemCoupon(auth, { coupon });
+    const first = await redeemSeatCoupon(auth, { coupon });
     expect(first.isOk()).toBe(true);
 
     // The partial unique index on (couponId, workspaceId) WHERE status IN ('pending','active')
     // blocks a second pending/active row for the same workspace+coupon.
-    const second = await redeemCoupon(auth, { coupon });
+    const second = await redeemSeatCoupon(auth, { coupon });
     expect(second.isErr()).toBe(true);
   });
 
@@ -664,7 +672,7 @@ describe("redeemCoupon", () => {
     );
     mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "credit-eur" }));
 
-    const result = await redeemCoupon(auth, {
+    const result = await redeemSeatCoupon(auth, {
       coupon,
       metronomePackageAlias: "pro-monthly",
     });
@@ -684,7 +692,7 @@ describe("redeemCoupon", () => {
     const coupon = await CouponFactory.create();
     mockListMetronomePackages.mockResolvedValueOnce(new Ok([]));
 
-    const result = await redeemCoupon(auth, {
+    const result = await redeemSeatCoupon(auth, {
       coupon,
       metronomePackageAlias: "nonexistent-alias",
     });
@@ -697,11 +705,11 @@ describe("redeemCoupon", () => {
   it("Metronome failure → status failed, redemptionCount decremented, same workspace can retry", async () => {
     const { auth } = await makeWorkspaceWithUserAuth();
     const coupon = await CouponFactory.create();
-    mockCreateMetronomeCredit.mockResolvedValue(
+    mockAddCreditToContract.mockResolvedValue(
       new Err(new Error("metronome down"))
     );
 
-    const failResult = await redeemCoupon(auth, { coupon });
+    const failResult = await redeemSeatCoupon(auth, { coupon });
     expect(failResult.isErr()).toBe(true);
 
     const redemptions = await CouponRedemptionResource.listAllByCoupon(coupon);
@@ -712,8 +720,10 @@ describe("redeemCoupon", () => {
     expect(updatedCoupon?.redemptionCount).toBe(0);
 
     // Retry succeeds — failed status does not trigger the unique index.
-    mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "credit-retry" }));
-    const retryResult = await redeemCoupon(auth, { coupon });
+    mockAddCreditToContract.mockResolvedValue(
+      new Ok({ creditId: "credit-retry" })
+    );
+    const retryResult = await redeemSeatCoupon(auth, { coupon });
     expect(retryResult.isOk()).toBe(true);
   });
 });
@@ -726,11 +736,11 @@ describe("revokeCouponRedemption", () => {
   it("calls endCouponCredit with stored credit IDs, sets status revoked, emits audit event", async () => {
     const { auth } = await makeWorkspaceWithUserAuth();
     const coupon = await CouponFactory.create();
-    mockCreateMetronomeCredit.mockResolvedValue(
-      new Ok({ id: "credit-to-revoke" })
+    mockAddCreditToContract.mockResolvedValue(
+      new Ok({ creditId: "credit-to-revoke" })
     );
 
-    const redeemResult = await redeemCoupon(auth, { coupon });
+    const redeemResult = await redeemSeatCoupon(auth, { coupon });
     expect(redeemResult.isOk()).toBe(true);
     if (!redeemResult.isOk()) {
       return;
@@ -759,9 +769,11 @@ describe("revokeCouponRedemption", () => {
   it("endCouponCredit failure → returns Err, redemption status unchanged", async () => {
     const { auth } = await makeWorkspaceWithUserAuth();
     const coupon = await CouponFactory.create();
-    mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "credit-fail" }));
+    mockAddCreditToContract.mockResolvedValue(
+      new Ok({ creditId: "credit-fail" })
+    );
 
-    const redeemResult = await redeemCoupon(auth, { coupon });
+    const redeemResult = await redeemSeatCoupon(auth, { coupon });
     expect(redeemResult.isOk()).toBe(true);
     if (!redeemResult.isOk()) {
       return;
@@ -780,10 +792,10 @@ describe("revokeCouponRedemption", () => {
 });
 
 // ---------------------------------------------------------------------------
-// redeemCreditsCoupon
+// redeemPoolTopupCoupon
 // ---------------------------------------------------------------------------
 
-describe("redeemCreditsCoupon", () => {
+describe("redeemPoolTopupCoupon", () => {
   it("happy path: grants AWU credit on the active contract, active redemption, count incremented, audit emitted", async () => {
     const { auth } = await makeWorkspaceWithUserAuth();
     const coupon = await CouponFactory.create({

--- a/front/lib/metronome/coupons.test.ts
+++ b/front/lib/metronome/coupons.test.ts
@@ -4,12 +4,12 @@ import {
   CREDIT_TYPE_USD_ID,
 } from "@app/lib/metronome/constants";
 import {
-  createCouponCredit,
+  createSeatCouponCredit,
   endCouponCredit,
   getCreditTypeFromContract,
   getCreditTypeFromPackage,
   redeemCoupon,
-  redeemCreditsCoupon,
+  redeemPoolTopupCoupon,
   revokeCouponRedemption,
 } from "@app/lib/metronome/coupons";
 import { SEAT_TAG } from "@app/lib/metronome/setup_common";
@@ -343,14 +343,14 @@ describe("getCreditTypeFromPackage", () => {
 });
 
 // ---------------------------------------------------------------------------
-// createCouponCredit
+// createSeatCouponCredit
 // ---------------------------------------------------------------------------
 
-describe("createCouponCredit", () => {
+describe("createSeatCouponCredit", () => {
   it("creates 1 credit spanning 1 month for a once coupon (durationMonths = null)", async () => {
     const coupon = makeCoupon({ durationMonths: null });
 
-    const result = await createCouponCredit({
+    const result = await createSeatCouponCredit({
       metronomeCustomerId: "cust-1",
       coupon,
       redemptionId: REDEMPTION_ID,
@@ -376,7 +376,7 @@ describe("createCouponCredit", () => {
   it("passes EUR amount as whole units (no ×100 ratio) for EUR credit type", async () => {
     const coupon = makeCoupon({ amount: 10, durationMonths: null });
 
-    await createCouponCredit({
+    await createSeatCouponCredit({
       metronomeCustomerId: "cust-1",
       coupon,
       redemptionId: REDEMPTION_ID,
@@ -396,7 +396,7 @@ describe("createCouponCredit", () => {
   it("uses correct date boundaries for a 3-month repeating coupon", async () => {
     const coupon = makeCoupon({ durationMonths: 3 });
 
-    await createCouponCredit({
+    await createSeatCouponCredit({
       metronomeCustomerId: "cust-1",
       coupon,
       redemptionId: REDEMPTION_ID,
@@ -417,7 +417,7 @@ describe("createCouponCredit", () => {
   it("uses correct 1-month date boundaries for a once coupon (durationMonths = null)", async () => {
     const coupon = makeCoupon({ durationMonths: null });
 
-    await createCouponCredit({
+    await createSeatCouponCredit({
       metronomeCustomerId: "cust-1",
       coupon,
       redemptionId: REDEMPTION_ID,
@@ -441,7 +441,7 @@ describe("createCouponCredit", () => {
 
     const coupon = makeCoupon({ durationMonths: 2 });
 
-    const result = await createCouponCredit({
+    const result = await createSeatCouponCredit({
       metronomeCustomerId: "cust-1",
       coupon,
       redemptionId: REDEMPTION_ID,
@@ -460,7 +460,7 @@ describe("createCouponCredit", () => {
 
     const coupon = makeCoupon({ durationMonths: 3 });
 
-    const result = await createCouponCredit({
+    const result = await createSeatCouponCredit({
       metronomeCustomerId: "cust-1",
       coupon,
       redemptionId: REDEMPTION_ID,
@@ -794,7 +794,7 @@ describe("redeemCreditsCoupon", () => {
       new Ok({ creditId: "awu-credit-1" })
     );
 
-    const result = await redeemCreditsCoupon(auth, { coupon });
+    const result = await redeemPoolTopupCoupon(auth, { coupon });
 
     expect(result.isOk()).toBe(true);
     if (!result.isOk()) {
@@ -830,7 +830,7 @@ describe("redeemCreditsCoupon", () => {
     mockGetActiveContract.mockResolvedValueOnce(null);
     mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "awu-credit-1" }));
 
-    const result = await redeemCreditsCoupon(auth, { coupon });
+    const result = await redeemPoolTopupCoupon(auth, { coupon });
 
     expect(result.isOk()).toBe(true);
     if (!result.isOk()) {
@@ -850,7 +850,7 @@ describe("redeemCreditsCoupon", () => {
     const { auth } = await makeWorkspaceWithUserAuth();
     const coupon = await CouponFactory.create({ discountType: "seat" });
 
-    const result = await redeemCreditsCoupon(auth, { coupon });
+    const result = await redeemPoolTopupCoupon(auth, { coupon });
 
     expect(result.isErr()).toBe(true);
     if (!result.isErr()) {
@@ -869,7 +869,7 @@ describe("redeemCreditsCoupon", () => {
       discountType: "credit_pool_top_up",
     });
 
-    const result = await redeemCreditsCoupon(auth, { coupon });
+    const result = await redeemPoolTopupCoupon(auth, { coupon });
 
     expect(result.isErr()).toBe(true);
     if (!result.isErr()) {
@@ -887,7 +887,7 @@ describe("redeemCreditsCoupon", () => {
       new Err(new Error("metronome down"))
     );
 
-    const result = await redeemCreditsCoupon(auth, { coupon });
+    const result = await redeemPoolTopupCoupon(auth, { coupon });
     expect(result.isErr()).toBe(true);
 
     const redemptions = await CouponRedemptionResource.listAllByCoupon(coupon);
@@ -906,10 +906,10 @@ describe("redeemCreditsCoupon", () => {
       new Ok({ creditId: "awu-credit-2" })
     );
 
-    const first = await redeemCreditsCoupon(auth, { coupon });
+    const first = await redeemPoolTopupCoupon(auth, { coupon });
     expect(first.isOk()).toBe(true);
 
-    const second = await redeemCreditsCoupon(auth, { coupon });
+    const second = await redeemPoolTopupCoupon(auth, { coupon });
     expect(second.isErr()).toBe(true);
     if (!second.isErr()) {
       return;

--- a/front/lib/metronome/coupons.test.ts
+++ b/front/lib/metronome/coupons.test.ts
@@ -47,6 +47,7 @@ function unwrapErr<T>(result: Result<T, Error>): Error {
 
 const {
   mockCreateMetronomeCredit,
+  mockAddCreditToContract,
   mockUpdateMetronomeCreditEndDate,
   mockGetActiveContract,
   mockEmitAuditLogEvent,
@@ -54,6 +55,7 @@ const {
   mockListMetronomePackages,
 } = vi.hoisted(() => ({
   mockCreateMetronomeCredit: vi.fn(),
+  mockAddCreditToContract: vi.fn(),
   mockUpdateMetronomeCreditEndDate: vi.fn(),
   mockGetActiveContract: vi.fn().mockResolvedValue(null),
   mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
@@ -67,6 +69,7 @@ vi.mock("@app/lib/metronome/client", async () => {
   >("@app/lib/metronome/client");
   return {
     ...actual,
+    addCreditToContract: mockAddCreditToContract,
     createMetronomeCredit: mockCreateMetronomeCredit,
     getMetronomeRateCardById: mockGetMetronomeRateCardById,
     listMetronomePackages: mockListMetronomePackages,
@@ -193,14 +196,21 @@ async function makeWorkspaceWithUserAuthNoMetronome() {
 
 beforeEach(() => {
   mockCreateMetronomeCredit.mockReset();
+  mockAddCreditToContract.mockReset();
   mockUpdateMetronomeCreditEndDate.mockReset();
   mockGetActiveContract.mockReset();
   mockEmitAuditLogEvent.mockReset();
   mockGetMetronomeRateCardById.mockReset();
   mockListMetronomePackages.mockReset();
   mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "credit-id-1" }));
+  mockAddCreditToContract.mockResolvedValue(
+    new Ok({ creditId: "contract-credit-1" })
+  );
   mockUpdateMetronomeCreditEndDate.mockResolvedValue(new Ok(undefined));
-  mockGetActiveContract.mockResolvedValue({ rate_card_id: "rate-card-1" });
+  mockGetActiveContract.mockResolvedValue({
+    id: "contract-1",
+    rate_card_id: "rate-card-1",
+  });
   mockEmitAuditLogEvent.mockResolvedValue(undefined);
   mockGetMetronomeRateCardById.mockResolvedValue(
     new Ok(makeRateCard(CREDIT_TYPE_USD_ID))
@@ -774,13 +784,15 @@ describe("revokeCouponRedemption", () => {
 // ---------------------------------------------------------------------------
 
 describe("redeemCreditsCoupon", () => {
-  it("happy path: grants AWU free credit, active redemption, count incremented, audit emitted", async () => {
+  it("happy path: grants AWU credit on the active contract, active redemption, count incremented, audit emitted", async () => {
     const { auth } = await makeWorkspaceWithUserAuth();
     const coupon = await CouponFactory.create({
       discountType: "credit_pool_top_up",
       amount: 5000,
     });
-    mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "awu-credit-1" }));
+    mockAddCreditToContract.mockResolvedValue(
+      new Ok({ creditId: "awu-credit-1" })
+    );
 
     const result = await redeemCreditsCoupon(auth, { coupon });
 
@@ -791,18 +803,47 @@ describe("redeemCreditsCoupon", () => {
     expect(result.value.status).toBe("active");
     expect(result.value.metronomeCreditIds).toEqual(["awu-credit-1"]);
 
-    // Granted directly as AWU credits (no currency conversion).
-    expect(mockCreateMetronomeCredit).toHaveBeenCalledWith(
-      expect.objectContaining({ amount: 5000 })
+    // Granted directly as AWU credits (no currency conversion), attached to
+    // the active contract.
+    expect(mockAddCreditToContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 5000,
+        metronomeContractId: "contract-1",
+        uniquenessKey: expect.stringMatching(/^coupon-credits-.*-0$/),
+      })
     );
-    // Does not resolve a contract — granted at the customer level.
-    expect(mockGetActiveContract).not.toHaveBeenCalled();
+    expect(mockCreateMetronomeCredit).not.toHaveBeenCalled();
 
     const updated = await CouponResourceClass.fetchByCouponId(coupon.sId);
     expect(updated?.redemptionCount).toBe(1);
     expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({ action: "coupon.redeemed" })
     );
+  });
+
+  it("no active contract → falls back to a customer-level credit", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create({
+      discountType: "credit_pool_top_up",
+      amount: 5000,
+    });
+    mockGetActiveContract.mockResolvedValueOnce(null);
+    mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "awu-credit-1" }));
+
+    const result = await redeemCreditsCoupon(auth, { coupon });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.metronomeCreditIds).toEqual(["awu-credit-1"]);
+    expect(mockCreateMetronomeCredit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 5000,
+        idempotencyKey: expect.stringMatching(/^coupon-credits-.*-0$/),
+      })
+    );
+    expect(mockAddCreditToContract).not.toHaveBeenCalled();
   });
 
   it("rejects a seat coupon with wrong_coupon_type, no credit created", async () => {
@@ -842,7 +883,7 @@ describe("redeemCreditsCoupon", () => {
     const coupon = await CouponFactory.create({
       discountType: "credit_pool_top_up",
     });
-    mockCreateMetronomeCredit.mockResolvedValue(
+    mockAddCreditToContract.mockResolvedValue(
       new Err(new Error("metronome down"))
     );
 
@@ -861,7 +902,9 @@ describe("redeemCreditsCoupon", () => {
     const coupon = await CouponFactory.create({
       discountType: "credit_pool_top_up",
     });
-    mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "awu-credit-2" }));
+    mockAddCreditToContract.mockResolvedValue(
+      new Ok({ creditId: "awu-credit-2" })
+    );
 
     const first = await redeemCreditsCoupon(auth, { coupon });
     expect(first.isOk()).toBe(true);

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -234,7 +234,7 @@ export type RedeemPoolTopupCouponError =
 
 // Redeem a "credit_pool_top_up" coupon as a standalone, synchronous action (the "Use
 // coupon" Top-Up tab): no payment is involved, the coupon simply grants free
-// AWU credits to the workspace pool. Mirrors `redeemCoupon` (the subscription
+// AWU credits to the workspace pool. Mirrors `redeemSeatCoupon` (the subscription
 // path) end-to-end: validate → check for an existing redemption → create the
 // pending redemption (incrementing the count) → grant the credit → mark active.
 // On a Metronome failure the pending redemption is rolled back so the count is
@@ -357,11 +357,11 @@ export async function endCouponCredit({
   return new Ok(undefined);
 }
 
-export type RedeemCouponError =
+export type RedeemSeatCouponError =
   | { code: "workspace_not_on_metronome" }
   | { code: "coupon_validation_failed"; reason: CouponValidationError };
 
-export async function redeemCoupon(
+export async function redeemSeatCoupon(
   auth: Authenticator,
   {
     coupon,
@@ -370,7 +370,7 @@ export async function redeemCoupon(
     coupon: CouponResource;
     metronomePackageAlias?: string;
   }
-): Promise<Result<CouponRedemptionResource, RedeemCouponError | Error>> {
+): Promise<Result<CouponRedemptionResource, RedeemSeatCouponError | Error>> {
   const validation = coupon.validateRedemptionForContext("subscription");
   if (validation.isErr()) {
     return new Err({
@@ -398,10 +398,11 @@ export async function redeemCoupon(
   }
 
   let creditTypeIdResult;
+  let contract: CachedContract | null = null;
   if (metronomePackageAlias) {
     creditTypeIdResult = await getCreditTypeFromPackage(metronomePackageAlias);
   } else {
-    const contract = await getActiveContract(workspace.sId);
+    contract = await getActiveContract(workspace.sId);
     if (!contract) {
       return new Err(
         new Error("No active Metronome contract found for workspace")
@@ -424,6 +425,7 @@ export async function redeemCoupon(
 
   const creditResult = await createSeatCouponCredit({
     metronomeCustomerId,
+    metronomeContractId: contract ? contract.id : undefined,
     coupon,
     redemptionId: redemption.sId,
     redeemedAt: redemption.redeemedAt,

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -177,11 +177,13 @@ const CREDITS_COUPON_DEFAULT_DURATION_MONTHS = 12;
 // is the number of AWU credits to grant directly (AWU is currency-independent).
 async function createCreditsCouponCredit({
   metronomeCustomerId,
+  metronomeContractId,
   coupon,
   redemptionId,
   redeemedAt,
 }: {
   metronomeCustomerId: string;
+  metronomeContractId?: string;
   coupon: CouponResource;
   redemptionId: string;
   redeemedAt: Date;
@@ -189,7 +191,7 @@ async function createCreditsCouponCredit({
   const durationMonths =
     coupon.durationMonths ?? CREDITS_COUPON_DEFAULT_DURATION_MONTHS;
 
-  const result = await createMetronomeCredit({
+  const sharedParams = {
     metronomeCustomerId,
     productId: getProductFreeCreditId(),
     creditTypeId: getCreditTypeAwuId(),
@@ -197,10 +199,26 @@ async function createCreditsCouponCredit({
     startingAt: floorToHourISO(redeemedAt),
     endingBefore: ceilToHourISO(addMonths(redeemedAt, durationMonths)),
     name: `Coupon: ${coupon.code}`,
-    idempotencyKey: `coupon-credits-${redemptionId}-0`,
     priority: AWU_PRIORITY_PURCHASED_COMMIT,
     applicableProductTags:
       getApplicableProductTagsForDiscountType("credit_pool_top_up"),
+  };
+
+  if (metronomeContractId) {
+    const result = await addCreditToContract({
+      ...sharedParams,
+      metronomeContractId,
+      uniquenessKey: `coupon-credits-${redemptionId}-0`,
+    });
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+    return new Ok(result.value !== null ? [result.value.creditId] : []);
+  }
+
+  const result = await createMetronomeCredit({
+    ...sharedParams,
+    idempotencyKey: `coupon-credits-${redemptionId}-0`,
   });
 
   if (result.isErr()) {
@@ -252,6 +270,11 @@ export async function redeemCreditsCoupon(
     });
   }
 
+  // Attach the credit to the active contract when there is one so it shows up
+  // on the contract (invoice preview, contract-scoped balances). Fall back to
+  // a customer-level credit otherwise, mirroring `createCouponCredit`.
+  const contract = await getActiveContract(workspace.sId);
+
   const pendingResult = await CouponRedemptionResource.createPending(auth, {
     coupon,
   });
@@ -262,6 +285,7 @@ export async function redeemCreditsCoupon(
 
   const creditResult = await createCreditsCouponCredit({
     metronomeCustomerId,
+    metronomeContractId: contract?.id,
     coupon,
     redemptionId: redemption.sId,
     redeemedAt: redemption.redeemedAt,

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -425,7 +425,7 @@ export async function redeemSeatCoupon(
 
   const creditResult = await createSeatCouponCredit({
     metronomeCustomerId,
-    metronomeContractId: contract ? contract.id : undefined,
+    metronomeContractId: contract?.id,
     coupon,
     redemptionId: redemption.sId,
     redeemedAt: redemption.redeemedAt,

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -110,7 +110,7 @@ function getApplicableProductTagsForDiscountType(
   }
 }
 
-export async function createCouponCredit({
+export async function createSeatCouponCredit({
   metronomeCustomerId,
   metronomeContractId,
   coupon,
@@ -175,7 +175,7 @@ const CREDITS_COUPON_DEFAULT_DURATION_MONTHS = 12;
 // the `grant-awu-credits` poke plugin: AWU credit type, "usage" tag,
 // purchased-commit priority. For "credit_pool_top_up" coupons, `coupon.amount`
 // is the number of AWU credits to grant directly (AWU is currency-independent).
-async function createCreditsCouponCredit({
+async function createPoolTopupCouponCredit({
   metronomeCustomerId,
   metronomeContractId,
   coupon,
@@ -228,7 +228,7 @@ async function createCreditsCouponCredit({
   return new Ok(result.value !== null ? [result.value.id] : []);
 }
 
-export type RedeemCreditsCouponError =
+export type RedeemPoolTopupCouponError =
   | { code: "workspace_not_on_metronome" }
   | { code: "coupon_validation_failed"; reason: CouponValidationError };
 
@@ -240,10 +240,12 @@ export type RedeemCreditsCouponError =
 // On a Metronome failure the pending redemption is rolled back so the count is
 // released (safe here because, unlike a payment-gated flow, nothing has been
 // charged).
-export async function redeemCreditsCoupon(
+export async function redeemPoolTopupCoupon(
   auth: Authenticator,
   { coupon }: { coupon: CouponResource }
-): Promise<Result<CouponRedemptionResource, RedeemCreditsCouponError | Error>> {
+): Promise<
+  Result<CouponRedemptionResource, RedeemPoolTopupCouponError | Error>
+> {
   const validation = coupon.validateRedemptionForContext("credits");
   if (validation.isErr()) {
     return new Err({
@@ -272,7 +274,7 @@ export async function redeemCreditsCoupon(
 
   // Attach the credit to the active contract when there is one so it shows up
   // on the contract (invoice preview, contract-scoped balances). Fall back to
-  // a customer-level credit otherwise, mirroring `createCouponCredit`.
+  // a customer-level credit otherwise, mirroring `createSeatCouponCredit`.
   const contract = await getActiveContract(workspace.sId);
 
   const pendingResult = await CouponRedemptionResource.createPending(auth, {
@@ -283,7 +285,7 @@ export async function redeemCreditsCoupon(
   }
   const redemption = pendingResult.value;
 
-  const creditResult = await createCreditsCouponCredit({
+  const creditResult = await createPoolTopupCouponCredit({
     metronomeCustomerId,
     metronomeContractId: contract?.id,
     coupon,
@@ -420,7 +422,7 @@ export async function redeemCoupon(
   }
   const redemption = pendingResult.value;
 
-  const creditResult = await createCouponCredit({
+  const creditResult = await createSeatCouponCredit({
     metronomeCustomerId,
     coupon,
     redemptionId: redemption.sId,

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -345,14 +345,14 @@ export function useAwuPurchaseInfo({
   };
 }
 
-export type RedeemCreditsCouponOutcome =
+export type RedeemPoolTopupCouponOutcome =
   | { status: "success" }
   | { status: "error"; message: string };
 
 // Redeems a "credits" coupon (the "Use coupon" Top-Up tab). Grants free AWU
 // credits synchronously — no payment involved. Refreshes the pool summary on
 // success.
-export function useRedeemCreditsCoupon({
+export function useRedeemPoolTopupCoupon({
   workspaceId,
 }: {
   workspaceId: string;
@@ -362,8 +362,8 @@ export function useRedeemCreditsCoupon({
     disabled: true,
   });
 
-  const redeemCreditsCoupon = useCallback(
-    async (code: string): Promise<RedeemCreditsCouponOutcome> => {
+  const redeemPoolTopupCoupon = useCallback(
+    async (code: string): Promise<RedeemPoolTopupCouponOutcome> => {
       try {
         const response = await clientFetch(
           `/api/w/${workspaceId}/coupon/redeem`,
@@ -394,7 +394,7 @@ export function useRedeemCreditsCoupon({
     [workspaceId, mutateAwuPoolSummary]
   );
 
-  return { redeemCreditsCoupon };
+  return { redeemPoolTopupCoupon };
 }
 
 export function useMyUsage({


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9428

To be consistent with the other kind of coupons

Also rename for clarity:
 -  createCouponCredit -> createSeatCouponCredit
 - createCreditsCouponCredit -> createPoolTopupCouponCredit
 - redeemCreditsCoupon -> redeemPoolTopupCoupon
 - RedeemCreditsCouponError -> RedeemPoolTopupCouponError

## Tests

tested locally: coupon is still counted in pool and still displayed in top up history.

## Risk

low

## Deploy Plan

deploy front
