### PR TITLE
Switch product metric

### DIFF
--- a/front/lib/metronome/setup_common.ts
+++ b/front/lib/metronome/setup_common.ts
@@ -300,7 +300,7 @@ export const PRODUCTS: ProductDef[] = [
   {
     name: "AI Usage",
     type: "USAGE",
-    billable_metric_name: "LLM Provider Cost AWU",
+    billable_metric_name: "LLM Provider Cost AWU v2",
     pricing_group_key: [USAGE_TYPE_GROUP_KEY],
     presentation_group_key: ["user_id"],
     tags: [USAGE_TAG],
@@ -308,7 +308,7 @@ export const PRODUCTS: ProductDef[] = [
   {
     name: "Tool Usage",
     type: "USAGE",
-    billable_metric_name: "Tool Invocations",
+    billable_metric_name: "Tool Invocations v2",
     pricing_group_key: [USAGE_TYPE_GROUP_KEY, "tool_category"],
     presentation_group_key: ["user_id"],
     tags: [USAGE_TAG],


### PR DESCRIPTION
## Description

Followup on https://github.com/dust-tt/dust/pull/28472

According to https://dust4ai.slack.com/archives/C0AGNMLBRB5/p1782740593425549 full events reflow over 34 days has been executed, so we should be able to switch to the new V2 metric.

## Tests

in sandbox. check token consumption after switch + alerts + all dashboards

## Risk

high, affect product pricing + alerts + spend measurements 

## Deploy Plan

run metronome setup script

