### PR TITLE
Decouple agent configuration's model from actual model during run loop.

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -202,7 +202,10 @@ app.post(
       userMessage,
       agentConfiguration,
       fallbackPrompt,
-      model,
+      model: {
+        ...agentConfiguration.model,
+        ...model,
+      },
       hasAvailableActions: availableActions.length > 0,
       errorContext: mcpToolsListingError,
       conversation,

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -173,7 +173,9 @@ function AgentActionsPanelContent({
           const contentParser = new AgentMessageContentParser(
             agentConfiguration,
             messageId,
-            getDelimitersConfiguration({ agentConfiguration })
+            getDelimitersConfiguration({
+              model: agentConfiguration.model,
+            })
           );
           const parsedContent = await contentParser.parseContents([
             c.content.value,

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -24,6 +24,7 @@ import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import type { ServerSideMCPToolTypeWithStakeAndRetryPolicy } from "@app/lib/api/mcp";
 import { Authenticator } from "@app/lib/auth";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import {
   AgentMessageModel,
   MessageModel,
@@ -707,10 +708,20 @@ describe("tryCallMCPTool", () => {
       generatedFiles: [],
     };
 
+    const { model: agentModel, ...agentConfiguration } = agentConfig;
+    const modelConfig = getSupportedModelConfig(agentModel);
+    if (!modelConfig) {
+      throw new Error("Supported model config should exist");
+    }
+
     // Create agent loop run context
     const agentLoopRunContext: AgentLoopRunContextType = {
       contextType: "agent_loop",
-      agentConfiguration: agentConfig,
+      agentConfiguration,
+      model: {
+        ...agentModel,
+        ...modelConfig,
+      },
       agentMessage,
       conversation,
       stepContext: {

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -15,6 +15,7 @@ import type { DataSourceNodeContentType } from "@app/lib/actions/mcp_internal_ac
 import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { Authenticator } from "@app/lib/auth";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
@@ -107,10 +108,18 @@ async function setupTest({
     rank: 1,
   });
 
+  const { model: agentModel, ...agentConfiguration } = agentConfig;
+  const modelConfig = getSupportedModelConfig(agentModel);
+  assert(modelConfig, "Supported model config should exist");
+
   const toolContext: ToolContextType = {
     runContext: {
       contextType: "agent_loop",
-      agentConfiguration: agentConfig,
+      agentConfiguration,
+      model: {
+        ...agentModel,
+        ...modelConfig,
+      },
       agentMessage,
       currentAction: action.toJSON(),
       conversation,

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -27,6 +27,7 @@ import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/action
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type {
   FileUseCase,

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -8,11 +8,8 @@ import type {
 import { pauseSandboxBashForBlockedChild } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type {
-  AgentMessageType,
-  ConversationWithoutContentType,
-} from "@app/types/assistant/conversation";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { MCPApproveExecutionEvent } from "@dust-tt/client";
 import { assertNever, isAgentPauseOutputResourceType } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -37,8 +34,8 @@ export async function getExitOrPauseEvents(
   }: {
     outputItems: MCPActionOutputItemWithContent[];
     action: AgentMCPActionResource;
-    agentConfiguration: AgentConfigurationType;
-    agentMessage: AgentMessageType;
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+    agentMessage: AgentLoopExecutionData["agentMessage"];
     conversation: ConversationWithoutContentType;
   }
 ): Promise<

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -5,12 +5,16 @@ import type {
 } from "@app/lib/actions/mcp";
 import type { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import type { AgentMCPActionType } from "@app/types/actions";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  AgentConfigurationWithoutModelType,
+  AgentModelConfigurationType,
+} from "@app/types/assistant/agent";
 import type {
   AgentMessageType,
   ConversationType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { z } from "zod";
 
@@ -148,7 +152,8 @@ export type ActionGeneratedFileType =
 
 export type AgentLoopRunContextType = {
   contextType: "agent_loop";
-  agentConfiguration: AgentConfigurationType;
+  agentConfiguration: AgentConfigurationWithoutModelType;
+  model: AgentModelConfigurationType & ModelConfigurationType;
   agentMessage: AgentMessageType;
   currentAction: AgentMCPActionType;
   conversation: ConversationType;
@@ -164,7 +169,7 @@ export type SandboxFunctionRunContextType = {
 };
 
 export type AgentLoopListToolsContextType = {
-  agentConfiguration: AgentConfigurationType;
+  agentConfiguration: AgentConfigurationWithoutModelType;
   agentActionConfiguration: MCPServerConfigurationType;
   clientSideActionConfigurations?: ClientSideMCPServerConfigurationType[];
   conversation: ConversationType;

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -2,8 +2,7 @@ import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { INTERNAL_SERVERS_WITH_WEBSEARCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { StepContext } from "@app/lib/actions/types";
 import { isServerSideMCPToolConfigurationWithName } from "@app/lib/actions/types/guards";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 
 export const WEBSEARCH_ACTION_NUM_RESULTS = 16;
 export const SLACK_SEARCH_ACTION_NUM_RESULTS = 24;
@@ -19,19 +18,12 @@ export const RUN_AGENT_ACTION_NUM_RESULTS = 64;
  * in the step.
  */
 export function getRetrievalTopK({
-  agentConfiguration,
+  model,
   stepActions,
 }: {
-  agentConfiguration: AgentConfigurationType;
+  model: ModelConfigurationType;
   stepActions: MCPToolConfigurationType[];
 }): number {
-  const model = getSupportedModelConfig(agentConfiguration.model);
-  if (!model) {
-    throw new Error(
-      `Model config not found for ${agentConfiguration.model.modelId}`
-    );
-  }
-
   const searchActions = stepActions.filter(
     (tool) =>
       isServerSideMCPToolConfigurationWithName(tool, "search") ||
@@ -104,11 +96,11 @@ export function getWebsearchNumResults({
  * - Returns the shared number of results for websearch actions.
  */
 export function getCitationsCount({
-  agentConfiguration,
+  model,
   stepActions,
   stepActionIndex,
 }: {
-  agentConfiguration: AgentConfigurationType;
+  model: ModelConfigurationType;
   stepActions: MCPToolConfigurationType[];
   stepActionIndex: number;
 }): number {
@@ -147,22 +139,22 @@ export function getCitationsCount({
   }
 
   return getRetrievalTopK({
-    agentConfiguration,
+    model,
     stepActions,
   });
 }
 
 export function computeStepContexts({
-  agentConfiguration,
+  model,
   stepActions,
   citationsRefsOffset,
 }: {
-  agentConfiguration: AgentConfigurationType;
+  model: ModelConfigurationType;
   stepActions: MCPToolConfigurationType[];
   citationsRefsOffset: number;
 }): StepContext[] {
   const retrievalTopK = getRetrievalTopK({
-    agentConfiguration,
+    model,
     stepActions,
   });
 
@@ -175,7 +167,7 @@ export function computeStepContexts({
 
   for (let i = 0; i < stepActions.length; i++) {
     const citationsCount = getCitationsCount({
-      agentConfiguration,
+      model,
       stepActions,
       stepActionIndex: i,
     });

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -25,7 +25,6 @@ import {
 import { getConversationDataSourceViews } from "@app/lib/api/assistant/jit/utils";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import {
   CONTENT_OUTDATED_MSG,
   getContentFragmentFromAttachmentFile,
@@ -146,12 +145,7 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
     );
 
     const conversation = toolContext.runContext.conversation;
-    const model = getSupportedModelConfig(
-      toolContext.runContext.agentConfiguration.model
-    );
-    if (!model) {
-      return new Err(new MCPError("Model configuration not found"));
-    }
+    const model = toolContext.runContext.model;
 
     const fileRes = await getFileFromConversation(
       auth,

--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -7,12 +7,8 @@ import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
 import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type {
-  ConversationType,
-  UserMessageType,
-} from "@app/types/assistant/conversation";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import type { UserMessageType } from "@app/types/assistant/conversation";
 import { isUserMessageType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -87,11 +83,13 @@ export async function getCoreDataSourceSearchCriterias(
 export async function getPromptForProcessDustApp({
   auth,
   agentConfiguration,
+  model,
   conversation,
 }: {
   auth: Authenticator;
-  agentConfiguration: AgentConfigurationType;
-  conversation: ConversationType;
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+  model: AgentLoopExecutionData["model"];
+  conversation: AgentLoopExecutionData["conversation"];
 }) {
   // Grab user message.
   const userMessagesFiltered = conversation.content.filter((m) =>
@@ -104,13 +102,6 @@ export async function getPromptForProcessDustApp({
   );
   const userMessage: UserMessageType =
     lastUserMessageTuple[0] as UserMessageType;
-
-  const model = getSupportedModelConfig(agentConfiguration.model);
-  if (!model) {
-    throw new Error(
-      `Model config not found for ${agentConfiguration.model.modelId}`
-    );
-  }
 
   return systemPromptToText(
     constructPromptMultiActions(auth, {

--- a/front/lib/api/actions/servers/extract_data/tools/index.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.ts
@@ -92,8 +92,7 @@ export function createExtractDataTools(
       isAgentLoopRunContext(toolContext?.runContext),
       "AgentLoopRunContext expected"
     );
-    const { agentConfiguration, conversation } = toolContext.runContext;
-    const { model } = agentConfiguration;
+    const { agentConfiguration, model, conversation } = toolContext.runContext;
 
     // Defensive handling: parse jsonSchema if it arrives as a JSON string.
     // This can happen when the LLM generates a stringified JSON schema instead of an object,
@@ -159,6 +158,7 @@ export function createExtractDataTools(
     const prompt = await getPromptForProcessDustApp({
       auth,
       agentConfiguration,
+      model,
       conversation,
     });
 

--- a/front/lib/api/actions/servers/run_agent/conversation.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.ts
@@ -16,12 +16,8 @@ import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import logger from "@app/logger/logger";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type {
-  AgentMessageType,
-  ConversationType,
-  UserMessageOrigin,
-} from "@app/types/assistant/conversation";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { isUserMessageType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -64,9 +60,9 @@ export async function getOrCreateConversation(
   }: {
     childAgentBlob: ChildAgentBlob;
     childAgentId: string;
-    mainAgent: AgentConfigurationType;
-    originMessage: AgentMessageType;
-    mainConversation: ConversationType;
+    mainAgent: AgentLoopExecutionData["agentConfiguration"];
+    originMessage: AgentLoopExecutionData["agentMessage"];
+    mainConversation: AgentLoopExecutionData["conversation"];
     query: string;
     toolsetsToAdd: string[] | null;
     fileOrContentFragmentIds: string[] | null;

--- a/front/lib/api/actions/servers/run_dust_app/helpers.ts
+++ b/front/lib/api/actions/servers/run_dust_app/helpers.ts
@@ -21,7 +21,6 @@ import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
 import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
 import type { Authenticator } from "@app/lib/auth";
 import { extractConfig } from "@app/lib/config";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AppResource } from "@app/lib/resources/app_resource";
 import logger from "@app/logger/logger";
 import type { BlockRunConfig, SpecificationBlockType } from "@app/types/app";
@@ -293,11 +292,9 @@ export async function prepareParamsWithHistory(
   if (
     schema?.some((s) => s.key === DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY)
   ) {
-    const model = getSupportedModelConfig(
-      agentLoopRunContext.agentConfiguration.model
-    );
+    const model = agentLoopRunContext.model;
 
-    if (model) {
+    if (agentLoopRunContext.model) {
       const allowedTokenCount = model.contextSize - MIN_GENERATION_TOKENS;
 
       const convoRes = await renderConversationForModel(auth, {

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -238,9 +238,9 @@ describe("runSandboxBashTool", () => {
         runContext: {
           contextType: "agent_loop",
           agentConfiguration: {
-            model: { providerId: "openai" },
             sId: "agent-id",
           },
+          model: { providerId: "openai" },
           agentMessage: { sId: "message-id", agentMessageId: 1 },
           conversation: { sId: "conversation-id" },
           currentAction: { sId: "sandbox-action-id" },
@@ -675,9 +675,9 @@ describe("runSandboxBashTool", () => {
           runContext: {
             contextType: "agent_loop",
             agentConfiguration: {
-              model: { providerId: "openai" },
               sId: "agent-id",
             },
+            model: { providerId: "openai" },
             agentMessage: { sId: "message-id", agentMessageId: 1 },
             conversation: { sId: "conversation-id" },
             currentAction: { sId: "sandbox-action-id" },

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -232,7 +232,7 @@ export async function createSandboxTools(
     bash: runSandboxBashTool,
     describe_toolset: async ({ format }, { auth, toolContext }) => {
       const providerId = isAgentLoopRunContext(toolContext?.runContext)
-        ? toolContext.runContext.agentConfiguration.model.providerId
+        ? toolContext.runContext.model.providerId
         : null;
       if (!providerId) {
         return new Err(new MCPError("Missing model provider ID"));
@@ -312,6 +312,7 @@ export async function runSandboxBashTool(
   const {
     conversation,
     agentConfiguration,
+    model,
     agentMessage,
     currentAction: sandboxAction,
     stepContext,
@@ -372,7 +373,7 @@ export async function runSandboxBashTool(
   const metricsCtx = { workspaceId: auth.getNonNullableWorkspace().sId };
   const startMs = performance.now();
 
-  const providerId = agentConfiguration.model.providerId;
+  const providerId = model.providerId;
   const commandTimeoutMs = timeoutMs ?? SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS;
   const timeoutSec = Math.ceil(commandTimeoutMs / 1000);
   // Give the provider a slightly longer timeout than the in-container one, so

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -103,11 +103,17 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       "AgentLoopRunContext expected"
     );
 
-    const { agentConfiguration, agentMessage, conversation, userMessage } =
-      toolContext.runContext;
+    const {
+      agentConfiguration,
+      model,
+      agentMessage,
+      conversation,
+      userMessage,
+    } = toolContext.runContext;
 
     const agentLoopData = {
       agentConfiguration,
+      model,
       agentMessage,
       conversation,
       userMessage,

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -6,7 +6,7 @@ import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import logger from "@app/logger/logger";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type {
   ModelConversationTypeMultiActions,
@@ -66,7 +66,7 @@ export async function renderConversationForModel(
     excludeImages?: boolean;
     onMissingAction?: "inject-placeholder" | "skip";
     enablePreviousInteractionsPruning?: boolean;
-    agentConfiguration?: AgentConfigurationType;
+    agentConfiguration?: AgentLoopExecutionData["agentConfiguration"];
     enabledSkills: EnabledSkill[];
   }
 ): Promise<

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -13,8 +13,8 @@ import {
 import type { EnabledSkill } from "@app/lib/api/assistant/skills_rendering";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { AgentTextContentType } from "@app/types/assistant/agent_message_content";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type {
   AgentMessageType,
   ConversationType,
@@ -153,7 +153,7 @@ export async function renderAllMessages(
     excludeActions?: boolean;
     excludeImages?: boolean;
     onMissingAction: "inject-placeholder" | "skip";
-    agentConfiguration?: AgentConfigurationType;
+    agentConfiguration?: AgentLoopExecutionData["agentConfiguration"];
     enabledSkills: EnabledSkill[];
   }
 ): Promise<ModelMessageTypeMultiActions[]> {

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -14,7 +14,10 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  AgentConfigurationType,
+  AgentConfigurationWithoutModelType,
+} from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type {
   ConversationType,
@@ -24,6 +27,23 @@ import type {
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { WorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it } from "vitest";
+
+function withoutModel(
+  config: AgentConfigurationType
+): AgentConfigurationWithoutModelType {
+  const { model: _model, ...agentConfiguration } = config;
+  return agentConfiguration;
+}
+
+function agentLoopModel(
+  config: AgentConfigurationType,
+  modelConfig: ModelConfigurationType
+) {
+  return {
+    ...config.model,
+    ...modelConfig,
+  };
+}
 
 function createForkedData(user: NonNullable<UserMessageType["user"]>) {
   return {
@@ -128,8 +148,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
   it("should generate identical system prompts for the same inputs", () => {
     const params = {
       userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
+      agentConfiguration: withoutModel(agentConfig1),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -146,8 +166,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     // Same workspace, same agent, but different conversation metadata
     const baseParams = {
       userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
+      agentConfiguration: withoutModel(agentConfig1),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -189,8 +209,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     // Different workspaces should produce different prompts (workspace name is in the prompt)
     const params1 = {
       userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
+      agentConfiguration: withoutModel(agentConfig1),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -200,8 +220,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
 
     const params2 = {
       userMessage: userMessage2,
-      agentConfiguration: agentConfig2,
-      model: modelConfig,
+      agentConfiguration: withoutModel(agentConfig2),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -226,8 +246,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
   it("should return flat context array for regular agents", () => {
     const params = {
       userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
+      agentConfiguration: withoutModel(agentConfig1),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -253,8 +273,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
 
     const params = {
       userMessage: userMessage1,
-      agentConfiguration: deepDiveConfig,
-      model: modelConfig,
+      agentConfiguration: withoutModel(deepDiveConfig),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -289,8 +309,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
 
     const params = {
       userMessage: userMessage1,
-      agentConfiguration: sidekickConfig,
-      model: modelConfig,
+      agentConfiguration: withoutModel(sidekickConfig),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -328,8 +348,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
   it("should include branch context in flat prompts using user-facing branch wording", () => {
     const params = {
       userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
+      agentConfiguration: withoutModel(agentConfig1),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -363,10 +383,9 @@ describe("constructPromptMultiActions - system prompt stability", () => {
   it("should mention the conversation title tool in conversation prompts", () => {
     const params = {
       userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
+      agentConfiguration: withoutModel(agentConfig1),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
-      agentsList: null,
       systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
@@ -403,8 +422,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
 
     const baseParams = {
       userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelWithFormatting,
+      agentConfiguration: withoutModel(agentConfig1),
+      model: agentLoopModel(agentConfig1, modelWithFormatting),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -436,8 +455,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
 
     const params = {
       userMessage: userMessage1,
-      agentConfiguration: deepDiveConfig,
-      model: modelConfig,
+      agentConfiguration: withoutModel(deepDiveConfig),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -479,8 +498,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
 
     const params = {
       userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
+      agentConfiguration: withoutModel(agentConfig1),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -504,8 +523,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
   it("should point agents to the Computer for uploaded files when Computer is available", () => {
     const params = {
       userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
+      agentConfiguration: withoutModel(agentConfig1),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -529,8 +548,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
   it("should point legacy attachment prompts to the Computer when Computer is available", () => {
     const params = {
       userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
+      agentConfiguration: withoutModel(agentConfig1),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -553,8 +572,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
   it("should not mention the Computer file mount when Computer is unavailable", () => {
     const params = {
       userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
+      agentConfiguration: withoutModel(agentConfig1),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [],
       enabledSkills: [],
@@ -585,8 +604,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
 
     const params = {
       userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
+      agentConfiguration: withoutModel(agentConfig1),
+      model: agentLoopModel(agentConfig1, modelConfig),
       hasAvailableActions: true,
       systemSkills: [discoverSkills],
       enabledSkills: [],

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -35,14 +35,13 @@ import type {
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { CHAIN_OF_THOUGHT_META_PROMPT } from "@app/types/assistant/chain_of_thought_meta_prompt";
 import type {
   ConversationWithoutContentType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { WorkspaceType } from "@app/types/user";
 import moment from "moment-timezone";
 
@@ -59,8 +58,8 @@ function constructContextSection({
   disableFormattingPrompt,
 }: {
   userMessage: UserMessageType;
-  agentConfiguration: AgentConfigurationType;
-  model: ModelConfigurationType;
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+  model: AgentLoopExecutionData["model"];
   owner: WorkspaceType | null;
   errorContext?: string;
   disableFormattingPrompt: boolean;
@@ -157,8 +156,8 @@ function constructToolsSection({
   serverToolsAndInstructions,
 }: {
   hasAvailableActions: boolean;
-  model: ModelConfigurationType;
-  agentConfiguration: AgentConfigurationType;
+  model: AgentLoopExecutionData["model"];
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
   conversation?: ConversationWithoutContentType;
   serverToolsAndInstructions?: ServerToolsAndInstructions[];
 }): string {
@@ -170,7 +169,7 @@ function constructToolsSection({
   }
   if (
     hasAvailableActions &&
-    agentConfiguration.model.reasoningEffort === "light" &&
+    model.reasoningEffort === "light" &&
     !model.useNativeLightReasoning
   ) {
     toolsSection += `${CHAIN_OF_THOUGHT_META_PROMPT}\n`;
@@ -319,7 +318,7 @@ function constructPastedContentSection(): string {
 export function constructGuidelinesSection({
   agentConfiguration,
 }: {
-  agentConfiguration: AgentConfigurationType;
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
 }): string {
   let guidelinesSection = "# GUIDELINES\n";
 
@@ -366,7 +365,7 @@ function constructInstructionsSection({
   agentConfiguration,
   fallbackPrompt,
 }: {
-  agentConfiguration: AgentConfigurationType;
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
   fallbackPrompt?: string;
 }): string {
   let instructions = "# INSTRUCTIONS\n\n";
@@ -403,10 +402,10 @@ export function constructPromptMultiActions(
     hasSandboxTools = false,
     disableFormattingPrompt = false,
   }: {
-    userMessage: UserMessageType;
-    agentConfiguration: AgentConfigurationType;
+    userMessage: AgentLoopExecutionData["userMessage"];
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
     fallbackPrompt?: string;
-    model: ModelConfigurationType;
+    model: AgentLoopExecutionData["model"];
     hasAvailableActions: boolean;
     errorContext?: string;
     conversation?: ConversationWithoutContentType;

--- a/front/lib/api/assistant/jit/ask_user_question.ts
+++ b/front/lib/api/assistant/jit/ask_user_question.ts
@@ -3,14 +3,14 @@ import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_interna
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 
 /**
  * Get the ask_user_question MCP server for interactive clarifying questions.
  */
 export function getAskUserQuestionServer(
-  agentConfiguration: LightAgentConfigurationType,
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"],
   conversation: ConversationWithoutContentType,
   autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): ServerSideMCPServerConfigurationType | null {

--- a/front/lib/api/assistant/jit/common_utilities.ts
+++ b/front/lib/api/assistant/jit/common_utilities.ts
@@ -4,7 +4,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 
 /**
@@ -12,7 +12,7 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
  */
 export async function getCommonUtilitiesServer(
   auth: Authenticator,
-  agentConfiguration: LightAgentConfigurationType,
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"],
   conversation: ConversationWithoutContentType,
   autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): Promise<ServerSideMCPServerConfigurationType | null> {

--- a/front/lib/api/assistant/jit/files.ts
+++ b/front/lib/api/assistant/jit/files.ts
@@ -3,14 +3,14 @@ import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_interna
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 
 /**
  * Get the files MCP server for conversation file system access.
  */
 export function getFilesServer(
-  agentConfiguration: LightAgentConfigurationType,
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"],
   conversation: ConversationWithoutContentType,
   autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): ServerSideMCPServerConfigurationType | null {

--- a/front/lib/api/assistant/jit/schedules_management.ts
+++ b/front/lib/api/assistant/jit/schedules_management.ts
@@ -4,7 +4,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 
 /**
@@ -13,7 +13,7 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
  */
 export async function getSchedulesManagementServer(
   auth: Authenticator,
-  agentConfiguration: LightAgentConfigurationType,
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"],
   conversation: ConversationWithoutContentType,
   autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): Promise<ServerSideMCPServerConfigurationType | null> {

--- a/front/lib/api/assistant/jit/skills.ts
+++ b/front/lib/api/assistant/jit/skills.ts
@@ -5,7 +5,7 @@ import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_r
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 
 /**
@@ -13,7 +13,7 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
  */
 export async function getSkillManagementServer(
   auth: Authenticator,
-  agentConfiguration: AgentConfigurationType,
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"],
   conversation: ConversationWithoutContentType,
   autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): Promise<ServerSideMCPServerConfigurationType | null> {

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import type { Authenticator } from "@app/lib/auth";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { projectsSkill } from "@app/lib/resources/skill/code_defined/global/projects";
 import { sandboxSkill } from "@app/lib/resources/skill/code_defined/global/sandbox";
@@ -258,8 +259,18 @@ describe("getJITServers", () => {
         }
       );
 
+      const { model: agentModel, ...agentConfiguration } = agentConfig;
+      const modelConfig = getSupportedModelConfig(agentModel);
+      if (!modelConfig) {
+        throw new Error("Supported model config should exist");
+      }
+
       const { equippedSkills } = await SkillResource.listForAgentLoop(auth, {
-        agentConfiguration: agentConfig,
+        agentConfiguration,
+        model: {
+          ...agentModel,
+          ...modelConfig,
+        },
         agentMessage,
         conversation,
         userMessage,

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -16,7 +16,7 @@ import { isSearchableFolder } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
 
@@ -38,7 +38,7 @@ async function getUnconditionalJITServers(
     conversation,
     autoInternalViews,
   }: {
-    agentConfiguration: AgentConfigurationType;
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
     conversation: ConversationWithoutContentType;
     autoInternalViews: Map<
       AutoInternalMCPServerNameType,
@@ -92,7 +92,7 @@ async function getConditionalJITServers(
     attachments,
     autoInternalViews,
   }: {
-    agentConfiguration: AgentConfigurationType;
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
     conversation: ConversationWithoutContentType;
     attachments: ConversationAttachmentType[];
     autoInternalViews: Map<
@@ -158,7 +158,7 @@ export async function getJITServers(
     conversation,
     attachments,
   }: {
-    agentConfiguration: AgentConfigurationType;
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
     conversation: ConversationWithoutContentType;
     attachments: ConversationAttachmentType[];
   }

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -8,10 +8,8 @@ import { isRemoteDatabase } from "@app/lib/data_sources";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import type {
-  AgentConfigurationType,
-  LightAgentConfigurationType,
-} from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
 
@@ -25,7 +23,7 @@ export async function getSkillServers(
     agentConfiguration,
     skills,
   }: {
-    agentConfiguration: LightAgentConfigurationType;
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
     skills: SkillResource[];
   }
 ): Promise<MCPServerConfigurationType[]> {

--- a/front/lib/api/mcp/error.ts
+++ b/front/lib/api/mcp/error.ts
@@ -3,14 +3,13 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { AgentMessageType } from "@app/types/assistant/conversation";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 type HandleErrorParams = {
   action: AgentMCPActionResource;
-  agentConfiguration: AgentConfigurationType;
-  agentMessage: AgentMessageType;
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+  agentMessage: AgentLoopExecutionData["agentMessage"];
   errorContent: CallToolResult["content"];
   status: ToolExecutionStatus;
   executionDurationMs: number;

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -27,12 +27,7 @@ import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS } from "@app/temporal/agent_loop/config";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type {
-  AgentMessageType,
-  ConversationType,
-  UserMessageType,
-} from "@app/types/assistant/conversation";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { heartbeat } from "@temporalio/activity";
 
@@ -53,15 +48,17 @@ export async function* runToolWithStreaming(
   {
     action,
     agentConfiguration,
+    model,
     agentMessage,
     conversation,
     userMessage,
   }: {
     action: AgentMCPActionResource;
-    agentConfiguration: AgentConfigurationType;
-    agentMessage: AgentMessageType;
-    conversation: ConversationType;
-    userMessage: UserMessageType;
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+    model: AgentLoopExecutionData["model"];
+    agentMessage: AgentLoopExecutionData["agentMessage"];
+    conversation: AgentLoopExecutionData["conversation"];
+    userMessage: AgentLoopExecutionData["userMessage"];
   },
   options?: { signal?: AbortSignal }
 ): AsyncGenerator<
@@ -91,6 +88,7 @@ export async function* runToolWithStreaming(
   const agentLoopRunContext: AgentLoopRunContextType = {
     contextType: "agent_loop",
     agentConfiguration,
+    model,
     agentMessage,
     currentAction: action.toJSON(),
     conversation,

--- a/front/lib/api/sandbox/access_tokens.ts
+++ b/front/lib/api/sandbox/access_tokens.ts
@@ -4,11 +4,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import type { AgentMCPActionType } from "@app/types/actions";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type {
-  AgentMessageType,
-  ConversationType,
-} from "@app/types/assistant/conversation";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import crypto from "crypto";
 import jwt from "jsonwebtoken";
@@ -174,9 +170,9 @@ export async function generateSandboxExecToken(
     sandboxAction,
     expiryMs = 2 * 60 * 1000, // Default to 2 minutes
   }: {
-    agentConfiguration: AgentConfigurationType;
-    agentMessage: AgentMessageType;
-    conversation: ConversationType;
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+    agentMessage: AgentLoopExecutionData["agentMessage"];
+    conversation: AgentLoopExecutionData["conversation"];
     sandbox: SandboxResource;
     execId: string;
     sandboxAction: AgentMCPActionType;

--- a/front/lib/llms/agent_message_content_parser.ts
+++ b/front/lib/llms/agent_message_content_parser.ts
@@ -1,6 +1,10 @@
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import assert from "@app/lib/utils/assert";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  AgentModelConfigurationType,
+  LightAgentConfigurationType,
+  LightAgentConfigurationWithoutModelType,
+} from "@app/types/assistant/agent";
 import {
   CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION,
   DEEPSEEK_CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION,
@@ -54,7 +58,7 @@ export class AgentMessageContentParser {
   >;
 
   constructor(
-    private agentConfiguration: LightAgentConfigurationType,
+    private agentConfiguration: LightAgentConfigurationWithoutModelType,
     private messageId: string,
     delimitersConfiguration: DelimitersConfiguration
   ) {
@@ -284,18 +288,21 @@ const DEEPSEEK_MODELS: ModelIdType[] = [
 ];
 
 export function getDelimitersConfiguration({
-  agentConfiguration,
+  model,
 }: {
-  agentConfiguration: LightAgentConfigurationType;
+  model: AgentModelConfigurationType;
 }): DelimitersConfiguration {
-  const model = getSupportedModelConfig(agentConfiguration.model);
-  assert(model, "Model configuration not found in getDelimitersConfiguration");
+  const supportedModel = getSupportedModelConfig(model);
+  assert(
+    supportedModel,
+    "Model configuration not found in getDelimitersConfiguration"
+  );
 
   if (DEEPSEEK_MODELS.includes(model.modelId)) {
     return DEEPSEEK_CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION;
   }
   const reasoningEffort =
-    agentConfiguration.model.reasoningEffort ?? model.defaultReasoningEffort;
+    model.reasoningEffort ?? supportedModel.defaultReasoningEffort;
   if (reasoningEffort !== "light") {
     return {
       delimiters: [],

--- a/front/lib/resources/agent_memory_resource.ts
+++ b/front/lib/resources/agent_memory_resource.ts
@@ -8,7 +8,7 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { LightAgentConfigurationWithoutModelType } from "@app/types/assistant/agent";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -128,7 +128,7 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
       agentConfiguration,
       user,
     }: {
-      agentConfiguration: LightAgentConfigurationType;
+      agentConfiguration: LightAgentConfigurationWithoutModelType;
       user: UserType | null;
     },
     transaction?: Transaction
@@ -188,7 +188,7 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
       agentConfiguration,
       user,
     }: {
-      agentConfiguration: LightAgentConfigurationType;
+      agentConfiguration: LightAgentConfigurationWithoutModelType;
       user: UserType | null;
     }
   ): Promise<AgentMemoryEntry[]> {
@@ -212,7 +212,7 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
       user,
       entries,
     }: {
-      agentConfiguration: LightAgentConfigurationType;
+      agentConfiguration: LightAgentConfigurationWithoutModelType;
       user: UserType | null;
       entries: string[];
     }
@@ -278,7 +278,7 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
       user,
       indexes,
     }: {
-      agentConfiguration: LightAgentConfigurationType;
+      agentConfiguration: LightAgentConfigurationWithoutModelType;
       user: UserType | null;
       indexes: number[];
     }
@@ -317,7 +317,7 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
       user,
       edits,
     }: {
-      agentConfiguration: LightAgentConfigurationType;
+      agentConfiguration: LightAgentConfigurationWithoutModelType;
       user: UserType | null;
       edits: AgentMemoryEdit[];
     }

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -369,7 +369,7 @@ export const sandboxSkill = {
       agentLoopData,
     }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
   ) => {
-    const providerId = agentLoopData?.agentConfiguration?.model.providerId;
+    const providerId = agentLoopData?.model.providerId;
     const flags = await getFeatureFlags(auth);
     const hasDsbxTools = isComputerFeatureEnabled(flags);
     const isProject = agentLoopData?.conversation

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -3,7 +3,6 @@ import type { Authenticator } from "@app/lib/auth";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import type { ResourceSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -36,14 +35,14 @@ interface BaseSkillDefinition {
   // isRestricted), without enabling it. Return true to make the skill available through
   // skill_management__enable_skill.
   readonly isAutoEquippedForAgentLoop?: (params: {
-    agentConfiguration: AgentConfigurationType;
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
     conversation: ConversationWithoutContentType;
   }) => boolean;
   // Optional callback to auto-enable a code-defined skill for an agent loop (subject to
   // isRestricted), without it being added to the agent configuration. Return true to enable.
   // Used for skills that are on by default for a given context (e.g. Pods in a Pod conversation).
   readonly isAutoEnabledForAgentLoop?: (params: {
-    agentConfiguration: AgentConfigurationType;
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
     conversation: ConversationWithoutContentType;
   }) => boolean;
   // Optional callback to hide a skill from a given agent loop (both from equipped and enabled).

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1,4 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { SkillDataSourceConfigurationModel } from "@app/lib/models/skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
@@ -1623,12 +1624,22 @@ describe("SkillResource", () => {
         }
       );
 
+      const { model: agentModel, ...agentConfiguration } = agent;
+      const modelConfig = getSupportedModelConfig(agentModel);
+      if (!modelConfig) {
+        throw new Error("Supported model config should exist");
+      }
+
       const skills = await SkillResource.fetchByIds(
         testContext.authenticator,
         ["mention_users"],
         {
           agentLoopData: {
-            agentConfiguration: agent,
+            agentConfiguration,
+            model: {
+              ...agentModel,
+              ...modelConfig,
+            },
             agentMessage,
             conversation,
             userMessage,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -61,7 +61,7 @@ import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
-  AgentConfigurationType,
+  AgentConfigurationWithoutModelType,
   LightAgentConfigurationType,
 } from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
@@ -1078,7 +1078,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async listByAgentConfiguration(
     auth: Authenticator,
-    agentConfiguration: AgentConfigurationType,
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"],
     { agentLoopData }: { agentLoopData?: AgentLoopExecutionData } = {}
   ): Promise<SkillResource[]> {
     const refs = await this.getSkillReferencesForAgent(
@@ -1101,9 +1101,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    */
   static async listByAgentConfigurations(
     auth: Authenticator,
-    agentConfigurations: AgentConfigurationType[]
+    agentConfigurations: AgentLoopExecutionData["agentConfiguration"][]
   ): Promise<
-    { agentConfiguration: AgentConfigurationType; skill: SkillResource }[]
+    {
+      agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+      skill: SkillResource;
+    }[]
   > {
     assert(
       agentConfigurations.every((c) => !isGlobalAgentId(c.sId)),
@@ -1175,7 +1178,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    */
   static async getSkillReferencesForAgent(
     auth: Authenticator,
-    agentConfiguration: AgentConfigurationType
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"]
   ): Promise<
     {
       customSkillId: ModelId | null;
@@ -1389,7 +1392,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       transaction,
     }: {
       conversation: ConversationWithoutContentType;
-      agentConfiguration?: AgentConfigurationType;
+      agentConfiguration?: AgentConfigurationWithoutModelType;
       agentLoopData?: AgentLoopExecutionData;
       transaction?: Transaction;
     }
@@ -1451,7 +1454,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       | AgentLoopExecutionData
       | Pick<AgentLoopExecutionData, "agentConfiguration" | "conversation">
       | {
-          agentConfiguration: AgentConfigurationType;
+          agentConfiguration: AgentConfigurationWithoutModelType;
           conversation: ConversationWithoutContentType;
         }
   ): Promise<{
@@ -3305,7 +3308,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       agentConfiguration,
       conversation,
     }: {
-      agentConfiguration: AgentConfigurationType;
+      agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
       conversation: ConversationType;
     }
   ): Promise<{ wasAlreadyEnabled: boolean }> {

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -20,7 +20,7 @@ import {
   cancelWakeUpTemporalWorkflow,
   launchOrScheduleWakeUpTemporalWorkflow,
 } from "@app/temporal/triggers/wakeup_client";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import {
   ACTIVE_WAKE_UP_STATUSES,
@@ -203,7 +203,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
           reason: string;
         },
     conversation: ConversationWithoutContentType,
-    agentConfiguration: AgentConfigurationType,
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"],
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<WakeUpResource, Error>> {
     const { scheduleType, fireAt, cronExpression, cronTimezone, reason } = blob;

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -177,7 +177,10 @@ makeScript(
       userMessage,
       agentConfiguration,
       fallbackPrompt,
-      model,
+      model: {
+        ...model,
+        ...agentConfiguration.model,
+      },
       hasAvailableActions: availableActions.length > 0,
       errorContext: mcpToolsListingError,
       conversation,

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -656,7 +656,7 @@ export async function finalizeCancellation(
       `Failed to get run agent data: ${runAgentDataRes.error.message}`
     );
   }
-  const { auth, agentConfiguration, agentMessage, conversation } =
+  const { auth, agentConfiguration, model, agentMessage, conversation } =
     runAgentDataRes.value;
 
   // get the last step of the agent message
@@ -665,7 +665,7 @@ export async function finalizeCancellation(
   const contentParser = new AgentMessageContentParser(
     agentConfiguration,
     agentMessage.sId,
-    getDelimitersConfiguration({ agentConfiguration })
+    getDelimitersConfiguration({ model })
   );
 
   // Flush pending tokens from the content parser, if any.
@@ -723,7 +723,7 @@ export async function finalizeInterruption(
       `Failed to get run agent data: ${runAgentDataRes.error.message}`
     );
   }
-  const { auth, agentConfiguration, agentMessage, conversation } =
+  const { auth, agentConfiguration, model, agentMessage, conversation } =
     runAgentDataRes.value;
 
   // The message may have been finalized by another path already (e.g. an orphaned activity
@@ -747,7 +747,7 @@ export async function finalizeInterruption(
   const contentParser = new AgentMessageContentParser(
     agentConfiguration,
     agentMessage.sId,
-    getDelimitersConfiguration({ agentConfiguration })
+    getDelimitersConfiguration({ model })
   );
 
   for await (const tokenEvent of contentParser.flushTokens()) {

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -140,6 +140,7 @@ export async function runToolActivity(
 
   const {
     agentConfiguration,
+    model,
     conversation: originalConversation,
     agentMessage: originalAgentMessage,
     userMessage,
@@ -175,6 +176,7 @@ export async function runToolActivity(
       return executeToolStreaming(auth, {
         action,
         agentConfiguration,
+        model,
         agentMessage,
         conversation,
         deferredEvents,
@@ -192,6 +194,7 @@ async function executeToolStreaming(
   {
     action,
     agentConfiguration,
+    model,
     agentMessage,
     conversation,
     deferredEvents,
@@ -201,6 +204,7 @@ async function executeToolStreaming(
   }: {
     action: AgentMCPActionResource;
     agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+    model: AgentLoopExecutionData["model"];
     agentMessage: AgentLoopExecutionData["agentMessage"];
     conversation: AgentLoopExecutionData["conversation"];
     deferredEvents: ToolExecutionResult["deferredEvents"];
@@ -229,6 +233,7 @@ async function executeToolStreaming(
     {
       action,
       agentConfiguration,
+      model,
       agentMessage,
       conversation,
       userMessage,

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -21,15 +21,10 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import logger from "@app/logger/logger";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
-import type {
-  AgentActionsEvent,
-  AgentConfigurationType,
-} from "@app/types/assistant/agent";
+import type { AgentActionsEvent } from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
-import type {
-  AgentMessageType,
-  ConversationWithoutContentType,
-} from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 
@@ -62,7 +57,8 @@ export async function createToolActionsActivity(
     runIds: string[];
   }
 ): Promise<CreateToolActionsResult> {
-  const { agentConfiguration, agentMessage, conversation } = runAgentData;
+  const { agentConfiguration, model, agentMessage, conversation } =
+    runAgentData;
 
   const actionBlobs: ActionBlob[] = [];
   const approvalEvents: Omit<
@@ -79,6 +75,7 @@ export async function createToolActionsActivity(
     const result = await createActionForTool(auth, {
       actionConfiguration,
       agentConfiguration,
+      model,
       agentMessage,
       conversation,
       stepContentId,
@@ -120,6 +117,7 @@ async function createActionForTool(
   {
     actionConfiguration,
     agentConfiguration,
+    model,
     agentMessage,
     conversation,
     stepContentId,
@@ -128,8 +126,9 @@ async function createActionForTool(
     runIds,
   }: {
     actionConfiguration: MCPToolConfigurationType;
-    agentConfiguration: AgentConfigurationType;
-    agentMessage: AgentMessageType;
+    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+    model: ModelConfigurationType;
+    agentMessage: AgentLoopExecutionData["agentMessage"];
     conversation: ConversationWithoutContentType;
     stepContentId: ModelId;
     stepContext: StepContext;
@@ -178,8 +177,8 @@ async function createActionForTool(
         conversationId: conversation.sId,
         agentMessageId: agentMessage.sId,
         stepContentId,
-        modelId: agentConfiguration.model.modelId,
-        providerId: agentConfiguration.model.providerId,
+        modelId: model.modelId,
+        providerId: model.providerId,
         error: validateToolInputsResult.error,
       },
       "Tool input validation failed"

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -406,6 +406,7 @@ async function handleToolRunFirstStep(
 } | null> {
   const {
     agentConfiguration,
+    model,
     conversation: originalConversation,
     userMessage,
     agentMessage: originalAgentMessage,
@@ -512,7 +513,7 @@ async function handleToolRunFirstStep(
   );
 
   const stepContexts = computeStepContexts({
-    agentConfiguration,
+    model,
     stepActions: actions.map((a) => a.action),
     citationsRefsOffset,
   });

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -52,7 +52,6 @@ import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -287,7 +286,7 @@ export async function runModel(
 
   localLogger.info("Starting multi-action loop iteration");
 
-  const model = getSupportedModelConfig(agentConfiguration.model);
+  const model = runAgentData.model;
 
   async function publishAgentError(
     error: {
@@ -332,17 +331,6 @@ export async function runModel(
         step,
       });
     }
-  }
-
-  if (!model) {
-    await publishAgentError({
-      code: "model_does_not_support_multi_actions",
-      message:
-        `The model you selected (${agentConfiguration.model.modelId}) ` +
-        `does not support multi-actions.`,
-      metadata: null,
-    });
-    return null;
   }
 
   const featureFlags = await getFeatureFlags(auth);
@@ -632,7 +620,7 @@ export async function runModel(
   const contentParser = new AgentMessageContentParser(
     agentConfiguration,
     agentMessage.sId,
-    getDelimitersConfiguration({ agentConfiguration })
+    getDelimitersConfiguration({ model })
   );
 
   const traceContext: LLMTraceContext = {
@@ -650,10 +638,10 @@ export async function runModel(
   const llm = await getStreamLLM(auth, {
     credentials,
     modelId: model.modelId,
-    temperature: agentConfiguration.model.temperature,
-    reasoningEffort: agentConfiguration.model.reasoningEffort,
-    responseFormat: agentConfiguration.model.responseFormat,
-    metaData: agentConfiguration.model.metaData,
+    temperature: model.temperature,
+    reasoningEffort: model.reasoningEffort,
+    responseFormat: model.responseFormat,
+    metaData: model.metaData,
     context: traceContext,
     omittedThinking: agentConfiguration.omittedThinking,
     // Custom trace input: show only the last user message instead of full conversation.
@@ -1130,7 +1118,7 @@ export async function runModel(
   agentMessage.contents.push(...newContents);
 
   const stepContexts = computeStepContexts({
-    agentConfiguration,
+    model,
     stepActions: actions.map((a) => a.action),
     citationsRefsOffset,
   });

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -4,13 +4,13 @@ import type { LLMErrorInfo } from "@app/lib/api/llm/types/errors";
 import type { SystemPromptSections } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMessageContentParser } from "@app/lib/llms/agent_message_content_parser";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentFunctionCallContentType,
   AgentProviderPassthroughContentType,
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type {
   AgentMessageType,
   ConversationType,
@@ -55,8 +55,8 @@ export type GetOutputRequestParams = {
   flushParserTokens: () => Promise<void>;
   contentParser: AgentMessageContentParser;
   step: number;
-  agentConfiguration: AgentConfigurationType;
-  agentMessage: AgentMessageType;
+  agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+  agentMessage: AgentLoopExecutionData["agentMessage"];
   model: ModelConfigurationType;
   activityTimeoutDeadlineMs: number;
   publishAgentError: (error: {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -200,6 +200,16 @@ export const AgentConfigurationSchema = LightAgentConfigurationSchema.extend({
 
 export type AgentConfigurationType = z.infer<typeof AgentConfigurationSchema>;
 
+export type AgentConfigurationWithoutModelType = Omit<
+  AgentConfigurationType,
+  "model"
+>;
+
+export type LightAgentConfigurationWithoutModelType = Omit<
+  LightAgentConfigurationType,
+  "model"
+>;
+
 export interface TemplateAgentConfigurationType {
   name: string;
   pictureUrl: string;

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -7,10 +7,13 @@ import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conver
 import { getStaticReplyForUserMessage } from "@app/lib/api/assistant/static_reply";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import type {
   AgentConfigurationType,
+  AgentConfigurationWithoutModelType,
+  AgentModelConfigurationType,
   GlobalAgentContext,
 } from "@app/types/assistant/agent";
 import type {
@@ -27,6 +30,7 @@ import type { Result } from "../shared/result";
 import { Err, Ok } from "../shared/result";
 import { isGlobalAgentId } from "./assistant";
 import { ConversationError } from "./conversation";
+import type { ModelConfigurationType } from "./models/types";
 
 /**
  * Error types for getAgentLoopData that indicate deleted or unavailable resources.
@@ -130,7 +134,9 @@ export type AgentMessageRef = {
 };
 
 export type AgentLoopExecutionData = {
-  agentConfiguration: AgentConfigurationType;
+  // No models on the agent configuration as it might be different at run time (eg: auto mode, override by inputbar picker)
+  agentConfiguration: AgentConfigurationWithoutModelType;
+  model: AgentModelConfigurationType & ModelConfigurationType;
   agentMessage: AgentMessageType;
   conversation: ConversationType;
   userMessage: UserMessageType;
@@ -315,11 +321,28 @@ export async function getAgentLoopDataWithAuth(
   });
 
   if (!agentConfiguration) {
-    return new Err(new Error("Agent configuration not found"));
+    return new Err(new Error(`Agent configuration not found ${agentId}`));
+  }
+
+  const { model: agentModel, ...agentConfigurationWithoutModel } =
+    agentConfiguration;
+
+  const model = getSupportedModelConfig(agentModel);
+
+  if (!model) {
+    return new Err(
+      new Error(
+        `The model you selected does not support multi-actions ${agentModel.modelId}.`
+      )
+    );
   }
 
   return new Ok({
-    agentConfiguration,
+    agentConfiguration: agentConfigurationWithoutModel,
+    model: {
+      ...agentModel,
+      ...model,
+    },
     agentMessage,
     auth,
     conversation,


### PR DESCRIPTION
## Description

Resolve the agent's `ModelConfigurationType` once at the start of the run loop and propagate it as a first-class `model` field in `AgentLoopRunContextType`, decoupled from `AgentConfigurationWithoutModelType`. Previously every callsite called `getSupportedModelConfig(agentConfiguration.model)` independently — this removes that repetition and eliminates the scattered failure modes. Enables future model overrides at run time (e.g., model tier enforcement) without mutating agent configuration.

New `AgentLoopExecutionData` type in `agent_run.ts` captures the resolved run-time shape; `AgentLoopRunContextType`, `AgentLoopListToolsContextType`, and downstream helpers (`getRetrievalTopK`, `getCitationsCount`, `computeStepContexts`, `getPromptForProcessDustApp`, `prepareParamsWithHistory`) are all updated to consume `model` directly.

## Tests

Updated `mcp_actions.test.ts` and `mcp_execution.test.ts` to construct `AgentLoopRunContextType` with the new shape. Tested locally.

## Risk

Pure structural refactor — no behavior change, no DB or schema changes. All 45 changed files are front-only. Low risk, safe to rollback.

## Deploy Plan

Deploy front.
