### PR TITLE
[front] block workspace deletion when an active Metronome contract exists

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.test.ts
@@ -1,0 +1,62 @@
+import { deleteWorkspacePlugin } from "@app/lib/api/poke/plugins/workspaces/delete_workspace";
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockDeleteWorkspace, mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockDeleteWorkspace: vi.fn(),
+  mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/api/workspace", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/workspace")>();
+  return { ...actual, deleteWorkspace: mockDeleteWorkspace };
+});
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+  return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
+});
+
+beforeEach(() => {
+  mockDeleteWorkspace.mockReset();
+  mockEmitAuditLogEvent.mockReset();
+  mockDeleteWorkspace.mockResolvedValue(new Ok(undefined));
+  mockEmitAuditLogEvent.mockResolvedValue(undefined);
+});
+
+describe("deleteWorkspacePlugin.execute", () => {
+  it("blocks deletion when the free-plan workspace still has an active Metronome contract", async () => {
+    // Credit-priced free plan: `isFreePlan` is true, yet the active subscription
+    // is Metronome-billed — the case the guard must catch.
+    const workspace = await WorkspaceFactory.creditPricedFree();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await deleteWorkspacePlugin.execute(auth, workspace, {
+      confirmation: "DELETE",
+      workspaceHasBeenRelocated: false,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(/active Metronome contract/i);
+    }
+    expect(mockDeleteWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("proceeds when the workspace is on a free plan with no Metronome contract", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await deleteWorkspacePlugin.execute(auth, workspace, {
+      confirmation: "DELETE",
+      workspaceHasBeenRelocated: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockDeleteWorkspace).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
@@ -78,6 +78,13 @@ export const deleteWorkspacePlugin = createPlugin({
           )
         );
       }
+      if (subscription.metronomeContractId !== null) {
+        return new Err(
+          new Error(
+            "Workspace has an active Metronome contract, please downgrade the contract before deleting the workspace."
+          )
+        );
+      }
 
       await deleteWorkspace(workspace);
     }


### PR DESCRIPTION
## Description

A credit-priced/Metronome-billed workspace whose plan code reads as "free" (e.g. CP_FREE_PLAN) passed both the plugin's isFreePlan check and areAllSubscriptionsCanceled (which only inspects Stripe subscriptions), so it could be deleted while its Metronome contract stayed live.

Guard the poke delete-workspace plugin on the active subscription's metronomeContractId and require the operator to downgrade the contract first.

## Tests

Unit
## Risk

Low
## Deploy Plan

Front