### PR TITLE
[front] fix: move pods skill's instructions in system prompt within pods

### DIFF
--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -296,7 +296,7 @@ describe("getJITServers", () => {
       ).toBeUndefined();
     });
 
-    it("should enable projects skill in listForAgentLoop when feature flag is enabled and conversation is in a project", async () => {
+    it("auto-enables projects as a system skill when conversation is in a project", async () => {
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
       const conversationInProject = {
@@ -304,12 +304,16 @@ describe("getJITServers", () => {
         spaceId: conversationsSpace.sId,
       };
 
-      const { enabledSkills } = await SkillResource.listForAgentLoop(auth, {
-        agentConfiguration: agentConfig,
-        conversation: conversationInProject,
-      });
+      const { enabledSkills, systemSkills, equippedSkills } =
+        await SkillResource.listForAgentLoop(auth, {
+          agentConfiguration: agentConfig,
+          conversation: conversationInProject,
+        });
 
-      const projectsSkill = enabledSkills.find((s) => s.sId === "projects");
+      expect(enabledSkills.some((s) => s.sId === "projects")).toBe(false);
+      expect(equippedSkills.some((s) => s.sId === "projects")).toBe(false);
+
+      const projectsSkill = systemSkills.find((s) => s.sId === "projects");
       expect(projectsSkill).toBeDefined();
       const viewNames = projectsSkill?.mcpServerConfigurations.map((c) => {
         const json = c.view.toJSON();
@@ -318,13 +322,15 @@ describe("getJITServers", () => {
       expect(viewNames).toContain("pod_manager");
     });
 
-    it("should not enable projects skill in listForAgentLoop when conversation is not in a project", async () => {
-      const { enabledSkills } = await SkillResource.listForAgentLoop(auth, {
-        agentConfiguration: agentConfig,
-        conversation,
-      });
+    it("should not auto-enable projects skill when conversation is not in a project", async () => {
+      const { enabledSkills, systemSkills } =
+        await SkillResource.listForAgentLoop(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+        });
 
       expect(enabledSkills.some((s) => s.sId === "projects")).toBe(false);
+      expect(systemSkills.some((s) => s.sId === "projects")).toBe(false);
     });
 
     it("auto-equips the projects skill for any agent", async () => {

--- a/front/lib/resources/skill/code_defined/global_registry.ts
+++ b/front/lib/resources/skill/code_defined/global_registry.ts
@@ -3,8 +3,10 @@ import { activationSkill } from "@app/lib/resources/skill/code_defined/activatio
 import { framesSkill } from "@app/lib/resources/skill/code_defined/frames";
 import { goDeepSkill } from "@app/lib/resources/skill/code_defined/go_deep";
 import { mentionUsersSkill } from "@app/lib/resources/skill/code_defined/mention_users";
+import { podFunctionsSkill } from "@app/lib/resources/skill/code_defined/pod_functions";
 import { pptxSkill } from "@app/lib/resources/skill/code_defined/pptx";
 import { projectsSkill } from "@app/lib/resources/skill/code_defined/projects";
+import { sandboxSkill } from "@app/lib/resources/skill/code_defined/sandbox";
 import {
   ensureUniqueSIds,
   filterSkillDefinitions,
@@ -23,8 +25,10 @@ const GLOBAL_SKILLS_ARRAY = ensureUniqueSIds([
   framesSkill,
   goDeepSkill,
   mentionUsersSkill,
+  podFunctionsSkill,
   pptxSkill,
   projectsSkill,
+  sandboxSkill,
   skillAuthoringSkill,
   supportSkill,
   workspaceAnalyticsSkill,

--- a/front/lib/resources/skill/code_defined/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/pod_functions.ts
@@ -1,7 +1,7 @@
 import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import type { SystemSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import { isPodConversation } from "@app/types/assistant/conversation";
 
 export const podFunctionsSkill = {
@@ -81,4 +81,4 @@ function's contract before relying on it. See each tool's own description for it
     !isPodConversation(agentLoopData.conversation),
   // Equipped in Pod conversations but not auto-enabled.
   isAutoEquippedForAgentLoop: (): boolean => true,
-} as const satisfies SystemSkillDefinition;
+} as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -9,7 +9,7 @@ import {
 } from "@app/lib/api/sandbox/image";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import type { SystemSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { isPodConversation } from "@app/types/assistant/conversation";
@@ -391,4 +391,4 @@ export const sandboxSkill = {
 
     return !isComputerFeatureEnabled(flags);
   },
-} as const satisfies SystemSkillDefinition;
+} as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -71,7 +71,9 @@ export type SkillDefinition =
 
 export type GlobalSkillDefinition = SkillDefinition;
 // System skills have no definition of "equipped". When they are present they are directly part of the system prompt.
-export type SystemSkillDefinition = SkillDefinition & { isAutoEquippedForAgentLoop?: never };
+export type SystemSkillDefinition = SkillDefinition & {
+  isAutoEquippedForAgentLoop?: never;
+};
 
 // Helper function that enforces unique sIds.
 export function ensureUniqueSIds<T extends readonly SkillDefinition[]>(

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -70,7 +70,8 @@ export type SkillDefinition =
   | WithDynamicInstructions<BaseSkillDefinition>;
 
 export type GlobalSkillDefinition = SkillDefinition;
-export type SystemSkillDefinition = SkillDefinition;
+// System skills have no definition of "equipped". When they are present they are directly part of the system prompt.
+export type SystemSkillDefinition = SkillDefinition & { isAutoEquippedForAgentLoop?: never };
 
 // Helper function that enforces unique sIds.
 export function ensureUniqueSIds<T extends readonly SkillDefinition[]>(

--- a/front/lib/resources/skill/code_defined/system_registry.ts
+++ b/front/lib/resources/skill/code_defined/system_registry.ts
@@ -3,8 +3,6 @@ import { discoverKnowledgeSkill } from "@app/lib/resources/skill/code_defined/di
 import { discoverSkillsSkill } from "@app/lib/resources/skill/code_defined/discover_skills";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discover_tools";
 import { planModeSkill } from "@app/lib/resources/skill/code_defined/plan_mode";
-import { podFunctionsSkill } from "@app/lib/resources/skill/code_defined/pod_functions";
-import { sandboxSkill } from "@app/lib/resources/skill/code_defined/sandbox";
 import {
   ensureUniqueSIds,
   filterSkillDefinitions,
@@ -18,8 +16,6 @@ const SYSTEM_SKILLS_ARRAY = ensureUniqueSIds([
   discoverSkillsSkill,
   discoverToolsSkill,
   planModeSkill,
-  podFunctionsSkill,
-  sandboxSkill,
 ] as const);
 
 // Build lookup map for direct access by sId.

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1492,9 +1492,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const sortByName = (a: SkillResource, b: SkillResource) =>
       a.name.localeCompare(b.name);
-    const uniqueBySId = (skills: SkillResource[]) => [
-      ...new Map(skills.map((s) => [s.sId, s])).values(),
-    ];
 
     // System skills are always treated as enabled when present in the agent configuration.
     const configSystemSkills = allAgentSkills.filter((s) => s.isSystemSkill);
@@ -1556,10 +1553,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     // System skills and contextually auto-enabled code-defined skills land in `systemSkills`.
     // They are active for the current loop without being conversation-enabled records.
-    const systemSkills = uniqueBySId([
-      ...configSystemSkills,
-      ...autoEnabledSkills,
-    ]);
+    const systemSkills = [
+      ...new Map(
+        [...configSystemSkills, ...autoEnabledSkills].map((s) => [s.sId, s])
+      ).values(),
+    ];
 
     const enabledSkills = conversationEnabledSkills
       .filter(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1492,6 +1492,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const sortByName = (a: SkillResource, b: SkillResource) =>
       a.name.localeCompare(b.name);
+    const uniqueBySId = (skills: SkillResource[]) => [
+      ...new Map(skills.map((s) => [s.sId, s])).values(),
+    ];
 
     // System skills are always treated as enabled when present in the agent configuration.
     const configSystemSkills = allAgentSkills.filter((s) => s.isSystemSkill);
@@ -1510,32 +1513,22 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         conversation,
       })
     );
+    // Auto-enabled means "active for this loop", not "stored as enabled on the conversation".
+    // For example, Pods is system context inside a Pod conversation but a normal global skill
+    // elsewhere. Keep these IDs handy so existing agent/conversation references do not also
+    // appear as enabled/equipped candidates in the same loop.
     const autoEnabledGlobalSkillIds = new Set(
       autoEnabledDefs.map((def) => def.sId)
     );
-    const autoEnabledSkillsAlreadyLoaded = [
-      ...configSystemSkills,
-      ...conversationEnabledSkills,
-      ...allAgentSkills,
-    ].filter((s) => s.globalSId && autoEnabledGlobalSkillIds.has(s.globalSId));
-    const loadedAutoEnabledGlobalSkillIds = new Set(
-      removeNulls(autoEnabledSkillsAlreadyLoaded.map((s) => s.globalSId))
-    );
-    const autoEnabledRefs = autoEnabledDefs
-      .filter((def) => !loadedAutoEnabledGlobalSkillIds.has(def.sId))
-      .map((def) => ({ globalSkillId: def.sId, customSkillId: null }));
-    const fetchedAutoEnabledSkills = autoEnabledRefs.length
+    const autoEnabledRefs = autoEnabledDefs.map((def) => ({
+      globalSkillId: def.sId,
+      customSkillId: null,
+    }));
+    const autoEnabledSkills = autoEnabledRefs.length
       ? await this.fetchBySkillReferences(auth, autoEnabledRefs, {
           agentLoopData,
         })
       : [];
-    const autoEnabledSkills = [
-      ...new Map(
-        [...autoEnabledSkillsAlreadyLoaded, ...fetchedAutoEnabledSkills].map(
-          (s) => [s.sId, s]
-        )
-      ).values(),
-    ];
 
     const equippedGlobalSkillIds = new Set(
       removeNulls([
@@ -1563,11 +1556,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     // System skills and contextually auto-enabled code-defined skills land in `systemSkills`.
     // They are active for the current loop without being conversation-enabled records.
-    const systemSkills = [
-      ...new Map(
-        [...configSystemSkills, ...autoEnabledSkills].map((s) => [s.sId, s])
-      ).values(),
-    ];
+    const systemSkills = uniqueBySId([
+      ...configSystemSkills,
+      ...autoEnabledSkills,
+    ]);
 
     const enabledSkills = conversationEnabledSkills
       .filter(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1499,30 +1499,43 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // Code-defined skills can opt into being auto-equipped or auto-enabled for the agent loop
     // without being added to the agent configuration. `findAll` already drops restricted skills,
     // so a flag-gated skill only shows up once its feature flag is on.
-    const enabledGlobalSkillIds = new Set(
-      removeNulls([
-        ...configSystemSkills.map((s) => s.globalSId),
-        ...conversationEnabledSkills.map((s) => s.globalSId),
-      ])
-    );
     const codeDefinedDefs = [
       ...(await SystemSkillsRegistry.findAll(auth)),
       ...(await GlobalSkillsRegistry.findAll(auth)),
     ];
-    const autoEnabledRefs = codeDefinedDefs
-      .filter(
-        (def) =>
-          def.isAutoEnabledForAgentLoop?.({
-            agentConfiguration,
-            conversation,
-          }) && !enabledGlobalSkillIds.has(def.sId)
-      )
+
+    const autoEnabledDefs = codeDefinedDefs.filter((def) =>
+      def.isAutoEnabledForAgentLoop?.({
+        agentConfiguration,
+        conversation,
+      })
+    );
+    const autoEnabledGlobalSkillIds = new Set(
+      autoEnabledDefs.map((def) => def.sId)
+    );
+    const autoEnabledSkillsAlreadyLoaded = [
+      ...configSystemSkills,
+      ...conversationEnabledSkills,
+      ...allAgentSkills,
+    ].filter((s) => s.globalSId && autoEnabledGlobalSkillIds.has(s.globalSId));
+    const loadedAutoEnabledGlobalSkillIds = new Set(
+      removeNulls(autoEnabledSkillsAlreadyLoaded.map((s) => s.globalSId))
+    );
+    const autoEnabledRefs = autoEnabledDefs
+      .filter((def) => !loadedAutoEnabledGlobalSkillIds.has(def.sId))
       .map((def) => ({ globalSkillId: def.sId, customSkillId: null }));
-    const autoEnabledSkills = autoEnabledRefs.length
+    const fetchedAutoEnabledSkills = autoEnabledRefs.length
       ? await this.fetchBySkillReferences(auth, autoEnabledRefs, {
           agentLoopData,
         })
       : [];
+    const autoEnabledSkills = [
+      ...new Map(
+        [...autoEnabledSkillsAlreadyLoaded, ...fetchedAutoEnabledSkills].map(
+          (s) => [s.sId, s]
+        )
+      ).values(),
+    ];
 
     const equippedGlobalSkillIds = new Set(
       removeNulls([
@@ -1548,22 +1561,28 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         })
       : [];
 
-    // System skills land in `systemSkills` (always enabled); auto-enabled global skills join
-    // the conversation-enabled skills.
+    // System skills and contextually auto-enabled code-defined skills land in `systemSkills`.
+    // They are active for the current loop without being conversation-enabled records.
     const systemSkills = [
-      ...configSystemSkills,
-      ...autoEnabledSkills.filter((s) => s.isSystemSkill),
+      ...new Map(
+        [...configSystemSkills, ...autoEnabledSkills].map((s) => [s.sId, s])
+      ).values(),
     ];
 
-    const enabledSkills = [
-      ...conversationEnabledSkills,
-      ...autoEnabledSkills.filter((s) => !s.isSystemSkill),
-    ].sort(sortByName);
+    const enabledSkills = conversationEnabledSkills
+      .filter(
+        (s) => !s.globalSId || !autoEnabledGlobalSkillIds.has(s.globalSId)
+      )
+      .sort(sortByName);
 
-    // Compute the equipped skills: all non-system agent skills, auto-equipped skills,
-    // plus discoverable skills that are not already equipped. Keep this list stable
-    // even after a skill is enabled.
-    const agentEquippedSkills = allAgentSkills.filter((s) => !s.isSystemSkill);
+    // Compute the equipped skills: all non-system, non-auto-enabled agent skills,
+    // auto-equipped skills, plus discoverable skills that are not already equipped.
+    // Keep this list stable even after a skill is enabled explicitly.
+    const agentEquippedSkills = allAgentSkills.filter(
+      (s) =>
+        !s.isSystemSkill &&
+        (!s.globalSId || !autoEnabledGlobalSkillIds.has(s.globalSId))
+    );
 
     const agentEquippedSkillIds = new Set(
       [...agentEquippedSkills, ...autoEquippedSkills].map((s) => s.sId)

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1510,10 +1510,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         conversation,
       })
     );
-    // Auto-enabled means "active for this loop", not "stored as enabled on the conversation".
-    // For example, Pods is system context inside a Pod conversation but a normal global skill
-    // elsewhere. Keep these IDs handy so existing agent/conversation references do not also
-    // appear as enabled/equipped candidates in the same loop.
     const autoEnabledGlobalSkillIds = new Set(
       autoEnabledDefs.map((def) => def.sId)
     );
@@ -1551,23 +1547,25 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         })
       : [];
 
-    // System skills and contextually auto-enabled code-defined skills land in `systemSkills`.
-    // They are active for the current loop without being conversation-enabled records.
+    // Active baseline skills for this loop: configured system skills, plus code-defined
+    // skills that this context promotes to always-on system prompt content.
     const systemSkills = [
       ...new Map(
         [...configSystemSkills, ...autoEnabledSkills].map((s) => [s.sId, s])
       ).values(),
     ];
 
+    // Conversation-enabled skills are rendered after an enable_skill action. If the same
+    // code-defined skill is auto-enabled for this loop, systemSkills owns it instead.
     const enabledSkills = conversationEnabledSkills
       .filter(
         (s) => !s.globalSId || !autoEnabledGlobalSkillIds.has(s.globalSId)
       )
       .sort(sortByName);
 
-    // Compute the equipped skills: all non-system, non-auto-enabled agent skills,
-    // auto-equipped skills, plus discoverable skills that are not already equipped.
-    // Keep this list stable even after a skill is enabled explicitly.
+    // Equipped skills are the enable-able candidates shown to the model. Exclude anything
+    // already active as system prompt content, then add default/discoverable candidates
+    // without duplicating agent-provided ones.
     const agentEquippedSkills = allAgentSkills.filter(
       (s) =>
         !s.isSystemSkill &&

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1510,9 +1510,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         conversation,
       })
     );
-    const autoEnabledGlobalSkillIds = new Set(
-      autoEnabledDefs.map((def) => def.sId)
-    );
     const autoEnabledRefs = autoEnabledDefs.map((def) => ({
       globalSkillId: def.sId,
       customSkillId: null,
@@ -1522,6 +1519,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           agentLoopData,
         })
       : [];
+    const autoEnabledGlobalSkillIds = new Set(
+      autoEnabledSkills.map((s) => s.sId)
+    );
 
     const equippedGlobalSkillIds = new Set(
       removeNulls([


### PR DESCRIPTION
## Description

This PR fixes how pod's instructions are exposed to the model.

- Move pods instruction to the system prompt when in a pod (this is the only actual behavior change).
- Keep Pods available as a normal global skill outside Pod conversations (i.e. model sees it and can enable).
- Other unrelated janitorial work: keep auto-equipped skills like Computer and Pod Functions as global skills that the model can enable on demand (this was always the case and was the intent, it was just typed in a confusing way).

This PR is mostly about fixing the behavior for pods. A follow up refactor-only PR will move the files around and strengthen the contract. 

## Tests

- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
