### PR TITLE
[front] enh: make img-generation tool credit-based

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -3,7 +3,10 @@ import {
   type MCPToolStakeLevelType,
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import {
   AGENT_ROUTER_SERVER,
@@ -1533,6 +1536,26 @@ export function getInternalMCPServerMetadata<
   const server = INTERNAL_MCP_SERVERS[name];
 
   return server.metadata;
+}
+
+/**
+ * Whether the tool may create its own LLM runs during execution and attach
+ * them to the action's stepContext.toolRunIds (e.g. image generation). Used by
+ * the tool activity to decide whether to refetch the action after execution —
+ * kept behind this flag so the common case pays no extra query.
+ */
+export function internalToolRecordsToolRuns(
+  serverName: string,
+  toolName: string
+): boolean {
+  if (!isInternalMCPServerName(serverName)) {
+    return false;
+  }
+  const metadata = getInternalMCPServerMetadata(serverName);
+  const tools: InternalMCPToolType[] = metadata.tools;
+  return tools.some(
+    (tool) => tool.name === toolName && tool.recordsToolRuns === true
+  );
 }
 
 const SENSITIVITY_LABEL_PROVIDER_BY_SERVER: Partial<

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -57,6 +57,11 @@ export interface ToolDefinition<
   displayLabels: ToolDisplayLabels;
   toolCostCategory: ToolCostCategory;
   freeUsage: boolean;
+  // When true, the tool may create its own LLM runs during execution and
+  // attach them to the action's stepContext.toolRunIds (see
+  // AgentMCPActionResource.appendToolRunIds). The tool activity only refetches
+  // the action to flow those runs back to the agent loop when this is set.
+  recordsToolRuns?: boolean;
   handler: (
     params: z.infer<z.ZodObject<TSchema>>,
     extra: ToolHandlerExtra
@@ -151,6 +156,7 @@ export type InternalMCPToolType<TName extends string = string> = Omit<
   displayLabels: ToolDisplayLabels;
   toolCostCategory: ToolCostCategory;
   freeUsage: boolean;
+  recordsToolRuns?: boolean;
 };
 
 export type ServerMetadata<

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -122,6 +122,10 @@ export type StepContext = {
   // Dust run IDs of LLM runs made by the tool itself (e.g. image generation).
   // Flowed back to the agent loop so the runs are billed like any other LLM
   // usage of the agent message.
+  // /!\ Append-only and owned by the DB: written exclusively through
+  // AgentMCPActionResource.appendToolRunIds (atomic JSONB append), and
+  // preserved by updateStepContext so stale in-memory spreads cannot clobber
+  // runs recorded mid-execution.
   toolRunIds?: string[];
 };
 

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -122,7 +122,7 @@ export type StepContext = {
   // Dust run IDs of LLM runs made by the tool itself (e.g. image generation).
   // Flowed back to the agent loop so the runs are billed like any other LLM
   // usage of the agent message.
-  runIds?: string[];
+  toolRunIds?: string[];
 };
 
 type ActionGeneratedFileBase = {

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -119,6 +119,10 @@ export type StepContext = {
   resumeState: Record<string, unknown> | null;
   retrievalTopK: number;
   websearchResultCount: number;
+  // Dust run IDs of LLM runs made by the tool itself (e.g. image generation).
+  // Flowed back to the agent loop so the runs are billed like any other LLM
+  // usage of the agent message.
+  runIds?: string[];
 };
 
 type ActionGeneratedFileBase = {

--- a/front/lib/api/actions/servers/image_generation/helpers.test.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.test.ts
@@ -1,0 +1,144 @@
+import { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { IMAGE_MODEL_IDS } from "@app/types/assistant/models/models";
+import { assert, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRateLimiter } = vi.hoisted(() => {
+  return {
+    mockRateLimiter: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/utils/rate_limiter", () => ({
+  rateLimiter: mockRateLimiter,
+}));
+
+import {
+  checkImageGenerationRateLimit,
+  recordImageGenerationRunUsage,
+} from "@app/lib/api/actions/servers/image_generation/helpers";
+
+describe("checkImageGenerationRateLimit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRateLimiter.mockResolvedValue(1);
+  });
+
+  it("skips the rate limiter entirely on credit-priced plans", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await checkImageGenerationRateLimit(
+      auth,
+      workspace,
+      "openai"
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockRateLimiter).not.toHaveBeenCalled();
+  });
+
+  it("enforces the plan weekly cap on legacy plans", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const { maxImagesPerWeek } =
+      auth.getNonNullablePlan().limits.capabilities.images;
+
+    const result = await checkImageGenerationRateLimit(
+      auth,
+      workspace,
+      "openai"
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockRateLimiter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: `image_generation_${workspace.sId}`,
+        maxPerTimeframe: maxImagesPerWeek,
+      })
+    );
+  });
+
+  it("returns an error when the weekly cap is exhausted on legacy plans", async () => {
+    mockRateLimiter.mockResolvedValue(0);
+
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await checkImageGenerationRateLimit(
+      auth,
+      workspace,
+      "openai"
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("requests per week exceeded");
+    }
+  });
+});
+
+describe("recordImageGenerationRunUsage", () => {
+  it("records a run usage for the image model", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const dustRunId = await recordImageGenerationRunUsage(auth, {
+      usageMetadata: { inputTokens: 100, outputTokens: 1000 },
+      modelId: IMAGE_MODEL_IDS[0],
+      providerId: "google_ai_studio",
+      actionId: null,
+    });
+
+    const run = await RunResource.fetchByDustRunId(auth, { dustRunId });
+    assert(run, "Run not found");
+
+    const usages = await run.listRunUsages(auth);
+    expect(usages).toHaveLength(1);
+    expect(usages[0]).toMatchObject({
+      modelId: IMAGE_MODEL_IDS[0],
+      providerId: "google_ai_studio",
+      promptTokens: 100,
+      completionTokens: 1000,
+      isBatch: false,
+    });
+    expect(usages[0].costMicroUsd).toBeGreaterThan(0);
+  });
+
+  it("attaches the run to the action's stepContext", async () => {
+    const { workspace, authenticator: auth } = await createResourceTest({});
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+    const { action } = await AgentMCPActionFactory.createWithAgentMessage(
+      auth,
+      { workspace, conversation }
+    );
+
+    const dustRunId = await recordImageGenerationRunUsage(auth, {
+      usageMetadata: { inputTokens: 100, outputTokens: 1000 },
+      modelId: IMAGE_MODEL_IDS[0],
+      providerId: "google_ai_studio",
+      actionId: action.id,
+    });
+
+    const refreshedAction = await AgentMCPActionResource.fetchByModelIdWithAuth(
+      auth,
+      action.id
+    );
+    assert(refreshedAction, "Action not found");
+    expect(refreshedAction.stepContext.runIds).toEqual([dustRunId]);
+    // Pre-existing stepContext fields are preserved.
+    expect(refreshedAction.stepContext.retrievalTopK).toBe(
+      action.stepContext.retrievalTopK
+    );
+  });
+});

--- a/front/lib/api/actions/servers/image_generation/helpers.test.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.test.ts
@@ -1,3 +1,7 @@
+import {
+  checkImageGenerationRateLimit,
+  recordImageGenerationRunUsage,
+} from "@app/lib/api/actions/servers/image_generation/helpers";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
@@ -14,14 +18,12 @@ const { mockRateLimiter } = vi.hoisted(() => {
   };
 });
 
-vi.mock("@app/lib/utils/rate_limiter", () => ({
+// Partial mock: other exports of the module (e.g. getTimeframeSecondsFromLiteral)
+// are used by transitive importers and must keep their real implementation.
+vi.mock(import("@app/lib/utils/rate_limiter"), async (importOriginal) => ({
+  ...(await importOriginal()),
   rateLimiter: mockRateLimiter,
 }));
-
-import {
-  checkImageGenerationRateLimit,
-  recordImageGenerationRunUsage,
-} from "@app/lib/api/actions/servers/image_generation/helpers";
 
 describe("checkImageGenerationRateLimit", () => {
   beforeEach(() => {
@@ -33,11 +35,7 @@ describe("checkImageGenerationRateLimit", () => {
     const workspace = await WorkspaceFactory.creditPriced();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const result = await checkImageGenerationRateLimit(
-      auth,
-      workspace,
-      "openai"
-    );
+    const result = await checkImageGenerationRateLimit(auth, "openai");
 
     expect(result.isOk()).toBe(true);
     expect(mockRateLimiter).not.toHaveBeenCalled();
@@ -49,11 +47,7 @@ describe("checkImageGenerationRateLimit", () => {
     const { maxImagesPerWeek } =
       auth.getNonNullablePlan().limits.capabilities.images;
 
-    const result = await checkImageGenerationRateLimit(
-      auth,
-      workspace,
-      "openai"
-    );
+    const result = await checkImageGenerationRateLimit(auth, "openai");
 
     expect(result.isOk()).toBe(true);
     expect(mockRateLimiter).toHaveBeenCalledWith(
@@ -70,11 +64,7 @@ describe("checkImageGenerationRateLimit", () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const result = await checkImageGenerationRateLimit(
-      auth,
-      workspace,
-      "openai"
-    );
+    const result = await checkImageGenerationRateLimit(auth, "openai");
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {

--- a/front/lib/api/actions/servers/image_generation/helpers.test.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.test.ts
@@ -135,7 +135,7 @@ describe("recordImageGenerationRunUsage", () => {
       action.id
     );
     assert(refreshedAction, "Action not found");
-    expect(refreshedAction.stepContext.runIds).toEqual([dustRunId]);
+    expect(refreshedAction.stepContext.toolRunIds).toEqual([dustRunId]);
     // Pre-existing stepContext fields are preserved.
     expect(refreshedAction.stepContext.retrievalTopK).toBe(
       action.stepContext.retrievalTopK

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -32,7 +32,6 @@ import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
 import { randomUUID } from "crypto";
@@ -155,7 +154,6 @@ export async function sendImageProgressNotification(
 
 export async function checkImageGenerationRateLimit(
   auth: Authenticator,
-  workspace: WorkspaceType,
   providerId: ModelProviderIdType
 ): Promise<Ok<void> | Err<MCPError>> {
   const plan = auth.getNonNullablePlan();
@@ -169,7 +167,7 @@ export async function checkImageGenerationRateLimit(
   const { maxImagesPerWeek } = plan.limits.capabilities.images;
 
   const remaining = await rateLimiter({
-    key: `${IMAGE_GENERATION_RATE_LIMITER_KEY}_${workspace.sId}`,
+    key: `${IMAGE_GENERATION_RATE_LIMITER_KEY}_${auth.getNonNullableWorkspace().sId}`,
     maxPerTimeframe: maxImagesPerWeek,
     timeframeSeconds: IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS,
     logger,
@@ -244,16 +242,10 @@ export async function recordImageGenerationRunUsage(
   ]);
 
   if (actionId !== null) {
-    const action = await AgentMCPActionResource.fetchByModelIdWithAuth(
-      auth,
-      actionId
-    );
-    if (action) {
-      await action.updateStepContext({
-        ...action.stepContext,
-        toolRunIds: [...(action.stepContext.toolRunIds ?? []), dustRunId],
-      });
-    }
+    await AgentMCPActionResource.appendToolRunIds(auth, {
+      actionId,
+      runIds: [dustRunId],
+    });
   }
 
   return dustRunId;

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -11,7 +11,10 @@ import {
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import { uploadBase64ImageToFileStorage } from "@app/lib/api/files/upload";
 import type { ReferenceImageFile } from "@app/lib/api/llm/imageGeneration";
+import { createLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { getStatsDClient } from "@app/lib/utils/statsd";
@@ -25,11 +28,14 @@ import {
   MAX_FILE_SIZES,
   stripFileExtension,
 } from "@app/types/files";
+import { isCreditPricedPlan } from "@app/types/plan";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
+import { randomUUID } from "crypto";
 
 export type ImageGenerationErrorCode =
   | "api_error"
@@ -152,8 +158,15 @@ export async function checkImageGenerationRateLimit(
   workspace: WorkspaceType,
   providerId: ModelProviderIdType
 ): Promise<Ok<void> | Err<MCPError>> {
-  const { limits } = auth.getNonNullablePlan();
-  const { maxImagesPerWeek } = limits.capabilities.images;
+  const plan = auth.getNonNullablePlan();
+
+  // Credit-priced plans have no weekly image cap: every image is metered and
+  // paid for in credits, so credits are the throttle.
+  if (isCreditPricedPlan(plan)) {
+    return new Ok(undefined);
+  }
+
+  const { maxImagesPerWeek } = plan.limits.capabilities.images;
 
   const remaining = await rateLimiter({
     key: `${IMAGE_GENERATION_RATE_LIMITER_KEY}_${workspace.sId}`,
@@ -181,25 +194,69 @@ export async function checkImageGenerationRateLimit(
   return new Ok(undefined);
 }
 
-export function trackTokenUsage({
-  inputTokens,
-  outputTokens,
-  providerId,
-}: {
-  inputTokens: number;
-  outputTokens: number;
-  providerId: ModelProviderIdType;
-}): void {
-  getStatsDClient().increment(
-    "tools.image_generation.usage.input_tokens",
-    inputTokens,
-    [`provider:${providerId}`]
-  );
-  getStatsDClient().increment(
-    "tools.image_generation.usage.output_tokens",
-    outputTokens,
-    [`provider:${providerId}`]
-  );
+/**
+ * Record the image model's usage as a run usage, like any LLM call. The run is
+ * attached to the action's stepContext so the agent loop accumulates it into
+ * the agent message runIds — from there the existing usage pipeline (Metronome
+ * llm_usage events, credit cost, programmatic usage, analytics) picks it up
+ * like any other LLM usage of the message.
+ */
+export async function recordImageGenerationRunUsage(
+  auth: Authenticator,
+  {
+    usageMetadata,
+    modelId,
+    providerId,
+    actionId,
+  }: {
+    usageMetadata: { inputTokens: number; outputTokens: number };
+    modelId: ImageModelIdType;
+    providerId: ModelProviderIdType;
+    actionId: ModelId | null;
+  }
+): Promise<string> {
+  const costMicroUsd = computeTokensCostForUsageInMicroUsd({
+    modelId,
+    promptTokens: usageMetadata.inputTokens,
+    completionTokens: usageMetadata.outputTokens,
+    cachedTokens: null,
+  });
+
+  const dustRunId = createLLMTraceId(randomUUID());
+  const run = await RunResource.makeNew({
+    appId: null,
+    dustRunId,
+    runType: "deploy",
+    useWorkspaceCredentials: false,
+    workspaceId: auth.getNonNullableWorkspace().id,
+  });
+
+  await run.recordRunUsage(auth, [
+    {
+      providerId,
+      modelId,
+      promptTokens: usageMetadata.inputTokens,
+      completionTokens: usageMetadata.outputTokens,
+      cachedTokens: null,
+      costMicroUsd,
+      isBatch: false,
+    },
+  ]);
+
+  if (actionId !== null) {
+    const action = await AgentMCPActionResource.fetchByModelIdWithAuth(
+      auth,
+      actionId
+    );
+    if (action) {
+      await action.updateStepContext({
+        ...action.stepContext,
+        runIds: [...(action.stepContext.runIds ?? []), dustRunId],
+      });
+    }
+  }
+
+  return dustRunId;
 }
 
 export async function uploadAndFormatImageResponse(

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -251,7 +251,7 @@ export async function recordImageGenerationRunUsage(
     if (action) {
       await action.updateStepContext({
         ...action.stepContext,
-        runIds: [...(action.stepContext.runIds ?? []), dustRunId],
+        toolRunIds: [...(action.stepContext.toolRunIds ?? []), dustRunId],
       });
     }
   }

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -78,7 +78,9 @@ export const IMAGE_GENERATION_TOOLS_METADATA = createToolsRecord({
       running: "Generating image",
       done: "Generate image",
     },
-    toolCostCategory: "advanced",
+    // Standard tool cost: the image model's actual cost is billed separately
+    // as LLM usage (see recordImageGenerationRunUsage in helpers.ts).
+    toolCostCategory: "basic",
     freeUsage: false,
   },
 });

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -82,6 +82,9 @@ export const IMAGE_GENERATION_TOOLS_METADATA = createToolsRecord({
     // as LLM usage (see recordImageGenerationRunUsage in helpers.ts).
     toolCostCategory: "basic",
     freeUsage: false,
+    // The tool records the image model's run and attaches it to the action's
+    // stepContext.toolRunIds — the tool activity flows it back for billing.
+    recordsToolRuns: true,
   },
 });
 

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -66,7 +66,6 @@ export function createImageGenerationTools(
 
       const rateLimitResult = await checkImageGenerationRateLimit(
         auth,
-        workspace,
         providerId
       );
       if (rateLimitResult.isErr()) {

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -4,13 +4,16 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  type ToolContextType,
+} from "@app/lib/actions/types";
 import {
   checkImageGenerationRateLimit,
   computeImageGenerationCostDetails,
   processImageFileIds,
+  recordImageGenerationRunUsage,
   sendImageProgressNotification,
-  trackTokenUsage,
   uploadAndFormatImageResponse,
 } from "@app/lib/api/actions/servers/image_generation/helpers";
 import { IMAGE_GENERATION_TOOLS_METADATA } from "@app/lib/api/actions/servers/image_generation/metadata";
@@ -150,9 +153,14 @@ export function createImageGenerationTools(
 
       const { images, usageMetadata } = generationResult.value;
 
-      trackTokenUsage({
-        ...usageMetadata,
+      await recordImageGenerationRunUsage(auth, {
+        usageMetadata,
+        modelId: imageGenerationModel.modelId,
         providerId: imageGenerationModel.providerId,
+        actionId:
+          toolContext && isAgentLoopRunContext(toolContext.runContext)
+            ? toolContext.runContext.currentAction.id
+            : null,
       });
 
       const { inputTokens, outputTokens, totalTokens, costDetails } =

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -41,6 +41,7 @@ import type {
   ConversationType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
+import { isModelId } from "@app/types/assistant/models/models";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isFileContentFragment } from "@app/types/content_fragment";
@@ -109,7 +110,9 @@ async function getForkCompactionModel(
       ? (await sourceMessageRun.run.listRunUsages(auth))[0]
       : null;
 
-  if (sourceUsage) {
+  // Run usages may belong to image models (e.g. image generation runs), which
+  // cannot be used for compaction — fall back to the small model in that case.
+  if (sourceUsage && isModelId(sourceUsage.modelId)) {
     return {
       providerId: sourceUsage.providerId,
       modelId: sourceUsage.modelId,

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -22,6 +22,7 @@ import { ConversationForkResource } from "@app/lib/resources/conversation_fork_r
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -101,22 +102,31 @@ async function getForkCompactionModel(
     transaction?: Transaction;
   }
 ): Promise<SupportedModel | null> {
-  const sourceMessageRun = await conversation.getLatestAgentMessageRun(auth, {
+  const sourceMessageRuns = await conversation.getLatestAgentMessageRuns(auth, {
     maxRank: sourceMessageRank,
     transaction,
   });
-  const sourceUsage =
-    sourceMessageRun?.rank === sourceMessageRank
-      ? (await sourceMessageRun.run.listRunUsages(auth))[0]
-      : null;
 
-  // Run usages may belong to image models (e.g. image generation runs), which
-  // cannot be used for compaction — fall back to the small model in that case.
-  if (sourceUsage && isModelId(sourceUsage.modelId)) {
-    return {
-      providerId: sourceUsage.providerId,
-      modelId: sourceUsage.modelId,
-    };
+  // Pick the most recent run backed by a text model: the message's runs may
+  // include tool-created image runs (e.g. image generation), which cannot be
+  // used for compaction — fall back to the small model when there is none.
+  if (sourceMessageRuns?.rank === sourceMessageRank) {
+    const usages = await RunResource.listRunUsagesForRuns(auth, {
+      runs: sourceMessageRuns.runs,
+    });
+
+    // O(runs × usages) acceptable: both are bounded by the message's step
+    // count (a handful of entries). Runs are sorted most recent first.
+    for (const run of sourceMessageRuns.runs) {
+      for (const usage of usages) {
+        if (usage.runModelId === run.id && isModelId(usage.modelId)) {
+          return {
+            providerId: usage.providerId,
+            modelId: usage.modelId,
+          };
+        }
+      }
+    }
   }
 
   const fallbackModel = getSmallWhitelistedModel(auth);

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -109,10 +109,27 @@ export async function computeAndStoreAgentMessageCredits(
       dustRunIds,
       runKey: computeRunKey(dustRunIds),
     });
+
+    // Tool-created runs (e.g. image generation) reach the persisted runIds
+    // only through the next model-turn event — on break paths (early exit,
+    // pause) there is none, so merge this execution's dustRunIds into the
+    // column to keep the message-level total (and any later consumer of
+    // agentMessage.runIds) complete. The Metronome events bill from
+    // dustRunIds directly; without this merge the displayed costCredits
+    // could miss runs that were billed.
+    await ConversationResource.mergeAgentMessageRunIds(auth, {
+      agentMessageModelId,
+      runIds: dustRunIds,
+    });
   }
 
   const [runUsages, actions] = await Promise.all([
-    fetchRunUsagesForAgentMessage(auth, runIds),
+    // Union with dustRunIds so the recompute is complete even if a concurrent
+    // writer raced the merge above (fetchRunUsagesForAgentMessage dedupes).
+    fetchRunUsagesForAgentMessage(auth, [
+      ...(runIds ?? []),
+      ...(dustRunIds ?? []),
+    ]),
     AgentMCPActionResource.listByAgentMessageIds(auth, [agentMessageModelId]),
   ]);
 

--- a/front/lib/plans/credit_priced_plans.ts
+++ b/front/lib/plans/credit_priced_plans.ts
@@ -34,6 +34,8 @@ if (isDevelopment() || isTest()) {
     maxAwuCredits: -1,
     maxAwuCreditsTimeframe: "lifetime",
     isDeepDiveAllowed: true,
+    // Ignored at enforcement: credit-priced plans have no weekly image cap
+    // (see checkImageGenerationRateLimit).
     maxImagesPerWeek: -1,
     maxUsersInWorkspace: 100,
     maxFreeUsersInWorkspace: 100,
@@ -71,6 +73,8 @@ if (isDevelopment() || isTest()) {
     maxAwuCredits: -1,
     maxAwuCreditsTimeframe: "lifetime",
     isDeepDiveAllowed: true,
+    // Ignored at enforcement: credit-priced plans have no weekly image cap
+    // (see checkImageGenerationRateLimit).
     maxImagesPerWeek: -1,
     maxUsersInWorkspace: 1000,
     maxFreeUsersInWorkspace: -1,
@@ -110,6 +114,8 @@ if (isDevelopment() || isTest()) {
     maxFreeUsersInWorkspace: 5,
     maxLifetimeFreeUsersInWorkspace: 5,
     maxVaultsInWorkspace: 5,
+    // Ignored at enforcement: credit-priced plans have no weekly image cap
+    // (see checkImageGenerationRateLimit).
     maxImagesPerWeek: 100,
     isSlackbotAllowed: true,
     isManagedConfluenceAllowed: true,
@@ -139,6 +145,8 @@ if (isDevelopment() || isTest()) {
     maxAwuCredits: -1,
     maxAwuCreditsTimeframe: "lifetime",
     isDeepDiveAllowed: true,
+    // Ignored at enforcement: credit-priced plans have no weekly image cap
+    // (see checkImageGenerationRateLimit).
     maxImagesPerWeek: -1,
     maxUsersInWorkspace: -1,
     maxFreeUsersInWorkspace: -1,

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -824,3 +824,75 @@ describe("warmGcsContentCache", () => {
     ).rejects.toThrow("redis down");
   });
 });
+
+describe("stepContext toolRunIds", () => {
+  async function setupAction() {
+    const { workspace, authenticator: auth } = await createResourceTest({});
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+    const { action } = await AgentMCPActionFactory.createWithAgentMessage(
+      auth,
+      { workspace, conversation }
+    );
+    return { auth, action };
+  }
+
+  it("appends across calls, preserving order", async () => {
+    const { auth, action } = await setupAction();
+
+    await AgentMCPActionResource.appendToolRunIds(auth, {
+      actionId: action.id,
+      runIds: ["llm_trace_run_1"],
+    });
+    await AgentMCPActionResource.appendToolRunIds(auth, {
+      actionId: action.id,
+      runIds: ["llm_trace_run_2"],
+    });
+
+    const refreshed = await AgentMCPActionResource.fetchByModelIdWithAuth(
+      auth,
+      action.id
+    );
+    assert(refreshed, "Action not found");
+    expect(refreshed.stepContext.toolRunIds).toEqual([
+      "llm_trace_run_1",
+      "llm_trace_run_2",
+    ]);
+  });
+
+  it("survives updateStepContext called with a stale stepContext", async () => {
+    const { auth, action } = await setupAction();
+
+    // Stale in-memory copy, as held by the tool activity machinery while the
+    // tool executes.
+    const staleStepContext = { ...action.stepContext };
+
+    // The tool records a run mid-execution.
+    await AgentMCPActionResource.appendToolRunIds(auth, {
+      actionId: action.id,
+      runIds: ["llm_trace_run_1"],
+    });
+
+    // A later write spreading the stale copy (e.g. exit_events persisting
+    // resumeState) must not clobber the appended run IDs.
+    await action.updateStepContext({
+      ...staleStepContext,
+      resumeState: { type: "test" },
+    });
+
+    const refreshed = await AgentMCPActionResource.fetchByModelIdWithAuth(
+      auth,
+      action.id
+    );
+    assert(refreshed, "Action not found");
+    expect(refreshed.stepContext.toolRunIds).toEqual(["llm_trace_run_1"]);
+    expect(refreshed.stepContext.resumeState).toEqual({ type: "test" });
+    // The rest of the stale write still lands.
+    expect(refreshed.stepContext.retrievalTopK).toBe(
+      staleStepContext.retrievalTopK
+    );
+  });
+});

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -48,6 +48,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -83,7 +84,7 @@ import type {
   NonAttribute,
   Transaction,
 } from "sequelize";
-import { Op } from "sequelize";
+import { literal, Op } from "sequelize";
 import { AgentStepContentModel } from "../models/agent/agent_step_content";
 
 // Batch size for fetching output items to avoid loading too many large rows at once.
@@ -1366,12 +1367,65 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
   }
 
-  async updateStepContext(
-    stepContext: StepContext
-  ): Promise<[affectedCount: number]> {
-    return this.update({
-      stepContext,
-    });
+  async updateStepContext(stepContext: StepContext): Promise<void> {
+    // `toolRunIds` is append-only and owned by the DB (see appendToolRunIds).
+    // Callers spread a possibly stale in-memory stepContext, so the stored
+    // value must win here — otherwise runs recorded mid-execution by the tool
+    // would be clobbered and never billed.
+    const { toolRunIds: _staleToolRunIds, ...sanitizedStepContext } =
+      stepContext;
+    const escapedStepContext = frontSequelize.escape(
+      JSON.stringify(sanitizedStepContext)
+    );
+
+    const [, affectedRows] = await AgentMCPActionModel.update(
+      {
+        stepContext: literal(
+          `CASE WHEN "stepContext" ? 'toolRunIds' ` +
+            `THEN jsonb_set(${escapedStepContext}::jsonb, '{toolRunIds}', "stepContext"->'toolRunIds') ` +
+            `ELSE ${escapedStepContext}::jsonb END`
+        ),
+      },
+      {
+        where: { id: this.id, workspaceId: this.workspaceId },
+        returning: true,
+      }
+    );
+
+    // Sync the in-memory instance to avoid stale data (mirrors BaseResource.update).
+    if (affectedRows[0]) {
+      Object.assign(this, affectedRows[0].get());
+    }
+  }
+
+  /**
+   * Atomically append tool-created run IDs to `stepContext.toolRunIds`.
+   *
+   * JSONB-level append so concurrent stepContext writers (the tool recording a
+   * run mid-execution vs. the agent loop machinery persisting resumeState)
+   * cannot lose entries. No dedup needed: each entry is a freshly minted trace
+   * ID (see recordImageGenerationRunUsage) — a Temporal retry mints a new run.
+   */
+  static async appendToolRunIds(
+    auth: Authenticator,
+    { actionId, runIds }: { actionId: ModelId; runIds: string[] }
+  ): Promise<void> {
+    if (runIds.length === 0) {
+      return;
+    }
+    const escapedRunIds = frontSequelize.escape(JSON.stringify(runIds));
+
+    await AgentMCPActionModel.update(
+      {
+        stepContext: literal(
+          `jsonb_set("stepContext", '{toolRunIds}', ` +
+            `COALESCE("stepContext"->'toolRunIds', '[]'::jsonb) || ${escapedRunIds}::jsonb)`
+        ),
+      },
+      {
+        where: { id: actionId, workspaceId: auth.getNonNullableWorkspace().id },
+      }
+    );
   }
 
   static async deleteByAgentMessageId(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -756,6 +756,46 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   }
 
   /**
+   * Merge run IDs into the agent message's persisted `runIds`, atomically and
+   * deduplicated at the SQL level (same idiom as the event-driven merge in
+   * temporal/agent_loop/activities/common.ts). Used at finalize to restore the
+   * "runIds accumulates every run of the message" invariant for tool-created
+   * runs (e.g. image generation) that never flowed through a model-turn event
+   * on break paths (early exit, pause).
+   */
+  static async mergeAgentMessageRunIds(
+    auth: Authenticator,
+    {
+      agentMessageModelId,
+      runIds,
+    }: { agentMessageModelId: ModelId; runIds: string[] }
+  ): Promise<void> {
+    if (runIds.length === 0) {
+      return;
+    }
+    const escapedRunIds = runIds
+      .map((runId) => frontSequelize.escape(runId))
+      .join(",");
+
+    await AgentMessageModel.update(
+      {
+        runIds: fn(
+          "ARRAY",
+          literal(
+            `SELECT DISTINCT unnest(COALESCE("runIds", '{}') || ARRAY[${escapedRunIds}]::text[])`
+          )
+        ),
+      },
+      {
+        where: {
+          id: agentMessageModelId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      }
+    );
+  }
+
+  /**
    * Recursively sums the `costCredits` of every sub-agent spawned by a single
    * origin agent message (one recursive query, `maxDepth`-bounded). Only counts
    * sub-agents whose triggering user message is a `run_agent` agentic origin
@@ -3141,7 +3181,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   // Return the latest run from an agent message. We accept all statuses as they all have valid
   // runIds that represent the actual latest run.
-  async getLatestAgentMessageRun(
+  async getLatestAgentMessageRuns(
     auth: Authenticator,
     {
       maxRank,
@@ -3150,7 +3190,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       maxRank?: number;
       transaction?: Transaction;
     } = {}
-  ): Promise<{ rank: number; run: RunResource } | null> {
+  ): Promise<{ rank: number; runs: RunResource[] } | null> {
     const owner = auth.getNonNullableWorkspace();
     const where: WhereOptions<MessageModel> = {
       conversationId: this.id,
@@ -3178,8 +3218,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return null;
     }
 
-    // The runIds array ordering is not guaranteed to be chronological. Fetch all runs and pick
-    // the most recently created one.
+    // The runIds array ordering is not guaranteed to be chronological. Fetch all runs and sort
+    // by creation date, most recent first.
     const runs = await RunResource.listByDustRunIds(auth, {
       dustRunIds: message.agentMessage.runIds,
     });
@@ -3190,8 +3230,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     return {
       rank: message.rank,
-      run: runs.reduce((latest, r) =>
-        r.createdAt > latest.createdAt ? r : latest
+      runs: [...runs].sort(
+        (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
       ),
     };
   }

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -16,6 +16,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { getRunExecutionsDeletionCutoffDate } from "@app/temporal/hard_delete/utils";
+import type { ImageModelIdType } from "@app/types/assistant/models/models";
 import type {
   ModelIdType,
   ModelProviderIdType,
@@ -226,7 +227,7 @@ export class RunResource extends BaseResource<RunModel> {
       runModelId: usage.runId,
       runKey: runKeyByModelId.get(usage.runId) ?? null,
       completionTokens: usage.completionTokens,
-      modelId: usage.modelId as ModelIdType,
+      modelId: usage.modelId as ModelIdType | ImageModelIdType,
       promptTokens: usage.promptTokens,
       providerId: usage.providerId as ModelProviderIdType,
       cachedTokens: usage.cachedTokens,
@@ -472,7 +473,7 @@ function addCreatedAtClause(where: WhereOptions<RunModel>) {
 
 export interface RunUsageType {
   completionTokens: number;
-  modelId: ModelIdType;
+  modelId: ModelIdType | ImageModelIdType;
   promptTokens: number;
   providerId: ModelProviderIdType;
   cachedTokens: number | null;

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -17,6 +17,7 @@ import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { getRunExecutionsDeletionCutoffDate } from "@app/temporal/hard_delete/utils";
 import type { ImageModelIdType } from "@app/types/assistant/models/models";
+import { isImageModelId, isModelId } from "@app/types/assistant/models/models";
 import type {
   ModelIdType,
   ModelProviderIdType,
@@ -223,18 +224,34 @@ export class RunResource extends BaseResource<RunModel> {
       },
     });
 
-    return usages.map((usage) => ({
-      runModelId: usage.runId,
-      runKey: runKeyByModelId.get(usage.runId) ?? null,
-      completionTokens: usage.completionTokens,
-      modelId: usage.modelId as ModelIdType | ImageModelIdType,
-      promptTokens: usage.promptTokens,
-      providerId: usage.providerId as ModelProviderIdType,
-      cachedTokens: usage.cachedTokens,
-      cacheCreationTokens: usage.cacheCreationTokens,
-      costMicroUsd: usage.costMicroUsd,
-      isBatch: usage.isBatch,
-    }));
+    return usages.flatMap((usage) => {
+      const { modelId } = usage;
+      if (!isModelId(modelId) && !isImageModelId(modelId)) {
+        // Write paths validate model IDs (see recordTokenUsage), so this only
+        // happens for historical rows whose model has since been removed from
+        // the configs (e.g. a deleted custom model).
+        logger.warn(
+          { modelId, runId: usage.runId },
+          "Run usage references an unknown model ID, skipping"
+        );
+        return [];
+      }
+
+      return [
+        {
+          runModelId: usage.runId,
+          runKey: runKeyByModelId.get(usage.runId) ?? null,
+          completionTokens: usage.completionTokens,
+          modelId,
+          promptTokens: usage.promptTokens,
+          providerId: usage.providerId as ModelProviderIdType,
+          cachedTokens: usage.cachedTokens,
+          cacheCreationTokens: usage.cacheCreationTokens,
+          costMicroUsd: usage.costMicroUsd,
+          isBatch: usage.isBatch,
+        },
+      ];
+    });
   }
 
   static async fetchByDustRunId(

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -18,6 +18,7 @@ import logger from "@app/logger/logger";
 import { getRunExecutionsDeletionCutoffDate } from "@app/temporal/hard_delete/utils";
 import type { ImageModelIdType } from "@app/types/assistant/models/models";
 import { isImageModelId, isModelId } from "@app/types/assistant/models/models";
+import { isModelProviderId } from "@app/types/assistant/models/providers";
 import type {
   ModelIdType,
   ModelProviderIdType,
@@ -225,14 +226,17 @@ export class RunResource extends BaseResource<RunModel> {
     });
 
     return usages.flatMap((usage) => {
-      const { modelId } = usage;
-      if (!isModelId(modelId) && !isImageModelId(modelId)) {
+      const { modelId, providerId } = usage;
+      if (
+        (!isModelId(modelId) && !isImageModelId(modelId)) ||
+        !isModelProviderId(providerId)
+      ) {
         // Write paths validate model IDs (see recordTokenUsage), so this only
-        // happens for historical rows whose model has since been removed from
-        // the configs (e.g. a deleted custom model).
+        // happens for historical rows whose model or provider has since been
+        // removed from the configs (e.g. a deleted custom model).
         logger.warn(
-          { modelId, runId: usage.runId },
-          "Run usage references an unknown model ID, skipping"
+          { modelId, providerId, runId: usage.runId },
+          "Run usage references an unknown model or provider ID, skipping"
         );
         return [];
       }
@@ -244,7 +248,7 @@ export class RunResource extends BaseResource<RunModel> {
           completionTokens: usage.completionTokens,
           modelId,
           promptTokens: usage.promptTokens,
-          providerId: usage.providerId as ModelProviderIdType,
+          providerId,
           cachedTokens: usage.cachedTokens,
           cacheCreationTokens: usage.cacheCreationTokens,
           costMicroUsd: usage.costMicroUsd,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -196,9 +196,9 @@ export async function runToolActivity(
     auth,
     actionId
   );
-  const toolRunIds = refreshedAction?.stepContext.runIds ?? [];
+  const toolRunIds = refreshedAction?.stepContext.toolRunIds ?? [];
 
-  return toolRunIds.length > 0 ? { ...result, runIds: toolRunIds } : result;
+  return toolRunIds.length > 0 ? { ...result, toolRunIds } : result;
 }
 
 async function executeToolStreaming(

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,4 +1,5 @@
 import { isAgentLoopToolNotificationEvent } from "@app/lib/actions/mcp";
+import { internalToolRecordsToolRuns } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { isLightClientSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
@@ -188,15 +189,24 @@ export async function runToolActivity(
     { asType: "tool" }
   );
 
-  // Tools may create their own LLM runs (e.g. image generation) and attach
-  // them to the action's stepContext during execution. Flow them back so the
-  // workflow accumulates them into the agent message runIds for usage
-  // tracking.
-  const refreshedAction = await AgentMCPActionResource.fetchByModelIdWithAuth(
-    auth,
-    actionId
-  );
-  const toolRunIds = refreshedAction?.stepContext.toolRunIds ?? [];
+  // Tools flagged with `recordsToolRuns` (e.g. image generation) create their
+  // own LLM runs during execution and attach them to the action's stepContext.
+  // Flow them back so the workflow accumulates them into the agent message
+  // runIds for usage tracking. Gated on the metadata flag so the common case
+  // pays no extra action fetch.
+  let toolRunIds: string[] = [];
+  if (
+    internalToolRecordsToolRuns(
+      action.toolConfiguration.mcpServerName,
+      action.toolConfiguration.originalName
+    )
+  ) {
+    const refreshedAction = await AgentMCPActionResource.fetchByModelIdWithAuth(
+      auth,
+      actionId
+    );
+    toolRunIds = refreshedAction?.stepContext.toolRunIds ?? [];
+  }
 
   return toolRunIds.length > 0 ? { ...result, toolRunIds } : result;
 }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -159,7 +159,7 @@ export async function runToolActivity(
       step: step + 1,
     });
 
-  return startActiveObservation(
+  const result = await startActiveObservation(
     `${action.toolConfiguration.mcpServerName}/${action.toolConfiguration.name}`,
     () => {
       updateActiveObservation(
@@ -187,6 +187,18 @@ export async function runToolActivity(
     },
     { asType: "tool" }
   );
+
+  // Tools may create their own LLM runs (e.g. image generation) and attach
+  // them to the action's stepContext during execution. Flow them back so the
+  // workflow accumulates them into the agent message runIds for usage
+  // tracking.
+  const refreshedAction = await AgentMCPActionResource.fetchByModelIdWithAuth(
+    auth,
+    actionId
+  );
+  const toolRunIds = refreshedAction?.stepContext.runIds ?? [];
+
+  return toolRunIds.length > 0 ? { ...result, runIds: toolRunIds } : result;
 }
 
 async function executeToolStreaming(

--- a/front/temporal/agent_loop/lib/deferred_events.ts
+++ b/front/temporal/agent_loop/lib/deferred_events.ts
@@ -53,5 +53,5 @@ export type ToolExecutionResult = {
   // Dust run IDs of LLM runs made by the tool itself (e.g. image generation),
   // accumulated by the workflow into the agent message runIds for usage
   // tracking.
-  runIds?: string[];
+  toolRunIds?: string[];
 };

--- a/front/temporal/agent_loop/lib/deferred_events.ts
+++ b/front/temporal/agent_loop/lib/deferred_events.ts
@@ -49,4 +49,9 @@ export type ToolExecutionResult = {
 
   // Whether this event should pause the agent loop until external action is taken.
   shouldPauseAgentLoop?: boolean;
+
+  // Dust run IDs of LLM runs made by the tool itself (e.g. image generation),
+  // accumulated by the workflow into the agent message runIds for usage
+  // tracking.
+  runIds?: string[];
 };

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -257,21 +257,23 @@ export async function agentLoopWorkflow({
 
         const stepStartTime = Date.now();
 
-        const { runId, shouldContinue } = await executeStepIteration({
-          authType,
-          agentLoopArgs: {
-            ...agentLoopArgs,
-            initialStartTime,
-          },
-          currentStep,
-          runIds,
-          startStep,
-        });
+        const { runId, toolRunIds, shouldContinue } =
+          await executeStepIteration({
+            authType,
+            agentLoopArgs: {
+              ...agentLoopArgs,
+              initialStartTime,
+            },
+            currentStep,
+            runIds,
+            startStep,
+          });
 
         // Update state with results.
         if (runId) {
           runIds.push(runId);
         }
+        runIds.push(...toolRunIds);
 
         metrics.logStepCompletion(
           agentMessageId,
@@ -423,6 +425,7 @@ async function executeStepIteration({
   startStep: number;
 }): Promise<{
   runId: string | null;
+  toolRunIds: string[];
   shouldContinue: boolean;
 }> {
   const result = await runModelAndCreateActionsActivity({
@@ -437,6 +440,7 @@ async function executeStepIteration({
     // Error occurred — no runId to capture.
     return {
       runId: null,
+      toolRunIds: [],
       shouldContinue: false,
     };
   }
@@ -447,6 +451,7 @@ async function executeStepIteration({
   if (actionBlobs.length === 0) {
     return {
       runId,
+      toolRunIds: [],
       // If runId is null that means we unpaused the loop with no new tools (eg: they were all
       // denied) and no LLM call, so we need to continue as the agent loop is not finished.
       shouldContinue: runId === null,
@@ -459,6 +464,7 @@ async function executeStepIteration({
   if (needsApproval) {
     return {
       runId,
+      toolRunIds: [],
       shouldContinue: false,
     };
   }
@@ -482,6 +488,10 @@ async function executeStepIteration({
     )
   );
 
+  // Collect LLM runs made by the tools themselves (e.g. image generation) so
+  // they are billed like any other LLM usage of the agent message.
+  const toolRunIds = toolResults.flatMap((result) => result.runIds ?? []);
+
   // Collect all deferred events from tool executions.
   const allDeferredEvents = toolResults.flatMap(
     (result) => result.deferredEvents
@@ -496,6 +506,7 @@ async function executeStepIteration({
       // Break the loop - workflow will be restarted externally once required action is completed.
       return {
         runId,
+        toolRunIds,
         shouldContinue: false,
       };
     }
@@ -503,6 +514,7 @@ async function executeStepIteration({
 
   return {
     runId,
+    toolRunIds,
     shouldContinue: !toolResults.some((result) => result.shouldPauseAgentLoop),
   };
 }

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -490,7 +490,7 @@ async function executeStepIteration({
 
   // Collect LLM runs made by the tools themselves (e.g. image generation) so
   // they are billed like any other LLM usage of the agent message.
-  const toolRunIds = toolResults.flatMap((result) => result.runIds ?? []);
+  const toolRunIds = toolResults.flatMap((result) => result.toolRunIds ?? []);
 
   // Collect all deferred events from tool executions.
   const allDeferredEvents = toolResults.flatMap(

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -530,6 +530,10 @@ export async function runSandboxChildToolWorkflow({
   actionModelId: number;
   step: number;
 }) {
+  // TODO(2026-07-07 IMG-BILLING): toolRunIds are intentionally dropped here —
+  // sandbox-child actions have no runIds accumulator to flow them into. If a
+  // run-recording tool (e.g. image generation) becomes reachable as a sandbox
+  // child, its runs must be merged into the parent agent message's runIds.
   const { deferredEvents } = await runToolActivity(authType, {
     actionId: actionModelId,
     runAgentArgs: agentLoopArgs,

--- a/front/types/assistant/models/models.ts
+++ b/front/types/assistant/models/models.ts
@@ -274,6 +274,9 @@ export const IMAGE_MODEL_IDS = [
 ] as const;
 
 export type ImageModelIdType = (typeof IMAGE_MODEL_IDS)[number];
+
+export const isImageModelId = (modelId: string): modelId is ImageModelIdType =>
+  IMAGE_MODEL_IDS.includes(modelId as ImageModelIdType);
 export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,


### PR DESCRIPTION
## Description

Currently, we do not bill LLM usage of image tool at all.
With the advent of credit-based pricing, it makes sense (and is desirable) to bill using the same logic, which means an all or nothing, we only bill if the img tool call was successful AND the agent-loop succeeded.

We do this by introducing runIds to tool call answer

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
