### PR TITLE
[Admin Gov] Phase 0 — scrub group_permissions on workspace deletion

### DIFF
--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -218,7 +218,7 @@ describe("GroupPermissionResource", () => {
       await GroupPermissionResource.deleteAllForWorkspace(auth);
 
       const remaining = await GroupPermissionResource.listForGroups(auth, {
-        groupIds: [groupA.id, groupB.id],
+        groupModelIds: [groupA.id, groupB.id],
       });
       expect(remaining).toEqual([]);
     });

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -199,4 +199,28 @@ describe("GroupPermissionResource", () => {
       ).rejects.toThrow(/type-wide/);
     });
   });
+
+  describe("deleteAllForWorkspace", () => {
+    it("drops every grant for the workspace (scrub hook)", async () => {
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 1,
+      });
+      await GroupPermissionResource.grant(auth, {
+        group: groupB,
+        permissionType: "write",
+        resourceType: "agent",
+        resourceId: 2,
+      });
+
+      await GroupPermissionResource.deleteAllForWorkspace(auth);
+
+      const remaining = await GroupPermissionResource.listForGroups(auth, {
+        groupIds: [groupA.id, groupB.id],
+      });
+      expect(remaining).toEqual([]);
+    });
+  });
 });

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -184,6 +184,14 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     });
   }
 
+  // Workspace-scrub hook: drop every grant for the workspace. Must run before groups and the
+  // workspace row are torn down, since both FKs are ON DELETE RESTRICT.
+  static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
+    await GroupPermissionModel.destroy({
+      where: { workspaceId: auth.getNonNullableWorkspace().id },
+    });
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -23,6 +23,7 @@ import {
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
@@ -129,6 +130,7 @@ export async function scrubWorkspaceData({
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
     dangerouslyRequestAllGroups: true,
   });
+  await deleteGroupPermissions(auth);
   await deleteAllConversations(auth);
   await deleteTakeaways(auth);
   await deleteKeys(auth);
@@ -184,6 +186,10 @@ export async function pauseAllTriggers({
       "Failed to disable workspace triggers during scrub"
     );
   }
+}
+
+async function deleteGroupPermissions(auth: Authenticator) {
+  await GroupPermissionResource.deleteAllForWorkspace(auth);
 }
 
 async function deleteTakeaways(auth: Authenticator) {


### PR DESCRIPTION
## Description

Admin Governance — Phase 0. Follows #28485.

Wires `group_permissions` into workspace teardown. The table FKs both `groups` and `workspaces` with `ON DELETE RESTRICT`, so its rows must be cleared before those are torn down — otherwise scrubbing a workspace that has grant rows would be blocked by the FK.

- Adds `GroupPermissionResource.deleteAllForWorkspace(auth)`.
- Calls it early in the workspace scrub workflow (`front/temporal/scrub_workspace/activities.ts`), before spaces/groups/workspace are removed. Goes through the resource (not the raw model) per BACK3.

Safe no-op in practice for Phase 0 (nothing writes grant rows yet), but the wiring is in place before Phase 2's first real grants.

Context: [Design Doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48) · [Implementation Plan](https://app.notion.com/p/dust-tt/Implementation-Plan-Admin-Governance-39528599d9418153aa9bf3dd69d5448d)

## Risks

Blast radius: one extra delete in the workspace scrub workflow (no rows exist yet).
Risk: none

## Deploy Plan

- deploy front
