### PR TITLE
fix(triggers): persist pod when saving from agent details panel

### DIFF
--- a/front/components/assistant/details/useTriggerSheetState.ts
+++ b/front/components/assistant/details/useTriggerSheetState.ts
@@ -178,6 +178,7 @@ export function useTriggerSheetState({
             naturalLanguageDescription: triggerData.naturalLanguageDescription,
             configuration: triggerData.configuration,
             status: triggerData.status,
+            spaceId: triggerData.spaceId,
           };
 
           if (triggerData.sId) {
@@ -214,6 +215,7 @@ export function useTriggerSheetState({
             executionPerDayLimitOverride:
               triggerData.executionPerDayLimitOverride ?? 0,
             status: triggerData.status,
+            spaceId: triggerData.spaceId,
           };
 
           if (triggerData.sId) {


### PR DESCRIPTION
## Description

When editing (or adding) a trigger from the agent details panel, the selected Pod was not saved.

The submit handler in `useTriggerSheetState.handleFormSubmit` builds its create/update request payloads field-by-field and omitted `spaceId` — the field that holds the Pod where the trigger's conversation runs ("Where to create this conversation?"). As a result the pod was silently dropped on both create and edit through that panel.

Fix: include `spaceId: triggerData.spaceId` in both the schedule and webhook payloads.

## Tests

Type-check passes (`tsgo --noEmit`). Verified manually against the flow: the pod selector binds to `schedule.spaceId` / `webhook.spaceId`, `formValuesTo*TriggerData` populate `triggerData.spaceId`, and the PATCH/POST handlers in `front-api` resolve and persist it — the only missing link was this client payload.

## Risk

Very low. Two-line change that adds an already-supported optional field to the request body. Safe to roll back.

## Deploy Plan

Standard front deploy. No migration or coordinated release required.