### PR TITLE
fix: use "Computer" feature name in user-facing Sandbox strings

### DIFF
--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -63,6 +63,8 @@ const MCP_TOOL_OVERRIDES: Partial<
   },
   sandbox: {
     add_egress_domain: {
+      title: (agentName) =>
+        `Allow ${asDisplayName(agentName)} to add a domain to the Computer?`,
       detailsExpanded: true,
     },
   },

--- a/front/lib/swr/sandbox.ts
+++ b/front/lib/swr/sandbox.ts
@@ -137,7 +137,7 @@ export function useUpsertWorkspaceSandboxEnvVar({
         title: data.created
           ? "Environment variable created"
           : "Environment variable replaced",
-        description: `${name} has been saved for future sandboxes.`,
+        description: `${name} has been saved for future Computers.`,
       });
       return true;
     } catch (error) {
@@ -314,21 +314,21 @@ export function useUpdateWorkspaceSandboxAgentEgressRequests({
       });
 
       if (!response.ok) {
-        throw new Error("Failed to update sandbox network setting");
+        throw new Error("Failed to update Computer network setting");
       }
 
       setIsEnabled(enabled);
       sendNotification({
         type: "success",
-        title: "Sandbox network setting updated",
+        title: "Computer network setting updated",
         description:
-          "Agent-requested sandbox domains setting has been updated.",
+          "Agent-requested Computer domains setting has been updated.",
       });
       return true;
     } catch (error) {
       sendNotification({
         type: "error",
-        title: "Failed to update sandbox network setting",
+        title: "Failed to update Computer network setting",
         description: normalizeError(error).message,
       });
       return false;
@@ -385,7 +385,7 @@ export function useUpdateWorkspaceEgressPolicy({
         type: "success",
         title: "Network policy updated",
         description:
-          "Sandbox egress policy changes will be applied by the proxy cache shortly.",
+          "Computer egress policy changes will be applied by the proxy cache shortly.",
       });
       return true;
     } catch {


### PR DESCRIPTION
## Description

A few customer-facing strings still said "Sandbox" instead of the "Computer" feature name. Renames them in the Computer admin toasts and the egress-domain approval prompt. Code, variables and backend keep the `sandbox` naming.

Fixes https://github.com/dust-tt/tasks/issues/9263

## Tests

Manual.

## Risk

None, copy-only change.

## Deploy Plan

Standard.