### PR TITLE
fix(transcripts): read non-Google-Docs transcript files via alt=media

### DIFF
--- a/front/temporal/labs/transcripts/utils/google.ts
+++ b/front/temporal/labs/transcripts/utils/google.ts
@@ -111,6 +111,46 @@ export async function retrieveGoogleTranscripts(
   return new Ok(fileIdsToProcess);
 }
 
+const GOOGLE_DOCS_MIME_TYPE = "application/vnd.google-apps.document";
+
+async function retrieveGoogleFileContent(
+  drive: drive_v3.Drive,
+  fileId: string,
+  mimeType: string | null | undefined
+): Promise<string> {
+  if (mimeType === GOOGLE_DOCS_MIME_TYPE) {
+    const contentRes = await drive.files.export({
+      fileId,
+      mimeType: "text/plain",
+    });
+
+    if (contentRes.status !== 200) {
+      throw new Error(
+        `Error exporting Google document. status_code: ${contentRes.status}. status_text: ${contentRes.statusText}`
+      );
+    }
+
+    return <string>contentRes.data;
+  }
+
+  if (mimeType && mimeType.startsWith("text/")) {
+    const contentRes = await drive.files.get(
+      { fileId, alt: "media" },
+      { responseType: "text" }
+    );
+
+    if (contentRes.status !== 200) {
+      throw new Error(
+        `Error downloading Google file. status_code: ${contentRes.status}. status_text: ${contentRes.statusText}`
+      );
+    }
+
+    return <string>contentRes.data;
+  }
+
+  throw new Error(`Unsupported transcript mime type: ${mimeType}`);
+}
+
 export async function retrieveGoogleTranscriptContent(
   auth: Authenticator,
   transcriptsConfiguration: LabsTranscriptsConfigurationResource,
@@ -129,7 +169,7 @@ export async function retrieveGoogleTranscriptContent(
 
   const metadataRes = await drive.files.get({
     fileId: fileId,
-    fields: "name",
+    fields: "name, mimeType",
   });
 
   localLogger.info(
@@ -138,31 +178,23 @@ export async function retrieveGoogleTranscriptContent(
   );
 
   try {
-    const contentRes = await drive.files.export({
-      fileId: fileId,
-      mimeType: "text/plain",
-    });
-
-    if (contentRes.status !== 200) {
-      localLogger.error(
-        { error: contentRes.statusText },
-        "Error exporting Google document."
-      );
-
-      throw new Error(
-        `Error exporting Google document. status_code: ${contentRes.status}. status_text: ${contentRes.statusText}`
-      );
-    }
-    const fileContentIsAccessible = true;
+    const transcriptContent = await retrieveGoogleFileContent(
+      drive,
+      fileId,
+      metadataRes.data.mimeType
+    );
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const transcriptTitle = metadataRes.data.name || "Untitled";
-    const transcriptContent = <string>contentRes.data;
 
-    return { transcriptTitle, transcriptContent, fileContentIsAccessible };
+    return {
+      transcriptTitle,
+      transcriptContent,
+      fileContentIsAccessible: true,
+    };
   } catch (error) {
     localLogger.error(
-      { fileId, error },
-      "Error exporting Google document. Skipping."
+      { fileId, mimeType: metadataRes.data.mimeType, error },
+      "Error retrieving Google document content. Skipping."
     );
     return {
       transcriptTitle: "",

--- a/front/temporal/labs/transcripts/utils/google.ts
+++ b/front/temporal/labs/transcripts/utils/google.ts
@@ -130,7 +130,13 @@ async function retrieveGoogleFileContent(
       );
     }
 
-    return <string>contentRes.data;
+    if (typeof contentRes.data !== "string") {
+      throw new Error(
+        `Unexpected exported content type: ${typeof contentRes.data}`
+      );
+    }
+
+    return contentRes.data;
   }
 
   if (mimeType && mimeType.startsWith("text/")) {
@@ -145,7 +151,13 @@ async function retrieveGoogleFileContent(
       );
     }
 
-    return <string>contentRes.data;
+    if (typeof contentRes.data !== "string") {
+      throw new Error(
+        `Unexpected downloaded content type: ${typeof contentRes.data}`
+      );
+    }
+
+    return contentRes.data;
   }
 
   throw new Error(`Unsupported transcript mime type: ${mimeType}`);


### PR DESCRIPTION
## Description

Google Meet/Gemini transcripts now land in Drive as text files rather than native Google Docs. drive.files.export only works on Docs Editors files, so it 403s on these, which surfaced as "[processTranscriptActivity] File content is not accessible. Stopping."

Fetch the mimeType and branch: export Google Docs, download text/* files with files.get({ alt: "media" }), and throw with the mime type otherwise. The failure log now includes the mimeType so unexpected types are diagnosable rather than silent.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low, the feature does not work without it anyway 😬 
## Deploy Plan

Front