### PR TITLE
Analytics/pricing: Add API keys in the usage graph

### DIFF
--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -47,7 +47,12 @@ interface AwuUsageFromAnalyticsChartProps {
 }
 
 export type Granularity = "day" | "week" | "month";
-export type AnalyticsGroupBy = "usage_type" | "agent" | "user" | "origin";
+export type AnalyticsGroupBy =
+  | "usage_type"
+  | "agent"
+  | "user"
+  | "origin"
+  | "api_key";
 
 type GroupByOption = { value: AnalyticsGroupBy | undefined; label: string };
 
@@ -57,6 +62,7 @@ const GROUP_BY_OPTIONS: GroupByOption[] = [
   { value: "agent", label: "By Agent" },
   { value: "user", label: "By User" },
   { value: "origin", label: "By Source" },
+  { value: "api_key", label: "By API Key" },
 ];
 
 // "By User" is redundant when the chart is already scoped to a single user.

--- a/front/components/workspace/analytics/analyticsFilter.ts
+++ b/front/components/workspace/analytics/analyticsFilter.ts
@@ -18,6 +18,7 @@ export const SCOPE_DIMENSION_LABEL: Record<AnalyticsScopeDimension, string> = {
   agent: "Agent",
   user: "User",
   origin: "Source",
+  api_key: "API Key",
 };
 
 export const SCOPE_DIMENSIONS = Object.keys(

--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -24,6 +24,12 @@
     "context_origin": {
       "type": "keyword"
     },
+    "auth_method": {
+      "type": "keyword"
+    },
+    "api_key_name": {
+      "type": "keyword"
+    },
     "timestamp": {
       "type": "date"
     },

--- a/front/lib/analytics/migrations/20260707_remove_system_api_key_name.http
+++ b/front/lib/analytics/migrations/20260707_remove_system_api_key_name.http
@@ -1,0 +1,11 @@
+POST /front.agent_message_analytics_2/_update_by_query
+{
+  "query": {
+    "term": {
+      "api_key_name": "DustSystemKey"
+    }
+  },
+  "script": {
+    "source": """ctx._source.remove("api_key_name")"""
+  }
+}

--- a/front/lib/api/analytics/awu_usage_analytics.ts
+++ b/front/lib/api/analytics/awu_usage_analytics.ts
@@ -15,6 +15,7 @@ const TERMS_GROUP_BY_KEYS = [
   "agent",
   "user",
   "origin",
+  "api_key",
 ] as const satisfies readonly CreditBreakdownBy[];
 
 // usage_type is derived (no stored field): User vs Programmatic, split on
@@ -95,6 +96,7 @@ export async function getAwuUsageFromAnalytics(
   const userIds = options.userIds ?? filter?.user;
   const agentIds = filter?.agent;
   const contextOrigin = filter?.origin;
+  const apiKeyNames = filter?.api_key;
 
   if (!groupBy) {
     const result = await fetchCreditTimeseries(auth, {
@@ -106,6 +108,7 @@ export async function getAwuUsageFromAnalytics(
       userIds,
       agentIds,
       contextOrigin,
+      apiKeyNames,
     });
     if (result.isErr()) {
       return new Err(toError(result.error));
@@ -133,6 +136,7 @@ export async function getAwuUsageFromAnalytics(
       userIds,
       agentIds,
       contextOrigin,
+      apiKeyNames,
     });
     if (result.isErr()) {
       return new Err(toError(result.error));
@@ -167,6 +171,7 @@ export async function getAwuUsageFromAnalytics(
     userIds,
     agentIds,
     contextOrigin,
+    apiKeyNames,
   });
   if (result.isErr()) {
     return new Err(toError(result.error));

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -1,6 +1,10 @@
 import { sourceLabelForOrigin } from "@app/lib/api/analytics/source_labels";
 import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
-import { buildCreditsScopeQuery } from "@app/lib/api/assistant/observability/utils";
+import {
+  buildCreditsScopeQuery,
+  NOT_API_GROUP_KEY,
+  NOT_API_GROUP_NAME,
+} from "@app/lib/api/assistant/observability/utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import {
   bucketsToArray,
@@ -15,7 +19,7 @@ import { Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { estypes } from "@elastic/elasticsearch";
 
-export type CreditBreakdownBy = "agent" | "user" | "origin";
+export type CreditBreakdownBy = "agent" | "user" | "origin" | "api_key";
 
 export type CreditGroupBy = CreditBreakdownBy | "none";
 
@@ -103,7 +107,7 @@ function totalCreditsFromSlice(slice: CreditSlice): number {
 
 function groupFieldFor(
   groupBy: CreditBreakdownBy
-): "agent_id" | "user_id" | "context_origin" {
+): "agent_id" | "user_id" | "context_origin" | "api_key_name" {
   switch (groupBy) {
     case "agent":
       return "agent_id";
@@ -111,9 +115,28 @@ function groupFieldFor(
       return "user_id";
     case "origin":
       return "context_origin";
+    case "api_key":
+      return "api_key_name";
     default:
       return assertNever(groupBy);
   }
+}
+
+// api_key_name is only set on API-key authenticated messages. Instead of
+// dropping the other messages (exists filter), bucket them under a "Not API"
+// group via the terms-agg `missing` value so the series still sums to the
+// total consumption.
+function groupTermsAggFor(
+  groupBy: CreditBreakdownBy
+): estypes.AggregationsTermsAggregation {
+  const terms: estypes.AggregationsTermsAggregation = {
+    field: groupFieldFor(groupBy),
+  };
+  if (groupBy === "api_key") {
+    terms.missing = NOT_API_GROUP_KEY;
+    terms.value_type = "string";
+  }
+  return terms;
 }
 
 function fallbackGroupName(groupBy: CreditBreakdownBy): string {
@@ -124,6 +147,8 @@ function fallbackGroupName(groupBy: CreditBreakdownBy): string {
       return "Programmatic usage";
     case "origin":
       return "Unknown source";
+    case "api_key":
+      return "Unknown API key";
     default:
       return assertNever(groupBy);
   }
@@ -157,6 +182,15 @@ async function resolveGroupNames(
       // Match the chart's user-facing source labels (e.g. web -> Conversation),
       // falling back to the raw origin for anything unlabeled.
       return new Map(ids.map((id) => [id, sourceLabelForOrigin(id) ?? id]));
+    case "api_key":
+      // The group key is already the key's display name; only the sentinel
+      // bucket for non-API messages needs a label.
+      return new Map(
+        ids.map((id) => [
+          id,
+          id === NOT_API_GROUP_KEY ? NOT_API_GROUP_NAME : id,
+        ])
+      );
     default:
       return assertNever(groupBy);
   }
@@ -211,6 +245,7 @@ export async function fetchCreditUsage(
     contextOrigin,
     agentIds,
     userIds,
+    apiKeyNames,
   }: {
     startDate: string;
     endDate: string;
@@ -219,6 +254,7 @@ export async function fetchCreditUsage(
     contextOrigin?: string | string[];
     agentIds?: string[];
     userIds?: string[];
+    apiKeyNames?: string[];
   }
 ): Promise<Result<CreditUsageResult, ElasticsearchError>> {
   const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
@@ -226,7 +262,7 @@ export async function fetchCreditUsage(
   if (groupBy !== "none") {
     aggregations.by_group = {
       terms: {
-        field: groupFieldFor(groupBy),
+        ...groupTermsAggFor(groupBy),
         size: limit,
         order: { total_cost: "desc" },
       },
@@ -240,8 +276,13 @@ export async function fetchCreditUsage(
     contextOrigin,
     agentIds,
     userIds,
+    apiKeyNames,
     extraFilters:
-      groupBy === "none" ? [] : [{ exists: { field: groupFieldFor(groupBy) } }],
+      // api_key buckets missing values under "Not API" instead of dropping
+      // them, so the rows keep summing to the total.
+      groupBy === "none" || groupBy === "api_key"
+        ? []
+        : [{ exists: { field: groupFieldFor(groupBy) } }],
   });
 
   const result = await searchAnalytics<never, CreditUsageAggs>(query, {
@@ -294,6 +335,7 @@ export async function fetchCreditTimeseries(
     contextOrigin,
     agentIds,
     userIds,
+    apiKeyNames,
     fillWindow,
   }: {
     startDate: string;
@@ -303,6 +345,7 @@ export async function fetchCreditTimeseries(
     contextOrigin?: string | string[];
     agentIds?: string[];
     userIds?: string[];
+    apiKeyNames?: string[];
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditTimeseriesPoint[], ElasticsearchError>> {
@@ -312,6 +355,7 @@ export async function fetchCreditTimeseries(
     contextOrigin,
     agentIds,
     userIds,
+    apiKeyNames,
   });
 
   const result = await searchAnalytics<never, CreditTimeseriesAggs>(query, {
@@ -362,6 +406,7 @@ export async function fetchCreditTimeseriesByUsageType(
     contextOrigin,
     agentIds,
     userIds,
+    apiKeyNames,
     fillWindow,
   }: {
     startDate: string;
@@ -371,6 +416,7 @@ export async function fetchCreditTimeseriesByUsageType(
     contextOrigin?: string | string[];
     agentIds?: string[];
     userIds?: string[];
+    apiKeyNames?: string[];
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditUsageTypePoint[], ElasticsearchError>> {
@@ -380,6 +426,7 @@ export async function fetchCreditTimeseriesByUsageType(
     contextOrigin,
     agentIds,
     userIds,
+    apiKeyNames,
   });
 
   const programmaticFilter = getProgrammaticUsageFilterClause();
@@ -443,6 +490,7 @@ export async function fetchCreditTimeseriesBreakdown(
     contextOrigin,
     agentIds,
     userIds,
+    apiKeyNames,
     fillWindow,
   }: {
     startDate: string;
@@ -454,6 +502,7 @@ export async function fetchCreditTimeseriesBreakdown(
     contextOrigin?: string | string[];
     agentIds?: string[];
     userIds?: string[];
+    apiKeyNames?: string[];
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditTimeseriesBreakdown, ElasticsearchError>> {
@@ -465,6 +514,7 @@ export async function fetchCreditTimeseriesBreakdown(
     contextOrigin,
     agentIds,
     userIds,
+    apiKeyNames,
   });
   if (ranking.isErr()) {
     return ranking;
@@ -485,6 +535,7 @@ export async function fetchCreditTimeseriesBreakdown(
     contextOrigin,
     agentIds,
     userIds,
+    apiKeyNames,
   });
 
   const result = await searchAnalytics<never, CreditTimeseriesBreakdownAggs>(
@@ -503,7 +554,7 @@ export async function fetchCreditTimeseriesBreakdown(
             ...creditSubAggs,
             by_group: {
               terms: {
-                field: groupFieldFor(breakdownBy),
+                ...groupTermsAggFor(breakdownBy),
                 include: groupKeys,
                 size: groupKeys.length,
               },

--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -35,6 +35,38 @@ export function daysToInstantRange(
   };
 }
 
+// Sentinel group key for messages sent without an API key (no `api_key_name`
+// on the document). Used both as the terms-agg `missing` bucket key and as a
+// filterable id, so grouping by API key still sums to the total consumption.
+export const NOT_API_GROUP_KEY = "__not_api__";
+export const NOT_API_GROUP_NAME = "Not API";
+
+// api_key_name is only set on API-key authenticated messages. The sentinel
+// selects everything else (missing field), so a mixed selection becomes a
+// disjunction of the two.
+function apiKeyNamesFilter(
+  apiKeyNames: string[] | undefined
+): estypes.QueryDslQueryContainer[] {
+  if (!apiKeyNames || apiKeyNames.length === 0) {
+    return [];
+  }
+  const names = apiKeyNames.filter((name) => name !== NOT_API_GROUP_KEY);
+  const clauses: estypes.QueryDslQueryContainer[] = [
+    ...termFilter("api_key_name", names),
+    ...(apiKeyNames.includes(NOT_API_GROUP_KEY)
+      ? [
+          {
+            bool: { must_not: [{ exists: { field: "api_key_name" } }] },
+          },
+        ]
+      : []),
+  ];
+  if (clauses.length <= 1) {
+    return clauses;
+  }
+  return [{ bool: { should: clauses, minimum_should_match: 1 } }];
+}
+
 function termFilter(
   field: string,
   value: string | string[] | undefined
@@ -60,6 +92,7 @@ export function buildAgentAnalyticsBaseQuery({
   agentId,
   agentIds,
   userIds,
+  apiKeyNames,
   contextOrigin,
   days,
   startDate,
@@ -69,6 +102,7 @@ export function buildAgentAnalyticsBaseQuery({
 }: {
   workspaceId: string;
   userIds?: string[];
+  apiKeyNames?: string[];
   contextOrigin?: string | string[];
   days?: number;
   startDate?: string;
@@ -84,6 +118,7 @@ export function buildAgentAnalyticsBaseQuery({
     ...(agentId ? [{ term: { agent_id: agentId } }] : []),
     ...termFilter("agent_id", agentIds),
     ...termFilter("user_id", userIds),
+    ...apiKeyNamesFilter(apiKeyNames),
     ...contextOriginFilter(contextOrigin),
   ];
 
@@ -126,6 +161,7 @@ export function buildCreditsScopeQuery(
     contextOrigin,
     agentIds,
     userIds,
+    apiKeyNames,
     extraFilters = [],
     extraMustNot = [],
   }: {
@@ -134,6 +170,7 @@ export function buildCreditsScopeQuery(
     contextOrigin?: string | string[];
     agentIds?: string[];
     userIds?: string[];
+    apiKeyNames?: string[];
     extraFilters?: estypes.QueryDslQueryContainer[];
     extraMustNot?: estypes.QueryDslQueryContainer[];
   }
@@ -145,6 +182,7 @@ export function buildCreditsScopeQuery(
     contextOrigin,
     agentIds,
     userIds,
+    apiKeyNames,
   });
   return {
     bool: {

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -609,7 +609,7 @@ export function useAwuUsageFromAnalytics({
   urlPrefix,
 }: {
   workspaceId: string;
-  groupBy?: "usage_type" | "agent" | "user" | "origin";
+  groupBy?: "usage_type" | "agent" | "user" | "origin" | "api_key";
   groupByCount?: number;
   granularity?: "day" | "week" | "month";
   days?: number;

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -100,7 +100,7 @@ export function usePokeAwuUsageFromAnalytics({
   filter,
   disabled,
 }: PokeConditionalFetchProps & {
-  groupBy?: "usage_type" | "agent" | "user" | "origin";
+  groupBy?: "usage_type" | "agent" | "user" | "origin" | "api_key";
   groupByCount?: number;
   granularity?: "day" | "week" | "month";
   days?: number;

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -227,6 +227,9 @@ export async function storeAgentAnalytics(
     : [];
 
   // Resolve API key name from stored ID, falling back to auth context if key was deleted.
+  // System keys are Dust-internal plumbing (Slack bot, connectors, ...), not
+  // workspace API usage: leave api_key_name unset so those messages report as
+  // "Not API" in analytics.
   let apiKeyName: string | undefined;
   const storedKeyId = userMessageModel.userContextApiKeyId;
   if (storedKeyId) {
@@ -234,7 +237,7 @@ export async function storeAgentAnalytics(
       workspace: auth.getNonNullableWorkspace(),
       id: storedKeyId,
     });
-    if (keyResource) {
+    if (keyResource && !keyResource.isSystem) {
       apiKeyName = keyResource.name;
     }
   }


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9427

Add the possibility to filter and groupby api key in the credits usage graph.
Add a "Not API" key to group values not matching an API key so the total is exact (also allow to filter on not API keys while drilling down on other fields).

There is a migration to remove the "DustSystemKey" value from the analytics (and not put it again) because it is not an actual value which should be shown to customers.

## Tests

Tested locally

<img width="2196" height="742" alt="image" src="https://github.com/user-attachments/assets/878397a4-5fc5-4ccd-bae1-b07ce193a023" />

<img width="2168" height="702" alt="image" src="https://github.com/user-attachments/assets/4445bf1f-e245-42c6-971c-9772109db257" />


## Risk

low

## Deploy Plan

Deploy then run ES migration
```
npx tsx scripts/execute_elasticsearch_http.ts --file lib/analytics/migrations/20260707_remove_system_api_key_name.http--execute
```