### PR TITLE
feat: add governance page

### DIFF
--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -92,6 +92,13 @@ const BillingPage = withSuspense(
   () => import("@dust-tt/front/components/pages/workspace/billing/BillingPage"),
   "BillingPage"
 );
+const GovernancePage = withSuspense(
+  () =>
+    import(
+      "@dust-tt/front/components/pages/workspace/governance/GovernancePage"
+    ),
+  "GovernancePage"
+);
 
 export const adminRoutes: RouteObject[] = [
   {
@@ -101,6 +108,7 @@ export const adminRoutes: RouteObject[] = [
       { path: "members", element: <MembersPage /> },
       { path: "analytics", element: <AnalyticsPage /> },
       { path: "usage", element: <UsagePage /> },
+      { path: "governance", element: <GovernancePage /> },
     ],
   },
   {

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -32,6 +32,7 @@ import {
   Shapes,
   Stars02,
   Terminal,
+  Toggle01Left,
   Users01,
   Zap,
 } from "@dust-tt/sparkle";
@@ -91,6 +92,7 @@ export type SubNavigationAdminId =
   | "subscription"
   | "billing"
   | "workspace"
+  | "governance"
   | "workspace_branding"
   | "model_providers"
   | "members"
@@ -108,6 +110,7 @@ export const ADMIN_ROUTE_PATTERNS: Record<SubNavigationAdminId, string[]> = {
   members: ["/w/[wId]/members"],
   identity_and_provisioning: ["/w/[wId]/identity-and-provisioning"],
   workspace: ["/w/[wId]/workspace"],
+  governance: ["/w/[wId]/governance"],
   workspace_branding: ["/w/[wId]/brand"],
   model_providers: ["/w/[wId]/model-providers"],
   analytics: ["/w/[wId]/analytics"],
@@ -210,7 +213,7 @@ export const getTopNavigationTabs = (
     ref: spaceMenuButtonRef,
   });
 
-  if (isAdmin(owner) || isOnlyBusinessAdmin(owner)) {
+  if (isBusinessAdmin(owner)) {
     nav.push({
       id: "settings",
       label: "Admin",
@@ -221,6 +224,7 @@ export const getTopNavigationTabs = (
           "/w/[wId]/members",
           "/w/[wId]/identity-and-provisioning",
           "/w/[wId]/workspace",
+          "/w/[wId]/governance",
           "/w/[wId]/branding",
           "/w/[wId]/model-providers",
           "/w/[wId]/subscription",
@@ -297,6 +301,18 @@ export const subNavigationAdmin = ({
         current: isCurrent("workspace"),
         disabled: !hasAdminRole,
       },
+      ...(featureFlags.includes("admin_governance")
+        ? [
+            {
+              id: "governance" as const,
+              label: "Governance",
+              icon: Toggle01Left,
+              href: `/w/${owner.sId}/governance`,
+              current: isCurrent("governance"),
+              disabled: !hasBusinessAdminRole,
+            },
+          ]
+        : []),
       ...(featureFlags.includes("whitelabel_frames")
         ? [
             {

--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -1,0 +1,132 @@
+import { GovernanceSettingSection } from "@app/components/pages/workspace/governance/GovernanceSettingSection";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useGovernancePermissions } from "@app/lib/swr/governance";
+import { useGroups } from "@app/lib/swr/groups";
+import type {
+  GovernancePermission,
+  GroupPermissionResourceType,
+  PermissionType,
+} from "@app/types/group_permissions";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  ActionFrame,
+  Page,
+  PuzzlePiece01,
+  Robot,
+  Toggle01Left,
+} from "@dust-tt/sparkle";
+import groupBy from "lodash/groupBy";
+
+export type GovernanceSetting = GovernancePermission & {
+  label: string;
+  description: string;
+};
+
+const GOVERNANCE_SETTING_METADATA: Partial<
+  Record<
+    `${PermissionType}:${GroupPermissionResourceType}`,
+    { label: string; description: string }
+  >
+> = {
+  "create:agent": {
+    label: "Members can create agents",
+    description: "Build new agents in the Agent Builder",
+  },
+  "publish:agent": {
+    label: "Members can publish agents",
+    description: "Publish agents in the Agent Builder",
+  },
+  "create:skill": {
+    label: "Members can create skills",
+    description: "Build custom Skills",
+  },
+  "publish:skill": {
+    label: "Members can publish skills",
+    description: "Publish Skills workspace-wide for all members to use",
+  },
+  "invite:frame": {
+    label: "Members + email invites",
+    description:
+      "Frames can be shared with workspace members or via email invite",
+  },
+};
+
+function toGovernanceSettings(
+  permissions: GovernancePermission[]
+): GovernanceSetting[] {
+  return permissions
+    .map((permission): GovernanceSetting | null => {
+      const metadata =
+        GOVERNANCE_SETTING_METADATA[
+          `${permission.permissionType}:${permission.resourceType}`
+        ];
+      if (!metadata) {
+        return null;
+      }
+      return { ...permission, ...metadata };
+    })
+    .filter((setting): setting is GovernanceSetting => setting !== null);
+}
+
+function useUpdateGovernancePermission(owner: LightWorkspaceType) {
+  return (input: GovernancePermission) => {
+    return true;
+  };
+}
+
+export const GovernancePage = () => {
+  const owner = useWorkspace();
+  const { groups } = useGroups({ owner, kinds: ["provisioned"] });
+  const { governancePermissions, isLoading } = useGovernancePermissions(owner);
+  const onPermissionChange = useUpdateGovernancePermission(owner);
+
+  const governanceSettingsMap = groupBy(
+    toGovernanceSettings(governancePermissions),
+    "resourceType"
+  );
+
+  const agentSettings = governanceSettingsMap.agent ?? [];
+  const skillSettings = governanceSettingsMap.skill ?? [];
+  const frameSettings = governanceSettingsMap.frame ?? [];
+
+  if (isLoading) {
+    return (
+      <Page>
+        <Page.Header title="Governance" description="Loading..." />
+      </Page>
+    );
+  }
+
+  return (
+    <Page>
+      <Page.Header
+        title="Governance"
+        description="Control what members can create and publish. Use groups to grant exceptions."
+        icon={Toggle01Left}
+      />
+      <div className="flex w-full flex-col gap-8">
+        <GovernanceSettingSection
+          label="Agents"
+          icon={Robot}
+          governanceSettings={agentSettings}
+          groups={groups}
+          onPermissionChange={onPermissionChange}
+        />
+        <GovernanceSettingSection
+          label="Skills"
+          icon={PuzzlePiece01}
+          governanceSettings={skillSettings}
+          groups={groups}
+          onPermissionChange={onPermissionChange}
+        />
+        <GovernanceSettingSection
+          label="Frames"
+          icon={ActionFrame}
+          governanceSettings={frameSettings}
+          groups={groups}
+          onPermissionChange={onPermissionChange}
+        />
+      </div>
+    </Page>
+  );
+};

--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -1,12 +1,8 @@
 import { GovernanceSettingSection } from "@app/components/pages/workspace/governance/GovernanceSettingSection";
-import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useGovernancePermissions } from "@app/lib/swr/governance";
 import { useGroups } from "@app/lib/swr/groups";
-import type {
-  GovernancePermission,
-  GroupPermissionResourceType,
-  PermissionType,
-} from "@app/types/group_permissions";
+import type { GovernancePermission } from "@app/types/group_permissions";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   ActionFrame,
@@ -17,57 +13,6 @@ import {
 } from "@dust-tt/sparkle";
 import groupBy from "lodash/groupBy";
 
-export type GovernanceSetting = GovernancePermission & {
-  label: string;
-  description: string;
-};
-
-const GOVERNANCE_SETTING_METADATA: Partial<
-  Record<
-    `${PermissionType}:${GroupPermissionResourceType}`,
-    { label: string; description: string }
-  >
-> = {
-  "create:agent": {
-    label: "Members can create agents",
-    description: "Build new agents in the Agent Builder",
-  },
-  "publish:agent": {
-    label: "Members can publish agents",
-    description: "Publish agents in the Agent Builder",
-  },
-  "create:skill": {
-    label: "Members can create skills",
-    description: "Build custom Skills",
-  },
-  "publish:skill": {
-    label: "Members can publish skills",
-    description: "Publish Skills workspace-wide for all members to use",
-  },
-  "invite:frame": {
-    label: "Members + email invites",
-    description:
-      "Frames can be shared with workspace members or via email invite",
-  },
-};
-
-function toGovernanceSettings(
-  permissions: GovernancePermission[]
-): GovernanceSetting[] {
-  return permissions
-    .map((permission): GovernanceSetting | null => {
-      const metadata =
-        GOVERNANCE_SETTING_METADATA[
-          `${permission.permissionType}:${permission.resourceType}`
-        ];
-      if (!metadata) {
-        return null;
-      }
-      return { ...permission, ...metadata };
-    })
-    .filter((setting): setting is GovernanceSetting => setting !== null);
-}
-
 function useUpdateGovernancePermission(owner: LightWorkspaceType) {
   return (input: GovernancePermission) => {
     return true;
@@ -75,19 +20,46 @@ function useUpdateGovernancePermission(owner: LightWorkspaceType) {
 }
 
 export const GovernancePage = () => {
+  const { hasFeature } = useFeatureFlags();
+  const hasAdminGovernanceFeature = hasFeature("admin_governance");
+
   const owner = useWorkspace();
-  const { groups } = useGroups({ owner, kinds: ["provisioned"] });
-  const { governancePermissions, isLoading } = useGovernancePermissions(owner);
+  const { groups, isGroupsLoading } = useGroups({
+    owner,
+    kinds: ["provisioned"],
+  });
+  const { governancePermissions, isLoading: isGovernancePermissionsLoading } =
+    useGovernancePermissions(owner);
   const onPermissionChange = useUpdateGovernancePermission(owner);
 
-  const governanceSettingsMap = groupBy(
-    toGovernanceSettings(governancePermissions),
+  const isLoading = isGroupsLoading || isGovernancePermissionsLoading;
+
+  const governancePermissionsMap = groupBy(
+    governancePermissions,
     "resourceType"
   );
 
-  const agentSettings = governanceSettingsMap.agent ?? [];
-  const skillSettings = governanceSettingsMap.skill ?? [];
-  const frameSettings = governanceSettingsMap.frame ?? [];
+  const sections = [
+    {
+      label: "Agents",
+      icon: Robot,
+      governancePermissions: governancePermissionsMap.agent ?? [],
+    },
+    {
+      label: "Skills",
+      icon: PuzzlePiece01,
+      governancePermissions: governancePermissionsMap.skill ?? [],
+    },
+    {
+      label: "Frames",
+      icon: ActionFrame,
+      governancePermissions: governancePermissionsMap.frame ?? [],
+    },
+  ];
+
+  if (!hasAdminGovernanceFeature) {
+    return null;
+  }
 
   if (isLoading) {
     return (
@@ -105,27 +77,16 @@ export const GovernancePage = () => {
         icon={Toggle01Left}
       />
       <div className="flex w-full flex-col gap-8">
-        <GovernanceSettingSection
-          label="Agents"
-          icon={Robot}
-          governanceSettings={agentSettings}
-          groups={groups}
-          onPermissionChange={onPermissionChange}
-        />
-        <GovernanceSettingSection
-          label="Skills"
-          icon={PuzzlePiece01}
-          governanceSettings={skillSettings}
-          groups={groups}
-          onPermissionChange={onPermissionChange}
-        />
-        <GovernanceSettingSection
-          label="Frames"
-          icon={ActionFrame}
-          governanceSettings={frameSettings}
-          groups={groups}
-          onPermissionChange={onPermissionChange}
-        />
+        {sections.map((section) => (
+          <GovernanceSettingSection
+            key={section.label}
+            label={section.label}
+            icon={section.icon}
+            governancePermissions={section.governancePermissions}
+            groups={groups}
+            onPermissionChange={onPermissionChange}
+          />
+        ))}
       </div>
     </Page>
   );

--- a/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
@@ -1,32 +1,89 @@
-import type { GovernanceSetting } from "@app/components/pages/workspace/governance/GovernancePage";
 import { GroupSelector } from "@app/components/pages/workspace/governance/GroupSelector";
 import {
+  type GovernancePermission,
   type GovernancePermissionConfiguration,
+  type GroupPermissionResourceType,
   isValidPermissionConfigurationScope,
+  type PermissionType,
 } from "@app/types/group_permissions";
 import type { GroupType } from "@app/types/groups";
-import { ButtonsSwitch, ButtonsSwitchList, Page } from "@dust-tt/sparkle";
+import {
+  ButtonsSwitch,
+  ButtonsSwitchList,
+  ContentMessage,
+  Page,
+} from "@dust-tt/sparkle";
 import { useState } from "react";
 
+const GOVERNANCE_SETTING_METADATA: Partial<
+  Record<
+    `${PermissionType}:${GroupPermissionResourceType}`,
+    { label: string; description: string }
+  >
+> = {
+  "create:agent": {
+    label: "Members can create agents",
+    description: "Build new agents in the Agent Builder",
+  },
+  "publish:agent": {
+    label: "Members can publish agents",
+    description: "Publish agents in the Agent Builder",
+  },
+  "create:skill": {
+    label: "Members can create skills",
+    description: "Build custom Skills",
+  },
+  "publish:skill": {
+    label: "Members can publish skills",
+    description: "Publish Skills workspace-wide for all members to use",
+  },
+  "invite:frame": {
+    label: "Members + email invites",
+    description:
+      "Frames can be shared with workspace members or via email invite",
+  },
+};
+
+function getGovernancePermissionMetadata(
+  permissions: GovernancePermission
+): { label: string; description: string } | null {
+  const metadata =
+    GOVERNANCE_SETTING_METADATA[
+      `${permissions.permissionType}:${permissions.resourceType}`
+    ];
+
+  if (!metadata) {
+    return null;
+  }
+
+  return metadata;
+}
+
 interface GovernanceSettingRowProps {
-  governanceSetting: GovernanceSetting;
+  governancePermission: GovernancePermission;
   groups: GroupType[];
   onChange: (permission: GovernancePermissionConfiguration) => void;
 }
 
 export const GovernanceSettingRow = ({
-  governanceSetting,
+  governancePermission,
   groups,
   onChange,
 }: GovernanceSettingRowProps) => {
   const [configuration, setConfiguration] =
     useState<GovernancePermissionConfiguration>(
-      governanceSetting.configuration
+      governancePermission.configuration
     );
 
-  const selectedGroupIds = new Set(configuration.groupIds ?? []);
+  const metadata = getGovernancePermissionMetadata(governancePermission);
+
+  const selectedGroupIds = new Set(
+    configuration.scope === "groups" ? configuration.groupIds : []
+  );
   const selectedGroups = groups.filter((g) => selectedGroupIds.has(g.sId));
   const selectableGroups = groups.filter((g) => !selectedGroupIds.has(g.sId));
+
+  const hasMissingGroups = selectedGroups.length !== selectedGroupIds.size;
 
   const handlePermissionChange = ({
     scope,
@@ -39,21 +96,38 @@ export const GovernanceSettingRow = ({
       return;
     }
 
-    const newConfiguration: GovernancePermissionConfiguration = {
-      scope,
-      groupIds: scope === "groups" ? (groupIds ?? []) : [],
-    };
+    const newConfiguration: GovernancePermissionConfiguration =
+      scope === "groups" ? { scope, groupIds: groupIds ?? [] } : { scope };
     setConfiguration(newConfiguration);
     onChange(newConfiguration);
   };
+
+  if (!metadata) {
+    return null;
+  }
+
+  if (hasMissingGroups) {
+    return (
+      <div className="w-full p-4">
+        <ContentMessage
+          title="Invalid configuration"
+          variant="warning"
+          size="lg"
+        >
+          This setting references groups that have not been found. Please reload
+          the page.
+        </ContentMessage>
+      </div>
+    );
+  }
 
   return (
     <div className="w-full flex flex-col gap-3 p-4">
       <div className="flex w-full items-center gap-4 justify-between">
         <Page.Vertical gap="xs" sizing="grow">
-          <Page.H variant="h6">{governanceSetting.label}</Page.H>
+          <Page.H variant="h6">{metadata.label}</Page.H>
           <Page.P variant="secondary" size="sm">
-            {governanceSetting.description}
+            {metadata.description}
           </Page.P>
         </Page.Vertical>
         <ButtonsSwitchList

--- a/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
@@ -1,8 +1,8 @@
 import type { GovernanceSetting } from "@app/components/pages/workspace/governance/GovernancePage";
 import { GroupSelector } from "@app/components/pages/workspace/governance/GroupSelector";
 import {
-  type GovernanceSettingConfiguration,
-  isValidPermissionScope,
+  type GovernancePermissionConfiguration,
+  isValidPermissionConfigurationScope,
 } from "@app/types/group_permissions";
 import type { GroupType } from "@app/types/groups";
 import { ButtonsSwitch, ButtonsSwitchList, Page } from "@dust-tt/sparkle";
@@ -11,7 +11,7 @@ import { useState } from "react";
 interface GovernanceSettingRowProps {
   governanceSetting: GovernanceSetting;
   groups: GroupType[];
-  onChange: (permission: GovernanceSettingConfiguration) => void;
+  onChange: (permission: GovernancePermissionConfiguration) => void;
 }
 
 export const GovernanceSettingRow = ({
@@ -20,7 +20,9 @@ export const GovernanceSettingRow = ({
   onChange,
 }: GovernanceSettingRowProps) => {
   const [configuration, setConfiguration] =
-    useState<GovernanceSettingConfiguration>(governanceSetting.configuration);
+    useState<GovernancePermissionConfiguration>(
+      governanceSetting.configuration
+    );
 
   const selectedGroupIds = new Set(configuration.groupIds ?? []);
   const selectedGroups = groups.filter((g) => selectedGroupIds.has(g.sId));
@@ -33,11 +35,11 @@ export const GovernanceSettingRow = ({
     scope: string;
     groupIds?: string[];
   }) => {
-    if (!isValidPermissionScope(scope)) {
+    if (!isValidPermissionConfigurationScope(scope)) {
       return;
     }
 
-    const newConfiguration: GovernanceSettingConfiguration = {
+    const newConfiguration: GovernancePermissionConfiguration = {
       scope,
       groupIds: scope === "groups" ? (groupIds ?? []) : [],
     };
@@ -68,7 +70,9 @@ export const GovernanceSettingRow = ({
         <GroupSelector
           selectedGroups={selectedGroups}
           selectableGroups={selectableGroups}
-          onPermissionChange={handlePermissionChange}
+          onSelectionChange={(groupIds) =>
+            handlePermissionChange({ scope: "groups", groupIds })
+          }
         />
       )}
     </div>

--- a/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
@@ -1,0 +1,76 @@
+import type { GovernanceSetting } from "@app/components/pages/workspace/governance/GovernancePage";
+import { GroupSelector } from "@app/components/pages/workspace/governance/GroupSelector";
+import {
+  type GovernanceSettingConfiguration,
+  isValidPermissionScope,
+} from "@app/types/group_permissions";
+import type { GroupType } from "@app/types/groups";
+import { ButtonsSwitch, ButtonsSwitchList, Page } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface GovernanceSettingRowProps {
+  governanceSetting: GovernanceSetting;
+  groups: GroupType[];
+  onChange: (permission: GovernanceSettingConfiguration) => void;
+}
+
+export const GovernanceSettingRow = ({
+  governanceSetting,
+  groups,
+  onChange,
+}: GovernanceSettingRowProps) => {
+  const [configuration, setConfiguration] =
+    useState<GovernanceSettingConfiguration>(governanceSetting.configuration);
+
+  const selectedGroupIds = new Set(configuration.groupIds ?? []);
+  const selectedGroups = groups.filter((g) => selectedGroupIds.has(g.sId));
+  const selectableGroups = groups.filter((g) => !selectedGroupIds.has(g.sId));
+
+  const handlePermissionChange = ({
+    scope,
+    groupIds,
+  }: {
+    scope: string;
+    groupIds?: string[];
+  }) => {
+    if (!isValidPermissionScope(scope)) {
+      return;
+    }
+
+    const newConfiguration: GovernanceSettingConfiguration = {
+      scope,
+      groupIds: scope === "groups" ? (groupIds ?? []) : [],
+    };
+    setConfiguration(newConfiguration);
+    onChange(newConfiguration);
+  };
+
+  return (
+    <div className="w-full flex flex-col gap-3 p-4">
+      <div className="flex w-full items-center gap-4 justify-between">
+        <Page.Vertical gap="xs" sizing="grow">
+          <Page.H variant="h6">{governanceSetting.label}</Page.H>
+          <Page.P variant="secondary" size="sm">
+            {governanceSetting.description}
+          </Page.P>
+        </Page.Vertical>
+        <ButtonsSwitchList
+          size="xs"
+          defaultValue={configuration.scope}
+          onValueChange={(value) => handlePermissionChange({ scope: value })}
+        >
+          <ButtonsSwitch value="everyone" label="Everyone" />
+          <ButtonsSwitch value="groups" label="Groups" />
+          <ButtonsSwitch value="disabled" label="Disabled" />
+        </ButtonsSwitchList>
+      </div>
+      {configuration.scope === "groups" && (
+        <GroupSelector
+          selectedGroups={selectedGroups}
+          selectableGroups={selectableGroups}
+          onPermissionChange={handlePermissionChange}
+        />
+      )}
+    </div>
+  );
+};

--- a/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
@@ -1,0 +1,47 @@
+import type { GovernanceSetting } from "@app/components/pages/workspace/governance/GovernancePage";
+import { GovernanceSettingRow } from "@app/components/pages/workspace/governance/GovernanceSettingRow";
+import type { GovernancePermission } from "@app/types/group_permissions";
+import type { GroupType } from "@app/types/groups";
+import { Icon, Page } from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+
+interface GovernanceSettingSectionProps {
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  governanceSettings: GovernanceSetting[];
+  groups: GroupType[];
+  onPermissionChange: (input: GovernancePermission) => void;
+}
+
+export const GovernanceSettingSection = ({
+  label,
+  icon,
+  governanceSettings,
+  groups,
+  onPermissionChange,
+}: GovernanceSettingSectionProps) => {
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Icon visual={icon} className="text-muted-foreground" />
+        <Page.H variant="h5">{label}</Page.H>
+      </div>
+      <div className="w-full rounded-xl border border-border">
+        {governanceSettings.map((governanceSetting) => (
+          <GovernanceSettingRow
+            key={governanceSetting.label}
+            governanceSetting={governanceSetting}
+            groups={groups}
+            onChange={(newConfiguration) =>
+              onPermissionChange({
+                permissionType: governanceSetting.permissionType,
+                resourceType: governanceSetting.resourceType,
+                configuration: newConfiguration,
+              })
+            }
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
@@ -1,4 +1,3 @@
-import type { GovernanceSetting } from "@app/components/pages/workspace/governance/GovernancePage";
 import { GovernanceSettingRow } from "@app/components/pages/workspace/governance/GovernanceSettingRow";
 import type { GovernancePermission } from "@app/types/group_permissions";
 import type { GroupType } from "@app/types/groups";
@@ -8,7 +7,7 @@ import type { ComponentType } from "react";
 interface GovernanceSettingSectionProps {
   label: string;
   icon: ComponentType;
-  governanceSettings: GovernanceSetting[];
+  governancePermissions: GovernancePermission[];
   groups: GroupType[];
   onPermissionChange: (input: GovernancePermission) => void;
 }
@@ -16,7 +15,7 @@ interface GovernanceSettingSectionProps {
 export const GovernanceSettingSection = ({
   label,
   icon,
-  governanceSettings,
+  governancePermissions,
   groups,
   onPermissionChange,
 }: GovernanceSettingSectionProps) => {
@@ -27,15 +26,19 @@ export const GovernanceSettingSection = ({
         <Page.H variant="h5">{label}</Page.H>
       </div>
       <div className="w-full rounded-xl border border-border">
-        {governanceSettings.map((governanceSetting) => (
+        {governancePermissions.map((governancePermission) => (
           <GovernanceSettingRow
-            key={governanceSetting.label}
-            governanceSetting={governanceSetting}
+            key={
+              governancePermission.permissionType +
+              ":" +
+              governancePermission.resourceType
+            }
+            governancePermission={governancePermission}
             groups={groups}
             onChange={(newConfiguration) =>
               onPermissionChange({
-                permissionType: governanceSetting.permissionType,
-                resourceType: governanceSetting.resourceType,
+                permissionType: governancePermission.permissionType,
+                resourceType: governancePermission.resourceType,
                 configuration: newConfiguration,
               })
             }

--- a/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
@@ -7,7 +7,7 @@ import type { ComponentType } from "react";
 
 interface GovernanceSettingSectionProps {
   label: string;
-  icon: ComponentType<{ className?: string }>;
+  icon: ComponentType;
   governanceSettings: GovernanceSetting[];
   groups: GroupType[];
   onPermissionChange: (input: GovernancePermission) => void;

--- a/front/components/pages/workspace/governance/GroupSelector.tsx
+++ b/front/components/pages/workspace/governance/GroupSelector.tsx
@@ -40,7 +40,7 @@ export const GroupSelector = ({
             isSelect
           />
         </DropdownMenuTrigger>
-        <DropdownMenuContent>
+        <DropdownMenuContent className="min-w-[320px]" collisionPadding={8}>
           <DropdownMenuSearchbar
             name="group-search"
             placeholder="Search groups"

--- a/front/components/pages/workspace/governance/GroupSelector.tsx
+++ b/front/components/pages/workspace/governance/GroupSelector.tsx
@@ -1,0 +1,98 @@
+import type { GovernanceSettingConfiguration } from "@app/types/group_permissions";
+import type { GroupType } from "@app/types/groups";
+import {
+  Button,
+  Chip,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuTrigger,
+  Plus,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface GroupSelectorProps {
+  selectedGroups: GroupType[];
+  selectableGroups: GroupType[];
+  onPermissionChange: (input: GovernanceSettingConfiguration) => void;
+}
+
+export const GroupSelector = ({
+  selectedGroups,
+  selectableGroups,
+  onPermissionChange,
+}: GroupSelectorProps) => {
+  const [groupSearch, setGroupSearch] = useState("");
+  const filteredGroups = selectableGroups.filter((g) =>
+    g.name.toLowerCase().includes(groupSearch.toLowerCase())
+  );
+
+  const selectedGroupIds = selectedGroups.map((g) => g.sId);
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="xs"
+            icon={Plus}
+            label="Add a group"
+            isSelect
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuSearchbar
+            name="group-search"
+            placeholder="Search groups"
+            value={groupSearch}
+            onChange={setGroupSearch}
+            autoFocus
+          />
+          {filteredGroups.map((group) => (
+            <DropdownMenuItem
+              key={group.sId}
+              label={group.name}
+              endComponent={
+                <Chip
+                  label={
+                    group.kind === "provisioned" ? "Provisioned" : "Manual"
+                  }
+                  color={group.kind === "provisioned" ? "primary" : "highlight"}
+                  size="xs"
+                />
+              }
+              onClick={() =>
+                onPermissionChange({
+                  scope: "groups",
+                  groupIds: [...selectedGroupIds, group.sId],
+                })
+              }
+            />
+          ))}
+          {filteredGroups.length === 0 && (
+            <DropdownMenuItem
+              label={groupSearch ? "No groups found" : "All groups added"}
+              disabled
+            />
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {selectedGroups.map((group) => (
+        <span key={group.sId}>
+          <Chip
+            label={group.name}
+            size="xs"
+            color="highlight"
+            onRemove={() =>
+              onPermissionChange({
+                scope: "groups",
+                groupIds: selectedGroupIds.filter((id) => id !== group.sId),
+              })
+            }
+          />
+        </span>
+      ))}
+    </div>
+  );
+};

--- a/front/components/pages/workspace/governance/GroupSelector.tsx
+++ b/front/components/pages/workspace/governance/GroupSelector.tsx
@@ -75,18 +75,15 @@ export const GroupSelector = ({
         </DropdownMenuContent>
       </DropdownMenu>
       {selectedGroups.map((group) => (
-        <span key={group.sId}>
-          <Chip
-            label={group.name}
-            size="xs"
-            color="highlight"
-            onRemove={() =>
-              onSelectionChange(
-                selectedGroupIds.filter((id) => id !== group.sId)
-              )
-            }
-          />
-        </span>
+        <Chip
+          key={group.sId}
+          label={group.name}
+          size="xs"
+          color="highlight"
+          onRemove={() =>
+            onSelectionChange(selectedGroupIds.filter((id) => id !== group.sId))
+          }
+        />
       ))}
     </div>
   );

--- a/front/components/pages/workspace/governance/GroupSelector.tsx
+++ b/front/components/pages/workspace/governance/GroupSelector.tsx
@@ -1,4 +1,3 @@
-import type { GovernanceSettingConfiguration } from "@app/types/group_permissions";
 import type { GroupType } from "@app/types/groups";
 import {
   Button,
@@ -15,13 +14,13 @@ import { useState } from "react";
 interface GroupSelectorProps {
   selectedGroups: GroupType[];
   selectableGroups: GroupType[];
-  onPermissionChange: (input: GovernanceSettingConfiguration) => void;
+  onSelectionChange: (groupIds: string[]) => void;
 }
 
 export const GroupSelector = ({
   selectedGroups,
   selectableGroups,
-  onPermissionChange,
+  onSelectionChange,
 }: GroupSelectorProps) => {
   const [groupSearch, setGroupSearch] = useState("");
   const filteredGroups = selectableGroups.filter((g) =>
@@ -63,10 +62,7 @@ export const GroupSelector = ({
                 />
               }
               onClick={() =>
-                onPermissionChange({
-                  scope: "groups",
-                  groupIds: [...selectedGroupIds, group.sId],
-                })
+                onSelectionChange([...selectedGroupIds, group.sId])
               }
             />
           ))}
@@ -85,10 +81,9 @@ export const GroupSelector = ({
             size="xs"
             color="highlight"
             onRemove={() =>
-              onPermissionChange({
-                scope: "groups",
-                groupIds: selectedGroupIds.filter((id) => id !== group.sId),
-              })
+              onSelectionChange(
+                selectedGroupIds.filter((id) => id !== group.sId)
+              )
             }
           />
         </span>

--- a/front/lib/swr/governance.ts
+++ b/front/lib/swr/governance.ts
@@ -1,0 +1,40 @@
+import type { GovernancePermission } from "@app/types/group_permissions";
+import type { LightWorkspaceType } from "@app/types/user";
+
+export function useGovernancePermissions(owner: LightWorkspaceType): {
+  governancePermissions: GovernancePermission[];
+  isLoading: boolean;
+} {
+  const governancePermissions: GovernancePermission[] = [
+    {
+      permissionType: "create",
+      resourceType: "agent",
+      configuration: { scope: "everyone" },
+    },
+    {
+      permissionType: "publish",
+      resourceType: "agent",
+      configuration: { scope: "everyone" },
+    },
+    {
+      permissionType: "create",
+      resourceType: "skill",
+      configuration: { scope: "everyone" },
+    },
+    {
+      permissionType: "publish",
+      resourceType: "skill",
+      configuration: { scope: "everyone" },
+    },
+    {
+      permissionType: "invite",
+      resourceType: "frame",
+      configuration: { scope: "disabled" },
+    },
+  ];
+
+  return {
+    governancePermissions,
+    isLoading: false,
+  };
+}

--- a/front/lib/swr/governance.ts
+++ b/front/lib/swr/governance.ts
@@ -1,37 +1,39 @@
 import type { GovernancePermission } from "@app/types/group_permissions";
 import type { LightWorkspaceType } from "@app/types/user";
 
+const TEST_GOVERNANCE_PERMISSIONS: GovernancePermission[] = [
+  {
+    permissionType: "create",
+    resourceType: "agent",
+    configuration: { scope: "everyone" },
+  },
+  {
+    permissionType: "publish",
+    resourceType: "agent",
+    configuration: { scope: "everyone" },
+  },
+  {
+    permissionType: "create",
+    resourceType: "skill",
+    configuration: { scope: "everyone" },
+  },
+  {
+    permissionType: "publish",
+    resourceType: "skill",
+    configuration: { scope: "everyone" },
+  },
+  {
+    permissionType: "invite",
+    resourceType: "frame",
+    configuration: { scope: "disabled" },
+  },
+];
+
 export function useGovernancePermissions(owner: LightWorkspaceType): {
   governancePermissions: GovernancePermission[];
   isLoading: boolean;
 } {
-  const governancePermissions: GovernancePermission[] = [
-    {
-      permissionType: "create",
-      resourceType: "agent",
-      configuration: { scope: "everyone" },
-    },
-    {
-      permissionType: "publish",
-      resourceType: "agent",
-      configuration: { scope: "everyone" },
-    },
-    {
-      permissionType: "create",
-      resourceType: "skill",
-      configuration: { scope: "everyone" },
-    },
-    {
-      permissionType: "publish",
-      resourceType: "skill",
-      configuration: { scope: "everyone" },
-    },
-    {
-      permissionType: "invite",
-      resourceType: "frame",
-      configuration: { scope: "disabled" },
-    },
-  ];
+  const governancePermissions = TEST_GOVERNANCE_PERMISSIONS;
 
   return {
     governancePermissions,

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -51,3 +51,24 @@ export function isGroupPermissionResourceType(
     (resourceType) => resourceType === value
   );
 }
+
+const PERMISSION_SCOPES = ["everyone", "groups", "disabled"] as const;
+
+type PermissionScope = (typeof PERMISSION_SCOPES)[number];
+
+export const isValidPermissionScope = (
+  scope: string
+): scope is PermissionScope => {
+  return PERMISSION_SCOPES.some((validScope) => validScope === scope);
+};
+
+export type GovernanceSettingConfiguration = {
+  scope: PermissionScope;
+  groupIds?: string[];
+};
+
+export type GovernancePermission = {
+  permissionType: PermissionType;
+  resourceType: GroupPermissionResourceType;
+  configuration: GovernanceSettingConfiguration;
+};

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -69,10 +69,14 @@ export const isValidPermissionConfigurationScope = (
   );
 };
 
-export type GovernancePermissionConfiguration = {
-  scope: PermissionConfigurationScope;
-  groupIds?: string[];
-};
+export type GovernancePermissionConfiguration =
+  | {
+      scope: Extract<PermissionConfigurationScope, "groups">;
+      groupIds: string[];
+    }
+  | {
+      scope: Exclude<PermissionConfigurationScope, "groups">;
+    };
 
 export type GovernancePermission = {
   permissionType: PermissionType;

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -52,23 +52,30 @@ export function isGroupPermissionResourceType(
   );
 }
 
-const PERMISSION_SCOPES = ["everyone", "groups", "disabled"] as const;
+const PERMISSION_CONFIGURATION_SCOPES = [
+  "everyone",
+  "groups",
+  "disabled",
+] as const;
 
-type PermissionScope = (typeof PERMISSION_SCOPES)[number];
+type PermissionConfigurationScope =
+  (typeof PERMISSION_CONFIGURATION_SCOPES)[number];
 
-export const isValidPermissionScope = (
+export const isValidPermissionConfigurationScope = (
   scope: string
-): scope is PermissionScope => {
-  return PERMISSION_SCOPES.some((validScope) => validScope === scope);
+): scope is PermissionConfigurationScope => {
+  return PERMISSION_CONFIGURATION_SCOPES.some(
+    (validScope) => validScope === scope
+  );
 };
 
-export type GovernanceSettingConfiguration = {
-  scope: PermissionScope;
+export type GovernancePermissionConfiguration = {
+  scope: PermissionConfigurationScope;
   groupIds?: string[];
 };
 
 export type GovernancePermission = {
   permissionType: PermissionType;
   resourceType: GroupPermissionResourceType;
-  configuration: GovernanceSettingConfiguration;
+  configuration: GovernancePermissionConfiguration;
 };


### PR DESCRIPTION
## Description

This PR introduces a first version of the Governance page that allows business admins and admins to manage governance settings.

Known missing features to be done in followup PRs:
- use real hooks
- mobile responsiveness
- groups only sections
- copy
- loading state

Note that the prototype is using an old version of the design system.


https://github.com/user-attachments/assets/af638aa9-7cd6-4e61-8050-7096350201cc



## Tests

Manually.

## Risks
Low. The page is hidden behind the feature flag.

## Deploy Plan

Standard deployment.