### PR TITLE
feat(sandbox): pod egress policy audit [dedicated-file variant]

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.test.ts
@@ -6,10 +6,25 @@ import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockReadPodSpacePolicy, mockWritePodSpacePolicy } = vi.hoisted(() => ({
+const {
+  mockEmitAuditLogEvent,
+  mockReadPodSpacePolicy,
+  mockWritePodSpacePolicy,
+} = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn(),
   mockReadPodSpacePolicy: vi.fn(),
   mockWritePodSpacePolicy: vi.fn(),
 }));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+
+  return {
+    ...actual,
+    emitAuditLogEvent: mockEmitAuditLogEvent,
+  };
+});
 
 vi.mock("@app/lib/api/sandbox/egress_policy", () => ({
   readPodSpacePolicy: mockReadPodSpacePolicy,
@@ -100,6 +115,23 @@ describe("GET/PUT /api/w/:wId/spaces/:spaceId/sandbox/egress-policy", () => {
         allowedDomains: ["api.github.com", "*.github.com"],
       },
     });
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "pod_egress_policy.updated",
+        auth: expect.any(Object),
+        context: expect.objectContaining({
+          location: expect.any(String),
+        }),
+        metadata: {
+          allowed_domain_count: "2",
+          allowed_domains: "api.github.com,*.github.com",
+        },
+        targets: [
+          expect.objectContaining({ type: "workspace", id: workspace.sId }),
+          expect.objectContaining({ type: "space", id: pod.sId }),
+        ],
+      })
+    );
   });
 
   it("rejects invalid domain entries", async () => {
@@ -112,6 +144,10 @@ describe("GET/PUT /api/w/:wId/spaces/:spaceId/sandbox/egress-policy", () => {
 
     expect(response.status).toBe(400);
     expect(mockWritePodSpacePolicy).not.toHaveBeenCalled();
+    // withSpace may emit `space.accessed`, but the policy-update event must not fire.
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "pod_egress_policy.updated" })
+    );
   });
 
   it("rejects non-admin users with a 403", async () => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
@@ -1,4 +1,9 @@
 import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import {
   readPodSpacePolicy,
   writePodSpacePolicy,
 } from "@app/lib/api/sandbox/egress_policy";
@@ -90,6 +95,21 @@ app.put(
         },
       });
     }
+
+    const auth = ctx.get("auth");
+    void emitAuditLogEvent({
+      auth,
+      action: "pod_egress_policy.updated",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("space", space),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        allowed_domain_count: String(result.value.allowedDomains.length),
+        allowed_domains: result.value.allowedDomains.join(","),
+      },
+    });
 
     return ctx.json({ policy: result.value });
   }

--- a/front/admin/audit_log_schemas/pod_egress_policy.updated.json
+++ b/front/admin/audit_log_schemas/pod_egress_policy.updated.json
@@ -1,0 +1,16 @@
+{
+  "action": "pod_egress_policy.updated",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "space"
+    }
+  ],
+  "metadata": {
+    "allowed_domain_count": "string",
+    "allowed_domains": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -49,6 +49,7 @@
   "oauth.authorized": 3,
   "oauth.initiated": 3,
   "oauth.revoked": 2,
+  "pod_egress_policy.updated": 1,
   "project.joined": 3,
   "project.left": 3,
   "sandbox_egress_policy.agent_requests_setting_updated": 1,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -77,6 +77,7 @@ export const AUDIT_ACTIONS = [
   "sandbox_egress_policy.agent_requests_setting_updated",
   "sandbox_egress_policy.sandbox_updated",
   "sandbox_egress_policy.updated",
+  "pod_egress_policy.updated",
   "sandbox_env_var.allowed_domains_updated",
   "sandbox_env_var.created",
   "sandbox_env_var.deleted",


### PR DESCRIPTION
> **Superseded** by the owner-keyed egress policy re-layout stack (`egress-relayout-*` branches, PRs `28652`–`28655`). Branch kept for reference.

## Pod egress allowlist — audit logging

**DEDICATED-FILE variant.** Same `pod_egress_policy.updated` event, schema (incl. `actor_type`), and metadata as the projection variant (#28514). The emit sits in the route handler after the successful write — exactly where the workspace route puts it.

> [!NOTE]
> The task spec referred to this event as `pod_sandbox.allowlist.updated`; the actual action (both variants) is `pod_egress_policy.updated`.

### Stack (DEDICATED-FILE variant, GCS-only)

Alternative implementation of pod-level egress allowlists that mirrors the workspace egress policy mechanism **exactly** — GCS-only, the policy file is the store, no DB record. Built for side-by-side comparison with the PROJECTION stack (#28352 → #28512 → #28513 → #28514 → #28515). **Do not merge both.**

1. #28544 — egress-proxy: pod space policy file (deploys first)
2. #28650 — backend: GCS trio + spaceId JWT claim
3. #28547 — admin API (route mirrors the workspace route; contract identical to projection variant)
4. #28548 — audit (emit in route, like the workspace route)
5. #28549 — settings UI (byte-identical to projection variant)

_(#28545, a dedicated DB table, was dropped in favor of exact workspace mimicry; #28546 was auto-closed with it and replaced by #28650.)_

### Deploy plan

- [ ] Register the schema with WorkOS before deploy: `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed` (not needed if the projection variant's registration already ran — same schema)