### PR TITLE
test(transcripts): add drive.readonly to labs_transcripts scope

### DIFF
--- a/front/lib/api/oauth/providers/google_drive.ts
+++ b/front/lib/api/oauth/providers/google_drive.ts
@@ -24,7 +24,10 @@ export class GoogleDriveOAuthProvider implements BaseOAuthStrategyProvider {
   }) {
     const scopes =
       useCase === "labs_transcripts"
-        ? ["https://www.googleapis.com/auth/drive.meet.readonly"]
+        ? [
+            "https://www.googleapis.com/auth/drive.meet.readonly",
+            "https://www.googleapis.com/auth/drive.readonly",
+          ]
         : [
             "https://www.googleapis.com/auth/drive.metadata.readonly",
             "https://www.googleapis.com/auth/drive.readonly",


### PR DESCRIPTION
## Description

Diagnostic for the export 404 on Meet transcript Docs: drive.meet.readonly allows metadata reads but not files.export (Google returns 404). Adding drive.readonly to confirm the scope is the cause. Requires re-consent to take effect.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low
## Deploy Plan

Front + user must reauth