### PR TITLE
[front] fix: preserve completed tool search replay blocks

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.test.ts
@@ -230,13 +230,14 @@ describe("stripUnreplayableToolSearchBlocks", () => {
     expect(blockTypes(sanitized[1])).toEqual(["tool_use"]);
   });
 
-  it("strips every tool search block when the request has no tool search tool", () => {
+  it("keeps completed pairs between thinking blocks when the request has no tool search tool", () => {
     const messages = [
       user(text("Find my meetings.")),
       assistant(
-        text("Searching."),
+        thinking(),
         search("srv_1"),
         searchResult("srv_1"),
+        { type: "thinking", thinking: "more reasoning", signature: "sig-2" },
         toolUse("tool_1")
       ),
       user(toolResult("tool_1")),
@@ -246,13 +247,20 @@ describe("stripUnreplayableToolSearchBlocks", () => {
       toolSearchInRequest: false,
     });
 
-    expect(blockTypes(sanitized[1])).toEqual(["text", "tool_use"]);
+    expect(sanitized).toBe(messages);
+    expect(blockTypes(sanitized[1])).toEqual([
+      "thinking",
+      "server_tool_use",
+      "tool_search_tool_result",
+      "thinking",
+      "tool_use",
+    ]);
   });
 
-  it("drops a message emptied by stripping and merges its same-role neighbors", () => {
+  it("drops a message emptied by stripping a dangling search and merges its same-role neighbors", () => {
     const messages = [
       user(text("Find my meetings.")),
-      assistant(search("srv_1"), searchResult("srv_1")),
+      assistant(search("srv_1")),
       user(text("Thanks, now summarize.")),
     ];
 

--- a/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.ts
@@ -107,24 +107,22 @@ export function parseAnthropicToolSearchBlock(
 // The API constrains how tool search blocks can be replayed, and rejects the whole request with a
 // 400 when a constraint is violated:
 //
-//   - Without the tool search tool in the request (auxiliary calls such as title generation), no
-//     tool search block is valid at all: the results carry tool_reference blocks the API cannot
-//     expand.
-//   - With it, completed pairs (a server_tool_use with its tool_search_tool_result) must be
-//     replayed verbatim. A pair can span two assistant messages: when a pending search is resumed,
-//     its result opens the next assistant turn, with the tool_result continuation in between. Both
-//     halves must be kept, so pairing is computed across the whole replay, not per message.
+//   - Completed pairs (a server_tool_use with its tool_search_tool_result) must be replayed
+//     verbatim, even when the current request no longer carries the tool search server tool. A pair
+//     can span two assistant messages: when a pending search is resumed, its result opens the next
+//     assistant turn, with the tool_result continuation in between. Both halves must be kept, so
+//     pairing is computed across the whole replay, not per message.
 //   - A dangling server_tool_use (a search the API never ran, e.g. because the turn ended on a
-//     client tool call or was interrupted) is valid only on the final assistant message when the
-//     continuation is exclusively tool_result blocks. The API then resumes the search.
+//     client tool call or was interrupted) is valid only when the request still carries the tool
+//     search server tool, it is on the final assistant message, and the continuation is exclusively
+//     tool_result blocks. The API then resumes the search.
 //   - A tool_search_tool_result without its server_tool_use earlier in the replay is always
 //     rejected, so a result whose matching use was stripped (or never persisted) must be stripped
 //     with it.
 //
-// This sanitizer keeps the replayable blocks and strips the rest, unbricking conversations that
-// captured a pending search. The model simply searches again when it needs the tools. Stripping is
-// verified safe next to signed thinking blocks: signatures cover the thinking blocks themselves,
-// not their siblings (see scripts/debug_tool_search_steering_pending_search.ts).
+// This sanitizer keeps completed pairs in place and strips dangling or unpaired blocks. Completed
+// pairs can sit between signed thinking blocks, so removing them changes the latest assistant
+// message shape.
 
 function isToolSearchServerToolUseBlock(
   block: ContentBlockParam
@@ -223,7 +221,8 @@ function mergeConsecutiveSameRoleMessages(
 }
 
 interface StripUnreplayableToolSearchBlocksOptions {
-  // Whether the request being built carries the tool search server tool.
+  // Whether the request being built carries the tool search server tool, allowing dangling final
+  // assistant searches to resume.
   toolSearchInRequest: boolean;
 }
 
@@ -258,7 +257,7 @@ export function stripUnreplayableToolSearchBlocks(
     const content = message.content.filter((block) => {
       if (isToolSearchServerToolUseBlock(block)) {
         const dangling = !resultIds.has(block.id);
-        const keep = toolSearchInRequest && (!dangling || danglingIsResumable);
+        const keep = !dangling || danglingIsResumable;
         if (keep) {
           keptServerToolUseIds.add(block.id);
         } else {
@@ -269,8 +268,7 @@ export function stripUnreplayableToolSearchBlocks(
       }
 
       if (isToolSearchToolResultBlock(block)) {
-        const keep =
-          toolSearchInRequest && keptServerToolUseIds.has(block.tool_use_id);
+        const keep = keptServerToolUseIds.has(block.tool_use_id);
         if (!keep) {
           strippedResultCount++;
         }


### PR DESCRIPTION
## Description

- Follow up on #28538.
- We can still hit Anthropic 400s when completed tool-search passthrough blocks are stripped from the latest assistant message. In the observed replay, those blocks sat between signed thinking blocks, so removing them shifted the following thinking block and made the latest assistant message look modified.
- This keeps completed `server_tool_use` / `tool_search_tool_result` pairs in replay even when the current request no longer includes the tool-search server tool. Dangling or unmatched search blocks keep the existing stripping behavior.

## Tests

- Updated existing Anthropic tool-search replay tests.

## Risk

- Low. Anthropic replay sanitizer only.

## Deploy Plan

- Deploy front.