### PR TITLE
Print applied migration SQL for #engineering_papertrail

### DIFF
--- a/scripts/db/migration-runner.ts
+++ b/scripts/db/migration-runner.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { QueryTypes } from "sequelize";
 import type { Sequelize } from "sequelize";
 import type { MigrationParams } from "umzug";
@@ -124,6 +124,27 @@ function createUmzug(
   });
 }
 
+// Dump the name and full SQL of every migration that was just applied to
+// stdout. This lets the run-migrations.sh operator copy-paste exactly what ran
+// into #engineering_papertrail.
+function printAppliedMigrationSql(applied: readonly { name: string }[]): void {
+  const sep = "=".repeat(72);
+  for (const { name } of applied) {
+    // `name` is prefixed with the phase (e.g. "pre-deploy/2024..._foo.sql"),
+    // and files live under `migrations/<phase>/`, so `migrations/<name>`
+    // resolves to the migration file relative to the component directory.
+    const filePath = `migrations/${name}`;
+    process.stdout.write(`\n${sep}\n${name}\n${sep}\n`);
+    if (existsSync(filePath)) {
+      const sql = readFileSync(filePath, "utf8");
+      process.stdout.write(sql.endsWith("\n") ? sql : `${sql}\n`);
+    } else {
+      process.stdout.write(`(migration file not found: ${filePath})\n`);
+    }
+  }
+  process.stdout.write(`${sep}\n`);
+}
+
 async function runUp(
   sequelize: Sequelize,
   getDatabaseURI: () => string,
@@ -140,6 +161,7 @@ async function runUp(
     { phase, count: applied.length, names: applied.map((m) => m.name) },
     "Migrations applied."
   );
+  printAppliedMigrationSql(applied);
 }
 
 async function runStatus(


### PR DESCRIPTION
## Description

When running `./scripts/run-migrations.sh pre-deploy front` (and its siblings: `post-deploy`, `connectors`), the operator had no easy way to see *what* SQL was actually applied so they can paste it into `#engineering_papertrail`.

This change makes the migration runner print, for every migration it just applied, the migration **name** followed by the **full SQL contents** (`cat`) in a clearly delimited, copy-paste-friendly block.

- `scripts/db/migration-runner.ts`: after `runUp` logs `"Migrations applied."`, it dumps each applied migration's name and file contents to stdout via the `printAppliedMigrationSql` helper. This now runs **unconditionally** — no env var is required.
- `scripts/run-migrations.sh`: no longer needs to opt in via an env var. Also restores the executable bit (`755`) on the script.

Because the runner only prints migrations that were *actually* applied, the output naturally appears once (in the first region that still had pending migrations) and stays empty in regions where nothing was pending.

Output format (name, then cat):

```
========================================================================
pre-deploy/20240101_add_col.sql
========================================================================
SET SESSION statement_timeout = 0;
ALTER TABLE "users" ADD COLUMN "nickname" VARCHAR(255);
========================================================================
```

## Tests

Manually validated the `printAppliedMigrationSql` logic in isolation:
- Prints the phase-prefixed name, separators, and the full SQL for each applied migration.
- Handles a missing migration file gracefully with a `(migration file not found: ...)` line instead of throwing.
- Confirmed the `migrations/<name>` path reconstruction works because the applied name is phase-prefixed (`pre-deploy/<file>.sql`) and the runner `cd`s into the component directory.

Note that the SQL now prints on every migration run, including local `npm run migration:apply`.
