### PR TITLE
[front] chore: unify skill auto enabled/equipped callback

### DIFF
--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -362,6 +362,29 @@ describe("getJITServers", () => {
       expect(equippedSkills.some((s) => s.sId === "projects")).toBe(true);
     });
 
+    it("keeps auto-equipped projects available after it is enabled", async () => {
+      const [projectSkill] = await SkillResource.fetchByIds(
+        auth,
+        ["projects"],
+        { onlyActive: true }
+      );
+      expect(projectSkill).toBeDefined();
+      await projectSkill?.enableForAgent(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
+
+      const { enabledSkills, systemSkills, equippedSkills } =
+        await SkillResource.listForAgentLoop(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+        });
+
+      expect(systemSkills.some((s) => s.sId === "projects")).toBe(false);
+      expect(enabledSkills.some((s) => s.sId === "projects")).toBe(true);
+      expect(equippedSkills.some((s) => s.sId === "projects")).toBe(true);
+    });
+
     it("includes skill_management so agents can enable the projects skill", async () => {
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -7,8 +7,7 @@ import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { projectsSkill } from "@app/lib/resources/skill/code_defined/global/projects";
-import { sandboxSkill } from "@app/lib/resources/skill/code_defined/global/sandbox";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -18,22 +17,12 @@ import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-function disableAutoEquippedSkills() {
-  vi.spyOn(
-    projectsSkill,
-    "getAutoEnabledOrEquippedForAgentLoop"
-  ).mockReturnValue(undefined);
-  vi.spyOn(
-    sandboxSkill,
-    "getAutoEnabledOrEquippedForAgentLoop"
-  ).mockReturnValue(undefined);
-}
+import { beforeEach, describe, expect, it } from "vitest";
 
 function expectSkillBuckets(
   buckets: {
@@ -197,12 +186,8 @@ describe("getJITServers", () => {
     });
 
     describe("when no auto-equipped skills", () => {
-      beforeEach(() => {
-        disableAutoEquippedSkills();
-      });
-
-      afterEach(() => {
-        vi.restoreAllMocks();
+      beforeEach(async () => {
+        await FeatureFlagFactory.basic(auth, "disable_computer_feature");
       });
 
       it("should not include skill_management server when agent has no skills", async () => {
@@ -210,7 +195,7 @@ describe("getJITServers", () => {
 
         const jitServers = await getJITServers(auth, {
           agentConfiguration: agentConfig,
-          conversation,
+          conversation: { ...conversation, spaceId: conversationsSpace.sId },
           attachments: [],
         });
 
@@ -229,7 +214,7 @@ describe("getJITServers", () => {
         });
         const jitServers = await getJITServers(auth, {
           agentConfiguration: agentConfig,
-          conversation,
+          conversation: { ...conversation, spaceId: conversationsSpace.sId },
           attachments: [],
         });
 
@@ -275,6 +260,40 @@ describe("getJITServers", () => {
         equipped: true,
       });
     });
+
+    it("keeps conversation-enabled system skills only in system skills", async () => {
+      await SkillFactory.linkGlobalSkillToAgent(auth, {
+        globalSkillId: "discover_tools",
+        agentConfigurationId: agentConfig.id,
+      });
+      const [discoverToolsSkill] = await SkillResource.fetchByIds(
+        auth,
+        ["discover_tools"],
+        { onlyActive: true }
+      );
+      if (!discoverToolsSkill) {
+        throw new Error("Expected discover_tools skill to be available");
+      }
+      await discoverToolsSkill.enableForAgent(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
+
+      const buckets = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
+
+      expectSkillBuckets(buckets, "discover_tools", {
+        enabled: false,
+        system: true,
+        equipped: false,
+      });
+      expect(
+        buckets.systemSkills.filter((s) => s.sId === "discover_tools")
+      ).toHaveLength(1);
+    });
+
     it("filters discoverable skills disabled for the current agent loop", async () => {
       await SkillFactory.linkGlobalSkillToAgent(auth, {
         globalSkillId: "discover_skills",
@@ -484,6 +503,121 @@ describe("getJITServers", () => {
       expect(
         buckets.equippedSkills.filter((s) => s.sId === "projects")
       ).toHaveLength(0);
+    });
+
+    it("keeps mixed system, enabled, and equipped sources in the right buckets", async () => {
+      const projectSpace = await SpaceFactory.project(
+        workspace,
+        auth.getNonNullableUser().id
+      );
+      await auth.refresh();
+      const projectConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+        spaceId: projectSpace.id,
+      });
+
+      const podDefaultSkill = await SkillFactory.create(auth, {
+        name: "A Pod Default Skill",
+      });
+      const enabledPodDefaultSkill = await SkillFactory.create(auth, {
+        name: "B Enabled Pod Default Skill",
+      });
+      const enabledOnlySkill = await SkillFactory.create(auth, {
+        name: "C Enabled Only Skill",
+      });
+      const agentSkill = await SkillFactory.create(auth, {
+        name: "D Agent Skill",
+      });
+
+      const metadata = await ProjectMetadataResource.makeNew(
+        auth,
+        projectSpace,
+        { description: "d" }
+      );
+      await metadata.setDefaultSkills(auth, [
+        podDefaultSkill,
+        enabledPodDefaultSkill,
+      ]);
+      await SkillFactory.linkGlobalSkillToAgent(auth, {
+        globalSkillId: "discover_tools",
+        agentConfigurationId: agentConfig.id,
+      });
+      await agentSkill.addToAgent(auth, agentConfig);
+      await enabledOnlySkill.enableForAgent(auth, {
+        agentConfiguration: agentConfig,
+        conversation: projectConversation,
+      });
+      await enabledPodDefaultSkill.enableForAgent(auth, {
+        agentConfiguration: agentConfig,
+        conversation: projectConversation,
+      });
+
+      const buckets = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation: projectConversation,
+      });
+
+      expectSkillBuckets(buckets, "projects", {
+        enabled: false,
+        system: true,
+        equipped: false,
+      });
+      expectSkillBuckets(buckets, "discover_tools", {
+        enabled: false,
+        system: true,
+        equipped: false,
+      });
+      expectSkillBuckets(buckets, "sandbox", {
+        enabled: false,
+        system: false,
+        equipped: true,
+      });
+      expectSkillBuckets(buckets, enabledOnlySkill.sId, {
+        enabled: true,
+        system: false,
+        equipped: false,
+      });
+      expectSkillBuckets(buckets, enabledPodDefaultSkill.sId, {
+        enabled: true,
+        system: false,
+        equipped: true,
+      });
+      expectSkillBuckets(buckets, podDefaultSkill.sId, {
+        enabled: false,
+        system: false,
+        equipped: true,
+      });
+      expectSkillBuckets(buckets, agentSkill.sId, {
+        enabled: false,
+        system: false,
+        equipped: true,
+      });
+
+      expect(
+        buckets.enabledSkills
+          .map((s) => s.name)
+          .filter((name) =>
+            ["B Enabled Pod Default Skill", "C Enabled Only Skill"].includes(
+              name
+            )
+          )
+      ).toEqual(["B Enabled Pod Default Skill", "C Enabled Only Skill"]);
+      expect(
+        buckets.equippedSkills
+          .map((s) => s.name)
+          .filter((name) =>
+            [
+              "A Pod Default Skill",
+              "B Enabled Pod Default Skill",
+              "D Agent Skill",
+            ].includes(name)
+          )
+      ).toEqual([
+        "A Pod Default Skill",
+        "B Enabled Pod Default Skill",
+        "D Agent Skill",
+      ]);
     });
 
     it("includes skill_management so agents can enable the projects skill", async () => {

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -261,7 +261,7 @@ describe("getJITServers", () => {
       });
     });
 
-    it("keeps conversation-enabled system skills only in system skills", async () => {
+    it("keeps agent-enabled system skills only in system skills", async () => {
       await SkillFactory.linkGlobalSkillToAgent(auth, {
         globalSkillId: "discover_tools",
         agentConfigurationId: agentConfig.id,
@@ -292,6 +292,82 @@ describe("getJITServers", () => {
       expect(
         buckets.systemSkills.filter((s) => s.sId === "discover_tools")
       ).toHaveLength(1);
+    });
+
+    it("keeps conversation-enabled custom skills enabled only", async () => {
+      const skill = await SkillFactory.create(auth, {
+        name: "Conversation Enabled Skill",
+      });
+      const res = await skill.upsertToConversation(auth, {
+        conversationId: conversation.id,
+        enabled: true,
+      });
+      expect(res.isOk()).toBe(true);
+
+      const buckets = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
+
+      expectSkillBuckets(buckets, skill.sId, {
+        enabled: true,
+        system: false,
+        equipped: false,
+      });
+    });
+
+    it("keeps conversation-enabled agent skills enabled and equipped", async () => {
+      const skill = await SkillFactory.create(auth, {
+        name: "Conversation Enabled Agent Skill",
+      });
+      await skill.addToAgent(auth, agentConfig);
+      const res = await skill.upsertToConversation(auth, {
+        conversationId: conversation.id,
+        enabled: true,
+      });
+      expect(res.isOk()).toBe(true);
+
+      const buckets = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
+
+      expectSkillBuckets(buckets, skill.sId, {
+        enabled: true,
+        system: false,
+        equipped: true,
+      });
+    });
+
+    it("keeps conversation-enabled system skills system only", async () => {
+      await SkillFactory.linkGlobalSkillToAgent(auth, {
+        globalSkillId: "discover_tools",
+        agentConfigurationId: agentConfig.id,
+      });
+      const [discoverToolsSkill] = await SkillResource.fetchByIds(
+        auth,
+        ["discover_tools"],
+        { onlyActive: true }
+      );
+      if (!discoverToolsSkill) {
+        throw new Error("Expected discover_tools skill to be available");
+      }
+      const res = await discoverToolsSkill.upsertToConversation(auth, {
+        conversationId: conversation.id,
+        enabled: true,
+      });
+      expect(res.isOk()).toBe(true);
+
+      const buckets = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
+
+      expectSkillBuckets(buckets, "discover_tools", {
+        enabled: false,
+        system: true,
+        equipped: false,
+      });
     });
 
     it("filters discoverable skills disabled for the current agent loop", async () => {

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -25,12 +25,8 @@ import type { WorkspaceType } from "@app/types/user";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 function disableAutoEquippedSkills() {
-  vi.spyOn(projectsSkill, "getAutoAgentLoopAvailability").mockReturnValue(
-    undefined
-  );
-  vi.spyOn(sandboxSkill, "getAutoAgentLoopAvailability").mockReturnValue(
-    undefined
-  );
+  vi.spyOn(projectsSkill, "getAutoModeForAgentLoop").mockReturnValue(undefined);
+  vi.spyOn(sandboxSkill, "getAutoModeForAgentLoop").mockReturnValue(undefined);
 }
 
 describe("getJITServers", () => {

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -25,8 +25,14 @@ import type { WorkspaceType } from "@app/types/user";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 function disableAutoEquippedSkills() {
-  vi.spyOn(projectsSkill, "getAutoModeForAgentLoop").mockReturnValue(undefined);
-  vi.spyOn(sandboxSkill, "getAutoModeForAgentLoop").mockReturnValue(undefined);
+  vi.spyOn(
+    projectsSkill,
+    "getAutoEnabledOrEquippedForAgentLoop"
+  ).mockReturnValue(undefined);
+  vi.spyOn(
+    sandboxSkill,
+    "getAutoEnabledOrEquippedForAgentLoop"
+  ).mockReturnValue(undefined);
 }
 
 describe("getJITServers", () => {

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -462,6 +462,30 @@ describe("getJITServers", () => {
       });
     });
 
+    it("keeps auto-enabled projects out of discoverable equipped skills in a project", async () => {
+      await SkillFactory.linkGlobalSkillToAgent(auth, {
+        globalSkillId: "discover_skills",
+        agentConfigurationId: agentConfig.id,
+      });
+
+      const buckets = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation: {
+          ...conversation,
+          spaceId: conversationsSpace.sId,
+        },
+      });
+
+      expectSkillBuckets(buckets, "projects", {
+        enabled: false,
+        system: true,
+        equipped: false,
+      });
+      expect(
+        buckets.equippedSkills.filter((s) => s.sId === "projects")
+      ).toHaveLength(0);
+    });
+
     it("includes skill_management so agents can enable the projects skill", async () => {
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -35,6 +35,30 @@ function disableAutoEquippedSkills() {
   ).mockReturnValue(undefined);
 }
 
+function expectSkillBuckets(
+  buckets: {
+    enabledSkills: SkillResource[];
+    systemSkills: SkillResource[];
+    equippedSkills: SkillResource[];
+  },
+  skillId: string,
+  expected: {
+    enabled: boolean;
+    system: boolean;
+    equipped: boolean;
+  }
+) {
+  expect(buckets.enabledSkills.some((s) => s.sId === skillId)).toBe(
+    expected.enabled
+  );
+  expect(buckets.systemSkills.some((s) => s.sId === skillId)).toBe(
+    expected.system
+  );
+  expect(buckets.equippedSkills.some((s) => s.sId === skillId)).toBe(
+    expected.equipped
+  );
+}
+
 describe("getJITServers", () => {
   let auth: Authenticator;
   let workspace: WorkspaceType;
@@ -217,7 +241,7 @@ describe("getJITServers", () => {
       });
     });
 
-    it("should return system skills separately from equipped skills", async () => {
+    it("keeps configured custom skills equipped after enabling them, but not system skills", async () => {
       await SkillFactory.linkGlobalSkillToAgent(auth, {
         globalSkillId: "discover_tools",
         agentConfigurationId: agentConfig.id,
@@ -230,17 +254,26 @@ describe("getJITServers", () => {
         skillId: customSkill.id,
         agentConfigurationId: agentConfig.id,
       });
+      await customSkill.enableForAgent(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
 
-      const { enabledSkills, systemSkills, equippedSkills } =
-        await SkillResource.listForAgentLoop(auth, {
-          agentConfiguration: agentConfig,
-          conversation,
-        });
+      const buckets = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
 
-      expect(systemSkills.map((s) => s.sId)).toContain("discover_tools");
-      expect(enabledSkills.map((s) => s.sId)).not.toContain("discover_tools");
-      expect(equippedSkills.map((s) => s.sId)).toContain(customSkill.sId);
-      expect(equippedSkills.map((s) => s.sId)).not.toContain("discover_tools");
+      expectSkillBuckets(buckets, "discover_tools", {
+        enabled: false,
+        system: true,
+        equipped: false,
+      });
+      expectSkillBuckets(buckets, customSkill.sId, {
+        enabled: true,
+        system: false,
+        equipped: true,
+      });
     });
     it("filters discoverable skills disabled for the current agent loop", async () => {
       await SkillFactory.linkGlobalSkillToAgent(auth, {
@@ -321,16 +354,20 @@ describe("getJITServers", () => {
         spaceId: conversationsSpace.sId,
       };
 
-      const { enabledSkills, systemSkills, equippedSkills } =
-        await SkillResource.listForAgentLoop(auth, {
-          agentConfiguration: agentConfig,
-          conversation: conversationInProject,
-        });
+      const buckets = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation: conversationInProject,
+      });
 
-      expect(enabledSkills.some((s) => s.sId === "projects")).toBe(false);
-      expect(equippedSkills.some((s) => s.sId === "projects")).toBe(false);
+      expectSkillBuckets(buckets, "projects", {
+        enabled: false,
+        system: true,
+        equipped: false,
+      });
 
-      const projectsSkill = systemSkills.find((s) => s.sId === "projects");
+      const projectsSkill = buckets.systemSkills.find(
+        (s) => s.sId === "projects"
+      );
       expect(projectsSkill).toBeDefined();
       const viewNames = projectsSkill?.mcpServerConfigurations.map((c) => {
         const json = c.view.toJSON();
@@ -339,27 +376,38 @@ describe("getJITServers", () => {
       expect(viewNames).toContain("pod_manager");
     });
 
-    it("should not auto-enable projects skill when conversation is not in a project", async () => {
-      const { enabledSkills, systemSkills } =
-        await SkillResource.listForAgentLoop(auth, {
-          agentConfiguration: agentConfig,
-          conversation,
-        });
+    it("auto-equips but does not auto-enable projects outside a project", async () => {
+      const buckets = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
 
-      expect(enabledSkills.some((s) => s.sId === "projects")).toBe(false);
-      expect(systemSkills.some((s) => s.sId === "projects")).toBe(false);
+      expectSkillBuckets(buckets, "projects", {
+        enabled: false,
+        system: false,
+        equipped: true,
+      });
     });
 
-    it("auto-equips the projects skill for any agent", async () => {
-      const { enabledSkills, systemSkills, equippedSkills } =
-        await SkillResource.listForAgentLoop(auth, {
-          agentConfiguration: agentConfig,
-          conversation,
-        });
+    it("does not duplicate auto-equipped projects already configured on the agent", async () => {
+      await SkillFactory.linkGlobalSkillToAgent(auth, {
+        globalSkillId: "projects",
+        agentConfigurationId: agentConfig.id,
+      });
 
-      expect(systemSkills.some((s) => s.sId === "projects")).toBe(false);
-      expect(enabledSkills.some((s) => s.sId === "projects")).toBe(false);
-      expect(equippedSkills.some((s) => s.sId === "projects")).toBe(true);
+      const buckets = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
+
+      expectSkillBuckets(buckets, "projects", {
+        enabled: false,
+        system: false,
+        equipped: true,
+      });
+      expect(
+        buckets.equippedSkills.filter((s) => s.sId === "projects")
+      ).toHaveLength(1);
     });
 
     it("keeps auto-equipped projects available after it is enabled", async () => {
@@ -374,15 +422,44 @@ describe("getJITServers", () => {
         conversation,
       });
 
-      const { enabledSkills, systemSkills, equippedSkills } =
-        await SkillResource.listForAgentLoop(auth, {
-          agentConfiguration: agentConfig,
-          conversation,
-        });
+      const buckets = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
 
-      expect(systemSkills.some((s) => s.sId === "projects")).toBe(false);
-      expect(enabledSkills.some((s) => s.sId === "projects")).toBe(true);
-      expect(equippedSkills.some((s) => s.sId === "projects")).toBe(true);
+      expectSkillBuckets(buckets, "projects", {
+        enabled: true,
+        system: false,
+        equipped: true,
+      });
+    });
+
+    it("keeps auto-enabled projects out of enabled and equipped after it is enabled", async () => {
+      const conversationInProject = {
+        ...conversation,
+        spaceId: conversationsSpace.sId,
+      };
+      const [projectSkill] = await SkillResource.fetchByIds(
+        auth,
+        ["projects"],
+        { onlyActive: true }
+      );
+      expect(projectSkill).toBeDefined();
+      await projectSkill?.enableForAgent(auth, {
+        agentConfiguration: agentConfig,
+        conversation: conversationInProject,
+      });
+
+      const buckets = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation: conversationInProject,
+      });
+
+      expectSkillBuckets(buckets, "projects", {
+        enabled: false,
+        system: true,
+        equipped: false,
+      });
     });
 
     it("includes skill_management so agents can enable the projects skill", async () => {

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -25,8 +25,12 @@ import type { WorkspaceType } from "@app/types/user";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 function disableAutoEquippedSkills() {
-  vi.spyOn(projectsSkill, "isAutoEquippedForAgentLoop").mockReturnValue(false);
-  vi.spyOn(sandboxSkill, "isAutoEquippedForAgentLoop").mockReturnValue(false);
+  vi.spyOn(projectsSkill, "getAutoAgentLoopAvailability").mockReturnValue(
+    undefined
+  );
+  vi.spyOn(sandboxSkill, "getAutoAgentLoopAvailability").mockReturnValue(
+    undefined
+  );
 }
 
 describe("getJITServers", () => {

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -1,10 +1,7 @@
 import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import type {
-  AutoEnabledOrEquippedForAgentLoop,
-  GlobalSkillDefinition,
-} from "@app/lib/resources/skill/code_defined/shared";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import { isPodConversation } from "@app/types/assistant/conversation";
 
 export const podFunctionsSkill = {
@@ -84,7 +81,5 @@ function's contract before relying on it. See each tool's own description for it
     !agentLoopData.conversation ||
     !isPodConversation(agentLoopData.conversation),
   // Equipped in Pod conversations but not auto-enabled.
-  getAutoEnabledOrEquippedForAgentLoop: ():
-    | AutoEnabledOrEquippedForAgentLoop
-    | undefined => "equipped",
+  getAutoEnabledOrEquippedForAgentLoop: () => "equipped",
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -81,6 +81,5 @@ function's contract before relying on it. See each tool's own description for it
     !agentLoopData.conversation ||
     !isPodConversation(agentLoopData.conversation),
   // Equipped in Pod conversations but not auto-enabled.
-  getAutoEnabledOrEquippedForAgentLoop: (): "equipped" | undefined =>
-    "equipped",
+  getAutoEnabledOrEquippedForAgentLoop: () => "equipped",
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -1,7 +1,10 @@
 import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import type {
+  AutoAgentLoopAvailability,
+  GlobalSkillDefinition,
+} from "@app/lib/resources/skill/code_defined/shared";
 import { isPodConversation } from "@app/types/assistant/conversation";
 
 export const podFunctionsSkill = {
@@ -81,5 +84,6 @@ function's contract before relying on it. See each tool's own description for it
     !agentLoopData.conversation ||
     !isPodConversation(agentLoopData.conversation),
   // Equipped in Pod conversations but not auto-enabled.
-  isAutoEquippedForAgentLoop: (): boolean => true,
+  getAutoAgentLoopAvailability: (): AutoAgentLoopAvailability | undefined =>
+    "equipped",
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -81,5 +81,6 @@ function's contract before relying on it. See each tool's own description for it
     !agentLoopData.conversation ||
     !isPodConversation(agentLoopData.conversation),
   // Equipped in Pod conversations but not auto-enabled.
-  getAutoEnabledOrEquippedForAgentLoop: () => "equipped",
+  getAutoEnabledOrEquippedForAgentLoop: (): "equipped" | undefined =>
+    "equipped",
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -2,7 +2,7 @@ import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sand
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type {
-  AutoAgentLoopAvailability,
+  AutoSkillModeForAgentLoop,
   GlobalSkillDefinition,
 } from "@app/lib/resources/skill/code_defined/shared";
 import { isPodConversation } from "@app/types/assistant/conversation";
@@ -84,6 +84,6 @@ function's contract before relying on it. See each tool's own description for it
     !agentLoopData.conversation ||
     !isPodConversation(agentLoopData.conversation),
   // Equipped in Pod conversations but not auto-enabled.
-  getAutoAgentLoopAvailability: (): AutoAgentLoopAvailability | undefined =>
+  getAutoModeForAgentLoop: (): AutoSkillModeForAgentLoop | undefined =>
     "equipped",
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -2,7 +2,7 @@ import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sand
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type {
-  AutoSkillModeForAgentLoop,
+  AutoEnabledOrEquippedForAgentLoop,
   GlobalSkillDefinition,
 } from "@app/lib/resources/skill/code_defined/shared";
 import { isPodConversation } from "@app/types/assistant/conversation";
@@ -84,6 +84,7 @@ function's contract before relying on it. See each tool's own description for it
     !agentLoopData.conversation ||
     !isPodConversation(agentLoopData.conversation),
   // Equipped in Pod conversations but not auto-enabled.
-  getAutoModeForAgentLoop: (): AutoSkillModeForAgentLoop | undefined =>
-    "equipped",
+  getAutoEnabledOrEquippedForAgentLoop: ():
+    | AutoEnabledOrEquippedForAgentLoop
+    | undefined => "equipped",
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/global/projects.ts
+++ b/front/lib/resources/skill/code_defined/global/projects.ts
@@ -6,10 +6,7 @@ import {
   readPodAgentsMdContent,
 } from "@app/lib/api/projects/agents_md";
 import type { Authenticator } from "@app/lib/auth";
-import type {
-  AutoEnabledOrEquippedForAgentLoop,
-  GlobalSkillDefinition,
-} from "@app/lib/resources/skill/code_defined/shared";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   type ConversationWithoutContentType,
@@ -70,8 +67,7 @@ When you need to find information, use this order (skip steps if the relevant to
   isRestricted: undefined,
   getAutoEnabledOrEquippedForAgentLoop: ({
     conversation,
-  }): AutoEnabledOrEquippedForAgentLoop | undefined =>
-    isPodConversation(conversation) ? "enabled" : "equipped",
+  }) => isPodConversation(conversation) ? "enabled" : "equipped",
 } as const satisfies GlobalSkillDefinition;
 
 export async function constructProjectContext(

--- a/front/lib/resources/skill/code_defined/global/projects.ts
+++ b/front/lib/resources/skill/code_defined/global/projects.ts
@@ -67,7 +67,8 @@ When you need to find information, use this order (skip steps if the relevant to
   isRestricted: undefined,
   getAutoEnabledOrEquippedForAgentLoop: ({
     conversation,
-  }) => isPodConversation(conversation) ? "enabled" : "equipped",
+  }): "enabled" | "equipped" | undefined =>
+    isPodConversation(conversation) ? "enabled" : "equipped",
 } as const satisfies GlobalSkillDefinition;
 
 export async function constructProjectContext(

--- a/front/lib/resources/skill/code_defined/global/projects.ts
+++ b/front/lib/resources/skill/code_defined/global/projects.ts
@@ -6,7 +6,10 @@ import {
   readPodAgentsMdContent,
 } from "@app/lib/api/projects/agents_md";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import type {
+  AutoAgentLoopAvailability,
+  GlobalSkillDefinition,
+} from "@app/lib/resources/skill/code_defined/shared";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   type ConversationWithoutContentType,
@@ -65,11 +68,10 @@ When you need to find information, use this order (skip steps if the relevant to
   version: 3,
   icon: "ActionFolderIcon",
   isRestricted: undefined,
-  // Auto-enabled whenever the conversation belongs to a Pod.
-  isAutoEnabledForAgentLoop: ({ conversation }) =>
-    isPodConversation(conversation),
-  // Auto-equipped for all agent loops.
-  isAutoEquippedForAgentLoop: (): boolean => true,
+  getAutoAgentLoopAvailability: ({
+    conversation,
+  }): AutoAgentLoopAvailability | undefined =>
+    isPodConversation(conversation) ? "enabled" : "equipped",
 } as const satisfies GlobalSkillDefinition;
 
 export async function constructProjectContext(

--- a/front/lib/resources/skill/code_defined/global/projects.ts
+++ b/front/lib/resources/skill/code_defined/global/projects.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/api/projects/agents_md";
 import type { Authenticator } from "@app/lib/auth";
 import type {
-  AutoSkillModeForAgentLoop,
+  AutoEnabledOrEquippedForAgentLoop,
   GlobalSkillDefinition,
 } from "@app/lib/resources/skill/code_defined/shared";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -68,9 +68,9 @@ When you need to find information, use this order (skip steps if the relevant to
   version: 3,
   icon: "ActionFolderIcon",
   isRestricted: undefined,
-  getAutoModeForAgentLoop: ({
+  getAutoEnabledOrEquippedForAgentLoop: ({
     conversation,
-  }): AutoSkillModeForAgentLoop | undefined =>
+  }): AutoEnabledOrEquippedForAgentLoop | undefined =>
     isPodConversation(conversation) ? "enabled" : "equipped",
 } as const satisfies GlobalSkillDefinition;
 

--- a/front/lib/resources/skill/code_defined/global/projects.ts
+++ b/front/lib/resources/skill/code_defined/global/projects.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/api/projects/agents_md";
 import type { Authenticator } from "@app/lib/auth";
 import type {
-  AutoAgentLoopAvailability,
+  AutoSkillModeForAgentLoop,
   GlobalSkillDefinition,
 } from "@app/lib/resources/skill/code_defined/shared";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -68,9 +68,9 @@ When you need to find information, use this order (skip steps if the relevant to
   version: 3,
   icon: "ActionFolderIcon",
   isRestricted: undefined,
-  getAutoAgentLoopAvailability: ({
+  getAutoModeForAgentLoop: ({
     conversation,
-  }): AutoAgentLoopAvailability | undefined =>
+  }): AutoSkillModeForAgentLoop | undefined =>
     isPodConversation(conversation) ? "enabled" : "equipped",
 } as const satisfies GlobalSkillDefinition;
 

--- a/front/lib/resources/skill/code_defined/global/projects.ts
+++ b/front/lib/resources/skill/code_defined/global/projects.ts
@@ -65,10 +65,7 @@ When you need to find information, use this order (skip steps if the relevant to
   version: 3,
   icon: "ActionFolderIcon",
   isRestricted: undefined,
-  getAutoEnabledOrEquippedForAgentLoop: ({
-    conversation,
-  }): "enabled" | "equipped" | undefined =>
-    isPodConversation(conversation) ? "enabled" : "equipped",
+  getAutoEnabledOrEquippedForAgentLoop: ({ conversation }) => isPodConversation(conversation) ? "enabled" : "equipped",
 } as const satisfies GlobalSkillDefinition;
 
 export async function constructProjectContext(

--- a/front/lib/resources/skill/code_defined/global/projects.ts
+++ b/front/lib/resources/skill/code_defined/global/projects.ts
@@ -65,7 +65,8 @@ When you need to find information, use this order (skip steps if the relevant to
   version: 3,
   icon: "ActionFolderIcon",
   isRestricted: undefined,
-  getAutoEnabledOrEquippedForAgentLoop: ({ conversation }) => isPodConversation(conversation) ? "enabled" : "equipped",
+  getAutoEnabledOrEquippedForAgentLoop: ({ conversation }) =>
+    isPodConversation(conversation) ? "enabled" : "equipped",
 } as const satisfies GlobalSkillDefinition;
 
 export async function constructProjectContext(

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -386,8 +386,7 @@ export const sandboxSkill = {
   icon: "CommandLineIcon",
   // Auto-equipped for every agent unless the workspace has disabled the
   // Computer, but not enabled until the agent decides to use it.
-  getAutoEnabledOrEquippedForAgentLoop: (): "equipped" | undefined =>
-    "equipped",
+  getAutoEnabledOrEquippedForAgentLoop: () => "equipped",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
 

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -386,7 +386,8 @@ export const sandboxSkill = {
   icon: "CommandLineIcon",
   // Auto-equipped for every agent unless the workspace has disabled the
   // Computer, but not enabled until the agent decides to use it.
-  getAutoEnabledOrEquippedForAgentLoop: () => "equipped",
+  getAutoEnabledOrEquippedForAgentLoop: (): "equipped" | undefined =>
+    "equipped",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
 

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -10,7 +10,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type {
-  AutoAgentLoopAvailability,
+  AutoSkillModeForAgentLoop,
   GlobalSkillDefinition,
 } from "@app/lib/resources/skill/code_defined/shared";
 import logger from "@app/logger/logger";
@@ -389,7 +389,7 @@ export const sandboxSkill = {
   icon: "CommandLineIcon",
   // Auto-equipped for every agent unless the workspace has disabled the
   // Computer, but not enabled until the agent decides to use it.
-  getAutoAgentLoopAvailability: (): AutoAgentLoopAvailability | undefined =>
+  getAutoModeForAgentLoop: (): AutoSkillModeForAgentLoop | undefined =>
     "equipped",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -9,7 +9,10 @@ import {
 } from "@app/lib/api/sandbox/image";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import type {
+  AutoAgentLoopAvailability,
+  GlobalSkillDefinition,
+} from "@app/lib/resources/skill/code_defined/shared";
 import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { isPodConversation } from "@app/types/assistant/conversation";
@@ -386,7 +389,8 @@ export const sandboxSkill = {
   icon: "CommandLineIcon",
   // Auto-equipped for every agent unless the workspace has disabled the
   // Computer, but not enabled until the agent decides to use it.
-  isAutoEquippedForAgentLoop: (): boolean => true,
+  getAutoAgentLoopAvailability: (): AutoAgentLoopAvailability | undefined =>
+    "equipped",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
 

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -9,10 +9,7 @@ import {
 } from "@app/lib/api/sandbox/image";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import type {
-  AutoEnabledOrEquippedForAgentLoop,
-  GlobalSkillDefinition,
-} from "@app/lib/resources/skill/code_defined/shared";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { isPodConversation } from "@app/types/assistant/conversation";
@@ -389,9 +386,7 @@ export const sandboxSkill = {
   icon: "CommandLineIcon",
   // Auto-equipped for every agent unless the workspace has disabled the
   // Computer, but not enabled until the agent decides to use it.
-  getAutoEnabledOrEquippedForAgentLoop: ():
-    | AutoEnabledOrEquippedForAgentLoop
-    | undefined => "equipped",
+  getAutoEnabledOrEquippedForAgentLoop: () => "equipped",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
 

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -10,7 +10,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type {
-  AutoSkillModeForAgentLoop,
+  AutoEnabledOrEquippedForAgentLoop,
   GlobalSkillDefinition,
 } from "@app/lib/resources/skill/code_defined/shared";
 import logger from "@app/logger/logger";
@@ -389,8 +389,9 @@ export const sandboxSkill = {
   icon: "CommandLineIcon",
   // Auto-equipped for every agent unless the workspace has disabled the
   // Computer, but not enabled until the agent decides to use it.
-  getAutoModeForAgentLoop: (): AutoSkillModeForAgentLoop | undefined =>
-    "equipped",
+  getAutoEnabledOrEquippedForAgentLoop: ():
+    | AutoEnabledOrEquippedForAgentLoop
+    | undefined => "equipped",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
 

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -15,16 +15,16 @@ export type MCPServerDefinition = {
   serverNameOverride?: string;
 };
 
-export type AutoAgentLoopAvailability = "enabled" | "equipped";
+export type AutoSkillModeForAgentLoop = "enabled" | "equipped";
 
-type AutoAgentLoopAvailabilityParams = {
+type AutoSkillModeForAgentLoopParams = {
   agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
   conversation: ConversationWithoutContentType;
 };
 
-type AutoAgentLoopAvailabilityCallback<
-  T extends AutoAgentLoopAvailability = AutoAgentLoopAvailability,
-> = (params: AutoAgentLoopAvailabilityParams) => T | undefined;
+type AutoSkillModeForAgentLoopCallback<
+  T extends AutoSkillModeForAgentLoop = AutoSkillModeForAgentLoop,
+> = (params: AutoSkillModeForAgentLoopParams) => T | undefined;
 
 interface BaseSkillDefinition {
   readonly agentFacingDescription: string;
@@ -45,7 +45,7 @@ interface BaseSkillDefinition {
   // Optional callback to auto-enable or auto-equip a code-defined skill for an
   // agent loop (subject to isRestricted), without adding it to the agent
   // configuration. Return undefined to leave the skill unchanged for this loop.
-  readonly getAutoAgentLoopAvailability?: AutoAgentLoopAvailabilityCallback;
+  readonly getAutoModeForAgentLoop?: AutoSkillModeForAgentLoopCallback;
   // Optional callback to hide a skill from a given agent loop (both from equipped and enabled).
   readonly isDisabledForAgentLoop?: (
     agentLoopData: AgentLoopExecutionData
@@ -79,7 +79,7 @@ export type GlobalSkillDefinition = SkillDefinition & {
 // System skills have no definition of "equipped". When they are present they are directly part of the system prompt.
 export type SystemSkillDefinition = SkillDefinition & {
   readonly kind: "system";
-  getAutoAgentLoopAvailability?: AutoAgentLoopAvailabilityCallback<"enabled">;
+  getAutoModeForAgentLoop?: AutoSkillModeForAgentLoopCallback<"enabled">;
 };
 
 // Helper function that enforces unique sIds.

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -33,9 +33,9 @@ interface BaseSkillDefinition<
   // opted in per skill (e.g. docs/pptx/xlsx). System skills stay hidden.
   readonly exposeInstructions?: boolean;
   readonly isRestricted?: (auth: Authenticator) => Promise<boolean>;
-  // Optional callback to auto-enable or auto-equip a code-defined skill for an
-  // agent loop (subject to isRestricted), without adding it to the agent
-  // configuration. Return undefined to leave the skill unchanged for this loop.
+  // Optional callback to auto-add a code-defined skill for an agent loop
+  // (subject to isRestricted), without adding it to the agent configuration.
+  // For global skills, returning "enabled" promotes it to a system skill.
   readonly getAutoEnabledOrEquippedForAgentLoop?: (params: {
     agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
     conversation: ConversationWithoutContentType;

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -15,17 +15,12 @@ export type MCPServerDefinition = {
   serverNameOverride?: string;
 };
 
-export type AutoEnabledOrEquippedForAgentLoop = "enabled" | "equipped";
-
-type AutoEnabledOrEquippedForAgentLoopParams = {
+type AutoEnabledOrEquippedForAgentLoopCallback<
+  T extends "enabled" | "equipped" = "enabled" | "equipped",
+> = (params: {
   agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
   conversation: ConversationWithoutContentType;
-};
-
-type AutoEnabledOrEquippedForAgentLoopCallback<
-  T extends
-    AutoEnabledOrEquippedForAgentLoop = AutoEnabledOrEquippedForAgentLoop,
-> = (params: AutoEnabledOrEquippedForAgentLoopParams) => T | undefined;
+}) => T | undefined;
 
 interface BaseSkillDefinition {
   readonly agentFacingDescription: string;

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -15,16 +15,17 @@ export type MCPServerDefinition = {
   serverNameOverride?: string;
 };
 
-export type AutoSkillModeForAgentLoop = "enabled" | "equipped";
+export type AutoEnabledOrEquippedForAgentLoop = "enabled" | "equipped";
 
-type AutoSkillModeForAgentLoopParams = {
+type AutoEnabledOrEquippedForAgentLoopParams = {
   agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
   conversation: ConversationWithoutContentType;
 };
 
-type AutoSkillModeForAgentLoopCallback<
-  T extends AutoSkillModeForAgentLoop = AutoSkillModeForAgentLoop,
-> = (params: AutoSkillModeForAgentLoopParams) => T | undefined;
+type AutoEnabledOrEquippedForAgentLoopCallback<
+  T extends
+    AutoEnabledOrEquippedForAgentLoop = AutoEnabledOrEquippedForAgentLoop,
+> = (params: AutoEnabledOrEquippedForAgentLoopParams) => T | undefined;
 
 interface BaseSkillDefinition {
   readonly agentFacingDescription: string;
@@ -45,7 +46,7 @@ interface BaseSkillDefinition {
   // Optional callback to auto-enable or auto-equip a code-defined skill for an
   // agent loop (subject to isRestricted), without adding it to the agent
   // configuration. Return undefined to leave the skill unchanged for this loop.
-  readonly getAutoModeForAgentLoop?: AutoSkillModeForAgentLoopCallback;
+  readonly getAutoEnabledOrEquippedForAgentLoop?: AutoEnabledOrEquippedForAgentLoopCallback;
   // Optional callback to hide a skill from a given agent loop (both from equipped and enabled).
   readonly isDisabledForAgentLoop?: (
     agentLoopData: AgentLoopExecutionData
@@ -79,7 +80,7 @@ export type GlobalSkillDefinition = SkillDefinition & {
 // System skills have no definition of "equipped". When they are present they are directly part of the system prompt.
 export type SystemSkillDefinition = SkillDefinition & {
   readonly kind: "system";
-  getAutoModeForAgentLoop?: AutoSkillModeForAgentLoopCallback<"enabled">;
+  getAutoEnabledOrEquippedForAgentLoop?: AutoEnabledOrEquippedForAgentLoopCallback<"enabled">;
 };
 
 // Helper function that enforces unique sIds.

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -15,8 +15,10 @@ export type MCPServerDefinition = {
   serverNameOverride?: string;
 };
 
+type SkillAgentLoopState = "enabled" | "equipped";
+
 interface BaseSkillDefinition<
-  T extends "enabled" | "equipped" = "enabled" | "equipped",
+  T extends SkillAgentLoopState = SkillAgentLoopState,
 > {
   readonly agentFacingDescription: string;
   readonly userFacingDescription: string;
@@ -63,7 +65,7 @@ type WithDynamicInstructions<T extends BaseSkillDefinition> = T & {
 };
 
 export type SkillDefinition<
-  T extends "enabled" | "equipped" = "enabled" | "equipped",
+  T extends SkillAgentLoopState = SkillAgentLoopState,
 > =
   | WithStaticInstructions<BaseSkillDefinition<T>>
   | WithDynamicInstructions<BaseSkillDefinition<T>>;

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -15,6 +15,17 @@ export type MCPServerDefinition = {
   serverNameOverride?: string;
 };
 
+export type AutoAgentLoopAvailability = "enabled" | "equipped";
+
+type AutoAgentLoopAvailabilityParams = {
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+  conversation: ConversationWithoutContentType;
+};
+
+type AutoAgentLoopAvailabilityCallback<
+  T extends AutoAgentLoopAvailability = AutoAgentLoopAvailability,
+> = (params: AutoAgentLoopAvailabilityParams) => T | undefined;
+
 interface BaseSkillDefinition {
   readonly agentFacingDescription: string;
   readonly userFacingDescription: string;
@@ -31,20 +42,10 @@ interface BaseSkillDefinition {
   // opted in per skill (e.g. docs/pptx/xlsx). System skills stay hidden.
   readonly exposeInstructions?: boolean;
   readonly isRestricted?: (auth: Authenticator) => Promise<boolean>;
-  // Optional callback to auto-equip a code-defined skill for an agent loop (subject to
-  // isRestricted), without enabling it. Return true to make the skill available through
-  // skill_management__enable_skill.
-  readonly isAutoEquippedForAgentLoop?: (params: {
-    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
-    conversation: ConversationWithoutContentType;
-  }) => boolean;
-  // Optional callback to auto-enable a code-defined skill for an agent loop (subject to
-  // isRestricted), without it being added to the agent configuration. Return true to enable.
-  // Used for skills that are on by default for a given context (e.g. Pods in a Pod conversation).
-  readonly isAutoEnabledForAgentLoop?: (params: {
-    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
-    conversation: ConversationWithoutContentType;
-  }) => boolean;
+  // Optional callback to auto-enable or auto-equip a code-defined skill for an
+  // agent loop (subject to isRestricted), without adding it to the agent
+  // configuration. Return undefined to leave the skill unchanged for this loop.
+  readonly getAutoAgentLoopAvailability?: AutoAgentLoopAvailabilityCallback;
   // Optional callback to hide a skill from a given agent loop (both from equipped and enabled).
   readonly isDisabledForAgentLoop?: (
     agentLoopData: AgentLoopExecutionData
@@ -78,7 +79,7 @@ export type GlobalSkillDefinition = SkillDefinition & {
 // System skills have no definition of "equipped". When they are present they are directly part of the system prompt.
 export type SystemSkillDefinition = SkillDefinition & {
   readonly kind: "system";
-  isAutoEquippedForAgentLoop?: never;
+  getAutoAgentLoopAvailability?: AutoAgentLoopAvailabilityCallback<"enabled">;
 };
 
 // Helper function that enforces unique sIds.

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -15,14 +15,18 @@ export type MCPServerDefinition = {
   serverNameOverride?: string;
 };
 
+type AutoEnabledOrEquippedForAgentLoop = "enabled" | "equipped";
+
 type AutoEnabledOrEquippedForAgentLoopCallback<
-  T extends "enabled" | "equipped" = "enabled" | "equipped",
+  T extends AutoEnabledOrEquippedForAgentLoop,
 > = (params: {
   agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
   conversation: ConversationWithoutContentType;
 }) => T | undefined;
 
-interface BaseSkillDefinition {
+interface BaseSkillDefinition<
+  TAutoEnabledOrEquipped extends AutoEnabledOrEquippedForAgentLoop,
+> {
   readonly agentFacingDescription: string;
   readonly userFacingDescription: string;
   readonly kind: "global" | "system";
@@ -41,19 +45,23 @@ interface BaseSkillDefinition {
   // Optional callback to auto-enable or auto-equip a code-defined skill for an
   // agent loop (subject to isRestricted), without adding it to the agent
   // configuration. Return undefined to leave the skill unchanged for this loop.
-  readonly getAutoEnabledOrEquippedForAgentLoop?: AutoEnabledOrEquippedForAgentLoopCallback;
+  readonly getAutoEnabledOrEquippedForAgentLoop?: AutoEnabledOrEquippedForAgentLoopCallback<TAutoEnabledOrEquipped>;
   // Optional callback to hide a skill from a given agent loop (both from equipped and enabled).
   readonly isDisabledForAgentLoop?: (
     agentLoopData: AgentLoopExecutionData
   ) => boolean;
 }
 
-type WithStaticInstructions<T extends BaseSkillDefinition> = T & {
+type WithStaticInstructions<
+  T extends BaseSkillDefinition<AutoEnabledOrEquippedForAgentLoop>,
+> = T & {
   readonly instructions: string;
   readonly fetchInstructions?: never;
 };
 
-type WithDynamicInstructions<T extends BaseSkillDefinition> = T & {
+type WithDynamicInstructions<
+  T extends BaseSkillDefinition<AutoEnabledOrEquippedForAgentLoop>,
+> = T & {
   readonly instructions?: never;
   readonly fetchInstructions: (
     auth: Authenticator,
@@ -64,18 +72,27 @@ type WithDynamicInstructions<T extends BaseSkillDefinition> = T & {
   ) => Promise<string>;
 };
 
-export type SkillDefinition =
-  | WithStaticInstructions<BaseSkillDefinition>
-  | WithDynamicInstructions<BaseSkillDefinition>;
+export type SkillDefinition<
+  TAutoEnabledOrEquipped extends
+    AutoEnabledOrEquippedForAgentLoop = AutoEnabledOrEquippedForAgentLoop,
+> =
+  | WithStaticInstructions<BaseSkillDefinition<TAutoEnabledOrEquipped>>
+  | WithDynamicInstructions<BaseSkillDefinition<TAutoEnabledOrEquipped>>;
 
-export type GlobalSkillDefinition = SkillDefinition & {
+type ProjectSkillDefinition = SkillDefinition & {
   readonly kind: "global";
+  readonly sId: "projects";
 };
 
+// Global skills are equip-able by the agent, not added to the system prompt automatically.
+// Pods are the exception: the same code-defined skill is equip-able outside Pods and system
+// prompt content inside Pod conversations.
+export type GlobalSkillDefinition =
+  | (SkillDefinition<"equipped"> & { readonly kind: "global" })
+  | ProjectSkillDefinition;
 // System skills have no definition of "equipped". When they are present they are directly part of the system prompt.
-export type SystemSkillDefinition = SkillDefinition & {
+export type SystemSkillDefinition = SkillDefinition<"enabled"> & {
   readonly kind: "system";
-  getAutoEnabledOrEquippedForAgentLoop?: AutoEnabledOrEquippedForAgentLoopCallback<"enabled">;
 };
 
 // Helper function that enforces unique sIds.

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -68,17 +68,9 @@ export type SkillDefinition<
   | WithStaticInstructions<BaseSkillDefinition<T>>
   | WithDynamicInstructions<BaseSkillDefinition<T>>;
 
-type ProjectSkillDefinition = SkillDefinition & {
+export type GlobalSkillDefinition = SkillDefinition & {
   readonly kind: "global";
-  readonly sId: "projects";
 };
-
-// Global skills are equip-able by the agent, not added to the system prompt automatically.
-// Pods are the exception: the same code-defined skill is equip-able outside Pods and system
-// prompt content inside Pod conversations.
-export type GlobalSkillDefinition =
-  | (SkillDefinition<"equipped"> & { readonly kind: "global" })
-  | ProjectSkillDefinition;
 // System skills have no definition of "equipped". When they are present they are directly part of the system prompt.
 export type SystemSkillDefinition = SkillDefinition<"enabled"> & {
   readonly kind: "system";

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -15,17 +15,8 @@ export type MCPServerDefinition = {
   serverNameOverride?: string;
 };
 
-type AutoEnabledOrEquippedForAgentLoop = "enabled" | "equipped";
-
-type AutoEnabledOrEquippedForAgentLoopCallback<
-  T extends AutoEnabledOrEquippedForAgentLoop,
-> = (params: {
-  agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
-  conversation: ConversationWithoutContentType;
-}) => T | undefined;
-
 interface BaseSkillDefinition<
-  TAutoEnabledOrEquipped extends AutoEnabledOrEquippedForAgentLoop,
+  T extends "enabled" | "equipped" = "enabled" | "equipped",
 > {
   readonly agentFacingDescription: string;
   readonly userFacingDescription: string;
@@ -45,23 +36,22 @@ interface BaseSkillDefinition<
   // Optional callback to auto-enable or auto-equip a code-defined skill for an
   // agent loop (subject to isRestricted), without adding it to the agent
   // configuration. Return undefined to leave the skill unchanged for this loop.
-  readonly getAutoEnabledOrEquippedForAgentLoop?: AutoEnabledOrEquippedForAgentLoopCallback<TAutoEnabledOrEquipped>;
+  readonly getAutoEnabledOrEquippedForAgentLoop?: (params: {
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+    conversation: ConversationWithoutContentType;
+  }) => T | undefined;
   // Optional callback to hide a skill from a given agent loop (both from equipped and enabled).
   readonly isDisabledForAgentLoop?: (
     agentLoopData: AgentLoopExecutionData
   ) => boolean;
 }
 
-type WithStaticInstructions<
-  T extends BaseSkillDefinition<AutoEnabledOrEquippedForAgentLoop>,
-> = T & {
+type WithStaticInstructions<T extends BaseSkillDefinition> = T & {
   readonly instructions: string;
   readonly fetchInstructions?: never;
 };
 
-type WithDynamicInstructions<
-  T extends BaseSkillDefinition<AutoEnabledOrEquippedForAgentLoop>,
-> = T & {
+type WithDynamicInstructions<T extends BaseSkillDefinition> = T & {
   readonly instructions?: never;
   readonly fetchInstructions: (
     auth: Authenticator,
@@ -73,11 +63,10 @@ type WithDynamicInstructions<
 };
 
 export type SkillDefinition<
-  TAutoEnabledOrEquipped extends
-    AutoEnabledOrEquippedForAgentLoop = AutoEnabledOrEquippedForAgentLoop,
+  T extends "enabled" | "equipped" = "enabled" | "equipped",
 > =
-  | WithStaticInstructions<BaseSkillDefinition<TAutoEnabledOrEquipped>>
-  | WithDynamicInstructions<BaseSkillDefinition<TAutoEnabledOrEquipped>>;
+  | WithStaticInstructions<BaseSkillDefinition<T>>
+  | WithDynamicInstructions<BaseSkillDefinition<T>>;
 
 type ProjectSkillDefinition = SkillDefinition & {
   readonly kind: "global";

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1722,7 +1722,7 @@ describe("SkillResource", () => {
       expect(enabledSkills.map((s) => s.sId)).not.toContain(defaultSkill.sId);
     });
 
-    it("moves a pod default into enabledSkills once the agent enables it", async () => {
+    it("keeps an enabled pod default in both enabled and equipped skills", async () => {
       const { authenticator, workspace, user } = testContext;
 
       const space = await SpaceFactory.project(workspace, user.id);
@@ -1751,12 +1751,14 @@ describe("SkillResource", () => {
         conversation,
       });
 
-      const { enabledSkills } = await SkillResource.listForAgentLoop(
-        authenticator,
-        { agentConfiguration: agent, conversation }
-      );
+      const { enabledSkills, equippedSkills } =
+        await SkillResource.listForAgentLoop(authenticator, {
+          agentConfiguration: agent,
+          conversation,
+        });
 
       expect(enabledSkills.map((s) => s.sId)).toContain(defaultSkill.sId);
+      expect(equippedSkills.map((s) => s.sId)).toContain(defaultSkill.sId);
     });
 
     it("does not duplicate a pod default that is also an agent skill", async () => {

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1794,6 +1794,49 @@ describe("SkillResource", () => {
 
       expect(equippedSkills.filter((s) => s.sId === skill.sId)).toHaveLength(1);
     });
+
+    it("sorts equipped skills across sources", async () => {
+      const { authenticator, workspace, user } = testContext;
+
+      const space = await SpaceFactory.project(workspace, user.id);
+      const podDefaultSkill = await SkillFactory.create(authenticator, {
+        name: "A Pod Default Skill",
+      });
+      const metadata = await ProjectMetadataResource.makeNew(
+        authenticator,
+        space,
+        { description: "d" }
+      );
+      await metadata.setDefaultSkills(authenticator, [podDefaultSkill]);
+
+      const agentSkill = await SkillFactory.create(authenticator, {
+        name: "Z Agent Skill",
+      });
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Pod Agent" }
+      );
+      await agentSkill.addToAgent(authenticator, agent);
+
+      const conversation = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+        spaceId: space.id,
+      });
+
+      const { equippedSkills } = await SkillResource.listForAgentLoop(
+        authenticator,
+        { agentConfiguration: agent, conversation }
+      );
+
+      expect(
+        equippedSkills
+          .map((s) => s.name)
+          .filter((name) =>
+            ["A Pod Default Skill", "Z Agent Skill"].includes(name)
+          )
+      ).toEqual(["A Pod Default Skill", "Z Agent Skill"]);
+    });
   });
 
   describe("batchFetchUsedBySkills", () => {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -37,7 +37,10 @@ import {
 } from "@app/lib/resources/permission_utils";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
-import type { SkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import type {
+  AutoEnabledOrEquippedForAgentLoop,
+  SkillDefinition,
+} from "@app/lib/resources/skill/code_defined/shared";
 import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
 import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -84,7 +87,6 @@ import { SKILL_GROUP_PREFIX } from "@app/types/groups";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -1509,12 +1511,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...(await GlobalSkillsRegistry.findAll(auth)),
     ];
 
-    const autoEnabledRefs: { globalSkillId: string; customSkillId: null }[] =
-      [];
-    const autoEquippedCandidateRefs: {
-      globalSkillId: string;
-      customSkillId: null;
-    }[] = [];
+    const autoRefsByEnabledOrEquipped: Record<
+      AutoEnabledOrEquippedForAgentLoop,
+      { globalSkillId: string; customSkillId: null }[]
+    > = {
+      enabled: [],
+      equipped: [],
+    };
     for (const def of codeDefinedDefs) {
       const autoEnabledOrEquipped = def.getAutoEnabledOrEquippedForAgentLoop?.({
         agentConfiguration,
@@ -1526,18 +1529,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       }
 
       const ref = { globalSkillId: def.sId, customSkillId: null };
-      switch (autoEnabledOrEquipped) {
-        case "enabled":
-          autoEnabledRefs.push(ref);
-          break;
-        case "equipped":
-          autoEquippedCandidateRefs.push(ref);
-          break;
-        default:
-          assertNever(autoEnabledOrEquipped);
-      }
+      autoRefsByEnabledOrEquipped[autoEnabledOrEquipped].push(ref);
     }
 
+    const autoEnabledRefs = autoRefsByEnabledOrEquipped.enabled;
     const autoEnabledSkills = autoEnabledRefs.length
       ? await this.fetchBySkillReferences(auth, autoEnabledRefs, {
           agentLoopData,
@@ -1547,15 +1542,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       autoEnabledSkills.map((s) => s.sId)
     );
 
-    const equippedGlobalSkillIds = new Set(
+    const activeGlobalSkillIds = new Set(
       removeNulls([
         ...allAgentSkills.map((s) => s.globalSId),
         ...conversationEnabledSkills.map((s) => s.globalSId),
         ...autoEnabledSkills.map((s) => s.globalSId),
       ])
     );
-    const autoEquippedRefs = autoEquippedCandidateRefs.filter(
-      (ref) => !equippedGlobalSkillIds.has(ref.globalSkillId)
+    const autoEquippedRefs = autoRefsByEnabledOrEquipped.equipped.filter(
+      (ref) => !activeGlobalSkillIds.has(ref.globalSkillId)
     );
     const autoEquippedSkills = autoEquippedRefs.length
       ? await this.fetchBySkillReferences(auth, autoEquippedRefs, {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1516,17 +1516,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const autoEnabledRefs: CodeDefinedSkillReference[] = [];
     const autoEquippedCandidateRefs: CodeDefinedSkillReference[] = [];
     for (const def of codeDefinedDefs) {
-      const autoAgentLoopAvailability = def.getAutoAgentLoopAvailability?.({
+      const autoMode = def.getAutoModeForAgentLoop?.({
         agentConfiguration,
         conversation,
       });
 
-      if (!autoAgentLoopAvailability) {
+      if (!autoMode) {
         continue;
       }
 
       const ref = { globalSkillId: def.sId, customSkillId: null };
-      switch (autoAgentLoopAvailability) {
+      switch (autoMode) {
         case "enabled":
           autoEnabledRefs.push(ref);
           break;
@@ -1534,7 +1534,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           autoEquippedCandidateRefs.push(ref);
           break;
         default:
-          assertNever(autoAgentLoopAvailability);
+          assertNever(autoMode);
       }
     }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1516,17 +1516,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       customSkillId: null;
     }[] = [];
     for (const def of codeDefinedDefs) {
-      const autoMode = def.getAutoModeForAgentLoop?.({
+      const autoEnabledOrEquipped = def.getAutoEnabledOrEquippedForAgentLoop?.({
         agentConfiguration,
         conversation,
       });
 
-      if (!autoMode) {
+      if (!autoEnabledOrEquipped) {
         continue;
       }
 
       const ref = { globalSkillId: def.sId, customSkillId: null };
-      switch (autoMode) {
+      switch (autoEnabledOrEquipped) {
         case "enabled":
           autoEnabledRefs.push(ref);
           break;
@@ -1534,7 +1534,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           autoEquippedCandidateRefs.push(ref);
           break;
         default:
-          assertNever(autoMode);
+          assertNever(autoEnabledOrEquipped);
       }
     }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1567,48 +1567,32 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const agentEquippedSkills = allAgentSkills.filter(
       (s) => !s.isSystemSkill && !isSystemSkillForLoop(s)
     );
-    const equippedSkillIds = new Set(agentEquippedSkills.map((s) => s.sId));
-    const autoEquippedRefs = autoEquippedSkillRefs.filter(
-      (ref) =>
-        !systemSkillIds.has(ref.globalSkillId) &&
-        !equippedSkillIds.has(ref.globalSkillId)
-    );
-    const autoEquippedSkills = autoEquippedRefs.length
-      ? await this.fetchBySkillReferences(auth, autoEquippedRefs, {
+    const autoEquippedSkills = autoEquippedSkillRefs.length
+      ? await this.fetchBySkillReferences(auth, autoEquippedSkillRefs, {
           agentLoopData,
           withInstructions: false,
           withTools: false,
         })
       : [];
-    for (const { sId } of autoEquippedSkills) {
-      equippedSkillIds.add(sId);
-    }
 
-    const podEquippedSkills = podDefaultSkills.filter(
-      (s) => !isSystemSkillForLoop(s) && !equippedSkillIds.has(s.sId)
-    );
-    for (const { sId } of podEquippedSkills) {
-      equippedSkillIds.add(sId);
-    }
-
-    const discoveredSkills = discoverableSkills.filter(
-      (s) => !isSystemSkillForLoop(s) && !equippedSkillIds.has(s.sId)
-    );
-    for (const { sId } of discoveredSkills) {
-      equippedSkillIds.add(sId);
+    const equippedSkillsById = new Map<string, SkillResource>();
+    for (const skill of [
+      ...agentEquippedSkills,
+      ...autoEquippedSkills,
+      ...podDefaultSkills,
+      ...discoverableSkills,
+    ]) {
+      if (!isSystemSkillForLoop(skill) && !equippedSkillsById.has(skill.sId)) {
+        equippedSkillsById.set(skill.sId, skill);
+      }
     }
 
     return {
+      systemSkills: systemSkills.sort(sortByName),
       enabledSkills: conversationEnabledSkills
         .filter((s) => !isSystemSkillForLoop(s))
         .sort(sortByName),
-      systemSkills: systemSkills.sort(sortByName),
-      equippedSkills: [
-        ...agentEquippedSkills,
-        ...autoEquippedSkills,
-        ...podEquippedSkills,
-        ...discoveredSkills,
-      ].sort(sortByName),
+      equippedSkills: [...equippedSkillsById.values()].sort(sortByName),
     };
   }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1508,7 +1508,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...(await GlobalSkillsRegistry.findAll(auth)),
     ];
 
-    const autoRefsByEnabledOrEquipped: Record<
+    const autoEnabledOrEquippedSkillsRef: Record<
       "enabled" | "equipped",
       { globalSkillId: string; customSkillId: null }[]
     > = {
@@ -1526,16 +1526,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       }
 
       const ref = { globalSkillId: def.sId, customSkillId: null };
-      autoRefsByEnabledOrEquipped[autoEnabledOrEquipped].push(ref);
+      autoEnabledOrEquippedSkillsRef[autoEnabledOrEquipped].push(ref);
     }
 
-    const autoEnabledRefs = autoRefsByEnabledOrEquipped.enabled;
-    const autoEnabledSkills = autoEnabledRefs.length
-      ? await this.fetchBySkillReferences(auth, autoEnabledRefs, {
+    const autoEnabledSkills = autoEnabledOrEquippedSkillsRef.enabled.length
+      ? await this.fetchBySkillReferences(auth, autoEnabledOrEquippedSkillsRef.enabled, {
           agentLoopData,
         })
       : [];
-    const autoEnabledGlobalSkillIds = new Set(
+    const autoEnabledSkillIds = new Set(
       autoEnabledSkills.map((s) => s.sId)
     );
 
@@ -1546,7 +1545,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         ...autoEnabledSkills.map((s) => s.globalSId),
       ])
     );
-    const autoEquippedRefs = autoRefsByEnabledOrEquipped.equipped.filter(
+    const autoEquippedRefs = autoEnabledOrEquippedSkillsRef.equipped.filter(
       (ref) => !activeGlobalSkillIds.has(ref.globalSkillId)
     );
     const autoEquippedSkills = autoEquippedRefs.length
@@ -1569,7 +1568,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // code-defined skill is auto-enabled for this loop, systemSkills owns it instead.
     const enabledSkills = conversationEnabledSkills
       .filter(
-        (s) => !s.globalSId || !autoEnabledGlobalSkillIds.has(s.globalSId)
+        (s) => !s.globalSId || !autoEnabledSkillIds.has(s.globalSId)
       )
       .sort(sortByName);
 
@@ -1579,7 +1578,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const agentEquippedSkills = allAgentSkills.filter(
       (s) =>
         !s.isSystemSkill &&
-        (!s.globalSId || !autoEnabledGlobalSkillIds.has(s.globalSId))
+        (!s.globalSId || !autoEnabledSkillIds.has(s.globalSId))
     );
 
     const agentEquippedSkillIds = new Set(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1543,43 +1543,34 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const autoEquippedSkills = autoEquippedSkillRefs.length
       ? await this.fetchBySkillReferences(auth, autoEquippedSkillRefs, {
-        agentLoopData,
-        withInstructions: false,
-        withTools: false,
-      })
+          agentLoopData,
+          withInstructions: false,
+          withTools: false,
+        })
       : [];
 
     const systemSkillsFromAgent = allAgentSkills.filter((s) => s.isSystemSkill);
     const systemSkillIds = new Set(
-      [...systemSkillsFromAgent, ...autoEnabledSkills].map(
-        (skill) => skill.sId
-      )
+      [...systemSkillsFromAgent, ...autoEnabledSkills].map((skill) => skill.sId)
     );
 
     // Active baseline skills for this loop: configured system skills, plus
     // code-defined skills that this context promotes to system prompt content.
     const systemSkills = [
       ...new Map(
-        [...systemSkillsFromAgent, ...autoEnabledSkills].map((s) => [
-          s.sId,
-          s,
-        ])
+        [...systemSkillsFromAgent, ...autoEnabledSkills].map((s) => [s.sId, s])
       ).values(),
     ];
 
     // Equipped skills are the enable-able candidates shown to the model. They
     // come from the agent configuration, context auto-equipping, Pod defaults,
     // and discoverable skills. System prompt skills are never enable-able.
-    const agentEquippedSkills = allAgentSkills.filter(
-      (s) => !systemSkillIds.has(s.sId)
-    );
-
     const equippedSkillsById = new Map<string, SkillResource>();
     for (const skill of [
       ...autoEquippedSkills,
       ...discoverableSkills,
       ...podDefaultSkills,
-      ...agentEquippedSkills,
+      ...allAgentSkills,
     ]) {
       if (
         !systemSkillIds.has(skill.sId) &&

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1542,13 +1542,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       : [];
 
     const systemSkillsFromAgent = allAgentSkills.filter((s) => s.isSystemSkill);
-    const skillIdForLoop = (skill: SkillResource) =>
-      skill.globalSId ?? skill.sId;
     const systemSkillIds = new Set(
-      [...systemSkillsFromAgent, ...autoEnabledSystemSkills].map(skillIdForLoop)
+      [...systemSkillsFromAgent, ...autoEnabledSystemSkills].map(skill.sId)
     );
     const isSystemSkillForLoop = (skill: SkillResource) =>
-      systemSkillIds.has(skillIdForLoop(skill));
+      systemSkillIds.has(skill.sId);
 
     // Active baseline skills for this loop: configured system skills, plus
     // code-defined skills that this context promotes to system prompt content.
@@ -1565,7 +1563,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // come from the agent configuration, context auto-equipping, Pod defaults,
     // and discoverable skills. System prompt skills are never enable-able.
     const agentEquippedSkills = allAgentSkills.filter(
-      (s) => !s.isSystemSkill && !isSystemSkillForLoop(s)
+      (s) => !isSystemSkillForLoop(s)
     );
     const autoEquippedSkills = autoEquippedSkillRefs.length
       ? await this.fetchBySkillReferences(auth, autoEquippedSkillRefs, {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1496,10 +1496,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const sortByName = (a: SkillResource, b: SkillResource) =>
       a.name.localeCompare(b.name);
 
-    // Code-defined skills can auto-add themselves to system prompt content or
-    // to equipped candidates for the current agent loop. `findAll` already
-    // drops restricted skills, so a flag-gated skill only shows up once its
-    // feature flag is on.
+    // Code-defined skills can auto-add themselves for the current loop.
+    // Returning "enabled" promotes a global skill to a system skill.
+    // `findAll` already drops restricted skills, so a flag-gated skill only
+    // shows up once its feature flag is on.
     const autoEnabledSkillRefs: {
       globalSkillId: string;
       customSkillId: null;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1547,8 +1547,22 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         ...autoEnabledSkills.map((s) => s.globalSId ?? s.sId),
       ])
     );
+
+    // Equipped skills are the enable-able candidates shown to the model. Exclude anything
+    // already active as system prompt content, then add default/discoverable candidates
+    // without duplicating agent-provided ones.
+    const agentEquippedSkills = allAgentSkills.filter(
+      (s) =>
+        !s.isSystemSkill &&
+        (!s.globalSId || !autoEnabledSkillIds.has(s.globalSId))
+    );
+    const agentEquippedGlobalSkillIds = new Set(
+      removeNulls(agentEquippedSkills.map((s) => s.globalSId))
+    );
     const autoEquippedRefs = skillRefsByAutoEnabledOrEquipped.equipped.filter(
-      (ref) => !systemPromptSkillIds.has(ref.globalSkillId)
+      (ref) =>
+        !systemPromptSkillIds.has(ref.globalSkillId) &&
+        !agentEquippedGlobalSkillIds.has(ref.globalSkillId)
     );
     const autoEquippedSkills = autoEquippedRefs.length
       ? await this.fetchBySkillReferences(auth, autoEquippedRefs, {
@@ -1574,15 +1588,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const enabledSkills = conversationEnabledSkills
       .filter((s) => !s.globalSId || !autoEnabledSkillIds.has(s.globalSId))
       .sort(sortByName);
-
-    // Equipped skills are the enable-able candidates shown to the model. Exclude anything
-    // already active as system prompt content, then add default/discoverable candidates
-    // without duplicating agent-provided ones.
-    const agentEquippedSkills = allAgentSkills.filter(
-      (s) =>
-        !s.isSystemSkill &&
-        (!s.globalSId || !autoEnabledSkillIds.has(s.globalSId))
-    );
 
     const agentEquippedSkillIds = new Set(
       [...agentEquippedSkills, ...autoEquippedSkills].map((s) => s.sId)

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1500,7 +1500,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // to equipped candidates for the current agent loop. `findAll` already
     // drops restricted skills, so a flag-gated skill only shows up once its
     // feature flag is on.
-    const autoEnabledSystemSkillRefs: {
+    const autoEnabledSkillRefs: {
       globalSkillId: string;
       customSkillId: null;
     }[] = [];
@@ -1519,7 +1519,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         })
       ) {
         case "enabled":
-          autoEnabledSystemSkillRefs.push({
+          autoEnabledSkillRefs.push({
             globalSkillId: def.sId,
             customSkillId: null,
           });
@@ -1535,24 +1535,32 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       }
     }
 
-    const autoEnabledSystemSkills = autoEnabledSystemSkillRefs.length
-      ? await this.fetchBySkillReferences(auth, autoEnabledSystemSkillRefs, {
+    const autoEnabledSkills = autoEnabledSkillRefs.length
+      ? await this.fetchBySkillReferences(auth, autoEnabledSkillRefs, {
           agentLoopData,
         })
       : [];
 
+    const autoEquippedSkills = autoEquippedSkillRefs.length
+      ? await this.fetchBySkillReferences(auth, autoEquippedSkillRefs, {
+        agentLoopData,
+        withInstructions: false,
+        withTools: false,
+      })
+      : [];
+
     const systemSkillsFromAgent = allAgentSkills.filter((s) => s.isSystemSkill);
     const systemSkillIds = new Set(
-      [...systemSkillsFromAgent, ...autoEnabledSystemSkills].map(skill.sId)
+      [...systemSkillsFromAgent, ...autoEnabledSkills].map(
+        (skill) => skill.sId
+      )
     );
-    const isSystemSkillForLoop = (skill: SkillResource) =>
-      systemSkillIds.has(skill.sId);
 
     // Active baseline skills for this loop: configured system skills, plus
     // code-defined skills that this context promotes to system prompt content.
     const systemSkills = [
       ...new Map(
-        [...systemSkillsFromAgent, ...autoEnabledSystemSkills].map((s) => [
+        [...systemSkillsFromAgent, ...autoEnabledSkills].map((s) => [
           s.sId,
           s,
         ])
@@ -1563,15 +1571,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // come from the agent configuration, context auto-equipping, Pod defaults,
     // and discoverable skills. System prompt skills are never enable-able.
     const agentEquippedSkills = allAgentSkills.filter(
-      (s) => !isSystemSkillForLoop(s)
+      (s) => !systemSkillIds.has(s.sId)
     );
-    const autoEquippedSkills = autoEquippedSkillRefs.length
-      ? await this.fetchBySkillReferences(auth, autoEquippedSkillRefs, {
-          agentLoopData,
-          withInstructions: false,
-          withTools: false,
-        })
-      : [];
 
     const equippedSkillsById = new Map<string, SkillResource>();
     for (const skill of [
@@ -1580,7 +1581,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...podDefaultSkills,
       ...agentEquippedSkills,
     ]) {
-      if (!isSystemSkillForLoop(skill) && !equippedSkillsById.has(skill.sId)) {
+      if (
+        !systemSkillIds.has(skill.sId) &&
+        !equippedSkillsById.has(skill.sId)
+      ) {
         equippedSkillsById.set(skill.sId, skill);
       }
     }
@@ -1588,7 +1592,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return {
       systemSkills: systemSkills.sort(sortByName),
       enabledSkills: conversationEnabledSkills
-        .filter((s) => !isSystemSkillForLoop(s))
+        .filter((s) => !systemSkillIds.has(s.sId))
         .sort(sortByName),
       equippedSkills: [...equippedSkillsById.values()].sort(sortByName),
     };

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1550,9 +1550,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       : [];
 
     const systemSkillsFromAgent = allAgentSkills.filter((s) => s.isSystemSkill);
-    const systemSkillIds = new Set(
-      [...systemSkillsFromAgent, ...autoEnabledSkills].map((skill) => skill.sId)
-    );
 
     // Active baseline skills for this loop: configured system skills, plus
     // code-defined skills that this context promotes to system prompt content.
@@ -1561,6 +1558,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         [...systemSkillsFromAgent, ...autoEnabledSkills].map((s) => [s.sId, s])
       ).values(),
     ];
+    const systemSkillIds = new Set(systemSkills.map((skill) => skill.sId));
 
     // Equipped skills are the enable-able candidates shown to the model. They
     // come from the agent configuration, context auto-equipping, Pod defaults,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1577,10 +1577,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const equippedSkillsById = new Map<string, SkillResource>();
     for (const skill of [
-      ...agentEquippedSkills,
       ...autoEquippedSkills,
-      ...podDefaultSkills,
       ...discoverableSkills,
+      ...podDefaultSkills,
+      ...agentEquippedSkills,
     ]) {
       if (!isSystemSkillForLoop(skill) && !equippedSkillsById.has(skill.sId)) {
         equippedSkillsById.set(skill.sId, skill);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -84,6 +84,7 @@ import { SKILL_GROUP_PREFIX } from "@app/types/groups";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -1499,24 +1500,44 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // System skills are always treated as enabled when present in the agent configuration.
     const configSystemSkills = allAgentSkills.filter((s) => s.isSystemSkill);
 
-    // Code-defined skills can opt into being auto-equipped or auto-enabled for the agent loop
-    // without being added to the agent configuration. `findAll` already drops restricted skills,
-    // so a flag-gated skill only shows up once its feature flag is on.
+    // Code-defined skills can opt into being auto-equipped or auto-enabled for
+    // the agent loop without being added to the agent configuration. `findAll`
+    // already drops restricted skills, so a flag-gated skill only shows up once
+    // its feature flag is on.
     const codeDefinedDefs = [
       ...(await SystemSkillsRegistry.findAll(auth)),
       ...(await GlobalSkillsRegistry.findAll(auth)),
     ];
 
-    const autoEnabledDefs = codeDefinedDefs.filter((def) =>
-      def.isAutoEnabledForAgentLoop?.({
+    type CodeDefinedSkillReference = {
+      globalSkillId: string;
+      customSkillId: null;
+    };
+    const autoEnabledRefs: CodeDefinedSkillReference[] = [];
+    const autoEquippedCandidateRefs: CodeDefinedSkillReference[] = [];
+    for (const def of codeDefinedDefs) {
+      const autoAgentLoopAvailability = def.getAutoAgentLoopAvailability?.({
         agentConfiguration,
         conversation,
-      })
-    );
-    const autoEnabledRefs = autoEnabledDefs.map((def) => ({
-      globalSkillId: def.sId,
-      customSkillId: null,
-    }));
+      });
+
+      if (!autoAgentLoopAvailability) {
+        continue;
+      }
+
+      const ref = { globalSkillId: def.sId, customSkillId: null };
+      switch (autoAgentLoopAvailability) {
+        case "enabled":
+          autoEnabledRefs.push(ref);
+          break;
+        case "equipped":
+          autoEquippedCandidateRefs.push(ref);
+          break;
+        default:
+          assertNever(autoAgentLoopAvailability);
+      }
+    }
+
     const autoEnabledSkills = autoEnabledRefs.length
       ? await this.fetchBySkillReferences(auth, autoEnabledRefs, {
           agentLoopData,
@@ -1533,15 +1554,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         ...autoEnabledSkills.map((s) => s.globalSId),
       ])
     );
-    const autoEquippedRefs = codeDefinedDefs
-      .filter(
-        (def) =>
-          def.isAutoEquippedForAgentLoop?.({
-            agentConfiguration,
-            conversation,
-          }) && !equippedGlobalSkillIds.has(def.sId)
-      )
-      .map((def) => ({ globalSkillId: def.sId, customSkillId: null }));
+    const autoEquippedRefs = autoEquippedCandidateRefs.filter(
+      (ref) => !equippedGlobalSkillIds.has(ref.globalSkillId)
+    );
     const autoEquippedSkills = autoEquippedRefs.length
       ? await this.fetchBySkillReferences(auth, autoEquippedRefs, {
           agentLoopData,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -84,7 +84,6 @@ import { SKILL_GROUP_PREFIX } from "@app/types/groups";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -1513,29 +1512,26 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...(await SystemSkillsRegistry.findAll(auth)),
       ...(await GlobalSkillsRegistry.findAll(auth)),
     ]) {
-      const autoEnabledOrEquipped = def.getAutoEnabledOrEquippedForAgentLoop?.({
-        agentConfiguration,
-        conversation,
-      });
-
-      if (!autoEnabledOrEquipped) {
-        continue;
-      }
-
-      const skillRef = {
-        globalSkillId: def.sId,
-        customSkillId: null,
-      };
-
-      switch (autoEnabledOrEquipped) {
+      switch (
+        def.getAutoEnabledOrEquippedForAgentLoop?.({
+          agentConfiguration,
+          conversation,
+        })
+      ) {
         case "enabled":
-          autoEnabledSystemSkillRefs.push(skillRef);
+          autoEnabledSystemSkillRefs.push({
+            globalSkillId: def.sId,
+            customSkillId: null,
+          });
           break;
         case "equipped":
-          autoEquippedSkillRefs.push(skillRef);
+          autoEquippedSkillRefs.push({
+            globalSkillId: def.sId,
+            customSkillId: null,
+          });
           break;
         default:
-          assertNever(autoEnabledOrEquipped);
+          break;
       }
     }
 
@@ -1608,11 +1604,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         .sort(sortByName),
       systemSkills: systemSkills.sort(sortByName),
       equippedSkills: [
-        ...agentEquippedSkills.sort(sortByName),
-        ...autoEquippedSkills.sort(sortByName),
-        ...podEquippedSkills.sort(sortByName),
-        ...discoveredSkills.sort(sortByName),
-      ],
+        ...agentEquippedSkills,
+        ...autoEquippedSkills,
+        ...podEquippedSkills,
+        ...discoveredSkills,
+      ].sort(sortByName),
     };
   }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1501,11 +1501,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // to equipped candidates for the current agent loop. `findAll` already
     // drops restricted skills, so a flag-gated skill only shows up once its
     // feature flag is on.
-    const codeDefinedDefs = [
-      ...(await SystemSkillsRegistry.findAll(auth)),
-      ...(await GlobalSkillsRegistry.findAll(auth)),
-    ];
-
     const autoEnabledSystemSkillRefs: {
       globalSkillId: string;
       customSkillId: null;
@@ -1514,7 +1509,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       globalSkillId: string;
       customSkillId: null;
     }[] = [];
-    for (const def of codeDefinedDefs) {
+    for (const def of [
+      ...(await SystemSkillsRegistry.findAll(auth)),
+      ...(await GlobalSkillsRegistry.findAll(auth)),
+    ]) {
       const autoEnabledOrEquipped = def.getAutoEnabledOrEquippedForAgentLoop?.({
         agentConfiguration,
         conversation,
@@ -1567,10 +1565,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ).values(),
     ];
 
-    const enabledSkills = conversationEnabledSkills
-      .filter((s) => !isSystemSkillForLoop(s))
-      .sort(sortByName);
-
     // Equipped skills are the enable-able candidates shown to the model. They
     // come from the agent configuration, context auto-equipping, Pod defaults,
     // and discoverable skills. System prompt skills are never enable-able.
@@ -1590,43 +1584,35 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           withTools: false,
         })
       : [];
-    for (const skill of autoEquippedSkills) {
-      equippedSkillIds.add(skill.sId);
+    for (const { sId } of autoEquippedSkills) {
+      equippedSkillIds.add(sId);
     }
 
-    const podEquippedSkills = podDefaultSkills.filter((s) => {
-      if (isSystemSkillForLoop(s)) {
-        return false;
-      }
-
-      return !equippedSkillIds.has(s.sId);
-    });
-    for (const skill of podEquippedSkills) {
-      equippedSkillIds.add(skill.sId);
+    const podEquippedSkills = podDefaultSkills.filter(
+      (s) => !isSystemSkillForLoop(s) && !equippedSkillIds.has(s.sId)
+    );
+    for (const { sId } of podEquippedSkills) {
+      equippedSkillIds.add(sId);
     }
 
-    const discoveredSkills = discoverableSkills.filter((s) => {
-      if (isSystemSkillForLoop(s)) {
-        return false;
-      }
-
-      return !equippedSkillIds.has(s.sId);
-    });
-    for (const skill of discoveredSkills) {
-      equippedSkillIds.add(skill.sId);
+    const discoveredSkills = discoverableSkills.filter(
+      (s) => !isSystemSkillForLoop(s) && !equippedSkillIds.has(s.sId)
+    );
+    for (const { sId } of discoveredSkills) {
+      equippedSkillIds.add(sId);
     }
-
-    const equippedSkills = [
-      ...agentEquippedSkills.sort(sortByName),
-      ...autoEquippedSkills.sort(sortByName),
-      ...podEquippedSkills.sort(sortByName),
-      ...discoveredSkills.sort(sortByName),
-    ];
 
     return {
-      enabledSkills,
+      enabledSkills: conversationEnabledSkills
+        .filter((s) => !isSystemSkillForLoop(s))
+        .sort(sortByName),
       systemSkills: systemSkills.sort(sortByName),
-      equippedSkills,
+      equippedSkills: [
+        ...agentEquippedSkills.sort(sortByName),
+        ...autoEquippedSkills.sort(sortByName),
+        ...podEquippedSkills.sort(sortByName),
+        ...discoveredSkills.sort(sortByName),
+      ],
     };
   }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1496,9 +1496,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const sortByName = (a: SkillResource, b: SkillResource) =>
       a.name.localeCompare(b.name);
 
-    // System skills are always treated as enabled when present in the agent configuration.
-    const configSystemSkills = allAgentSkills.filter((s) => s.isSystemSkill);
-
     // Code-defined skills can opt into being auto-equipped or auto-enabled for
     // the agent loop without being added to the agent configuration. `findAll`
     // already drops restricted skills, so a flag-gated skill only shows up once
@@ -1508,7 +1505,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...(await GlobalSkillsRegistry.findAll(auth)),
     ];
 
-    const autoEnabledOrEquippedSkillsRef: Record<
+    const skillRefsByAutoEnabledOrEquipped: Record<
       "enabled" | "equipped",
       { globalSkillId: string; customSkillId: null }[]
     > = {
@@ -1525,28 +1522,33 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         continue;
       }
 
-      const ref = { globalSkillId: def.sId, customSkillId: null };
-      autoEnabledOrEquippedSkillsRef[autoEnabledOrEquipped].push(ref);
+      skillRefsByAutoEnabledOrEquipped[autoEnabledOrEquipped].push({
+        globalSkillId: def.sId,
+        customSkillId: null,
+      });
     }
 
-    const autoEnabledSkills = autoEnabledOrEquippedSkillsRef.enabled.length
-      ? await this.fetchBySkillReferences(auth, autoEnabledOrEquippedSkillsRef.enabled, {
-          agentLoopData,
-        })
+    const autoEnabledSkills = skillRefsByAutoEnabledOrEquipped.enabled.length
+      ? await this.fetchBySkillReferences(
+          auth,
+          skillRefsByAutoEnabledOrEquipped.enabled,
+          {
+            agentLoopData,
+          }
+        )
       : [];
-    const autoEnabledSkillIds = new Set(
-      autoEnabledSkills.map((s) => s.sId)
+    const autoEnabledSkillIds = new Set(autoEnabledSkills.map((s) => s.sId));
+    const systemSkillsAddedToAgent = allAgentSkills.filter(
+      (s) => s.isSystemSkill
     );
-
-    const activeGlobalSkillIds = new Set(
+    const systemPromptSkillIds = new Set(
       removeNulls([
-        ...allAgentSkills.map((s) => s.globalSId),
-        ...conversationEnabledSkills.map((s) => s.globalSId),
-        ...autoEnabledSkills.map((s) => s.globalSId),
+        ...systemSkillsAddedToAgent.map((s) => s.globalSId),
+        ...autoEnabledSkills.map((s) => s.globalSId ?? s.sId),
       ])
     );
-    const autoEquippedRefs = autoEnabledOrEquippedSkillsRef.equipped.filter(
-      (ref) => !activeGlobalSkillIds.has(ref.globalSkillId)
+    const autoEquippedRefs = skillRefsByAutoEnabledOrEquipped.equipped.filter(
+      (ref) => !systemPromptSkillIds.has(ref.globalSkillId)
     );
     const autoEquippedSkills = autoEquippedRefs.length
       ? await this.fetchBySkillReferences(auth, autoEquippedRefs, {
@@ -1560,16 +1562,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // skills that this context promotes to always-on system prompt content.
     const systemSkills = [
       ...new Map(
-        [...configSystemSkills, ...autoEnabledSkills].map((s) => [s.sId, s])
+        [...systemSkillsAddedToAgent, ...autoEnabledSkills].map((s) => [
+          s.sId,
+          s,
+        ])
       ).values(),
     ];
 
     // Conversation-enabled skills are rendered after an enable_skill action. If the same
     // code-defined skill is auto-enabled for this loop, systemSkills owns it instead.
     const enabledSkills = conversationEnabledSkills
-      .filter(
-        (s) => !s.globalSId || !autoEnabledSkillIds.has(s.globalSId)
-      )
+      .filter((s) => !s.globalSId || !autoEnabledSkillIds.has(s.globalSId))
       .sort(sortByName);
 
     // Equipped skills are the enable-able candidates shown to the model. Exclude anything

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1509,12 +1509,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...(await GlobalSkillsRegistry.findAll(auth)),
     ];
 
-    type CodeDefinedSkillReference = {
+    const autoEnabledRefs: { globalSkillId: string; customSkillId: null }[] =
+      [];
+    const autoEquippedCandidateRefs: {
       globalSkillId: string;
       customSkillId: null;
-    };
-    const autoEnabledRefs: CodeDefinedSkillReference[] = [];
-    const autoEquippedCandidateRefs: CodeDefinedSkillReference[] = [];
+    }[] = [];
     for (const def of codeDefinedDefs) {
       const autoMode = def.getAutoModeForAgentLoop?.({
         agentConfiguration,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -37,10 +37,7 @@ import {
 } from "@app/lib/resources/permission_utils";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
-import type {
-  AutoEnabledOrEquippedForAgentLoop,
-  SkillDefinition,
-} from "@app/lib/resources/skill/code_defined/shared";
+import type { SkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
 import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -1512,7 +1509,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     ];
 
     const autoRefsByEnabledOrEquipped: Record<
-      AutoEnabledOrEquippedForAgentLoop,
+      "enabled" | "equipped",
       { globalSkillId: string; customSkillId: null }[]
     > = {
       enabled: [],

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -84,6 +84,7 @@ import { SKILL_GROUP_PREFIX } from "@app/types/groups";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -1496,22 +1497,23 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const sortByName = (a: SkillResource, b: SkillResource) =>
       a.name.localeCompare(b.name);
 
-    // Code-defined skills can opt into being auto-equipped or auto-enabled for
-    // the agent loop without being added to the agent configuration. `findAll`
-    // already drops restricted skills, so a flag-gated skill only shows up once
-    // its feature flag is on.
+    // Code-defined skills can auto-add themselves to system prompt content or
+    // to equipped candidates for the current agent loop. `findAll` already
+    // drops restricted skills, so a flag-gated skill only shows up once its
+    // feature flag is on.
     const codeDefinedDefs = [
       ...(await SystemSkillsRegistry.findAll(auth)),
       ...(await GlobalSkillsRegistry.findAll(auth)),
     ];
 
-    const skillRefsByAutoEnabledOrEquipped: Record<
-      "enabled" | "equipped",
-      { globalSkillId: string; customSkillId: null }[]
-    > = {
-      enabled: [],
-      equipped: [],
-    };
+    const autoEnabledSystemSkillRefs: {
+      globalSkillId: string;
+      customSkillId: null;
+    }[] = [];
+    const autoEquippedSkillRefs: {
+      globalSkillId: string;
+      customSkillId: null;
+    }[] = [];
     for (const def of codeDefinedDefs) {
       const autoEnabledOrEquipped = def.getAutoEnabledOrEquippedForAgentLoop?.({
         agentConfiguration,
@@ -1522,47 +1524,64 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         continue;
       }
 
-      skillRefsByAutoEnabledOrEquipped[autoEnabledOrEquipped].push({
+      const skillRef = {
         globalSkillId: def.sId,
         customSkillId: null,
-      });
+      };
+
+      switch (autoEnabledOrEquipped) {
+        case "enabled":
+          autoEnabledSystemSkillRefs.push(skillRef);
+          break;
+        case "equipped":
+          autoEquippedSkillRefs.push(skillRef);
+          break;
+        default:
+          assertNever(autoEnabledOrEquipped);
+      }
     }
 
-    const autoEnabledSkills = skillRefsByAutoEnabledOrEquipped.enabled.length
-      ? await this.fetchBySkillReferences(
-          auth,
-          skillRefsByAutoEnabledOrEquipped.enabled,
-          {
-            agentLoopData,
-          }
-        )
+    const autoEnabledSystemSkills = autoEnabledSystemSkillRefs.length
+      ? await this.fetchBySkillReferences(auth, autoEnabledSystemSkillRefs, {
+          agentLoopData,
+        })
       : [];
-    const autoEnabledSkillIds = new Set(autoEnabledSkills.map((s) => s.sId));
-    const systemSkillsAddedToAgent = allAgentSkills.filter(
-      (s) => s.isSystemSkill
-    );
-    const systemPromptSkillIds = new Set(
-      removeNulls([
-        ...systemSkillsAddedToAgent.map((s) => s.globalSId),
-        ...autoEnabledSkills.map((s) => s.globalSId ?? s.sId),
-      ])
-    );
 
-    // Equipped skills are the enable-able candidates shown to the model. Exclude anything
-    // already active as system prompt content, then add default/discoverable candidates
-    // without duplicating agent-provided ones.
+    const systemSkillsFromAgent = allAgentSkills.filter((s) => s.isSystemSkill);
+    const skillIdForLoop = (skill: SkillResource) =>
+      skill.globalSId ?? skill.sId;
+    const systemSkillIds = new Set(
+      [...systemSkillsFromAgent, ...autoEnabledSystemSkills].map(skillIdForLoop)
+    );
+    const isSystemSkillForLoop = (skill: SkillResource) =>
+      systemSkillIds.has(skillIdForLoop(skill));
+
+    // Active baseline skills for this loop: configured system skills, plus
+    // code-defined skills that this context promotes to system prompt content.
+    const systemSkills = [
+      ...new Map(
+        [...systemSkillsFromAgent, ...autoEnabledSystemSkills].map((s) => [
+          s.sId,
+          s,
+        ])
+      ).values(),
+    ];
+
+    const enabledSkills = conversationEnabledSkills
+      .filter((s) => !isSystemSkillForLoop(s))
+      .sort(sortByName);
+
+    // Equipped skills are the enable-able candidates shown to the model. They
+    // come from the agent configuration, context auto-equipping, Pod defaults,
+    // and discoverable skills. System prompt skills are never enable-able.
     const agentEquippedSkills = allAgentSkills.filter(
-      (s) =>
-        !s.isSystemSkill &&
-        (!s.globalSId || !autoEnabledSkillIds.has(s.globalSId))
+      (s) => !s.isSystemSkill && !isSystemSkillForLoop(s)
     );
-    const agentEquippedGlobalSkillIds = new Set(
-      removeNulls(agentEquippedSkills.map((s) => s.globalSId))
-    );
-    const autoEquippedRefs = skillRefsByAutoEnabledOrEquipped.equipped.filter(
+    const equippedSkillIds = new Set(agentEquippedSkills.map((s) => s.sId));
+    const autoEquippedRefs = autoEquippedSkillRefs.filter(
       (ref) =>
-        !systemPromptSkillIds.has(ref.globalSkillId) &&
-        !agentEquippedGlobalSkillIds.has(ref.globalSkillId)
+        !systemSkillIds.has(ref.globalSkillId) &&
+        !equippedSkillIds.has(ref.globalSkillId)
     );
     const autoEquippedSkills = autoEquippedRefs.length
       ? await this.fetchBySkillReferences(auth, autoEquippedRefs, {
@@ -1571,44 +1590,38 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           withTools: false,
         })
       : [];
+    for (const skill of autoEquippedSkills) {
+      equippedSkillIds.add(skill.sId);
+    }
 
-    // Active baseline skills for this loop: configured system skills, plus code-defined
-    // skills that this context promotes to always-on system prompt content.
-    const systemSkills = [
-      ...new Map(
-        [...systemSkillsAddedToAgent, ...autoEnabledSkills].map((s) => [
-          s.sId,
-          s,
-        ])
-      ).values(),
-    ];
+    const podEquippedSkills = podDefaultSkills.filter((s) => {
+      if (isSystemSkillForLoop(s)) {
+        return false;
+      }
 
-    // Conversation-enabled skills are rendered after an enable_skill action. If the same
-    // code-defined skill is auto-enabled for this loop, systemSkills owns it instead.
-    const enabledSkills = conversationEnabledSkills
-      .filter((s) => !s.globalSId || !autoEnabledSkillIds.has(s.globalSId))
-      .sort(sortByName);
+      return !equippedSkillIds.has(s.sId);
+    });
+    for (const skill of podEquippedSkills) {
+      equippedSkillIds.add(skill.sId);
+    }
 
-    const agentEquippedSkillIds = new Set(
-      [...agentEquippedSkills, ...autoEquippedSkills].map((s) => s.sId)
-    );
-    const podEquippedSkills = podDefaultSkills.filter(
-      (s) => !agentEquippedSkillIds.has(s.sId)
-    );
-    const equippedSkillIds = new Set([
-      ...agentEquippedSkillIds,
-      ...podEquippedSkills.map((s) => s.sId),
-    ]);
-    const discoveredSkills = discoverableSkills.filter(
-      (s) => !equippedSkillIds.has(s.sId)
-    );
+    const discoveredSkills = discoverableSkills.filter((s) => {
+      if (isSystemSkillForLoop(s)) {
+        return false;
+      }
 
-    const equippedSkills = removeNulls([
+      return !equippedSkillIds.has(s.sId);
+    });
+    for (const skill of discoveredSkills) {
+      equippedSkillIds.add(skill.sId);
+    }
+
+    const equippedSkills = [
       ...agentEquippedSkills.sort(sortByName),
       ...autoEquippedSkills.sort(sortByName),
       ...podEquippedSkills.sort(sortByName),
       ...discoveredSkills.sort(sortByName),
-    ]);
+    ];
 
     return {
       enabledSkills,


### PR DESCRIPTION
## Description

This PR fixes and refactors how equipped/enabled is defined for skills, notably rationalizing the `isAutoXxx` callbacks, that proved to add several edge cases.

Also adds quite a few tests: the goal is really to make sure we do not alter what ends up in each bucket (system, enabled, equipped). We used to have a very simple rule (added in agent builder -> equipped, enabled by agent -> enabled) but have grown to have more needs in terms of customization (some skills are always equipped, some conditionally on the current conversation) so the few invariants are now encoded in tests rather than in implementation, which can outgrow them.

`listForAgentLoop` now builds the three buckets as follows:
- system skills come from agent-added system skills plus auto-enabled code-defined skills;
- enabled skills come from `listEnabledByConversation`, excluding skills already owned by system prompt content;
- equipped skills come from agent skills, auto-equipped skills, Pod defaults, and discoverable skills, excluding system prompt skills and de-duping across equipped sources.

The definition types now prevent system skills from returning `"equipped"`. `projects` remains the narrow global exception because it is equip-able outside Pods and system prompt content inside Pod conversations.

Also sorts skills in a stable way within the list of equipped skills.

## Tests

- Added a bunch of tests.
- Tested locally with pods/computer/go deep (all edge cases of auto smth).

## Risk

- Low.

## Deploy Plan

- Deploy front.
