### PR TITLE
feat: snapshot browser tab state at message-send time

### DIFF
--- a/extension/shared/background.ts
+++ b/extension/shared/background.ts
@@ -28,8 +28,11 @@ import type {
   GetSessionInfoMessage,
   GetSessionInfoResponse,
   InputBarStatusMessage,
+  SnapshotTabStateMessage,
+  SnapshotTabStateResponse,
   TabActionMessage,
   TabActionResponse,
+  TabInfo,
   TypeTextMessage,
   TypeTextResponse,
 } from "@extension/shared/messages";
@@ -80,6 +83,17 @@ function withTabLock<T>(fn: () => Promise<T>): Promise<T> {
   );
   return next;
 }
+
+const toTabInfo = (tabs: chrome.tabs.Tab[]): TabInfo[] =>
+  tabs.flatMap((t) =>
+    t.id !== undefined && t.url
+      ? [{ tabId: t.id, title: t.title || "", url: t.url, active: t.active }]
+      : []
+  );
+
+// Tabs captured at send time so tab tools stay anchored to what the user saw
+// when they sent, not where they navigated while the agent was processing.
+let currentTurnTabSnapshot: TabInfo[] | null = null;
 
 const shouldDisableContextMenuForDomain = async (
   url: string,
@@ -536,6 +550,7 @@ export const registerMessageListener = (platform: PlatformService) => {
         | GetActiveTabBackgroundMessage
         | CaptureMesssage
         | InputBarStatusMessage
+        | SnapshotTabStateMessage
         | TabActionMessage
         | GetPageElementsMessage
         | ClickPageElementMessage
@@ -550,6 +565,7 @@ export const registerMessageListener = (platform: PlatformService) => {
           | AuthBackgroundResponseError
           | CaptureResponse
           | GetActiveTabBackgroundResponse
+          | SnapshotTabStateResponse
           | TabActionResponse
           | GetPageElementsResponse
           | ClickPageElementResponse
@@ -859,20 +875,20 @@ export const registerMessageListener = (platform: PlatformService) => {
           })();
           return true;
 
-        case "LIST_TABS":
+        case "SNAPSHOT_TAB_STATE":
           void (async () => {
             const tabs = await chrome.tabs.query({ currentWindow: true });
-            sendResponse({
-              success: true,
-              tabs: tabs
-                .filter((t) => t.id !== undefined && t.url)
-                .map((t) => ({
-                  tabId: t.id!,
-                  title: t.title || "",
-                  url: t.url || "",
-                  active: t.active,
-                })),
-            });
+            currentTurnTabSnapshot = toTabInfo(tabs);
+            sendResponse({ success: true });
+          })();
+          return true;
+
+        case "LIST_TABS":
+          void (async () => {
+            const tabs =
+              currentTurnTabSnapshot ??
+              toTabInfo(await chrome.tabs.query({ currentWindow: true }));
+            sendResponse({ success: true, tabs });
           })();
           return true;
 

--- a/extension/shared/messages.ts
+++ b/extension/shared/messages.ts
@@ -58,6 +58,14 @@ export type TabActionResponse = {
   tabs?: TabInfo[];
 };
 
+export type SnapshotTabStateMessage = {
+  type: "SNAPSHOT_TAB_STATE";
+};
+
+export type SnapshotTabStateResponse = {
+  success: boolean;
+};
+
 export type InputBarStatusMessage = {
   type: "INPUT_BAR_STATUS";
   available: boolean;

--- a/extension/ui/components/conversation/ExtensionInputBarProvider.tsx
+++ b/extension/ui/components/conversation/ExtensionInputBarProvider.tsx
@@ -11,7 +11,7 @@ import { useSearchParam } from "@extension/shared/platform";
 import { useExtensionQuickActions } from "@extension/ui/components/quick_actions/ExtensionQuickActionsProvider";
 import { useFileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
 import type { ReactNode } from "react";
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 
 interface ExtensionInputBarProviderProps {
   workspace: LightWorkspaceType;
@@ -70,10 +70,15 @@ export function ExtensionInputBarProvider({
     };
   }, [platform.messaging, fileUploaderService.uploadContentTab]);
 
+  const handleBeforeSubmit = useCallback(() => {
+    void platform.messaging?.sendMessage({ type: "SNAPSHOT_TAB_STATE" });
+  }, [platform.messaging]);
+
   return (
     <InputBarContextProvider
       captureActions={captureActions}
       fileUploaderService={fileUploaderService}
+      onBeforeSubmit={handleBeforeSubmit}
     >
       <AgentQueryParamHandler workspaceId={workspace.sId} />
       {children}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -122,6 +122,7 @@ export const InputBar = React.memo(function InputBar({
     getAndClearPendingInputText,
     fileUploaderService,
     isLoadingGoTemplate,
+    onBeforeSubmit,
   } = useContext(InputBarContext);
 
   // We use this specific hook because this component is involved in the new conversation page.
@@ -288,6 +289,8 @@ export const InputBar = React.memo(function InputBar({
     ) {
       return;
     }
+
+    onBeforeSubmit?.();
 
     const { mentions: rawMentions, markdown } = markdownAndMentions;
     const shouldInjectSelectedAgent =

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -61,6 +61,8 @@ export const InputBarContext = createContext<{
   setIsLoadingGoTemplate: (loading: boolean) => void;
   fileUploaderService: FileUploaderService;
   captureActions?: CaptureActions;
+  // Fired right before submit; the extension uses it to snapshot browser tab state.
+  onBeforeSubmit?: () => void;
 }>({
   shouldFocusInput: false,
   getAndClearSelectedAgent: () => null,
@@ -92,12 +94,14 @@ interface InputBarContextProviderProps {
   children: ReactNode;
   fileUploaderService: FileUploaderService;
   captureActions?: CaptureActions;
+  onBeforeSubmit?: () => void;
 }
 
 export function InputBarContextProvider({
   children,
   fileUploaderService,
   captureActions,
+  onBeforeSubmit,
 }: InputBarContextProviderProps) {
   const [shouldFocusInput, setShouldFocusInput] = useState<boolean>(false);
 
@@ -202,6 +206,7 @@ export function InputBarContextProvider({
       setIsLoadingGoTemplate,
       captureActions,
       fileUploaderService,
+      onBeforeSubmit,
     }),
     [
       shouldFocusInput,
@@ -216,6 +221,7 @@ export function InputBarContextProvider({
       isLoadingGoTemplate,
       captureActions,
       fileUploaderService,
+      onBeforeSubmit,
     ]
   );
 


### PR DESCRIPTION
## Description

`list_browser_tabs` read live tab state at tool-execution time. The agent can take several seconds to reach the tool, so if the user switched or navigated tabs in the meantime, the stale tab leaked into the result and the agent acted on the wrong one.

This snapshots the tab list when the user sends a message and serves `list_browser_tabs` from that snapshot (falling back to a live query if none exists yet).

- `GET_ACTIVE_TAB` stays live on purpose — its only no-`tabId` caller is the manual "attach current tab" button, an immediate user action that should reflect the current tab.
- The send-time trigger goes through an optional `onBeforeSubmit` callback on `InputBarContext`, so no `chrome.*` APIs leak into shared `front` code.

## Tests

Manual. No test harness exists for the extension background message handlers.

## Risk

Low. Worst case, `list_browser_tabs` shows a slightly stale list within a turn; falls back to a live query when no snapshot exists. `onBeforeSubmit` is a no-op outside the extension. Safe to rollback.

## Deploy Plan

Standard front + extension deploy, no ordering constraints.