### PR TITLE
Add top-up metadata/custom fields on invoices

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
@@ -11,7 +11,12 @@ import {
   createMetronomeCredit,
 } from "@app/lib/metronome/client";
 import {
+  AWU_AMOUNT_CUSTOM_FIELD_KEY,
+  AWU_DISCOUNT_PERCENT_CUSTOM_FIELD_KEY,
   AWU_PRIORITY_PURCHASED_COMMIT,
+  AWU_PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_POOL,
   CURRENCY_TO_CREDIT_TYPE_ID,
   getCreditTypeAwuId,
   getProductFreeCreditId,
@@ -288,14 +293,11 @@ export const grantAwuCreditsPlugin = createPlugin({
       });
     }
 
-    const commitNameBase = validatedArgs.setPrice
+    const commitName = validatedArgs.setPrice
       ? `Commits added by Dust representative: ${amountCredits.toLocaleString()} credits (manual price)`
       : discountPercent > 0
         ? `Commits added by Dust representative: ${amountCredits.toLocaleString()} credits (${discountPercent}% discount)`
         : `Commits added by Dust representative: ${amountCredits.toLocaleString()} credits`;
-    const commitName = validatedArgs.purchaseOrderId
-      ? `${commitNameBase} [PO: ${validatedArgs.purchaseOrderId}]`
-      : commitNameBase;
 
     const result = await createMetronomeCommit({
       metronomeCustomerId,
@@ -313,6 +315,21 @@ export const grantAwuCreditsPlugin = createPlugin({
         unitPrice: invoiceUnitPrice,
         quantity: 1,
         timestamp: startDate,
+      },
+      customFields: {
+        [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
+        [AWU_AMOUNT_CUSTOM_FIELD_KEY]: `${amountCredits}`,
+        ...(validatedArgs.purchaseOrderId
+          ? {
+              [AWU_PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY]:
+                validatedArgs.purchaseOrderId,
+            }
+          : {}),
+        ...(discountPercent > 0
+          ? {
+              [AWU_DISCOUNT_PERCENT_CUSTOM_FIELD_KEY]: `${discountPercent}`,
+            }
+          : {}),
       },
     });
 

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -15,8 +15,12 @@ import {
   getMetronomeCustomerStripeCustomerId,
 } from "@app/lib/metronome/client";
 import {
+  AWU_AMOUNT_CUSTOM_FIELD_KEY,
+  AWU_DISCOUNT_PERCENT_CUSTOM_FIELD_KEY,
   AWU_PRIORITY_PURCHASED_COMMIT,
   CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_POOL,
   CURRENCY_TO_CREDIT_TYPE_ID,
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
@@ -358,6 +362,13 @@ export async function purchaseAwuCredits(
     uniquenessKey,
     customFields: {
       [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: floorToHourISO(accessEndingBefore),
+      [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
+      [AWU_AMOUNT_CUSTOM_FIELD_KEY]: String(amountCredits),
+      ...(discountPercent > 0
+        ? {
+            [AWU_DISCOUNT_PERCENT_CUSTOM_FIELD_KEY]: String(discountPercent),
+          }
+        : {}),
     },
     // Stamped on the Stripe invoice Metronome pushes downstream so the
     // existing eligibility check (`isAwuPurchaseInvoice`) still recognises

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -148,6 +148,14 @@ export const CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY = "DUST_CARRY_ON_RENEWAL";
 
 export const CARRY_ON_RENEWAL_FOREVER_VALUE = "forever";
 
+// Custom fields stamped on AWU pool commits (admin grants via
+// `grantAwuCreditsPlugin` and self-serve top-ups via `addPaymentGatedCommitToContract`)
+// for finance reconciliation against the Stripe invoice Metronome generates.
+export const AWU_PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY = "DUST_PURCHASE_ORDER_ID";
+export const AWU_AMOUNT_CUSTOM_FIELD_KEY = "DUST_AWU_AMOUNT";
+export const AWU_DISCOUNT_PERCENT_CUSTOM_FIELD_KEY =
+  "DUST_AWU_DISCOUNT_PERCENT";
+
 export const FOREVER_ENDING_BEFORE = new Date("2999-01-01T00:00:00.000Z");
 
 export function oneYearAfter(start: Date): Date {

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,6 +1,7 @@
 import type { CheckoutSeatType } from "@app/lib/api/checkout/types";
 import config from "@app/lib/api/config";
 import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
+import { CONTRACT_CREDIT_TYPE_POOL } from "@app/lib/metronome/constants";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { PHONE_TRIAL_ENABLED } from "@app/lib/plans/trial/constants";
@@ -1850,6 +1851,8 @@ async function cleanMetronomeInvoiceLines(
   totalsMatch: boolean;
   originalTotalCents: number;
   newTotalCents: number;
+  awuPurchaseMetadata: Record<string, string> | null;
+  purchaseOrder: string | null;
 }> {
   const invoiceCurrency = invoice.currency;
   const originalTotalCents = invoice.total;
@@ -1867,6 +1870,15 @@ async function cleanMetronomeInvoiceLines(
   }
 
   const commitAppliedLineIds = findCommitAppliedLineIds(lines);
+
+  // AWU pool commits are stamped (via Metronome custom fields on the commit,
+  // mapped to Stripe line-item metadata by Metronome's Stripe integration
+  // config) with credit_type=pool plus the credited amount, and optionally a
+  // PO / discount. Detected here so the whole invoice can be tagged
+  // awu_purchase=true, matching the shape `isAwuPurchaseInvoice` already
+  // reads for the payment-gated self-serve path.
+  let awuPurchaseMetadata: Record<string, string> | null = null;
+  let purchaseOrder: string | null = null;
 
   for (const line of lines) {
     const isNegative = line.amount < 1;
@@ -1890,6 +1902,20 @@ async function cleanMetronomeInvoiceLines(
       },
       "[Stripe] Metronome invoice line item"
     );
+
+    if (line.metadata?.credit_type === CONTRACT_CREDIT_TYPE_POOL) {
+      awuPurchaseMetadata = {
+        awu_purchase: "true",
+        awu_amount_credits: line.metadata.awu_amount ?? "",
+        ...(line.metadata.awu_discount_percent
+          ? { awu_discount_percent: line.metadata.awu_discount_percent }
+          : {}),
+      };
+    }
+
+    if (line.metadata?.purchase_order_id) {
+      purchaseOrder = line.metadata.purchase_order_id;
+    }
 
     if (!shouldRemove) {
       await normalizeSubCentUnitAmount(stripe, invoice, line);
@@ -1919,6 +1945,8 @@ async function cleanMetronomeInvoiceLines(
     totalsMatch: newTotalCents === originalTotalCents,
     originalTotalCents,
     newTotalCents,
+    awuPurchaseMetadata,
+    purchaseOrder,
   };
 }
 
@@ -1987,14 +2015,28 @@ export async function cleanAndFinalizeMetronomeDraftInvoice({
       creditConfig?.autoInvoiceFinalizationEnabled ??
       DEFAULT_AUTO_INVOICE_FINALIZATION_ENABLED;
 
-    const { totalsMatch, originalTotalCents, newTotalCents } =
-      await cleanMetronomeInvoiceLines(stripe, invoice);
+    const {
+      totalsMatch,
+      originalTotalCents,
+      newTotalCents,
+      awuPurchaseMetadata,
+      purchaseOrder,
+    } = await cleanMetronomeInvoiceLines(stripe, invoice);
 
     await stripe.invoices.update(invoiceId, {
       metadata: {
         ...invoice.metadata,
+        workspace_id: workspaceId,
+        ...awuPurchaseMetadata,
+        ...(purchaseOrder ? { purchase_order_id: purchaseOrder } : {}),
         [METRONOME_INVOICE_LINES_CLEANED_FLAG]: "true",
       },
+      // Displayed on the printed/hosted invoice, unlike `metadata`.
+      ...(purchaseOrder
+        ? {
+            custom_fields: [{ name: "Purchase Order", value: purchaseOrder }],
+          }
+        : {}),
     });
 
     if (!totalsMatch) {
@@ -2033,6 +2075,17 @@ export async function cleanAndFinalizeMetronomeDraftInvoice({
     );
     return new Ok({ outcome: "cleaned" });
   } catch (error) {
+    if (
+      error instanceof Stripe.errors.StripeInvalidRequestError &&
+      error.code === "resource_missing"
+    ) {
+      logger.info(
+        { stripeInvoiceId: invoiceId, workspaceId },
+        "[Stripe] Skipping invoice clean: invoice no longer exists"
+      );
+      return new Ok({ outcome: "skipped" });
+    }
+
     logger.error(
       {
         stripeInvoiceId: invoiceId,

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -16,6 +16,9 @@ import { baseUniquenessKey } from "@app/lib/metronome/alerts";
 import { DEFAULT_ALERT_UNIQUENESS_KEYS } from "@app/lib/metronome/alerts/default_alerts";
 import { getMetronomeClient } from "@app/lib/metronome/client";
 import {
+  AWU_AMOUNT_CUSTOM_FIELD_KEY,
+  AWU_DISCOUNT_PERCENT_CUSTOM_FIELD_KEY,
+  AWU_PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY,
   CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
   CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
   CONTRACT_CREDIT_TYPE_POOL,
@@ -1544,6 +1547,21 @@ const CUSTOM_FIELD_KEYS: Array<{
   {
     entity: "contract_credit",
     key: CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
+  },
+  // Stamped on AWU pool commits (admin grants and self-serve top-ups) with the
+  // customer's PO number and the AWU credit amount purchased, for finance
+  // reconciliation against the Stripe invoice Metronome generates.
+  {
+    entity: "commit",
+    key: AWU_PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY,
+  },
+  {
+    entity: "commit",
+    key: AWU_AMOUNT_CUSTOM_FIELD_KEY,
+  },
+  {
+    entity: "commit",
+    key: AWU_DISCOUNT_PERCENT_CUSTOM_FIELD_KEY,
   },
   // Stamped on each seat-style product (Workspace / Pro / Max / Free).
   // Runtime code reads `product.custom_fields.DUST_SEAT_TYPE` (cached in


### PR DESCRIPTION
## Description

Add multiple custom fields on metronome commits and stamp them on the final invoice. Send purchase order on custom fields (directly visible on pdf).

## Tests

locally

## Risk

low

## Deploy Plan

deploy custom fields with metronome_setup, add stripe fields mapping manually
then deploy front

