### PR TITLE
fix(labs-transcripts): skip file instead of deleting schedule on config drift

### DIFF
--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -383,9 +383,8 @@ export async function processTranscriptActivity(
     if (!dataSourceViewId) {
       localLogger.error(
         {},
-        "[processTranscriptActivity] No datasource view id found. Stopping."
+        "[processTranscriptActivity] No datasource view id found. Skipping file."
       );
-      await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
       return;
     }
 
@@ -404,9 +403,8 @@ export async function processTranscriptActivity(
     if (!datasourceView) {
       localLogger.error(
         {},
-        "[processTranscriptActivity] No datasource view found. Stopping."
+        "[processTranscriptActivity] No datasource view found. Skipping file."
       );
-      await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
       return;
     }
 
@@ -414,9 +412,8 @@ export async function processTranscriptActivity(
     if (!canWrite) {
       localLogger.error(
         {},
-        "[processTranscriptActivity] User does not have permission to write to datasource view. Stopping."
+        "[processTranscriptActivity] User does not have permission to write to datasource view. Skipping file."
       );
-      await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
       return;
     }
 
@@ -425,9 +422,8 @@ export async function processTranscriptActivity(
     if (!dataSource) {
       localLogger.error(
         {},
-        "[processTranscriptActivity] No datasource found. Stopping."
+        "[processTranscriptActivity] No datasource found. Skipping file."
       );
-      await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
       return;
     }
 
@@ -495,10 +491,9 @@ export async function processTranscriptActivity(
     const { agentConfigurationId } = transcriptsConfiguration;
 
     if (!agentConfigurationId) {
-      await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
       localLogger.error(
         {},
-        "[processTranscriptActivity] No agent configuration id found. Stopping."
+        "[processTranscriptActivity] No agent configuration id found. Skipping file."
       );
       return;
     }
@@ -509,10 +504,9 @@ export async function processTranscriptActivity(
     });
 
     if (!agent) {
-      await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
       localLogger.error(
         {},
-        "[processTranscriptActivity] Agent configuration not found. Stopping."
+        "[processTranscriptActivity] Agent configuration not found. Skipping file."
       );
       return;
     }


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9004
Follow-up to https://github.com/dust-tt/dust/pull/28480.

processTranscriptActivity deleted the whole retrieval schedule when a single file could not be stored or processed (missing data source view, no write permission, missing data source, missing/archived agent). A transient permission/fetch blip or a since-removed resource would therefore permanently disable processing for the user with no auto-recovery. Replace the six per-file `stopRetrieveTranscriptsWorkflow() + return` blocks with a plain `return` (skip this file, log it). The schedule survives, so the file is retried on the next tick and recovers on its own once the underlying config issue is resolved. Logs updated from "Stopping." to "Skipping file." to match the new behavior. The remaining teardown calls (workspace/user/config not found) are left as-is: those reflect a genuinely orphaned config and are out of scope for this fix.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
