### PR TITLE
[front] fix: deduplicate Go Deep company data tools

### DIFF
--- a/front/lib/api/assistant/skill_actions.test.ts
+++ b/front/lib/api/assistant/skill_actions.test.ts
@@ -1,0 +1,55 @@
+import { deduplicateMCPServerConfigurations } from "@app/lib/actions/mcp_actions";
+import { isServerSideMCPServerConfigurationWithName } from "@app/lib/actions/types/guards";
+import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { describe, expect, it } from "vitest";
+
+describe("getSkillServers", () => {
+  it("deduplicates shared company data tools from Discover Knowledge and Go Deep", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    await MCPServerViewResource.ensureAllAutoToolsAreCreated(authenticator);
+
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const skills = await SkillResource.fetchByIds(authenticator, [
+      "discover_knowledge",
+      "go-deep",
+    ]);
+
+    const skillServers = await getSkillServers(authenticator, {
+      agentConfiguration,
+      skills,
+    });
+
+    const fileSystemServers = skillServers.filter((server) =>
+      isServerSideMCPServerConfigurationWithName(
+        server,
+        "data_sources_file_system"
+      )
+    );
+    expect(fileSystemServers).toHaveLength(2);
+    expect(fileSystemServers.map((server) => server.name)).toEqual([
+      "company_data",
+      "company_data",
+    ]);
+
+    const deduplicatedServers = deduplicateMCPServerConfigurations({
+      agentActions: [],
+      clientSideActions: [],
+      skillServers,
+      jitServers: [],
+    });
+
+    const deduplicatedFileSystemServers = deduplicatedServers.filter((server) =>
+      isServerSideMCPServerConfigurationWithName(
+        server,
+        "data_sources_file_system"
+      )
+    );
+    expect(deduplicatedFileSystemServers).toHaveLength(1);
+    expect(deduplicatedFileSystemServers[0].name).toBe("company_data");
+  });
+});

--- a/front/lib/api/assistant/skill_actions.test.ts
+++ b/front/lib/api/assistant/skill_actions.test.ts
@@ -1,6 +1,7 @@
 import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
 import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SKILL_COMPANY_DATA_SERVER_NAME } from "@app/lib/resources/skill/code_defined/shared";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -75,20 +76,22 @@ describe("resolveSkillMCPServers", () => {
     const serverNames = serverToolsAndInstructions.map(
       ({ serverName }) => serverName
     );
-    expect(serverNames).toContain("company_data");
+    expect(serverNames).toContain(SKILL_COMPANY_DATA_SERVER_NAME);
     expect(serverNames).not.toContain("data_sources_file_system");
 
     const companyDataTools = serverToolsAndInstructions
-      .filter(({ serverName }) => serverName === "company_data")
+      .filter(({ serverName }) => serverName === SKILL_COMPANY_DATA_SERVER_NAME)
       .flatMap(({ tools }) => tools);
     expect(companyDataTools.map((tool) => tool.name)).toEqual(
       expect.arrayContaining([
-        "company_data__cat",
-        "company_data__semantic_search",
+        `${SKILL_COMPANY_DATA_SERVER_NAME}__cat`,
+        `${SKILL_COMPANY_DATA_SERVER_NAME}__semantic_search`,
       ])
     );
     expect(
-      companyDataTools.filter((tool) => tool.name === "company_data__cat")
+      companyDataTools.filter(
+        (tool) => tool.name === `${SKILL_COMPANY_DATA_SERVER_NAME}__cat`
+      )
     ).toHaveLength(1);
     expect(
       serverToolsAndInstructions

--- a/front/lib/api/assistant/skill_actions.test.ts
+++ b/front/lib/api/assistant/skill_actions.test.ts
@@ -1,55 +1,99 @@
-import { deduplicateMCPServerConfigurations } from "@app/lib/actions/mcp_actions";
-import { isServerSideMCPServerConfigurationWithName } from "@app/lib/actions/types/guards";
-import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
+import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
+import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { describe, expect, it } from "vitest";
 
-describe("getSkillServers", () => {
-  it("deduplicates shared company data tools from Discover Knowledge and Go Deep", async () => {
-    const { authenticator } = await createResourceTest({ role: "admin" });
+describe("resolveSkillMCPServers", () => {
+  it("exposes one set of company data tools when Discover Knowledge and Go Deep are enabled", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
     await MCPServerViewResource.ensureAllAutoToolsAreCreated(authenticator);
 
     const agentConfiguration =
       await AgentConfigurationFactory.createTestAgent(authenticator);
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [],
+    });
+    const { agentMessage } = await ConversationFactory.createAgentMessage(
+      authenticator,
+      {
+        workspace,
+        conversation,
+        agentConfig: agentConfiguration,
+      }
+    );
+
     const skills = await SkillResource.fetchByIds(authenticator, [
       "discover_knowledge",
       "go-deep",
     ]);
+    const discoverKnowledge = skills.find(
+      (skill) => skill.sId === "discover_knowledge"
+    );
+    const goDeep = skills.find((skill) => skill.sId === "go-deep");
+    expect(discoverKnowledge).toBeDefined();
+    expect(goDeep).toBeDefined();
+    if (!discoverKnowledge || !goDeep) {
+      throw new Error("Expected Discover Knowledge and Go Deep skills.");
+    }
 
-    const skillServers = await getSkillServers(authenticator, {
+    await SkillResource.addManyToAgent(authenticator, {
       agentConfiguration,
-      skills,
+      skills: [discoverKnowledge, goDeep],
+    });
+    await goDeep.enableForAgent(authenticator, {
+      agentConfiguration,
+      conversation,
     });
 
-    const fileSystemServers = skillServers.filter((server) =>
-      isServerSideMCPServerConfigurationWithName(
-        server,
-        "data_sources_file_system"
-      )
-    );
-    expect(fileSystemServers).toHaveLength(2);
-    expect(fileSystemServers.map((server) => server.name)).toEqual([
-      "company_data",
-      "company_data",
-    ]);
-
-    const deduplicatedServers = deduplicateMCPServerConfigurations({
-      agentActions: [],
-      clientSideActions: [],
-      skillServers,
-      jitServers: [],
+    const skillServers = await resolveSkillMCPServers(authenticator, {
+      agentConfiguration,
+      conversation,
     });
 
-    const deduplicatedFileSystemServers = deduplicatedServers.filter((server) =>
-      isServerSideMCPServerConfigurationWithName(
-        server,
-        "data_sources_file_system"
-      )
+    const { error, serverToolsAndInstructions } = await tryListMCPTools(
+      authenticator,
+      {
+        agentConfiguration,
+        agentMessage,
+        clientSideActionConfigurations: [],
+        conversation,
+      },
+      {
+        jitServers: [],
+        skillServers,
+      }
     );
-    expect(deduplicatedFileSystemServers).toHaveLength(1);
-    expect(deduplicatedFileSystemServers[0].name).toBe("company_data");
+    expect(error).toBeUndefined();
+
+    const serverNames = serverToolsAndInstructions.map(
+      ({ serverName }) => serverName
+    );
+    expect(serverNames).toContain("company_data");
+    expect(serverNames).not.toContain("data_sources_file_system");
+
+    const companyDataTools = serverToolsAndInstructions
+      .filter(({ serverName }) => serverName === "company_data")
+      .flatMap(({ tools }) => tools);
+    expect(companyDataTools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining([
+        "company_data__cat",
+        "company_data__semantic_search",
+      ])
+    );
+    expect(
+      companyDataTools.filter((tool) => tool.name === "company_data__cat")
+    ).toHaveLength(1);
+    expect(
+      serverToolsAndInstructions
+        .flatMap(({ tools }) => tools)
+        .some((tool) => tool.name.startsWith("data_sources_file_system__"))
+    ).toBe(false);
   });
 });

--- a/front/lib/resources/skill/code_defined/discover_knowledge.ts
+++ b/front/lib/resources/skill/code_defined/discover_knowledge.ts
@@ -1,4 +1,7 @@
-import type { SystemSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import {
+  SKILL_COMPANY_DATA_SERVER_NAME,
+  type SystemSkillDefinition,
+} from "@app/lib/resources/skill/code_defined/shared";
 
 const DISCOVER_KNOWLEDGE_INSTRUCTIONS =
   "Default behavior: optimize for speed by starting with `semantic_search`.\n" +
@@ -39,7 +42,10 @@ export const discoverKnowledgeSkill = {
     "Search documents, browse folder hierarchies, read file contents, and query data warehouse tables with SQL.",
   instructions: DISCOVER_KNOWLEDGE_INSTRUCTIONS,
   mcpServers: [
-    { name: "data_sources_file_system", serverNameOverride: "company_data" },
+    {
+      name: "data_sources_file_system",
+      serverNameOverride: SKILL_COMPANY_DATA_SERVER_NAME,
+    },
     { name: "data_warehouses" },
   ],
   version: 1,

--- a/front/lib/resources/skill/code_defined/go_deep.ts
+++ b/front/lib/resources/skill/code_defined/go_deep.ts
@@ -2,7 +2,10 @@ import { getDeepDiveInstructions } from "@app/lib/api/assistant/global_agents/co
 import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import {
+  type GlobalSkillDefinition,
+  SKILL_COMPANY_DATA_SERVER_NAME,
+} from "@app/lib/resources/skill/code_defined/shared";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
@@ -42,7 +45,10 @@ export const goDeepSkill = {
       childAgentId: GLOBAL_AGENTS_SID.DUST_PLANNING,
       serverNameOverride: "planning_agent",
     },
-    { name: "data_sources_file_system", serverNameOverride: "company_data" },
+    {
+      name: "data_sources_file_system",
+      serverNameOverride: SKILL_COMPANY_DATA_SERVER_NAME,
+    },
     { name: "web_search_&_browse" },
     { name: "data_warehouses" },
   ],

--- a/front/lib/resources/skill/code_defined/go_deep.ts
+++ b/front/lib/resources/skill/code_defined/go_deep.ts
@@ -42,7 +42,7 @@ export const goDeepSkill = {
       childAgentId: GLOBAL_AGENTS_SID.DUST_PLANNING,
       serverNameOverride: "planning_agent",
     },
-    { name: "data_sources_file_system" },
+    { name: "data_sources_file_system", serverNameOverride: "company_data" },
     { name: "web_search_&_browse" },
     { name: "data_warehouses" },
   ],

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -8,6 +8,8 @@ import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
 
+export const SKILL_COMPANY_DATA_SERVER_NAME = "company_data";
+
 export type MCPServerDefinition = {
   name: AutoInternalMCPServerNameType;
   childAgentId?: string;


### PR DESCRIPTION
## Description

This PR fixes Go Deep exposing a separate `data_sources_file_system` set of tools from Discover Knowledge.

Go Deep now uses the same `company_data` server name override as Discover Knowledge, so when both skills are enabled the shared company data filesystem tools deduplicate through the existing MCP server configuration dedupe path.

## Tests

- Added a test.

## Risk

- Low.

## Deploy Plan

- Deploy front.
