### PR TITLE
fix(front): guard against undefined pod members to avoid page crash

### DIFF
--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -38,7 +38,7 @@ import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import { isString } from "@app/types/shared/utils/general";
 import type { PodType, SpaceKind, SpaceType } from "@app/types/space";
-import type { LightWorkspaceType } from "@app/types/user";
+import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
 import { useCallback, useMemo } from "react";
 import type { Fetcher, KeyedMutator } from "swr";
 
@@ -168,8 +168,19 @@ export function useSpaceInfo({
       }
     );
 
+  // A partial cache entry can lack `members`; normalize it so consumers don't
+  // crash on `members.filter`/`.length`.
+  const spaceInfo = useMemo(() => {
+    if (!data) {
+      return null;
+    }
+    return data.space.members
+      ? data.space
+      : { ...data.space, members: emptyArray<SpaceUserType>() };
+  }, [data]);
+
   return {
-    spaceInfo: data ? data.space : null,
+    spaceInfo,
     canWriteInSpace: data?.space.canWrite ?? false,
     canReadInSpace: data?.space.isMember ?? false,
     mutateSpaceInfo: mutate,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9420

The pod page (`/w/:wId/pods/:podId`) crashed for some pods with:

```
TypeError: Cannot read properties of undefined (reading 'filter')
```

The failing code is `PodHeaderActions` running `members.filter((m) => m.isEditor)` with `members` being `undefined`. The header renders first in the tree, so its `members.filter` threw before the sibling `members.length` accessors — hence the `'filter'` message. A point-fix in the header would just move the crash to the next consumer.

While the space GET endpoint always returns `members`, a partial/stale cache entry (e.g. the bare `SpaceType` shape) can lack it. The sibling `PodMenu` already guards defensively (`podInfo?.members?.filter(...) ?? []`), confirming the field is known to be occasionally absent.

This normalizes `members` to an array at the `useSpaceInfo` boundary so every consumer is protected at once, keeping the original object reference when `members` is already present to avoid re-renders.

## Tests

Typechecked and linted.

## Risk

Very low.

## Deploy Plan

Standard front deploy, no migration.