### PR TITLE
[front] feat: add litestream and pod-state layout to sandbox image

### DIFF
--- a/front/lib/api/sandbox/hardening.ts
+++ b/front/lib/api/sandbox/hardening.ts
@@ -40,6 +40,9 @@ export const SANDBOX_STATIC_ROOT_CONSUMED_DIRS = [
 export const SANDBOX_ROOT_INVOKED_HELPERS = [
   "/opt/bin/dsbx",
   "/usr/local/bin/dust-install-trust-bundle",
+  // Root invokes litestream on the pod-state sleep barrier (`litestream sync
+  // -wait`) and cold-start restore, so it must stay root-owned/non-writable.
+  "/opt/bin/litestream",
 ] as const;
 
 const ROOT_SAFE_PATH_PROFILE = "/etc/profile.d/zz-dust-root-safe-path.sh";

--- a/front/lib/api/sandbox/image/bun_build.ts
+++ b/front/lib/api/sandbox/image/bun_build.ts
@@ -1,0 +1,102 @@
+import { spawnSync } from "child_process";
+import { createHash } from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const BUN_BUILD_CACHE = new Map<string, Buffer>();
+
+function isENOENT(err: Error | undefined): err is NodeJS.ErrnoException {
+  return err !== undefined && "code" in err && err.code === "ENOENT";
+}
+
+function walkFiles(dir: string): string[] {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules") {
+          return [];
+        }
+        return walkFiles(entryPath);
+      }
+      return [entryPath];
+    })
+    .sort();
+}
+
+function getSourceHash(srcDir: string, extraFiles: readonly string[]): string {
+  const hash = createHash("sha256");
+  for (const filePath of [...walkFiles(srcDir), ...extraFiles]) {
+    hash.update(path.relative(srcDir, filePath));
+    hash.update("\0");
+    hash.update(fs.readFileSync(filePath));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+interface BunBuildOptions {
+  /** Artifact name used in error messages, e.g. "the sandbox dust-tools binary". */
+  name: string;
+  entrypoint: string;
+  /** Source directory whose content (with extraHashFiles) forms the cache key. */
+  srcDir: string;
+  /** Files outside srcDir that must invalidate the cache, e.g. a package.json. */
+  extraHashFiles?: readonly string[];
+  cwd: string;
+  /** `bun build` flags, e.g. --compile or --bundle plus their targets. */
+  bunArgs: readonly string[];
+}
+
+/**
+ * Runs `bun build` on the entrypoint and returns the output file, cached per
+ * process on a content hash of the sources so repeated image builds do not
+ * rebuild unchanged artifacts.
+ */
+export function runCachedBunBuild({
+  name,
+  entrypoint,
+  srcDir,
+  extraHashFiles = [],
+  cwd,
+  bunArgs,
+}: BunBuildOptions): Buffer {
+  const cacheKey = `${name}:${getSourceHash(srcDir, extraHashFiles)}`;
+  const cached = BUN_BUILD_CACHE.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dust-bun-build-"));
+  const outputPath = path.join(tempDir, "output");
+
+  try {
+    const result = spawnSync(
+      "bun",
+      ["build", ...bunArgs, entrypoint, "--outfile", outputPath],
+      { cwd, encoding: "utf8" }
+    );
+
+    if (isENOENT(result.error)) {
+      throw new Error(
+        `bun is required to build ${name}, but it was not found on PATH`
+      );
+    }
+
+    if (result.status !== 0) {
+      throw new Error(
+        `Failed to build ${name} with bun: ${
+          result.stderr || result.stdout || "unknown error"
+        }`
+      );
+    }
+
+    const output = fs.readFileSync(outputPath);
+    BUN_BUILD_CACHE.set(cacheKey, output);
+    return output;
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}

--- a/front/lib/api/sandbox/image/litestream/litestream.service
+++ b/front/lib/api/sandbox/image/litestream/litestream.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Dust Litestream replication daemon for pod state
+After=network.target
+
+[Service]
+User=dust-state
+Group=dust-state
+ExecStart=/opt/bin/litestream replicate -config /etc/litestream.yml
+Restart=always
+RestartSec=2s
+
+# Control socket directory (/run/litestream), created by systemd as
+# dust-state. The pre-sleep `litestream sync -wait` runs against the socket
+# in there; the socket is enabled by the static /etc/litestream.yml baked at
+# image build (directory-watcher config over /pod-state/databases).
+RuntimeDirectory=litestream
+RuntimeDirectoryMode=0755
+
+# Defense in depth, modeled on dust-egress-resolver.service. The daemon only
+# needs rw under /pod-state (live databases + replica gcsfuse mount); the
+# control socket is AF_UNIX and the file replica needs no network.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ReadWritePaths=/pod-state
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/front/lib/api/sandbox/image/litestream/litestream.yml
+++ b/front/lib/api/sandbox/image/litestream/litestream.yml
@@ -1,0 +1,24 @@
+# Managed by Dust. Static config: every path is a fixed constant of the
+# pod-state layout, so it is baked at image build. The litestream.service unit
+# stays disabled at build and is started by front at runtime AFTER the replica
+# gcsfuse mount and the cold-start restore — starting at boot would let the
+# daemon write to the unmounted local directory and manage files mid-restore.
+
+# Control socket for the pre-sleep `litestream sync -wait`. Lives in the
+# unit's RuntimeDirectory (unix socket paths are capped ~104 chars).
+socket:
+  enabled: true
+  path: /run/litestream/litestream.sock
+
+# Directory watcher (verified on v0.5.13): databases created after daemon
+# start — e.g. by a publish-time `dsbx db reconcile` — are discovered and
+# replicated within seconds. Non-SQLite files matching the pattern are
+# ignored by the watcher (header validation). Replica subdirectories are
+# named by database FILENAME: /pod-state/replica/{db}.db/ltx/...
+dbs:
+  - dir: /pod-state/databases
+    pattern: "*.db"
+    watch: true
+    replica:
+      type: file
+      path: /pod-state/replica

--- a/front/lib/api/sandbox/image/pod_package.test.ts
+++ b/front/lib/api/sandbox/image/pod_package.test.ts
@@ -1,0 +1,29 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import {
+  getPodPackageSrcDir,
+  POD_PACKAGE_IMAGE_DIR,
+} from "@app/lib/api/sandbox/image/pod_package";
+import { describe, expect, test } from "vitest";
+
+describe("pod package build paths", () => {
+  test("resolves the @dust/pod source dir under the repo root", () => {
+    // cli/dust-sandbox/pod itself lands in a parallel stack, so assert the
+    // resolution through markers that exist in every checkout: the repo root
+    // must contain front/ (where this test runs from) and cli/dust-sandbox/
+    // (the parent of the pod package).
+    const srcDir = getPodPackageSrcDir();
+    // pod → dust-sandbox → cli → repo root.
+    const repoRoot = path.dirname(path.dirname(path.dirname(srcDir)));
+
+    expect(srcDir.endsWith("cli/dust-sandbox/pod")).toBe(true);
+    expect(existsSync(path.join(repoRoot, "front", "package.json"))).toBe(true);
+    expect(existsSync(path.join(repoRoot, "cli", "dust-sandbox"))).toBe(true);
+  });
+
+  test("targets the @dust scope inside the global node_modules", () => {
+    expect(POD_PACKAGE_IMAGE_DIR).toBe(
+      "/opt/npm-global/lib/node_modules/@dust/pod"
+    );
+  });
+});

--- a/front/lib/api/sandbox/image/pod_package.ts
+++ b/front/lib/api/sandbox/image/pod_package.ts
@@ -1,0 +1,81 @@
+import { runCachedBunBuild } from "@app/lib/api/sandbox/image/bun_build";
+import fs from "fs";
+import path from "path";
+
+// @dust/pod is the pod-state runtime package exposed to sandbox function
+// code: db(name) returns a handle on one of the pod's SQLite databases
+// (bun:sqlite). The @dust scope is never published to npm, so the package is
+// vendored at image build time: bun-bundle the entrypoint (dependencies stay
+// external and resolve through NODE_PATH, like zod) and copy a flat
+// {package.json, index.js} into the image's global node_modules.
+export const POD_PACKAGE_NAME = "@dust/pod";
+export const POD_PACKAGE_VERSION = "0.1.0";
+export const POD_PACKAGE_IMAGE_DIR = `/opt/npm-global/lib/node_modules/${POD_PACKAGE_NAME}`;
+
+let podPackageSrcDir: string | undefined;
+
+/**
+ * The @dust/pod source lives at cli/dust-sandbox/pod, resolved by walking up
+ * from this file to the first ancestor containing cli/dust-sandbox instead of
+ * counting `..` segments. Lazy on purpose: the repo layout exists where
+ * images are built, not necessarily where front is deployed.
+ */
+export function getPodPackageSrcDir(): string {
+  if (podPackageSrcDir) {
+    return podPackageSrcDir;
+  }
+
+  let dir = __dirname;
+  while (!fs.existsSync(path.join(dir, "cli", "dust-sandbox"))) {
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error(
+        `Could not resolve the repo root: no ancestor of ${__dirname} contains cli/dust-sandbox`
+      );
+    }
+    dir = parent;
+  }
+
+  podPackageSrcDir = path.join(dir, "cli", "dust-sandbox", "pod");
+  return podPackageSrcDir;
+}
+
+function buildPackageJson(): string {
+  return `${JSON.stringify(
+    {
+      name: POD_PACKAGE_NAME,
+      version: POD_PACKAGE_VERSION,
+      private: true,
+      type: "module",
+      main: "index.js",
+    },
+    null,
+    2
+  )}\n`;
+}
+
+export function buildPodPackage(): Map<string, Buffer | string> {
+  const srcDir = getPodPackageSrcDir();
+  const entrypoint = path.join(srcDir, "index.ts");
+
+  // The source dir lands in a parallel PR. This generator only runs at image
+  // build time (content generators are lazy), so a missing dir must fail the
+  // build loudly rather than ship an image without the package.
+  if (!fs.existsSync(entrypoint)) {
+    throw new Error(`@dust/pod source not found at ${entrypoint}`);
+  }
+
+  return new Map<string, Buffer | string>([
+    ["package.json", buildPackageJson()],
+    [
+      "index.js",
+      runCachedBunBuild({
+        name: "the sandbox @dust/pod package",
+        entrypoint,
+        srcDir,
+        cwd: srcDir,
+        bunArgs: ["--bundle", "--target=bun", "--packages=external"],
+      }),
+    ],
+  ]);
+}

--- a/front/lib/api/sandbox/image/profile/build.ts
+++ b/front/lib/api/sandbox/image/profile/build.ts
@@ -1,94 +1,18 @@
-import { spawnSync } from "child_process";
-import { createHash } from "crypto";
-import fs from "fs";
-import os from "os";
+import { runCachedBunBuild } from "@app/lib/api/sandbox/image/bun_build";
 import path from "path";
 
-const PROFILE_LOCAL_DIR = __dirname;
-const PROFILE_SRC_DIR = path.join(PROFILE_LOCAL_DIR, "src");
+const PROFILE_SRC_DIR = path.join(__dirname, "src");
 const FRONT_ROOT_DIR = path.resolve(__dirname, "../../../../..");
 const DUST_TOOLS_ENTRYPOINT = path.join(PROFILE_SRC_DIR, "index.ts");
-const DUST_TOOLS_BINARY_CACHE = new Map<string, Buffer>();
-
-function isENOENT(err: Error | undefined): err is NodeJS.ErrnoException {
-  return err !== undefined && "code" in err && err.code === "ENOENT";
-}
-
-function walkFiles(dir: string): string[] {
-  return fs
-    .readdirSync(dir, { withFileTypes: true })
-    .flatMap((entry) => {
-      const entryPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        return walkFiles(entryPath);
-      }
-      return [entryPath];
-    })
-    .sort();
-}
-
-function getDustToolsBuildHash(): string {
-  const hash = createHash("sha256");
-  const files = [
-    ...walkFiles(PROFILE_SRC_DIR),
-    path.join(FRONT_ROOT_DIR, "package.json"),
-  ];
-
-  for (const filePath of files) {
-    hash.update(path.relative(FRONT_ROOT_DIR, filePath));
-    hash.update("\0");
-    hash.update(fs.readFileSync(filePath));
-    hash.update("\0");
-  }
-
-  return hash.digest("hex");
-}
 
 export function buildDustToolsBinary(): Buffer {
-  const buildHash = getDustToolsBuildHash();
-  const cached = DUST_TOOLS_BINARY_CACHE.get(buildHash);
-  if (cached) {
-    return cached;
-  }
-
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dust-tools-build-"));
-  const outputPath = path.join(tempDir, "dust-tools");
-
-  try {
-    const result = spawnSync(
-      "bun",
-      [
-        "build",
-        "--compile",
-        "--target=bun-linux-x64",
-        DUST_TOOLS_ENTRYPOINT,
-        "--outfile",
-        outputPath,
-      ],
-      {
-        cwd: FRONT_ROOT_DIR,
-        encoding: "utf8",
-      }
-    );
-
-    if (isENOENT(result.error)) {
-      throw new Error(
-        "bun is required to build the sandbox dust-tools binary, but it was not found on PATH"
-      );
-    }
-
-    if (result.status !== 0) {
-      throw new Error(
-        `Failed to build sandbox dust-tools binary with bun: ${
-          result.stderr || result.stdout || "unknown error"
-        }`
-      );
-    }
-
-    const binary = fs.readFileSync(outputPath);
-    DUST_TOOLS_BINARY_CACHE.set(buildHash, binary);
-    return binary;
-  } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  }
+  return runCachedBunBuild({
+    name: "the sandbox dust-tools binary",
+    entrypoint: DUST_TOOLS_ENTRYPOINT,
+    srcDir: PROFILE_SRC_DIR,
+    // Dependency bumps in front change the compiled binary.
+    extraHashFiles: [path.join(FRONT_ROOT_DIR, "package.json")],
+    cwd: FRONT_ROOT_DIR,
+    bunArgs: ["--compile", "--target=bun-linux-x64"],
+  });
 }

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -167,7 +167,7 @@ describe("sandbox image registry", () => {
       expect(command).toContain("/usr/bin/systemd-analyze unit-paths");
       expect(command).toContain("systemd unit path must be absolute");
       expect(command).toContain(
-        "for path in /opt/bin/dsbx /usr/local/bin/dust-install-trust-bundle"
+        "for path in /opt/bin/dsbx /usr/local/bin/dust-install-trust-bundle /opt/bin/litestream"
       );
       expect(command).toContain("empty-password local accounts must not exist");
       expect(command).toContain("privileged primary group");
@@ -348,6 +348,171 @@ describe("sandbox image registry", () => {
         ),
       ])
     );
+  });
+
+  test("installs the pinned litestream release to /opt/bin", () => {
+    const runCommands = getRunCommands(getDustBaseImageOperations());
+    const installCommand = runCommands.find((command) =>
+      command.includes("benbjohnson/litestream/releases/download")
+    );
+
+    expect(installCommand).toBeDefined();
+    expect(installCommand).toContain(
+      "https://github.com/benbjohnson/litestream/releases/download/v0.5.13/litestream-0.5.13-linux-x86_64.tar.gz"
+    );
+    expect(installCommand).toContain(
+      "chown root:root /opt/bin/litestream && chmod 755 /opt/bin/litestream"
+    );
+  });
+
+  test("creates the dust-state user and the pod-state directory layout", () => {
+    const runCommands = getRunCommands(getDustBaseImageOperations());
+
+    expect(runCommands).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "useradd --system --no-create-home --gid dust-state --groups agent --shell /usr/sbin/nologin dust-state"
+        ),
+        expect.stringContaining("install -d -o root -g root -m 755 /pod-state"),
+        expect.stringContaining(
+          "install -d -o dust-state -g agent -m 2770 /pod-state/databases"
+        ),
+        expect.stringContaining("setfacl -R -d -m g::rwx /pod-state/databases"),
+        expect.stringContaining("setfacl -R -m g::rwx /pod-state/databases"),
+        expect.stringContaining(
+          "install -d -o dust-state -g dust-state -m 700 /pod-state/replica"
+        ),
+      ])
+    );
+  });
+
+  test("copies the litestream systemd unit for runtime start only", () => {
+    const operations = getDustBaseImageOperations();
+    const runCommands = getRunCommands(operations);
+    const copyOperations = getCopyOperations(operations);
+    const litestreamUnit = getCopiedContent(
+      copyOperations,
+      "/etc/systemd/system/litestream.service"
+    );
+
+    expect(litestreamUnit).toContain(
+      "Description=Dust Litestream replication daemon for pod state"
+    );
+    expect(litestreamUnit).toContain("User=dust-state");
+    expect(litestreamUnit).toContain("Group=dust-state");
+    expect(litestreamUnit).toContain(
+      "ExecStart=/opt/bin/litestream replicate -config /etc/litestream.yml"
+    );
+    expect(litestreamUnit).toContain("Restart=always");
+    expect(litestreamUnit).toContain("RuntimeDirectory=litestream");
+    expect(litestreamUnit).toContain("NoNewPrivileges=yes");
+    expect(litestreamUnit).toContain("ProtectSystem=strict");
+    expect(litestreamUnit).toContain("ReadWritePaths=/pod-state");
+    expect(litestreamUnit).toContain("RestrictAddressFamilies=AF_UNIX");
+    expect(litestreamUnit).toContain("MemoryDenyWriteExecute=yes");
+
+    // The unit must NOT be enabled at build: front starts the daemon at
+    // runtime AFTER the replica mount + restore. Enabled at boot, the daemon
+    // would write to the unmounted local replica dir (the silent-unmount
+    // failure mode) and manage files mid-restore.
+    const enableCommands = runCommands.filter((command) =>
+      command.includes("systemctl enable")
+    );
+    expect(enableCommands.length).toBeGreaterThan(0);
+    for (const command of enableCommands) {
+      expect(command).not.toContain("litestream");
+    }
+  });
+
+  test("bakes the static litestream directory-watcher config", () => {
+    const copyOperations = getCopyOperations(getDustBaseImageOperations());
+    const litestreamConfig = getCopiedContent(
+      copyOperations,
+      "/etc/litestream.yml"
+    );
+
+    // Control socket for the pre-sleep `litestream sync -wait`.
+    expect(litestreamConfig).toContain("socket:");
+    expect(litestreamConfig).toContain("enabled: true");
+    expect(litestreamConfig).toContain("path: /run/litestream/litestream.sock");
+
+    // Directory watcher: post-cold-start databases are discovered
+    // automatically; the replica subdir is named by db FILENAME ({db}.db).
+    expect(litestreamConfig).toContain("dir: /pod-state/databases");
+    expect(litestreamConfig).toContain('pattern: "*.db"');
+    expect(litestreamConfig).toContain("watch: true");
+    expect(litestreamConfig).toContain("type: file");
+    expect(litestreamConfig).toContain("path: /pod-state/replica");
+  });
+
+  test("pins drizzle packages and vendors @dust/pod", () => {
+    const operations = getDustBaseImageOperations();
+    const runCommands = getRunCommands(operations);
+    const copyOperations = getCopyOperations(operations);
+    const image = getDustBaseImage();
+
+    expect(runCommands).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "npm install -g typescript tsx pptxgenjs@4.0.1 zod@4.4.3 drizzle-orm@0.45.2 drizzle-kit@0.31.10"
+        ),
+        expect.stringContaining(
+          "mkdir -p /opt/npm-global/lib/node_modules/@dust"
+        ),
+      ])
+    );
+
+    // Vendored copy of @dust/pod. Do NOT materialize the content here: the
+    // generator bun-builds cli/dust-sandbox/pod, which is written by a
+    // parallel track and may be absent in this checkout.
+    const podCopy = copyOperations.find(
+      (operation) =>
+        operation.dest === "/opt/npm-global/lib/node_modules/@dust/pod"
+    );
+    expect(podCopy).toBeDefined();
+    expect(podCopy?.src.type).toBe("content");
+
+    expect(image.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "drizzle-orm", version: "0.45.2" }),
+        expect.objectContaining({ name: "drizzle-kit", version: "0.31.10" }),
+        expect.objectContaining({ name: "@dust/pod", version: "0.1.0" }),
+      ])
+    );
+  });
+
+  test("runs pod-state install ops before the final hardening re-run", () => {
+    const runCommands = getRunCommands(getDustBaseImageOperations());
+    const lastHardeningIndex = runCommands.reduce(
+      (last, command, index) =>
+        command.includes("sudo must not be installed in sandbox images")
+          ? index
+          : last,
+      -1
+    );
+    const litestreamIndex = runCommands.findIndex((command) =>
+      command.includes("benbjohnson/litestream/releases/download")
+    );
+    const podStateIndex = runCommands.findIndex((command) =>
+      command.includes("install -d -o dust-state -g agent -m 2770")
+    );
+    const drizzleIndex = runCommands.findIndex((command) =>
+      command.includes("drizzle-orm@0.45.2")
+    );
+    const podPackageMkdirIndex = runCommands.findIndex((command) =>
+      command.includes("mkdir -p /opt/npm-global/lib/node_modules/@dust")
+    );
+
+    expect(lastHardeningIndex).toBeGreaterThanOrEqual(0);
+    for (const index of [
+      litestreamIndex,
+      podStateIndex,
+      drizzleIndex,
+      podPackageMkdirIndex,
+    ]) {
+      expect(index).toBeGreaterThanOrEqual(0);
+      expect(index).toBeLessThan(lastHardeningIndex);
+    }
   });
 
   test("keeps the nftables UID filter aligned with untrusted sandbox UIDs", () => {

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -2,6 +2,12 @@ import {
   getLocalAccountPrivilegeHardeningCommand,
   getRootConsumedPathHardeningCommand,
 } from "@app/lib/api/sandbox/hardening";
+import {
+  buildPodPackage,
+  POD_PACKAGE_IMAGE_DIR,
+  POD_PACKAGE_NAME,
+  POD_PACKAGE_VERSION,
+} from "@app/lib/api/sandbox/image/pod_package";
 import { PROFILE_DIR } from "@app/lib/api/sandbox/image/profile";
 import { buildDustToolsBinary } from "@app/lib/api/sandbox/image/profile/build";
 import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
@@ -39,7 +45,11 @@ const BUN_VERSION = "1.3.14";
 // machine and not another. This assumes an Ubuntu base and build-time egress to
 // launchpad.net; if PPAs are blocked, install the TDF .deb bundle instead.
 const LIBREOFFICE_PPA = "ppa:libreoffice/ppa";
+// Litestream (Apache-2.0) replicates the pod-state SQLite databases to the
+// GCS replica mount.
+const LITESTREAM_VERSION = "0.5.13";
 const EGRESS_LOCAL_DIR = path.resolve(__dirname, "egress");
+const LITESTREAM_LOCAL_DIR = path.resolve(__dirname, "litestream");
 const PROFILE_LOCAL_DIR = path.resolve(__dirname, "profile");
 const TELEMETRY_LOCAL_DIR = path.resolve(__dirname, "telemetry");
 
@@ -199,6 +209,35 @@ function getEgressResolverUserSetupCommand(): string {
   ].join(" && ");
 }
 
+function getDustStateUserSetupCommand(): string {
+  // dust-state runs the litestream replication daemon (pod state). Primary
+  // group dust-state owns the replica mount point; supplementary membership
+  // in `agent` grants rw on the live databases dir shared with agent-proxied
+  // function code. Deliberately NOT in SANDBOX_UNTRUSTED_UIDS: it never
+  // executes workload code.
+  return [
+    "groupadd --system dust-state",
+    "useradd --system --no-create-home --gid dust-state --groups agent --shell /usr/sbin/nologin dust-state",
+  ].join(" && ");
+}
+
+function getPodStateSetupCommand(): string {
+  // /pod-state/databases holds the live SQLite files: both agent-proxied
+  // function code (group agent) and the litestream daemon (user dust-state)
+  // need rw, so it gets the same setgid + default-ACL treatment as /files.
+  // /pod-state/replica is the gcsfuse mount point for the litestream replica
+  // — the durable copy of pod state. Untrusted workload code must never read
+  // or tamper with it, so the directory is dust-state-only: 0700 here, no
+  // allow_other on the runtime mount.
+  return [
+    "install -d -o root -g root -m 755 /pod-state",
+    "install -d -o dust-state -g agent -m 2770 /pod-state/databases",
+    "setfacl -R -d -m g::rwx /pod-state/databases",
+    "setfacl -R -m g::rwx /pod-state/databases",
+    "install -d -o dust-state -g dust-state -m 700 /pod-state/replica",
+  ].join(" && ");
+}
+
 function getSshHardeningCommand(): string {
   // Layered on purpose, not redundant. `AllowUsers agent` is the load-bearing
   // lock (whitelist). The other lines defend the case where a future bedrock
@@ -279,6 +318,8 @@ SHELLEOF`,
   )
   .runCmd("chmod 755 /home/agent/.bin/token-server.sh", { user: "root" })
   .runCmd(getEgressResolverUserSetupCommand(), { user: "root" })
+  .runCmd(getDustStateUserSetupCommand(), { user: "root" })
+  .runCmd(getPodStateSetupCommand(), { user: "root" })
   // Hidden tools: installed but not in manifest (back profile functions)
   .runCmd("apt-get update && apt-get install -y ripgrep fd-find sd", {
     user: "root",
@@ -372,8 +413,25 @@ SHELLEOF`,
         description: "Schema validation (sandbox function contracts)",
         runtime: "node",
       },
+      {
+        name: "drizzle-orm",
+        version: "0.45.2",
+        description:
+          "SQLite ORM (pod database schema files and function queries)",
+        runtime: "node",
+      },
+      {
+        name: "drizzle-kit",
+        version: "0.31.10",
+        description:
+          "Schema push/pull engine (used by dsbx db commands, not function code)",
+        runtime: "node",
+      },
     ],
-    { installCmd: "npm install -g typescript tsx pptxgenjs@4.0.1 zod@4.4.3" }
+    {
+      installCmd:
+        "npm install -g typescript tsx pptxgenjs@4.0.1 zod@4.4.3 drizzle-orm@0.45.2 drizzle-kit@0.31.10",
+    }
   )
   .runCmd(
     `curl -fsSL https://github.com/dust-tt/dust/releases/download/dsbx-v${DSBX_CLI_VERSION}/dsbx-linux-x86_64 -o /tmp/dsbx && ` +
@@ -420,6 +478,43 @@ SHELLEOF`,
   .registerTool({
     name: "bun",
     description: "Fast JavaScript/TypeScript runtime and package manager",
+    runtime: "node",
+  })
+  .runCmd(
+    `curl -fsSL https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-${LITESTREAM_VERSION}-linux-x86_64.tar.gz -o /tmp/litestream.tar.gz && ` +
+      "tar -xzf /tmp/litestream.tar.gz -C /tmp litestream && " +
+      "rm /tmp/litestream.tar.gz && " +
+      "mv /tmp/litestream /opt/bin/litestream && " +
+      "chown root:root /opt/bin/litestream && chmod 755 /opt/bin/litestream",
+    { user: "root" }
+  )
+  // Litestream unit + STATIC config (all paths are pod-state contract
+  // constants), both baked at build. The unit is deliberately NOT enabled:
+  // front starts it at runtime AFTER the replica gcsfuse mount and the
+  // cold-start restore — at boot the daemon would write to the unmounted
+  // local directory (the silent-unmount failure mode) and manage files
+  // mid-restore.
+  .copy(
+    getLocalContent(LITESTREAM_LOCAL_DIR, "litestream.service"),
+    "/etc/systemd/system/litestream.service",
+    { user: "root" }
+  )
+  .copy(
+    getLocalContent(LITESTREAM_LOCAL_DIR, "litestream.yml"),
+    "/etc/litestream.yml",
+    { user: "root" }
+  )
+  // Vendor @dust/pod into the global node_modules (see pod_package.ts for why
+  // this is a build-time copy rather than an npm install).
+  .runCmd(`mkdir -p ${path.posix.dirname(POD_PACKAGE_IMAGE_DIR)}`, {
+    user: "root",
+  })
+  .copy(buildPodPackage, POD_PACKAGE_IMAGE_DIR, { user: "root" })
+  .registerTool({
+    name: POD_PACKAGE_NAME,
+    version: POD_PACKAGE_VERSION,
+    description:
+      "Pod database access: db(name) returns a drizzle instance over the pod's SQLite database",
     runtime: "node",
   })
   .runCmd(`mkdir -p ${PROFILE_DIR}`, { user: "root" })

--- a/front/scripts/sandbox_security_check.test.ts
+++ b/front/scripts/sandbox_security_check.test.ts
@@ -7,6 +7,7 @@ import {
   assertNoEmptyPasswordAccounts,
   assertNoPasswordlessSudoers,
   assertNoPrivilegedGroupMembers,
+  assertPodStateDirsSafe,
   assertRootInvokedHelpersSafe,
   assertRootPathSafe,
   assertStaticRootConsumedDirsSafe,
@@ -146,19 +147,57 @@ describe("sandbox security check assertions", () => {
   test("detects unsafe root-invoked helper ownership or modes", () => {
     expect(() =>
       assertRootInvokedHelpersSafe(
-        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x"
+        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x\n/opt/bin/litestream root:root 755 -rwxr-xr-x"
       )
     ).not.toThrow();
     expect(() =>
       assertRootInvokedHelpersSafe(
-        "/opt/bin/dsbx root:root 777 -rwxrwxrwx\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x"
+        "/opt/bin/dsbx root:root 777 -rwxrwxrwx\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x\n/opt/bin/litestream root:root 755 -rwxr-xr-x"
       )
     ).toThrow("root-invoked helper is not root-owned");
     expect(() =>
-      assertRootInvokedHelpersSafe("/opt/bin/dsbx root:root 755 -rwxr-xr-x")
+      assertRootInvokedHelpersSafe(
+        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/opt/bin/litestream root:root 755 -rwxr-xr-x"
+      )
     ).toThrow(
       "missing root-invoked helper audit for /usr/local/bin/dust-install-trust-bundle"
     );
+    expect(() =>
+      assertRootInvokedHelpersSafe(
+        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x"
+      )
+    ).toThrow("missing root-invoked helper audit for /opt/bin/litestream");
+  });
+
+  test("detects unsafe pod-state directory ownership or modes", () => {
+    const safeOutput = [
+      "POD_STATE_DIR=/pod-state root:root 755 drwxr-xr-x",
+      "POD_STATE_DIR=/pod-state/databases dust-state:agent 2770 drwxrws---",
+      "POD_STATE_DIR=/pod-state/replica dust-state:dust-state 700 drwx------",
+    ].join("\n");
+
+    expect(() => assertPodStateDirsSafe(safeOutput)).not.toThrow();
+    expect(() =>
+      assertPodStateDirsSafe(
+        safeOutput.replace(
+          "/pod-state/replica dust-state:dust-state 700",
+          "/pod-state/replica dust-state:dust-state 755"
+        )
+      )
+    ).toThrow("pod-state directory /pod-state/replica");
+    expect(() =>
+      assertPodStateDirsSafe(
+        safeOutput.replace(
+          "/pod-state/databases dust-state:agent 2770",
+          "/pod-state/databases agent:agent 2770"
+        )
+      )
+    ).toThrow("pod-state directory /pod-state/databases");
+    expect(() =>
+      assertPodStateDirsSafe(
+        "POD_STATE_DIR=/pod-state root:root 755 drwxr-xr-x"
+      )
+    ).toThrow("missing pod-state directory audit for /pod-state/databases");
   });
 
   test("detects root PATH entries that can resolve agent-writable binaries", () => {

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -567,6 +567,45 @@ export function assertRootInvokedHelpersSafe(output: string): void {
   }
 }
 
+const POD_STATE_DIR_EXPECTATIONS = [
+  { path: "/pod-state", owner: "root:root", mode: "755" },
+  { path: "/pod-state/databases", owner: "dust-state:agent", mode: "2770" },
+  { path: "/pod-state/replica", owner: "dust-state:dust-state", mode: "700" },
+] as const;
+
+export function assertPodStateDirsSafe(output: string): void {
+  const lineByPath = new Map<string, string>();
+  for (const line of output.split("\n")) {
+    if (!line.startsWith("POD_STATE_DIR=")) {
+      continue;
+    }
+    const [path] = line.replace("POD_STATE_DIR=", "").split(/\s+/, 1);
+    if (path) {
+      lineByPath.set(path, line);
+    }
+  }
+
+  for (const expectation of POD_STATE_DIR_EXPECTATIONS) {
+    const line = lineByPath.get(expectation.path);
+    if (!line) {
+      throw new Error(
+        `missing pod-state directory audit for ${expectation.path}:\n${output}`
+      );
+    }
+
+    const fields = line.replace("POD_STATE_DIR=", "").split(/\s+/);
+    const owner = fields[1];
+    const mode = fields[2];
+
+    if (owner !== expectation.owner || mode !== expectation.mode) {
+      throw new Error(
+        `pod-state directory ${expectation.path} must be ${expectation.owner} ` +
+          `mode ${expectation.mode}:\n${line}`
+      );
+    }
+  }
+}
+
 export function assertRootPathSafe(output: string): void {
   const rootPathLines = output
     .split("\n")
@@ -654,6 +693,12 @@ for path in ${SANDBOX_ROOT_INVOKED_HELPERS.map((path) => shellQuote(path)).join(
     stat -c '%n %U:%G %a %A' "$path"
   fi
 done
+echo "--- pod-state-dirs ---"
+for dir in ${POD_STATE_DIR_EXPECTATIONS.map((expectation) =>
+      shellQuote(expectation.path)
+    ).join(" ")}; do
+  stat -c 'POD_STATE_DIR=%n %U:%G %a %A' "$dir"
+done
 echo "--- root-path ---"
 printf 'ROOT_EXEC_PATH=%s\n' "$PATH"
 /bin/bash --noprofile --norc -c 'source /etc/profile; printf "ROOT_LOGIN_PATH=%s\n" "$PATH"'
@@ -669,6 +714,7 @@ printf 'ROOT_EXEC_PATH=%s\n' "$PATH"
   assertStaticRootConsumedDirsSafe(output);
   assertSystemdUnitPathsSafe(output);
   assertRootInvokedHelpersSafe(output);
+  assertPodStateDirsSafe(output);
   assertRootPathSafe(output);
 }
 
@@ -843,6 +889,63 @@ fi
   }
 }
 
+async function checkPodStateWorkloadAccess(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  // The live databases dir must be read-write for the workload user (function
+  // code opens SQLite files there), exercising the setgid + default-ACL
+  // inheritance like the /files smoke test does.
+  const databasesAccess = await runBashScript(
+    provider,
+    providerId,
+    `
+set -euo pipefail
+test -d /pod-state/databases
+proof=$(mktemp /pod-state/databases/dust-security-smoke-XXXXXX)
+printf 'db-ok' > "$proof"
+test "$(cat "$proof")" = "db-ok"
+rm -f "$proof"
+`,
+    { user: AGENT_PROXIED_USER }
+  );
+  assertCommandSucceeded(
+    "pod-state databases workload access",
+    databasesAccess
+  );
+
+  // The replica dir (gcsfuse mount point for the litestream file replica),
+  // the litestream binary, and the litestream unit must all be untouchable by
+  // uid 1003. This sandbox has no gcsfuse mount, so the replica probe covers
+  // the underlying 0700 directory; the mounted case is additionally protected
+  // by mounting without allow_other.
+  const denials = await runBashScript(
+    provider,
+    providerId,
+    `
+set -euo pipefail
+if ls /pod-state/replica >/dev/null 2>&1; then
+  echo "CRITICAL: workload user can list /pod-state/replica"
+  exit 1
+fi
+if touch /pod-state/replica/dust-security-proof 2>/dev/null; then
+  echo "CRITICAL: workload user can write /pod-state/replica"
+  exit 1
+fi
+if [ -w /opt/bin/litestream ]; then
+  echo "CRITICAL: workload user can write /opt/bin/litestream"
+  exit 1
+fi
+if printf '' >> /etc/systemd/system/litestream.service 2>/dev/null; then
+  echo "CRITICAL: workload user can write the litestream systemd unit"
+  exit 1
+fi
+`,
+    { user: AGENT_PROXIED_USER }
+  );
+  assertCommandSucceeded("pod-state workload denial probes", denials);
+}
+
 function assertSshAndDnsHardening(output: string): void {
   if (!output.includes("SSH_PORT_22_LISTENING=0")) {
     throw new Error(`sshd appears to be listening on port 22:\n${output}`);
@@ -950,6 +1053,7 @@ async function checkImage(image: SandboxImage): Promise<void> {
     await checkSshAndDnsHardening(provider, providerId);
     await checkRootExecPathHijack(provider, providerId);
     await checkSystemdUnitSearchPathShadow(provider, providerId);
+    await checkPodStateWorkloadAccess(provider, providerId);
 
     logger.info(
       { imageId, providerId },


### PR DESCRIPTION
## Description

🪨 Img foundations for app/pod state db

- **litestream v0.5.13 binary** at `/opt/bin/litestream` (root:root 755).
- **`dust-state` system user** (primary group `dust-state`, supplementary `agent`, nologin) runs the replication daemon. **3-location split** of `/pod-state`:
  - `/pod-state/databases`: live SQLite files, `dust-state:agent` 2770 + default ACLs (same hardening block as `/files`): uid-1003 function code and the daemon both need rw. SQLite never touches gcsfuse.
  - `/pod-state/replica`: gcsfuse mount point for the litestream file replica, `dust-state:dust-state` 0700: must be invisible to the workload.
- **`litestream.service`** (User=dust-state, Restart=always, hardening modeled on dust-egress-resolver.service) + a **static `/etc/litestream.yml`** using litestream's **directory watcher** (`dir` + `pattern: "*.db"` + `watch: true`): databases created at any point, including publish-time `dsbx db reconcile` are discovered and replicated within seconds. The unit is **deliberately not enabled at boot**: front starts it at runtime after the replica mount + restore at boot the daemon would write to the unmounted local directory (the design's silent-unmount failure mode) and manage files mid-restore. Also, because we're still sharing imgs between pod/conv sandboxes, so conv would be paying for something they're not using.

- **npm pins** `drizzle-orm@0.45.2` / `drizzle-kit@0.31.10`, and **`@dust/pod` vendored** by a build-time bun bundle into `/opt/npm-global/lib/node_modules/@dust/pod

- no need to killswitch since no-op 

## Tests

- `registry.test.ts` (17): version/sha pins, dust-state user, `/pod-state` modes + ACLs, unit content + **not-enabled-at-boot**, static watcher-config content, all new ops ordered **before** the final hardening re-run.
- `pod_package.test.ts` (2): repo-root resolution pinned against markers (the source dir lands in a sibling PR).
- `sandbox_security_check` unit tests (12) + new **live probes** run by CI against the built template: `/pod-state` ownership audit, uid-1003 rw on `databases/`, uid-1003 denied on `replica/`, litestream binary + unit not workload-writable.

Manually tested using this script

<details><summary>Manually tested using this script (from the top of the stack)</summary>
<p>

```typescript

import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
import { createSpaceAndGroup } from "@app/lib/api/spaces";
import { Authenticator } from "@app/lib/auth";
import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
import { SpaceResource } from "@app/lib/resources/space_resource";
import { UserResource } from "@app/lib/resources/user_resource";
import { makeScript } from "@app/scripts/helpers";

// Operator-only: get or create a pod (project space) and boot its sandbox
// through ensurePodSandboxReady (GCS mounts + pod-state cold start), so the
// pod-state stream can be exercised live with scripts/sandbox_exec.ts without
// going through the product.
makeScript(
  {
    wId: {
      type: "string",
      demandOption: true,
      description: "Workspace sId",
    },
    userEmail: {
      type: "string",
      demandOption: true,
      description:
        "Email of the user to act as (becomes the pod editor on creation)",
    },
    podId: {
      type: "string",
      description: "Existing pod (project space) sId — reused when provided",
    },
    name: {
      type: "string",
      default: "pod-state-live-test",
      description: "Pod name to reuse or create when --podId is omitted",
    },
    fresh: {
      type: "boolean",
      default: false,
      description:
        "Kill any existing pod sandbox first so the run goes through the full cold start (mounts + pod-state restore only run on creation)",
    },
  },
  async ({ wId, userEmail, podId, name, fresh, execute }, logger) => {
    const user = await UserResource.fetchByEmail(userEmail);
    if (!user) {
      logger.error({ userEmail }, "User not found");
      return;
    }
    let auth = await Authenticator.fromUserIdAndWorkspaceId(user.sId, wId);

    let pod: SpaceResource | null = null;
    if (podId) {
      pod = await SpaceResource.fetchById(auth, podId);
      if (!pod || !pod.isProject()) {
        logger.error({ podId }, "Pod not found (or not a project space)");
        return;
      }
    } else {
      const spaces = await SpaceResource.listWorkspaceSpaces(auth, {
        includeProjectSpaces: true,
      });
      pod =
        spaces.find((space) => space.isProject() && space.name === name) ??
        null;
    }

    if (!execute) {
      logger.info(
        {
          pod: pod ? pod.sId : `(would create "${name}")`,
        },
        "Dry run — pass --execute to boot the pod sandbox"
      );
      return;
    }

    if (!pod) {
      const createResult = await createSpaceAndGroup(auth, {
        name,
        isRestricted: true,
        spaceKind: "project",
        managementMode: "manual",
        memberIds: [],
      });
      if (createResult.isErr()) {
        logger.error({ err: createResult.error }, "Pod creation failed");
        return;
      }
      logger.info({ podId: createResult.value.sId, name }, "Pod created");

      // createSpaceAndGroup grants the creator access through a NEW editor
      // group, but Authenticator snapshots group memberships at construction —
      // rebuild the auth and refetch the pod so canRead sees the membership.
      auth = await Authenticator.fromUserIdAndWorkspaceId(user.sId, wId);
      pod = await SpaceResource.fetchById(auth, createResult.value.sId);
      if (!pod) {
        logger.error(
          { podId: createResult.value.sId },
          "Pod created but could not be refetched"
        );
        return;
      }
    }

    if (!pod.canRead(auth)) {
      logger.error(
        { podId: pod.sId, userEmail },
        "User has no read access to this pod — pass a pod they are an editor of, or a fresh --name to create one"
      );
      return;
    }

    if (fresh) {
      const existing = await PodSandboxAdapter.fetchSandbox(auth, pod);
      if (existing) {
        // ensureActive's kill-requested branch destroys (running the
        // pre-destroy pod-state flush) and recreates — the same path an image
        // rollout takes.
        await existing.requestKill();
        logger.info(
          { e2bSandboxId: existing.providerId },
          "Existing sandbox marked for kill — it will be destroyed and recreated"
        );
      }
    }

    const readyResult = await ensurePodSandboxReady(auth, pod);
    if (readyResult.isErr()) {
      logger.error({ err: readyResult.error }, "ensurePodSandboxReady failed");
      return;
    }

    const { sandbox, freshlyCreated } = readyResult.value;
    if (!freshlyCreated) {
      logger.warn(
        {},
        "Reused a RUNNING sandbox: the GCS mounts and pod-state cold start only run on creation — rerun with --fresh to force the full lifecycle"
      );
    }
    logger.info(
      {
        podId: pod.sId,
        sandboxId: sandbox.sId,
        e2bSandboxId: sandbox.providerId,
        freshlyCreated,
      },
      `Pod sandbox ready — inspect it with: npx tsx scripts/sandbox_exec.ts -s ${sandbox.providerId}`
    );
  }
);


```

</p>
</details> 

## Risk

No-op so very low

## Deploy Plan

- deploy front