### PR TITLE
feat(activation): add recommendation decision tool [S1-6]

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -50,6 +50,7 @@ import {
   UserAllowedAdvancedModel,
   WorkspaceAllowedAdvancedModel,
 } from "@app/lib/models/allowed_advanced_model";
+import { ActivationRecommendationModel } from "@app/lib/models/activation/activation_recommendation";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { ExtensionConfigurationModel } from "@app/lib/models/extension";
 import { FeatureFlagModel } from "@app/lib/models/feature_flag";
@@ -286,6 +287,7 @@ export function loadAllModels() {
     WorkspaceSensitivityLabelConfigModel,
     WorkspaceSandboxEnvVarModel,
     WorkspaceSeatLimitModel,
+    ActivationRecommendationModel,
   ];
 }
 

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -1,3 +1,4 @@
+import { ActivationRecommendationModel } from "@app/lib/models/activation/activation_recommendation";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
@@ -50,7 +51,6 @@ import {
   UserAllowedAdvancedModel,
   WorkspaceAllowedAdvancedModel,
 } from "@app/lib/models/allowed_advanced_model";
-import { ActivationRecommendationModel } from "@app/lib/models/activation/activation_recommendation";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { ExtensionConfigurationModel } from "@app/lib/models/extension";
 import { FeatureFlagModel } from "@app/lib/models/feature_flag";

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2,6 +2,20 @@
 
 exports[`MCP Servers Metadata Snapshot > should have stable tool billing info across all servers 1`] = `
 {
+  "activation_recommendations": {
+    "create_recommendation": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "list_recommendations": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "update_recommendation": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
   "agent_memory": {
     "compact_memory": {
       "freeUsage": true,
@@ -2490,6 +2504,11 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
 
 exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across all servers 1`] = `
 {
+  "activation_recommendations": {
+    "create_recommendation": "never_ask",
+    "list_recommendations": "never_ask",
+    "update_recommendation": "never_ask",
+  },
   "agent_memory": {
     "compact_memory": "never_ask",
     "edit_entries": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -4,6 +4,7 @@ import {
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { ACTIVATION_RECOMMENDATIONS_SERVER } from "@app/lib/api/actions/servers/activation_recommendations/metadata";
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import {
   AGENT_ROUTER_SERVER,
@@ -230,6 +231,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "wakeups",
   "plan_mode",
   "workspace_analytics",
+  "activation_recommendations",
 ] as const;
 
 export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
@@ -1203,6 +1205,18 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: USER_ANALYTICS_SERVER,
+  },
+  activation_recommendations: {
+    id: 1040,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isRestricted: ({ featureFlags }) =>
+      !featureFlags.includes("activation_skill"),
+    isPreview: false,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: ACTIVATION_RECOMMENDATIONS_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -34,7 +34,8 @@
     { "name": "skill_authoring", "id": 1034 },
     { "name": "workspace_analytics", "id": 1035 },
     { "name": "sandbox_functions", "id": 1037 },
-    { "name": "user_analytics", "id": 1039 }
+    { "name": "user_analytics", "id": 1039 },
+    { "name": "activation_recommendations", "id": 1040 }
   ],
   "manual": [
     { "name": "github", "id": 1 },

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -5,6 +5,7 @@ import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
 } from "@app/lib/actions/types/guards";
+import { default as activationRecommendationsServer } from "@app/lib/api/actions/servers/activation_recommendations";
 import { default as agentMemoryServer } from "@app/lib/api/actions/servers/agent_memory";
 import { default as agentRouterServer } from "@app/lib/api/actions/servers/agent_router";
 import { default as agentSidekickAgentStateServer } from "@app/lib/api/actions/servers/agent_sidekick_agent_state";
@@ -282,6 +283,8 @@ export async function getInternalMCPServer(
       return workdayServer(auth, toolContext);
     case "user_analytics":
       return userAnalyticsServer(auth, toolContext);
+    case "activation_recommendations":
+      return activationRecommendationsServer(auth, toolContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -51,8 +51,14 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
 
       if (!rec) {
         return new Err(
+          new MCPError(`Recommendation not found: ${recommendationId}.`)
+        );
+      }
+
+      if (rec.userId !== auth.getNonNullableUser().id) {
+        return new Err(
           new MCPError(
-            `Recommendation not found: ${recommendationId}.`
+            `Cannot update recommendation ${recommendationId}: not owned by the calling user.`
           )
         );
       }

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -1,0 +1,142 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { ToolContextType } from "@app/lib/actions/types";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
+import {
+  ACTIVATION_RECOMMENDATIONS_SERVER_NAME,
+  ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/activation_recommendations/metadata";
+import type { Authenticator } from "@app/lib/auth";
+import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { Err, Ok } from "@app/types/shared/result";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
+  {
+    create_recommendation: async (
+      { content, rationale },
+      { auth, toolContext }
+    ) => {
+      const conversationId = isAgentLoopRunContext(toolContext?.runContext)
+        ? toolContext.runContext.conversation.id
+        : null;
+
+      const rec = await ActivationRecommendationResource.makeNew(auth, {
+        content,
+        rationale,
+        conversationId,
+      });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Recommendation recorded. recommendationId: ${rec.sId}`,
+        },
+      ]);
+    },
+
+    update_recommendation: async (
+      { recommendationId, status, createdSkillId, createdTriggerId },
+      { auth }
+    ) => {
+      const rec = await ActivationRecommendationResource.fetchById(
+        auth,
+        recommendationId
+      );
+
+      if (!rec) {
+        return new Err(
+          new MCPError(
+            `Recommendation not found: ${recommendationId}.`
+          )
+        );
+      }
+
+      let createdSkillModelId: number | undefined;
+      let createdTriggerModelId: number | undefined;
+
+      if (createdSkillId) {
+        const skill = await SkillResource.fetchById(auth, createdSkillId);
+        if (skill) {
+          createdSkillModelId = skill.id;
+        }
+      }
+
+      if (createdTriggerId) {
+        const trigger = await TriggerResource.fetchById(auth, createdTriggerId);
+        if (trigger) {
+          createdTriggerModelId = trigger.id;
+        }
+      }
+
+      await rec.updateFields({
+        status,
+        createdSkillModelId,
+        createdTriggerModelId,
+      });
+
+      const statusMsg = status ? ` Status set to "${status}".` : "";
+      const skillMsg = createdSkillModelId ? " Skill linked." : "";
+      const triggerMsg = createdTriggerModelId ? " Trigger linked." : "";
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Recommendation updated.${statusMsg}${skillMsg}${triggerMsg}`,
+        },
+      ]);
+    },
+
+    list_recommendations: async (_params, { auth }) => {
+      const recs = await ActivationRecommendationResource.fetchByUser(auth);
+
+      if (recs.length === 0) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: "No previous recommendations for this user.",
+          },
+        ]);
+      }
+
+      const lines = recs.map((r, i) => {
+        const statusLabel =
+          r.status === "suggested"
+            ? "shown (no decision yet)"
+            : r.status === "executed"
+              ? "accepted"
+              : "dismissed";
+        return `${i + 1}. [${statusLabel}] ${r.content}`;
+      });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Previous recommendations (${recs.length}):\n${lines.join("\n")}`,
+        },
+      ]);
+    },
+  };
+
+function createServer(
+  auth: Authenticator,
+  toolContext?: ToolContextType
+): McpServer {
+  const server = makeInternalMCPServer(ACTIVATION_RECOMMENDATIONS_SERVER_NAME);
+
+  const tools = buildTools(ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA, handlers);
+  for (const tool of tools) {
+    registerTool(auth, toolContext, server, tool, {
+      monitoringName: ACTIVATION_RECOMMENDATIONS_SERVER_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -68,7 +68,7 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = createToolsRecord({
   },
   list_recommendations: {
     description:
-      "List past activation recommendations for this conversation. " +
+      "List past activation recommendations for this user. " +
       "Call before generating a new recommendation to avoid repeating suggestions " +
       "the user has already seen or dismissed.",
     schema: {},

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -1,0 +1,109 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const ACTIVATION_RECOMMENDATIONS_SERVER_NAME =
+  "activation_recommendations" as const;
+
+export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = createToolsRecord({
+  create_recommendation: {
+    description:
+      "Record a new activation recommendation that was shown to the user. " +
+      "Call this immediately after surfacing a recommendation so it is tracked. " +
+      "Returns a recommendationId to reference in update_recommendation.",
+    schema: {
+      content: z
+        .string()
+        .max(4096)
+        .describe("The recommendation text shown to the user (1-3 sentences)."),
+      rationale: z
+        .string()
+        .max(4096)
+        .describe(
+          "Internal reasoning for why this recommendation was selected."
+        ),
+    },
+    stake: "never_ask",
+    toolCostCategory: "basic",
+    freeUsage: true,
+    displayLabels: {
+      running: "Recording recommendation",
+      done: "Recommendation recorded",
+    },
+  },
+  update_recommendation: {
+    description:
+      "Update an activation recommendation's status or link created artifacts to it. " +
+      "Use status 'executed' when the user accepts and runs the recommendation, " +
+      "'dismissed' when the user declines. " +
+      "Pass createdSkillId or createdTriggerId when the recommendation produced those artifacts.",
+    schema: {
+      recommendationId: z
+        .string()
+        .describe("The sId returned by create_recommendation."),
+      status: z
+        .enum(["executed", "dismissed"])
+        .optional()
+        .describe("New status for the recommendation."),
+      createdSkillId: z
+        .string()
+        .optional()
+        .describe("sId of a skill created as a result of this recommendation."),
+      createdTriggerId: z
+        .string()
+        .optional()
+        .describe(
+          "sId of a trigger created as a result of this recommendation."
+        ),
+    },
+    stake: "never_ask",
+    toolCostCategory: "basic",
+    freeUsage: true,
+    displayLabels: {
+      running: "Updating recommendation",
+      done: "Recommendation updated",
+    },
+  },
+  list_recommendations: {
+    description:
+      "List past activation recommendations for this conversation. " +
+      "Call before generating a new recommendation to avoid repeating suggestions " +
+      "the user has already seen or dismissed.",
+    schema: {},
+    stake: "never_ask",
+    toolCostCategory: "basic",
+    freeUsage: true,
+    displayLabels: {
+      running: "Fetching recommendation history",
+      done: "Recommendation history fetched",
+    },
+  },
+});
+
+export const ACTIVATION_RECOMMENDATIONS_SERVER = {
+  serverInfo: {
+    name: ACTIVATION_RECOMMENDATIONS_SERVER_NAME,
+    version: "1.0.0",
+    description:
+      "Track activation recommendations and record user decisions on them.",
+    authorization: null,
+    icon: "ActionBrainIcon",
+    documentationUrl: null,
+  },
+  tools: Object.values(ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA).map((t) => [
+      t.name,
+      t.stake,
+    ])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/resources/activation_recommendation_resource.test.ts
+++ b/front/lib/resources/activation_recommendation_resource.test.ts
@@ -1,0 +1,163 @@
+import { Authenticator } from "@app/lib/auth";
+import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { describe, expect, it } from "vitest";
+
+const makeRec = (auth: Authenticator) =>
+  ActivationRecommendationResource.makeNew(auth, {
+    content: "Try the Slack integration",
+    rationale: "User has Slack but no Slack skill",
+    conversationId: null,
+  });
+
+describe("ActivationRecommendationResource", () => {
+  describe("makeNew", () => {
+    it("creates a recommendation with status 'suggested'", async () => {
+      const { authenticator } = await createResourceTest({ role: "user" });
+
+      const rec = await makeRec(authenticator);
+
+      expect(rec.status).toBe("suggested");
+      expect(rec.content).toBe("Try the Slack integration");
+      expect(rec.rationale).toBe("User has Slack but no Slack skill");
+      expect(rec.sId).toBeTruthy();
+    });
+  });
+
+  describe("fetchById", () => {
+    it("returns the recommendation by sId", async () => {
+      const { authenticator } = await createResourceTest({ role: "user" });
+      const rec = await makeRec(authenticator);
+
+      const fetched = await ActivationRecommendationResource.fetchById(
+        authenticator,
+        rec.sId
+      );
+
+      expect(fetched).not.toBeNull();
+      expect(fetched!.sId).toBe(rec.sId);
+    });
+
+    it("returns null for a non-existent sId", async () => {
+      const { authenticator } = await createResourceTest({ role: "user" });
+
+      const fetched = await ActivationRecommendationResource.fetchById(
+        authenticator,
+        "arc_nonexistent"
+      );
+
+      expect(fetched).toBeNull();
+    });
+
+    it("does not return a recommendation from another workspace", async () => {
+      const { authenticator: auth1 } = await createResourceTest({
+        role: "user",
+      });
+      const { authenticator: auth2 } = await createResourceTest({
+        role: "user",
+      });
+      const rec = await makeRec(auth1);
+
+      const fetched = await ActivationRecommendationResource.fetchById(
+        auth2,
+        rec.sId
+      );
+
+      expect(fetched).toBeNull();
+    });
+  });
+
+  describe("fetchByUser", () => {
+    it("returns all recommendations for the calling user", async () => {
+      const { authenticator } = await createResourceTest({ role: "user" });
+      await makeRec(authenticator);
+      await makeRec(authenticator);
+
+      const recs =
+        await ActivationRecommendationResource.fetchByUser(authenticator);
+
+      expect(recs.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("does not return recommendations from another user in the same workspace", async () => {
+      const { workspace, authenticator } = await createResourceTest({
+        role: "user",
+      });
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, {
+        role: "user",
+      });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      await makeRec(otherAuth);
+
+      const recs =
+        await ActivationRecommendationResource.fetchByUser(authenticator);
+
+      expect(recs).toHaveLength(0);
+    });
+  });
+
+  describe("updateFields", () => {
+    it("updates the status of a recommendation", async () => {
+      const { authenticator } = await createResourceTest({ role: "user" });
+      const rec = await makeRec(authenticator);
+
+      await rec.updateFields({ status: "executed" });
+
+      const updated = await ActivationRecommendationResource.fetchById(
+        authenticator,
+        rec.sId
+      );
+      expect(updated!.status).toBe("executed");
+    });
+
+    it("does not update when called with no fields", async () => {
+      const { authenticator } = await createResourceTest({ role: "user" });
+      const rec = await makeRec(authenticator);
+
+      await rec.updateFields({});
+
+      const fetched = await ActivationRecommendationResource.fetchById(
+        authenticator,
+        rec.sId
+      );
+      expect(fetched!.status).toBe("suggested");
+    });
+  });
+
+  describe("ownership check in update_recommendation handler", () => {
+    it("userId on the record matches the creating user", async () => {
+      const { authenticator, user } = await createResourceTest({
+        role: "user",
+      });
+      const rec = await makeRec(authenticator);
+
+      expect(rec.userId).toBe(user.id);
+    });
+
+    it("a different user in the same workspace has a different userId", async () => {
+      const { workspace, authenticator, user } = await createResourceTest({
+        role: "user",
+      });
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, {
+        role: "user",
+      });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      const rec = await makeRec(authenticator);
+
+      expect(rec.userId).toBe(user.id);
+      expect(rec.userId).not.toBe(otherAuth.getNonNullableUser().id);
+    });
+  });
+});

--- a/front/lib/resources/activation_recommendation_resource.ts
+++ b/front/lib/resources/activation_recommendation_resource.ts
@@ -1,0 +1,162 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  ActivationRecommendationModel,
+  type ActivationRecommendationStatus,
+} from "@app/lib/models/activation/activation_recommendation";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type {
+  Attributes,
+  CreationAttributes,
+  ModelStatic,
+  Transaction,
+} from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ActivationRecommendationResource
+  extends ReadonlyAttributesType<ActivationRecommendationModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ActivationRecommendationResource extends BaseResource<ActivationRecommendationModel> {
+  static model: ModelStatic<ActivationRecommendationModel> =
+    ActivationRecommendationModel;
+
+  constructor(
+    _: ModelStatic<ActivationRecommendationModel>,
+    blob: Attributes<ActivationRecommendationModel>
+  ) {
+    super(ActivationRecommendationModel, blob);
+  }
+
+  get sId(): string {
+    return ActivationRecommendationResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("activation_recommendation", { id, workspaceId });
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    blob: Pick<
+      CreationAttributes<ActivationRecommendationModel>,
+      "content" | "rationale" | "conversationId"
+    >
+  ): Promise<ActivationRecommendationResource> {
+    const workspace = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
+
+    const rec = await this.model.create({
+      workspaceId: workspace.id,
+      userId: user.id,
+      status: "suggested",
+      content: blob.content,
+      rationale: blob.rationale,
+      conversationId: blob.conversationId ?? null,
+    });
+
+    return new this(this.model, rec.get());
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    sId: string
+  ): Promise<ActivationRecommendationResource | null> {
+    const resourceId = getResourceIdFromSId(sId);
+    if (!resourceId) {
+      return null;
+    }
+
+    const rec = await this.model.findOne({
+      where: {
+        id: resourceId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    if (!rec) {
+      return null;
+    }
+
+    return new this(this.model, rec.get());
+  }
+
+  static async fetchByUser(
+    auth: Authenticator,
+    { limit = 100 }: { limit?: number } = {}
+  ): Promise<ActivationRecommendationResource[]> {
+    const user = auth.getNonNullableUser();
+    const recs = await this.model.findAll({
+      where: {
+        userId: user.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      order: [["createdAt", "DESC"]],
+      limit,
+    });
+
+    return recs.map((rec) => new this(this.model, rec.get()));
+  }
+
+  async updateFields(fields: {
+    status?: Exclude<ActivationRecommendationStatus, "suggested">;
+    createdSkillModelId?: ModelId;
+    createdTriggerModelId?: ModelId;
+  }): Promise<Result<undefined, Error>> {
+    const patch: Partial<Attributes<ActivationRecommendationModel>> = {};
+    if (fields.status !== undefined) {
+      patch.status = fields.status;
+    }
+    if (fields.createdSkillModelId !== undefined) {
+      patch.createdSkillId = fields.createdSkillModelId;
+    }
+    if (fields.createdTriggerModelId !== undefined) {
+      patch.createdTriggerId = fields.createdTriggerModelId;
+    }
+    if (Object.keys(patch).length === 0) {
+      return new Ok(undefined);
+    }
+    await this.update(patch);
+    return new Ok(undefined);
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await this.model.destroy({
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        transaction,
+      });
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  toJSON() {
+    return {
+      sId: this.sId,
+      status: this.status,
+      content: this.content,
+      rationale: this.rationale,
+      createdAt: this.createdAt,
+    };
+  }
+}

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -6848,6 +6848,9 @@ const KNOWN_CONVERSATION_RELATED_MODELS = [
   // skill_suggestion.notificationConversationId is ON DELETE SET NULL, so no
   // explicit cleanup is needed in destroyConversation — the DB clears it.
   "skill_suggestion",
+  // activation_recommendation.conversationId is ON DELETE SET NULL, so no
+  // explicit cleanup is needed in destroyConversation — the DB clears it.
+  "activation_recommendation",
   // self_improving_skills_usage.conversationId is ON DELETE SET NULL, so no
   // explicit cleanup is needed in destroyConversation — the DB clears it.
   "self_improving_skills_usage",

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -20,6 +20,7 @@ Before providing a new use case for the user, you MUST acquire context to inform
 - Call \`get_personal_usage\` to understand what the user has already used in the last 30 days.
 - Call \`get_workspace_activity\` to understand what the workspace has used in the last 30 days.
 - Call \`list_skills\` to see what skills are pinned or available.
+- Call \`list_recommendations\` to see what recommendations have already been shown to the user. Do not repeat recommendations the user has already executed or dismissed.
 
 Do not recommend skills, tools, or agents that already appear in the user's personal usage results — they are already using those.
 - Account for the data already provided to you, including user job type, user preferred tools, and the existing tools
@@ -37,6 +38,13 @@ Each recommendation includes:
 - A 1-2 sentence rationale explaining why this is worth their time.
 - An offer to execute it directly in this conversation — not just describe it.
 - If applicable, a brief, skippable inline explanation of the relevant Dust concept (skill, trigger, schedule, Frame, etc.). One sentence, easy to ignore.
+
+Immediately after surfacing a recommendation, call \`create_recommendation\` with the recommendation text and your internal rationale.
+
+When the user responds to a recommendation:
+- If they accept (e.g. "Let's try it", "Yes"), call \`update_recommendation\` with \`status: "executed"\`, then proceed with execution.
+- If they decline (e.g. "Not for me", "Skip"), call \`update_recommendation\` with \`status: "dismissed"\`, then generate a new recommendation.
+- After creating a skill or trigger from a recommendation, call \`update_recommendation\` again with the corresponding \`createdSkillId\` or \`createdTriggerId\`.
 
 ## After Successful Use Case Execution
 
@@ -150,6 +158,7 @@ export const activationSkill = {
     { name: "skill_authoring" },
     { name: "schedules_management" },
     { name: "files" },
+    { name: "activation_recommendations" },
   ],
   version: 2,
   icon: "ActionRocketIcon",

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -105,6 +105,9 @@ export const RESOURCES_PREFIX = {
 
   // User project notification preferences.
   user_project_notification_preference: "upnp",
+
+  // Activation recommendations.
+  activation_recommendation: "arc",
 } as const;
 
 export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;


### PR DESCRIPTION
## Summary

- https://github.com/dust-tt/tasks/issues/9357
- Primary goals are: Improve future recommendations by giving reference to history + save data for our own metrics
- Add resource object for ActivationRecomendation
- Add CRUD tool for recommendations

## Testing
<img width="539" height="498" alt="Screenshot 2026-07-06 at 2 59 23 PM" src="https://github.com/user-attachments/assets/fe4faaee-be52-4c86-9e23-02db5f33db29" />

## Risk
Low - not customer facing yet

## Deploy
1. deploy front