### PR TITLE
fix: RFC 2047-encode Gmail recipient display names

### DIFF
--- a/front/lib/api/actions/servers/gmail/helpers.test.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.test.ts
@@ -1,5 +1,6 @@
 import type { GmailMessagePayload } from "@app/lib/api/actions/servers/gmail/helpers";
 import {
+  encodeEmailAddressHeader,
   findAttachmentData,
   findAttachmentIdByPartId,
 } from "@app/lib/api/actions/servers/gmail/helpers";
@@ -49,6 +50,44 @@ describe("findAttachmentIdByPartId", () => {
 
   it("returns null when the payload is undefined", () => {
     expect(findAttachmentIdByPartId(undefined, "1")).toBeNull();
+  });
+});
+
+describe("encodeEmailAddressHeader", () => {
+  it("RFC 2047-encodes a display name with accents, keeping the email intact", () => {
+    expect(encodeEmailAddressHeader("Amélie Doré <amelie@example.com>")).toBe(
+      "=?UTF-8?B?QW3DqWxpZSBEb3LDqQ==?= <amelie@example.com>"
+    );
+  });
+
+  it("leaves an all-ASCII named address unchanged", () => {
+    expect(encodeEmailAddressHeader("John Doe <john@example.com>")).toBe(
+      "John Doe <john@example.com>"
+    );
+  });
+
+  it("leaves a bare email address unchanged", () => {
+    expect(encodeEmailAddressHeader("john@example.com")).toBe(
+      "john@example.com"
+    );
+  });
+
+  it("strips surrounding quotes from an all-ASCII display name", () => {
+    expect(encodeEmailAddressHeader('"John Doe" <john@example.com>')).toBe(
+      "John Doe <john@example.com>"
+    );
+  });
+
+  it("encodes a quoted display name with accents", () => {
+    expect(encodeEmailAddressHeader('"Amélie Doré" <amelie@example.com>')).toBe(
+      "=?UTF-8?B?QW3DqWxpZSBEb3LDqQ==?= <amelie@example.com>"
+    );
+  });
+
+  it("keeps only the email when the display name is empty", () => {
+    expect(encodeEmailAddressHeader("<john@example.com>")).toBe(
+      "<john@example.com>"
+    );
   });
 });
 

--- a/front/lib/api/actions/servers/gmail/helpers.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.ts
@@ -330,10 +330,50 @@ export async function getErrorText(response: Response): Promise<string> {
 }
 
 /**
+ * Encode a string as an RFC 2047 "encoded-word" (UTF-8, base64). Required for
+ * header values that contain non-ASCII characters, otherwise the raw 8-bit
+ * bytes are interpreted as Latin-1 by mail clients (e.g. "é" becomes "Ã©").
+ */
+function encodeRfc2047Word(text: string): string {
+  return `=?UTF-8?B?${Buffer.from(text, "utf-8").toString("base64")}?=`;
+}
+
+/**
  * Encode subject line using RFC 2047 to handle special characters
  */
 export function encodeSubject(subject: string): string {
-  return `=?UTF-8?B?${Buffer.from(subject, "utf-8").toString("base64")}?=`;
+  return encodeRfc2047Word(subject);
+}
+
+/**
+ * Encode the display-name portion of an address header (To/From/Cc/Bcc) using
+ * RFC 2047 when it contains non-ASCII characters, leaving the `<email>` part
+ * untouched. Address headers must be pure ASCII, so an unencoded accented name
+ * like `Amélie Doré <a@x.com>` would otherwise render as `AmÃ©lie DorÃ©`.
+ * All-ASCII addresses are returned unchanged to keep the header readable.
+ */
+export function encodeEmailAddressHeader(address: string): string {
+  const trimmed = address.trim();
+
+  // Split `Display Name <email>`; leave bare `email` addresses as-is.
+  const match = trimmed.match(/^(.*?)\s*<([^>]+)>$/);
+  if (!match) {
+    return trimmed;
+  }
+
+  const [, rawName, email] = match;
+  // Strip surrounding quotes Gmail may include around the display name.
+  const name = rawName.replace(/^"(.*)"$/, "$1").trim();
+  if (!name) {
+    return `<${email}>`;
+  }
+
+  // eslint-disable-next-line no-control-regex
+  if (!/[^\x00-\x7F]/.test(name)) {
+    return `${name} <${email}>`;
+  }
+
+  return `${encodeRfc2047Word(name)} <${email}>`;
 }
 
 /**

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -21,6 +21,7 @@ import {
   buildReplyBody,
   createThreadingHeaders,
   decodeMessageBody,
+  encodeEmailAddressHeader,
   encodeMessageForGmail,
   encodeSubject,
   extractAttachments,
@@ -93,10 +94,14 @@ function buildAndEncodeEmail(params: {
   let messageLines: string[];
 
   const commonLines = [
-    `To: ${params.to.join(", ")}`,
-    params.from ? `From: ${params.from}` : null,
-    params.cc?.length ? `Cc: ${params.cc.join(", ")}` : null,
-    params.bcc?.length ? `Bcc: ${params.bcc.join(", ")}` : null,
+    `To: ${params.to.map(encodeEmailAddressHeader).join(", ")}`,
+    params.from ? `From: ${encodeEmailAddressHeader(params.from)}` : null,
+    params.cc?.length
+      ? `Cc: ${params.cc.map(encodeEmailAddressHeader).join(", ")}`
+      : null,
+    params.bcc?.length
+      ? `Bcc: ${params.bcc.map(encodeEmailAddressHeader).join(", ")}`
+      : null,
     `Subject: ${encodedSubject}`,
   ].filter((line): line is string => line !== null);
 


### PR DESCRIPTION
## Description

The `To`/`From`/`Cc`/`Bcc` headers were built with raw UTF-8 display names, while only `Subject` was RFC 2047-encoded. When the message is base64-encoded, the header carries undeclared 8-bit bytes, which mail clients interpret as Latin-1.

Encode the display-name portion of each address header when it contains non-ASCII characters, leaving the `<email>` part and all-ASCII names untouched. Already-encoded ASCII words pass through unchanged, so there's no double-encoding regardless of whether Gmail returns names decoded or pre-encoded.

## Tests

Added unit tests in `helpers.test.ts` covering accented names, quoted names, all-ASCII passthrough, bare addresses, and empty display names. All gmail helper tests pass; typecheck and biome clean.

## Risk

Low.

## Deploy Plan

Standard deploy, no migration.