### PR TITLE
[Agentic User Activation] Poke provisioning plugin skeleton

### DIFF
--- a/front/lib/api/poke/plugins/spaces/index.ts
+++ b/front/lib/api/poke/plugins/spaces/index.ts
@@ -1,3 +1,4 @@
 export * from "./force_run_task_generation";
 export * from "./import_app";
+export * from "./join_activation_pod";
 export * from "./update_pod_members";

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -1,4 +1,10 @@
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { writeCanonicalFileContent } from "@app/lib/api/files/file_system_ops";
 import { createPlugin } from "@app/lib/api/poke/types";
+import {
+  getPodAgentsMdScopedPath,
+  POD_AGENTS_MD_MAX_CHARACTER_COUNT,
+} from "@app/lib/api/projects/constants";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -70,19 +76,74 @@ function formatDefaultSkillsSuffix(skillNames: string[]): string {
   return ` Set ${skillNames.length} default skill(s): ${skillNames.join(", ")}.`;
 }
 
+// Writes pod-wide agent instructions to the pod's AGENTS.md file.
+async function setPodAgentsMd(
+  auth: Authenticator,
+  pod: SpaceResource,
+  user: UserResource,
+  instructions: string
+): Promise<Result<{ written: boolean }, Error>> {
+  const trimmed = instructions.trim();
+  if (trimmed.length === 0) {
+    return new Ok({ written: false });
+  }
+
+  if (trimmed.length > POD_AGENTS_MD_MAX_CHARACTER_COUNT) {
+    return new Err(
+      new Error(
+        `AGENTS.md instructions exceed the ${POD_AGENTS_MD_MAX_CHARACTER_COUNT}-character limit.`
+      )
+    );
+  }
+
+  const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    auth.getNonNullableWorkspace().sId
+  );
+
+  const scopedPath = getPodAgentsMdScopedPath(pod.sId);
+  const fsResult = await DustFileSystem.fromScopedPath(editorAuth, scopedPath);
+  if (fsResult.isErr()) {
+    return new Err(
+      new Error(`Failed to open the Pod file system: ${fsResult.error.message}`)
+    );
+  }
+
+  const writeResult = await writeCanonicalFileContent(
+    editorAuth,
+    fsResult.value,
+    scopedPath,
+    Buffer.from(trimmed, "utf8"),
+    "text/markdown"
+  );
+  if (writeResult.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to write the Pod AGENTS.md: ${writeResult.error.message}`
+      )
+    );
+  }
+
+  return new Ok({ written: true });
+}
+
+function formatAgentsMdSuffix(written: boolean): string {
+  return written ? " Saved AGENTS.md instructions." : "";
+}
+
 export const joinActivationPodPlugin = createPlugin({
   manifest: {
     id: "join-activation-pod",
     name: "Join Activation Pod",
     description:
-      "Create a personal activation Pod for a workspace member and invite them to it.",
+      "Create a personal Activation Pod for a workspace member and invite them to it.",
     resourceTypes: ["workspaces"],
     args: {
       userEmail: {
         type: "string",
         label: "User email",
         description:
-          "Email of the workspace member to provision an activation Pod for.",
+          "Email of the workspace member to provision an Activation Pod for.",
       },
       defaultSkillIds: {
         type: "enum",
@@ -92,6 +153,13 @@ export const joinActivationPodPlugin = createPlugin({
         async: true,
         values: [],
         multiple: true,
+      },
+      agentsMdInstructions: {
+        type: "text",
+        label: "AGENTS.md instructions",
+        description:
+          "Optional. Pod-wide instructions saved to the Pod's AGENTS.md file and followed by all " +
+          `agents in the Pod. Max ${POD_AGENTS_MD_MAX_CHARACTER_COUNT} characters.`,
       },
     },
     requiredRoles: ["support"],
@@ -114,13 +182,18 @@ export const joinActivationPodPlugin = createPlugin({
         .sort((a, b) => a.label.localeCompare(b.label)),
     });
   },
-  execute: async (auth, _resource, { userEmail, defaultSkillIds }) => {
+  execute: async (
+    auth,
+    _resource,
+    { userEmail, defaultSkillIds, agentsMdInstructions }
+  ) => {
     const email = userEmail.trim().toLowerCase();
     if (email.length === 0) {
       return new Err(new Error("A user email is required."));
     }
 
     const selectedSkillIds = defaultSkillIds ?? [];
+    const agentsMd = agentsMdInstructions ?? "";
 
     const workspace = auth.getNonNullableWorkspace();
 
@@ -164,17 +237,28 @@ export const joinActivationPodPlugin = createPlugin({
         return skillsResult;
       }
 
+      const agentsMdResult = await setPodAgentsMd(
+        auth,
+        existingPod,
+        user,
+        agentsMd
+      );
+      if (agentsMdResult.isErr()) {
+        return agentsMdResult;
+      }
+
       joinActivationPodLogger.info(
         {
           action: "join_activation_pod",
           created: false,
           addedAsEditor: editorResult.value.added,
           defaultSkills: skillsResult.value.skillNames,
+          agentsMdWritten: agentsMdResult.value.written,
           spaceId: existingPod.sId,
           userId: user.sId,
           workspaceId: workspace.sId,
         },
-        "Returned existing activation pod via poke"
+        "Returned existing Activation Pod via poke"
       );
 
       return new Ok({
@@ -184,7 +268,8 @@ export const joinActivationPodPlugin = createPlugin({
           (editorResult.value.added
             ? "The user was missing and has been added as an editor."
             : "The user is already an editor.") +
-          formatDefaultSkillsSuffix(skillsResult.value.skillNames),
+          formatDefaultSkillsSuffix(skillsResult.value.skillNames) +
+          formatAgentsMdSuffix(agentsMdResult.value.written),
         link: podLink(existingPod),
         linkText: "Open Pod in Poke",
       });
@@ -212,23 +297,30 @@ export const joinActivationPodPlugin = createPlugin({
       return skillsResult;
     }
 
+    const agentsMdResult = await setPodAgentsMd(auth, pod, user, agentsMd);
+    if (agentsMdResult.isErr()) {
+      return agentsMdResult;
+    }
+
     joinActivationPodLogger.info(
       {
         action: "join_activation_pod",
         created: true,
         defaultSkills: skillsResult.value.skillNames,
+        agentsMdWritten: agentsMdResult.value.written,
         spaceId: pod.sId,
         userId: user.sId,
         workspaceId: workspace.sId,
       },
-      "Created activation pod via poke"
+      "Created Activation Pod via poke"
     );
 
     return new Ok({
       display: "textWithLink",
       value:
-        `Created activation Pod for ${user.username} and added them as an editor.` +
-        formatDefaultSkillsSuffix(skillsResult.value.skillNames),
+        `Created Activation Pod for ${user.username} and added them as an editor.` +
+        formatDefaultSkillsSuffix(skillsResult.value.skillNames) +
+        formatAgentsMdSuffix(agentsMdResult.value.written),
       link: podLink(pod),
       linkText: "Open Pod in Poke",
     });

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -254,32 +254,11 @@ export const joinActivationPodPlugin = createPlugin({
         return editorResult;
       }
 
-      const skillsResult = await setPodDefaultSkills(
-        auth,
-        existingPod,
-        selectedSkillIds
-      );
-      if (skillsResult.isErr()) {
-        return skillsResult;
-      }
-
-      const agentsMdResult = await setPodAgentsMd(
-        auth,
-        existingPod,
-        user,
-        agentsMd
-      );
-      if (agentsMdResult.isErr()) {
-        return agentsMdResult;
-      }
-
       joinActivationPodLogger.info(
         {
           action: "join_activation_pod",
           created: false,
           addedAsEditor: editorResult.value.added,
-          defaultSkills: skillsResult.value.skillNames,
-          agentsMdWritten: agentsMdResult.value.written,
           spaceId: existingPod.sId,
           userId: user.sId,
           workspaceId: workspace.sId,
@@ -293,9 +272,7 @@ export const joinActivationPodPlugin = createPlugin({
           `Activation Pod already exists for ${email}. ` +
           (editorResult.value.added
             ? "The user was missing and has been added as an editor."
-            : "The user is already an editor.") +
-          formatDefaultSkillsSuffix(skillsResult.value.skillNames) +
-          formatAgentsMdSuffix(agentsMdResult.value.written),
+            : "The user is already an editor."),
         link: podLink(existingPod),
         linkText: "Open Pod in Poke",
       });

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -10,7 +10,7 @@ import { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -28,24 +28,6 @@ function activationPodNameForUser(
 ): string {
   const fullName = [firstName, lastName].filter(Boolean).join(" ");
   return `${fullName}${ACTIVATION_POD_NAME_PREFIX}`;
-}
-
-// Adds the user to the pod as an editor.
-async function addUserAsEditor(
-  auth: Authenticator,
-  pod: SpaceResource,
-  user: UserResource
-): Promise<Result<{ added: boolean }, Error>> {
-  const res = await pod.addEditors(auth, { userIds: [user.sId] });
-  if (res.isErr()) {
-    return new Err(
-      new Error(
-        `Failed to add the user as an editor of the pod: ${res.error.message}`
-      )
-    );
-  }
-
-  return new Ok({ added: res.value.length > 0 });
 }
 
 // Select the pod's default skills.
@@ -78,23 +60,6 @@ function formatDefaultSkillsSuffix(skillNames: string[]): string {
     return "";
   }
   return ` Set ${skillNames.length} default skill(s): ${skillNames.join(", ")}.`;
-}
-
-// Record user's email in project_metadata to check for idempotency.
-async function recordActivationPodMemberEmail(
-  auth: Authenticator,
-  pod: SpaceResource,
-  email: string
-): Promise<void> {
-  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
-  if (metadata) {
-    await metadata.updateActivationPodMemberEmail(email);
-  } else {
-    await ProjectMetadataResource.makeNew(auth, pod, {
-      description: null,
-      activationPodMemberEmail: email,
-    });
-  }
 }
 
 // Writes pod-wide agent instructions to the pod's AGENTS.md file.
@@ -238,46 +203,6 @@ export const joinActivationPodPlugin = createPlugin({
     const podLink = (space: SpaceResource) =>
       `/poke/${workspace.sId}/spaces/${space.sId}`;
 
-    const existingMetadata =
-      await ProjectMetadataResource.fetchByActivationPodMemberEmail(
-        auth,
-        user.email
-      );
-    const existingPod = existingMetadata
-      ? ((
-          await SpaceResource.fetchByModelIds(auth, [existingMetadata.spaceId])
-        )[0] ?? null)
-      : null;
-    if (existingPod) {
-      const editorResult = await addUserAsEditor(auth, existingPod, user);
-      if (editorResult.isErr()) {
-        return editorResult;
-      }
-
-      joinActivationPodLogger.info(
-        {
-          action: "join_activation_pod",
-          created: false,
-          addedAsEditor: editorResult.value.added,
-          spaceId: existingPod.sId,
-          userId: user.sId,
-          workspaceId: workspace.sId,
-        },
-        "Returned existing Activation Pod via poke"
-      );
-
-      return new Ok({
-        display: "textWithLink",
-        value:
-          `Activation Pod already exists for ${email}. ` +
-          (editorResult.value.added
-            ? "The user was missing and has been added as an editor."
-            : "The user is already an editor."),
-        link: podLink(existingPod),
-        linkText: "Open Pod in Poke",
-      });
-    }
-
     const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
       workspace.sId
@@ -294,8 +219,6 @@ export const joinActivationPodPlugin = createPlugin({
       return new Err(new Error(createResult.error.message));
     }
     const pod = createResult.value;
-
-    await recordActivationPodMemberEmail(auth, pod, user.email);
 
     const skillsResult = await setPodDefaultSkills(auth, pod, selectedSkillIds);
     if (skillsResult.isErr()) {

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -1,0 +1,192 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { createSpaceAndGroup } from "@app/lib/api/spaces";
+import { Authenticator } from "@app/lib/auth";
+import type { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const ACTIVATION_POD_NAME_PREFIX = "Activation Pod - ";
+
+const joinActivationPodLogger = logger.child({
+  activity: "join-activation-pod",
+});
+
+function activationPodNameForEmail(email: string): string {
+  return `${ACTIVATION_POD_NAME_PREFIX}${email}`;
+}
+
+async function getManualMemberGroup(
+  space: SpaceResource
+): Promise<GroupResource | null> {
+  const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
+    space,
+    filterOnManagementMode: true,
+  });
+  if (memberGroupSpaces.length !== 1) {
+    return null;
+  }
+  return memberGroupSpaces[0].group;
+}
+
+// Adds the user to the pod's manual member group if they are not already in it.
+// Does not add the same user multiple times, so it is safe to call repeatedly for the same user and pod.
+async function ensureUserInMemberGroup(
+  auth: Authenticator,
+  space: SpaceResource,
+  user: UserResource
+): Promise<Result<{ added: boolean }, Error>> {
+  const memberGroup = await getManualMemberGroup(space);
+  if (!memberGroup) {
+    return new Err(new Error("Pod does not have a manual member group."));
+  }
+
+  const currentMembers = await memberGroup.getActiveMembers(auth);
+  if (currentMembers.some((member) => member.sId === user.sId)) {
+    return new Ok({ added: false });
+  }
+
+  const addResult = await memberGroup.dangerouslyAddMembers(auth, {
+    users: [user.toJSON()],
+  });
+  if (addResult.isErr()) {
+    return new Err(
+      new Error(`Failed to add the user to the pod: ${addResult.error.message}`)
+    );
+  }
+
+  return new Ok({ added: true });
+}
+
+export const joinActivationPodPlugin = createPlugin({
+  manifest: {
+    id: "join-activation-pod",
+    name: "Join Activation Pod",
+    description:
+      "Create a personal activation Pod for a workspace member and invite them to it.",
+    resourceTypes: ["workspaces"],
+    args: {
+      userEmail: {
+        type: "string",
+        label: "User email",
+        description:
+          "Email of the workspace member(s) to provision an activation Pod for.",
+      },
+    },
+    requiredRoles: ["support"],
+  },
+  execute: async (auth, _resource, { userEmail }) => {
+    const email = userEmail.trim().toLowerCase();
+    if (email.length === 0) {
+      return new Err(new Error("A user email is required."));
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    const user = await UserResource.fetchByEmail(email);
+    if (!user) {
+      return new Err(new Error(`No user found with email "${email}".`));
+    }
+
+    const membership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace,
+      });
+    if (!membership) {
+      return new Err(
+        new Error(
+          `User "${user.username}" is not an active member of this workspace.`
+        )
+      );
+    }
+
+    const podName = activationPodNameForEmail(user.email);
+    const podLink = (space: SpaceResource) =>
+      `/poke/${workspace.sId}/spaces/${space.sId}`;
+
+    // If the activation pod already exists, return it (after making sure the user is invited).
+    const existingPods = await SpaceResource.listProjectSpaces(auth);
+    const existingPod = existingPods.find((space) => space.name === podName);
+    if (existingPod) {
+      const inviteResult = await ensureUserInMemberGroup(
+        auth,
+        existingPod,
+        user
+      );
+      if (inviteResult.isErr()) {
+        return inviteResult;
+      }
+
+      joinActivationPodLogger.info(
+        {
+          action: "join_activation_pod",
+          created: false,
+          invited: inviteResult.value.added,
+          spaceId: existingPod.sId,
+          userId: user.sId,
+          workspaceId: workspace.sId,
+        },
+        "Returned existing activation pod via poke"
+      );
+
+      return new Ok({
+        display: "textWithLink",
+        value:
+          `Activation Pod already exists for ${user.username}. ` +
+          (inviteResult.value.added
+            ? "The user was missing and has been invited."
+            : "The user is already a member."),
+        link: podLink(existingPod),
+        linkText: "Open Pod in Poke",
+      });
+    }
+
+    // The user is added to the pod as editor. Pods reject members at creation time, so the user
+    // is added to the member group in a second step.
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const createResult = await createSpaceAndGroup(userAuth, {
+      name: podName,
+      isRestricted: true,
+      spaceKind: "project",
+      managementMode: "manual",
+      memberIds: [],
+    });
+
+    if (createResult.isErr()) {
+      return new Err(new Error(createResult.error.message));
+    }
+    const pod = createResult.value;
+
+    const inviteResult = await ensureUserInMemberGroup(auth, pod, user);
+    if (inviteResult.isErr()) {
+      return inviteResult;
+    }
+
+    joinActivationPodLogger.info(
+      {
+        action: "join_activation_pod",
+        created: true,
+        invited: inviteResult.value.added,
+        spaceId: pod.sId,
+        userId: user.sId,
+        workspaceId: workspace.sId,
+      },
+      "Created activation pod via poke"
+    );
+
+    return new Ok({
+      display: "textWithLink",
+      value: `Created activation Pod for ${user.username} and invited them.`,
+      link: podLink(pod),
+      linkText: "Open Pod in Poke",
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -1,9 +1,9 @@
 import { createPlugin } from "@app/lib/api/poke/types";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import { Authenticator } from "@app/lib/auth";
-import type { GroupResource } from "@app/lib/resources/group_resource";
-import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
@@ -20,46 +20,54 @@ function activationPodNameForEmail(email: string): string {
   return `${ACTIVATION_POD_NAME_PREFIX}${email}`;
 }
 
-async function getManualMemberGroup(
-  space: SpaceResource
-): Promise<GroupResource | null> {
-  const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
-    space,
-    filterOnManagementMode: true,
-  });
-  if (memberGroupSpaces.length !== 1) {
-    return null;
-  }
-  return memberGroupSpaces[0].group;
-}
-
-// Adds the user to the pod's manual member group if they are not already in it.
-// Does not add the same user multiple times, so it is safe to call repeatedly for the same user and pod.
-async function ensureUserInMemberGroup(
+// Adds the user to the pod as an editor.
+async function addUserAsEditor(
   auth: Authenticator,
-  space: SpaceResource,
+  pod: SpaceResource,
   user: UserResource
 ): Promise<Result<{ added: boolean }, Error>> {
-  const memberGroup = await getManualMemberGroup(space);
-  if (!memberGroup) {
-    return new Err(new Error("Pod does not have a manual member group."));
-  }
-
-  const currentMembers = await memberGroup.getActiveMembers(auth);
-  if (currentMembers.some((member) => member.sId === user.sId)) {
-    return new Ok({ added: false });
-  }
-
-  const addResult = await memberGroup.dangerouslyAddMembers(auth, {
-    users: [user.toJSON()],
-  });
-  if (addResult.isErr()) {
+  const res = await pod.addEditors(auth, { userIds: [user.sId] });
+  if (res.isErr()) {
     return new Err(
-      new Error(`Failed to add the user to the pod: ${addResult.error.message}`)
+      new Error(
+        `Failed to add the user as an editor of the pod: ${res.error.message}`
+      )
     );
   }
 
-  return new Ok({ added: true });
+  return new Ok({ added: res.value.length > 0 });
+}
+
+// Select the pod's default skills.
+async function setPodDefaultSkills(
+  auth: Authenticator,
+  pod: SpaceResource,
+  selectedSkillIds: string[]
+): Promise<Result<{ skillNames: string[] }, Error>> {
+  if (selectedSkillIds.length === 0) {
+    return new Ok({ skillNames: [] });
+  }
+
+  let metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+  if (!metadata) {
+    metadata = await ProjectMetadataResource.makeNew(auth, pod, {
+      description: null,
+    });
+  }
+
+  const skills = await SkillResource.fetchByIds(auth, selectedSkillIds, {
+    onlyActive: true,
+  });
+  await metadata.setDefaultSkills(auth, skills);
+
+  return new Ok({ skillNames: skills.map((skill) => skill.name) });
+}
+
+function formatDefaultSkillsSuffix(skillNames: string[]): string {
+  if (skillNames.length === 0) {
+    return "";
+  }
+  return ` Set ${skillNames.length} default skill(s): ${skillNames.join(", ")}.`;
 }
 
 export const joinActivationPodPlugin = createPlugin({
@@ -74,16 +82,45 @@ export const joinActivationPodPlugin = createPlugin({
         type: "string",
         label: "User email",
         description:
-          "Email of the workspace member(s) to provision an activation Pod for.",
+          "Email of the workspace member to provision an activation Pod for.",
+      },
+      defaultSkillIds: {
+        type: "enum",
+        label: "Default skills",
+        description:
+          "Optional. Select workspace skills to add as default skills for the Activation Pod.",
+        async: true,
+        values: [],
+        multiple: true,
       },
     },
     requiredRoles: ["support"],
   },
-  execute: async (auth, _resource, { userEmail }) => {
+  populateAsyncArgs: async (auth) => {
+    const skills = await SkillResource.listByWorkspace(auth, {
+      status: "active",
+      globalSpaceOnly: true,
+      withInstructions: false,
+      withTools: false,
+    });
+
+    return new Ok({
+      defaultSkillIds: skills
+        .map((skill) => ({
+          label: skill.name,
+          value: skill.sId,
+          checked: false,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    });
+  },
+  execute: async (auth, _resource, { userEmail, defaultSkillIds }) => {
     const email = userEmail.trim().toLowerCase();
     if (email.length === 0) {
       return new Err(new Error("A user email is required."));
     }
+
+    const selectedSkillIds = defaultSkillIds ?? [];
 
     const workspace = auth.getNonNullableWorkspace();
 
@@ -113,20 +150,26 @@ export const joinActivationPodPlugin = createPlugin({
     const existingPods = await SpaceResource.listProjectSpaces(auth);
     const existingPod = existingPods.find((space) => space.name === podName);
     if (existingPod) {
-      const inviteResult = await ensureUserInMemberGroup(
+      const editorResult = await addUserAsEditor(auth, existingPod, user);
+      if (editorResult.isErr()) {
+        return editorResult;
+      }
+
+      const skillsResult = await setPodDefaultSkills(
         auth,
         existingPod,
-        user
+        selectedSkillIds
       );
-      if (inviteResult.isErr()) {
-        return inviteResult;
+      if (skillsResult.isErr()) {
+        return skillsResult;
       }
 
       joinActivationPodLogger.info(
         {
           action: "join_activation_pod",
           created: false,
-          invited: inviteResult.value.added,
+          addedAsEditor: editorResult.value.added,
+          defaultSkills: skillsResult.value.skillNames,
           spaceId: existingPod.sId,
           userId: user.sId,
           workspaceId: workspace.sId,
@@ -138,16 +181,15 @@ export const joinActivationPodPlugin = createPlugin({
         display: "textWithLink",
         value:
           `Activation Pod already exists for ${user.username}. ` +
-          (inviteResult.value.added
-            ? "The user was missing and has been invited."
-            : "The user is already a member."),
+          (editorResult.value.added
+            ? "The user was missing and has been added as an editor."
+            : "The user is already an editor.") +
+          formatDefaultSkillsSuffix(skillsResult.value.skillNames),
         link: podLink(existingPod),
         linkText: "Open Pod in Poke",
       });
     }
 
-    // The user is added to the pod as editor. Pods reject members at creation time, so the user
-    // is added to the member group in a second step.
     const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
       workspace.sId
@@ -165,16 +207,16 @@ export const joinActivationPodPlugin = createPlugin({
     }
     const pod = createResult.value;
 
-    const inviteResult = await ensureUserInMemberGroup(auth, pod, user);
-    if (inviteResult.isErr()) {
-      return inviteResult;
+    const skillsResult = await setPodDefaultSkills(auth, pod, selectedSkillIds);
+    if (skillsResult.isErr()) {
+      return skillsResult;
     }
 
     joinActivationPodLogger.info(
       {
         action: "join_activation_pod",
         created: true,
-        invited: inviteResult.value.added,
+        defaultSkills: skillsResult.value.skillNames,
         spaceId: pod.sId,
         userId: user.sId,
         workspaceId: workspace.sId,
@@ -184,7 +226,9 @@ export const joinActivationPodPlugin = createPlugin({
 
     return new Ok({
       display: "textWithLink",
-      value: `Created activation Pod for ${user.username} and invited them.`,
+      value:
+        `Created activation Pod for ${user.username} and added them as an editor.` +
+        formatDefaultSkillsSuffix(skillsResult.value.skillNames),
       link: podLink(pod),
       linkText: "Open Pod in Poke",
     });

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -16,14 +16,18 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-const ACTIVATION_POD_NAME_PREFIX = "Activation Pod - ";
+const ACTIVATION_POD_NAME_PREFIX = "'s Activation Pod";
 
 const joinActivationPodLogger = logger.child({
   activity: "join-activation-pod",
 });
 
-function activationPodNameForEmail(email: string): string {
-  return `${ACTIVATION_POD_NAME_PREFIX}${email}`;
+function activationPodNameForUser(
+  firstName: string,
+  lastName: string | null
+): string {
+  const fullName = [firstName, lastName].filter(Boolean).join(" ");
+  return `${fullName}${ACTIVATION_POD_NAME_PREFIX}`;
 }
 
 // Adds the user to the pod as an editor.
@@ -74,6 +78,23 @@ function formatDefaultSkillsSuffix(skillNames: string[]): string {
     return "";
   }
   return ` Set ${skillNames.length} default skill(s): ${skillNames.join(", ")}.`;
+}
+
+// Record user's email in project_metadata to check for idempotency.
+async function recordActivationPodMemberEmail(
+  auth: Authenticator,
+  pod: SpaceResource,
+  email: string
+): Promise<void> {
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+  if (metadata) {
+    await metadata.updateActivationPodMemberEmail(email);
+  } else {
+    await ProjectMetadataResource.makeNew(auth, pod, {
+      description: null,
+      activationPodMemberEmail: email,
+    });
+  }
 }
 
 // Writes pod-wide agent instructions to the pod's AGENTS.md file.
@@ -209,19 +230,24 @@ export const joinActivationPodPlugin = createPlugin({
       });
     if (!membership) {
       return new Err(
-        new Error(
-          `User "${user.username}" is not an active member of this workspace.`
-        )
+        new Error(`"${email}" is not an active member of this workspace.`)
       );
     }
 
-    const podName = activationPodNameForEmail(user.email);
+    const podName = activationPodNameForUser(user.firstName, user.lastName);
     const podLink = (space: SpaceResource) =>
       `/poke/${workspace.sId}/spaces/${space.sId}`;
 
-    // If the activation pod already exists, return it (after making sure the user is invited).
-    const existingPods = await SpaceResource.listProjectSpaces(auth);
-    const existingPod = existingPods.find((space) => space.name === podName);
+    const existingMetadata =
+      await ProjectMetadataResource.fetchByActivationPodMemberEmail(
+        auth,
+        user.email
+      );
+    const existingPod = existingMetadata
+      ? ((
+          await SpaceResource.fetchByModelIds(auth, [existingMetadata.spaceId])
+        )[0] ?? null)
+      : null;
     if (existingPod) {
       const editorResult = await addUserAsEditor(auth, existingPod, user);
       if (editorResult.isErr()) {
@@ -264,7 +290,7 @@ export const joinActivationPodPlugin = createPlugin({
       return new Ok({
         display: "textWithLink",
         value:
-          `Activation Pod already exists for ${user.username}. ` +
+          `Activation Pod already exists for ${email}. ` +
           (editorResult.value.added
             ? "The user was missing and has been added as an editor."
             : "The user is already an editor.") +
@@ -292,6 +318,8 @@ export const joinActivationPodPlugin = createPlugin({
     }
     const pod = createResult.value;
 
+    await recordActivationPodMemberEmail(auth, pod, user.email);
+
     const skillsResult = await setPodDefaultSkills(auth, pod, selectedSkillIds);
     if (skillsResult.isErr()) {
       return skillsResult;
@@ -318,7 +346,7 @@ export const joinActivationPodPlugin = createPlugin({
     return new Ok({
       display: "textWithLink",
       value:
-        `Created Activation Pod for ${user.username} and added them as an editor.` +
+        `Created Activation Pod for ${email} and added them as an editor.` +
         formatDefaultSkillsSuffix(skillsResult.value.skillNames) +
         formatAgentsMdSuffix(agentsMdResult.value.written),
       link: podLink(pod),

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -95,23 +95,6 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     return this.fetchBySpaceModelIds(auth, spaceModelIds);
   }
 
-  // Only activation Pods set "activationPodMemberEmail"; for idempotency of the activation pod.
-  static async fetchByActivationPodMemberEmail(
-    auth: Authenticator,
-    activationPodMemberEmail: string
-  ): Promise<ProjectMetadataResource | null> {
-    const model = await ProjectMetadataModel.findOne({
-      where: {
-        activationPodMemberEmail,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-    });
-
-    return model
-      ? ProjectMetadataResource.fromModel(model, model.spaceId)
-      : null;
-  }
-
   static async fetchBySpaceModelIds(
     auth: Authenticator,
     spaceModelIds: number[]
@@ -241,13 +224,6 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     transaction?: Transaction
   ) {
     await this.update({ defaultAgentId }, transaction);
-  }
-
-  async updateActivationPodMemberEmail(
-    activationPodMemberEmail: string | null,
-    transaction?: Transaction
-  ) {
-    await this.update({ activationPodMemberEmail }, transaction);
   }
 
   async setDefaultSkills(

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -95,6 +95,23 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     return this.fetchBySpaceModelIds(auth, spaceModelIds);
   }
 
+  // Only activation Pods set "activationPodMemberEmail"; for idempotency of the activation pod.
+  static async fetchByActivationPodMemberEmail(
+    auth: Authenticator,
+    activationPodMemberEmail: string
+  ): Promise<ProjectMetadataResource | null> {
+    const model = await ProjectMetadataModel.findOne({
+      where: {
+        activationPodMemberEmail,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    return model
+      ? ProjectMetadataResource.fromModel(model, model.spaceId)
+      : null;
+  }
+
   static async fetchBySpaceModelIds(
     auth: Authenticator,
     spaceModelIds: number[]
@@ -224,6 +241,13 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     transaction?: Transaction
   ) {
     await this.update({ defaultAgentId }, transaction);
+  }
+
+  async updateActivationPodMemberEmail(
+    activationPodMemberEmail: string | null,
+    transaction?: Transaction
+  ) {
+    await this.update({ activationPodMemberEmail }, transaction);
   }
 
   async setDefaultSkills(


### PR DESCRIPTION
Poke plugin to provision an Activation Pod for workspace member(s): creates the project space, adds members as editors, sets default skills, and writes AGENTS.md instructions.

---
### Stack
Stacked on top of the schema migration — review/merge the base PR first:
- #28492 — Migration for Poke provisioning plugin _(base)_
- **this PR** — Poke provisioning plugin
