### PR TITLE
feat(egress-proxy): pod space policy file [dedicated-file variant]

### DIFF
--- a/egress-proxy/src/connection.rs
+++ b/egress-proxy/src/connection.rs
@@ -195,7 +195,12 @@ async fn handle_connection_inner(
     if !default_allows
         && !state
             .policy_provider
-            .evaluate(token.w_id.as_deref(), sb_id, &request.domain)
+            .evaluate(
+                token.w_id.as_deref(),
+                token.space_id.as_deref(),
+                sb_id,
+                &request.domain,
+            )
             .await
     {
         deny(

--- a/egress-proxy/src/gcs.rs
+++ b/egress-proxy/src/gcs.rs
@@ -78,7 +78,22 @@ impl GcsPolicyProvider {
             .await
     }
 
-    pub async fn evaluate(&self, w_id: Option<&str>, sb_id: &str, domain: &str) -> bool {
+    // Pod (Shared Computer) policy, keyed by the pod's space sId. Unlike the
+    // per-sandbox file this one survives sandbox destroy/recreate cycles.
+    pub async fn get_pod_policy(&self, space_id: &str) -> Result<Option<Policy>> {
+        self.get_policy(&format!("p:{space_id}"), &format!("pods/{space_id}.json"))
+            .await
+    }
+
+    // A domain is allowed if ANY of the workspace, pod, or sandbox policies
+    // allows it. Every lookup fails closed: a GCS error never grants.
+    pub async fn evaluate(
+        &self,
+        w_id: Option<&str>,
+        space_id: Option<&str>,
+        sb_id: &str,
+        domain: &str,
+    ) -> bool {
         let workspace_allows = match w_id {
             Some(workspace_id) => match self.get_workspace_policy(workspace_id).await {
                 Ok(Some(policy)) => policy.allows(domain),
@@ -92,6 +107,22 @@ impl GcsPolicyProvider {
         };
 
         if workspace_allows {
+            return true;
+        }
+
+        let pod_allows = match space_id {
+            Some(space_id) => match self.get_pod_policy(space_id).await {
+                Ok(Some(policy)) => policy.allows(domain),
+                Ok(None) => false,
+                Err(error) => {
+                    warn!(error = %error, space_id, "pod policy lookup failed");
+                    false
+                }
+            },
+            None => false,
+        };
+
+        if pod_allows {
             return true;
         }
 

--- a/egress-proxy/src/health.rs
+++ b/egress-proxy/src/health.rs
@@ -77,12 +77,18 @@ async fn invalidate_policy(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    // Derive the cache key from claims: exactly one of wId or sbId must be set.
-    let cache_key = match (validated.w_id.as_deref(), validated.sb_id.as_deref()) {
-        (Some(w_id), None) => format!("w:{w_id}"),
-        (None, Some(sb_id)) => format!("s:{sb_id}"),
+    // Derive the cache key from claims: exactly one of wId, spaceId, or sbId
+    // must be set.
+    let cache_key = match (
+        validated.w_id.as_deref(),
+        validated.space_id.as_deref(),
+        validated.sb_id.as_deref(),
+    ) {
+        (Some(w_id), None, None) => format!("w:{w_id}"),
+        (None, Some(space_id), None) => format!("p:{space_id}"),
+        (None, None, Some(sb_id)) => format!("s:{sb_id}"),
         _ => {
-            warn!("invalidate-policy: token must have exactly one of wId or sbId");
+            warn!("invalidate-policy: token must have exactly one of wId, spaceId, or sbId");
             return Err(StatusCode::BAD_REQUEST);
         }
     };

--- a/egress-proxy/src/jwt.rs
+++ b/egress-proxy/src/jwt.rs
@@ -15,6 +15,9 @@ pub struct JwtValidator {
 pub struct ValidatedToken {
     pub sb_id: Option<String>,
     pub w_id: Option<String>,
+    // Pod space sId, set for pod (Shared Computer) sandboxes so their
+    // space-level policy file (`pods/{spaceId}.json`) can be evaluated.
+    pub space_id: Option<String>,
     pub action: Option<String>,
 }
 
@@ -34,6 +37,8 @@ struct Claims {
     sb_id: Option<String>,
     #[serde(rename = "wId")]
     w_id: Option<String>,
+    #[serde(rename = "spaceId")]
+    space_id: Option<String>,
     action: Option<String>,
     exp: usize,
 }
@@ -91,6 +96,15 @@ fn claims_to_validated_token(
         }
     });
 
+    let space_id = claims.space_id.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    });
+
     let action = claims.action.and_then(|value| {
         let trimmed = value.trim();
         if trimmed.is_empty() {
@@ -103,6 +117,7 @@ fn claims_to_validated_token(
     Ok(ValidatedToken {
         sb_id,
         w_id,
+        space_id,
         action,
     })
 }
@@ -141,6 +156,8 @@ mod tests {
         sb_id: Option<&'a str>,
         #[serde(rename = "wId", skip_serializing_if = "Option::is_none")]
         w_id: Option<&'a str>,
+        #[serde(rename = "spaceId", skip_serializing_if = "Option::is_none")]
+        space_id: Option<&'a str>,
         #[serde(skip_serializing_if = "Option::is_none")]
         action: Option<&'a str>,
         iss: &'a str,
@@ -168,6 +185,7 @@ mod tests {
         let token = token_with_claims(TestClaims {
             sb_id: None,
             w_id: None,
+            space_id: None,
             action: Some("invalidate-policy"),
             iss: EXPECTED_ISSUER,
             aud: EXPECTED_AUDIENCE,
@@ -226,6 +244,7 @@ mod tests {
         let token = token_with_claims(TestClaims {
             sb_id: None,
             w_id: Some("workspace"),
+            space_id: None,
             action: Some("invalidate-policy"),
             iss: EXPECTED_ISSUER,
             aud: EXPECTED_AUDIENCE,
@@ -241,9 +260,65 @@ mod tests {
             ValidatedToken {
                 sb_id: None,
                 w_id: Some("workspace".to_string()),
+                space_id: None,
                 action: Some("invalidate-policy".to_string()),
             }
         );
+    }
+
+    #[test]
+    fn validates_pod_token_with_space_id() {
+        let validator = JwtValidator::new("secret");
+        let token = token_with_claims(TestClaims {
+            sb_id: Some("sbx"),
+            w_id: Some("workspace"),
+            space_id: Some("space"),
+            action: None,
+            iss: EXPECTED_ISSUER,
+            aud: EXPECTED_AUDIENCE,
+            exp: future_exp(60),
+        });
+
+        let validated = validator
+            .validate(&token)
+            .expect("token with spaceId should validate");
+
+        assert_eq!(validated.sb_id.as_deref(), Some("sbx"));
+        assert_eq!(validated.w_id.as_deref(), Some("workspace"));
+        assert_eq!(validated.space_id.as_deref(), Some("space"));
+    }
+
+    #[test]
+    fn accepts_tokens_without_space_id() {
+        // Back-compat: tokens minted by older front builds carry no spaceId.
+        let validator = JwtValidator::new("secret");
+        let token = sandbox_token("secret", "sbx", Some("workspace"), 60);
+
+        let validated = validator
+            .validate(&token)
+            .expect("token without spaceId should validate");
+
+        assert_eq!(validated.space_id, None);
+    }
+
+    #[test]
+    fn normalizes_empty_space_id_to_none() {
+        let validator = JwtValidator::new("secret");
+        let token = token_with_claims(TestClaims {
+            sb_id: Some("sbx"),
+            w_id: Some("workspace"),
+            space_id: Some("   "),
+            action: None,
+            iss: EXPECTED_ISSUER,
+            aud: EXPECTED_AUDIENCE,
+            exp: future_exp(60),
+        });
+
+        let validated = validator
+            .validate(&token)
+            .expect("empty spaceId should normalize to None");
+
+        assert_eq!(validated.space_id, None);
     }
 
     #[test]
@@ -263,6 +338,7 @@ mod tests {
         let token = token_with_claims(TestClaims {
             sb_id: Some("sbx"),
             w_id: Some("workspace"),
+            space_id: None,
             action: None,
             iss: EXPECTED_ISSUER,
             aud: "wrong",
@@ -284,6 +360,7 @@ mod tests {
         let claims = TestClaims {
             sb_id: Some(sb_id),
             w_id,
+            space_id: None,
             action: None,
             iss: EXPECTED_ISSUER,
             aud: EXPECTED_AUDIENCE,

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -61,10 +61,12 @@ enum MockGcsResponse {
 #[derive(Default)]
 struct MockPolicies {
     workspace: Option<MockGcsResponse>,
+    pod: Option<MockGcsResponse>,
     sandbox: Option<MockGcsResponse>,
 }
 
 const TEST_WORKSPACE_ID: &str = "workspace-456";
+const TEST_SPACE_ID: &str = "space-789";
 
 #[derive(Debug, Serialize)]
 struct TestClaims {
@@ -72,6 +74,8 @@ struct TestClaims {
     sb_id: Option<String>,
     #[serde(rename = "wId", skip_serializing_if = "Option::is_none")]
     w_id: Option<String>,
+    #[serde(rename = "spaceId", skip_serializing_if = "Option::is_none")]
+    space_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     action: Option<String>,
     iss: String,
@@ -184,6 +188,7 @@ async fn workspace_policy_allows_domain() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: Some(policy_response(&["localhost"])),
+            pod: None,
             sandbox: None,
         },
         None,
@@ -219,6 +224,7 @@ async fn sandbox_policy_allows_when_workspace_has_no_policy() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
+            pod: None,
             sandbox: Some(policy_response(&["localhost"])),
         },
         None,
@@ -248,10 +254,131 @@ async fn sandbox_policy_allows_when_workspace_has_no_policy() -> Result<()> {
 }
 
 #[tokio::test]
+async fn pod_policy_allows_when_workspace_and_sandbox_do_not() -> Result<()> {
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: Some(policy_response(&["other.example.com"])),
+            pod: Some(policy_response(&["localhost"])),
+            sandbox: None,
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token_with_space(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn pod_policy_ignored_without_space_id_claim() -> Result<()> {
+    // Back-compat / fail-closed: a token without the spaceId claim must not
+    // pick up pod-level grants, even when the pod policy file exists.
+    let (upstream_port, _upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: None,
+            pod: Some(policy_response(&["localhost"])),
+            sandbox: None,
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token_with_workspace(SECRET, 60);
+
+    let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn denied_when_no_policy_allows_domain_with_space_id() -> Result<()> {
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: Some(policy_response(&["other.example.com"])),
+            pod: Some(policy_response(&["another.example.com"])),
+            sandbox: Some(policy_response(&["third.example.com"])),
+        },
+        None,
+        false,
+        "production",
+    )
+    .await?;
+    let token = make_token_with_space(SECRET, 60);
+
+    let response = send_handshake(&proxy, &token, "localhost", 254).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn pod_gcs_failure_falls_back_to_sandbox() -> Result<()> {
+    // A pod policy lookup error fails closed for the pod policy but the union
+    // still consults the sandbox policy.
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: None,
+            pod: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
+            sandbox: Some(policy_response(&["localhost"])),
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token_with_space(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn denied_when_neither_workspace_nor_sandbox_allows_domain() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: Some(policy_response(&["other.example.com"])),
+            pod: None,
             sandbox: Some(policy_response(&["another.example.com"])),
         },
         None,
@@ -274,6 +401,7 @@ async fn workspace_gcs_failure_falls_back_to_sandbox() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
+            pod: None,
             sandbox: Some(policy_response(&["localhost"])),
         },
         None,
@@ -307,6 +435,7 @@ async fn sandbox_gcs_failure_denies_connection() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
+            pod: None,
             sandbox: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
         },
         None,
@@ -390,6 +519,7 @@ async fn invalid_issuer_returns_deny() -> Result<()> {
         FullClaims {
             sb_id: Some(TEST_SANDBOX_ID),
             w_id: None,
+            space_id: None,
             action: None,
             iss: "wrong-front",
             aud: "dust-egress-proxy",
@@ -411,6 +541,7 @@ async fn invalid_audience_returns_deny() -> Result<()> {
         FullClaims {
             sb_id: Some(TEST_SANDBOX_ID),
             w_id: None,
+            space_id: None,
             action: None,
             iss: "dust-front",
             aud: "wrong-audience",
@@ -432,6 +563,7 @@ async fn empty_sandbox_id_claim_returns_deny() -> Result<()> {
         FullClaims {
             sb_id: Some("   "),
             w_id: None,
+            space_id: None,
             action: None,
             iss: "dust-front",
             aud: "dust-egress-proxy",
@@ -754,6 +886,7 @@ async fn invalidate_policy_evicts_cached_workspace_entry() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: Some(policy_response(&["localhost"])),
+            pod: None,
             sandbox: None,
         },
         None,
@@ -833,6 +966,79 @@ async fn invalidate_policy_rejects_token_with_both_wid_and_sbid() -> Result<()> 
         FullClaims {
             sb_id: Some(TEST_SANDBOX_ID),
             w_id: Some(TEST_WORKSPACE_ID),
+            space_id: None,
+            action: Some("invalidate-policy"),
+            iss: "dust-front",
+            aud: "dust-egress-proxy",
+            exp_offset_seconds: 60,
+        },
+    );
+
+    let status =
+        http_post_status(proxy.health_addr, "/invalidate-policy", "", Some(&token)).await?;
+
+    assert_eq!(status, 400);
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalidate_policy_evicts_cached_pod_entry() -> Result<()> {
+    let (upstream_port, _upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: None,
+            pod: Some(policy_response(&["localhost"])),
+            sandbox: None,
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+
+    // First request populates the cache with a pod policy allowing "localhost".
+    let token = make_token_with_space(SECRET, 60);
+    let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
+    assert_eq!(response, Some(ALLOW_RESPONSE));
+
+    // Change the backing GCS pod policy to deny "localhost".
+    {
+        let mut objects = proxy.mock_gcs.as_ref().unwrap().objects.write().unwrap();
+        objects.insert(
+            format!("pods/{TEST_SPACE_ID}.json"),
+            policy_response(&["other.example.com"]),
+        );
+    }
+
+    // Invalidate the pod cache entry via a spaceId-keyed invalidation token.
+    let admin_token = make_pod_invalidation_token(SECRET, 60);
+    let status = http_post_status(
+        proxy.health_addr,
+        "/invalidate-policy",
+        "",
+        Some(&admin_token),
+    )
+    .await?;
+    assert_eq!(status, 200);
+
+    // After invalidation the proxy re-fetches and the new policy denies.
+    let token = make_token_with_space(SECRET, 60);
+    let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
+    assert_eq!(response, Some(DENY_RESPONSE));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalidate_policy_rejects_token_with_wid_and_spaceid() -> Result<()> {
+    let proxy = start_proxy(false, "production").await?;
+    let token = make_token_with_claims(
+        SECRET,
+        FullClaims {
+            sb_id: None,
+            w_id: Some(TEST_WORKSPACE_ID),
+            space_id: Some(TEST_SPACE_ID),
             action: Some("invalidate-policy"),
             iss: "dust-front",
             aud: "dust-egress-proxy",
@@ -894,6 +1100,7 @@ async fn start_proxy_with_sandbox_policy(
     start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
+            pod: None,
             sandbox: Some(policy_response(allowed_domains)),
         },
         None,
@@ -958,6 +1165,9 @@ async fn start_mock_gcs_server(policies: MockPolicies) -> Result<MockGcsServer> 
     let mut objects = HashMap::new();
     if let Some(workspace) = policies.workspace {
         objects.insert(format!("workspaces/{TEST_WORKSPACE_ID}.json"), workspace);
+    }
+    if let Some(pod) = policies.pod {
+        objects.insert(format!("pods/{TEST_SPACE_ID}.json"), pod);
     }
     if let Some(sandbox) = policies.sandbox {
         objects.insert(format!("sandboxes/{TEST_SANDBOX_ID}.json"), sandbox);
@@ -1184,6 +1394,7 @@ fn make_token(secret: &str, exp_offset_seconds: i64) -> String {
         FullClaims {
             sb_id: Some(TEST_SANDBOX_ID),
             w_id: None,
+            space_id: None,
             action: None,
             iss: "dust-front",
             aud: "dust-egress-proxy",
@@ -1198,6 +1409,7 @@ fn make_token_with_workspace(secret: &str, exp_offset_seconds: i64) -> String {
         FullClaims {
             sb_id: Some(TEST_SANDBOX_ID),
             w_id: Some(TEST_WORKSPACE_ID),
+            space_id: None,
             action: None,
             iss: "dust-front",
             aud: "dust-egress-proxy",
@@ -1212,6 +1424,37 @@ fn make_invalidation_token(secret: &str, exp_offset_seconds: i64) -> String {
         FullClaims {
             sb_id: None,
             w_id: Some(TEST_WORKSPACE_ID),
+            space_id: None,
+            action: Some("invalidate-policy"),
+            iss: "dust-front",
+            aud: "dust-egress-proxy",
+            exp_offset_seconds,
+        },
+    )
+}
+
+fn make_token_with_space(secret: &str, exp_offset_seconds: i64) -> String {
+    make_token_with_claims(
+        secret,
+        FullClaims {
+            sb_id: Some(TEST_SANDBOX_ID),
+            w_id: Some(TEST_WORKSPACE_ID),
+            space_id: Some(TEST_SPACE_ID),
+            action: None,
+            iss: "dust-front",
+            aud: "dust-egress-proxy",
+            exp_offset_seconds,
+        },
+    )
+}
+
+fn make_pod_invalidation_token(secret: &str, exp_offset_seconds: i64) -> String {
+    make_token_with_claims(
+        secret,
+        FullClaims {
+            sb_id: None,
+            w_id: None,
+            space_id: Some(TEST_SPACE_ID),
             action: Some("invalidate-policy"),
             iss: "dust-front",
             aud: "dust-egress-proxy",
@@ -1233,6 +1476,7 @@ fn make_token_with_claims(secret: &str, claims: FullClaims<'_>) -> String {
     let claims = TestClaims {
         sb_id: claims.sb_id.map(|s| s.to_string()),
         w_id: claims.w_id.map(|s| s.to_string()),
+        space_id: claims.space_id.map(|s| s.to_string()),
         action: claims.action.map(|s| s.to_string()),
         iss: claims.iss.to_string(),
         aud: claims.aud.to_string(),
@@ -1256,6 +1500,7 @@ struct TestCerts {
 struct FullClaims<'a> {
     sb_id: Option<&'a str>,
     w_id: Option<&'a str>,
+    space_id: Option<&'a str>,
     action: Option<&'a str>,
     iss: &'a str,
     aud: &'a str,


### PR DESCRIPTION
> **Superseded** by the owner-keyed egress policy re-layout stack (`egress-relayout-*` branches, PRs `28652`–`28655`). Branch kept for reference.

## Pod egress allowlist — proxy support for a dedicated pod policy file

**DEDICATED-FILE variant.** Unlike the PROJECTION stack (which reuses the per-sandbox file the proxy already reads and needs **zero proxy changes**), this variant teaches the proxy a third, space-keyed policy source so a Pod's allowlist survives sandbox destroy/recreate cycles without any re-projection:

- Optional `spaceId` JWT claim — back-compatible, tokens without it validate and get no pod grants (fail-closed).
- `get_pod_policy` reads `pods/{spaceId}.json`, cached under `p:{spaceId}` with the existing TTLs.
- `evaluate()` unions workspace + pod + sandbox policies (allow if in ANY); each lookup stays fail-closed on GCS errors.
- `/invalidate-policy` accepts a spaceId-keyed token (exactly one of `wId` / `spaceId` / `sbId`).

Global blocklist, SSRF protection, and default-allowlist behavior untouched.

### Stack (DEDICATED-FILE variant)

Alternative implementation of pod-level egress allowlists, built for side-by-side comparison with the PROJECTION stack (#28352 → #28512 → #28513 → #28514 → #28515). **Do not merge both.**

1. #28544 — egress-proxy: pod space policy file (deploys first)
2. #28545 — data layer (dedicated table)
3. #28546 — backend (space-file render + spaceId JWT claim)
4. #28547 — admin API (contract identical to projection variant)
5. #28548 — audit (emit on the canonical DB write)
6. #28549 — settings UI (byte-identical to projection variant)

### Tests

- jwt: spaceId claim validation, back-compat without it, empty-string normalization.
- Integration: pod policy allows when workspace/sandbox don't; pod file ignored without the claim; 3-way deny; pod GCS 500 fails closed but sandbox policy still consulted; spaceId cache invalidation end-to-end; ambiguous invalidation claims → 400.

### Risk / rollout

Inert until front mints the claim and writes `pods/` files. **This PR must deploy and be healthy before the front side of the stack** — until then behavior degrades to "pod domains not applied" (never an error, never an over-grant).