### PR TITLE
Skip tool search self references when synthesizing replay placeholder tools

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/tool_search_passthrough.ts
@@ -7,7 +7,7 @@ import type {
 import logger from "@app/logger/logger";
 import { z } from "zod";
 
-const TOOL_SEARCH_SERVER_TOOL_NAMES = [
+export const TOOL_SEARCH_SERVER_TOOL_NAMES = [
   "tool_search_tool_bm25",
   "tool_search_tool_regex",
 ] as const;

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -33,7 +33,10 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { getStreamLLM } from "@app/lib/api/llm";
 import { ANTHROPIC_PROVIDER_ID } from "@app/lib/api/llm/clients/anthropic/types";
-import { parseAnthropicToolSearchBlock } from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
+import {
+  parseAnthropicToolSearchBlock,
+  TOOL_SEARCH_SERVER_TOOL_NAMES,
+} from "@app/lib/api/llm/clients/anthropic/utils/tool_search_passthrough";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import {
   getByokUserFacingLLMErrorMessage,
@@ -128,6 +131,9 @@ function concatWithNewlineBoundary(
   return previous + current;
 }
 
+// TODO(2026-07-06 flav): Avoid leaking provider specifics in the agent loop. The Anthropic
+// passthrough parsing below (block shapes, server tool names) belongs behind a
+// provider-agnostic dispatch keyed on the passthrough provider id.
 function getReplayedToolNames(
   modelConversation: ModelConversationTypeMultiActions
 ): string[] {
@@ -151,6 +157,17 @@ function getReplayedToolNames(
               block.content.type === "tool_search_tool_search_result"
             ) {
               for (const ref of block.content.tool_references) {
+                // The search can match the tool search tool itself. Never
+                // synthesize a replay placeholder for it: the Anthropic client
+                // prepends the real server tool, and a placeholder would
+                // duplicate its name in the request.
+                if (
+                  TOOL_SEARCH_SERVER_TOOL_NAMES.some(
+                    (name) => name === ref.tool_name
+                  )
+                ) {
+                  continue;
+                }
                 toolNames.add(ref.tool_name);
               }
             }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When replaying a conversation, the agent loop synthesizes inert placeholder definitions for tools referenced in the history that no longer exist in the agent's toolset, so the provider does not reject the replayed calls. Anthropic's server-side tool search can match its own tool and return it as a reference in the search results, which we observed in production with generic queries. The placeholder synthesis treated that self reference like any other missing tool and fabricated a definition carrying the same name as the real search tool the client prepends to every request, producing a duplicate tool name the API rejects. The fix skips the tool search tool names when harvesting referenced tools, since the real server tool already covers their replay. I added a TODO that this Anthropic-specific parsing in the agent loop should eventually move behind a provider-agnostic dispatch.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
