### PR TITLE
Eagerly load custom agents' configured tools

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -161,9 +161,9 @@ describe("buildBaseSpecifications", () => {
       }
     );
 
-    expect(specifications.find((s) => s.name === "configured_tool")?.eager).toBe(
-      true
-    );
+    expect(
+      specifications.find((s) => s.name === "configured_tool")?.eager
+    ).toBe(true);
     expect(
       specifications.find((s) => s.name === "jit_tool")?.eager
     ).toBeUndefined();
@@ -209,7 +209,10 @@ describe("buildBaseSpecifications", () => {
     });
 
     // Before the skill is enabled, its tools are not in the request at all.
-    const before = buildBaseSpecifications([configuredTool], agentConfiguration);
+    const before = buildBaseSpecifications(
+      [configuredTool],
+      agentConfiguration
+    );
     expect(before.map((s) => s.name)).toEqual(["configured_tool"]);
 
     // Once enabled, the skill's server is appended to the available actions

--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -1,6 +1,11 @@
+import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp_schemas";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { ANTHROPIC_PROVIDER_ID } from "@app/lib/api/llm/clients/anthropic/types";
-import { buildSpecificationsWithReplayPlaceholders } from "@app/temporal/agent_loop/lib/run_model";
+import {
+  buildBaseSpecifications,
+  buildSpecificationsWithReplayPlaceholders,
+} from "@app/temporal/agent_loop/lib/run_model";
 import type {
   ModelConversationTypeMultiActions,
   ModelMessageTypeMultiActionsWithoutContentFragment,
@@ -65,6 +70,174 @@ function makeConversation(
 ): ModelConversationTypeMultiActions {
   return { messages };
 }
+
+function makeServerSideToolConfiguration(
+  name: string,
+  { mcpServerViewId, eager }: { mcpServerViewId: string; eager?: boolean }
+): MCPToolConfigurationType {
+  return {
+    id: -1,
+    sId: `tool_${name}`,
+    type: "mcp_configuration",
+    name,
+    description: `Description of ${name}`,
+    inputSchema: { type: "object", properties: {}, required: [] },
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId,
+    dustAppConfiguration: null,
+    secretName: null,
+    dustProject: null,
+    internalMCPServerId: null,
+    originalName: name,
+    mcpServerName: "server",
+    availability: "manual",
+    permission: "never_ask",
+    toolServerId: "server_id",
+    retryPolicy: "no_retry",
+    ...(eager !== undefined ? { eager } : {}),
+  };
+}
+
+function makeClientSideToolConfiguration(
+  name: string
+): MCPToolConfigurationType {
+  return {
+    id: -1,
+    sId: `tool_${name}`,
+    type: "mcp_configuration",
+    name,
+    description: `Description of ${name}`,
+    inputSchema: { type: "object", properties: {}, required: [] },
+    clientSideMcpServerId: "client_side_server_id",
+    originalName: name,
+    mcpServerName: "server",
+    permission: "never_ask",
+    toolServerId: "server_id",
+  };
+}
+
+function makeAgentServerConfiguration(
+  mcpServerViewId: string
+): ServerSideMCPServerConfigurationType {
+  return {
+    id: -1,
+    sId: `action_${mcpServerViewId}`,
+    type: "mcp_server_configuration",
+    name: "server",
+    description: null,
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId,
+    dustAppConfiguration: null,
+    secretName: null,
+    dustProject: null,
+    internalMCPServerId: null,
+  };
+}
+
+describe("buildBaseSpecifications", () => {
+  it("marks a custom agent's configured tools eager", () => {
+    const specifications = buildBaseSpecifications(
+      [
+        makeServerSideToolConfiguration("configured_tool", {
+          mcpServerViewId: "view_configured",
+        }),
+        makeServerSideToolConfiguration("jit_tool", {
+          mcpServerViewId: "view_jit",
+        }),
+      ],
+      {
+        sId: "custom_agent",
+        actions: [makeAgentServerConfiguration("view_configured")],
+      }
+    );
+
+    expect(specifications.find((s) => s.name === "configured_tool")?.eager).toBe(
+      true
+    );
+    expect(
+      specifications.find((s) => s.name === "jit_tool")?.eager
+    ).toBeUndefined();
+  });
+
+  it("does not promote configured tools of a global agent", () => {
+    const specifications = buildBaseSpecifications(
+      [
+        makeServerSideToolConfiguration("configured_tool", {
+          mcpServerViewId: "view_configured",
+        }),
+      ],
+      {
+        sId: "dust",
+        actions: [makeAgentServerConfiguration("view_configured")],
+      }
+    );
+
+    expect(specifications[0].eager).toBeUndefined();
+  });
+
+  it("preserves the intrinsic eager flag on non-configured tools", () => {
+    const specifications = buildBaseSpecifications(
+      [
+        makeServerSideToolConfiguration("hot_jit_tool", {
+          mcpServerViewId: "view_jit",
+          eager: true,
+        }),
+      ],
+      { sId: "custom_agent", actions: [] }
+    );
+
+    expect(specifications[0].eager).toBe(true);
+  });
+
+  it("keeps skill tools deferred when a skill is enabled mid-conversation", () => {
+    const agentConfiguration = {
+      sId: "custom_agent",
+      actions: [makeAgentServerConfiguration("view_configured")],
+    };
+    const configuredTool = makeServerSideToolConfiguration("configured_tool", {
+      mcpServerViewId: "view_configured",
+    });
+
+    // Before the skill is enabled, its tools are not in the request at all.
+    const before = buildBaseSpecifications([configuredTool], agentConfiguration);
+    expect(before.map((s) => s.name)).toEqual(["configured_tool"]);
+
+    // Once enabled, the skill's server is appended to the available actions
+    // without touching the agent's configured set: its tools must stay
+    // deferred so the cached tool prefix is not rewritten.
+    const after = buildBaseSpecifications(
+      [
+        configuredTool,
+        makeServerSideToolConfiguration("skill_tool", {
+          mcpServerViewId: "view_skill",
+        }),
+      ],
+      agentConfiguration
+    );
+
+    expect(after.find((s) => s.name === "skill_tool")?.eager).toBeUndefined();
+    expect(after.find((s) => s.name === "configured_tool")?.eager).toBe(true);
+  });
+
+  it("keeps client-side tools deferred for custom agents", () => {
+    const specifications = buildBaseSpecifications(
+      [makeClientSideToolConfiguration("client_tool")],
+      { sId: "custom_agent", actions: [] }
+    );
+
+    expect(specifications[0].eager).toBeUndefined();
+  });
+});
 
 describe("buildSpecificationsWithReplayPlaceholders", () => {
   it("does not eagerly load replayed tools that are still configured", () => {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -1,11 +1,16 @@
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
+import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { buildToolSpecification } from "@app/lib/actions/mcp";
 import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { isServerSideMCPServerConfigurationWithName } from "@app/lib/actions/types/guards";
+import {
+  isServerSideMCPServerConfiguration,
+  isServerSideMCPServerConfigurationWithName,
+  isServerSideMCPToolConfiguration,
+} from "@app/lib/actions/types/guards";
 import { computeStepContexts } from "@app/lib/actions/utils";
 import { getAdvancedModelAccessErrorForAgentConfiguration } from "@app/lib/advanced_models/access";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
@@ -72,8 +77,12 @@ import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
 import { getOutputFromLLMStream } from "@app/temporal/agent_loop/lib/get_output_from_llm";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import { makeRunModelLLMError } from "@app/temporal/agent_loop/lib/run_model_errors";
-import type { AgentActionsEvent } from "@app/types/assistant/agent";
+import type {
+  AgentActionsEvent,
+  AgentConfigurationType,
+} from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type {
   AgentMessageType,
   UserMessageOrigin,
@@ -201,6 +210,38 @@ function buildReplayOnlyToolSpecification(
       additionalProperties: true,
     },
   };
+}
+
+// A custom agent's configured tools are its identity: they stay in the eagerly
+// loaded set so the model always sees them instead of having to discover them
+// through tool search. The set is small and stable per agent version, so the
+// cached tool prefix stays byte-stable. Global agents keep the curated per-tool
+// metadata flags, and conversation, skill and JIT provided tools stay deferred
+// so mid-conversation additions append to the deferred catalog instead of
+// rewriting the prefix.
+export function buildBaseSpecifications(
+  availableActions: MCPToolConfigurationType[],
+  agentConfiguration: Pick<AgentConfigurationType, "sId" | "actions">
+): AgentActionSpecification[] {
+  const isCustomAgent = !isGlobalAgentId(agentConfiguration.sId);
+  const agentActionViewIds = new Set(
+    agentConfiguration.actions
+      .filter(isServerSideMCPServerConfiguration)
+      .map((action) => action.mcpServerViewId)
+  );
+
+  return availableActions.map((action) => {
+    const specification = buildToolSpecification(action);
+    if (
+      isCustomAgent &&
+      isServerSideMCPToolConfiguration(action) &&
+      agentActionViewIds.has(action.mcpServerViewId)
+    ) {
+      return { ...specification, eager: true };
+    }
+
+    return specification;
+  });
 }
 
 // Replayed tools keep their intrinsic `eager` flag: providers resolve deferred
@@ -528,9 +569,8 @@ export async function runModel(
   // deferred behind tool search is an Anthropic-specific policy applied in the
   // Anthropic client, gated on `toolSearchEnabled` (threaded through below).
   const toolSearchEnabled = featureFlags.includes("anthropic_tool_search");
-  const baseSpecifications: AgentActionSpecification[] = availableActions.map(
-    (a) => buildToolSpecification(a)
-  );
+  const baseSpecifications: AgentActionSpecification[] =
+    buildBaseSpecifications(availableActions, agentConfiguration);
 
   // Count the number of tokens used by the functions presented to the model.
   // This is a rough estimate of the number of tokens.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When tool search is enabled, a custom agent's hand-picked tools were deferred behind search like everything else. Those tools are the agent's identity: the builder chose them deliberately, and making the model discover them through search adds a round trip and a recall risk, for no cache benefit since the set _is expected to be small_ and stable per agent version. This change keeps every tool coming from the agent's configured actions in the eagerly loaded set when the agent is not a global one. Global agents keep their curated hot set, and tools added by skills, conversation state or client-side servers stay deferred for everyone, so mid-conversation additions still append to the deferred catalog instead of rewriting the cached prefix.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
