### PR TITLE
fix(user-analytics): update billing snapshot with user_analytics server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2271,6 +2271,16 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "toolCostCategory": "advanced",
     },
   },
+  "user_analytics": {
+    "get_personal_usage": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "get_workspace_activity": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
   "user_mentions": {
     "get_mention_markdown": {
       "freeUsage": true,


### PR DESCRIPTION
## Summary
- Updates the `mcp_servers_metadata` billing snapshot to include the `user_analytics` server, which was added by #28422 but the snapshot wasn't updated

## Test plan
- [ ] `NODE_ENV=test npm test -w front -- lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)