### PR TITLE
fix(triggers): reconcile Temporal schedule when disabling triggers, even if already at target status

### DIFF
--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -294,4 +294,121 @@ describe("TriggerResource", () => {
       mockDeleteWorkflow.mockRestore();
     });
   });
+
+  describe("disable", () => {
+    it("re-attempts schedule removal even when already disabled", async () => {
+      const mockCreateOrUpdateWorkflow = vi
+        .spyOn(temporalClient, "createOrUpdateAgentSchedule")
+        .mockResolvedValue(new Ok("workflow-id"));
+      const mockDeleteWorkflow = vi
+        .spyOn(temporalClient, "deleteTriggerSchedule")
+        .mockResolvedValue(new Ok(undefined));
+
+      const { workspace, authenticator } = await createResourceTest({
+        role: "admin",
+      });
+
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+
+      const triggerResult = await TriggerResource.makeNew(authenticator, {
+        id: 200,
+        workspaceId: workspace.id,
+        name: "Schedule Trigger",
+        kind: "schedule",
+        agentConfigurationId: agentConfig.sId,
+        editor: authenticator.getNonNullableUser().id,
+        customPrompt: null,
+        status: "enabled",
+        configuration: {
+          cron: "0 9 * * 1",
+          timezone: "UTC",
+        },
+        origin: "user",
+      });
+      expect(triggerResult.isOk()).toBe(true);
+      if (triggerResult.isErr()) {
+        throw new Error("Failed to create test trigger");
+      }
+      const trigger = triggerResult.value;
+
+      // First disable: flips status and removes the schedule.
+      const first = await trigger.disable(authenticator);
+      expect(first.isOk()).toBe(true);
+      expect(trigger.status).toBe("disabled");
+      expect(mockDeleteWorkflow).toHaveBeenCalledTimes(1);
+
+      // Second disable on an already-disabled trigger: must still reconcile the
+      // Temporal schedule (this is what self-heals an orphaned schedule left by
+      // a previously failed removal).
+      mockDeleteWorkflow.mockClear();
+      const second = await trigger.disable(authenticator);
+      expect(second.isOk()).toBe(true);
+      expect(mockDeleteWorkflow).toHaveBeenCalledTimes(1);
+
+      mockCreateOrUpdateWorkflow.mockRestore();
+      mockDeleteWorkflow.mockRestore();
+    });
+  });
+
+  describe("disableMany", () => {
+    it("reconciles schedules for triggers already at the target status", async () => {
+      const mockCreateOrUpdateWorkflow = vi
+        .spyOn(temporalClient, "createOrUpdateAgentSchedule")
+        .mockResolvedValue(new Ok("workflow-id"));
+      const mockDeleteWorkflow = vi
+        .spyOn(temporalClient, "deleteTriggerSchedule")
+        .mockResolvedValue(new Ok(undefined));
+
+      const { workspace, authenticator } = await createResourceTest({
+        role: "admin",
+      });
+
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+
+      // A trigger whose status was already flipped to disabled, but whose
+      // schedule removal previously failed and was swallowed.
+      const triggerResult = await TriggerResource.makeNew(authenticator, {
+        id: 201,
+        workspaceId: workspace.id,
+        name: "Already Disabled Trigger",
+        kind: "schedule",
+        agentConfigurationId: agentConfig.sId,
+        editor: authenticator.getNonNullableUser().id,
+        customPrompt: null,
+        status: "disabled",
+        configuration: {
+          cron: "0 9 * * 1",
+          timezone: "UTC",
+        },
+        origin: "user",
+      });
+      expect(triggerResult.isOk()).toBe(true);
+      if (triggerResult.isErr()) {
+        throw new Error("Failed to create test trigger");
+      }
+      const trigger = triggerResult.value;
+
+      mockDeleteWorkflow.mockClear();
+
+      // disableMany used to early-return when every trigger was already at the
+      // target status, leaving the orphaned schedule alive. It must now still
+      // reconcile the Temporal schedule.
+      const result = await TriggerResource.disableMany(
+        authenticator,
+        [trigger],
+        "disabled"
+      );
+      expect(result.isOk()).toBe(true);
+      expect(mockDeleteWorkflow).toHaveBeenCalledTimes(1);
+
+      mockCreateOrUpdateWorkflow.mockRestore();
+      mockDeleteWorkflow.mockRestore();
+    });
+  });
 });

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -533,23 +533,25 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       return new Ok(undefined);
     }
 
-    // Only disable enabled triggers
-    const enabledTriggers = triggers.filter((t) => t.status === "enabled");
-    if (enabledTriggers.length === 0) {
-      return new Ok(undefined);
-    }
-
-    const disabledTriggersResult = await concurrentExecutor(
-      enabledTriggers,
-      async (trigger) => trigger.disable(auth, targetStatus),
+    // Enabled triggers get the full disable (status flip + schedule removal).
+    // Triggers already in a non-enabled status keep their status but still have
+    // their Temporal schedule reconciled: a prior run may have flipped the
+    // status yet failed to remove the schedule (the error is logged and
+    // swallowed), leaving an orphaned schedule that keeps firing.
+    // removeTemporalWorkflow is idempotent, so this is a no-op once the schedule
+    // is gone.
+    const results = await concurrentExecutor(
+      triggers,
+      async (trigger) =>
+        trigger.status === "enabled"
+          ? trigger.disable(auth, targetStatus)
+          : trigger.removeTemporalWorkflow(auth),
       {
         concurrency: 10,
       }
     );
 
-    const failuresCount = disabledTriggersResult.filter((res) =>
-      res.isErr()
-    ).length;
+    const failuresCount = results.filter((res) => res.isErr()).length;
 
     if (failuresCount > 0) {
       return new Err(new Error(`Failed to disable ${failuresCount} triggers`));
@@ -754,47 +756,49 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     auth: Authenticator,
     targetStatus: Exclude<TriggerStatus, "enabled"> = "disabled"
   ): Promise<Result<undefined, Error>> {
-    if (this.status === targetStatus) {
-      return new Ok(undefined);
+    // Even when the status is already the target, we still reconcile the
+    // Temporal workflow below: a previous disable may have flipped the status
+    // but failed (or been interrupted) before removing the schedule, leaving an
+    // orphaned schedule that keeps firing. removeTemporalWorkflow is idempotent.
+    if (this.status !== targetStatus) {
+      const previousStatus = this.status;
+
+      try {
+        await this.update({ status: targetStatus });
+      } catch (error) {
+        return new Err(normalizeError(error));
+      }
+
+      logger.info(
+        {
+          triggerId: this.sId,
+          triggerName: this.name,
+          triggerKind: this.kind,
+          previousStatus,
+          newStatus: targetStatus,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          agentConfigurationId: this.agentConfigurationId,
+          editorId: this.editor,
+        },
+        `Trigger status changed: ${targetStatus}`
+      );
+
+      void emitAuditLogEvent({
+        auth,
+        action: "trigger.disabled",
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("trigger", {
+            sId: this.sId,
+            name: this.name,
+          }),
+        ],
+        metadata: {
+          trigger_type: this.kind,
+          agent_id: this.agentConfigurationId,
+        },
+      });
     }
-
-    const previousStatus = this.status;
-
-    try {
-      await this.update({ status: targetStatus });
-    } catch (error) {
-      return new Err(normalizeError(error));
-    }
-
-    logger.info(
-      {
-        triggerId: this.sId,
-        triggerName: this.name,
-        triggerKind: this.kind,
-        previousStatus,
-        newStatus: targetStatus,
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        agentConfigurationId: this.agentConfigurationId,
-        editorId: this.editor,
-      },
-      `Trigger status changed: ${targetStatus}`
-    );
-
-    void emitAuditLogEvent({
-      auth,
-      action: "trigger.disabled",
-      targets: [
-        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-        buildAuditLogTarget("trigger", {
-          sId: this.sId,
-          name: this.name,
-        }),
-      ],
-      metadata: {
-        trigger_type: this.kind,
-        agent_id: this.agentConfigurationId,
-      },
-    });
 
     // Remove the temporal workflow
     const r = await this.removeTemporalWorkflow(auth);
@@ -813,21 +817,24 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     const workspace = auth.getNonNullableWorkspace();
 
     const toUpdate = triggers.filter((t) => t.status !== targetStatus);
-    if (toUpdate.length === 0) {
-      return new Ok(undefined);
+    if (toUpdate.length > 0) {
+      await this.model.update(
+        { status: targetStatus },
+        {
+          where: {
+            id: { [Op.in]: toUpdate.map((t) => t.id) },
+            workspaceId: workspace.id,
+          },
+        }
+      );
     }
 
-    await this.model.update(
-      { status: targetStatus },
-      {
-        where: {
-          id: { [Op.in]: toUpdate.map((t) => t.id) },
-          workspaceId: workspace.id,
-        },
-      }
-    );
-
-    for (const trigger of toUpdate) {
+    // Reconcile the Temporal schedule for every trigger, including those already
+    // at the target status: a prior run may have flipped the status but failed
+    // to remove the schedule (the error is logged and swallowed below), leaving
+    // an orphaned schedule that keeps firing. removeTemporalWorkflow is
+    // idempotent, so this is a no-op once the schedule is gone.
+    for (const trigger of triggers) {
       const r = await trigger.removeTemporalWorkflow(auth);
       if (r.isErr()) {
         logger.error(


### PR DESCRIPTION
## Description

Disabling a trigger updates the DB, then removes the temporal schedule. If the schedule removal fails, it is impossible to heal because any code path to clean short circuit on the DB status.

This makes sure we retry removing the temporal schedules even when the db status is disabled.

## Tests

Unit
## Risk

Low

## Deploy Plan

Front