### PR TITLE
feat(sandbox): pod egress policy data layer [dedicated-file variant]

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -111,6 +111,7 @@ import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { MembershipUpgradeRequestModel } from "@app/lib/resources/storage/models/membership_upgrade_requests";
 import { OnboardingTaskModel } from "@app/lib/resources/storage/models/onboarding_tasks";
 import { PluginRunModel } from "@app/lib/resources/storage/models/plugin_runs";
+import { PodEgressPolicyModel } from "@app/lib/resources/storage/models/pod_egress_policy";
 import { ProgrammaticUsageConfigurationModel } from "@app/lib/resources/storage/models/programmatic_usage_configurations";
 import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
 import {
@@ -171,6 +172,7 @@ export function loadAllModels() {
     TagModel,
     SpaceModel,
     ProjectMetadataModel,
+    PodEgressPolicyModel,
     AppModel,
     DatasetModel,
     ProviderModel,

--- a/front/lib/resources/pod_egress_policy_resource.test.ts
+++ b/front/lib/resources/pod_egress_policy_resource.test.ts
@@ -1,0 +1,75 @@
+import { Authenticator } from "@app/lib/auth";
+import { PodEgressPolicyResource } from "@app/lib/resources/pod_egress_policy_resource";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it } from "vitest";
+
+async function setupTest() {
+  const workspace = await WorkspaceFactory.basic();
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  return { workspace, auth };
+}
+
+describe("PodEgressPolicyResource", () => {
+  it("returns null for a pod with no policy", async () => {
+    const { workspace, auth } = await setupTest();
+    const pod = await SpaceFactory.project(workspace);
+
+    const policy = await PodEgressPolicyResource.fetchBySpace(auth, pod);
+
+    expect(policy).toBeNull();
+  });
+
+  it("returns null for non-project spaces", async () => {
+    const { workspace, auth } = await setupTest();
+    const space = await SpaceFactory.regular(workspace);
+
+    const policy = await PodEgressPolicyResource.fetchBySpace(auth, space);
+
+    expect(policy).toBeNull();
+  });
+
+  it("creates, fetches and updates a pod policy", async () => {
+    const { workspace, auth } = await setupTest();
+    const pod = await SpaceFactory.project(workspace);
+
+    await PodEgressPolicyResource.makeNew(auth, pod, {
+      allowedDomains: ["api.github.com"],
+    });
+
+    const fetched = await PodEgressPolicyResource.fetchBySpace(auth, pod);
+    expect(fetched?.allowedDomains).toEqual(["api.github.com"]);
+
+    await fetched?.updateAllowedDomains(["api.github.com", "*.npmjs.org"]);
+
+    const updated = await PodEgressPolicyResource.fetchBySpace(auth, pod);
+    expect(updated?.allowedDomains).toEqual(["api.github.com", "*.npmjs.org"]);
+  });
+
+  it("scopes policies to their pod", async () => {
+    const { workspace, auth } = await setupTest();
+    const podA = await SpaceFactory.project(workspace);
+    const podB = await SpaceFactory.project(workspace);
+
+    await PodEgressPolicyResource.makeNew(auth, podA, {
+      allowedDomains: ["a.example.com"],
+    });
+
+    const policyB = await PodEgressPolicyResource.fetchBySpace(auth, podB);
+    expect(policyB).toBeNull();
+  });
+
+  it("deletes policies by space", async () => {
+    const { workspace, auth } = await setupTest();
+    const pod = await SpaceFactory.project(workspace);
+
+    await PodEgressPolicyResource.makeNew(auth, pod, {
+      allowedDomains: ["api.github.com"],
+    });
+
+    await PodEgressPolicyResource.deleteBySpace(auth, pod);
+
+    const fetched = await PodEgressPolicyResource.fetchBySpace(auth, pod);
+    expect(fetched).toBeNull();
+  });
+});

--- a/front/lib/resources/pod_egress_policy_resource.ts
+++ b/front/lib/resources/pod_egress_policy_resource.ts
@@ -1,0 +1,105 @@
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { PodEgressPolicyModel } from "@app/lib/resources/storage/models/pod_egress_policy";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { Attributes, Transaction } from "sequelize";
+
+// Admin record of truth for a pod's egress allowlist. The GCS file
+// `pods/{spaceSId}.json` read by the egress proxy is a render of this row —
+// see lib/api/sandbox/pod_egress_policy.ts for the render/invalidation flow.
+// No sId: this is internal pod config, never addressed by id over the API
+// (the route is keyed by the pod space's sId).
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface PodEgressPolicyResource
+  extends ReadonlyAttributesType<PodEgressPolicyModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class PodEgressPolicyResource extends BaseResource<PodEgressPolicyModel> {
+  static model: typeof PodEgressPolicyModel = PodEgressPolicyModel;
+
+  constructor(
+    model: typeof PodEgressPolicyModel,
+    blob: Attributes<PodEgressPolicyModel>
+  ) {
+    super(PodEgressPolicyModel, blob);
+  }
+
+  static fromModel(model: PodEgressPolicyModel): PodEgressPolicyResource {
+    return new PodEgressPolicyResource(PodEgressPolicyModel, model.get());
+  }
+
+  static async fetchBySpace(
+    auth: Authenticator,
+    space: SpaceResource
+  ): Promise<PodEgressPolicyResource | null> {
+    if (!space.isProject()) {
+      return null;
+    }
+
+    const model = await PodEgressPolicyModel.findOne({
+      where: {
+        spaceId: space.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    return model ? PodEgressPolicyResource.fromModel(model) : null;
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    space: SpaceResource,
+    { allowedDomains }: { allowedDomains: string[] },
+    transaction?: Transaction
+  ): Promise<PodEgressPolicyResource> {
+    const model = await PodEgressPolicyModel.create(
+      {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId: space.id,
+        allowedDomains,
+      },
+      { transaction }
+    );
+
+    return PodEgressPolicyResource.fromModel(model);
+  }
+
+  async updateAllowedDomains(
+    allowedDomains: string[],
+    transaction?: Transaction
+  ): Promise<void> {
+    await this.update({ allowedDomains }, transaction);
+  }
+
+  static async deleteBySpace(
+    auth: Authenticator,
+    space: SpaceResource,
+    transaction?: Transaction
+  ): Promise<void> {
+    await PodEgressPolicyModel.destroy({
+      where: {
+        spaceId: space.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction }
+  ): Promise<Result<undefined, Error>> {
+    await PodEgressPolicyModel.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+    return new Ok(undefined);
+  }
+}

--- a/front/lib/resources/storage/models/pod_egress_policy.ts
+++ b/front/lib/resources/storage/models/pod_egress_policy.ts
@@ -1,0 +1,62 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey } from "sequelize";
+
+// Admin record of truth for a pod's egress allowlist (pods are project
+// spaces, so the FK targets the `vaults` table via SpaceModel). The GCS file
+// `pods/{spaceSId}.json` that the egress proxy reads is a render of this row,
+// rewritten on every admin change. Dedicated table rather than a column on
+// ProjectMetadata: pod sandbox config does not hang off ProjectMetadata (see
+// the pod-secrets design and PodSandboxEnvVarModel, which this mirrors).
+export class PodEgressPolicyModel extends WorkspaceAwareModel<PodEgressPolicyModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare spaceId: ForeignKey<SpaceModel["id"]>;
+  declare allowedDomains: string[];
+}
+
+PodEgressPolicyModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    allowedDomains: {
+      type: DataTypes.ARRAY(DANGEROUSLY_UNBOUNDED_TEXT),
+      allowNull: false,
+      defaultValue: [],
+      field: "allowed_domains",
+    },
+  },
+  {
+    modelName: "pod_egress_policy",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "pod_egress_policies_space_idx",
+        unique: true,
+        fields: ["spaceId"],
+        concurrently: true,
+      },
+      { fields: ["workspaceId"], concurrently: true },
+    ],
+  }
+);
+
+PodEgressPolicyModel.belongsTo(SpaceModel, {
+  foreignKey: { name: "spaceId", allowNull: false },
+  onDelete: "RESTRICT",
+});

--- a/front/migrations/pre-deploy/20260706120000_create_pod_egress_policies.sql
+++ b/front/migrations/pre-deploy/20260706120000_create_pod_egress_policies.sql
@@ -1,0 +1,88 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE SEQUENCE "public"."pod_egress_policies_id_seq"
+	AS bigint
+	INCREMENT BY 1
+	MINVALUE 1 MAXVALUE 9223372036854775807
+	START WITH 1 CACHE 1 NO CYCLE
+;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."pod_egress_policies" (
+	"workspaceId" bigint NOT NULL,
+	"updatedAt" timestamp with time zone NOT NULL,
+	"createdAt" timestamp with time zone NOT NULL,
+	"spaceId" bigint NOT NULL,
+	"id" bigint DEFAULT nextval('pod_egress_policies_id_seq'::regclass) NOT NULL,
+	"allowed_domains" text[] COLLATE "pg_catalog"."default" DEFAULT '{}'::text[] NOT NULL
+);
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY pod_egress_policies_pkey ON public.pod_egress_policies USING btree (id);
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."pod_egress_policies" ADD CONSTRAINT "pod_egress_policies_pkey" PRIMARY KEY USING INDEX "pod_egress_policies_pkey";
+
+/*
+Statement 4
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY pod_egress_policies_space_idx ON public.pod_egress_policies USING btree ("spaceId");
+
+/*
+Statement 5
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY pod_egress_policies_workspace_id ON public.pod_egress_policies USING btree ("workspaceId");
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER SEQUENCE "public"."pod_egress_policies_id_seq" OWNED BY "public"."pod_egress_policies"."id";
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."pod_egress_policies" ADD CONSTRAINT "pod_egress_policies_spaceId_fkey" FOREIGN KEY ("spaceId") REFERENCES vaults(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 8
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."pod_egress_policies" VALIDATE CONSTRAINT "pod_egress_policies_spaceId_fkey";
+
+/*
+Statement 9
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."pod_egress_policies" ADD CONSTRAINT "pod_egress_policies_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 10
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."pod_egress_policies" VALIDATE CONSTRAINT "pod_egress_policies_workspaceId_fkey";


### PR DESCRIPTION
## Pod egress allowlist — data layer (dedicated table)

**DEDICATED-FILE variant.** Admin record of truth on a dedicated `pod_egress_policies` table — one row per pod, `allowed_domains text[]`, unique `spaceId` FK (RESTRICT) — rather than a column on `ProjectMetadata` as in the PROJECTION variant. Rationale: pod sandbox config does not hang off ProjectMetadata (per the pod-secrets design; this mirrors `PodSandboxEnvVarModel`). Keeping a DB record (vs GCS-only) preserves transactional writes, FK lifecycle with the space, and workspace-relocation handling.

Pre-deploy migration included. Resource: `fetchBySpace` / `makeNew` / `updateAllowedDomains` / `deleteBySpace`, with tests.

### Stack (DEDICATED-FILE variant)

Alternative implementation of pod-level egress allowlists, built for side-by-side comparison with the PROJECTION stack (#28352 → #28512 → #28513 → #28514 → #28515). **Do not merge both.**

1. #28544 — egress-proxy: pod space policy file (deploys first)
2. #28545 — data layer (dedicated table)
3. #28546 — backend (space-file render + spaceId JWT claim)
4. #28547 — admin API (contract identical to projection variant)
5. #28548 — audit (emit on the canonical DB write)
6. #28549 — settings UI (byte-identical to projection variant)

### Risk

Worst case, an unused table. Safe to rollback.

### Deploy plan

- [ ] Apply the pre-deploy migration before deploying `front`
