### PR TITLE
[Admin Gov] Drop external doc references from group_permissions comments

### DIFF
--- a/front/lib/resources/storage/models/group_permissions.ts
+++ b/front/lib/resources/storage/models/group_permissions.ts
@@ -8,8 +8,8 @@ import type {
 } from "@app/types/group_permissions";
 import type { CreationOptional, ForeignKey } from "sequelize";
 
-// Single table backing all Admin Governance permission grants (design doc §1A). See
-// `@app/types/group_permissions` for the vocabulary and `group_permission_registry` for validity.
+// Single table backing all group permission grants. See `@app/types/group_permissions` for the
+// vocabulary and `group_permission_registry` for validity.
 export class GroupPermissionModel extends WorkspaceAwareModel<GroupPermissionModel> {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -1,5 +1,5 @@
 /**
- * Vocabulary for the `group_permissions` table (Admin Governance §1A).
+ * Vocabulary for the `group_permissions` table.
  *
  * All permission grants — resource-level access (spaces, agents, skills) and workspace-level
  * capabilities (billing, identity, …) — live in a single table keyed by a plain-verb


### PR DESCRIPTION
## Description

Admin Governance — Phase 0. Housekeeping on the merged model PR.

The design doc and implementation plan live in Notion, not the repo, so the `§1A` / `design doc` references in the `group_permissions` model and vocabulary comments (merged alongside the model + migration) are dangling. This removes them so the comments stay self-contained. The already-applied migration's comment is left as immutable history.

Context: [Design Doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48) · [Implementation Plan](https://app.notion.com/p/dust-tt/Implementation-Plan-Admin-Governance-39528599d9418153aa9bf3dd69d5448d)

## Risks

Blast radius: comment-only change to two files.
Risk: none

## Deploy Plan

- deploy front