### PR TITLE
Enrich search_crm_objects description and add dynamic HubSpot tool labels

### DIFF
--- a/front/lib/actions/tool_display_labels.test.ts
+++ b/front/lib/actions/tool_display_labels.test.ts
@@ -174,6 +174,50 @@ describe("getToolDisplayLabels", () => {
       done: "Read file",
     });
   });
+
+  it("labels a HubSpot search by object type", () => {
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "hubspot",
+        toolName: "search_crm_objects",
+        inputs: { objectType: "companies" },
+      })
+    ).toEqual({
+      running: "Searching HubSpot companies",
+      done: "Search HubSpot companies",
+    });
+  });
+
+  it("labels a HubSpot id lookup as a retrieval", () => {
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "hubspot",
+        toolName: "search_crm_objects",
+        inputs: {
+          objectType: "contacts",
+          filters: [
+            { propertyName: "hs_object_id", operator: "EQ", value: "1" },
+          ],
+        },
+      })
+    ).toEqual({
+      running: "Retrieving HubSpot contacts",
+      done: "Retrieve HubSpot contacts",
+    });
+  });
+
+  it("includes the free-text query in a HubSpot search label", () => {
+    expect(
+      getToolDisplayLabels({
+        internalMCPServerName: "hubspot",
+        toolName: "search_crm_objects",
+        inputs: { objectType: "deals", query: "acme renewal" },
+      })
+    ).toEqual({
+      running: "Searching HubSpot deals “acme renewal”",
+      done: "Search HubSpot deals “acme renewal”",
+    });
+  });
 });
 
 describe("getStaticToolDisplayLabelsFromFunctionCallName", () => {

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -992,6 +992,33 @@ function getDynamicToolDisplayLabels({
       }
       return null;
 
+    case "hubspot":
+      if (toolName === "search_crm_objects" && isString(inputs.objectType)) {
+        const objectType = inputs.objectType;
+        const filters = inputs.filters;
+        const isByIdLookup =
+          Array.isArray(filters) &&
+          filters.some((f) => f?.propertyName === "hs_object_id");
+        if (isByIdLookup) {
+          return {
+            running: `Retrieving HubSpot ${objectType}`,
+            done: `Retrieve HubSpot ${objectType}`,
+          };
+        }
+        if (isString(inputs.query) && inputs.query.length > 0) {
+          const q = truncateQuery(inputs.query);
+          return {
+            running: `Searching HubSpot ${objectType} “${q}”`,
+            done: `Search HubSpot ${objectType} “${q}”`,
+          };
+        }
+        return {
+          running: `Searching HubSpot ${objectType}`,
+          done: `Search HubSpot ${objectType}`,
+        };
+      }
+      return null;
+
     // All other servers: no dynamic labels.
     case "agent_sidekick_agent_state":
     case "agent_sidekick_context":
@@ -1003,7 +1030,6 @@ function getDynamicToolDisplayLabels({
     case "fathom":
     case "freshservice":
     case "gong":
-    case "hubspot":
     case "include_data":
     case "luma":
     case "missing_action_catcher":

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -635,6 +635,25 @@ const QUERIES: LabeledQuery[] = [
 
   // --- hubspot ---
   {
+    query: "find a hubspot contact by email address",
+    expected: "hubspot.search_crm_objects",
+    maxRank: 2,
+  },
+  {
+    query: "read hubspot contact 123",
+    expected: "hubspot.search_crm_objects",
+    maxRank: 2,
+  },
+  {
+    query: "open a hubspot company record",
+    expected: "hubspot.search_crm_objects",
+  },
+  {
+    query: "read a hubspot deal by id",
+    expected: "hubspot.search_crm_objects",
+    maxRank: 2,
+  },
+  {
     query: "search hubspot deals by close date",
     expected: "hubspot.search_crm_objects",
   },

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -178,13 +178,17 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   search_crm_objects: {
     description:
-      "Find HubSpot contacts, companies, deals, leads, and activity records when " +
-      "you do not know the object ID. " +
-      "Use this to find contacts at a company, search deals by close date, " +
-      "or locate tasks, notes, meetings, calls, and emails. " +
-      "Supports advanced filtering by properties, date ranges, owners, and free-text queries. " +
-      "IMPORTANT: For enumeration properties (like industry), always use get_object_properties first to discover the exact values. " +
-      "Use this for specific searches, or use get_user_activity for comprehensive user activity across all types.",
+      "Search, filter, read, open, or retrieve HubSpot records: contacts, companies, deals, " +
+      "leads, tickets, and activity records (tasks, notes, meetings, calls, emails). " +
+      "Filter by any property to: open or read a single contact, company, or deal record " +
+      "by its id (hs_object_id EQ <id>); find a contact or company by email; " +
+      "find contacts at a company; search deals by close date or amount; " +
+      "filter by owner (hubspot_owner_id); or match any other property. " +
+      "Omit filters to get the most recently created records (sorted newest-first). " +
+      "Also supports free-text queries. " +
+      "IMPORTANT: For enumeration properties (like industry or dealstage), use " +
+      "get_object_properties first to discover the exact values. " +
+      "For comprehensive user activity across all types, use get_user_activity.",
     schema: {
       objectType: z.enum(searchableObjectTypes),
       filters: z


### PR DESCRIPTION
## Description
 - Enrich the `search_crm_objects` description to guide how to search/retrieve (by id, by email, latest, ..).
 - Add dynamic display labels for `search_crm_objects` so the UI shows the object type (ex: "Searching HubSpot contacts", "Retrieving HubSpot deals") instead of the generic label, restoring the richness lost when the per-object get tools were removed.
 - Restore the removed bm25 tool-search query cases, pointed at `search_crm_objects` with realistic `maxRank`s.
  

## Tests

Tested locally that the dynamic display labels worked.

## Risk

Low

## Deploy Plan

Standard label of front