### PR TITLE
feat(sandbox): pod egress policy backend [dedicated-file variant]

### DIFF
--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -106,13 +106,22 @@ async function runSuccessfulRootCommand(
   return new Ok(undefined);
 }
 
-export function mintEgressJwt(providerId: string, workspaceId: string): string {
+// spaceId is set for pod (Shared Computer) sandboxes so the proxy evaluates
+// the pod's space policy file (`pods/{spaceId}.json`) in addition to the
+// workspace and sandbox policies. Optional and back-compatible: proxy builds
+// that predate the claim ignore it.
+export function mintEgressJwt(
+  providerId: string,
+  workspaceId: string,
+  { spaceId }: { spaceId?: string } = {}
+): string {
   return jwt.sign(
     {
       iss: "dust-front",
       aud: "dust-egress-proxy",
       sbId: providerId,
       wId: workspaceId,
+      ...(spaceId ? { spaceId } : {}),
     },
     config.getEgressProxyJwtSecret(),
     {
@@ -124,11 +133,15 @@ export function mintEgressJwt(providerId: string, workspaceId: string): string {
 
 const INVALIDATION_JWT_TTL_SECONDS = 60;
 
+// The proxy derives the cache key to evict from the claims: exactly one of
+// workspaceId, spaceId, or sandboxId must be set.
 export function mintEgressInvalidationJwt({
   workspaceId,
+  spaceId,
   sandboxId,
 }: {
   workspaceId?: string;
+  spaceId?: string;
   sandboxId?: string;
 }): string {
   return jwt.sign(
@@ -137,6 +150,7 @@ export function mintEgressInvalidationJwt({
       aud: "dust-egress-proxy",
       action: "invalidate-policy",
       ...(workspaceId ? { wId: workspaceId } : {}),
+      ...(spaceId ? { spaceId } : {}),
       ...(sandboxId ? { sbId: sandboxId } : {}),
     },
     config.getEgressProxyJwtSecret(),
@@ -507,7 +521,10 @@ export async function setupEgressForwarder(
 
   const token = mintEgressJwt(
     sandbox.providerId,
-    auth.getNonNullableWorkspace().sId
+    auth.getNonNullableWorkspace().sId,
+    // Pod sandboxes carry the pod's space sId so the proxy evaluates the
+    // pod-level policy file on top of the workspace/sandbox ones.
+    { spaceId: runtimeOwner.kind === "pod" ? runtimeOwner.spaceId : undefined }
   );
 
   // Token, secrets, and manifest are written in order, each gated on the

--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -39,11 +39,13 @@ vi.mock("@app/lib/file_storage", () => ({
 
 import {
   addSandboxPolicyDomain,
+  deletePodSpacePolicy,
   deleteSandboxPolicy,
   deleteWorkspacePolicy,
   parseExactEgressDomain,
   readSandboxPolicy,
   readWorkspacePolicy,
+  writePodSpacePolicy,
   writeWorkspacePolicy,
 } from "./egress_policy";
 
@@ -316,5 +318,109 @@ describe("sandbox egress policy storage", () => {
     );
     expect(parseExactEgressDomain("127.0.0.1").isErr()).toBe(true);
     expect(parseExactEgressDomain("*.github.com").isErr()).toBe(true);
+  });
+});
+
+describe("pod space egress policy storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGetEgressPolicyBucket.mockReturnValue("egress-policy-bucket");
+    mockGetEgressProxyInternalUrl.mockReturnValue("https://egress-proxy");
+    mockMintEgressInvalidationJwt.mockReturnValue("invalidation-token");
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", mockFetch);
+    mockUploadRawContentToBucket.mockResolvedValue(undefined);
+    mockDelete.mockResolvedValue(undefined);
+    mockGetBucketInstance.mockReturnValue({
+      delete: mockDelete,
+      fetchFileContent: mockFetchFileContent,
+      uploadRawContentToBucket: mockUploadRawContentToBucket,
+    });
+  });
+
+  it("renders normalized pod domains to the space file and supports wildcards", async () => {
+    const result = await writePodSpacePolicy("space-sid", [
+      "API.GitHub.COM",
+      "*.GitHub.COM",
+    ]);
+
+    expect(result).toEqual(
+      new Ok({ allowedDomains: ["api.github.com", "*.github.com"] })
+    );
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
+      content: JSON.stringify({
+        allowedDomains: ["api.github.com", "*.github.com"],
+      }),
+      contentType: "application/json",
+      filePath: "pods/space-sid.json",
+    });
+  });
+
+  it("renders an empty pod policy when no domains are configured", async () => {
+    const result = await writePodSpacePolicy("space-sid", []);
+
+    expect(result).toEqual(new Ok({ allowedDomains: [] }));
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
+      content: JSON.stringify({ allowedDomains: [] }),
+      contentType: "application/json",
+      filePath: "pods/space-sid.json",
+    });
+  });
+
+  it("does not render invalid pod domains", async () => {
+    const result = await writePodSpacePolicy("space-sid", ["127.0.0.1"]);
+
+    expect(result.isErr()).toBe(true);
+    expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
+  });
+
+  it("rejects pod policies over the domain cap", async () => {
+    const domains = Array.from(
+      { length: 101 },
+      (_, i) => `domain-${i}.example.com`
+    );
+
+    const result = await writePodSpacePolicy("space-sid", domains);
+
+    expect(result.isErr()).toBe(true);
+    expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the pod policy cache by spaceId after writes", async () => {
+    await writePodSpacePolicy("space-sid", ["example.org"]);
+
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://egress-proxy/invalidate-policy",
+        expect.objectContaining({
+          headers: {
+            Authorization: "Bearer invalidation-token",
+          },
+          method: "POST",
+        })
+      );
+    });
+    expect(mockMintEgressInvalidationJwt).toHaveBeenCalledWith({
+      spaceId: "space-sid",
+    });
+  });
+
+  it("deletes pod space policy files and invalidates cache", async () => {
+    const result = await deletePodSpacePolicy("space-sid");
+
+    expect(result).toEqual(new Ok(undefined));
+    expect(mockDelete).toHaveBeenCalledWith("pods/space-sid.json", {
+      ignoreNotFound: true,
+    });
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://egress-proxy/invalidate-policy",
+        expect.anything()
+      );
+    });
+    expect(mockMintEgressInvalidationJwt).toHaveBeenCalledWith({
+      spaceId: "space-sid",
+    });
   });
 });

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -9,13 +9,14 @@ import {
   EMPTY_EGRESS_POLICY,
   normalizeEgressPolicy,
   normalizeEgressPolicyDomain,
+  normalizeEgressPolicyDomains,
   parseEgressPolicy,
 } from "@app/types/sandbox/egress_policy";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const INVALIDATION_TIMEOUT_MS = 5_000;
-const SANDBOX_POLICY_MAX_DOMAINS = 100;
+export const SANDBOX_POLICY_MAX_DOMAINS = 100;
 
 function getWorkspacePolicyPath(auth: Authenticator): string {
   return `workspaces/${auth.getNonNullableWorkspace().sId}.json`;
@@ -196,6 +197,108 @@ export async function deleteSandboxPolicy(
     return new Ok(undefined);
   } catch (error) {
     return new Err(normalizeError(error));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pod space egress policy
+//
+// A Pod's egress allowlist lives in a dedicated, space-keyed policy file
+// (`pods/{spaceSId}.json`) that the egress proxy reads directly and unions
+// with the workspace and sandbox policies. Unlike the per-sandbox file it
+// survives sandbox destroy/recreate cycles, so nothing needs re-projecting at
+// activation. The file is a render of the admin record of truth
+// (PodEgressPolicyResource); it is rewritten on every admin change and
+// deleted when the pod space is deleted.
+// ---------------------------------------------------------------------------
+
+function getPodSpacePolicyPath(spaceId: string): string {
+  return `pods/${spaceId}.json`;
+}
+
+// Renders the pod's configured domains to its space policy file and
+// invalidates the proxy cache. Like the workspace-level policy (and unlike
+// the sandbox `add_egress_domain` tool), wildcard domains such as
+// `*.github.com` are supported.
+export async function writePodSpacePolicy(
+  spaceId: string,
+  domains: string[]
+): Promise<Result<EgressPolicy, Error>> {
+  const normalizedDomains = normalizeEgressPolicyDomains(domains);
+  if (normalizedDomains.isErr()) {
+    return new Err(normalizedDomains.error);
+  }
+
+  if (normalizedDomains.value.length > SANDBOX_POLICY_MAX_DOMAINS) {
+    return new Err(
+      new Error(
+        `Pod egress policy cannot exceed ${SANDBOX_POLICY_MAX_DOMAINS} domains.`
+      )
+    );
+  }
+
+  const policy: EgressPolicy = { allowedDomains: normalizedDomains.value };
+
+  try {
+    await getPolicyBucket().uploadRawContentToBucket({
+      content: JSON.stringify(policy),
+      contentType: "application/json",
+      filePath: getPodSpacePolicyPath(spaceId),
+    });
+
+    void invalidatePodPolicyCache(spaceId);
+
+    return new Ok(policy);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+export async function deletePodSpacePolicy(
+  spaceId: string
+): Promise<Result<void, Error>> {
+  try {
+    await getPolicyBucket().delete(getPodSpacePolicyPath(spaceId), {
+      ignoreNotFound: true,
+    });
+
+    void invalidatePodPolicyCache(spaceId);
+
+    return new Ok(undefined);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+async function invalidatePodPolicyCache(spaceId: string): Promise<void> {
+  try {
+    const baseUrl = config.getEgressProxyInternalUrl();
+    if (!baseUrl) {
+      return;
+    }
+
+    const token = mintEgressInvalidationJwt({ spaceId });
+    const url = `${baseUrl.replace(/\/+$/, "")}/invalidate-policy`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      signal: AbortSignal.timeout(INVALIDATION_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      logger.warn(
+        { statusCode: response.status, spaceId },
+        "Egress proxy cache invalidation failed"
+      );
+    }
+  } catch (error) {
+    logger.warn(
+      { error: normalizeError(error), spaceId },
+      "Egress proxy cache invalidation error"
+    );
   }
 }
 

--- a/front/lib/api/sandbox/pod_egress_policy.ts
+++ b/front/lib/api/sandbox/pod_egress_policy.ts
@@ -1,0 +1,132 @@
+import {
+  SANDBOX_POLICY_MAX_DOMAINS,
+  writePodSpacePolicy,
+} from "@app/lib/api/sandbox/egress_policy";
+import type { Authenticator } from "@app/lib/auth";
+import { PodEgressPolicyResource } from "@app/lib/resources/pod_egress_policy_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+import { normalizeEgressPolicyDomains } from "@app/types/sandbox/egress_policy";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+
+// The admin record of truth for a Pod's egress allowlist is
+// `PodEgressPolicyResource` (DB). The space policy file `pods/{spaceSId}.json`
+// that the egress proxy reads is a render of it, rewritten on every admin
+// change. Because the file is keyed by the pod's stable space sId (not the
+// ephemeral sandbox providerId), it survives sandbox destroy/recreate cycles
+// and nothing needs re-projecting at wake.
+
+export async function getPodEgressDomains(
+  auth: Authenticator,
+  pod: SpaceResource
+): Promise<string[]> {
+  const policy = await PodEgressPolicyResource.fetchBySpace(auth, pod);
+  return policy?.allowedDomains ?? [];
+}
+
+// Validates and normalizes the requested domains, persists them to the pod's
+// policy record (record of truth), then renders them to the pod's space
+// policy file. Returns the normalized policy.
+//
+// A failed render returns an error even though the DB row was updated: the
+// proxy reads the file, so silently succeeding would leave enforcement stale
+// with no signal. Retrying the request re-renders idempotently, and the next
+// pod sandbox activation self-heals the file as well.
+export async function setPodEgressDomains(
+  auth: Authenticator,
+  pod: SpaceResource,
+  requestedDomains: string[]
+): Promise<Result<EgressPolicy, Error>> {
+  const normalizedDomains = normalizeEgressPolicyDomains(requestedDomains);
+  if (normalizedDomains.isErr()) {
+    return new Err(normalizedDomains.error);
+  }
+
+  if (normalizedDomains.value.length > SANDBOX_POLICY_MAX_DOMAINS) {
+    return new Err(
+      new Error(
+        `Pod egress policy cannot exceed ${SANDBOX_POLICY_MAX_DOMAINS} domains.`
+      )
+    );
+  }
+
+  const domains = normalizedDomains.value;
+
+  const policy = await PodEgressPolicyResource.fetchBySpace(auth, pod);
+  if (policy) {
+    await policy.updateAllowedDomains(domains);
+  } else {
+    await PodEgressPolicyResource.makeNew(auth, pod, {
+      allowedDomains: domains,
+    });
+  }
+
+  const writeResult = await writePodSpacePolicy(pod.sId, domains);
+  if (writeResult.isErr()) {
+    return new Err(
+      new Error(
+        `Saved, but failed to sync the policy to the egress proxy: ${writeResult.error.message}. Retry to re-sync.`
+      )
+    );
+  }
+
+  return new Ok({ allowedDomains: domains });
+}
+
+// Idempotent single-domain append for the manifest-declared-domain approve
+// path: reads the current allowlist, normalizes the incoming domain, no-ops
+// if already present, then delegates to setPodEgressDomains. Unlike the
+// projection approach (pod policy stored in `sandboxes/{providerId}.json`),
+// there is no shared-file collision with the `add_egress_domain` agent tool
+// here: the pod policy lives in its own `pods/{spaceSId}.json` file.
+export async function addPodEgressDomain(
+  auth: Authenticator,
+  pod: SpaceResource,
+  domain: string
+): Promise<Result<{ allowedDomains: string[] }, Error>> {
+  const normalized = normalizeEgressPolicyDomains([domain]);
+  if (normalized.isErr()) {
+    return new Err(normalized.error);
+  }
+
+  if (normalized.value.length === 0) {
+    return new Err(new Error(`Invalid domain: ${domain}`));
+  }
+
+  const current = await getPodEgressDomains(auth, pod);
+  const normalizedDomain = normalized.value[0];
+
+  if (current.includes(normalizedDomain)) {
+    return new Ok({ allowedDomains: current });
+  }
+
+  return setPodEgressDomains(auth, pod, [...current, normalizedDomain]);
+}
+
+// Best-effort render of the pod's space policy file from the DB record.
+// Called at pod sandbox creation as a self-heal: the file normally already
+// exists (rewritten on every admin change), but this covers a lost bucket
+// object or a workspace relocation, where the DB row moves with the
+// workspace and the file must be re-rendered in the new region. Failing to
+// render only falls back to the (stricter) workspace-level allowlist.
+export async function ensurePodSpacePolicyFile(
+  auth: Authenticator,
+  pod: SpaceResource
+): Promise<void> {
+  const policy = await PodEgressPolicyResource.fetchBySpace(auth, pod);
+  if (!policy || policy.allowedDomains.length === 0) {
+    return;
+  }
+
+  const writeResult = await writePodSpacePolicy(pod.sId, policy.allowedDomains);
+  if (writeResult.isErr()) {
+    logger.warn(
+      {
+        err: writeResult.error,
+        spaceId: pod.sId,
+      },
+      "Failed to render pod egress policy file at sandbox creation — DB record is authoritative and admins can re-sync by saving."
+    );
+  }
+}

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -1,6 +1,7 @@
 import { hardDeleteApp } from "@app/lib/api/apps";
 import { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent_requirements";
 import { createDataSourceAndConnectorForProject } from "@app/lib/api/projects/connector";
+import { deletePodSpacePolicy } from "@app/lib/api/sandbox/egress_policy";
 import { getWorkspaceAdministrationVersionLock } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -12,6 +13,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { PodEgressPolicyResource } from "@app/lib/resources/pod_egress_policy_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -426,6 +428,9 @@ export async function hardDeleteSpace(
       transaction: t,
     });
 
+    // FK is RESTRICT, so the pod egress policy row must go before the space.
+    await PodEgressPolicyResource.deleteBySpace(auth, space, t);
+
     const res = await space.delete(auth, { hardDelete: true, transaction: t });
     if (res.isErr()) {
       throw res.error;
@@ -437,6 +442,18 @@ export async function hardDeleteSpace(
       workspaceId: auth.getNonNullableWorkspace().sId,
       spaceId: space.sId,
       stopReason: "project hard deleted",
+    });
+
+    // Best-effort scrub of the pod's egress policy file: a stale file only
+    // matters if the space sId were ever reused (it is not), but we don't
+    // leave orphans in the bucket.
+    void deletePodSpacePolicy(space.sId).then((res) => {
+      if (res.isErr()) {
+        logger.warn(
+          { err: res.error, spaceId: space.sId },
+          "Failed to delete pod egress policy file on space deletion."
+        );
+      }
     });
   }
 

--- a/front/lib/resources/pod_sandbox_adapter.ts
+++ b/front/lib/resources/pod_sandbox_adapter.ts
@@ -1,3 +1,4 @@
+import { ensurePodSpacePolicyFile } from "@app/lib/api/sandbox/pod_egress_policy";
 import type { Authenticator } from "@app/lib/auth";
 import {
   type EnsureSandboxResult,
@@ -122,13 +123,25 @@ export class PodSandboxAdapter {
   ): Promise<Result<EnsureSandboxResult, Error>> {
     this.assertPod(pod);
 
-    return SandboxResource.ensureActive(auth, {
+    const result = await SandboxResource.ensureActive(auth, {
       lockKey: pod.sId,
       envVars: { SPACE_ID: pod.sId },
       logLabel: "pod",
       fetchSandbox: () => this.fetchSandboxByPod(auth, pod),
       createSandbox: (blob) => this.createSandboxRecordForPod(auth, pod, blob),
     });
+
+    // Self-heal the pod's space policy file (`pods/{spaceSId}.json`) on fresh
+    // creation only. The file is space-keyed and survives sandbox
+    // destroy/recreate and sleep/wake cycles, so unlike a per-sandbox
+    // projection there is nothing to rewrite at wake; this covers a lost
+    // bucket object or a workspace relocation. Best-effort: a missing file
+    // only falls back to the (stricter) workspace-level allowlist.
+    if (result.isOk() && result.value.freshlyCreated) {
+      await ensurePodSpacePolicyFile(auth, pod);
+    }
+
+    return result;
   }
 
   static async pauseSandboxForApproval(


### PR DESCRIPTION
## Pod egress allowlist — backend (space-file render)

**DEDICATED-FILE variant.** The render/enforcement layer:

- `writePodSpacePolicy` / `deletePodSpacePolicy` render the DB record to `pods/{spaceSId}.json` (wildcards, 100-domain cap) and invalidate the proxy cache by spaceId.
- `mintEgressJwt` gains an optional `spaceId` claim, set for pod sandboxes from the runtime owner in `setupEgressForwarder`; `mintEgressInvalidationJwt` gains the matching key. Back-compatible with proxy builds that predate the claim.
- `setPodEgressDomains`: DB write, then render. A failed render **surfaces an error** (the proxy reads the file; silent success would hide stale enforcement) — unlike the projection variant's best-effort write, whose per-activation re-projection makes silent failure self-healing.
- `addPodEgressDomain` (manifest-approve path): idempotent append with **no shared-file collision** with the `add_egress_domain` agent tool — the pod policy no longer lives in `sandboxes/{providerId}.json`.
- Activation: **no per-activation projection and no wake rewrite** (the space-keyed file survives sandbox lifecycles). Fresh creation runs a best-effort self-heal render, covering lost bucket objects and workspace relocation (the projection variant's wake-time rewrite disappears entirely).
- `hardDeleteSpace` deletes the policy row (FK RESTRICT) and best-effort scrubs the file — note the workspace policy file has no such scrub today; this variant does not copy that gap.

### Stack (DEDICATED-FILE variant)

Alternative implementation of pod-level egress allowlists, built for side-by-side comparison with the PROJECTION stack (#28352 → #28512 → #28513 → #28514 → #28515). **Do not merge both.**

1. #28544 — egress-proxy: pod space policy file (deploys first)
2. #28545 — data layer (dedicated table)
3. #28546 — backend (space-file render + spaceId JWT claim)
4. #28547 — admin API (contract identical to projection variant)
5. #28548 — audit (emit on the canonical DB write)
6. #28549 — settings UI (byte-identical to projection variant)

### Risk

Worst case, the pod file is missing/stale → fail-closed to the workspace allowlist. Requires #28544 deployed first.
