### PR TITLE
[front] fix: defer monthly→yearly seat switches to end of period

### DIFF
--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -625,6 +625,81 @@ describe("classifySeatChange", () => {
     expect(classify("pro", "max")).toEqual({ kind: "immediate" });
   });
 
+  it("defers a monthly→yearly switch of the same tier (pro → pro_yearly) to the next credit renewal", () => {
+    // Same allowance, so not a downgrade — but committing to annual billing is
+    // deferred to end of period rather than applied mid-period.
+    const { contract: c, productSeatTypes: types } = makeContract({
+      seats: [
+        { seatType: "pro", awu: 100 },
+        { seatType: "pro_yearly", awu: 100, frequency: "ANNUAL" },
+      ],
+      currentBillingPeriodStartingAt: CURRENT_PERIOD,
+      nextBillingPeriodStartingAt: "2027-01-15T00:00:00Z",
+    });
+    expect(
+      classifySeatChange({
+        contract: c,
+        productSeatTypes: types,
+        now: NOW,
+        change: {
+          userId: "u1",
+          previousSeatType: "pro",
+          newSeatType: "pro_yearly",
+        },
+      })
+    ).toEqual({ kind: "deferred", at: NEXT_RENEWAL });
+  });
+
+  it("defers a monthly→yearly switch even when the target tier is higher (pro → max_yearly)", () => {
+    // A tier upgrade would normally be immediate, but the monthly→yearly
+    // billing commitment forces a deferral to end of period.
+    const { contract: c, productSeatTypes: types } = makeContract({
+      seats: [
+        { seatType: "pro", awu: 100 },
+        { seatType: "max_yearly", awu: 500, frequency: "ANNUAL" },
+      ],
+      currentBillingPeriodStartingAt: CURRENT_PERIOD,
+      nextBillingPeriodStartingAt: "2027-01-15T00:00:00Z",
+    });
+    expect(
+      classifySeatChange({
+        contract: c,
+        productSeatTypes: types,
+        now: NOW,
+        change: {
+          userId: "u1",
+          previousSeatType: "pro",
+          newSeatType: "max_yearly",
+        },
+      })
+    ).toEqual({ kind: "deferred", at: NEXT_RENEWAL });
+  });
+
+  it("applies a yearly→monthly switch immediately (pro_yearly → pro)", () => {
+    // Only monthly→yearly is deferred; the reverse keeps the default
+    // allocation-based timing (same allowance → immediate).
+    const { contract: c, productSeatTypes: types } = makeContract({
+      seats: [
+        { seatType: "pro", awu: 100 },
+        { seatType: "pro_yearly", awu: 100, frequency: "ANNUAL" },
+      ],
+      currentBillingPeriodStartingAt: CURRENT_PERIOD,
+      nextBillingPeriodStartingAt: "2027-01-15T00:00:00Z",
+    });
+    expect(
+      classifySeatChange({
+        contract: c,
+        productSeatTypes: types,
+        now: NOW,
+        change: {
+          userId: "u1",
+          previousSeatType: "pro_yearly",
+          newSeatType: "pro",
+        },
+      })
+    ).toEqual({ kind: "immediate" });
+  });
+
   it("is a noop when selecting the current seat with no pending change", () => {
     expect(classify("pro", "pro")).toEqual({ kind: "noop" });
   });

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -54,7 +54,11 @@ import {
 } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
-import { isMembershipSeatType, SEAT_TYPE_ORDER } from "@app/types/memberships";
+import {
+  isMembershipSeatType,
+  isPaidSeatType,
+  SEAT_TYPE_ORDER,
+} from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -160,8 +164,12 @@ export type SeatChangeOutcome =
  *   else `noop`.
  * - `free` → `none`: `immediate`. A `free` seat carries no renewing, already-paid
  *   allowance to preserve, so removing it takes effect right away.
- * - New allocation ≥ previous: `immediate` (the user gains/keeps access
- *   right away).
+ * - Monthly → yearly switch (a monthly paid seat moving to a yearly cadence,
+ *   e.g. `pro` → `pro_yearly` or `pro` → `max_yearly`): `deferred`, even when
+ *   the target tier is higher. Committing to annual billing takes effect at
+ *   the end of the current period, never mid-period.
+ * - New allocation ≥ previous (and not the monthly→yearly case above):
+ *   `immediate` (the user gains/keeps access right away).
  * - New allocation < previous: `deferred` to the next time the previous
  *   seat's AWU allowance renews, so the user keeps the richer access through
  *   the allowance they already paid for. Returns `undefined` when no renewal
@@ -205,24 +213,37 @@ export function classifySeatChange({
     newSeatType,
     productSeatTypes
   );
-  // Keep or gain allowance — takes effect right away. This also covers
-  // removing a seat that carried no allowance (e.g. workspace seats:
-  // 0 >= 0): there's nothing already paid for to preserve, so the removal
-  // is immediate.
-  if (newAllocation >= previousAllocation) {
+  // A monthly→yearly switch commits the seat to annual billing. That
+  // commitment must never take effect mid-period — even when the target tier
+  // is higher (which the allocation comparison below would otherwise apply
+  // immediately) — so it is deferred to the end of the current period, exactly
+  // like a downgrade. Only a monthly paid seat can switch to yearly; adding a
+  // yearly seat from `free`/`none` is a fresh subscription and stays immediate.
+  const isMonthlyToYearlySwitch =
+    isPaidSeatType(previousSeatType) &&
+    !previousSeatType.endsWith("_yearly") &&
+    newSeatType.endsWith("_yearly");
+
+  // Keep or gain allowance — takes effect right away, unless it is the
+  // monthly→yearly commitment above. This also covers removing a seat that
+  // carried no allowance (e.g. workspace seats: 0 >= 0): there's nothing
+  // already paid for to preserve, so the removal is immediate.
+  if (newAllocation >= previousAllocation && !isMonthlyToYearlySwitch) {
     return { kind: "immediate" };
   }
 
-  // Losing allowance (downgrade, or removal of a seat that had allowance) —
-  // defer until the previous seat's AWU allowance next renews, so the user
-  // keeps the richer allowance they've already paid for until it would have
-  // refreshed anyway. The renewal cadence is the credit's `recurrence_frequency`
-  // (MONTHLY in new pricing, even for annually-billed seats — see
-  // `getNextSeatCreditRenewalDate`), which is independent of the billing period.
+  // Deferred: either losing allowance (downgrade, or removal of a seat that had
+  // allowance) or a monthly→yearly switch. Defer until the previous seat's AWU
+  // allowance next renews, so the user keeps the allowance they've already paid
+  // for until it would have refreshed anyway. The renewal cadence is the
+  // credit's `recurrence_frequency` (MONTHLY in new pricing, even for
+  // annually-billed seats — see `getNextSeatCreditRenewalDate`), which is
+  // independent of the billing period.
   //
-  // Defensive: a downgrade is always from a credit-bearing seat (`free` →
+  // Defensive: the previous seat is credit-bearing in the common case (`free` →
   // `none` is handled above as a no-op), but if the credit's recurrence can't
-  // be resolved, fall back to the next billing-period start rather than
+  // be resolved (e.g. a zero-allowance `workspace` seat switching to
+  // `workspace_yearly`), fall back to the next billing-period start rather than
   // failing the change.
   const creditRenewalAt = getNextSeatCreditRenewalDate({
     contract,


### PR DESCRIPTION
## What

Switching a seat from monthly to yearly billing now **defers to the end of the current period** in all cases, rather than applying immediately.

## Why

`classifySeatChange` (`front/lib/metronome/seats.ts`) decides whether a seat change is applied immediately or deferred. It deferred only true downgrades (new AWU allocation < previous) and applied everything equal-or-higher immediately.

A monthly→yearly switch of the same tier (e.g. `pro → pro_yearly`) shares the **same** allocation, so it was applying mid-period — the same for `pro → max_yearly`. Committing to annual billing should take effect at the next period boundary, mirroring how downgrades (e.g. `max → pro`) already behave.

## Change

- Added an `isMonthlyToYearlySwitch` check: previous seat is a paid **monthly** seat (`pro`/`max`/`workspace`) and the new seat is a `_yearly` variant.
- Such switches now take the **deferred** branch, anchored to the previous seat's next AWU credit renewal (same end-of-period anchor downgrades use), **even when the target tier is higher**.
- Additions from `free`/`none` to a yearly seat stay immediate (fresh subscription); yearly→monthly is unchanged.

Applies to the customer-facing seat-change path (`PATCH /api/w/:wId/members/:uId/seat-type` → `updateMembershipSeatAndTrack`). The forced-`immediate` internal path (e.g. auto seat upgrade) bypasses the classifier by design and is unaffected.

## Tests

Added 3 cases to `seats.test.ts`:
- `pro → pro_yearly` → deferred to next renewal
- `pro → max_yearly` (higher tier) → deferred
- `pro_yearly → pro` → immediate (reverse direction unaffected)

All 57 tests pass; `tsgo --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)