### PR TITLE
[front] Fix GBP currency classification and binary usd/eur assumptions

### DIFF
--- a/front/components/workspace/SeatCard.tsx
+++ b/front/components/workspace/SeatCard.tsx
@@ -107,9 +107,11 @@ export function formatPriceCents(
     quarterly: "/qtr",
     annual: "/yr",
   };
-  return currency === "usd"
-    ? `${symbol}${amount}${suffixByFrequency[billingFrequency]}`
-    : `${amount}${symbol}${suffixByFrequency[billingFrequency]}`;
+  // EUR is the only currency we render with a trailing symbol (e.g. "30€");
+  // USD and GBP are prefix currencies ("$30", "£30").
+  return currency === "eur"
+    ? `${amount}${symbol}${suffixByFrequency[billingFrequency]}`
+    : `${symbol}${amount}${suffixByFrequency[billingFrequency]}`;
 }
 
 export function formatAwuCredits(info: SeatTypeInfo): string {

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/lib/metronome/client";
 import {
   CREDIT_TYPE_EUR_ID,
+  CREDIT_TYPE_GBP_ID,
   CREDIT_TYPE_USD_ID,
   getCreditTypeAwuId,
 } from "@app/lib/metronome/constants";
@@ -28,6 +29,9 @@ function creditTypeIdToCurrency(
   }
   if (creditTypeId === CREDIT_TYPE_EUR_ID) {
     return "eur";
+  }
+  if (creditTypeId === CREDIT_TYPE_GBP_ID) {
+    return "gbp";
   }
   return null;
 }

--- a/front/lib/metronome/types.test.ts
+++ b/front/lib/metronome/types.test.ts
@@ -49,11 +49,19 @@ describe("classifyMetronomePackageCurrencyByName", () => {
     );
   });
 
-  it("is case-insensitive", () => {
-    expect(classifyMetronomePackageCurrencyByName("BUSINESS eur")).toBe("eur");
+  it("returns gbp when the name contains a pound marker", () => {
+    expect(classifyMetronomePackageCurrencyByName("Business GBP")).toBe("gbp");
+    expect(classifyMetronomePackageCurrencyByName("Enterprise sterling")).toBe(
+      "gbp"
+    );
   });
 
-  it("defaults to usd when no euro marker is present", () => {
+  it("is case-insensitive", () => {
+    expect(classifyMetronomePackageCurrencyByName("BUSINESS eur")).toBe("eur");
+    expect(classifyMetronomePackageCurrencyByName("business gbp")).toBe("gbp");
+  });
+
+  it("defaults to usd when no euro or pound marker is present", () => {
     expect(classifyMetronomePackageCurrencyByName("Legacy Pro Monthly")).toBe(
       "usd"
     );

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -95,6 +95,9 @@ export function classifyMetronomePackageCurrencyByName(
   if (/\b(?:eur|euro)\b/.test(normalized)) {
     return "eur";
   }
+  if (/\b(?:gbp|pound|sterling)\b/.test(normalized)) {
+    return "gbp";
+  }
   return "usd";
 }
 

--- a/front/lib/plans/stripe.test.ts
+++ b/front/lib/plans/stripe.test.ts
@@ -808,6 +808,7 @@ describe("getStripePricingData", () => {
       currency_options: {
         usd: { unit_amount: 1000 },
         eur: { unit_amount: 900 },
+        gbp: { unit_amount: 800 },
       },
     });
 
@@ -817,13 +818,13 @@ describe("getStripePricingData", () => {
       currencyOptions: {
         usd: { unitAmount: 1000 },
         eur: { unitAmount: 900 },
-        gbp: { unitAmount: 0 },
+        gbp: { unitAmount: 800 },
       },
     });
   });
 
   it("should not throw when a supported currency option is missing", async () => {
-    // Price configured with USD only; EUR has no currency option.
+    // Price configured with USD only; EUR and GBP have no currency option.
     mockPrices.retrieve.mockResolvedValue({
       unit_amount: 1000,
       currency_options: {


### PR DESCRIPTION
## What

Follow-up to the merged GBP work (#28482). Fixes the bugs that blocked migrating a workspace with a **GBP** Metronome contract, plus two more binary usd/eur assumptions found during a sweep.

## Root cause of the migration failure

`migrate_legacy_pro_monthly_to_business` on a GBP workspace failed with:

> Metronome package 79a7cd51… is USD, but Stripe customer … resolves to GBP. Pick a GBP package.

`listMetronomePackages` derives each package's `currency` from its **name** via `classifyMetronomePackageCurrencyByName`, which only recognized EUR and defaulted everything else to USD — so the "Business GBP" package (all-GBP rates) was classified USD and `switch_contract` rejected the GBP Stripe customer.

## Changes

- `classifyMetronomePackageCurrencyByName` — add a `gbp`/`pound`/`sterling` branch (+ tests). Unblocks the migration.
- `awu_pool_summary.ts` `creditTypeIdToCurrency` — mapped only USD/EUR credit-type IDs and returned `null` for GBP, so the AWU pool summary couldn't resolve currency for GBP contracts. Add the GBP branch.
- `SeatCard.tsx` `formatSeatPrice` — used `currency === "usd" ? prefix : suffix`, rendering GBP as `30£`. EUR is the only trailing-symbol currency; USD and GBP are prefix (`£30`).

## Not changed (flagged)

- `webhook_handler.ts` `invoice.currency !== "eur"` — correct: SEPA is euro-only, GBP is rightly excluded.
- `getBillingCurrencyForCountry` — deliberate binary EU→EUR / else→USD map (GB→USD). UK self-serve users never see GBP pricing; changing that is a product/pricing decision (needs Stripe GBP price options). Migration is unaffected (it reads the actual Stripe currency).

## Test plan

- `tsgo --noEmit` clean.
- `lib/metronome/types.test.ts` passes (incl. new GBP cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)