### PR TITLE
[front] allow self-serve cancellation for PRO_PLAN_SEAT_39 workspaces

### DIFF
--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -19,6 +19,7 @@ import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   isEnterprisePlanPrefix,
+  isProOrBusinessPlanCode,
   isProPlan,
   isUpgraded,
   isWhitelistedBusinessPlan,
@@ -444,14 +445,17 @@ export function SubscriptionPage() {
     });
 
   const plan = subscription.plan;
-  const isWorkspaceOnProPlan = isProPlan(plan);
+  // Legacy Pro (SEAT_29 / LARGE_FILES) and Business (SEAT_39) both migrate to
+  // Business and share the same cancel / migration flow — see
+  // FORCE_LEGACY_LARGE_PLAN_CODES.
+  const isWorkspaceOnProOrBusinessPlan = isProOrBusinessPlanCode(plan);
 
   // Hooks must run unconditionally (before any early return): the migration
   // fetch is gated via `disabled`, not by skipping the hook.
   const { pendingMigrationDate, willBeRefundedOnEnd, mutateMigration } =
     useWorkspaceMigration({
       workspaceId: owner.sId,
-      disabled: !isWorkspaceOnProPlan,
+      disabled: !isWorkspaceOnProOrBusinessPlan,
     });
   const { cancelMigration, isCancellingMigration } =
     useCancelWorkspaceMigration({ workspaceId: owner.sId });
@@ -464,8 +468,10 @@ export function SubscriptionPage() {
   }
 
   const isWorkspaceWhitelistedBusinessPlan = isWhitelistedBusinessPlan(owner);
+  // Only legacy Pro can upsell to Business; a Business (SEAT_39) workspace is
+  // already there.
   const canUpsellToBusinessPlan =
-    isWorkspaceOnProPlan &&
+    isProPlan(plan) &&
     isWorkspaceWhitelistedBusinessPlan &&
     !isMetronomeCheckout;
 
@@ -485,16 +491,16 @@ export function SubscriptionPage() {
   // Cancelled (churning at the end date) only when not migrating.
   const isCancelledNotMigrating = !isMigrating && subscription.endDate !== null;
 
-  // A legacy Pro workspace (Stripe-billed, not trialing) can cancel — while
+  // A Stripe-billed Pro or Business workspace (not trialing) can cancel — while
   // active or while migrating (opt out). Not when already cancelled (→ Resume).
   const canCancelSubscription =
-    isWorkspaceOnProPlan &&
+    isWorkspaceOnProOrBusinessPlan &&
     !subscription.trialing &&
     subscription.stripeSubscriptionId !== null &&
     !isCancelledNotMigrating;
   // Cancelled (not migrating) but not yet ended — resume re-stages the migration.
   const canResumeMigration =
-    isWorkspaceOnProPlan &&
+    isWorkspaceOnProOrBusinessPlan &&
     isCancelledNotMigrating &&
     subscription.endDate !== null &&
     new Date(subscription.endDate).getTime() > Date.now();
@@ -536,7 +542,11 @@ export function SubscriptionPage() {
     : null;
 
   const migrationDate = (() => {
-    if (!isWorkspaceOnProPlan || !isMetronomeCheckout || !perSeatPricing) {
+    if (
+      !isWorkspaceOnProOrBusinessPlan ||
+      !isMetronomeCheckout ||
+      !perSeatPricing
+    ) {
       return null;
     }
     // Rollout window [Jul 23, Aug 23) 2026 (UTC), matching the migration script.


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9423

PRO_PLAN_SEAT_39 (Business) workspaces are Stripe-billed and land on the legacy /subscription page, but the cancel button was gated on isProPlan(plan) which only matches SEAT_29 / LARGE_FILES, so admins had no self-serve way to cancel.

SEAT_39 is a forced migration candidate (FORCE_LEGACY_LARGE_PLAN_CODES), so it migrates to Business and shares the exact same cancel / migration flow as SEAT_29. Broaden the shared predicate to isProOrBusinessPlanCode so SEAT_39 flows through the identical branches (migration-status fetch, cancel, resume, migration-date banner).
## Tests

Local

## Risk

Low

## Deploy Plan

Front