### PR TITLE
Analytics: display monthly/weekly date more precisely

### DIFF
--- a/front/components/workspace/AwuUsageFromAnalyticsChart.test.ts
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.test.ts
@@ -1,0 +1,64 @@
+import { formatBucketRange } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("formatBucketRange", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Monday Jul 6, 2026. Last 30 days window: Jun 7 - Jul 6 (UTC).
+    vi.setSystemTime(new Date("2026-07-06T15:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("month granularity", () => {
+    it("clamps the first bucket to the window start", () => {
+      expect(formatBucketRange(Date.UTC(2026, 5, 1), "month", 30)).toBe(
+        "Jun 7 - 30"
+      );
+    });
+
+    it("clamps the last bucket to today", () => {
+      expect(formatBucketRange(Date.UTC(2026, 6, 1), "month", 30)).toBe(
+        "Jul 1 - 6"
+      );
+    });
+
+    it("shows the full range for an untruncated month", () => {
+      expect(formatBucketRange(Date.UTC(2026, 4, 1), "month", 90)).toBe(
+        "May 1 - 31"
+      );
+    });
+  });
+
+  describe("week granularity", () => {
+    it("shows the full range for an untruncated week", () => {
+      expect(formatBucketRange(Date.UTC(2026, 5, 8), "week", 30)).toBe(
+        "Jun 8 - 14"
+      );
+    });
+
+    it("repeats the month for a week spanning two months", () => {
+      expect(formatBucketRange(Date.UTC(2026, 5, 29), "week", 30)).toBe(
+        "Jun 29 - Jul 5"
+      );
+    });
+
+    it("collapses a single-day bucket to one date", () => {
+      // The week starting today only covers today.
+      expect(formatBucketRange(Date.UTC(2026, 6, 6), "week", 30)).toBe("Jul 6");
+    });
+
+    it("collapses the first bucket when only its last day is in the window", () => {
+      // Week of Jun 1 - 7 clamped to the Jun 7 window start.
+      expect(formatBucketRange(Date.UTC(2026, 5, 1), "week", 30)).toBe("Jun 7");
+    });
+
+    it("repeats the month for a week spanning two years", () => {
+      expect(formatBucketRange(Date.UTC(2025, 11, 29), "week", 365)).toBe(
+        "Dec 29 - Jan 4"
+      );
+    });
+  });
+});

--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -26,6 +26,7 @@ import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import type { AwuUsageAnalyticsResponse } from "@app/lib/api/analytics/awu_usage_analytics";
 import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import { useAwuUsageFromAnalytics } from "@app/lib/swr/workspaces";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   Button,
   Chip,
@@ -91,13 +92,77 @@ function getColorClassName(
   return getIndexedColor(groupKey, allKeys);
 }
 
-function formatTimestamp(timestamp: number, granularity: Granularity): string {
-  return new Date(timestamp).toLocaleDateString("en-US", {
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function formatUtcMonthDay(date: Date): string {
+  return date.toLocaleDateString("en-US", {
     month: "short",
-    day: granularity === "month" ? undefined : "numeric",
-    year: granularity === "month" ? "numeric" : undefined,
+    day: "numeric",
     timeZone: "UTC",
   });
+}
+
+// Weekly and monthly buckets slide with the trailing window, so the first and
+// last buckets are usually truncated (e.g. on Jul 6, "last 30 days" covers
+// "Jun 6 - 30" and "Jul 1 - 6"). Label buckets with the exact dates covered,
+// clamped to the window, to avoid suggesting full calendar periods.
+export function formatBucketRange(
+  bucketStartMs: number,
+  granularity: "week" | "month",
+  days: number
+): string {
+  const now = new Date();
+  const todayMs = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate()
+  );
+  // Mirrors the server-side window from daysToInstantRange(days, "UTC").
+  const windowStartMs = todayMs - (days - 1) * DAY_MS;
+
+  const bucketStart = new Date(bucketStartMs);
+  const bucketEndMs =
+    granularity === "week"
+      ? bucketStartMs + 6 * DAY_MS
+      : Date.UTC(
+          bucketStart.getUTCFullYear(),
+          bucketStart.getUTCMonth() + 1,
+          0
+        );
+
+  const startDate = new Date(Math.max(bucketStartMs, windowStartMs));
+  const endDate = new Date(Math.min(bucketEndMs, todayMs));
+
+  if (startDate.getTime() >= endDate.getTime()) {
+    // Single day like "Jun 30"
+    return formatUtcMonthDay(startDate);
+  }
+  if (
+    startDate.getUTCFullYear() === endDate.getUTCFullYear() &&
+    startDate.getUTCMonth() === endDate.getUTCMonth()
+  ) {
+    // Several days in same month like "Jun 6 - 30"
+    return `${formatUtcMonthDay(startDate)} - ${endDate.getUTCDate()}`;
+  }
+  // Cross months period like "Jun 29 - July 5"
+  return `${formatUtcMonthDay(startDate)} - ${formatUtcMonthDay(endDate)}`;
+}
+
+function formatTimestamp(
+  timestamp: number,
+  granularity: Granularity,
+  days: number
+): string {
+  switch (granularity) {
+    case "day":
+      return formatUtcMonthDay(new Date(timestamp));
+    case "week":
+    case "month":
+      return formatBucketRange(timestamp, granularity, days);
+    default:
+      assertNeverAndIgnore(granularity);
+      return formatUtcMonthDay(new Date(timestamp));
+  }
 }
 
 export interface BaseAwuUsageFromAnalyticsChartProps {
@@ -253,6 +318,7 @@ interface UsageChartBarsProps {
   groupBy: AnalyticsGroupBy | undefined;
   groups: { groupKey: string; name: string }[];
   granularity: Granularity;
+  days: number;
   // Injected by the parent ResponsiveContainer (via cloneElement) and forwarded
   // to BarChart. Without forwarding, BarChart has no dimensions and renders
   // blank.
@@ -267,6 +333,7 @@ function UsageChartBars({
   groupBy,
   groups,
   granularity,
+  days,
   width,
   height,
 }: UsageChartBarsProps) {
@@ -286,7 +353,7 @@ function UsageChartBars({
         axisLine={false}
         tickMargin={8}
         minTickGap={16}
-        tickFormatter={(value) => formatTimestamp(value, granularity)}
+        tickFormatter={(value) => formatTimestamp(value, granularity, days)}
       />
       <YAxis
         className="text-xs text-muted-foreground"
@@ -302,6 +369,7 @@ function UsageChartBars({
             groupBy={groupBy}
             groups={groups}
             granularity={granularity}
+            days={days}
           />
         )}
         cursor={false}
@@ -576,6 +644,7 @@ export function BaseAwuUsageFromAnalyticsChart({
         groupBy={groupBy}
         groups={groups}
         granularity={granularity}
+        days={days}
       />
     </ChartContainer>
   );
@@ -676,9 +745,10 @@ function CreditTooltip(
     groupBy: AnalyticsGroupBy | undefined;
     groups: { groupKey: string; name: string }[];
     granularity: Granularity;
+    days: number;
   }
 ): JSX.Element | null {
-  const { active, payload, groupBy, groups, granularity } = props;
+  const { active, payload, groupBy, groups, granularity, days } = props;
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -721,7 +791,7 @@ function CreditTooltip(
 
   return (
     <ChartTooltipCard
-      title={formatTimestamp(data.timestamp, granularity)}
+      title={formatTimestamp(data.timestamp, granularity, days)}
       rows={rows}
     />
   );


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9425

Make the bucket less confusing when they don't cover the whole period due to the days window of the analytics


<img width="1089" height="348" alt="Screenshot 2026-07-06 at 17 28 12" src="https://github.com/user-attachments/assets/5518fbca-be6d-4bf4-9f53-820b1cfaadb2" />
<img width="1086" height="349" alt="Screenshot 2026-07-06 at 17 28 24" src="https://github.com/user-attachments/assets/875e3060-fe09-4d17-875f-de70713055e7" />
<img width="2162" height="702" alt="image" src="https://github.com/user-attachments/assets/ecaf5c9e-e633-4a3f-8a3e-d8c922cb6718" />

## Tests

 - tested locally
 - added unit tests

## Risk

low: purely UI and can be reverted

## Deploy Plan

deploy front
