### PR TITLE
[LLM] Add Agent Platform EU stream endpoints for Claude Opus 4.6/4.7/4.8 and Sonnet 5

### DIFF
--- a/front/lib/llms/stream/endpoints/agent_platform_eu_claude_opus_four_dot_eight.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_eu_claude_opus_four_dot_eight.ts
@@ -1,0 +1,18 @@
+import { WithDustClaudeOpusFourDotEightConfig } from "@app/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AgentPlatformEuropeClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_eight";
+
+export class DustAgentPlatformEuropeClaudeOpusFourDotEightStream extends WithDustClaudeOpusFourDotEightConfig(
+  AgentPlatformEuropeClaudeOpusFourDotEightStream
+) {
+  static readonly endpointFilter = {
+    or: [
+      {
+        featureFlags: { contains: "use_vertex_for_supported_models" as const },
+      },
+      { isCreditPriced: { eq: true } },
+    ],
+  };
+}
+
+defineDustStreamEndpoint(DustAgentPlatformEuropeClaudeOpusFourDotEightStream);

--- a/front/lib/llms/stream/endpoints/agent_platform_eu_claude_opus_four_dot_seven.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_eu_claude_opus_four_dot_seven.ts
@@ -1,0 +1,18 @@
+import { WithDustClaudeOpusFourDotSevenConfig } from "@app/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AgentPlatformEuropeClaudeOpusFourDotSevenStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_seven";
+
+export class DustAgentPlatformEuropeClaudeOpusFourDotSevenStream extends WithDustClaudeOpusFourDotSevenConfig(
+  AgentPlatformEuropeClaudeOpusFourDotSevenStream
+) {
+  static readonly endpointFilter = {
+    or: [
+      {
+        featureFlags: { contains: "use_vertex_for_supported_models" as const },
+      },
+      { isCreditPriced: { eq: true } },
+    ],
+  };
+}
+
+defineDustStreamEndpoint(DustAgentPlatformEuropeClaudeOpusFourDotSevenStream);

--- a/front/lib/llms/stream/endpoints/agent_platform_eu_claude_opus_four_dot_six.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_eu_claude_opus_four_dot_six.ts
@@ -1,0 +1,18 @@
+import { WithDustClaudeOpusFourDotSixConfig } from "@app/lib/llms/providers/anthropic/models/claude_opus_four_dot_six";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AgentPlatformEuropeClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_six";
+
+export class DustAgentPlatformEuropeClaudeOpusFourDotSixStream extends WithDustClaudeOpusFourDotSixConfig(
+  AgentPlatformEuropeClaudeOpusFourDotSixStream
+) {
+  static readonly endpointFilter = {
+    or: [
+      {
+        featureFlags: { contains: "use_vertex_for_supported_models" as const },
+      },
+      { isCreditPriced: { eq: true } },
+    ],
+  };
+}
+
+defineDustStreamEndpoint(DustAgentPlatformEuropeClaudeOpusFourDotSixStream);

--- a/front/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_five.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_five.ts
@@ -1,0 +1,18 @@
+import { WithDustClaudeSonnetFiveConfig } from "@app/lib/llms/providers/anthropic/models/claude_sonnet_five";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AgentPlatformEuropeClaudeSonnetFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_five";
+
+export class DustAgentPlatformEuropeClaudeSonnetFiveStream extends WithDustClaudeSonnetFiveConfig(
+  AgentPlatformEuropeClaudeSonnetFiveStream
+) {
+  static readonly endpointFilter = {
+    or: [
+      {
+        featureFlags: { contains: "use_vertex_for_supported_models" as const },
+      },
+      { isCreditPriced: { eq: true } },
+    ],
+  };
+}
+
+defineDustStreamEndpoint(DustAgentPlatformEuropeClaudeSonnetFiveStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -1,5 +1,9 @@
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import { DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
+import { DustAgentPlatformEuropeClaudeOpusFourDotEightStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_opus_four_dot_eight";
+import { DustAgentPlatformEuropeClaudeOpusFourDotSevenStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_opus_four_dot_seven";
+import { DustAgentPlatformEuropeClaudeOpusFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_opus_four_dot_six";
+import { DustAgentPlatformEuropeClaudeSonnetFiveStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_five";
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
 import { DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
@@ -48,6 +52,14 @@ import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
 export const DUST_STREAM_ENDPOINTS = {
   [DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
     DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream,
+  [DustAgentPlatformEuropeClaudeOpusFourDotEightStream.id]:
+    DustAgentPlatformEuropeClaudeOpusFourDotEightStream,
+  [DustAgentPlatformEuropeClaudeOpusFourDotSevenStream.id]:
+    DustAgentPlatformEuropeClaudeOpusFourDotSevenStream,
+  [DustAgentPlatformEuropeClaudeOpusFourDotSixStream.id]:
+    DustAgentPlatformEuropeClaudeOpusFourDotSixStream,
+  [DustAgentPlatformEuropeClaudeSonnetFiveStream.id]:
+    DustAgentPlatformEuropeClaudeSonnetFiveStream,
   [DustAgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
   [DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]:

--- a/front/lib/model_constructors/stream/clients/anthropic_agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic_agent_platform.ts
@@ -28,7 +28,7 @@ import { z } from "zod";
 // Can be extended later (e.g. "us", "asia-east1"...)
 export type AgentPlatformRegionalEndpoint = "global" | "eu";
 
-const configSchema = inputConfigSchema.extend({
+export const anthropicAgentPlatformConfigSchema = inputConfigSchema.extend({
   reasoning: z
     .object({
       effort: z.enum([
@@ -62,8 +62,9 @@ export abstract class AnthropicAgentPlatformStream extends WithAnthropicAIInputC
 
   static readonly regionalEndpoint: AgentPlatformRegionalEndpoint;
 
-  static readonly configSchema: z.ZodType<z.infer<typeof configSchema>> =
-    configSchema;
+  static readonly configSchema: z.ZodType<
+    z.infer<typeof anthropicAgentPlatformConfigSchema>
+  > = anthropicAgentPlatformConfigSchema;
 
   private readonly client: AnthropicVertex;
 

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_eight.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_eight.ts
@@ -1,0 +1,25 @@
+import { WithAnthropicClaudeOpusFourDotEightConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_eight";
+import { AnthropicAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/anthropic_agent_platform";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+
+export class AgentPlatformEuropeClaudeOpusFourDotEightStream extends WithAnthropicClaudeOpusFourDotEightConfig(
+  AnthropicAgentPlatformStream
+) {
+  // Vertex regional/multi-region endpoints add a 10% premium over global.
+  // https://platform.claude.com/docs/en/about-claude/pricing
+  static readonly tokenPricing = {
+    cacheCreated: 6.88,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 6.88,
+    longCacheCreated: 11.0,
+    cacheHit: 0.55,
+    standardInput: 5.5,
+    standardOutput: 27.5,
+  };
+  static readonly region = "eu";
+  static readonly regionalEndpoint = "eu";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformEuropeClaudeOpusFourDotEightStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_seven.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_seven.ts
@@ -1,0 +1,25 @@
+import { WithAnthropicClaudeOpusFourDotSevenConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_seven";
+import { AnthropicAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/anthropic_agent_platform";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+
+export class AgentPlatformEuropeClaudeOpusFourDotSevenStream extends WithAnthropicClaudeOpusFourDotSevenConfig(
+  AnthropicAgentPlatformStream
+) {
+  // Vertex regional/multi-region endpoints add a 10% premium over global.
+  // https://platform.claude.com/docs/en/about-claude/pricing
+  static readonly tokenPricing = {
+    cacheCreated: 6.88,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 6.88,
+    longCacheCreated: 11.0,
+    cacheHit: 0.55,
+    standardInput: 5.5,
+    standardOutput: 27.5,
+  };
+  static readonly region = "eu";
+  static readonly regionalEndpoint = "eu";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformEuropeClaudeOpusFourDotSevenStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_six.ts
@@ -1,0 +1,25 @@
+import { WithAnthropicClaudeOpusFourDotSixConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six";
+import { AnthropicAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/anthropic_agent_platform";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+
+export class AgentPlatformEuropeClaudeOpusFourDotSixStream extends WithAnthropicClaudeOpusFourDotSixConfig(
+  AnthropicAgentPlatformStream
+) {
+  // Vertex regional/multi-region endpoints add a 10% premium over global.
+  // https://platform.claude.com/docs/en/about-claude/pricing
+  static readonly tokenPricing = {
+    cacheCreated: 6.88,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 6.88,
+    longCacheCreated: 11.0,
+    cacheHit: 0.55,
+    standardInput: 5.5,
+    standardOutput: 27.5,
+  };
+  static readonly region = "eu";
+  static readonly regionalEndpoint = "eu";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformEuropeClaudeOpusFourDotSixStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_five.ts
@@ -1,0 +1,25 @@
+import { WithAnthropicClaudeSonnetFiveConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_sonnet_five";
+import { AnthropicAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/anthropic_agent_platform";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+
+export class AgentPlatformEuropeClaudeSonnetFiveStream extends WithAnthropicClaudeSonnetFiveConfig(
+  AnthropicAgentPlatformStream
+) {
+  // Vertex regional/multi-region endpoints add a 10% premium over global.
+  // https://platform.claude.com/docs/en/about-claude/pricing
+  static readonly tokenPricing = {
+    cacheCreated: 2.75,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 2.75,
+    longCacheCreated: 4.4,
+    cacheHit: 0.22,
+    standardInput: 2.2,
+    standardOutput: 11.0,
+  };
+  static readonly region = "eu";
+  static readonly regionalEndpoint = "eu";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformEuropeClaudeSonnetFiveStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -1,5 +1,9 @@
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
+import { AgentPlatformEuropeClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_eight";
+import { AgentPlatformEuropeClaudeOpusFourDotSevenStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_seven";
+import { AgentPlatformEuropeClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_six";
+import { AgentPlatformEuropeClaudeSonnetFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_five";
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
 import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
@@ -41,6 +45,14 @@ import { TogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/model_co
 export const STREAM_ENDPOINTS = {
   [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
     AgentPlatformEuropeClaudeHaikuFourDotFiveStream,
+  [AgentPlatformEuropeClaudeOpusFourDotEightStream.id]:
+    AgentPlatformEuropeClaudeOpusFourDotEightStream,
+  [AgentPlatformEuropeClaudeOpusFourDotSevenStream.id]:
+    AgentPlatformEuropeClaudeOpusFourDotSevenStream,
+  [AgentPlatformEuropeClaudeOpusFourDotSixStream.id]:
+    AgentPlatformEuropeClaudeOpusFourDotSixStream,
+  [AgentPlatformEuropeClaudeSonnetFiveStream.id]:
+    AgentPlatformEuropeClaudeSonnetFiveStream,
   [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     AgentPlatformEuropeClaudeSonnetFourDotSixStream,
   [AgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]:

--- a/front/lib/model_constructors/test/cases.ts
+++ b/front/lib/model_constructors/test/cases.ts
@@ -116,7 +116,8 @@ const REASONING_CONVERSATION: BaseConversation = {
       role: "system",
       type: "text",
       content: {
-        value: "You must reason as much as you can before answering logically.",
+        value:
+          "You must reason as much as you can before answering logically. YOU MUST REASON STEP BY STEP BEFORE ANSWERING !!!",
       },
     },
   ],
@@ -125,8 +126,8 @@ const REASONING_CONVERSATION: BaseConversation = {
       role: "user",
       type: "text",
       content: {
-        value:
-          "I am 4 times the age of my son. In 20 years, I will be twice his age. How old are we?",
+        // Large novel arithmetic (can't be memorized, must carry digits):
+        value: "Compute 4871 × 3926 and show the result.",
       },
     },
   ],

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_opus_four_dot_eight.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_opus_four_dot_eight.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+
+import { AgentPlatformEuropeClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_eight";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const AgentPlatformEuropeClaudeOpusFourDotEightStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new AgentPlatformEuropeClaudeOpusFourDotEightStream({
+        AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+      }),
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    tests: {
+      // Minimal reasoning effort is not supported by the model.
+      "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      // When forcing tool use, reasoning must be set to none.
+      "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
+
+      "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-none": null,
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-default/r-maximal": null,
+      "simple/no-tools/t-0/r-default": null,
+      "simple/no-tools/t-0/r-none": null,
+      "simple/no-tools/t-0/r-low": null,
+      "simple/no-tools/t-0/r-medium": null,
+      "simple/no-tools/t-0/r-high": null,
+      "simple/no-tools/t-0/r-maximal": null,
+      "simple/no-tools/t-0.1/r-default": null,
+      "simple/no-tools/t-0.1/r-none": null,
+      "simple/no-tools/t-0.1/r-low": null,
+      "simple/no-tools/t-0.1/r-medium": null,
+      "simple/no-tools/t-0.1/r-high": null,
+      "simple/no-tools/t-0.1/r-maximal": null,
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-none": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
+      "simple/no-tools/t-1/r-maximal": null,
+
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": null,
+      "calc/calc/t-0.1/r-medium": null,
+
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-none/force-tool": null,
+
+      "reasoning/no-tools/t-default/r-none": null,
+      "reasoning/no-tools/t-default/r-low": null,
+
+      "output-format/json-schema/t-default/r-none": null,
+      "output-format/json-schema/t-default/r-high": null,
+
+      "following/no-tools/t-default/r-default": null,
+
+      "cache/no-tools/t-default/r-default": null,
+    },
+  };
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_claude_opus_four_dot_eight.test.ts
+runStreamEndpointTests(
+  AgentPlatformEuropeClaudeOpusFourDotEightStream,
+  AgentPlatformEuropeClaudeOpusFourDotEightStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_opus_four_dot_seven.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_opus_four_dot_seven.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+
+import { AgentPlatformEuropeClaudeOpusFourDotSevenStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_seven";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const AgentPlatformEuropeClaudeOpusFourDotSevenStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new AgentPlatformEuropeClaudeOpusFourDotSevenStream({
+        AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+      }),
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    tests: {
+      // Minimal reasoning effort is not supported by the model.
+      "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      // When forcing tool use, reasoning must be set to none.
+      "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
+
+      "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-none": null,
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-default/r-maximal": null,
+      "simple/no-tools/t-0/r-default": null,
+      "simple/no-tools/t-0/r-none": null,
+      "simple/no-tools/t-0/r-low": null,
+      "simple/no-tools/t-0/r-medium": null,
+      "simple/no-tools/t-0/r-high": null,
+      "simple/no-tools/t-0/r-maximal": null,
+      "simple/no-tools/t-0.1/r-default": null,
+      "simple/no-tools/t-0.1/r-none": null,
+      "simple/no-tools/t-0.1/r-low": null,
+      "simple/no-tools/t-0.1/r-medium": null,
+      "simple/no-tools/t-0.1/r-high": null,
+      "simple/no-tools/t-0.1/r-maximal": null,
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-none": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
+      "simple/no-tools/t-1/r-maximal": null,
+
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": null,
+      "calc/calc/t-0.1/r-medium": null,
+
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-none/force-tool": null,
+
+      "reasoning/no-tools/t-default/r-none": null,
+      "reasoning/no-tools/t-default/r-low": null,
+
+      "output-format/json-schema/t-default/r-none": null,
+      "output-format/json-schema/t-default/r-high": null,
+
+      "following/no-tools/t-default/r-default": null,
+
+      "cache/no-tools/t-default/r-default": null,
+    },
+  };
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_claude_opus_four_dot_seven.test.ts
+runStreamEndpointTests(
+  AgentPlatformEuropeClaudeOpusFourDotSevenStream,
+  AgentPlatformEuropeClaudeOpusFourDotSevenStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_opus_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_opus_four_dot_six.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+
+import { AgentPlatformEuropeClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_six";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const AgentPlatformEuropeClaudeOpusFourDotSixStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new AgentPlatformEuropeClaudeOpusFourDotSixStream({
+      AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Minimal reasoning effort is not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    // When forcing tool use, reasoning must be set to none.
+    "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_claude_opus_four_dot_six.test.ts
+runStreamEndpointTests(
+  AgentPlatformEuropeClaudeOpusFourDotSixStream,
+  AgentPlatformEuropeClaudeOpusFourDotSixStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_five.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+
+import { AgentPlatformEuropeClaudeSonnetFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_five";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const AgentPlatformEuropeClaudeSonnetFiveStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new AgentPlatformEuropeClaudeSonnetFiveStream({
+      AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Minimal reasoning effort is not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    // When forcing tool use, reasoning must be set to none.
+    "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_five.test.ts
+runStreamEndpointTests(
+  AgentPlatformEuropeClaudeSonnetFiveStream,
+  AgentPlatformEuropeClaudeSonnetFiveStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_seven.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_seven.test.ts
@@ -1,10 +1,7 @@
 // @vitest-environment node
 
 import { AnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
-import {
-  INPUT_CONFIGURATION_ERROR,
-  SUCCESS,
-} from "@app/lib/model_constructors/test/cases";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
@@ -57,9 +54,7 @@ export const AnthropicGlobalClaudeOpusFourDotSevenStreamSetup: StreamSetup = {
     "calc/calc/t-default/r-none/force-tool": null,
 
     "reasoning/no-tools/t-default/r-none": null,
-    // Opus 4.7's adaptive thinking declines to reason at `low` effort on this
-    // prompt, so we only assert the stream completes.
-    "reasoning/no-tools/t-default/r-low": [SUCCESS],
+    "reasoning/no-tools/t-default/r-low": null,
 
     "output-format/json-schema/t-default/r-none": null,
     "output-format/json-schema/t-default/r-high": null,

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_six.test.ts
@@ -1,10 +1,7 @@
 // @vitest-environment node
 
 import { AnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
-import {
-  INPUT_CONFIGURATION_ERROR,
-  SUCCESS,
-} from "@app/lib/model_constructors/test/cases";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
@@ -57,9 +54,7 @@ export const AnthropicGlobalClaudeOpusFourDotSixStreamSetup: StreamSetup = {
     "calc/calc/t-default/r-none/force-tool": null,
 
     "reasoning/no-tools/t-default/r-none": null,
-    // Opus 4.6's adaptive thinking declines to reason at `low` effort on this
-    // prompt, so we only assert the stream completes.
-    "reasoning/no-tools/t-default/r-low": [SUCCESS],
+    "reasoning/no-tools/t-default/r-low": null,
 
     "output-format/json-schema/t-default/r-none": null,
     "output-format/json-schema/t-default/r-high": null,

--- a/front/lib/model_constructors/test/endpoints/setups.ts
+++ b/front/lib/model_constructors/test/endpoints/setups.ts
@@ -4,6 +4,10 @@
 // matching test file exporting its `setup`, forcing the test to be written.
 import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
 import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
+import { AgentPlatformEuropeClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_eight";
+import { AgentPlatformEuropeClaudeOpusFourDotSevenStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_seven";
+import { AgentPlatformEuropeClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_opus_four_dot_six";
+import { AgentPlatformEuropeClaudeSonnetFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_five";
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
 import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
@@ -42,6 +46,10 @@ import { OpenAIResponsesGlobalGptFiveMiniStream } from "@app/lib/model_construct
 import { OpenAIResponsesGlobalGptFiveNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_nano";
 import { TogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/model_constructors/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo";
 import { AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test";
+import { AgentPlatformEuropeClaudeOpusFourDotEightStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_opus_four_dot_eight.test";
+import { AgentPlatformEuropeClaudeOpusFourDotSevenStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_opus_four_dot_seven.test";
+import { AgentPlatformEuropeClaudeOpusFourDotSixStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_opus_four_dot_six.test";
+import { AgentPlatformEuropeClaudeSonnetFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_five.test";
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test";
 import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test";
 import { AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test";
@@ -84,6 +92,14 @@ import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 export const STREAM_ENDPOINT_SETUPS = {
   [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
     AgentPlatformEuropeClaudeHaikuFourDotFiveStreamSetup,
+  [AgentPlatformEuropeClaudeOpusFourDotEightStream.id]:
+    AgentPlatformEuropeClaudeOpusFourDotEightStreamSetup,
+  [AgentPlatformEuropeClaudeOpusFourDotSevenStream.id]:
+    AgentPlatformEuropeClaudeOpusFourDotSevenStreamSetup,
+  [AgentPlatformEuropeClaudeOpusFourDotSixStream.id]:
+    AgentPlatformEuropeClaudeOpusFourDotSixStreamSetup,
+  [AgentPlatformEuropeClaudeSonnetFiveStream.id]:
+    AgentPlatformEuropeClaudeSonnetFiveStreamSetup,
   [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup,
   [AgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]:


### PR DESCRIPTION
## Description

Add Agent Platform (Vertex) EU stream endpoints for Claude Opus 4.6/4.7/4.8 and Sonnet 5, and update the reasoning test case to a novel arithmetic prompt.

## Tests

Added integration test setups for each new endpoint; adjusted existing Opus 4.6/4.7 reasoning assertions.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`