### PR TITLE
[front] add logging for non supported file type

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -341,6 +341,17 @@ export async function processToolResults(
               file: fileUpsertResult.value,
             };
           } else {
+            localLogger.warn(
+              {
+                workspaceId: auth.getNonNullableWorkspace().sId,
+                conversationId: conversation.sId,
+                mimeType: block.resource.mimeType ?? null,
+                toolName: toolConfiguration.name,
+                serverName: toolConfiguration.mcpServerName,
+              },
+              "MCP tool returned an unsupported file type; embedding resource as tool output."
+            );
+
             const text =
               "text" in block.resource &&
               typeof block.resource.text === "string"

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -341,7 +341,7 @@ export async function processToolResults(
               file: fileUpsertResult.value,
             };
           } else {
-            localLogger.warn(
+            localLogger.info(
               {
                 workspaceId: auth.getNonNullableWorkspace().sId,
                 conversationId: conversation.sId,


### PR DESCRIPTION
## Description
This PR is a part of investing agent loop worker's OOM. What we noticed is that when a tool returns a file type we don't support, we embed base64 as a tool output which can be huge (we found the one that is almost 70mb). We first would like to understand which tools return what kind of unsupported file types. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
