### PR TITLE
Always cache the system prompt instructions block for 1h

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -120,7 +120,7 @@ app.post(
     const userMessage: UserMessageType = lastUserMessage;
 
     const attachments = await listAttachments(auth, { conversation });
-    const { servers: jitServers } = await getJITServers(auth, {
+    const jitServers = await getJITServers(auth, {
       agentConfiguration,
       conversation,
       attachments,

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
@@ -78,7 +78,7 @@ app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
 
   const conversation = conversationResult.value;
   const attachments = await listAttachments(auth, { conversation });
-  const { servers: jitServers } = await getJITServers(auth, {
+  const jitServers = await getJITServers(auth, {
     agentConfiguration: agentConfig,
     conversation,
     attachments,

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -57,7 +57,7 @@ describe("getJITServers", () => {
 
   describe("basic MCP servers", () => {
     it("should return common_utilities MCP server when no attachments", async () => {
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -73,7 +73,7 @@ describe("getJITServers", () => {
     });
 
     it("should always return the ask_user_question MCP server", async () => {
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -117,7 +117,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -148,7 +148,7 @@ describe("getJITServers", () => {
         agentConfigurationId: agentConfig.id,
       });
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -177,7 +177,7 @@ describe("getJITServers", () => {
       it("should not include skill_management server when agent has no skills", async () => {
         await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
-        const { servers: jitServers } = await getJITServers(auth, {
+        const jitServers = await getJITServers(auth, {
           agentConfiguration: agentConfig,
           conversation,
           attachments: [],
@@ -196,7 +196,7 @@ describe("getJITServers", () => {
           globalSkillId: "discover_tools",
           agentConfigurationId: agentConfig.id,
         });
-        const { servers: jitServers } = await getJITServers(auth, {
+        const jitServers = await getJITServers(auth, {
           agentConfiguration: agentConfig,
           conversation,
           attachments: [],
@@ -285,7 +285,7 @@ describe("getJITServers", () => {
         spaceId: conversationsSpace.sId,
       };
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation: conversationWithSpace,
         attachments: [],
@@ -348,7 +348,7 @@ describe("getJITServers", () => {
     it("includes skill_management so agents can enable the projects skill", async () => {
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -410,7 +410,7 @@ describe("getJITServers", () => {
     it("includes skill_management so agents can enable the sandbox skill", async () => {
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -433,7 +433,7 @@ describe("getJITServers", () => {
         workspace.id
       );
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -451,7 +451,7 @@ describe("getJITServers", () => {
     });
 
     it("should not include schedules_management server for non-onboarding conversations", async () => {
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -495,7 +495,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -551,7 +551,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -603,7 +603,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -646,7 +646,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -692,7 +692,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -746,7 +746,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -767,7 +767,7 @@ describe("getJITServers", () => {
 
   describe("server structure", () => {
     it("should return servers with correct structure", async () => {
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -828,7 +828,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -162,10 +162,7 @@ export async function getJITServers(
     conversation: ConversationWithoutContentType;
     attachments: ConversationAttachmentType[];
   }
-): Promise<{
-  servers: ServerSideMCPServerConfigurationType[];
-  hasConditionalJITTools: boolean;
-}> {
+): Promise<ServerSideMCPServerConfigurationType[]> {
   const mcpServersToFetch = new Set<AutoInternalMCPServerNameType>(
     ALWAYS_PREFETCHED_MCP_SERVERS
   );
@@ -204,8 +201,5 @@ export async function getJITServers(
     }),
   ]);
 
-  return {
-    servers: [...baseServers, ...conditionalServers],
-    hasConditionalJITTools: conditionalServers.length > 0,
-  };
+  return [...baseServers, ...conditionalServers];
 }

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -105,23 +105,16 @@ type AnthropicStreamPayload = BetaMessageStreamParams & {
 export function buildSystemBlocks(
   { instructions, sharedContext, ephemeralContext }: StructuredSystemPrompt,
   {
-    hasConditionalJITTools,
     includeToolSearchInstruction,
   }: {
-    hasConditionalJITTools?: boolean;
     includeToolSearchInstruction?: boolean;
   }
 ) {
   const instructionsText = instructions.map((s) => s.content).join("\n");
-  // The tool search instruction is a constant string that renders on every turn
-  // tool search is on, so it could live in the long-lived 1h instructions tier.
-  // It stays in the shared 5min tier for now because conditional JIT tools
-  // (attachment-driven: files, query, search) are auto-internal and hot, not
-  // deferred, so they still force the instructions tier to downgrade.
-  //
-  // TODO(tool-search): once the hot tool set is reduced to a minimal curated set
-  // so those conditional additions are deferred too, move this instruction to the
-  // instructions tier to get the 1h TTL.
+  // The tool search instruction stays in the shared 5min tier rather than the
+  // long-lived instructions tier: its presence is derived per request from
+  // whether the search tool is actually sent, so it is not guaranteed to be
+  // byte-stable across the lifetime of the 1h block.
   const sharedText = [
     sharedContext.map((s) => s.content).join("\n"),
     ...(includeToolSearchInstruction ? [TOOL_SEARCH_INSTRUCTION] : []),
@@ -133,18 +126,14 @@ export function buildSystemBlocks(
   const system: Anthropic.Beta.Messages.BetaTextBlockParam[] = [];
 
   if (instructionsText) {
-    // If we have conditional JIT tools, we expect more variability in the instructions, so we keep
-    // the default ephemeral cache. Otherwise, we can set a longer TTL to maximize cache hits.
-    //
-    // TODO: the tool directives and available-servers overview (the main source of JIT-driven
-    // variability in this block) now live in the shared-context block instead, so this downgrade
-    // should eventually be removable in favor of always using the 1h TTL, once we validate that no
-    // other conditional-JIT content remains in the instructions block.
-    const ttl: "1h" | undefined = hasConditionalJITTools ? undefined : "1h";
+    // The instructions tier only carries content that is stable per agent
+    // version and workspace settings (the tool directives and server listing,
+    // which vary with conversation state, live in the shared-context tier),
+    // so it always takes the 1h TTL.
     system.push({
       type: "text",
       text: instructionsText,
-      cache_control: { type: "ephemeral", ttl },
+      cache_control: { type: "ephemeral", ttl: "1h" },
     });
   }
 
@@ -207,7 +196,6 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
   ): Promise<MessageCreateParamsNonStreaming> {
     const {
       conversation,
-      hasConditionalJITTools,
       toolSearchEnabled,
       prompt,
       specifications,
@@ -285,7 +273,6 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     }
 
     const system = buildSystemBlocks(normalizePrompt(prompt), {
-      hasConditionalJITTools,
       includeToolSearchInstruction: includesToolSearchTool(tools),
     });
 

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -531,7 +531,7 @@ abstract class BaseTransition extends LLM {
   // Builds the provider-agnostic conversation payload (system + messages) shared
   // by both the streaming and batch surfaces.
   protected buildPayload(streamParameters: LLMStreamParameters): Payload {
-    const { conversation, hasConditionalJITTools, prompt } = streamParameters;
+    const { conversation, prompt } = streamParameters;
 
     const baseMessages = conversation.messages.flatMap(toBaseMessages);
 
@@ -555,11 +555,15 @@ abstract class BaseTransition extends LLM {
 
     const instructionsText = instructions.map((s) => s.content).join("\n");
     if (instructionsText) {
+      // The instructions tier only carries content that is stable per agent
+      // version and workspace settings (the tool directives and server listing,
+      // which vary with conversation state, live in the shared-context tier),
+      // so it always takes the long TTL.
       system.push({
         role: "system",
         type: "text",
         content: { value: instructionsText },
-        cache: hasConditionalJITTools ? "short" : "long",
+        cache: "long",
       });
     }
 

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -151,7 +151,6 @@ export type ExclusiveToolChoiceParameters =
 
 interface LLMStreamParametersBase {
   conversation: ModelConversationTypeMultiActions;
-  hasConditionalJITTools?: boolean;
   // When true, the Anthropic clients defer non-eager tools behind tool search.
   // Other provider clients ignore it.
   toolSearchEnabled?: boolean;

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -109,7 +109,7 @@ export async function createSandboxChildAction(
   // agent-loop path (`tryListMCPTools`): when several configs share a name
   // across spaces, the model-visible name is space-prefixed, and approval keys
   // are derived from it.
-  const { servers: jitServers } = await getJITServers(auth, {
+  const jitServers = await getJITServers(auth, {
     agentConfiguration,
     conversation,
     attachments: [],

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -95,7 +95,7 @@ makeScript(
     const userMessage: UserMessageType = lastUserMessage;
 
     const attachments = await listAttachments(auth, { conversation });
-    const { servers: jitServers } = await getJITServers(auth, {
+    const jitServers = await getJITServers(auth, {
       agentConfiguration,
       conversation,
       attachments,

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -238,7 +238,6 @@ export async function getOutputFromLLMStream(
   {
     modelConversationRes,
     conversation,
-    hasConditionalJITTools,
     toolSearchEnabled,
     disableToolUse,
     cacheDiagnosticsEnabled,
@@ -290,7 +289,6 @@ export async function getOutputFromLLMStream(
   const events = llm.stream(
     {
       conversation: modelConversationRes.value.modelConversation,
-      hasConditionalJITTools,
       toolSearchEnabled,
       disableToolUse,
       prompt,

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -156,7 +156,7 @@ async function listAvailableTools(
     });
 
   const attachments = await listAttachments(auth, { conversation });
-  const { servers: jitServers } = await getJITServers(auth, {
+  const jitServers = await getJITServers(auth, {
     agentConfiguration,
     conversation,
     attachments,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -366,19 +366,15 @@ export async function runModel(
     enabledSkills,
     systemSkills,
     equippedSkills,
-    hasConditionalJITTools,
     mcpActions,
     mcpToolsListingError,
   } = await startActiveObservation("resolve-tools", async () => {
     const attachments = await listAttachments(auth, { conversation });
-    const { servers: jitServers, hasConditionalJITTools } = await getJITServers(
-      auth,
-      {
-        agentConfiguration,
-        conversation,
-        attachments,
-      }
-    );
+    const jitServers = await getJITServers(auth, {
+      agentConfiguration,
+      conversation,
+      attachments,
+    });
 
     const clientSideMCPServerIds = [
       ...(userMessage.context.clientSideMCPServerIds ?? []),
@@ -415,7 +411,6 @@ export async function runModel(
     );
 
     return {
-      hasConditionalJITTools,
       enabledSkills,
       equippedSkills,
       systemSkills,
@@ -735,7 +730,6 @@ export async function runModel(
   const getOutputFromActionResponse = await getOutputFromLLMStream(auth, {
     modelConversationRes,
     conversation,
-    hasConditionalJITTools,
     toolSearchEnabled,
     disableToolUse,
     cacheDiagnosticsEnabled: featureFlags.includes(

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -41,7 +41,6 @@ export type GetOutputRequestParams = {
     tokensUsed: number;
   }>;
   conversation: ConversationType;
-  hasConditionalJITTools: boolean;
   // When true, the Anthropic client defers non-eager tools behind tool search.
   // Provider-agnostic signal: clients without tool-search support ignore it.
   toolSearchEnabled: boolean;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The instructions block of the system prompt was only given the 1h cache TTL when the conversation had no conditional just in time tools, falling back to the default 5 minutes otherwise. That guard is obsolete: the content that varies with conversation state, namely the tools, and its directives and the server listing, has since moved to the shared context tier / deferred tools search, so the instructions block is now stable per agent version and workspace settings. This change makes the 1h TTL unconditional in both the model constructors path and the legacy Anthropic client, and removes the flag that was threaded through the agent loop solely to drive the downgrade, since nothing consumes it anymore.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
