### PR TITLE
Pricing: Add a Coupons tab in billing to list redeemed coupons

### DIFF
--- a/front-api/routes/w/[wId]/coupon/index.ts
+++ b/front-api/routes/w/[wId]/coupon/index.ts
@@ -1,6 +1,7 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
 import redeem from "./redeem";
+import redemptions from "./redemptions";
 import validate from "./validate";
 
 // Mounted under /api/w/:wId/coupon.
@@ -8,5 +9,6 @@ const app = workspaceApp();
 
 app.route("/validate", validate);
 app.route("/redeem", redeem);
+app.route("/redemptions", redemptions);
 
 export default app;

--- a/front-api/routes/w/[wId]/coupon/redemptions.test.ts
+++ b/front-api/routes/w/[wId]/coupon/redemptions.test.ts
@@ -1,0 +1,269 @@
+import * as metronomeClient from "@app/lib/metronome/client";
+import { CURRENCY_TO_CREDIT_TYPE_ID } from "@app/lib/metronome/constants";
+import type { MetronomeCredit } from "@app/lib/metronome/types";
+import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import { CouponFactory } from "@app/tests/utils/CouponFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<typeof metronomeClient>(
+    "@app/lib/metronome/client"
+  );
+  return {
+    ...actual,
+    listMetronomeCustomerCredits: vi.fn(),
+  };
+});
+
+function redemptionsUrl(wId: string) {
+  return `/api/w/${wId}/coupon/redemptions`;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW_MS = Date.now();
+const TWO_MONTHS_AGO = new Date(NOW_MS - 60 * DAY_MS).toISOString();
+const ONE_MONTH_AGO = new Date(NOW_MS - 30 * DAY_MS).toISOString();
+const ONE_WEEK_AGO = new Date(NOW_MS - 7 * DAY_MS).toISOString();
+const NEXT_YEAR = new Date(NOW_MS + 365 * DAY_MS).toISOString();
+
+// A seat coupon credit in USD: Metronome amounts are already in cents.
+function makeSeatCouponCredit({
+  id,
+  amountCents,
+  balanceCents,
+  deductions,
+}: {
+  id: string;
+  amountCents: number;
+  balanceCents: number;
+  deductions: { amountCents: number; timestamp: string }[];
+}): MetronomeCredit {
+  return {
+    id,
+    type: "CREDIT",
+    product: { id: "product-seat-credits", name: "Seat subscription credits" },
+    balance: balanceCents,
+    access_schedule: {
+      credit_type: { id: CURRENCY_TO_CREDIT_TYPE_ID.usd, name: "USD (cents)" },
+      schedule_items: [
+        {
+          id: `${id}-item-0`,
+          amount: amountCents,
+          starting_at: TWO_MONTHS_AGO,
+          ending_before: NEXT_YEAR,
+        },
+      ],
+    },
+    ledger: [
+      {
+        type: "CREDIT_SEGMENT_START",
+        amount: amountCents,
+        segment_id: `${id}-segment`,
+        timestamp: TWO_MONTHS_AGO,
+      },
+      ...deductions.map((d) => ({
+        type: "CREDIT_AUTOMATED_INVOICE_DEDUCTION" as const,
+        amount: -d.amountCents,
+        invoice_id: "invoice-id",
+        segment_id: `${id}-segment`,
+        timestamp: d.timestamp,
+      })),
+    ],
+    name: "Coupon: SEAT500",
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(metronomeClient.listMetronomeCustomerCredits).mockResolvedValue(
+    new Ok([])
+  );
+});
+
+describe("GET /api/w/[wId]/coupon/redemptions", () => {
+  it("returns 403 when the caller is a user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(redemptionsUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+    expect(metronomeClient.listMetronomeCustomerCredits).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty list without calling Metronome when nothing was redeemed", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const response = await honoApp.request(redemptionsUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).coupons).toEqual([]);
+    expect(metronomeClient.listMetronomeCustomerCredits).not.toHaveBeenCalled();
+  });
+
+  it("returns credit pool top-up redemptions without calling Metronome", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    const { auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+      workspace,
+    });
+
+    const coupon = await CouponFactory.create({
+      discountType: "credit_pool_top_up",
+      amount: 1000,
+    });
+    const pending = await CouponRedemptionResource.createPending(auth, {
+      coupon,
+    });
+    if (pending.isErr()) {
+      throw pending.error;
+    }
+    await pending.value.markActive(["metronome-credit-topup"]);
+
+    const response = await honoApp.request(redemptionsUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.coupons).toEqual([
+      {
+        discountType: "credit_pool_top_up",
+        redemptionId: pending.value.sId,
+        code: coupon.code,
+        status: "active",
+        redeemedAtMs: pending.value.redeemedAt.getTime(),
+        amountCredits: 1000,
+      },
+    ]);
+    expect(metronomeClient.listMetronomeCustomerCredits).not.toHaveBeenCalled();
+  });
+
+  it("returns seat coupon redemptions with their consumption ledger, including revoked ones", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    const { auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+      workspace,
+    });
+
+    const activeCoupon = await CouponFactory.create({
+      discountType: "seat",
+      amount: 500,
+    });
+    const activePending = await CouponRedemptionResource.createPending(auth, {
+      coupon: activeCoupon,
+    });
+    if (activePending.isErr()) {
+      throw activePending.error;
+    }
+    await activePending.value.markActive(["credit-active"]);
+
+    const revokedCoupon = await CouponFactory.create({
+      discountType: "seat",
+      amount: 100,
+    });
+    const revokedPending = await CouponRedemptionResource.createPending(auth, {
+      coupon: revokedCoupon,
+    });
+    if (revokedPending.isErr()) {
+      throw revokedPending.error;
+    }
+    await revokedPending.value.markActive(["credit-revoked"]);
+    await revokedPending.value.markRevoked();
+
+    // A failed redemption must not be surfaced.
+    const failedCoupon = await CouponFactory.create({ discountType: "seat" });
+    const failedPending = await CouponRedemptionResource.createPending(auth, {
+      coupon: failedCoupon,
+    });
+    if (failedPending.isErr()) {
+      throw failedPending.error;
+    }
+    await failedPending.value.markFailed();
+
+    // The endpoint fetches each credit individually by id.
+    const creditsById: Record<string, MetronomeCredit> = {
+      "credit-active": makeSeatCouponCredit({
+        id: "credit-active",
+        amountCents: 50_000,
+        balanceCents: 42_000,
+        deductions: [
+          { amountCents: 4_000, timestamp: ONE_MONTH_AGO },
+          { amountCents: 4_000, timestamp: ONE_WEEK_AGO },
+        ],
+      }),
+      "credit-revoked": makeSeatCouponCredit({
+        id: "credit-revoked",
+        amountCents: 10_000,
+        balanceCents: 0,
+        deductions: [{ amountCents: 2_000, timestamp: ONE_MONTH_AGO }],
+      }),
+    };
+    vi.mocked(metronomeClient.listMetronomeCustomerCredits).mockImplementation(
+      async ({ creditId }) => {
+        const credit = creditId ? creditsById[creditId] : undefined;
+        return new Ok(credit ? [credit] : []);
+      }
+    );
+
+    const response = await honoApp.request(redemptionsUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.coupons).toHaveLength(2);
+
+    const active = body.coupons.find(
+      (c: { code: string }) => c.code === activeCoupon.code
+    );
+    expect(active).toEqual({
+      discountType: "seat",
+      redemptionId: activePending.value.sId,
+      code: activeCoupon.code,
+      status: "active",
+      redeemedAtMs: activePending.value.redeemedAt.getTime(),
+      totalAmountCents: 50_000,
+      remainingAmountCents: 42_000,
+      currency: "usd",
+      consumptions: [
+        {
+          timestampMs: new Date(ONE_MONTH_AGO).getTime(),
+          amountCents: 4_000,
+        },
+        { timestampMs: new Date(ONE_WEEK_AGO).getTime(), amountCents: 4_000 },
+      ],
+    });
+
+    const revoked = body.coupons.find(
+      (c: { code: string }) => c.code === revokedCoupon.code
+    );
+    expect(revoked).toEqual({
+      discountType: "seat",
+      redemptionId: revokedPending.value.sId,
+      code: revokedCoupon.code,
+      status: "revoked",
+      redeemedAtMs: revokedPending.value.redeemedAt.getTime(),
+      totalAmountCents: 10_000,
+      remainingAmountCents: 0,
+      currency: "usd",
+      consumptions: [
+        {
+          timestampMs: new Date(ONE_MONTH_AGO).getTime(),
+          amountCents: 2_000,
+        },
+      ],
+    });
+
+    // One targeted call per seat coupon credit.
+    expect(metronomeClient.listMetronomeCustomerCredits).toHaveBeenCalledTimes(
+      2
+    );
+  });
+});

--- a/front-api/routes/w/[wId]/coupon/redemptions.ts
+++ b/front-api/routes/w/[wId]/coupon/redemptions.ts
@@ -1,0 +1,52 @@
+import type { WorkspaceCouponsError } from "@app/lib/api/coupons";
+import { getWorkspaceCoupons } from "@app/lib/api/coupons";
+import type { GetWorkspaceCouponsResponseBody } from "@app/types/api/coupons";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+function couponsErrorToApi(ctx: Context, err: WorkspaceCouponsError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "credits_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome credits: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/w/:wId/coupon/redemptions.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetWorkspaceCouponsResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const result = await getWorkspaceCoupons(auth);
+    if (result.isErr()) {
+      return couponsErrorToApi(ctx, result.error);
+    }
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front/components/pages/workspace/billing/BillingPage.tsx
+++ b/front/components/pages/workspace/billing/BillingPage.tsx
@@ -2,6 +2,7 @@ import { BillingInformation } from "@app/components/workspace/billing/BillingInf
 import { BillingOverview } from "@app/components/workspace/billing/BillingOverview";
 import { BillingSeatsOverview } from "@app/components/workspace/billing/BillingSeatsOverview";
 import { BillingUpgrade } from "@app/components/workspace/billing/BillingUpgrade";
+import { CouponsList } from "@app/components/workspace/billing/CouponsList";
 import { FreePlanBilling } from "@app/components/workspace/billing/FreePlanBilling";
 import { NextInvoiceOverview } from "@app/components/workspace/billing/NextInvoiceOverview";
 import { NextInvoicePreview } from "@app/components/workspace/billing/NextInvoicePreview";
@@ -9,6 +10,7 @@ import { RecentInvoices } from "@app/components/workspace/billing/RecentInvoices
 import { SubscriptionProvider } from "@app/components/workspace/billing/SubscriptionContext";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { isCreditPricedFreePlan } from "@app/lib/plans/plan_codes";
+import { useWorkspaceCoupons } from "@app/lib/swr/workspaces";
 import {
   CreditCard01,
   Page,
@@ -21,6 +23,14 @@ import {
 export function BillingPage() {
   const { workspace: owner, subscription } = useAuth();
   const freePlan = isCreditPricedFreePlan(subscription.plan.code);
+
+  // The Coupons tab is only shown when the workspace has redeemed at least
+  // one coupon — most workspaces never do.
+  const { coupons } = useWorkspaceCoupons({
+    workspaceId: owner.sId,
+    disabled: freePlan,
+  });
+  const hasCoupons = coupons.length > 0;
 
   return (
     <Page.Vertical gap="xl" align="stretch">
@@ -40,6 +50,7 @@ export function BillingPage() {
                 label="Billing information"
               />
               <TabsTrigger value="invoices" label="Invoices" />
+              {hasCoupons && <TabsTrigger value="coupons" label="Coupons" />}
             </TabsList>
             <TabsContent value="billing-information">
               <div className="flex flex-col mt-8 gap-8">
@@ -58,6 +69,13 @@ export function BillingPage() {
                 <RecentInvoices />
               </div>
             </TabsContent>
+            {hasCoupons && (
+              <TabsContent value="coupons">
+                <div className="flex flex-col mt-8 gap-8">
+                  <CouponsList />
+                </div>
+              </TabsContent>
+            )}
           </Tabs>
         )}
       </SubscriptionProvider>

--- a/front/components/workspace/billing/CouponsList.tsx
+++ b/front/components/workspace/billing/CouponsList.tsx
@@ -1,0 +1,310 @@
+import { formatCredits } from "@app/lib/client/credits";
+import { formatCurrencyAmountCents } from "@app/lib/metronome/amounts";
+import { useWorkspaceCoupons } from "@app/lib/swr/workspaces";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type {
+  CreditPoolTopUpCouponData,
+  SeatCouponData,
+} from "@app/types/api/coupons";
+import type { SupportedCurrency } from "@app/types/currency";
+import {
+  ChevronDown,
+  ChevronRight,
+  Chip,
+  cn,
+  DataTable,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useState } from "react";
+import { useSubscriptionContext } from "./SubscriptionContext";
+
+interface CouponRow {
+  name: string;
+  redeemedOn: string;
+  amount: string;
+  remaining: string;
+  isRevoked?: boolean;
+  isBold?: boolean;
+  isGroup?: boolean;
+  isExpanded?: boolean;
+  isChild?: boolean;
+  onClick?: () => void;
+  menuItems?: never[];
+}
+
+function nameColumn(): ColumnDef<CouponRow> {
+  return {
+    accessorKey: "name",
+    header: "Coupon",
+    enableSorting: false,
+    meta: { className: "w-1/2" },
+    cell: ({ row }) => {
+      const { name, isRevoked, isGroup, isExpanded, isChild, isBold } =
+        row.original;
+      return (
+        <div
+          className={cn(
+            "flex items-center gap-3",
+            isGroup && "cursor-pointer",
+            isChild && "pl-5"
+          )}
+        >
+          <span
+            className={cn(
+              "text-sm",
+              isChild && "text-muted-foreground",
+              isBold && "font-semibold"
+            )}
+          >
+            {name}
+          </span>
+          {isRevoked ? (
+            <Chip label="Revoked" size="mini" color="warning" />
+          ) : null}
+          {isGroup ? (
+            isExpanded ? (
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            )
+          ) : null}
+        </div>
+      );
+    },
+  };
+}
+
+function redeemedOnColumn(): ColumnDef<CouponRow> {
+  return {
+    accessorKey: "redeemedOn",
+    header: "Redeemed on",
+    enableSorting: false,
+    meta: { className: "w-[18%]" },
+    cell: ({ row }) => (
+      <span className="text-sm text-muted-foreground">
+        {row.original.redeemedOn}
+      </span>
+    ),
+  };
+}
+
+function amountColumn(): ColumnDef<CouponRow> {
+  return {
+    accessorKey: "amount",
+    header: "Credits",
+    enableSorting: false,
+    meta: { headerAlign: "right", className: "w-[16%]" },
+    cell: ({ row }) => (
+      <span
+        className={cn(
+          "block text-right text-sm",
+          row.original.isChild && "text-muted-foreground"
+        )}
+      >
+        {row.original.amount}
+      </span>
+    ),
+  };
+}
+
+function remainingColumn(): ColumnDef<CouponRow> {
+  return {
+    accessorKey: "remaining",
+    header: "Remaining",
+    enableSorting: false,
+    meta: { headerAlign: "right", className: "w-[16%]" },
+    cell: ({ row }) => (
+      <span
+        className={cn(
+          "block text-right text-sm",
+          !row.original.isChild && "font-semibold"
+        )}
+      >
+        {row.original.remaining}
+      </span>
+    ),
+  };
+}
+
+const SEAT_COLUMNS: ColumnDef<CouponRow>[] = [
+  nameColumn(),
+  redeemedOnColumn(),
+  amountColumn(),
+  remainingColumn(),
+];
+
+const TOP_UP_COLUMNS: ColumnDef<CouponRow>[] = [
+  nameColumn(),
+  redeemedOnColumn(),
+  amountColumn(),
+];
+
+function formatRedeemedOn(redeemedAtMs: number): string {
+  return formatTimestampToFriendlyDate(redeemedAtMs, "compactWithDay");
+}
+
+function buildSeatRows(
+  coupons: SeatCouponData[],
+  expandedCoupons: Set<string>,
+  toggleCoupon: (redemptionId: string) => void
+): CouponRow[] {
+  const rows: CouponRow[] = [];
+  for (const coupon of coupons) {
+    const base = {
+      name: coupon.code,
+      redeemedOn: formatRedeemedOn(coupon.redeemedAtMs),
+      isRevoked: coupon.status === "revoked",
+      amount: formatCurrencyAmountCents({
+        amountCents: coupon.totalAmountCents,
+        currency: coupon.currency,
+      }),
+      remaining: formatCurrencyAmountCents({
+        amountCents: coupon.remainingAmountCents,
+        currency: coupon.currency,
+      }),
+    };
+
+    if (coupon.consumptions.length === 0) {
+      rows.push(base);
+      continue;
+    }
+
+    const isExpanded = expandedCoupons.has(coupon.redemptionId);
+    rows.push({
+      ...base,
+      isGroup: true,
+      isExpanded,
+      onClick: () => toggleCoupon(coupon.redemptionId),
+    });
+    if (isExpanded) {
+      for (const consumption of coupon.consumptions) {
+        rows.push({
+          name: formatTimestampToFriendlyDate(
+            consumption.timestampMs,
+            "compactWithDay"
+          ),
+          redeemedOn: "",
+          amount: `-${formatCurrencyAmountCents({
+            amountCents: consumption.amountCents,
+            currency: coupon.currency,
+          })}`,
+          remaining: "",
+          isChild: true,
+        });
+      }
+    }
+  }
+
+  // Total of the remaining money across seat coupons. Grouped by currency —
+  // in practice a workspace's coupons are all in its billing currency, so
+  // this renders a single line.
+  const remainingByCurrency = new Map<SupportedCurrency, number>();
+  for (const coupon of coupons) {
+    remainingByCurrency.set(
+      coupon.currency,
+      (remainingByCurrency.get(coupon.currency) ?? 0) +
+        coupon.remainingAmountCents
+    );
+  }
+  for (const [currency, remainingCents] of remainingByCurrency) {
+    rows.push({
+      name: "Total",
+      redeemedOn: "",
+      amount: "",
+      remaining: formatCurrencyAmountCents({
+        amountCents: remainingCents,
+        currency,
+      }),
+      isBold: true,
+    });
+  }
+
+  return rows;
+}
+
+function buildTopUpRows(coupons: CreditPoolTopUpCouponData[]): CouponRow[] {
+  return coupons.map((coupon) => ({
+    name: coupon.code,
+    redeemedOn: formatRedeemedOn(coupon.redeemedAtMs),
+    amount: `${formatCredits(coupon.amountCredits)} credits`,
+    remaining: "",
+    isRevoked: coupon.status === "revoked",
+  }));
+}
+
+export function CouponsList() {
+  const { owner } = useSubscriptionContext();
+  const [expandedCoupons, setExpandedCoupons] = useState<Set<string>>(
+    new Set()
+  );
+
+  const { coupons, isCouponsLoading } = useWorkspaceCoupons({
+    workspaceId: owner.sId,
+  });
+
+  if (isCouponsLoading) {
+    return (
+      <div className="w-full p-6">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (coupons.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        No coupons have been redeemed on this workspace.
+      </div>
+    );
+  }
+
+  const toggleCoupon = (redemptionId: string) => {
+    setExpandedCoupons((prev) => {
+      const next = new Set(prev);
+      if (next.has(redemptionId)) {
+        next.delete(redemptionId);
+      } else {
+        next.add(redemptionId);
+      }
+      return next;
+    });
+  };
+
+  const seatCoupons = coupons.filter(
+    (c): c is SeatCouponData => c.discountType === "seat"
+  );
+  const topUpCoupons = coupons.filter(
+    (c): c is CreditPoolTopUpCouponData =>
+      c.discountType === "credit_pool_top_up"
+  );
+
+  return (
+    <>
+      {seatCoupons.length > 0 && (
+        <div className="flex flex-col gap-4">
+          <h2 className="text-xl font-semibold text-foreground">
+            Seat coupons
+          </h2>
+          <DataTable
+            data={buildSeatRows(seatCoupons, expandedCoupons, toggleCoupon)}
+            columns={SEAT_COLUMNS}
+            hideRowDivider={false}
+          />
+        </div>
+      )}
+      {topUpCoupons.length > 0 && (
+        <div className="flex flex-col gap-4">
+          <h2 className="text-xl font-semibold text-foreground">
+            Credit top-ups
+          </h2>
+          <DataTable
+            data={buildTopUpRows(topUpCoupons)}
+            columns={TOP_UP_COLUMNS}
+            hideRowDivider={false}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/front/lib/api/coupons.ts
+++ b/front/lib/api/coupons.ts
@@ -1,0 +1,209 @@
+import type { Authenticator } from "@app/lib/auth";
+import { amountCents } from "@app/lib/metronome/amounts";
+import { listMetronomeCustomerCredits } from "@app/lib/metronome/client";
+import { CURRENCY_TO_CREDIT_TYPE_ID } from "@app/lib/metronome/constants";
+import type { MetronomeCredit } from "@app/lib/metronome/types";
+import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type {
+  GetWorkspaceCouponsResponseBody,
+  SeatCouponConsumptionData,
+  WorkspaceCouponData,
+  WorkspaceCouponStatus,
+} from "@app/types/api/coupons";
+import type { SupportedCurrency } from "@app/types/currency";
+import { isSupportedCurrency } from "@app/types/currency";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export class WorkspaceCouponsError extends Error {
+  constructor(
+    readonly type: "not_configured" | "credits_fetch_failed",
+    readonly cause?: Error
+  ) {
+    super(type);
+  }
+}
+
+function isWorkspaceCouponStatus(
+  status: string
+): status is WorkspaceCouponStatus {
+  return status === "active" || status === "revoked";
+}
+
+function currencyFromCreditTypeId(
+  creditTypeId: string | undefined
+): SupportedCurrency | null {
+  if (!creditTypeId) {
+    return null;
+  }
+  const entry = Object.entries(CURRENCY_TO_CREDIT_TYPE_ID).find(
+    ([, id]) => id === creditTypeId
+  );
+  if (!entry) {
+    return null;
+  }
+  const [currency] = entry;
+  return isSupportedCurrency(currency) ? currency : null;
+}
+
+// Aggregate the Metronome state of the credits granted by a seat coupon
+// redemption: total granted amount (access schedule), invoice deductions
+// (one per billing period) and remaining balance. Amounts are in cents.
+function summarizeSeatCouponCredits(credits: MetronomeCredit[]): {
+  currency: SupportedCurrency;
+  totalAmountCents: number;
+  remainingAmountCents: number;
+  consumptions: SeatCouponConsumptionData[];
+} | null {
+  const currency = currencyFromCreditTypeId(
+    credits[0]?.access_schedule?.credit_type?.id
+  );
+  if (!currency) {
+    return null;
+  }
+
+  let totalAmountCents = 0;
+  let remainingAmountCents = 0;
+  const consumptions: SeatCouponConsumptionData[] = [];
+  for (const credit of credits) {
+    // Note: use metronome for total and not DB to use a single source of truth.
+    for (const item of credit.access_schedule?.schedule_items ?? []) {
+      totalAmountCents += amountCents(item.amount, currency);
+    }
+    remainingAmountCents += amountCents(credit.balance ?? 0, currency);
+    for (const entry of credit.ledger ?? []) {
+      if (
+        entry.type === "CREDIT_AUTOMATED_INVOICE_DEDUCTION" &&
+        entry.amount < 0
+      ) {
+        consumptions.push({
+          timestampMs: new Date(entry.timestamp).getTime(),
+          amountCents: amountCents(-entry.amount, currency),
+        });
+      }
+    }
+  }
+
+  return {
+    currency,
+    totalAmountCents,
+    remainingAmountCents,
+    consumptions: consumptions.sort((a, b) => a.timestampMs - b.timestampMs),
+  };
+}
+
+/**
+ * List the coupons redeemed by the workspace (active and revoked) with their
+ * consumption state. Seat coupons are enriched with the Metronome ledger of
+ * the fiat credit they granted; credit pool top-up coupons only carry the
+ * redeemed AWU amount (their consumption happens in the shared pool).
+ *
+ * Fast return without calling metronome when no coupons.
+ */
+export async function getWorkspaceCoupons(
+  auth: Authenticator
+): Promise<Result<GetWorkspaceCouponsResponseBody, WorkspaceCouponsError>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const items = await CouponRedemptionResource.listByWorkspaceAndStatuses(
+    auth,
+    { statuses: ["active", "revoked"] }
+  );
+  if (items.length === 0) {
+    return new Ok({ coupons: [] });
+  }
+
+  const seatCreditIds = [
+    ...new Set(
+      items
+        .filter(({ coupon }) => coupon.discountType === "seat")
+        .flatMap(({ redemption }) => redemption.metronomeCreditIds)
+    ),
+  ];
+
+  // The Metronome list API only filters on a single credit id, so fetch each
+  // seat coupon credit (with its ledger) individually rather than paginating
+  // through all the customer credits. A workspace has at most a handful of
+  // seat coupon redemptions, so this stays a few small requests. Archived
+  // credits are included so revoked coupons keep their history.
+  const creditById = new Map<string, MetronomeCredit>();
+  if (seatCreditIds.length > 0) {
+    const { metronomeCustomerId } = workspace;
+    if (!metronomeCustomerId) {
+      return new Err(new WorkspaceCouponsError("not_configured"));
+    }
+    const creditsResults = await concurrentExecutor(
+      seatCreditIds,
+      (creditId) =>
+        listMetronomeCustomerCredits({
+          metronomeCustomerId,
+          creditId,
+          includeContractCredits: true,
+          includeBalance: true,
+          includeLedgers: true,
+          includeArchived: true,
+        }),
+      { concurrency: 4 }
+    );
+    for (const creditsResult of creditsResults) {
+      if (creditsResult.isErr()) {
+        return new Err(
+          new WorkspaceCouponsError("credits_fetch_failed", creditsResult.error)
+        );
+      }
+      for (const credit of creditsResult.value) {
+        creditById.set(credit.id, credit);
+      }
+    }
+  }
+
+  const coupons: WorkspaceCouponData[] = [];
+  for (const { redemption, coupon } of items) {
+    const { status } = redemption;
+    if (!isWorkspaceCouponStatus(status)) {
+      continue;
+    }
+    const base = {
+      redemptionId: redemption.sId,
+      code: coupon.code,
+      status,
+      redeemedAtMs: redemption.redeemedAt.getTime(),
+    };
+
+    switch (coupon.discountType) {
+      case "credit_pool_top_up":
+        coupons.push({
+          ...base,
+          discountType: "credit_pool_top_up",
+          amountCredits: coupon.amount,
+        });
+        break;
+      case "seat": {
+        const credits = redemption.metronomeCreditIds
+          .map((id) => creditById.get(id))
+          .filter((c): c is MetronomeCredit => c !== undefined);
+        const summary = summarizeSeatCouponCredits(credits);
+        if (!summary) {
+          logger.warn(
+            {
+              workspaceId: workspace.sId,
+              redemptionId: redemption.sId,
+              metronomeCreditIds: redemption.metronomeCreditIds,
+            },
+            "[Coupons] Seat coupon redemption has no resolvable Metronome credit"
+          );
+          break;
+        }
+        coupons.push({ ...base, discountType: "seat", ...summary });
+        break;
+      }
+      default:
+        assertNever(coupon.discountType);
+    }
+  }
+
+  return new Ok({ coupons });
+}

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -3167,12 +3167,16 @@ export async function listMetronomeCustomerCredits({
   creditId,
   includeContractCredits = false,
   includeBalance = false,
+  includeLedgers = false,
+  includeArchived = false,
   coveringDate,
 }: {
   metronomeCustomerId: string;
   creditId?: string;
   includeContractCredits?: boolean;
   includeBalance?: boolean;
+  includeLedgers?: boolean;
+  includeArchived?: boolean;
   coveringDate?: string;
 }): Promise<Result<Credit[], Error>> {
   try {
@@ -3183,6 +3187,8 @@ export async function listMetronomeCustomerCredits({
       ...(coveringDate ? { covering_date: coveringDate } : {}),
       include_contract_credits: includeContractCredits,
       include_balance: includeBalance,
+      ...(includeLedgers ? { include_ledgers: true } : {}),
+      ...(includeArchived ? { include_archived: true } : {}),
     })) {
       credits.push(entry);
     }

--- a/front/lib/resources/coupon_redemption_resource.ts
+++ b/front/lib/resources/coupon_redemption_resource.ts
@@ -150,9 +150,24 @@ export class CouponRedemptionResource extends BaseResource<CouponRedemptionModel
   ): Promise<
     Array<{ redemption: CouponRedemptionResource; couponCode: string }>
   > {
+    const items = await this.listByWorkspaceAndStatuses(auth, {
+      statuses: ["active"],
+    });
+    return items.map(({ redemption, coupon }) => ({
+      redemption,
+      couponCode: coupon.code,
+    }));
+  }
+
+  static async listByWorkspaceAndStatuses(
+    auth: Authenticator,
+    { statuses }: { statuses: CouponRedemptionStatus[] }
+  ): Promise<
+    Array<{ redemption: CouponRedemptionResource; coupon: CouponResource }>
+  > {
     const workspace = auth.getNonNullableWorkspace();
     const rows = await this.model.findAll({
-      where: { workspaceId: workspace.id, status: "active" },
+      where: { workspaceId: workspace.id, status: statuses },
       include: [
         { model: CouponModel, as: "coupon", required: true },
         { model: UserModel, as: "redeemedByUser", required: false },
@@ -165,7 +180,7 @@ export class CouponRedemptionResource extends BaseResource<CouponRedemptionModel
         couponSId: CouponResource.modelIdToSId({ id: r.couponId }),
         redeemedByUserSId: r.redeemedByUser?.sId ?? null,
       }),
-      couponCode: r.coupon.code,
+      coupon: new CouponResource(CouponResource.model, r.coupon.get()),
     }));
   }
 

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -54,6 +54,7 @@ import type {
 import type { GetBillingInfoResponseBody } from "@app/types/api/billing/info";
 import type { GetBillingInvoicesResponseBody } from "@app/types/api/billing/invoices";
 import type { GetPreparePaymentResponseBody } from "@app/types/api/checkout/prepare_payment";
+import type { GetWorkspaceCouponsResponseBody } from "@app/types/api/coupons";
 import type { GetMetronomeContractResponseBody } from "@app/types/api/credits/metronome_contract";
 import type { GetPendingInvitationsLookupResponseBody } from "@app/types/api/invitation";
 import type {
@@ -1353,6 +1354,33 @@ export function usePreparePayment({
       (!error && !data && !disabled && !!setupSessionId) ||
       (isPending && !pollTimedOut),
     isPreparePaymentError: !!error || pollTimedOut,
+  };
+}
+
+export function useWorkspaceCoupons({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const couponsFetcher: Fetcher<GetWorkspaceCouponsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/coupon/redemptions`,
+    couponsFetcher,
+    {
+      disabled,
+      revalidateOnFocus: false,
+    }
+  );
+
+  return {
+    coupons: data?.coupons ?? emptyArray(),
+    isCouponsLoading: !error && !data && !disabled,
+    isCouponsError: error,
+    mutateCoupons: mutate,
   };
 }
 

--- a/front/types/api/coupons.ts
+++ b/front/types/api/coupons.ts
@@ -1,0 +1,42 @@
+import type { SupportedCurrency } from "@app/types/currency";
+
+// Statuses surfaced to workspace admins in the Billing > Coupons tab. Pending
+// and failed redemptions are internal transient states and are not exposed.
+export type WorkspaceCouponStatus = "active" | "revoked";
+
+// One consumption of a seat coupon credit: the (negative) deduction applied to
+// an invoice for a billing period, surfaced as a positive amount.
+export interface SeatCouponConsumptionData {
+  timestampMs: number;
+  amountCents: number;
+}
+
+export interface SeatCouponData {
+  discountType: "seat";
+  redemptionId: string;
+  code: string;
+  status: WorkspaceCouponStatus;
+  redeemedAtMs: number;
+  totalAmountCents: number;
+  remainingAmountCents: number;
+  currency: SupportedCurrency;
+  consumptions: SeatCouponConsumptionData[];
+}
+
+// For "credit_pool_top_up" coupons the amount is in AWU credits (currency
+// independent) and consumption is tracked in the shared workspace pool, so
+// only the redeemed amount is surfaced.
+export interface CreditPoolTopUpCouponData {
+  discountType: "credit_pool_top_up";
+  redemptionId: string;
+  code: string;
+  status: WorkspaceCouponStatus;
+  redeemedAtMs: number;
+  amountCredits: number;
+}
+
+export type WorkspaceCouponData = SeatCouponData | CreditPoolTopUpCouponData;
+
+export interface GetWorkspaceCouponsResponseBody {
+  coupons: WorkspaceCouponData[];
+}


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9433

Add a tab to show the coupons redeemed and the remaining money on it, plus the invoiced period corresponding to the spending.
The tab is only shown to user with redeemed coupons.

Changes:
 - new API to retrieve the coupons: seat coupons fetches the data from metronome, and topup coupons are straightforward.
 - new endpoint + SWR + tests
 - new UI component

<img width="3428" height="1678" alt="image" src="https://github.com/user-attachments/assets/1bac2950-b364-46ae-9f3c-6ce89797854b" />

<img width="2356" height="1086" alt="image" src="https://github.com/user-attachments/assets/26432cd0-4c33-47bd-86f7-35c5a0c49ba4" />


Final design may be subject to change when looping back with design team.


## Tests

 - tested locally
 - added some unit test for the endpoint

## Risk

low

## Deploy Plan

deploy front
