### PR TITLE
feat(front): persist model picker selection and surface per-message model

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -2,6 +2,7 @@ import { useBlockedActionsContext } from "@app/components/assistant/conversation
 import { ContextUsageWarningBanner } from "@app/components/assistant/conversation/ContextUsageWarningBanner";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { InputBarMessageNavigation } from "@app/components/assistant/conversation/input_bar/InputBarMessageNavigation";
 import { INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
 import { useInputBarCompactMode } from "@app/components/assistant/conversation/input_bar/useInputBarCompactMode";
@@ -24,6 +25,7 @@ import {
   useConversationContextUsage,
 } from "@app/hooks/conversations";
 import { CONTEXT_USAGE_PERCENT_THRESHOLDS } from "@app/hooks/conversations/useConversationContextUsage";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
@@ -44,7 +46,7 @@ import {
   useVirtuosoLocation,
   useVirtuosoMethods,
 } from "@virtuoso.dev/message-list";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
 const DOUBLE_ESC_WINDOW_MS = 300;
@@ -119,6 +121,42 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
       ?.richMentions.find(isRichAgentMention) ?? null;
 
   const draftAgent = agentBuilderContext?.draftAgent;
+
+  // On (re)load of an existing conversation, restore the model picker to the
+  // model the latest agent message ran on — mirroring how the sticky agent is
+  // re-derived from the conversation. We apply this once per conversation so we
+  // don't clobber the user's picker choice while they keep chatting.
+  const { setSelectedModelSelection } = useContext(InputBarContext);
+  const appliedModelConversationRef = useRef<string | null>(null);
+  useEffect(() => {
+    const conversationId = context.conversation?.sId ?? null;
+    if (conversationId === appliedModelConversationRef.current) {
+      return;
+    }
+    // Wait until the conversation's messages are available before deriving.
+    const lastAgentMessage = allMessages.findLast(isAgentMessageWithStreaming);
+    if (!lastAgentMessage) {
+      return;
+    }
+    appliedModelConversationRef.current = conversationId;
+
+    const { requestedModel } = lastAgentMessage;
+    const modelConfig = requestedModel
+      ? getSupportedModelConfig({
+          providerId: requestedModel.providerId,
+          modelId: requestedModel.modelId,
+        })
+      : null;
+    setSelectedModelSelection(
+      requestedModel && modelConfig
+        ? {
+            kind: "model",
+            model: modelConfig,
+            effort: requestedModel.reasoningEffort,
+          }
+        : { kind: "auto" }
+    );
+  }, [context.conversation?.sId, allMessages, setSelectedModelSelection]);
 
   const { contextUsage, contextUsagePercentage } = useConversationContextUsage({
     conversationId: context.conversation?.sId ?? "",

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -14,7 +14,7 @@ import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conver
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
 import { useAutoOpenFilesPanel } from "@app/components/assistant/conversation/files_panel/useAutoOpenFilesPanel";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
-import { getLineLabel } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import { getModelWithReasoningEffortLabel } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { useAutoOpenInteractiveContent } from "@app/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent";
 import type {
   AgentMessageStateWithControlEvent,
@@ -994,7 +994,7 @@ export function AgentMessage({
     : null;
   const requestedModelLabel =
     requestedModel && requestedModelConfig
-      ? getLineLabel({
+      ? getModelWithReasoningEffortLabel({
           kind: "model",
           model: requestedModelConfig,
           effort: requestedModel.reasoningEffort,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -14,6 +14,7 @@ import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conver
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
 import { useAutoOpenFilesPanel } from "@app/components/assistant/conversation/files_panel/useAutoOpenFilesPanel";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { getLineLabel } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { useAutoOpenInteractiveContent } from "@app/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent";
 import type {
   AgentMessageStateWithControlEvent,
@@ -64,6 +65,7 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { getFilePreviewDirectivePaths } from "@app/lib/markdown/file_preview";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
@@ -980,6 +982,25 @@ export function AgentMessage({
     canShowAgentConversationActions(agentConfiguration.sId);
   const isArchived = agentConfiguration.status === "archived";
 
+  // When this message ran on a per-message model override (from the input-bar
+  // model picker), surface the model next to the agent name (e.g. "with GPT 5.5
+  // High"). Null when the agent ran its own configured model.
+  const requestedModel = agentMessage.requestedModel;
+  const requestedModelConfig = requestedModel
+    ? getSupportedModelConfig({
+        providerId: requestedModel.providerId,
+        modelId: requestedModel.modelId,
+      })
+    : null;
+  const requestedModelLabel =
+    requestedModel && requestedModelConfig
+      ? getLineLabel({
+          kind: "model",
+          model: requestedModelConfig,
+          effort: requestedModel.reasoningEffort,
+        })
+      : null;
+
   const renderName = useCallback(
     () => (
       <span className="inline-flex items-center">
@@ -991,6 +1012,11 @@ export function AgentMessage({
           canMention={canMention}
           isDisabled={isArchived}
         />
+        {requestedModelLabel && (
+          <span className="ml-1 font-normal text-muted-foreground">
+            with {requestedModelLabel}
+          </span>
+        )}
         {parentAgent && (
           <Chip
             label={`handoff from @${parentAgent.name}`}
@@ -1009,6 +1035,7 @@ export function AgentMessage({
       isArchived,
       parentAgent,
       agentMessage.status,
+      requestedModelLabel,
     ]
   );
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -13,6 +13,7 @@ import {
   INPUT_BAR_COMPACT_MORPH_TRANSITION_CLASSES,
   INPUT_BAR_COMPACT_PILL_CLASSES,
 } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
+import { toModelSelection } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
 import { PlanCard } from "@app/components/assistant/conversation/plan_mode/PlanCard";
 import {
@@ -44,7 +45,6 @@ import React, {
   useContext,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 
@@ -119,25 +119,20 @@ export const InputBar = React.memo(function InputBar({
     DataSourceViewContentNode[]
   >([]);
 
-  // Latest model-picker selection, kept in a ref so the picker's change events
-  // don't re-render the whole input bar; read at submit time. `undefined` means
-  // no override (run the agent's configured model).
-  const modelSelectionRef = useRef<ModelSelectionType | undefined>(undefined);
-  const handleModelSelectionChange = useCallback(
-    (modelSelection: ModelSelectionType | undefined) => {
-      modelSelectionRef.current = modelSelection;
-    },
-    []
-  );
-
   const {
     getAndClearSelectedAgent,
     selectedSingleAgent,
+    selectedModelSelection,
     getAndClearPendingInputText,
     fileUploaderService,
     isLoadingGoTemplate,
     onBeforeSubmit,
   } = useContext(InputBarContext);
+
+  // The picker's selection lives in InputBarContext so it persists across
+  // messages; convert it to the API override at submit time. `undefined` means
+  // no override (run the agent's configured model).
+  const modelSelection = toModelSelection(selectedModelSelection);
 
   // We use this specific hook because this component is involved in the new conversation page.
   const { agentConfigurations } = useUnifiedAgentConfigurations({
@@ -365,7 +360,7 @@ export const InputBar = React.memo(function InputBar({
           // Only send the selectedMCPServerViewIds if we are creating a new conversation.
           // Once the conversation is created, the selectedMCPServerViewIds will be updated in the conversationTools hook.
           selectedMCPServerViews.map((sv) => sv.sId),
-          modelSelectionRef.current
+          modelSelection
         );
 
         if (r.isOk()) {
@@ -398,7 +393,7 @@ export const InputBar = React.memo(function InputBar({
           // Existing conversation: MCP server views are synced via the
           // conversationTools hook, so only the model selection is passed here.
           undefined,
-          modelSelectionRef.current
+          modelSelection
         );
 
         // Execute these operations in parallel with the submission.
@@ -538,7 +533,6 @@ export const InputBar = React.memo(function InputBar({
             onNodeUnselect={handleNodesAttachmentRemove}
             selectedMCPServerViews={selectedMCPServerViews}
             onMCPServerViewSelect={handleMCPServerViewSelect}
-            onModelSelectionChange={handleModelSelectionChange}
             onMCPServerViewDeselect={handleMCPServerViewDeselect}
             onResetMCPServerViews={handleResetMCPServerViews}
             isAgentBuilder={isAgentBuilder}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -13,7 +13,7 @@ import {
   INPUT_BAR_COMPACT_MORPH_TRANSITION_CLASSES,
   INPUT_BAR_COMPACT_PILL_CLASSES,
 } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
-import { toModelSelection } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import { convertModelSelection } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
 import { PlanCard } from "@app/components/assistant/conversation/plan_mode/PlanCard";
 import {
@@ -129,10 +129,7 @@ export const InputBar = React.memo(function InputBar({
     onBeforeSubmit,
   } = useContext(InputBarContext);
 
-  // The picker's selection lives in InputBarContext so it persists across
-  // messages; convert it to the API override at submit time. `undefined` means
-  // no override (run the agent's configured model).
-  const modelSelection = toModelSelection(selectedModelSelection);
+  const modelSelection = convertModelSelection(selectedModelSelection);
 
   // We use this specific hook because this component is involved in the new conversation page.
   const { agentConfigurations } = useUnifiedAgentConfigurations({

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -16,7 +16,6 @@ import type {
   RichMention,
 } from "@app/types/assistant/mentions";
 import { toRichAgentMentionType } from "@app/types/assistant/mentions";
-import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { getSupportedFileExtensions } from "@app/types/files";
@@ -56,9 +55,6 @@ interface InputBarButtonsProps {
   isInputDisabled: boolean;
   onAgentRemove: () => void;
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
-  onModelSelectionChange?: (
-    modelSelection: ModelSelectionType | undefined
-  ) => void;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
   onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
@@ -89,7 +85,6 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   isInputDisabled,
   onAgentRemove,
   onMCPServerViewSelect,
-  onModelSelectionChange,
   onNodeSelect,
   onNodeUnselect,
   onSkillSelect,
@@ -253,7 +248,6 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       buttonSize={buttonSize}
       side={conversation ? "top" : "bottom"}
       disabled={isInputDisabled}
-      onSelectionChange={onModelSelectionChange}
     />
   );
 

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -236,14 +236,8 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       </>
     );
 
-  const selectedAgentModel =
-    (selectedAgent &&
-      allAgents.find((a) => a.sId === selectedAgent.id)?.model) ??
-    null;
-
   const modelPickerButton = actions.includes("model-picker") && (
     <InputBarModelPicker
-      agentModel={selectedAgentModel}
       owner={owner}
       buttonSize={buttonSize}
       side={conversation ? "top" : "bottom"}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -65,7 +65,6 @@ import {
   isRichUserMention,
   toRichAgentMentionType,
 } from "@app/types/assistant/mentions";
-import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import {
@@ -219,9 +218,6 @@ export interface InputBarContainerProps {
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
   onMCPServerViewDeselect: (serverView: MCPServerViewType) => void;
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
-  onModelSelectionChange?: (
-    modelSelection: ModelSelectionType | undefined
-  ) => void;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
   onResetMCPServerViews: () => void;
@@ -271,7 +267,6 @@ const InputBarContainer = ({
   onNodeUnselect,
   attachedNodes,
   onMCPServerViewSelect,
-  onModelSelectionChange,
   onMCPServerViewDeselect,
   selectedMCPServerViews,
   onResetMCPServerViews,
@@ -1660,7 +1655,6 @@ const InputBarContainer = ({
                       isInputDisabled={disableInput}
                       onAgentRemove={() => setSelectedSingleAgent(null)}
                       onMCPServerViewSelect={onMCPServerViewSelect}
-                      onModelSelectionChange={onModelSelectionChange}
                       onNodeSelect={onNodeSelect}
                       onNodeUnselect={onNodeUnselect}
                       onSkillSelect={handleSkillSelect}

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -1,4 +1,4 @@
-import type { Selection } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import type { ModelSelection } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import {
   type FileUploaderService,
@@ -45,11 +45,8 @@ export const InputBarContext = createContext<{
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
   selectedSingleAgent: RichAgentMention | null;
   setSelectedSingleAgent: (agentMention: RichAgentMention | null) => void;
-  // Persistent per-message model override (displayed in the model picker
-  // button). Like the agent selection, it lives here so it survives switching
-  // between conversations/messages rather than resetting on remount.
-  selectedModelSelection: Selection;
-  setSelectedModelSelection: (selection: Selection) => void;
+  selectedModelSelection: ModelSelection;
+  setSelectedModelSelection: (modelSelection: ModelSelection) => void;
   getAndClearPendingInputText: () => PendingInputText | null;
   setPendingInputText: (
     text: string | null,
@@ -124,7 +121,7 @@ export function InputBarContextProvider({
 
   // Persistent per-message model override (see type definition above).
   const [selectedModelSelection, setSelectedModelSelection] =
-    useState<Selection>({ kind: "auto" });
+    useState<ModelSelection>({ kind: "auto" });
 
   // Useful when a component needs to pre-fill the input bar with text.
   const [pendingInputText, setPendingInputTextState] =

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -1,3 +1,4 @@
+import type { Selection } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import {
   type FileUploaderService,
@@ -44,6 +45,11 @@ export const InputBarContext = createContext<{
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
   selectedSingleAgent: RichAgentMention | null;
   setSelectedSingleAgent: (agentMention: RichAgentMention | null) => void;
+  // Persistent per-message model override (displayed in the model picker
+  // button). Like the agent selection, it lives here so it survives switching
+  // between conversations/messages rather than resetting on remount.
+  selectedModelSelection: Selection;
+  setSelectedModelSelection: (selection: Selection) => void;
   getAndClearPendingInputText: () => PendingInputText | null;
   setPendingInputText: (
     text: string | null,
@@ -70,6 +76,8 @@ export const InputBarContext = createContext<{
   setSelectedAgent: () => {},
   selectedSingleAgent: null,
   setSelectedSingleAgent: () => {},
+  selectedModelSelection: { kind: "auto" },
+  setSelectedModelSelection: () => {},
   getAndClearPendingInputText: () => null,
   setPendingInputText: () => {},
   peekPendingFirstMessage: () => null,
@@ -113,6 +121,10 @@ export function InputBarContextProvider({
   // Persistent agent selection for single-agent input mode (displayed in the agent picker button).
   const [selectedSingleAgent, setSelectedSingleAgent] =
     useState<RichAgentMention | null>(null);
+
+  // Persistent per-message model override (see type definition above).
+  const [selectedModelSelection, setSelectedModelSelection] =
+    useState<Selection>({ kind: "auto" });
 
   // Useful when a component needs to pre-fill the input bar with text.
   const [pendingInputText, setPendingInputTextState] =
@@ -197,6 +209,8 @@ export function InputBarContextProvider({
       setSelectedAgent: setSelectedAgentOuter,
       selectedSingleAgent,
       setSelectedSingleAgent,
+      selectedModelSelection,
+      setSelectedModelSelection,
       getAndClearPendingInputText,
       setPendingInputText,
       peekPendingFirstMessage,
@@ -213,6 +227,7 @@ export function InputBarContextProvider({
       getAndClearSelectedAgent,
       setSelectedAgentOuter,
       selectedSingleAgent,
+      selectedModelSelection,
       getAndClearPendingInputText,
       setPendingInputText,
       peekPendingFirstMessage,

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -1,3 +1,4 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { ModelPickerContent } from "@app/components/assistant/conversation/input_bar/ModelPickerContent";
 import type {
   ModelPickerListState,
@@ -11,7 +12,6 @@ import {
   getModelWithReasoningEffortLabel,
   getSelectableReasoningEfforts,
   SUGGESTED_PINS,
-  toModelSelection,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
@@ -23,13 +23,12 @@ import { getProviderDisplayName } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
-  ModelSelectionType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, DropdownMenu, DropdownMenuTrigger } from "@dust-tt/sparkle";
-import { useMemo, useRef, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 
 interface InputBarModelPickerProps {
   agentModel: AgentModelConfigurationType | null;
@@ -40,7 +39,6 @@ interface InputBarModelPickerProps {
   // conversation screen where there is room below.
   side?: "top" | "bottom";
   disabled?: boolean;
-  onSelectionChange?: (modelSelection: ModelSelectionType | undefined) => void;
 }
 
 export function InputBarModelPicker({
@@ -49,7 +47,6 @@ export function InputBarModelPicker({
   buttonSize,
   side = "top",
   disabled,
-  onSelectionChange,
 }: InputBarModelPickerProps) {
   const { hasFeature } = useFeatureFlags();
   const hasModelsPicker = hasFeature("models_picker");
@@ -61,34 +58,45 @@ export function InputBarModelPicker({
 
   // The list of models is hidden while "Auto" is on.
   const [expanded, setExpanded] = useState(false);
-  const [selection, setSelection] = useState<Selection>({ kind: "auto" });
+
+  // The selection lives in InputBarContext so it persists across
+  // conversations/messages (like the selected agent) instead of resetting when
+  // the input bar remounts.
+  const { selectedModelSelection: selection, setSelectedModelSelection } =
+    useContext(InputBarContext);
 
   // On mobile there are no nested submenus: the "More models" providers expand
   // inline below their name. This tracks the single provider currently expanded.
   const [expandedProvider, setExpandedProvider] =
     useState<ModelProviderIdType | null>(null);
 
-  // Commit a selection and notify the parent so it can attach (or, for "auto",
-  // clear) the per-message model override on the next send. Called from the
-  // user-driven handlers below and from the agent-change reset. `onSelectionChange`
-  // only stashes the value in a parent ref, so calling it here — including during
-  // the render-time reset — triggers no parent re-render.
   const commitSelection = (next: Selection) => {
-    setSelection(next);
-    onSelectionChange?.(toModelSelection(next));
+    setSelectedModelSelection(next);
   };
 
-  // Reset to Auto when the agent changes: a per-message override should not leak
-  // across agents.
+  // Reset to Auto when the agent's model changes: a per-message override should
+  // not leak across agents. Done in an effect (not during render) because the
+  // selection now lives in a parent context, and updating parent state during a
+  // child's render is not allowed.
   const agentModelKey = agentModel
     ? `${agentModel.providerId}/${agentModel.modelId}`
     : null;
   const prevAgentModelKeyRef = useRef(agentModelKey);
-  if (agentModelKey !== prevAgentModelKeyRef.current) {
+  useEffect(() => {
+    const prevAgentModelKey = prevAgentModelKeyRef.current;
     prevAgentModelKeyRef.current = agentModelKey;
-    commitSelection({ kind: "auto" });
-    setExpanded(false);
-  }
+    // Only reset across two concrete, different agent models. Transitions
+    // to/from null (agent list still loading after a remount, or no agent
+    // selected) must not wipe the persisted override.
+    if (
+      prevAgentModelKey !== null &&
+      agentModelKey !== null &&
+      prevAgentModelKey !== agentModelKey
+    ) {
+      setSelectedModelSelection({ kind: "auto" });
+      setExpanded(false);
+    }
+  }, [agentModelKey, setSelectedModelSelection]);
 
   const { models, isModelsLoading } = useModels({
     owner,

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -2,9 +2,9 @@ import { InputBarContext } from "@app/components/assistant/conversation/input_ba
 import { ModelPickerContent } from "@app/components/assistant/conversation/input_bar/ModelPickerContent";
 import type {
   ModelPickerListState,
+  ModelSelection,
   ModelWithReasoningEffort,
   ProviderGroup,
-  Selection,
   SuggestedModelWithReasoningEffort,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import {
@@ -18,7 +18,6 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useModels } from "@app/lib/swr/models";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
-import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import { getProviderDisplayName } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
@@ -28,10 +27,9 @@ import type {
 import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, DropdownMenu, DropdownMenuTrigger } from "@dust-tt/sparkle";
-import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 
 interface InputBarModelPickerProps {
-  agentModel: AgentModelConfigurationType | null;
   owner: LightWorkspaceType;
   buttonSize: "xs" | "sm";
   // Which side the dropdown opens toward. Mirrors the agent picker: "top" in an
@@ -42,7 +40,6 @@ interface InputBarModelPickerProps {
 }
 
 export function InputBarModelPicker({
-  agentModel,
   owner,
   buttonSize,
   side = "top",
@@ -70,33 +67,9 @@ export function InputBarModelPicker({
   const [expandedProvider, setExpandedProvider] =
     useState<ModelProviderIdType | null>(null);
 
-  const commitSelection = (next: Selection) => {
+  const commitSelection = (next: ModelSelection) => {
     setSelectedModelSelection(next);
   };
-
-  // Reset to Auto when the agent's model changes: a per-message override should
-  // not leak across agents. Done in an effect (not during render) because the
-  // selection now lives in a parent context, and updating parent state during a
-  // child's render is not allowed.
-  const agentModelKey = agentModel
-    ? `${agentModel.providerId}/${agentModel.modelId}`
-    : null;
-  const prevAgentModelKeyRef = useRef(agentModelKey);
-  useEffect(() => {
-    const prevAgentModelKey = prevAgentModelKeyRef.current;
-    prevAgentModelKeyRef.current = agentModelKey;
-    // Only reset across two concrete, different agent models. Transitions
-    // to/from null (agent list still loading after a remount, or no agent
-    // selected) must not wipe the persisted override.
-    if (
-      prevAgentModelKey !== null &&
-      agentModelKey !== null &&
-      prevAgentModelKey !== agentModelKey
-    ) {
-      setSelectedModelSelection({ kind: "auto" });
-      setExpanded(false);
-    }
-  }, [agentModelKey, setSelectedModelSelection]);
 
   const { models, isModelsLoading } = useModels({
     owner,

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -77,7 +77,7 @@ export interface ProviderGroup {
   models: { model: ModelConfigurationType; efforts: ReasoningEffort[] }[];
 }
 
-export type Selection =
+export type ModelSelection =
   | { kind: "auto" }
   | { kind: "model"; model: ModelConfigurationType; effort: ReasoningEffort };
 
@@ -112,7 +112,9 @@ export function getModelWithReasoningEffortKey(
   return `${providerId}/${modelId}/${effort}`;
 }
 
-export function getModelWithReasoningEffortLabel(selection: Selection): string {
+export function getModelWithReasoningEffortLabel(
+  selection: ModelSelection
+): string {
   if (selection.kind === "auto") {
     return "Auto";
   }
@@ -126,8 +128,8 @@ export function getModelWithReasoningEffortLabel(selection: Selection): string {
 }
 
 // Converts the picker's local selection into the API model selection
-export function toModelSelection(
-  selection: Selection
+export function convertModelSelection(
+  selection: ModelSelection
 ): ModelSelectionType | undefined {
   switch (selection.kind) {
     case "auto":

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -200,5 +200,6 @@ export function getLightAgentMessageFromAgentMessage(
     costCredits: agentMessage.costCredits,
     subAgentCostCredits: agentMessage.subAgentCostCredits,
     activitySteps: [],
+    requestedModel: agentMessage.requestedModel,
   };
 }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -388,6 +388,10 @@ export type LightAgentMessageType = BaseAgentMessageType & {
   citations: Record<string, CitationType>;
   generatedFiles: Omit<ActionGeneratedFileType, "snippet">[];
   activitySteps: InlineActivityStep[];
+  // Per-message model override from the input-bar model picker: the resolved
+  // model. Null/undefined when the agent ran its own configured model. Optional
+  // during rollout. See [BACK12].
+  requestedModel?: ResolvedRequestedModel | null;
 };
 
 // This type represents the agent message we can reconstruct by accumulating streaming events


### PR DESCRIPTION
## Description

Builds on the input-bar model picker. Three related changes so that a per-message model override behaves like the agent selection and stays visible:

- **Persist the picker selection across messages.** The model-picker selection now lives in `InputBarContext` (like the sticky agent) instead of local component state, so it no longer resets to "Auto" when the input bar remounts (sending a message, navigating between conversations). Removed the now-redundant `onModelSelectionChange` callback chain — the context is the single source of truth, read at submit time.
- **Show the model used on the agent message header.** When a message ran on a per-message override, the message header now displays `with <model>` (e.g. "with GPT 5.5 High") next to the agent name, in a muted style. This required threading the already-existing `requestedModel` through `getLightAgentMessageFromAgentMessage` and adding it (optional) to `LightAgentMessageType`.
- **Restore the picker from the conversation on reload.** On loading an existing conversation, the picker is seeded from the model the latest agent message ran on (its `requestedModel`, or "Auto" if none), mirroring how the sticky agent is re-derived from history. Applied once per conversation so it does not clobber the user's manual picker changes.

## Tests

Manual, in an existing conversation with the `models_picker` flag enabled:
- Pick a model override, send several messages → picker keeps the override (does not reset to Auto).
- Each agent message that ran on an override shows "with <model>" next to the agent name.
- Reload the page → picker is set to the latest message's model; a conversation whose last message ran on the agent's own model shows "Auto".
