### PR TITLE
Add: auto model and update agent builder picker

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -1,6 +1,6 @@
 import { compactConversation } from "@app/lib/api/assistant/conversation/compaction";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
+import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
 import { isSupportedModel } from "@app/types/assistant/assistant";
 import type { CompactionMessageType } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
@@ -112,7 +112,7 @@ app.post(
       });
     }
 
-    if (!isProviderWhitelisted(auth, model.providerId)) {
+    if (!isProviderWhitelistedForAuth(auth, model.providerId)) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -649,7 +649,7 @@ function AgentBuilderForm({
     );
     sendNotification({
       title: `Agent ${agentConfiguration ? "edition" : "creation"} failed.`,
-      description: "There was an error validating the form.",
+      description: errorMessage,
       type: "error",
     });
   };

--- a/front/components/agent_builder/instructions/AdvancedSettings.tsx
+++ b/front/components/agent_builder/instructions/AdvancedSettings.tsx
@@ -6,6 +6,7 @@ import { SuspensedCodeEditor } from "@app/components/SuspensedCodeEditor";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useModels } from "@app/lib/swr/models";
 import { isSupportingResponseFormat } from "@app/types/assistant/assistant";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import { validateResponseFormat } from "@app/types/assistant/models/utils";
 import {
   Button,
@@ -22,8 +23,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   File04,
+  SliderToggle,
 } from "@dust-tt/sparkle";
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import { useController } from "react-hook-form";
 
 function getResponseFormatError(value: string): string | null {
@@ -57,6 +59,14 @@ export function AdvancedSettings() {
   const { isDark } = useTheme();
   const { owner } = useAgentBuilderContext();
   const { models } = useModels({ owner });
+
+  const [autoModel, otherModels] = useMemo(() => {
+    return [
+      models.find((model) => model.modelId === AUTO_MODEL_ID),
+      models.filter((model) => model.modelId !== AUTO_MODEL_ID),
+    ];
+  }, [models]);
+
   const { field: modelSettingsField } = useController<
     AgentBuilderFormData,
     "generationSettings.modelSettings"
@@ -75,6 +85,33 @@ export function AdvancedSettings() {
     string | null
   >(null);
 
+  const [modelSettingsBeforeAuto, setModelSettingsBeforeAuto] = React.useState<
+    AgentBuilderFormData["generationSettings"]["modelSettings"] | null
+  >(null);
+
+  const isAutoModelSelected =
+    modelSettingsField.value?.modelId === AUTO_MODEL_ID || false;
+
+  const handleAutoModelSelection = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (!isAutoModelSelected) {
+        setModelSettingsBeforeAuto(modelSettingsField.value);
+        modelSettingsField.onChange({ ...autoModel });
+      } else {
+        modelSettingsField.onChange(modelSettingsBeforeAuto ?? null);
+      }
+    },
+    [
+      modelSettingsField,
+      modelSettingsBeforeAuto,
+      autoModel,
+      isAutoModelSelected,
+    ]
+  );
+
   if (!models) {
     return null;
   }
@@ -82,9 +119,9 @@ export function AdvancedSettings() {
   const currentValue = tempResponseFormat ?? responseFormatField.value ?? "";
   const validationError = getResponseFormatError(currentValue);
 
-  const supportsResponseFormat = isSupportingResponseFormat(
-    modelSettingsField.value.modelId
-  );
+  const supportsResponseFormat =
+    modelSettingsField.value &&
+    isSupportingResponseFormat(modelSettingsField.value.modelId);
   return (
     <>
       <DropdownMenu>
@@ -92,9 +129,26 @@ export function AdvancedSettings() {
           <Button label="Advanced" variant="outline" size="sm" isSelect />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
-          <ModelSelectionSubmenu models={models} />
+          {autoModel && (
+            <DropdownMenuItem
+              label="Auto"
+              description="Select the best model for the task."
+              onClick={handleAutoModelSelection}
+              endComponent={
+                <SliderToggle
+                  selected={isAutoModelSelected}
+                  onClick={handleAutoModelSelection}
+                />
+              }
+            ></DropdownMenuItem>
+          )}
 
-          <ReasoningEffortSubmenu models={models} />
+          {!isAutoModelSelected && (
+            <>
+              <ModelSelectionSubmenu models={otherModels} />
+              <ReasoningEffortSubmenu models={otherModels} />
+            </>
+          )}
 
           {supportsResponseFormat && (
             <DropdownMenuItem

--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -10,7 +10,6 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import { getProviderDisplayName } from "@app/types/assistant/models/providers";
-import type { RegionType } from "@app/types/region";
 import {
   DropdownMenuLabel,
   DropdownMenuPortal,
@@ -64,11 +63,6 @@ function ModelRadioItem({
   );
 }
 
-const SHOULD_DISPLAY_FLAG: Record<RegionType, boolean> = {
-  "europe-west1": true,
-  "us-central1": false,
-};
-
 export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
   const { isDark } = useTheme();
   const { field: modelField } = useController<
@@ -89,22 +83,16 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
   const { subscription } = useAuth();
 
   const showRegionalFlag =
-    hasFeature("use_vertex_for_supported_models") &&
-    SHOULD_DISPLAY_FLAG[regionInfo.name] &&
-    !subscription.plan.isByok;
-
-  const flag = showRegionalFlag ? (
-    <RegionalFlag region={regionInfo.name} />
-  ) : null;
+    hasFeature("use_vertex_for_supported_models") && !subscription.plan.isByok;
 
   const { bestGeneralModels, providerGroups } = getModelsCategorization(models);
 
-  const currentModelKey = modelField.value.modelId;
+  const currentModelKey = modelField.value?.modelId;
 
   const selectedModel = models.find(
     (model) =>
-      model.modelId === modelField.value.modelId &&
-      model.providerId === modelField.value.providerId
+      model.modelId === modelField.value?.modelId &&
+      model.providerId === modelField.value?.providerId
   );
 
   const isSelectedModelNotInBest =
@@ -128,8 +116,8 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
   };
 
   const isModelSelected = (modelConfig: EnabledModelConfigurationType) =>
-    modelConfig.modelId === modelField.value.modelId &&
-    modelConfig.providerId === modelField.value.providerId;
+    modelConfig.modelId === modelField.value?.modelId &&
+    modelConfig.providerId === modelField.value?.providerId;
 
   return (
     <DropdownMenuSub>
@@ -147,9 +135,10 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                   isSelected={true}
                   onModelSelection={handleModelSelection}
                   regionalComponent={
-                    selectedModel.regionalAvailability[regionInfo.name]
-                      ? flag
-                      : null
+                    selectedModel.regionalAvailability[regionInfo.name] &&
+                    showRegionalFlag ? (
+                      <RegionalFlag region={regionInfo.name} />
+                    ) : null
                   }
                 />
               </DropdownMenuRadioGroup>
@@ -166,9 +155,10 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                 isSelected={isModelSelected(modelConfig)}
                 onModelSelection={handleModelSelection}
                 regionalComponent={
-                  modelConfig.regionalAvailability[regionInfo.name]
-                    ? flag
-                    : null
+                  modelConfig.regionalAvailability[regionInfo.name] &&
+                  showRegionalFlag ? (
+                    <RegionalFlag region={regionInfo.name} />
+                  ) : null
                 }
               />
             ))}
@@ -199,9 +189,9 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                               regionalComponent={
                                 modelConfig.regionalAvailability[
                                   regionInfo.name
-                                ]
-                                  ? flag
-                                  : null
+                                ] && showRegionalFlag ? (
+                                  <RegionalFlag region={regionInfo.name} />
+                                ) : null
                               }
                             />
                           ))}
@@ -226,9 +216,9 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                               regionalComponent={
                                 modelConfig.regionalAvailability[
                                   regionInfo.name
-                                ]
-                                  ? flag
-                                  : null
+                                ] && showRegionalFlag ? (
+                                  <RegionalFlag region={regionInfo.name} />
+                                ) : null
                               }
                             />
                           ))}

--- a/front/components/agent_builder/instructions/ReasoningEffortSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ReasoningEffortSubmenu.tsx
@@ -51,10 +51,10 @@ export function ReasoningEffortSubmenu({
     () =>
       models.find(
         (m) =>
-          m.modelId === modelSettings.modelId &&
-          m.providerId === modelSettings.providerId
+          m.modelId === modelSettings?.modelId &&
+          m.providerId === modelSettings?.providerId
       ),
-    [models, modelSettings.modelId, modelSettings.providerId]
+    [models, modelSettings?.modelId, modelSettings?.providerId]
   );
 
   useEffect(() => {
@@ -64,7 +64,7 @@ export function ReasoningEffortSubmenu({
         modelConfig.supportedReasoningEfforts
       );
 
-      if (!availableEfforts.includes(currentEffort)) {
+      if (!currentEffort || !availableEfforts.includes(currentEffort)) {
         field.onChange(modelConfig.defaultReasoningEffort);
       }
     }
@@ -92,7 +92,7 @@ export function ReasoningEffortSubmenu({
       <DropdownMenuPortal>
         <DropdownMenuSubContent className="w-80">
           <DropdownMenuLabel label="Select reasoning effort" />
-          <DropdownMenuRadioGroup value={field.value}>
+          <DropdownMenuRadioGroup value={field.value ?? undefined}>
             {availableEfforts.map((effort) => (
               <DropdownMenuRadioItem
                 key={effort}

--- a/front/components/agent_builder/sidekick/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/sidekick/tools/getAgentConfig.ts
@@ -67,8 +67,8 @@ The response includes:
         instructionsHtml,
         scope: formData.agentSettings.scope,
         model: {
-          modelId: formData.generationSettings.modelSettings.modelId,
-          providerId: formData.generationSettings.modelSettings.providerId,
+          modelId: formData.generationSettings.modelSettings?.modelId,
+          providerId: formData.generationSettings.modelSettings?.providerId,
           reasoningEffort: formData.generationSettings.reasoningEffort,
         },
         tools: formData.actions.map((action) => ({

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -392,6 +392,10 @@ export async function submitAgentBuilderForm({
   const pictureUrlToUse =
     formData.agentSettings.pictureUrl ?? getRandomDefaultAvatar();
 
+  if (!formData.generationSettings.modelSettings) {
+    return new Err(new Error("Model settings are required"));
+  }
+
   // Process actions asynchronously to handle folder-to-table expansion
   const mcpActions = formData.actions;
 
@@ -466,7 +470,8 @@ export async function submitAgentBuilderForm({
         modelId: formData.generationSettings.modelSettings.modelId,
         providerId: formData.generationSettings.modelSettings.providerId,
         temperature: formData.generationSettings.temperature,
-        reasoningEffort: formData.generationSettings.reasoningEffort,
+        reasoningEffort:
+          formData.generationSettings.reasoningEffort ?? undefined,
         responseFormat: formData.generationSettings.responseFormat,
       },
       skills: formData.skills.map((skill) => ({

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -117,10 +117,10 @@ export function transformTemplateToFormData(
       modelSettings: {
         providerId:
           template.presetProviderId ??
-          defaultFormData.generationSettings.modelSettings.providerId,
+          defaultFormData.generationSettings.modelSettings?.providerId,
         modelId:
           template.presetModelId ??
-          defaultFormData.generationSettings.modelSettings.modelId,
+          defaultFormData.generationSettings.modelSettings?.modelId,
       },
       temperature: template.presetTemperature
         ? AGENT_CREATIVITY_LEVEL_TEMPERATURES[template.presetTemperature]

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -7,6 +7,7 @@ import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { isModelAvailable } from "@app/lib/assistant";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
@@ -40,6 +41,7 @@ export function ModelProvidersPageContent({
   // Filter models based on feature flags and build modelProviders dynamically
   const filteredModels = uniqBy(USED_MODEL_CONFIGS, (m) => m.modelId).filter(
     (model) =>
+      model.modelId !== AUTO_MODEL_ID &&
       !model.isLegacy &&
       isModelAvailable(model, {
         featureFlags,

--- a/front/components/providers/model_configs.ts
+++ b/front/components/providers/model_configs.ts
@@ -6,6 +6,7 @@ import {
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import {
   FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG,
   FIREWORKS_GLM_5P2_MODEL_CONFIG,
@@ -55,4 +56,5 @@ export const USED_MODEL_CONFIGS: readonly ModelConfig[] = [
   FIREWORKS_MINIMAX_M2P5_MODEL_CONFIG,
   FIREWORKS_GLM_5P2_MODEL_CONFIG,
   GROK_4_MODEL_CONFIG,
+  AUTO_MODEL_CONFIG,
 ] as const;

--- a/front/components/providers/types.ts
+++ b/front/components/providers/types.ts
@@ -48,6 +48,9 @@ const MODEL_PROVIDER_LOGOS: ModelProviderLogos = {
   noop: {
     light: DustLogo,
   },
+  auto: {
+    light: DustLogo,
+  },
 };
 
 export const getModelProviderLogo = (

--- a/front/components/shared/tools_picker/types.ts
+++ b/front/components/shared/tools_picker/types.ts
@@ -21,9 +21,9 @@ const supportedModelSchema = z.object({
 });
 
 export const generationSettingsSchema = z.object({
-  modelSettings: supportedModelSchema,
+  modelSettings: supportedModelSchema.nullable(),
   temperature: z.number().min(0).max(1),
-  reasoningEffort: reasoningEffortSchema,
+  reasoningEffort: reasoningEffortSchema.nullable(),
   responseFormat: z.string().optional(),
 });
 

--- a/front/lib/advanced_models/enabled_models.test.ts
+++ b/front/lib/advanced_models/enabled_models.test.ts
@@ -14,6 +14,7 @@ import {
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import { describe, expect, it } from "vitest";
@@ -120,6 +121,16 @@ describe("withModelSelectability", () => {
 });
 
 describe("getDefaultModelFromEnabledModels", () => {
+  it("prefers auto when it is selectable", () => {
+    const defaultModel = getDefaultModelFromEnabledModels([
+      { ...AUTO_MODEL_CONFIG, isSelectable: true },
+      { ...CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG, isSelectable: true },
+    ]);
+
+    expect(defaultModel.modelId).toBe(AUTO_MODEL_CONFIG.modelId);
+    expect(defaultModel.isSelectable).toBe(true);
+  });
+
   it("picks the first selectable model in the preferred order", () => {
     const defaultModel = getDefaultModelFromEnabledModels([
       { ...GPT_5_5_MODEL_CONFIG, isSelectable: true },

--- a/front/lib/advanced_models/enabled_models.ts
+++ b/front/lib/advanced_models/enabled_models.ts
@@ -1,11 +1,12 @@
 import { advancedModelKey } from "@app/lib/advanced_models/resolve_allowed";
-import { pickPreferredLargeModel } from "@app/lib/api/assistant/models";
+import { pickPreferredLargeModel } from "@app/lib/api/assistant/model_preferences";
 import { getAvailableModelsForWorkspace } from "@app/lib/api/assistant/workspace_capabilities";
 import { isAdvancedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { AdvancedModelResource } from "@app/lib/resources/advanced_model_resource";
 import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 
 export async function withModelSelectability(
@@ -49,9 +50,23 @@ export function getDefaultModelFromEnabledModels(
   models: EnabledModelConfigurationType[]
 ): EnabledModelConfigurationType {
   const selectableModels = models.filter((m) => m.isSelectable);
+  const autoModel = selectableModels.find((m) => m.modelId === AUTO_MODEL_ID);
+  if (autoModel) {
+    return autoModel;
+  }
+
   return {
     ...pickPreferredLargeModel(selectableModels),
     isSelectable: true,
+  };
+}
+
+export async function getAutoModelForAuth(
+  auth: Authenticator
+): Promise<EnabledModelConfigurationType | null> {
+  const availableModels = await getEnabledModelsForAuth(auth);
+  return {
+    ...pickPreferredLargeModel(availableModels.filter((m) => m.isSelectable)),
   };
 }
 

--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -50,8 +50,8 @@ export class AgentYAMLConverter {
         },
         instructions: formData.instructions,
         generation_settings: {
-          model_id: formData.generationSettings.modelSettings.modelId,
-          provider_id: formData.generationSettings.modelSettings.providerId,
+          model_id: formData.generationSettings.modelSettings?.modelId,
+          provider_id: formData.generationSettings.modelSettings?.providerId,
           temperature: formData.generationSettings.temperature,
           reasoning_effort: formData.generationSettings.reasoningEffort,
           response_format: formData.generationSettings.responseFormat,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -27,7 +27,7 @@ import {
   batchRenderMessages,
   batchRenderUserMessagesWithoutMentions,
 } from "@app/lib/api/assistant/messages";
-import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
+import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
 import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import {
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR,
@@ -779,7 +779,7 @@ export async function postUserMessage(
       });
     }
 
-    const isProviderEnabled = isProviderWhitelisted(
+    const isProviderEnabled = isProviderWhitelistedForAuth(
       auth,
       agentConfig.model.providerId
     );
@@ -1274,7 +1274,7 @@ export async function editUserMessage(
       });
     }
 
-    const isProviderEnabled = isProviderWhitelisted(
+    const isProviderEnabled = isProviderWhitelistedForAuth(
       auth,
       agentConfig.model.providerId
     );

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -4,10 +4,8 @@ import {
   updateConversationRequirements,
 } from "@app/lib/api/assistant/conversation/permissions";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
-import {
-  resolvedModelFromAgentMessageRow,
-  resolveModel,
-} from "@app/lib/api/assistant/models";
+import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
+import { resolveModel } from "@app/lib/api/assistant/resolve_model";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import {
   AgentMessageModel,
@@ -468,7 +466,7 @@ export const createAgentMessages = async (
               { transaction }
             );
 
-            const { resolvedModel, modelResolutionMethod } = resolveModel(
+            const { resolvedModel, modelResolutionMethod } = await resolveModel(
               auth,
               {
                 selection: metadata.userMessage.requestedModel ?? undefined,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -113,7 +113,7 @@ import {
   getDataSourcesAndWorkspaceIdForGlobalAgents,
   getMCPServerViewsForGlobalAgents,
 } from "@app/lib/api/assistant/global_agents/tools";
-import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
+import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
@@ -1144,7 +1144,7 @@ export async function getGlobalAgents(
     if (
       agentFetcherResult &&
       agentFetcherResult.scope === "global" &&
-      isProviderWhitelisted(auth, agentFetcherResult.model.providerId)
+      isProviderWhitelistedForAuth(auth, agentFetcherResult.model.providerId)
     ) {
       globalAgents.push(agentFetcherResult);
     }

--- a/front/lib/api/assistant/model_preferences.ts
+++ b/front/lib/api/assistant/model_preferences.ts
@@ -1,0 +1,31 @@
+import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { GEMINI_3_1_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
+import { MISTRAL_MEDIUM_3_5_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
+import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import { GROK_4_MODEL_CONFIG } from "@app/types/assistant/models/xai";
+
+export const PREFERRED_LARGE_MODEL_CONFIGS: ModelConfigurationType[] = [
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+  GPT_5_5_MODEL_CONFIG,
+  GEMINI_3_1_PRO_MODEL_CONFIG,
+  MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
+  GROK_4_MODEL_CONFIG,
+];
+
+export function pickPreferredLargeModel<
+  T extends Pick<ModelConfigurationType, "modelId" | "largeModel">,
+>(models: T[]): T {
+  for (const preferred of PREFERRED_LARGE_MODEL_CONFIGS) {
+    const match = models.find((m) => m.modelId === preferred.modelId);
+    if (match) {
+      return match;
+    }
+  }
+
+  return (
+    models.find((m) => m.largeModel) ??
+    models[0] ??
+    CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG
+  );
+}

--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -1,18 +1,21 @@
+import * as enabledModels from "@app/lib/advanced_models/enabled_models";
+import { pickPreferredLargeModel } from "@app/lib/api/assistant/model_preferences";
 import {
   getWhitelistedProviders,
-  pickPreferredLargeModel,
-  resolveModel,
   selectEnabledModel,
 } from "@app/lib/api/assistant/models";
+import { resolveModel } from "@app/lib/api/assistant/resolve_model";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import {
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type {
@@ -209,7 +212,7 @@ describe("resolveModel", () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const { resolvedModel, modelResolutionMethod } = resolveModel(auth, {
+    const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
       selection: {
         providerId: GPT_5_5_MODEL_CONFIG.providerId,
         modelId: GPT_5_5_MODEL_CONFIG.modelId,
@@ -233,7 +236,7 @@ describe("resolveModel", () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const { resolvedModel, modelResolutionMethod } = resolveModel(auth, {
+    const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
       configuration: makeAgentConfiguration({
         providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
         modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
@@ -254,7 +257,7 @@ describe("resolveModel", () => {
     vi.spyOn(regionConfig, "getCurrentRegion").mockReturnValue("europe-west1");
     const auth = await enterpriseRegionalOnlyAuth();
 
-    const { resolvedModel, modelResolutionMethod } = resolveModel(auth, {
+    const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
       configuration: makeAgentConfiguration({
         providerId: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG.providerId,
         modelId: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG.modelId,
@@ -275,7 +278,7 @@ describe("resolveModel", () => {
     vi.spyOn(regionConfig, "getCurrentRegion").mockReturnValue("europe-west1");
     const auth = await enterpriseRegionalOnlyAuth();
 
-    const { resolvedModel, modelResolutionMethod } = resolveModel(auth, {
+    const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
       selection: {
         providerId: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG.providerId,
         modelId: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG.modelId,
@@ -300,7 +303,7 @@ describe("resolveModel", () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const { resolvedModel } = resolveModel(auth, {
+    const { resolvedModel } = await resolveModel(auth, {
       selection: {
         providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
         modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
@@ -320,7 +323,7 @@ describe("resolveModel", () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const { resolvedModel } = resolveModel(auth, {
+    const { resolvedModel } = await resolveModel(auth, {
       selection: {
         providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
         modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
@@ -336,6 +339,86 @@ describe("resolveModel", () => {
     expect(resolvedModel.reasoningEffort).toBe(
       CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort
     );
+  });
+
+  it("resolves an auto agent configuration to a concrete model when models_picker is enabled", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await FeatureFlagFactory.basic(auth, "models_picker");
+
+    const getAutoModelSpy = vi.spyOn(enabledModels, "getAutoModelForAuth");
+
+    const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
+      configuration: makeAgentConfiguration({
+        providerId: AUTO_MODEL_ID,
+        modelId: AUTO_MODEL_ID,
+      }),
+      featureFlags: ["models_picker"],
+    });
+
+    expect(getAutoModelSpy).toHaveBeenCalledOnce();
+    expect(modelResolutionMethod).toBe("auto");
+    expect(resolvedModel.modelId).not.toBe(AUTO_MODEL_ID);
+    expect(resolvedModel).toEqual({
+      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+      reasoningEffort:
+        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+    });
+  });
+
+  it("resolves an auto user selection to a concrete model when models_picker is enabled", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await FeatureFlagFactory.basic(auth, "models_picker");
+
+    const getAutoModelSpy = vi.spyOn(enabledModels, "getAutoModelForAuth");
+
+    const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
+      selection: {
+        providerId: AUTO_MODEL_ID,
+        modelId: AUTO_MODEL_ID,
+      },
+      configuration: makeAgentConfiguration({
+        providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+        modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+      }),
+      featureFlags: ["models_picker"],
+    });
+
+    expect(getAutoModelSpy).toHaveBeenCalledOnce();
+    expect(modelResolutionMethod).toBe("auto");
+    expect(resolvedModel.modelId).not.toBe(AUTO_MODEL_ID);
+    expect(resolvedModel).toEqual({
+      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+      reasoningEffort:
+        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+    });
+  });
+
+  it("falls back to a preferred large model when the agent is on auto without models_picker", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const getAutoModelSpy = vi.spyOn(enabledModels, "getAutoModelForAuth");
+
+    const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
+      configuration: makeAgentConfiguration({
+        providerId: AUTO_MODEL_ID,
+        modelId: AUTO_MODEL_ID,
+      }),
+      featureFlags: [],
+    });
+
+    expect(getAutoModelSpy).not.toHaveBeenCalled();
+    expect(modelResolutionMethod).toBe("agent");
+    expect(resolvedModel).toEqual({
+      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+      reasoningEffort:
+        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+    });
   });
 });
 

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -1,32 +1,15 @@
+import { PREFERRED_LARGE_MODEL_CONFIGS } from "@app/lib/api/assistant/model_preferences";
+import { isProviderWhitelisted } from "@app/lib/api/assistant/provider_whitelist";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { isModelEnabled } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import type {
-  ModelResolutionMethodType,
-  UserMessageModel,
-} from "@app/lib/models/agent/conversation";
+import type { UserMessageModel } from "@app/lib/models/agent/conversation";
 import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import {
-  CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
-  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-} from "@app/types/assistant/models/anthropic";
-import {
-  GEMINI_3_1_PRO_MODEL_CONFIG,
-  GEMINI_3_5_FLASH_MODEL_CONFIG,
-} from "@app/types/assistant/models/google_ai_studio";
-import {
-  MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
-  MISTRAL_SMALL_MODEL_CONFIG,
-} from "@app/types/assistant/models/mistral";
-import {
-  isModelId,
-  SUPPORTED_MODEL_CONFIGS,
-} from "@app/types/assistant/models/models";
-import {
-  GPT_5_5_MODEL_CONFIG,
-  GPT_5_MINI_MODEL_CONFIG,
-} from "@app/types/assistant/models/openai";
+import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { GEMINI_3_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
+import { MISTRAL_SMALL_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
+import { isModelId } from "@app/types/assistant/models/models";
+import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import {
   BYOK_MODEL_PROVIDER_IDS,
   isModelProviderId,
@@ -36,17 +19,11 @@ import { isReasoningEffort } from "@app/types/assistant/models/reasoning";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
-  ModelSelectionType,
   ReasoningEffort,
   ResolvedRequestedModel,
 } from "@app/types/assistant/models/types";
-import {
-  GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG,
-  GROK_4_MODEL_CONFIG,
-} from "@app/types/assistant/models/xai";
+import { GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG } from "@app/types/assistant/models/xai";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
-import { removeNulls } from "@app/types/shared/utils/general";
-import assert from "assert";
 
 export function getWhitelistedProviders(
   auth: Authenticator
@@ -88,12 +65,13 @@ export function getWhitelistedProviders(
   return whiteListedProviders.intersection(configuredProviders);
 }
 
-export function isProviderWhitelisted(
+export { isProviderWhitelisted } from "@app/lib/api/assistant/provider_whitelist";
+
+export function isProviderWhitelistedForAuth(
   auth: Authenticator,
   providerId: ModelProviderIdType
 ): boolean {
-  const whitelistedProviders = getWhitelistedProviders(auth);
-  return whitelistedProviders.has(providerId);
+  return isProviderWhitelisted(getWhitelistedProviders(auth), providerId);
 }
 
 type ModelEnablementContext = Parameters<typeof isModelEnabled>[1];
@@ -196,31 +174,6 @@ function _getSmallWhitelistedModel(
   );
 }
 
-export const PREFERRED_LARGE_MODEL_CONFIGS: ModelConfigurationType[] = [
-  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-  GPT_5_5_MODEL_CONFIG,
-  GEMINI_3_1_PRO_MODEL_CONFIG,
-  MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
-  GROK_4_MODEL_CONFIG,
-];
-
-export function pickPreferredLargeModel<
-  T extends Pick<ModelConfigurationType, "modelId" | "largeModel">,
->(models: T[]): T {
-  for (const preferred of PREFERRED_LARGE_MODEL_CONFIGS) {
-    const match = models.find((m) => m.modelId === preferred.modelId);
-    if (match) {
-      return match;
-    }
-  }
-
-  return (
-    models.find((m) => m.largeModel) ??
-    models[0] ??
-    CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG
-  );
-}
-
 function _getLargeWhitelistedModel(
   context: ModelEnablementContext,
   { forBatch: hasBatch }: { forBatch?: boolean } = {}
@@ -231,86 +184,6 @@ function _getLargeWhitelistedModel(
         isModelEnabled(m, context) && (!hasBatch || m.supportsBatchProcessing)
     ) ?? null
   );
-}
-
-// ---------------------------------------------------------------------------
-// Per-message model picker.
-//
-// A picker selection is an explicit provider/model pick. It is validated against
-// the workspace's enabled models via the same isModelEnabled predicate enforced
-// everywhere else, so the resolved model can never be rejected later. Most picks
-// use the model's own defaultReasoningEffort; the pick may pin an explicit one.
-// ---------------------------------------------------------------------------
-
-function toResolvedModel(
-  config: ModelConfigurationType,
-  reasoningEffort?: ReasoningEffort
-): ResolvedRequestedModel {
-  return {
-    providerId: config.providerId,
-    modelId: config.modelId,
-    reasoningEffort: reasoningEffort ?? config.defaultReasoningEffort,
-  };
-}
-
-// Resolves the model for an agent message according to these rules:
-// 1. Pick the user's selection
-// 2. If the user did not select a model, pick the agent's configured model
-// 3. Finally fallback to the a supported model by the workspace.
-export function resolveModel(
-  auth: Authenticator,
-  {
-    selection,
-    configuration,
-    featureFlags,
-  }: {
-    selection?: ModelSelectionType;
-    configuration: LightAgentConfigurationType;
-    featureFlags: WhitelistableFeature[];
-  }
-): {
-  resolvedModel: ResolvedRequestedModel;
-  modelResolutionMethod: ModelResolutionMethodType;
-} {
-  const userConfig = selection
-    ? SUPPORTED_MODEL_CONFIGS.find(
-        (m) =>
-          m.providerId === selection.providerId &&
-          m.modelId === selection.modelId
-      )
-    : null;
-
-  const agentConfig = SUPPORTED_MODEL_CONFIGS.find(
-    (m) =>
-      m.providerId === configuration.model.providerId &&
-      m.modelId === configuration.model.modelId
-  );
-
-  //TODO(models_picker): handle auto model selection.
-
-  const enabled = selectEnabledModel(
-    auth,
-    removeNulls([userConfig, agentConfig, ...PREFERRED_LARGE_MODEL_CONFIGS]),
-    {
-      featureFlags,
-    }
-  );
-
-  // Should never happen as we should at least fallback to our selection of PREFERRED_LARGE_MODEL_CONFIGS.
-  assert(enabled, "No enabled model found");
-
-  // Honor an explicit effort only if the model supports it; otherwise fall back
-  // to its default (raw API clients can send an unsupported effort).
-  const effort =
-    selection?.reasoningEffort &&
-    enabled.supportedReasoningEfforts[selection.reasoningEffort]
-      ? selection.reasoningEffort
-      : enabled.defaultReasoningEffort;
-
-  return {
-    resolvedModel: toResolvedModel(enabled, effort),
-    modelResolutionMethod: selection ? "user" : "agent",
-  };
 }
 
 function isResolvedModel(m: {

--- a/front/lib/api/assistant/provider_whitelist.ts
+++ b/front/lib/api/assistant/provider_whitelist.ts
@@ -1,0 +1,11 @@
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+
+// Canonical way to check if a provider is whitelisted.
+// Handle the special case of the auto model.
+export function isProviderWhitelisted(
+  whitelistedProviders: Set<ModelProviderIdType>,
+  providerId: ModelProviderIdType
+): boolean {
+  return providerId === AUTO_MODEL_ID || whitelistedProviders.has(providerId);
+}

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -1,0 +1,97 @@
+import { getAutoModelForAuth } from "@app/lib/advanced_models/enabled_models";
+import { PREFERRED_LARGE_MODEL_CONFIGS } from "@app/lib/api/assistant/model_preferences";
+import { selectEnabledModel } from "@app/lib/api/assistant/models";
+import type { Authenticator } from "@app/lib/auth";
+import type { ModelResolutionMethodType } from "@app/lib/models/agent/conversation";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
+import type {
+  ModelConfigurationType,
+  ModelSelectionType,
+  ReasoningEffort,
+  ResolvedRequestedModel,
+} from "@app/types/assistant/models/types";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import { removeNulls } from "@app/types/shared/utils/general";
+import assert from "assert";
+
+function toResolvedModel(
+  config: ModelConfigurationType,
+  reasoningEffort?: ReasoningEffort
+): ResolvedRequestedModel {
+  return {
+    providerId: config.providerId,
+    modelId: config.modelId,
+    reasoningEffort: reasoningEffort ?? config.defaultReasoningEffort,
+  };
+}
+
+// Resolves the model for an agent message according to these rules:
+// 1. Pick the user's selection if it's part of their allowlist.
+// 2. If the user did not select a model, pick the agent's configured model.
+// 3. If the agent is set on auto mode, pick the auto model.
+// 4. Finally fallback to a supported model by the workspace.
+export async function resolveModel(
+  auth: Authenticator,
+  {
+    selection,
+    configuration,
+    featureFlags,
+  }: {
+    selection?: ModelSelectionType;
+    configuration: LightAgentConfigurationType;
+    featureFlags: WhitelistableFeature[];
+  }
+): Promise<{
+  resolvedModel: ResolvedRequestedModel;
+  modelResolutionMethod: ModelResolutionMethodType;
+}> {
+  let modelResolutionMethod: ModelResolutionMethodType = selection
+    ? "user"
+    : "agent";
+  const userConfig = selection
+    ? SUPPORTED_MODEL_CONFIGS.find(
+        (m) =>
+          m.providerId === selection.providerId &&
+          m.modelId === selection.modelId
+      )
+    : null;
+
+  const agentConfig = SUPPORTED_MODEL_CONFIGS.find(
+    (m) =>
+      m.providerId === configuration.model.providerId &&
+      m.modelId === configuration.model.modelId
+  );
+
+  let enabled = selectEnabledModel(
+    auth,
+    removeNulls([userConfig, agentConfig, ...PREFERRED_LARGE_MODEL_CONFIGS]),
+    {
+      featureFlags,
+    }
+  );
+
+  if (enabled?.modelId === AUTO_MODEL_ID) {
+    // Alternatively, we could remove the agent config from the list of candidates and let the auto model fallback to a supported model by the workspace.
+    // However, to be future-proof, we keep do it here to allow evolution on the way the auto model is selected.
+    enabled = await getAutoModelForAuth(auth);
+    modelResolutionMethod = "auto";
+  }
+
+  // Should never happen as we should at least fallback to our selection of PREFERRED_LARGE_MODEL_CONFIGS.
+  assert(enabled, "No enabled model found");
+
+  // Honor an explicit effort only if the model supports it; otherwise fall back
+  // to its default (raw API clients can send an unsupported effort).
+  const effort =
+    selection?.reasoningEffort &&
+    enabled.supportedReasoningEfforts[selection.reasoningEffort]
+      ? selection.reasoningEffort
+      : enabled.defaultReasoningEffort;
+
+  return {
+    resolvedModel: toResolvedModel(enabled, effort),
+    modelResolutionMethod,
+  };
+}

--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -381,6 +381,14 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     input: 0,
     output: 0,
   },
+  // Fake model for auto selection.
+  // This model is not real and is used to select the best model for the task.
+  // It is not used for actual generation.
+  auto: {
+    input: 0,
+    output: 0,
+    cache_read_input_tokens: 0,
+  },
 };
 
 const IMAGE_MODEL_PRICING: Record<string, PricingEntry> = {

--- a/front/lib/api/llm/getImageGenerationLLM.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.ts
@@ -1,4 +1,4 @@
-import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
+import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
 import { ImageGenerationGoogleLLM } from "@app/lib/api/llm/clients/google/imageGeneration";
 import { ImageGenerationOpenAILLM } from "@app/lib/api/llm/clients/openai/imageGeneration";
 import type { ImageGenerationLLM } from "@app/lib/api/llm/imageGeneration";
@@ -22,21 +22,21 @@ export async function getImageGenerationLLM(
   // back to Gemini for image generation if workspace-enabled, or image 1.5.
   const isEuRegion = regionConfig.getCurrentRegion() === "europe-west1";
 
-  if (!isEuRegion && isProviderWhitelisted(auth, "openai")) {
+  if (!isEuRegion && isProviderWhitelistedForAuth(auth, "openai")) {
     return new ImageGenerationOpenAILLM(auth, {
       modelId: GPT_IMAGE_2_MODEL_ID,
       credentials,
     });
   }
 
-  if (isProviderWhitelisted(auth, "google_ai_studio")) {
+  if (isProviderWhitelistedForAuth(auth, "google_ai_studio")) {
     return new ImageGenerationGoogleLLM(auth, {
       modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
       credentials,
     });
   }
 
-  if (isProviderWhitelisted(auth, "openai")) {
+  if (isProviderWhitelistedForAuth(auth, "openai")) {
     return new ImageGenerationOpenAILLM(auth, {
       modelId: GPT_IMAGE_1_5_MODEL_ID,
       credentials,

--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -242,6 +242,7 @@ const USERFACING_CLIENT_ID: Record<ModelProviderIdType, string> = {
   xai: "xAI",
   google_ai_studio: "Google AI Studio",
   noop: "Noop",
+  auto: "Auto",
 };
 
 /**

--- a/front/lib/api/sandbox/image/profile.ts
+++ b/front/lib/api/sandbox/image/profile.ts
@@ -23,6 +23,7 @@ export function providerToProfile(
     case "xai":
     case "fireworks":
     case "noop":
+    case "auto":
       return "anthropic";
     default:
       assertNever(providerId);

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,3 +1,4 @@
+import { isProviderWhitelisted } from "@app/lib/api/assistant/provider_whitelist";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import { isByokProviderId } from "@app/types/assistant/models/providers";
@@ -87,7 +88,7 @@ export function isModelEnabled(
 ) {
   return (
     isModelAvailable(m, { featureFlags, plan, regionalModelsOnly, region }) &&
-    whitelistedProviders.has(m.providerId)
+    isProviderWhitelisted(whitelistedProviders, m.providerId)
   );
 }
 

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -16,7 +16,7 @@ export function useModels({
   const { data, error } = useSWRWithDefaults(
     `/api/w/${owner.sId}/models`,
     modelsFetcher,
-    { disabled }
+    { disabled, revalidateOnFocus: false }
   );
 
   return {

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -5,7 +5,7 @@ import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/conversat
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
-import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
+import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import type { DustFileSystemError } from "@app/lib/api/file_system/types";
@@ -315,7 +315,7 @@ export async function runCompaction(
     return new Err(new Error("Compaction message not found"));
   }
 
-  if (!isProviderWhitelisted(auth, model.providerId)) {
+  if (!isProviderWhitelistedForAuth(auth, model.providerId)) {
     return new Err(
       new Error(
         `The model provider ${model.providerId} has been disabled by your workspace admin.`

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -1,0 +1,37 @@
+import type { ModelConfigurationType } from "./types";
+
+export const AUTO_MODEL_ID = "auto" as const;
+export const AUTO_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: AUTO_MODEL_ID,
+  modelId: AUTO_MODEL_ID,
+  displayName: "Auto",
+  description: "Let's Dust select the best model for the task.",
+  shortDescription: "Select the best model for the task.",
+
+  // Everything below is just some value to make it compatible with the ModelConfigurationType.
+  // This model configuration will be dynamically routed to the best model for the task.
+  contextSize: 1_000_000,
+  recommendedTopK: 64,
+  recommendedExhaustiveTopK: 64,
+  largeModel: true,
+  isLegacy: false,
+  isLatest: true,
+  generationTokensCount: 64_000,
+  supportsVision: false,
+  supportedReasoningEfforts: {
+    none: true,
+    light: false,
+    medium: false,
+    high: false,
+  },
+  defaultReasoningEffort: "none",
+  supportsResponseFormat: false,
+  availableIfOneOf: {
+    featureFlag: "models_picker",
+  },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
+};

--- a/front/types/assistant/models/models.ts
+++ b/front/types/assistant/models/models.ts
@@ -38,6 +38,7 @@ import {
   CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_5_MODEL_ID,
 } from "./anthropic";
+import { AUTO_MODEL_CONFIG, AUTO_MODEL_ID } from "./auto";
 // Custom models (generated at build time from GCS, empty in dev).
 import {
   CUSTOM_MODEL_CONFIGS,
@@ -228,6 +229,7 @@ export const STATIC_MODEL_IDS = [
   GROK_4_1_FAST_NON_REASONING_MODEL_ID,
   GROK_4_1_FAST_REASONING_MODEL_ID,
   NOOP_MODEL_ID,
+  AUTO_MODEL_ID,
 ] as const;
 
 // Type for static model IDs only (excludes custom models from GCS).
@@ -325,6 +327,7 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GROK_4_1_FAST_REASONING_MODEL_CONFIG,
   GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG,
   NOOP_MODEL_CONFIG,
+  AUTO_MODEL_CONFIG,
   // Custom models (generated at build time from GCS).
   ...CUSTOM_MODEL_CONFIGS,
 ];

--- a/front/types/assistant/models/providers.ts
+++ b/front/types/assistant/models/providers.ts
@@ -17,6 +17,7 @@ export const MODEL_PROVIDER_IDS = [
   "fireworks",
   "xai",
   "noop",
+  "auto",
 ] as const;
 
 export const BYOK_MODEL_PROVIDER_IDS = [
@@ -45,6 +46,8 @@ export function getProviderDisplayName(
       return "xAI";
     case "noop":
       return "noop";
+    case "auto":
+      return "Dust";
     default:
       return providerId;
   }

--- a/front/types/provider_selection.ts
+++ b/front/types/provider_selection.ts
@@ -11,6 +11,7 @@ export const ALL_PROVIDERS_SELECTED: ProvidersSelection = {
   fireworks: true,
   xai: true,
   noop: true,
+  auto: true,
 };
 
 export const NO_PROVIDERS_SELECTED: ProvidersSelection = {
@@ -22,6 +23,7 @@ export const NO_PROVIDERS_SELECTED: ProvidersSelection = {
   fireworks: false,
   xai: false,
   noop: false,
+  auto: true,
 };
 
 export const PRETTIFIED_PROVIDER_NAMES: Record<ModelProviderIdType, string> = {
@@ -33,4 +35,5 @@ export const PRETTIFIED_PROVIDER_NAMES: Record<ModelProviderIdType, string> = {
   fireworks: "Fireworks",
   xai: "xAI",
   noop: "noop",
+  auto: "Auto",
 };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -23,6 +23,7 @@ const ModelProviderIdSchema = FlexibleEnumSchema<
   | "fireworks"
   | "xai"
   | "noop"
+  | "auto"
 >();
 
 export type KnownModelLLMId =
@@ -94,7 +95,8 @@ export type KnownModelLLMId =
   | "grok-4-fast-reasoning-latest"
   | "grok-4-1-fast-non-reasoning-latest"
   | "grok-4-1-fast-reasoning-latest"
-  | "noop"; // Noop
+  | "noop" // Noop
+  | "auto"; // Auto
 
 // Cast to allow custom/unknown model IDs while preserving autocomplete.
 const ModelLLMIdSchema = FlexibleEnumSchema<KnownModelLLMId>() as z.ZodType<


### PR DESCRIPTION
## Description

Introduces `AUTO_MODEL_ID` / `AUTO_MODEL_CONFIG` (`front/types/assistant/models/auto.ts`) — a virtual model gated on `models_picker` FF that represents dynamic routing to the best model for the task. Registers `auto` across the type system: `STATIC_MODEL_IDS`, `MODEL_PROVIDER_IDS`, `SUPPORTED_MODEL_CONFIGS`, `USED_MODEL_CONFIGS`, token pricing (zero-cost), error labels, sandbox profile fallback, and the JS SDK's `KnownModelLLMId`.

In the agent builder's `AdvancedSettings`, adds a `SliderToggle` row for "Auto" at the top of the model dropdown. Selecting it stores the current `modelSettings` and switches to `AUTO_MODEL_CONFIG`; deselecting restores the previous selection. `ModelSelectionSubmenu` and `ReasoningEffortSubmenu` are hidden while Auto is active. Also fixes `ModelSelectionSubmenu` regional flag logic: removes the `SHOULD_DISPLAY_FLAG` region map so `RegionalFlag` shows in all regions when `use_vertex_for_supported_models` is on and not BYOK.

## Tests

Tested locally in the agent builder. No new automated tests added (UI-only change).

## Risk

Auto model is gated on `models_picker` FF — no impact for workspaces without the flag. The virtual model is excluded from `ModelProvidersPageContent` and priced at zero to avoid side effects. Low risk, straightforward rollback.

## Deploy Plan

Deploy front.
