### PR TITLE
[front] Fix crash in getStripePricingData when a currency option is missing

### DIFF
--- a/front/lib/plans/stripe.test.ts
+++ b/front/lib/plans/stripe.test.ts
@@ -3,6 +3,7 @@ import {
   finalizeInvoice,
   getCreditAmountFromInvoice,
   getCreditPurchaseCouponId,
+  getStripePricingData,
   getSubscriptionInvoices,
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
@@ -14,33 +15,48 @@ import {
 import type { Stripe } from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockInvoices, mockCoupons, mockSubscriptions, mockInvoiceItems } =
-  vi.hoisted(() => {
-    const mockInvoices = {
-      list: vi.fn(),
-      create: vi.fn(),
-      finalizeInvoice: vi.fn(),
-      pay: vi.fn(),
-      retrieve: vi.fn(),
-      voidInvoice: vi.fn(),
-      update: vi.fn(),
-    };
+const {
+  mockInvoices,
+  mockCoupons,
+  mockSubscriptions,
+  mockInvoiceItems,
+  mockPrices,
+} = vi.hoisted(() => {
+  const mockInvoices = {
+    list: vi.fn(),
+    create: vi.fn(),
+    finalizeInvoice: vi.fn(),
+    pay: vi.fn(),
+    retrieve: vi.fn(),
+    voidInvoice: vi.fn(),
+    update: vi.fn(),
+  };
 
-    const mockInvoiceItems = {
-      create: vi.fn(),
-    };
+  const mockInvoiceItems = {
+    create: vi.fn(),
+  };
 
-    const mockCoupons = {
-      retrieve: vi.fn(),
-      create: vi.fn(),
-    };
+  const mockCoupons = {
+    retrieve: vi.fn(),
+    create: vi.fn(),
+  };
 
-    const mockSubscriptions = {
-      retrieve: vi.fn(),
-    };
+  const mockSubscriptions = {
+    retrieve: vi.fn(),
+  };
 
-    return { mockInvoices, mockCoupons, mockSubscriptions, mockInvoiceItems };
-  });
+  const mockPrices = {
+    retrieve: vi.fn(),
+  };
+
+  return {
+    mockInvoices,
+    mockCoupons,
+    mockSubscriptions,
+    mockInvoiceItems,
+    mockPrices,
+  };
+});
 
 const { MockStripeError, MockStripeInvalidRequestError } = vi.hoisted(() => {
   class MockStripeError extends Error {
@@ -73,6 +89,7 @@ vi.mock("stripe", () => {
     invoiceItems: mockInvoiceItems,
     coupons: mockCoupons,
     subscriptions: mockSubscriptions,
+    prices: mockPrices,
   };
 
   return {
@@ -777,5 +794,49 @@ describe("makeCreditsPAYGInvoice", () => {
     if (result.isErr()) {
       expect(result.error.error_type).toBe("other");
     }
+  });
+});
+
+describe("getStripePricingData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return currency options for a fully configured price", async () => {
+    mockPrices.retrieve.mockResolvedValue({
+      unit_amount: 1000,
+      currency_options: {
+        usd: { unit_amount: 1000 },
+        eur: { unit_amount: 900 },
+      },
+    });
+
+    const result = await getStripePricingData("price_test");
+
+    expect(result).toEqual({
+      currencyOptions: {
+        usd: { unitAmount: 1000 },
+        eur: { unitAmount: 900 },
+      },
+    });
+  });
+
+  it("should not throw when a supported currency option is missing", async () => {
+    // Price configured with USD only; EUR has no currency option.
+    mockPrices.retrieve.mockResolvedValue({
+      unit_amount: 1000,
+      currency_options: {
+        usd: { unit_amount: 1000 },
+      },
+    });
+
+    const result = await getStripePricingData("price_test");
+
+    expect(result).toEqual({
+      currencyOptions: {
+        usd: { unitAmount: 1000 },
+        eur: { unitAmount: 0 },
+      },
+    });
   });
 });

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -98,9 +98,9 @@ export async function getStripePricingData(
 
   for (const currency of SUPPORTED_CURRENCIES) {
     const currencyOption = price.currency_options[currency];
-    const unitAmount = Number(
-      currencyOption.unit_amount ?? currencyOption.unit_amount_decimal
-    );
+    const unitAmount = currencyOption
+      ? Number(currencyOption.unit_amount ?? currencyOption.unit_amount_decimal)
+      : 0;
     if (unitAmount) {
       currencyOptions[currency] = {
         unitAmount,


### PR DESCRIPTION
## Problem

`GET /api/w/:wId/credits/purchase` was throwing a 500 in production:

```
TypeError: Cannot read properties of undefined (reading 'unit_amount')
    at getStripePricingData (/app/front/lib/plans/stripe.ts:103:22)
    at getCreditPurchaseInfo (/app/front/lib/api/credits/purchase.ts:157:25)
```

`getStripePricingData` iterates over `SUPPORTED_CURRENCIES` (`usd`, `eur`) and read
`price.currency_options[currency].unit_amount` without first checking that the option
existed. When a Stripe price has an option configured for `usd` but not `eur`,
`price.currency_options["eur"]` is `undefined`, so dereferencing it throws.

TypeScript didn't catch this because `noUncheckedIndexedAccess` is not enabled.

## Fix

The loop's existing `else` branch already logs `"[Stripe] Currency option not configured"`
and skips such currencies — the intent was always to tolerate a missing option, it just
dereferenced before checking. The fix treats a missing option as `unitAmount = 0`, which
falls into that existing log-and-skip path. The `assert(currencyOptions.usd.unitAmount > 0)`
still guards the critical case where USD itself is misconfigured.

## Tests

Added a `getStripePricingData` test block (with a `prices.retrieve` mock). The
"missing currency option" test reproduced the exact production error before the fix and
passes after. All 34 tests in the file pass; typecheck and biome are clean.