### PR TITLE
Remove old code

### DIFF
--- a/front/components/assistant/conversation/ConversationBranchApprovalModal.tsx
+++ b/front/components/assistant/conversation/ConversationBranchApprovalModal.tsx
@@ -1,4 +1,4 @@
-import { AgentActionsPanelForMessage } from "@app/components/assistant/conversation/actions/AgentActionsPanel";
+import { AgentSingleActionPanel } from "@app/components/assistant/conversation/actions/AgentActionsPanel";
 import { MessageItem } from "@app/components/assistant/conversation/MessageItem";
 import {
   type AgentMessageWithStreaming,
@@ -13,7 +13,6 @@ import {
 import { useAppRouter } from "@app/lib/platform";
 import { getPodRoute } from "@app/lib/utils/router";
 import {
-  ArrowLeft,
   ScrollArea,
   Sheet,
   SheetContent,
@@ -61,8 +60,10 @@ export function ConversationBranchApprovalModal({
   const [selectedTab, setSelectedTab] = useState<"messages" | "details">(
     "messages"
   );
-  const [selectedMessage, setSelectedMessage] =
-    useState<AgentMessageWithStreaming | null>(null);
+  const [selectedMessageAndAction, setSelectedMessageAndAction] = useState<{
+    message: AgentMessageWithStreaming;
+    actionId: string;
+  } | null>(null);
 
   const router = useAppRouter();
 
@@ -132,13 +133,25 @@ export function ConversationBranchApprovalModal({
                       context={context}
                       nextData={branchMessagesToApprove.at(index + 1) ?? null}
                       prevData={branchMessagesToApprove.at(index - 1) ?? null}
-                      onAgentMessageCompletionStatusClick={(messageId) => {
-                        setSelectedMessage(
-                          branchMessagesToApprove
+                      onAgentMessageCompletionStatusClick={(
+                        messageId,
+                        actionId
+                      ) => {
+                        if (messageId && actionId) {
+                          const message = branchMessagesToApprove
                             .filter(isAgentMessageWithStreaming)
-                            .find((m) => m.sId === messageId) ?? null
-                        );
-                        setSelectedTab("details");
+                            .find((m) => m.sId === messageId);
+
+                          setSelectedMessageAndAction(
+                            message
+                              ? {
+                                  message,
+                                  actionId,
+                                }
+                              : null
+                          );
+                          setSelectedTab("details");
+                        }
                       }}
                     />
                   </div>
@@ -147,21 +160,22 @@ export function ConversationBranchApprovalModal({
             </TabsContent>
             <TabsContent value="details" className="h-full">
               <div className="h-full">
-                {context.conversation && selectedMessage ? (
-                  <AgentActionsPanelForMessage
+                {context.conversation && selectedMessageAndAction ? (
+                  <AgentSingleActionPanel
+                    key={selectedMessageAndAction.actionId}
                     conversation={context.conversation}
                     owner={context.owner}
-                    messageId={selectedMessage.sId}
-                    virtuosoMsg={selectedMessage}
-                    closeIcon={ArrowLeft}
+                    messageId={selectedMessageAndAction.message.sId}
+                    actionId={selectedMessageAndAction.actionId}
+                    virtuosoMsg={selectedMessageAndAction.message}
                     onClose={() => {
-                      setSelectedMessage(null);
+                      setSelectedMessageAndAction(null);
                       setSelectedTab("messages");
                     }}
                   />
                 ) : (
                   <div className="flex h-full items-center justify-center px-4 text-sm text-muted-foreground">
-                    Select an agent message to view its details.
+                    Select an agent action to view its details.
                   </div>
                 )}
               </div>

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -82,7 +82,10 @@ interface MessageItemProps {
   context: VirtuosoMessageListContext;
   nextData: VirtuosoMessage | null;
   prevData: VirtuosoMessage | null;
-  onAgentMessageCompletionStatusClick?: (messageId: string) => void;
+  onAgentMessageCompletionStatusClick?: (
+    messageId: string,
+    actionId?: string
+  ) => void;
 }
 
 export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -1,389 +1,20 @@
 import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
 import { AgentActionsPanelHeader } from "@app/components/assistant/conversation/actions/AgentActionsPanelHeader";
-import { AgentActionSummary } from "@app/components/assistant/conversation/actions/AgentActionsPanelSummary";
-import { PanelAgentStep } from "@app/components/assistant/conversation/actions/PanelAgentStep";
 import {
   parseDataAsMessageIdAndActionId,
   useConversationSidePanelContext,
 } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import type {
-  ActionProgressState,
-  AgentMessageWithStreaming,
-} from "@app/components/assistant/conversation/types";
-import { getIcon } from "@app/components/resources/resources_icons";
-import {
-  useAgentMessageSkills,
-  useAgentMessageTools,
-  useConversationMessage,
-  useConversationMessageAction,
-} from "@app/hooks/conversations";
-import {
-  AgentMessageContentParser,
-  getDelimitersConfiguration,
-} from "@app/lib/llms/agent_message_content_parser";
-import { getSkillIcon } from "@app/lib/skill";
-import {
-  isAgentFunctionCallContent,
-  isAgentReasoningContent,
-  isAgentTextContent,
-} from "@app/types/assistant/agent_message_content";
-import type {
-  AgentMessageStatus,
-  AgentMessageType,
-  ConversationWithoutContentType,
-  ParsedContentItem,
-} from "@app/types/assistant/conversation";
+import type { AgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
+import { useConversationMessageAction } from "@app/hooks/conversations";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Chip, Spinner, XClose } from "@dust-tt/sparkle";
+import { Spinner, XClose } from "@dust-tt/sparkle";
 
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
 
 interface AgentActionsPanelProps {
   conversation: ConversationWithoutContentType;
   owner: LightWorkspaceType;
-}
-
-interface AgentActionsPanelContentProps {
-  conversation: ConversationWithoutContentType | null;
-  owner: LightWorkspaceType;
-  fullAgentMessage: AgentMessageType;
-  virtuosoMsg?: AgentMessageWithStreaming | null;
-  closeIcon: React.ComponentType<{}>;
-  closePanel: () => void;
-  mutateMessage: () => void;
-}
-
-function AgentActionsPanelContent({
-  conversation,
-  owner,
-  fullAgentMessage,
-  virtuosoMsg,
-  closeIcon,
-  closePanel,
-  mutateMessage,
-}: AgentActionsPanelContentProps) {
-  const messageId = fullAgentMessage.sId;
-  const [currentStreamingStep, setCurrentStreamingStep] = useState(1);
-  const [successActionIds, setSuccessActionIds] = useState<string[]>([]);
-  const [lastMessageStreamStatus, setLastMessageStreamStatus] =
-    useState<AgentMessageStatus | null>(null);
-
-  const { skills, mutateSkills } = useAgentMessageSkills({
-    conversation,
-    owner,
-    messageId,
-  });
-
-  const { tools, mutateTools } = useAgentMessageTools({
-    owner,
-    conversation,
-    agentConfigurationId: fullAgentMessage.configuration.sId,
-  });
-
-  // The message from Virtuoso doesn't contain the contents array and only actions if it's has been streamed.
-  // So if it's not in a "created" status, we focus on the fullAgentMessage from the backend call.
-  const rawMessageStreamState =
-    virtuosoMsg && virtuosoMsg.sId === messageId ? virtuosoMsg : null;
-
-  // Make it null to ignore it in the rendering and consider only the fullAgentMessage from the backend call.
-  const messageStreamState =
-    rawMessageStreamState?.status === "created" ? rawMessageStreamState : null;
-
-  useEffect(() => {
-    if (!rawMessageStreamState) {
-      return;
-    }
-
-    const currentMaxStep = Math.max(
-      currentStreamingStep,
-      Math.max(...rawMessageStreamState.actions.map((a) => a.step)) + 1
-    );
-
-    // Check if we moved to a new step.
-    if (currentMaxStep > currentStreamingStep) {
-      setCurrentStreamingStep(currentMaxStep);
-    }
-
-    // Check if any new actions have been completed.
-    const prevCompletedActionsCount = successActionIds.length;
-    const newCompletedActionsCount = rawMessageStreamState.actions.filter(
-      (a) => a.status === "succeeded"
-    ).length;
-    if (newCompletedActionsCount > prevCompletedActionsCount) {
-      setSuccessActionIds(
-        rawMessageStreamState.actions
-          .filter((a) => a.status === "succeeded")
-          .map((a) => a.sId)
-      );
-      mutateMessage();
-      return;
-    }
-
-    if (lastMessageStreamStatus === rawMessageStreamState.status) {
-      return;
-    }
-
-    // The message status changed, upate everything.
-    setLastMessageStreamStatus(rawMessageStreamState?.status ?? null);
-    void mutateMessage();
-    void mutateSkills();
-    void mutateTools();
-  }, [
-    rawMessageStreamState,
-    currentStreamingStep,
-    successActionIds,
-    lastMessageStreamStatus,
-    mutateMessage,
-    mutateSkills,
-    mutateTools,
-  ]);
-
-  const [steps, setSteps] = useState<Record<number, ParsedContentItem[]>>({});
-
-  useEffect(() => {
-    async function generateParsedContents() {
-      const actions = fullAgentMessage.actions;
-      const agentConfiguration = fullAgentMessage.configuration;
-      const messageId = fullAgentMessage.sId;
-      const contents = fullAgentMessage.contents;
-      const parsedContents: Record<number, ParsedContentItem[]> = {};
-      const actionsByCallId = new Map(
-        actions.map((a) => [a.functionCallId, a])
-      );
-
-      for (const c of contents) {
-        const step = c.step + 1; // Convert to 1-indexed for display
-        if (!parsedContents[step]) {
-          parsedContents[step] = [];
-        }
-
-        if (isAgentReasoningContent(c.content)) {
-          const reasoning = c.content.value.reasoning;
-          if (reasoning && reasoning.trim()) {
-            parsedContents[step].push({
-              kind: "reasoning",
-              content: reasoning,
-            });
-          }
-          continue;
-        }
-
-        if (isAgentTextContent(c.content)) {
-          const contentParser = new AgentMessageContentParser(
-            agentConfiguration,
-            messageId,
-            getDelimitersConfiguration({
-              model: agentConfiguration.model,
-            })
-          );
-          const parsedContent = await contentParser.parseContents([
-            c.content.value,
-          ]);
-
-          if (
-            parsedContent.chainOfThought &&
-            parsedContent.chainOfThought.trim()
-          ) {
-            parsedContents[step].push({
-              kind: "reasoning",
-              content: parsedContent.chainOfThought,
-            });
-          }
-          continue;
-        }
-
-        if (isAgentFunctionCallContent(c.content)) {
-          const functionCallId = c.content.value.id;
-          const matchingAction = actionsByCallId.get(functionCallId);
-
-          if (matchingAction) {
-            parsedContents[step].push({
-              kind: "action",
-              action: matchingAction,
-            });
-          }
-        }
-      }
-      setSteps(parsedContents);
-    }
-    generateParsedContents().catch(console.error);
-  }, [
-    fullAgentMessage.actions,
-    fullAgentMessage.configuration,
-    fullAgentMessage.sId,
-    fullAgentMessage.contents,
-  ]);
-
-  const nbSteps = Object.entries(steps || {}).filter(
-    ([, entries]) => Array.isArray(entries) && entries.length > 0
-  ).length;
-
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  // Track whether the user is currently scrolled to the bottom of the panel
-  const shouldAutoScroll = useRef<boolean>(true);
-
-  /**
-   * Preserve chain of thought content to prevent flickering during state transitions.
-   * We store the step of the cot item to ensure we don't start displaying the next step
-   * when a subagent is still running.
-   */
-  const lastChainOfThoughtRef = useRef<{ step: number; content: string }>({
-    step: 0,
-    content: "",
-  });
-
-  useEffect(() => {
-    if (messageStreamState?.chainOfThought) {
-      lastChainOfThoughtRef.current = {
-        step: currentStreamingStep,
-        content: messageStreamState.chainOfThought,
-      };
-    }
-  }, [messageStreamState?.chainOfThought, currentStreamingStep]);
-
-  useEffect(() => {
-    if (!messageStreamState) {
-      return;
-    }
-
-    const el = scrollContainerRef.current;
-    if (!el) {
-      return;
-    }
-
-    if (shouldAutoScroll.current) {
-      el.scrollTo({
-        top: el.scrollHeight,
-        behavior: "smooth",
-      });
-    }
-  }, [messageStreamState]);
-
-  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
-    const el = e.currentTarget;
-    const scrollUp =
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      Number(el.scrollTop) < Number(el.dataset.lastScrollTop || 0);
-
-    el.dataset.lastScrollTop = el.scrollTop.toString();
-    /**
-     * 1000px threshold is used to determine if the user is at the bottom of the panel.
-     * If the user is within 1000px of the bottom, we consider them to be at the bottom.
-     * This is to prevent losing auto-scroll when we receive a visually BIG chunk.
-     */
-    const threshold = 1000;
-    shouldAutoScroll.current =
-      !scrollUp &&
-      el.scrollHeight - el.clientHeight <= el.scrollTop + threshold;
-  };
-
-  const streamActionProgress: ActionProgressState =
-    messageStreamState?.streaming.actionProgress ?? new Map();
-  const pendingToolCalls = messageStreamState?.streaming.pendingToolCalls ?? [];
-  return (
-    <div className="flex h-full flex-col bg-background">
-      <AgentActionsPanelHeader
-        closeIcon={closeIcon}
-        title="Breakdown of the tools used"
-        onClose={closePanel}
-      />
-      <div
-        ref={scrollContainerRef}
-        className="flex-1 overflow-y-auto p-4 pb-12"
-        onScroll={handleScroll}
-      >
-        <div className="flex h-full flex-col gap-4">
-          {/* Render all parsed steps in order */}
-          {Object.entries(steps || {})
-            .sort(([a], [b]) => parseInt(a, 10) - parseInt(b, 10))
-            .map(([step, entries]) => {
-              if (!entries || !Array.isArray(entries) || entries.length === 0) {
-                return null;
-              }
-
-              return (
-                <PanelAgentStep
-                  key={step}
-                  stepNumber={parseInt(step, 10)}
-                  entries={entries}
-                  streamActionProgress={streamActionProgress}
-                  owner={owner}
-                  messageStatus={fullAgentMessage.status}
-                />
-              );
-            })}
-          {/* Show current streaming step with live updates. */}
-          {messageStreamState &&
-            messageStreamState.streaming.agentState !== "done" &&
-            !steps[currentStreamingStep] && (
-              <PanelAgentStep
-                stepNumber={currentStreamingStep}
-                reasoningContent={
-                  lastChainOfThoughtRef.current.step === currentStreamingStep
-                    ? lastChainOfThoughtRef.current.content
-                    : "Thinking..."
-                }
-                isStreaming={
-                  messageStreamState.streaming.agentState === "thinking"
-                }
-                pendingToolCalls={pendingToolCalls}
-                streamingActions={
-                  messageStreamState.streaming.agentState === "acting"
-                    ? messageStreamState.actions.filter((action) => {
-                        // Only show actions not yet in any completed step.
-                        return !Object.values(steps || {}).some(
-                          (entries: ParsedContentItem[]) =>
-                            Array.isArray(entries) &&
-                            entries.some(
-                              (entry) =>
-                                entry.kind === "action" &&
-                                entry.action?.id === action.id
-                            )
-                        );
-                      })
-                    : []
-                }
-                streamActionProgress={streamActionProgress}
-                owner={owner}
-                messageStatus="created"
-              />
-            )}
-          {!messageStreamState && (
-            <AgentActionSummary
-              agentMessageToRender={fullAgentMessage}
-              nbSteps={nbSteps}
-            />
-          )}
-          <div>&nbsp;</div>
-        </div>
-      </div>
-      {(skills.length > 0 || tools.length > 0) && (
-        <div className="flex flex-col gap-4 border-t border-separator bg-background p-4">
-          <span className="text-semibold text-sm">Enabled capabilities</span>
-          <div className="flex flex-wrap items-center gap-1">
-            {skills.map((skill) => (
-              <Chip
-                key={skill.sId}
-                size="xs"
-                color="highlight"
-                label={skill.name}
-                icon={getSkillIcon(skill.icon)}
-              />
-            ))}
-            {tools.map((tool) => (
-              <Chip
-                key={tool.sId}
-                size="xs"
-                label={tool.name ?? tool.server.name}
-                icon={getIcon(tool.server.icon)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
 }
 
 interface AgentSingleActionPanelProps extends AgentActionsPanelProps {
@@ -394,7 +25,7 @@ interface AgentSingleActionPanelProps extends AgentActionsPanelProps {
   onClose: () => void;
 }
 
-function AgentSingleActionPanel({
+export function AgentSingleActionPanel({
   conversation,
   owner,
   messageId,
@@ -478,85 +109,6 @@ function AgentSingleActionPanel({
   );
 }
 
-// TODO(2026-04-07: inline activity): can be deprecated in favor of AgentSingleActionPanel with inline activity.
-export function AgentActionsPanelForMessage({
-  conversation,
-  owner,
-  messageId,
-  virtuosoMsg,
-  closeIcon = XClose,
-  onClose,
-}: AgentActionsPanelProps & {
-  messageId: string;
-  virtuosoMsg: AgentMessageWithStreaming | null;
-  closeIcon?: React.ComponentType<{}>;
-  onClose: () => void;
-}) {
-  const {
-    message: fullAgentMessage,
-    isMessageLoading,
-    mutateMessage,
-  } = useConversationMessage({
-    conversationId: conversation.sId,
-    workspaceId: owner.sId,
-    messageId,
-  });
-
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
-  useEffect(() => {
-    if (scrollContainerRef.current) {
-      scrollContainerRef.current.scrollTo({
-        top: scrollContainerRef.current.scrollHeight,
-        behavior: "smooth",
-      });
-    }
-  }, [fullAgentMessage]);
-
-  if (isMessageLoading) {
-    return (
-      <AgentActionsPanelHeader
-        title="Breakdown of the tools used"
-        closeIcon={closeIcon}
-        onClose={onClose}
-      >
-        <div className="flex items-center justify-center">
-          <Spinner variant="color" />
-        </div>
-      </AgentActionsPanelHeader>
-    );
-  }
-
-  if (!fullAgentMessage || fullAgentMessage.type !== "agent_message") {
-    return (
-      <AgentActionsPanelHeader
-        title="Breakdown of the tools used"
-        closeIcon={closeIcon}
-        onClose={onClose}
-      >
-        <div className="flex items-center justify-center">
-          <span className="text-muted-foreground">Nothing to display.</span>
-        </div>
-      </AgentActionsPanelHeader>
-    );
-  }
-
-  // Use key to force remount when the message changes for proper state reset.
-  return (
-    <AgentActionsPanelContent
-      key={fullAgentMessage.sId}
-      conversation={conversation}
-      owner={owner}
-      fullAgentMessage={fullAgentMessage}
-      virtuosoMsg={virtuosoMsg}
-      closeIcon={closeIcon}
-      closePanel={onClose}
-      mutateMessage={mutateMessage}
-    />
-  );
-}
-
 export function AgentActionsPanel({
   conversation,
   owner,
@@ -569,29 +121,17 @@ export function AgentActionsPanel({
 
   const { messageId, actionId } = parseDataAsMessageIdAndActionId(rawData);
 
-  if (!messageId) {
+  if (!messageId || !actionId) {
     return null;
   }
 
-  if (actionId) {
-    return (
-      <AgentSingleActionPanel
-        key={actionId}
-        conversation={conversation}
-        owner={owner}
-        messageId={messageId}
-        actionId={actionId}
-        virtuosoMsg={virtuosoMsg}
-        onClose={onPanelClosed}
-      />
-    );
-  }
-
   return (
-    <AgentActionsPanelForMessage
+    <AgentSingleActionPanel
+      key={actionId}
       conversation={conversation}
       owner={owner}
       messageId={messageId}
+      actionId={actionId}
       virtuosoMsg={virtuosoMsg}
       onClose={onPanelClosed}
     />

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -24,7 +24,7 @@ interface InlineActivityStepsProps {
   lastAgentStateClassification: AgentStateClassification;
   completedSteps: InlineActivityStep[];
   pendingToolCalls: PendingToolCall[];
-  onOpenDetails?: (messageId: string) => void;
+  onOpenDetails?: (messageId: string, actionId?: string) => void;
   owner: WorkspaceType;
   isLastMessage: boolean;
 }
@@ -81,7 +81,7 @@ export function InlineActivitySteps({
 
   const openBreakdownPanel = (actionId?: string) => {
     if (onOpenDetails) {
-      onOpenDetails(agentMessage.sId);
+      onOpenDetails(agentMessage.sId, actionId);
       return;
     }
     togglePanel({


### PR DESCRIPTION
## Description

Removes `AgentActionsPanelForMessage` and `AgentActionsPanelContent` from `AgentActionsPanel.tsx` (~370 lines deleted), completing the inline activity migration flagged in the `TODO(2026-04-07)` comment. `AgentSingleActionPanel` is now the sole rendering path and is exported directly. `AgentActionsPanel` now requires both `messageId` and `actionId` — the message-level fallback is gone.

Callers updated accordingly:
- `ConversationBranchApprovalModal` — state tracks `{message, actionId}` instead of just `message`; uses `AgentSingleActionPanel`
- `InlineActivitySteps` — `onOpenDetails` forwards `actionId` alongside `messageId`
- `MessageItem` — `onAgentMessageCompletionStatusClick` callback gains optional `actionId`

## Tests

Tested locally — branch approval modal details tab and conversation side panel both render correctly with the new action-scoped panel.

## Risk

Low. Pure dead-code removal; the `AgentActionsPanelForMessage` path was deprecated and all callers have been migrated. No data model or API changes.

## Deploy Plan

Deploy `front`.
