### PR TITLE
Stop eagerly loading replayed tools behind tool search

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.test.ts
@@ -41,7 +41,6 @@ const replayOnlySpec: AgentActionSpecification = {
     required: [],
     additionalProperties: true,
   },
-  eager: true,
 };
 
 describe("toTool", () => {
@@ -130,22 +129,7 @@ describe("toToolsParam", () => {
     );
   });
 
-  it("keeps a replay-only placeholder specification eager", () => {
-    const tools = toToolsParam([replayOnlySpec], undefined, {
-      toolSearchEnabled: true,
-    });
-
-    expect(tools).toHaveLength(1);
-    expect(tools[0]).toMatchObject({
-      name: "github__create_issue",
-      description: replayOnlySpec.description,
-      eager_input_streaming: true,
-      input_schema: replayOnlySpec.inputSchema,
-    });
-    expect(tools[0]).not.toHaveProperty("defer_loading");
-  });
-
-  it("does not defer a replay-only placeholder when other tools are deferred", () => {
+  it("defers a replay-only placeholder like any other non-eager tool", () => {
     const tools = toToolsParam([replayOnlySpec, coldSpec], undefined, {
       toolSearchEnabled: true,
     });
@@ -157,10 +141,7 @@ describe("toToolsParam", () => {
       name: "github__create_issue",
       input_schema: replayOnlySpec.inputSchema,
     });
-    expect(replayTool).not.toHaveProperty("defer_loading");
-
-    const deferredTool = tools.find((tool) => tool.name === coldSpec.name);
-    expect(deferredTool).toHaveProperty("defer_loading", true);
+    expect(replayTool).toHaveProperty("defer_loading", true);
   });
 });
 

--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -1,0 +1,174 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { ANTHROPIC_PROVIDER_ID } from "@app/lib/api/llm/clients/anthropic/types";
+import { buildSpecificationsWithReplayPlaceholders } from "@app/temporal/agent_loop/lib/run_model";
+import type {
+  ModelConversationTypeMultiActions,
+  ModelMessageTypeMultiActionsWithoutContentFragment,
+} from "@app/types/assistant/generation";
+import { describe, expect, it } from "vitest";
+
+function makeSpecification(
+  name: string,
+  { eager }: { eager?: boolean } = {}
+): AgentActionSpecification {
+  return {
+    name,
+    description: `Description of ${name}`,
+    inputSchema: { type: "object", properties: {}, required: [] },
+    ...(eager !== undefined ? { eager } : {}),
+  };
+}
+
+function assistantMessageWithFunctionCalls(
+  toolNames: string[]
+): ModelMessageTypeMultiActionsWithoutContentFragment {
+  return {
+    role: "assistant",
+    name: "agent",
+    contents: toolNames.map((name, i) => ({
+      type: "function_call",
+      value: { id: `call_${i}`, name, arguments: "{}" },
+    })),
+  };
+}
+
+function assistantMessageWithToolSearchResult(
+  toolNames: string[]
+): ModelMessageTypeMultiActionsWithoutContentFragment {
+  return {
+    role: "assistant",
+    name: "agent",
+    contents: [
+      {
+        type: "provider_passthrough",
+        value: {
+          provider: ANTHROPIC_PROVIDER_ID,
+          block: {
+            type: "tool_search_tool_result",
+            tool_use_id: "srvtoolu_test",
+            content: {
+              type: "tool_search_tool_search_result",
+              tool_references: toolNames.map((name) => ({
+                type: "tool_reference",
+                tool_name: name,
+              })),
+            },
+          },
+        },
+      },
+    ],
+  };
+}
+
+function makeConversation(
+  messages: ModelMessageTypeMultiActionsWithoutContentFragment[]
+): ModelConversationTypeMultiActions {
+  return { messages };
+}
+
+describe("buildSpecificationsWithReplayPlaceholders", () => {
+  it("does not eagerly load replayed tools that are still configured", () => {
+    const baseSpecifications = [
+      makeSpecification("get_weather"),
+      makeSpecification("search_files"),
+    ];
+    const conversation = makeConversation([
+      assistantMessageWithFunctionCalls(["get_weather"]),
+    ]);
+
+    const { specifications, missingReplayedToolNames } =
+      buildSpecificationsWithReplayPlaceholders(
+        baseSpecifications,
+        conversation
+      );
+
+    expect(specifications).toEqual(baseSpecifications);
+    expect(missingReplayedToolNames).toEqual([]);
+  });
+
+  it("preserves the intrinsic eager flag of replayed tools", () => {
+    const baseSpecifications = [
+      makeSpecification("enable_skill", { eager: true }),
+    ];
+    const conversation = makeConversation([
+      assistantMessageWithFunctionCalls(["enable_skill"]),
+    ]);
+
+    const { specifications } = buildSpecificationsWithReplayPlaceholders(
+      baseSpecifications,
+      conversation
+    );
+
+    expect(specifications[0].eager).toBe(true);
+  });
+
+  it("appends a non-eager placeholder for replayed tools no longer configured", () => {
+    const baseSpecifications = [makeSpecification("get_weather")];
+    const conversation = makeConversation([
+      assistantMessageWithFunctionCalls(["removed_tool"]),
+    ]);
+
+    const { specifications, missingReplayedToolNames } =
+      buildSpecificationsWithReplayPlaceholders(
+        baseSpecifications,
+        conversation
+      );
+
+    expect(missingReplayedToolNames).toEqual(["removed_tool"]);
+    expect(specifications).toHaveLength(2);
+    const placeholder = specifications[1];
+    expect(placeholder.name).toBe("removed_tool");
+    expect(placeholder.eager).toBeUndefined();
+  });
+
+  it("appends placeholders for tools referenced by replayed tool search results", () => {
+    const baseSpecifications = [makeSpecification("get_weather")];
+    const conversation = makeConversation([
+      assistantMessageWithToolSearchResult(["get_weather", "removed_tool"]),
+    ]);
+
+    const { specifications, missingReplayedToolNames } =
+      buildSpecificationsWithReplayPlaceholders(
+        baseSpecifications,
+        conversation
+      );
+
+    expect(missingReplayedToolNames).toEqual(["removed_tool"]);
+    expect(specifications.map((s) => s.name)).toEqual([
+      "get_weather",
+      "removed_tool",
+    ]);
+  });
+
+  it("never synthesizes a placeholder for the tool search tool itself", () => {
+    const baseSpecifications = [makeSpecification("get_weather")];
+    const conversation = makeConversation([
+      assistantMessageWithToolSearchResult([
+        "tool_search_tool_bm25",
+        "tool_search_tool_regex",
+      ]),
+    ]);
+
+    const { specifications, missingReplayedToolNames } =
+      buildSpecificationsWithReplayPlaceholders(
+        baseSpecifications,
+        conversation
+      );
+
+    expect(missingReplayedToolNames).toEqual([]);
+    expect(specifications).toEqual(baseSpecifications);
+  });
+
+  it("dedupes missing tools replayed multiple times", () => {
+    const conversation = makeConversation([
+      assistantMessageWithFunctionCalls(["removed_tool", "removed_tool"]),
+      assistantMessageWithToolSearchResult(["removed_tool"]),
+    ]);
+
+    const { specifications, missingReplayedToolNames } =
+      buildSpecificationsWithReplayPlaceholders([], conversation);
+
+    expect(missingReplayedToolNames).toEqual(["removed_tool"]);
+    expect(specifications).toHaveLength(1);
+  });
+});

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -200,7 +200,34 @@ function buildReplayOnlyToolSpecification(
       required: [],
       additionalProperties: true,
     },
-    eager: true,
+  };
+}
+
+// Replayed tools keep their intrinsic `eager` flag: providers resolve deferred
+// tools from the replayed history, and promoting them would invalidate the
+// cached tool prefix. We only append placeholders for replayed tools that are
+// no longer configured, since every tool referenced in history must have a
+// definition.
+export function buildSpecificationsWithReplayPlaceholders(
+  baseSpecifications: AgentActionSpecification[],
+  modelConversation: ModelConversationTypeMultiActions
+): {
+  specifications: AgentActionSpecification[];
+  missingReplayedToolNames: string[];
+} {
+  const currentToolNames = new Set(baseSpecifications.map((spec) => spec.name));
+  const missingReplayedToolNames = getReplayedToolNames(
+    modelConversation
+  ).filter((name) => !currentToolNames.has(name));
+
+  return {
+    specifications: [
+      ...baseSpecifications,
+      ...missingReplayedToolNames.map((name) =>
+        buildReplayOnlyToolSpecification(name)
+      ),
+    ],
+    missingReplayedToolNames,
   };
 }
 
@@ -559,33 +586,18 @@ export async function runModel(
     return null;
   }
 
-  const replayedToolNames = getReplayedToolNames(
-    modelConversationRes.value.modelConversation
-  );
-  const replayedToolNameSet = new Set(replayedToolNames);
-  const currentToolNames = new Set(baseSpecifications.map((spec) => spec.name));
-  const missingReplayedToolNames = replayedToolNames.filter(
-    (name) => !currentToolNames.has(name)
-  );
+  const { specifications, missingReplayedToolNames } =
+    buildSpecificationsWithReplayPlaceholders(
+      baseSpecifications,
+      modelConversationRes.value.modelConversation
+    );
 
   if (missingReplayedToolNames.length > 0) {
     localLogger.info(
-      {
-        missingReplayedToolNames,
-        replayedToolNames,
-      },
+      { missingReplayedToolNames },
       "Replayed tools missing from current specifications"
     );
   }
-
-  const specifications: AgentActionSpecification[] = [
-    ...baseSpecifications.map((spec) =>
-      replayedToolNameSet.has(spec.name) ? { ...spec, eager: true } : spec
-    ),
-    ...missingReplayedToolNames.map((name) =>
-      buildReplayOnlyToolSpecification(name)
-    ),
-  ];
 
   // Temporarily adding this to check if we can consider contents property only in llms
   const unexpectedMessage =


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Until now, any tool that had been called or discovered earlier in a conversation and missing in the last turn was promoted to eager loading on every subsequent model call, pulling it out of the deferred tool-search catalog. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
