### PR TITLE
Fix tool search pair detection across assistant messages

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.test.ts
@@ -202,6 +202,34 @@ describe("stripUnreplayableToolSearchBlocks", () => {
     ]);
   });
 
+  it("keeps a pair split across assistant messages after a resumed search completed on the next turn", () => {
+    const messages = [
+      user(text("Find my meetings.")),
+      assistant(text("Searching."), search("srv_1"), toolUse("tool_1")),
+      user(toolResult("tool_1")),
+      assistant(searchResult("srv_1"), toolUse("tool_2")),
+      user(toolResult("tool_2")),
+    ];
+
+    expect(
+      stripUnreplayableToolSearchBlocks(messages, { toolSearchInRequest: true })
+    ).toBe(messages);
+  });
+
+  it("strips a result whose server_tool_use is missing from the replay", () => {
+    const messages = [
+      user(text("Find my meetings.")),
+      assistant(searchResult("srv_1"), toolUse("tool_1")),
+      user(toolResult("tool_1")),
+    ];
+
+    const sanitized = stripUnreplayableToolSearchBlocks(messages, {
+      toolSearchInRequest: true,
+    });
+
+    expect(blockTypes(sanitized[1])).toEqual(["tool_use"]);
+  });
+
   it("strips every tool search block when the request has no tool search tool", () => {
     const messages = [
       user(text("Find my meetings.")),

--- a/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.ts
@@ -111,10 +111,15 @@ export function parseAnthropicToolSearchBlock(
 //     tool search block is valid at all: the results carry tool_reference blocks the API cannot
 //     expand.
 //   - With it, completed pairs (a server_tool_use with its tool_search_tool_result) must be
-//     replayed verbatim.
+//     replayed verbatim. A pair can span two assistant messages: when a pending search is resumed,
+//     its result opens the next assistant turn, with the tool_result continuation in between. Both
+//     halves must be kept, so pairing is computed across the whole replay, not per message.
 //   - A dangling server_tool_use (a search the API never ran, e.g. because the turn ended on a
 //     client tool call or was interrupted) is valid only on the final assistant message when the
 //     continuation is exclusively tool_result blocks. The API then resumes the search.
+//   - A tool_search_tool_result without its server_tool_use earlier in the replay is always
+//     rejected, so a result whose matching use was stripped (or never persisted) must be stripped
+//     with it.
 //
 // This sanitizer keeps the replayable blocks and strips the rest, unbricking conversations that
 // captured a pending search. The model simply searches again when it needs the tools. Stripping is
@@ -136,19 +141,23 @@ function isToolSearchToolResultBlock(
   return block.type === "tool_search_tool_result";
 }
 
-function getDanglingServerToolUseIds(
-  content: ContentBlockParam[]
-): Set<string> {
-  const resultIds = new Set(
-    content.filter(isToolSearchToolResultBlock).map((b) => b.tool_use_id)
-  );
+// Ids of every tool search result across the whole replay. A server_tool_use is dangling only
+// when no result matches it anywhere, since a resumed search completes in a later assistant
+// message than the one that issued it.
+function collectToolSearchResultIds(messages: MessageParam[]): Set<string> {
+  const resultIds = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== "assistant" || typeof message.content === "string") {
+      continue;
+    }
+    for (const block of message.content) {
+      if (isToolSearchToolResultBlock(block)) {
+        resultIds.add(block.tool_use_id);
+      }
+    }
+  }
 
-  return new Set(
-    content
-      .filter(isToolSearchServerToolUseBlock)
-      .filter((b) => !resultIds.has(b.id))
-      .map((b) => b.id)
-  );
+  return resultIds;
 }
 
 function isToolResultOnlyUserMessage(message: MessageParam): boolean {
@@ -226,10 +235,15 @@ export function stripUnreplayableToolSearchBlocks(
   { toolSearchInRequest }: StripUnreplayableToolSearchBlocksOptions
 ): MessageParam[] {
   const resumableAssistantIndex = findResumableAssistantIndex(messages);
+  const resultIds = collectToolSearchResultIds(messages);
 
   let strippedServerToolUseCount = 0;
   let strippedResultCount = 0;
   let droppedMessageCount = 0;
+
+  // A server_tool_use always precedes its result in the replay, so by the time a result block is
+  // reached its use has already been kept or stripped.
+  const keptServerToolUseIds = new Set<string>();
 
   const sanitized: MessageParam[] = [];
   for (const [index, message] of messages.entries()) {
@@ -238,16 +252,16 @@ export function stripUnreplayableToolSearchBlocks(
       continue;
     }
 
-    const danglingIds = getDanglingServerToolUseIds(message.content);
     const danglingIsResumable =
       toolSearchInRequest && index === resumableAssistantIndex;
 
     const content = message.content.filter((block) => {
       if (isToolSearchServerToolUseBlock(block)) {
-        const keep =
-          toolSearchInRequest &&
-          (!danglingIds.has(block.id) || danglingIsResumable);
-        if (!keep) {
+        const dangling = !resultIds.has(block.id);
+        const keep = toolSearchInRequest && (!dangling || danglingIsResumable);
+        if (keep) {
+          keptServerToolUseIds.add(block.id);
+        } else {
           strippedServerToolUseCount++;
         }
 
@@ -255,13 +269,13 @@ export function stripUnreplayableToolSearchBlocks(
       }
 
       if (isToolSearchToolResultBlock(block)) {
-        if (!toolSearchInRequest) {
+        const keep =
+          toolSearchInRequest && keptServerToolUseIds.has(block.tool_use_id);
+        if (!keep) {
           strippedResultCount++;
-
-          return false;
         }
 
-        return true;
+        return keep;
       }
 
       return true;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The replay sanitizer from #28517 decided whether an Anthropic tool search was still pending by looking for its result inside the same assistant message. That assumption breaks in the flow the sanitizer was built to preserve: when a pending search is kept and the API resumes it, the result opens the next assistant turn, so a completed pair legitimately spans two assistant messages with the tool result continuation in between. On the following replay the call half was misclassified as pending and stripped while the result half was kept, and the API rejected the request with a 400 for a search result lacking its corresponding call. This is the production error seen after deploy.

Pairing is now computed across the whole conversation: a call counts as pending only when no result matches it anywhere, and a result is kept only when its call was kept, which also removes genuinely orphaned results defensively. The resumable-pending rule, the byte-identical fast path for prompt caching, and the strip warning log are unchanged. The sanitizer is stateless at request build time, so affected conversations kept their full history and replay correctly once this is deployed. A regression test reproduces the exact production topology and asserts the messages pass through untouched, with a second test covering the orphaned result case.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
