### PR TITLE
Stop eagerly loading the sandbox bash tool

### DIFF
--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -63,7 +63,6 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
-    eager: true,
     displayLabels: {
       running: "Executing command",
       done: "Execute command in the Computer",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The bash tool of the Computer toolset was marked as eager, keeping it out of tool search and pinned in the always-loaded tool prefix given it's frequent use. But the Computer is not always available: it only ships when the corresponding skill is enabled.

Discoverability is not a concern: the skill instructions explicitly direct the model to use bash for running commands and scripts, and the tool description closely matches how the model searches for shell execution, so a single tool search surfaces it on first use. Nothing changes when tool search is disabled or on other providers, where all tools are sent upfront regardless, and forced tool calls are still promoted automatically when needed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
