### PR TITLE
feat(sandbox): pod network settings UI [dedicated-file variant]

### DIFF
--- a/front/components/pod/settings/PodNetworkSection.tsx
+++ b/front/components/pod/settings/PodNetworkSection.tsx
@@ -1,0 +1,163 @@
+import {
+  usePodEgressPolicy,
+  useUpdatePodEgressPolicy,
+} from "@app/lib/swr/pods";
+import { normalizeEgressPolicyDomain } from "@app/types/sandbox/egress_policy";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  ContentMessage,
+  InfoCircle,
+  Input,
+  Plus,
+  Spinner,
+  Trash01,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface PodNetworkSectionProps {
+  owner: LightWorkspaceType;
+  podId: string;
+}
+
+// Pod-level sandbox egress allowlist. Merged on top of the workspace-level
+// allowlist for the Pod's Shared Computer. Workspace-admin only (matching the
+// API), gated behind the `sandbox_functions` feature at the call site.
+export function PodNetworkSection({ owner, podId }: PodNetworkSectionProps) {
+  const [domainInput, setDomainInput] = useState("");
+
+  const { policy, isPodEgressPolicyLoading, isPodEgressPolicyError } =
+    usePodEgressPolicy({ owner, podId });
+  const { updatePodEgressPolicy, isUpdatingPodEgressPolicy } =
+    useUpdatePodEgressPolicy({ owner, podId });
+
+  const hasDomainInput = domainInput.trim().length > 0;
+  const domainInputResult = hasDomainInput
+    ? normalizeEgressPolicyDomain(domainInput)
+    : null;
+  const normalizedDomain =
+    domainInputResult?.isOk() === true ? domainInputResult.value : null;
+  const isDuplicate =
+    normalizedDomain !== null &&
+    policy.allowedDomains.includes(normalizedDomain);
+  const domainInputMessage =
+    domainInputResult?.isErr() === true
+      ? domainInputResult.error.message
+      : isDuplicate
+        ? "This domain is already allowed."
+        : normalizedDomain
+          ? `Will be saved as ${normalizedDomain}.`
+          : "Use an exact domain such as api.openai.com or a wildcard such as *.mistral.ai.";
+  const isDomainInputInvalid =
+    domainInputResult?.isErr() === true || isDuplicate;
+  const canAddDomain =
+    normalizedDomain !== null && !isDuplicate && !isUpdatingPodEgressPolicy;
+
+  const saveDomains = async (allowedDomains: string[]) => {
+    return updatePodEgressPolicy({ allowedDomains });
+  };
+
+  const handleAddDomain = async () => {
+    if (!canAddDomain || normalizedDomain === null) {
+      return;
+    }
+
+    const success = await saveDomains([
+      ...policy.allowedDomains,
+      normalizedDomain,
+    ]);
+    if (success) {
+      setDomainInput("");
+    }
+  };
+
+  const handleRemoveDomain = async (domain: string) => {
+    await saveDomains(policy.allowedDomains.filter((d) => d !== domain));
+  };
+
+  if (isPodEgressPolicyLoading) {
+    return <Spinner />;
+  }
+  if (isPodEgressPolicyError) {
+    return (
+      <ContentMessage
+        variant="warning"
+        icon={InfoCircle}
+        size="lg"
+        title="Failed to load"
+      >
+        The Pod network settings could not be loaded.
+      </ContentMessage>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <div className="heading-lg">Network</div>
+      <p className="text-sm text-muted-foreground">
+        These domains apply to this Pod's Computer, in addition to the
+        workspace-wide allowlist. Changes are picked up by egress proxy cache
+        refreshes, typically within 60 seconds.
+      </p>
+
+      <form
+        className="flex flex-col gap-3 sm:flex-row sm:items-start"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void handleAddDomain();
+        }}
+      >
+        <div className="grow">
+          <Input
+            label="Domain"
+            name="domain"
+            placeholder="e.g. api.openai.com or *.mistral.ai"
+            value={domainInput}
+            message={domainInputMessage}
+            messageStatus={isDomainInputInvalid ? "error" : "info"}
+            onChange={(event) => setDomainInput(event.target.value)}
+            disabled={isUpdatingPodEgressPolicy}
+          />
+        </div>
+        <Button
+          type="submit"
+          label="Add domain"
+          icon={Plus}
+          disabled={!canAddDomain}
+          isLoading={isUpdatingPodEgressPolicy}
+          className="mt-0 sm:mt-7"
+        />
+      </form>
+
+      {policy.allowedDomains.length === 0 ? (
+        <ContentMessage variant="outline" size="lg">
+          No Pod-specific domains are currently allowed.
+        </ContentMessage>
+      ) : (
+        <div className="flex w-full flex-col divide-y divide-separator">
+          {policy.allowedDomains.map((domain) => (
+            <div key={domain} className="flex items-center gap-3 py-3">
+              <pre
+                title={domain}
+                className="min-w-0 grow overflow-x-auto whitespace-nowrap rounded bg-muted-background p-2 text-sm text-foreground"
+              >
+                {domain}
+              </pre>
+              <Button
+                variant="warning"
+                size="mini"
+                icon={Trash01}
+                tooltip={`Remove ${domain}`}
+                disabled={isUpdatingPodEgressPolicy}
+                onClick={() => {
+                  void handleRemoveDomain(domain);
+                }}
+                className="shrink-0"
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -3,6 +3,7 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { MarkdownFileEditor } from "@app/components/editor/MarkdownFileEditor";
 import { DeletePodDialog } from "@app/components/pod/settings/DeletePodDialog";
 import { PodMembersTable } from "@app/components/pod/settings/PodMembersTable";
+import { PodNetworkSection } from "@app/components/pod/settings/PodNetworkSection";
 import { PodSettingsOptionLabel } from "@app/components/pod/settings/PodSettingsOptionLabel";
 import { SuggestedTasksGenerationTile } from "@app/components/pod/settings/SuggestedTasksGenerationTile";
 import { usePodConversationsSummary } from "@app/hooks/conversations";
@@ -12,7 +13,7 @@ import {
   POD_AGENTS_MD_FILENAME,
   POD_AGENTS_MD_MAX_CHARACTER_COUNT,
 } from "@app/lib/api/projects/constants";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
@@ -95,10 +96,14 @@ export function PodSettingsTab({
 
   const confirm = useContext(ConfirmContext);
   const { hasFeature } = useFeatureFlags();
+  const { isAdmin } = useAuth();
   const hasWorkspaceDefaultAgentFeature = hasFeature("workspace_default_agent");
   const isDefaultAgentEnabled =
     hasFeature("pod_default_agent") || hasWorkspaceDefaultAgentFeature;
   const isDefaultSkillsEnabled = hasFeature("pod_default_skills");
+  // The pod sandbox network allowlist is workspace-admin only (matching the
+  // API) and part of the Sandbox Functions surface.
+  const isPodNetworkEnabled = isAdmin && hasFeature("sandbox_functions");
 
   const { podMetadata, isPodMetadataLoading } = usePodMetadata({
     workspaceId: owner.sId,
@@ -722,6 +727,10 @@ export function PodSettingsTab({
             </div>
           </div>
         </div>
+
+        {isPodNetworkEnabled && (
+          <PodNetworkSection owner={owner} podId={pod.sId} />
+        )}
 
         <div className="flex flex-col gap-3">
           <div className="flex items-center gap-2">

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -44,6 +44,10 @@ import type {
   PostStartPodTaskResponseBody,
 } from "@app/types/api/projects/tasks";
 import type {
+  GetPodEgressPolicyResponseBody,
+  PutPodEgressPolicyResponseBody,
+} from "@app/types/api/sandbox/egress_policy";
+import type {
   CheckNameResponseBody,
   PatchPodMetadataBodyType,
 } from "@app/types/api/spaces";
@@ -57,6 +61,8 @@ import type {
   PodTaskStatus,
   PodTaskType,
 } from "@app/types/project_task";
+import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+import { EMPTY_EGRESS_POLICY } from "@app/types/sandbox/egress_policy";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -1346,4 +1352,93 @@ export function useStarPod({
     },
     [workspaceId, podId, mutatePodConversationsSummary, sendNotification]
   );
+}
+
+function podEgressPolicyUrl(workspaceId: string, podId: string) {
+  return `/api/w/${workspaceId}/spaces/${podId}/sandbox/egress-policy`;
+}
+
+export function usePodEgressPolicy({
+  owner,
+  podId,
+  disabled = false,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const policyFetcher: Fetcher<GetPodEgressPolicyResponseBody> = fetcher;
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
+    podEgressPolicyUrl(owner.sId, podId),
+    policyFetcher,
+    { disabled }
+  );
+
+  return {
+    policy: data?.policy ?? EMPTY_EGRESS_POLICY,
+    isPodEgressPolicyLoading: disabled ? false : isLoading,
+    isPodEgressPolicyError: !!error,
+    mutatePodEgressPolicy: mutate,
+  };
+}
+
+export function useUpdatePodEgressPolicy({
+  owner,
+  podId,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const [isUpdatingPodEgressPolicy, setIsUpdating] = useState(false);
+  const { mutatePodEgressPolicy } = usePodEgressPolicy({
+    owner,
+    podId,
+    disabled: true,
+  });
+
+  const updatePodEgressPolicy = async (
+    policy: EgressPolicy
+  ): Promise<boolean> => {
+    setIsUpdating(true);
+    try {
+      const response = await clientFetch(podEgressPolicyUrl(owner.sId, podId), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(policy),
+      });
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to update Pod network policy",
+          description: error.message,
+        });
+        return false;
+      }
+
+      const data: PutPodEgressPolicyResponseBody = await response.json();
+      await mutatePodEgressPolicy({ policy: data.policy }, false);
+      sendNotification({
+        type: "success",
+        title: "Pod network policy updated",
+        description:
+          "Sandbox egress policy changes will be applied by the proxy cache shortly.",
+      });
+      return true;
+    } catch {
+      sendNotification({
+        type: "error",
+        title: "Failed to update Pod network policy",
+        description: "An unexpected error occurred. Please try again.",
+      });
+      return false;
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return { updatePodEgressPolicy, isUpdatingPodEgressPolicy };
 }


### PR DESCRIPTION
> **Superseded** by the owner-keyed egress policy re-layout stack (`egress-relayout-*` branches, PRs `28652`–`28655`). Branch kept for reference.

## Pod egress allowlist — settings UI

**DEDICATED-FILE variant.** Byte-identical to the projection variant's UI (#28515): the API contract is unchanged, so the Network section, settings-tab wiring, and SWR hooks carry over untouched.

### Stack (DEDICATED-FILE variant, GCS-only)

Alternative implementation of pod-level egress allowlists that mirrors the workspace egress policy mechanism **exactly** — GCS-only, the policy file is the store, no DB record. Built for side-by-side comparison with the PROJECTION stack (#28352 → #28512 → #28513 → #28514 → #28515). **Do not merge both.**

1. #28544 — egress-proxy: pod space policy file (deploys first)
2. #28650 — backend: GCS trio + spaceId JWT claim
3. #28547 — admin API (route mirrors the workspace route; contract identical to projection variant)
4. #28548 — audit (emit in route, like the workspace route)
5. #28549 — settings UI (byte-identical to projection variant)

_(#28545, a dedicated DB table, was dropped in favor of exact workspace mimicry; #28546 was auto-closed with it and replaced by #28650.)_

---

## Comparison: DEDICATED-FILE (GCS-only) vs PROJECTION

| | PROJECTION (#28352–#28515) | DEDICATED-FILE (this stack) |
|---|---|---|
| Proxy (Rust) changes | **None** | spaceId claim + `pods/` lookup + `p:` cache key + invalidation case (~120 lines + tests) |
| Deploy sequencing | None (front-only) | **Two-phase: proxy ships first**, then front |
| Storage | DB column on `ProjectMetadata` (source of truth) + per-sandbox GCS projection | **GCS file only** (`pods/{spaceSId}.json`) — exact workspace-policy architecture |
| DB migration | Required | **None** |
| Front diff size | model + resource + lib + adapter + route (~600 lines) | egress_policy trio + JWT + route (~350 lines) |
| Activation work | Re-project at every fresh create **and wake** | **None** |
| `add_egress_domain` shared-file collision | Latent (projection replaces the file the tool appends to) | **None** — separate files |
| Works with no sandbox ever created | DB yes; GCS file deferred to first activation | Yes, immediately |
| Failed GCS write on admin save | Silent (re-projected at next activation) | 500 to the admin (same as workspace route) |
| Domain-count cap | 100 | None (mirrors `writeWorkspacePolicy`) |
| Space deletion / relocation | Row cascades; file dies with sandbox / re-projects | **Inherits the workspace gaps**: no scrub, no relocation handling (stale files are inert) |
| Transactions / FK lifecycle / DB backup | Yes | No — the file is the store, exactly like the workspace policy |

**Names that differed from the task spec:** audit action is `pod_egress_policy.updated` (not `pod_sandbox.allowlist.updated`); the invalidation handler lives in `egress-proxy/src/health.rs`. Everything else matched.

**Spec deviation, per explicit follow-up direction:** the spec's primary DB-modeling option (dedicated spaceId-FK table) was built first (#28545/#28546), then replaced by the spec's GCS-only fallback to mimic the workspace policy exactly — accepting the stated tradeoff (no transactional writes, no FK lifecycle, no relocation handling). `addPodEgressDomain` (the manifest-approve seam) was dropped with the DB record; when Category G lands it can mirror `addSandboxPolicyDomain` (read-merge-write on the file), with no shared-file collision.