### PR TITLE
Truncate tool error message in 'Tool execution error' log

### DIFF
--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -193,10 +193,7 @@ function withToolLogging<T>(
           ),
           code: result.error.code,
           cause: result.error.cause
-            ? truncate(
-                errorToString(result.error.cause),
-                MAX_LOGGED_ERROR_MESSAGE_LENGTH
-              )
+            ? errorToString(result.error.cause)
             : undefined,
         },
       };

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -191,8 +191,13 @@ function withToolLogging<T>(
             result.error.message,
             MAX_LOGGED_ERROR_MESSAGE_LENGTH
           ),
-          tracked: result.error.tracked,
           code: result.error.code,
+          cause: result.error.cause
+            ? truncate(
+                errorToString(result.error.cause),
+                MAX_LOGGED_ERROR_MESSAGE_LENGTH
+              )
+            : undefined,
         },
       };
       if (result.error.tracked) {

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -14,6 +14,7 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { errorToString } from "@app/types/shared/utils/error_utils";
+import { truncate } from "@app/types/shared/utils/string_utils";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
@@ -21,6 +22,8 @@ import type {
   ServerNotification,
   ServerRequest,
 } from "@modelcontextprotocol/sdk/types.js";
+
+const MAX_LOGGED_ERROR_MESSAGE_LENGTH = 200;
 
 export function registerTool(
   auth: Authenticator,
@@ -183,7 +186,14 @@ function withToolLogging<T>(
       const logContext = {
         ...loggerArgs,
         duration: elapsed,
-        error: result.error,
+        error: {
+          message: truncate(
+            result.error.message,
+            MAX_LOGGED_ERROR_MESSAGE_LENGTH
+          ),
+          tracked: result.error.tracked,
+          code: result.error.code,
+        },
       };
       if (result.error.tracked) {
         logger.error(logContext, "Tool execution error");


### PR DESCRIPTION
## Description

The tool's error message can be very large, bloating our logs. This caps it at 200 chars in the `"Tool execution error"` log context in `wrappers.ts`, while preserving the `tracked` and `code` fields that were previously logged via pino's `err` serializer.
