### PR TITLE
[front] feat: pod-state lifecycle

### DIFF
--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -1,0 +1,135 @@
+import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
+import {
+  buildMountCommand,
+  type GCSMountTarget,
+  GCSSandboxMountAdapter,
+} from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
+import { podSandboxOnlyMounts } from "@app/lib/api/sandbox/pod_mounts";
+import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
+import { beforeAll, describe, expect, test } from "vitest";
+
+function workloadTarget(
+  overrides: Partial<GCSMountTarget> = {}
+): GCSMountTarget {
+  return {
+    gcsPrefix: "w/ws1/pods/spc1/files",
+    sandboxMountPoint: "/files/pod-spc1",
+    legacySandboxMountPoint: "/files/pod",
+    readOnly: false,
+    mountProfile: "workload",
+    ...overrides,
+  };
+}
+
+describe("buildMountCommand", () => {
+  test("workload profile mounts as root with allow_other and permissive modes", () => {
+    const command = renderRootCommand(
+      buildMountCommand({ bucket: "bucket-x", target: workloadTarget() })
+    );
+
+    expect(command).toContain("/usr/bin/gcsfuse");
+    expect(command).not.toContain("runuser");
+    expect(command).toContain("-o allow_other");
+    expect(command).toContain("--file-mode=666");
+    expect(command).toContain("--dir-mode=777");
+    expect(command).toContain("--kernel-list-cache-ttl-secs=60");
+    expect(command).toContain("--only-dir w/ws1/pods/spc1/files");
+    expect(command).toContain("--enable-hns=false");
+    expect(command).toContain("bucket-x /files/pod-spc1");
+  });
+
+  test("workload profile adds ro for read-only targets", () => {
+    const command = renderRootCommand(
+      buildMountCommand({
+        bucket: "bucket-x",
+        target: workloadTarget({
+          gcsPrefix: "w/ws1/pods/spc1/sandbox-functions",
+          sandboxMountPoint: "/sandbox-functions/pods/spc1",
+          legacySandboxMountPoint: null,
+          readOnly: true,
+        }),
+      })
+    );
+
+    expect(command).toContain("-o allow_other,ro");
+  });
+
+  test("pod_state_replica profile mounts as dust-state without allow_other or list caching", () => {
+    const command = renderRootCommand(
+      buildMountCommand({
+        bucket: "bucket-x",
+        target: {
+          gcsPrefix: "w/ws1/pods/spc1/state",
+          sandboxMountPoint: "/pod-state/replica",
+          legacySandboxMountPoint: null,
+          readOnly: false,
+          mountProfile: "pod_state_replica",
+        },
+      })
+    );
+
+    // Mounted as dust-state: FUSE denies every other uid without allow_other,
+    // which is what keeps the replica invisible to the workload uid 1003.
+    expect(command).toContain(
+      "/usr/sbin/runuser -u dust-state -- /usr/bin/gcsfuse"
+    );
+    expect(command).not.toContain("allow_other");
+    // Restore must never see a cached LTX listing.
+    expect(command).toContain("--kernel-list-cache-ttl-secs=0");
+    expect(command).toContain("--file-mode=600");
+    expect(command).toContain("--dir-mode=700");
+    expect(command).toContain("--only-dir w/ws1/pods/spc1/state");
+    expect(command).toContain("--enable-hns=false");
+    expect(command).toContain("bucket-x /pod-state/replica");
+  });
+});
+
+describe("pod sandbox mount wiring", () => {
+  beforeAll(() => {
+    // Config reads used by createSandboxAdapter/getAccessBoundaryRules.
+    process.env.GOOGLE_CLOUD_PROJECT_ID ??= "test-project";
+    process.env.DUST_PRIVATE_UPLOADS_BUCKET ??= "test-private-uploads";
+  });
+
+  test("the real pod mount set produces the full 7-rule CAB grant including the state prefix", () => {
+    // Derived from the ACTUAL wiring (podSandboxOnlyMounts + the backend's
+    // prefix mapping) rather than hand-built prefixes, so dropping the state
+    // mount from the pod set — or regressing its prefix string — fails here.
+    const backend = new GCSFileSystemBackend("ws1", "test-private-uploads");
+    const adapter = backend.createSandboxAdapter(
+      [
+        {
+          kind: "pod",
+          id: "spc1",
+          scopedPrefix: "pod-spc1",
+          sandboxMountPoint: "/files/pod-spc1",
+          legacyPrefix: "project",
+          legacySandboxMountPoint: "/files/pod",
+          permissions: { canRead: true, canWrite: true },
+        },
+      ],
+      podSandboxOnlyMounts({ sId: "spc1" })
+    );
+
+    if (!(adapter instanceof GCSSandboxMountAdapter)) {
+      throw new Error("expected a GCSSandboxMountAdapter");
+    }
+
+    // 1 unconditional bucket-get rule + 2 rules per prefix × 3 prefixes
+    // (files rw, sandbox-functions ro, state rw) = 7, under the 10-rule CAB
+    // ceiling.
+    const rules = adapter.getAccessBoundaryRules();
+    expect(rules).toHaveLength(7);
+
+    const conditions = rules
+      .map((rule) =>
+        "availabilityCondition" in rule
+          ? rule.availabilityCondition.expression
+          : ""
+      )
+      .join("\n");
+    expect(conditions).toContain("w/ws1/pods/spc1/files/");
+    expect(conditions).toContain("w/ws1/pods/spc1/sandbox-functions/");
+    expect(conditions).toContain("w/ws1/pods/spc1/state/");
+  });
+});

--- a/front/lib/api/sandbox/db.test.ts
+++ b/front/lib/api/sandbox/db.test.ts
@@ -1,4 +1,5 @@
 import {
+  isFuseStatfsMagic,
   isValidPodDatabaseName,
   parseLiveDatabaseNames,
   parseReplicaDatabaseNames,
@@ -53,5 +54,16 @@ describe("pod state helpers", () => {
 
     expect(parseLiveDatabaseNames(findOutput)).toEqual(["chat", "tasks"]);
     expect(parseLiveDatabaseNames("")).toEqual([]);
+  });
+
+  test("recognizes the FUSE statfs magic", () => {
+    expect(isFuseStatfsMagic("65735546")).toBe(true);
+    expect(isFuseStatfsMagic("65735546\n")).toBe(true);
+    expect(isFuseStatfsMagic("65735546 ")).toBe(true);
+
+    // ext4 / overlayfs magics: the underlying directory after a clean unmount.
+    expect(isFuseStatfsMagic("ef53")).toBe(false);
+    expect(isFuseStatfsMagic("794c7630")).toBe(false);
+    expect(isFuseStatfsMagic("")).toBe(false);
   });
 });

--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -1,5 +1,9 @@
 import { getPodStateBasePath } from "@app/lib/api/files/mount_path";
-import { traceSandboxStartupPhase } from "@app/lib/api/sandbox/instrumentation";
+import {
+  recordPodStateHealth,
+  traceSandboxStartupPhase,
+} from "@app/lib/api/sandbox/instrumentation";
+import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
 import {
   type RootCommand,
   type RootCommandArg,
@@ -30,6 +34,11 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
  *    then start the litestream systemd unit — strictly in that order, so the
  *    watcher never manages files mid-restore or writes to an unmounted
  *    replica dir.
+ *  - Pre-sleep (`ensurePodStateHealthOnSleep`, before the provider pause):
+ *    verify the replica mount is a live FUSE mount and the daemon is active,
+ *    then `litestream sync -wait` each database so every committed WAL frame
+ *    is in GCS before the VM can be destroyed. On failure the sandbox is NOT
+ *    paused; the daemon is restarted and a failure metric is emitted.
  *  - Wake from pause needs nothing: the Firecracker snapshot preserves the
  *    daemon, its control socket, the mounts and the database files.
  */
@@ -43,14 +52,20 @@ export const POD_STATE_USER = "dust-state";
 
 const LITESTREAM_BIN = "/opt/bin/litestream";
 const LITESTREAM_UNIT_NAME = "litestream";
+// Short by necessity: unix socket paths are capped around 104 chars. Created
+// by the unit's RuntimeDirectory=litestream as dust-state; enabled by the
+// static /etc/litestream.yml baked at image build.
+const LITESTREAM_SOCKET_PATH = "/run/litestream/litestream.sock";
 
 const RUNUSER_BIN = "/usr/sbin/runuser";
 const SYSTEMCTL_BIN = "/usr/bin/systemctl";
 const SQLITE3_BIN = "/usr/bin/sqlite3";
 const FIND_BIN = "/usr/bin/find";
+const STAT_BIN = "/usr/bin/stat";
 const MV_BIN = "/usr/bin/mv";
 const RM_BIN = "/usr/bin/rm";
 const CHMOD_BIN = "/usr/bin/chmod";
+const HEAD_BIN = "/usr/bin/head";
 const TEST_BIN = "/usr/bin/test";
 
 // Database name shape. Doubles as an allowlist: enumeration outputs are
@@ -58,6 +73,19 @@ const TEST_BIN = "/usr/bin/test";
 // dirs, hostile names) is skipped.
 const POD_DATABASE_NAME_REGEX = /^[a-z][a-z0-9_]{0,63}$/;
 
+// First 15 bytes of every SQLite file ("SQLite format 3" — the trailing NUL of
+// the 16-byte magic is dropped so it survives stdout transport).
+const SQLITE_HEADER_MAGIC = "SQLite format 3";
+
+// FUSE_SUPER_MAGIC, as printed by `stat -f -c %t` (hex, no 0x prefix).
+// If you are wondering, it is a value in a enum used by statf libc to flag different filesystems (ext2,3,4, fuse etc.)
+// https://man7.org/linux/man-pages/man2/statfs.2.html
+const FUSE_STATFS_MAGIC_HEX = "65735546";
+
+// The pre-sleep sync runs inside the reaper's per-batch budget, so every exec
+// is tightly bounded.
+const SYNC_WAIT_TIMEOUT_SECONDS = 10;
+const SYNC_EXEC_TIMEOUT_MS = 15_000;
 // Cheap probes and file operations stay tightly bounded.
 const PROBE_EXEC_TIMEOUT_MS = 10_000;
 // Cold-start restore may pull a large snapshot + LTX chain through gcsfuse.
@@ -99,6 +127,11 @@ function parseFindBasenames(findOutput: string): string[] {
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
     .map((line) => line.slice(line.lastIndexOf("/") + 1));
+}
+
+/** True when `stat -f -c %t` output is the FUSE filesystem magic. */
+export function isFuseStatfsMagic(statOutput: string): boolean {
+  return statOutput.trim().toLowerCase() === FUSE_STATFS_MAGIC_HEX;
 }
 
 /**
@@ -360,6 +393,299 @@ async function startLitestreamDaemon(
     return new Err(execFailure("litestream daemon start", result.value));
   }
   return new Ok(undefined);
+}
+
+/**
+ * Pre-sleep health check (reaper sleep, pauseForApproval, and best-effort
+ * before kill-requested destroys): make sure every committed transaction
+ * reached the GCS replica before the VM is allowed to pause (and later be
+ * destroyed).
+ *
+ * Databases created after cold start are the directory watcher's job (static
+ * config, discovery within seconds); this only checks that the daemon is
+ * actually active (starting it when dead, e.g. after a half-failed cold
+ * start) and then syncs each live database.
+ *
+ * On any failure the caller must NOT pause. A failure health metric +
+ * logger.error with a stable message are emitted — Datadog monitors do the
+ * paging. A `SandboxNotFoundError` from the provider is treated as success:
+ * the sandbox is already gone, there is nothing left to sync, and exec already
+ * marked the row deleted.
+ */
+export async function ensurePodStateHealthOnSleep(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  opts: {
+    /**
+     * Rewrites /tmp/token.json. The sync flushes LTX files through gcsfuse,
+     * and a sandbox can sit idle past the CAB token's ~1h lifetime (reaper
+     * backlog): without a refresh the sync would fail on every retry,
+     * forever.
+     */
+    refreshMountCredential?: () => Promise<Result<void, Error>>;
+  } = {}
+): Promise<Result<void, Error>> {
+  const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
+  const childLogger = logger.child({
+    sandboxId: sandbox.sId,
+    workspaceId: ctx.workspaceId,
+  });
+
+  // 0. Fresh GCS credential for the flush below.
+  if (opts.refreshMountCredential) {
+    const refreshResult = await opts.refreshMountCredential();
+    if (refreshResult.isErr()) {
+      if (refreshResult.error instanceof SandboxNotFoundError) {
+        return new Ok(undefined);
+      }
+      recordPodStateHealth("failure", ctx);
+      childLogger.error(
+        { err: refreshResult.error },
+        "Pod state pre-sleep: GCS credential refresh failed — not pausing"
+      );
+      return refreshResult;
+    }
+  }
+
+  // 1. Mount liveness (statfs magic): a cleanly-unmounted replica path makes
+  // litestream write to the underlying local directory and SUCCEED silently,
+  // so a passing sync would be meaningless.
+  const livenessResult = await checkReplicaMountLiveness(auth, sandbox);
+  if (livenessResult.isErr()) {
+    if (livenessResult.error instanceof SandboxNotFoundError) {
+      return new Ok(undefined);
+    }
+    recordPodStateHealth("failure", ctx);
+    childLogger.error(
+      { err: livenessResult.error },
+      "Pod state pre-sleep: replica mount is not a live FUSE mount — not pausing"
+    );
+    return livenessResult;
+  }
+
+  // 2. Managed set: enumerate live databases, dropping files that are not
+  // real SQLite databases. The dir is deliberately workload-writable, so a
+  // planted garbage `.db` must be excluded (alerted) rather than allowed to
+  // wedge the pod's lifecycle with forever-failing syncs.
+  const namesResult = await listValidLiveDatabases(auth, sandbox, ctx);
+  if (namesResult.isErr()) {
+    if (namesResult.error instanceof SandboxNotFoundError) {
+      return new Ok(undefined);
+    }
+    recordPodStateHealth("failure", ctx);
+    childLogger.error(
+      { err: namesResult.error },
+      "Pod state pre-sleep: database enumeration failed — not pausing"
+    );
+    return namesResult;
+  }
+  const names = namesResult.value;
+
+  // 3. Daemon liveness: the sync below needs the control socket, and a dead
+  // or never-started daemon (e.g. a half-failed cold start) means nothing is
+  // replicating. Start it if needed — the static directory-watcher config is
+  // baked in the image, so a plain start recovers the full managed set.
+  const daemonResult = await ensureLitestreamDaemonActive(
+    auth,
+    sandbox,
+    childLogger
+  );
+  if (daemonResult.isErr()) {
+    if (daemonResult.error instanceof SandboxNotFoundError) {
+      return new Ok(undefined);
+    }
+    recordPodStateHealth("failure", ctx);
+    childLogger.error(
+      { err: daemonResult.error },
+      "Pod state pre-sleep: litestream daemon is not active — not pausing"
+    );
+    return daemonResult;
+  }
+
+  // 4. Sync each database through the daemon control socket.
+  for (const name of names) {
+    const dbPath = `${POD_STATE_DATABASES_DIR}/${name}.db`;
+    const syncResult = await sandbox.execRoot(
+      auth,
+      rootCommand.exec(LITESTREAM_BIN, [
+        "sync",
+        "-wait",
+        "-timeout",
+        SYNC_WAIT_TIMEOUT_SECONDS,
+        "-socket",
+        LITESTREAM_SOCKET_PATH,
+        "--",
+        dbPath,
+      ]),
+      { timeoutMs: SYNC_EXEC_TIMEOUT_MS }
+    );
+
+    const failure = syncResult.isErr()
+      ? syncResult.error
+      : syncResult.value.exitCode !== 0
+        ? execFailure(`litestream sync of ${name}`, syncResult.value)
+        : null;
+
+    if (failure) {
+      if (failure instanceof SandboxNotFoundError) {
+        return new Ok(undefined);
+      }
+      recordPodStateHealth("failure", ctx);
+      childLogger.error(
+        { err: failure, database: name },
+        "Pod state pre-sleep: litestream sync failed — restarting daemon, not pausing"
+      );
+      // Best-effort recovery; the reaper retries the whole check on its next
+      // cycle (status stays `running`). The config is static (baked at image
+      // build) and the directory watcher re-discovers every live database on
+      // start, so a plain restart recovers the full managed set.
+      await sandbox.execRoot(
+        auth,
+        rootCommand.exec(SYSTEMCTL_BIN, ["restart", LITESTREAM_UNIT_NAME]),
+        { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
+      );
+      return new Err(failure);
+    }
+  }
+
+  recordPodStateHealth("success", ctx);
+
+  return new Ok(undefined);
+}
+
+async function checkReplicaMountLiveness(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<void, Error>> {
+  // As dust-state: without allow_other the FUSE layer denies every other uid,
+  // including root. `stat -f -c %t` prints the statfs filesystem magic.
+  const result = await sandbox.execRoot(
+    auth,
+    asPodStateUser(STAT_BIN, ["-f", "-c", "%t", POD_STATE_REPLICA_MOUNT_POINT]),
+    { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
+  );
+  if (result.isErr()) {
+    return result;
+  }
+  if (result.value.exitCode !== 0) {
+    return new Err(execFailure("pod state replica statfs", result.value));
+  }
+  if (!isFuseStatfsMagic(result.value.stdout)) {
+    return new Err(
+      new Error(
+        `pod state replica mount point is not a FUSE mount (statfs magic: ${result.value.stdout.trim()})`
+      )
+    );
+  }
+  return new Ok(undefined);
+}
+
+async function listLiveDatabases(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<string[], Error>> {
+  const result = await sandbox.execRoot(
+    auth,
+    rootCommand.exec(FIND_BIN, [
+      POD_STATE_DATABASES_DIR,
+      "-mindepth",
+      "1",
+      "-maxdepth",
+      "1",
+      "-type",
+      "f",
+      "-name",
+      "*.db",
+    ]),
+    { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
+  );
+  if (result.isErr()) {
+    return result;
+  }
+  if (result.value.exitCode !== 0) {
+    return new Err(execFailure("pod state database enumeration", result.value));
+  }
+  return new Ok(parseLiveDatabaseNames(result.value.stdout));
+}
+
+/**
+ * Live databases whose file content starts with the SQLite header magic.
+ * /pod-state/databases is workload-writable by design, so enumeration output
+ * must be treated as untrusted: non-SQLite files are excluded from the
+ * managed set (with a warning log) instead of being handed to litestream,
+ * where they would fail every sync and wedge the pod's lifecycle. A valid
+ * header on a corrupt database still enters the set — its sync failure then
+ * blocks-and-alerts, which is the designed behavior for real corruption.
+ */
+async function listValidLiveDatabases(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  ctx: { workspaceId: string }
+): Promise<Result<string[], Error>> {
+  const namesResult = await listLiveDatabases(auth, sandbox);
+  if (namesResult.isErr()) {
+    return namesResult;
+  }
+
+  const valid: string[] = [];
+  for (const name of namesResult.value) {
+    const dbPath = `${POD_STATE_DATABASES_DIR}/${name}.db`;
+    const headResult = await sandbox.execRoot(
+      auth,
+      rootCommand.exec(HEAD_BIN, ["-c", "15", "--", dbPath]),
+      { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
+    );
+    if (headResult.isErr()) {
+      return headResult;
+    }
+    if (
+      headResult.value.exitCode === 0 &&
+      headResult.value.stdout.startsWith(SQLITE_HEADER_MAGIC)
+    ) {
+      valid.push(name);
+    } else {
+      logger.warn(
+        {
+          sandboxId: sandbox.sId,
+          workspaceId: ctx.workspaceId,
+          database: name,
+        },
+        "Pod state: non-SQLite file in the databases dir — excluded from the managed set"
+      );
+    }
+  }
+  return new Ok(valid);
+}
+
+/**
+ * Make sure the litestream unit is running, starting it when dead. The static
+ * directory-watcher config re-discovers every live database on start, so a
+ * plain start recovers the full managed set (e.g. after a half-failed cold
+ * start that never reached the daemon-start step).
+ */
+async function ensureLitestreamDaemonActive(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  childLogger: typeof logger
+): Promise<Result<void, Error>> {
+  const activeResult = await sandbox.execRoot(
+    auth,
+    rootCommand.exec(SYSTEMCTL_BIN, [
+      "is-active",
+      "--quiet",
+      LITESTREAM_UNIT_NAME,
+    ]),
+    { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
+  );
+  if (activeResult.isErr()) {
+    return activeResult;
+  }
+  if (activeResult.value.exitCode === 0) {
+    return new Ok(undefined);
+  }
+
+  childLogger.warn({}, "Pod state: litestream daemon not active — starting it");
+  return startLitestreamDaemon(auth, sandbox);
 }
 
 /**

--- a/front/lib/api/sandbox/hardening.ts
+++ b/front/lib/api/sandbox/hardening.ts
@@ -40,7 +40,7 @@ export const SANDBOX_STATIC_ROOT_CONSUMED_DIRS = [
 export const SANDBOX_ROOT_INVOKED_HELPERS = [
   "/opt/bin/dsbx",
   "/usr/local/bin/dust-install-trust-bundle",
-  // Root invokes litestream on the pod-state sleep barrier (`litestream sync
+  // Root invokes litestream on the pod-state pre-sleep sync (`litestream sync
   // -wait`) and cold-start restore, so it must stay root-owned/non-writable.
   "/opt/bin/litestream",
 ] as const;

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.50",
+      tag: "0.8.51",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,7 +25,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.50";
+const DUST_BASE_IMAGE_VERSION = "0.8.51";
 const DSBX_CLI_VERSION = "0.1.32";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -135,3 +135,16 @@ export function recordToolDuration(
     `status:${status}`,
   ]);
 }
+
+// Health of the pod-state pre-sleep flush: a success/failure counter. Datadog
+// monitors page on the failure count; the stable logger.error message next to
+// each failing call site carries the cause.
+export function recordPodStateHealth(
+  status: "success" | "failure",
+  ctx: MetricContext
+): void {
+  getStatsDClient().increment("sandbox.pod_state.health", 1, [
+    ...buildTags(ctx),
+    `status:${status}`,
+  ]);
+}

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -16,6 +16,7 @@ const {
   mockRefreshSandboxMount,
   mockPrepareSandboxEgressBeforeMount,
   mockStartTelemetry,
+  mockSetupPodStateOnColdStart,
 } = vi.hoisted(() => {
   const mockSetupSandboxMount = vi.fn();
   const mockRefreshSandboxMount = vi.fn();
@@ -34,6 +35,18 @@ const {
     mockRefreshSandboxMount,
     mockPrepareSandboxEgressBeforeMount: vi.fn(),
     mockStartTelemetry: vi.fn(),
+    mockSetupPodStateOnColdStart: vi.fn(),
+  };
+});
+
+// Partial mock: pod_mounts.ts imports POD_STATE_REPLICA_MOUNT_POINT from the
+// same module, so the real constants must be preserved.
+vi.mock("@app/lib/api/sandbox/db", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/sandbox/db")>();
+  return {
+    ...actual,
+    setupPodStateOnColdStart: mockSetupPodStateOnColdStart,
   };
 });
 
@@ -111,9 +124,11 @@ describe("ensureConversationSandboxReady", () => {
     spaceId: pod.sId,
   };
   const image = { name: "dust-base" };
+  const mockRequestKill = vi.fn().mockResolvedValue(undefined);
   const sandbox = {
     providerId: "provider-id",
     sId: "sandbox-id",
+    requestKill: mockRequestKill,
   };
   const mockFs = {
     setupSandboxMount: mockSetupSandboxMount,
@@ -137,6 +152,7 @@ describe("ensureConversationSandboxReady", () => {
     mockForPod.mockResolvedValue(new Ok(mockFs));
     mockSetupSandboxMount.mockResolvedValue(new Ok(undefined));
     mockRefreshSandboxMount.mockResolvedValue(new Ok(undefined));
+    mockSetupPodStateOnColdStart.mockResolvedValue(new Ok(undefined));
   });
 
   it("preps egress, mounts files, and ensures egress on exec for freshly-created sandboxes", async () => {
@@ -279,10 +295,49 @@ describe("ensureConversationSandboxReady", () => {
     );
     expect(mockStartTelemetry).toHaveBeenCalledWith(auth, sandbox, podOwner);
     expect(mockSetupSandboxMount).toHaveBeenCalledWith(sandbox, image);
+    // Pod state bring-up runs after the mounts and before egress-on-exec.
+    expect(mockSetupPodStateOnColdStart).toHaveBeenCalledWith(auth, sandbox);
+    expect(mockSetupSandboxMount.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSetupPodStateOnColdStart.mock.invocationCallOrder[0]
+    );
+    expect(
+      mockSetupPodStateOnColdStart.mock.invocationCallOrder[0]
+    ).toBeLessThan(mockEnsureSandboxEgressOnExec.mock.invocationCallOrder[0]);
     expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
       runtimeOwner: podOwner,
       wokeFromSleep: false,
     });
+  });
+
+  it("does not run pod state bring-up for conversation sandboxes", async () => {
+    mockEnsureSandboxActive.mockResolvedValue(
+      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+    );
+
+    const result = await ensureConversationSandboxReady(
+      auth as never,
+      conversation as never
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockSetupPodStateOnColdStart).not.toHaveBeenCalled();
+  });
+
+  it("requests a sandbox kill when pod state cold start fails", async () => {
+    mockEnsurePodSandboxActive.mockResolvedValue(
+      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+    );
+    const podStateError = new Error("restore failed");
+    mockSetupPodStateOnColdStart.mockResolvedValue(new Err(podStateError));
+
+    const result = await ensurePodSandboxReady(auth as never, pod as never);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBe(podStateError);
+    }
+    expect(mockRequestKill).toHaveBeenCalledTimes(1);
+    expect(mockEnsureSandboxEgressOnExec).not.toHaveBeenCalled();
   });
 
   it("short-circuits when the sandbox image lookup fails", async () => {

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -1,4 +1,5 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { setupPodStateOnColdStart } from "@app/lib/api/sandbox/db";
 import {
   ensureSandboxEgressOnExec,
   prepareSandboxEgressBeforeMount,
@@ -124,6 +125,30 @@ async function ensureOwnerSandboxReady(
         if (refreshResult.isErr()) {
           status = "error";
           return refreshResult;
+        }
+      }
+
+      // Pod state bring-up must run strictly AFTER the mounts (restore reads
+      // through the replica mount) and is awaited: `invoke` awaits
+      // ensurePodSandboxReady, which is what guarantees no function runs
+      // before the restore + daemon start completed. Only runs for pod
+      // owners.
+      if (freshlyCreated && runtimeOwner.kind === "pod") {
+        const podStateResult = await setupPodStateOnColdStart(auth, sandbox);
+        if (podStateResult.isErr()) {
+          // status=running was already committed by ensureActive, and this
+          // block only runs when freshlyCreated — a plain Err would make the
+          // NEXT call take the warm path and happily serve a half-initialized
+          // sandbox (unrestored databases, no litestream daemon). Request a
+          // kill instead: ensureActive's kill-requested branch destroys and
+          // recreates on the next access, re-running this setup from scratch.
+          logger.error(
+            { err: podStateResult.error, sandboxId: sandbox.sId },
+            "Pod state cold start failed — requesting sandbox kill so the next access recreates it."
+          );
+          await sandbox.requestKill();
+          status = "error";
+          return podStateResult;
         }
       }
 

--- a/front/lib/resources/pod_sandbox_adapter.ts
+++ b/front/lib/resources/pod_sandbox_adapter.ts
@@ -1,9 +1,14 @@
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { ensurePodStateHealthOnSleep } from "@app/lib/api/sandbox/db";
+import { getSandboxImage } from "@app/lib/api/sandbox/image";
+import { podSandboxOnlyMounts } from "@app/lib/api/sandbox/pod_mounts";
 import type { Authenticator } from "@app/lib/auth";
 import {
   type EnsureSandboxResult,
   type SandboxCreateBlob,
   type SandboxDeleteOwner,
   type SandboxLifecycleOwner,
+  type SandboxPreSleepCheck,
   SandboxResource,
 } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -84,6 +89,32 @@ export class PodSandboxAdapter {
     };
   }
 
+  // Pod state pre-sleep flush: every committed SQLite transaction must reach
+  // the GCS replica before the sandbox may pause or be destroyed. The refresh
+  // callback rewrites /tmp/token.json first — the sync flushes through
+  // gcsfuse and the token may have expired while the sandbox sat idle.
+  private static podPreSleepCheck(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): SandboxPreSleepCheck {
+    return (sandbox) =>
+      ensurePodStateHealthOnSleep(auth, sandbox, {
+        refreshMountCredential: async () => {
+          const imageResult = getSandboxImage(auth);
+          if (imageResult.isErr()) {
+            return imageResult;
+          }
+          const fsResult = await DustFileSystem.forPod(auth, pod, {
+            sandboxOnlyMounts: podSandboxOnlyMounts(pod),
+          });
+          if (fsResult.isErr()) {
+            return fsResult;
+          }
+          return fsResult.value.refreshSandboxMount(sandbox, imageResult.value);
+        },
+      });
+  }
+
   private static toSandboxDeleteOwner(
     auth: Authenticator,
     pod: SpaceResource
@@ -122,13 +153,17 @@ export class PodSandboxAdapter {
   ): Promise<Result<EnsureSandboxResult, Error>> {
     this.assertPod(pod);
 
-    return SandboxResource.ensureActive(auth, {
-      lockKey: pod.sId,
-      envVars: { SPACE_ID: pod.sId },
-      logLabel: "pod",
-      fetchSandbox: () => this.fetchSandboxByPod(auth, pod),
-      createSandbox: (blob) => this.createSandboxRecordForPod(auth, pod, blob),
-    });
+    return SandboxResource.ensureActive(
+      auth,
+      {
+        ...this.toSandboxLifecycleOwner(auth, pod),
+        envVars: { SPACE_ID: pod.sId },
+        logLabel: "pod",
+        createSandbox: (blob) =>
+          this.createSandboxRecordForPod(auth, pod, blob),
+      },
+      { beforeSleep: this.podPreSleepCheck(auth, pod) }
+    );
   }
 
   static async pauseSandboxForApproval(
@@ -137,10 +172,11 @@ export class PodSandboxAdapter {
   ): Promise<Result<void, Error>> {
     this.assertPod(pod);
 
-    return SandboxResource.pauseForApproval(auth, {
-      lockKey: pod.sId,
-      fetchSandbox: () => this.fetchSandboxByPod(auth, pod),
-    });
+    return SandboxResource.pauseForApproval(
+      auth,
+      this.toSandboxLifecycleOwner(auth, pod),
+      { beforeSleep: this.podPreSleepCheck(auth, pod) }
+    );
   }
 
   static async deleteSandbox(
@@ -159,7 +195,8 @@ export class PodSandboxAdapter {
   ): Promise<Result<void, Error>> {
     return SandboxResource.dangerouslySleepIfRunning(
       auth,
-      this.toSandboxLifecycleOwner(auth, pod)
+      this.toSandboxLifecycleOwner(auth, pod),
+      { beforeSleep: this.podPreSleepCheck(auth, pod) }
     );
   }
 
@@ -189,7 +226,8 @@ export class PodSandboxAdapter {
   ): Promise<Result<void, Error>> {
     return SandboxResource.dangerouslyDestroyIfKillRequested(
       auth,
-      this.toSandboxLifecycleOwner(auth, pod)
+      this.toSandboxLifecycleOwner(auth, pod),
+      { beforeSleep: this.podPreSleepCheck(auth, pod) }
     );
   }
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -60,6 +60,14 @@ export type SandboxLifecycleOwner = {
   fetchSandbox: () => Promise<SandboxResource | null>;
 };
 
+// Health check run under the lifecycle lock on a still-running sandbox,
+// before the provider pause/destroy. Ok means the sandbox's durable state is
+// safely flushed. Whether an Err blocks the operation — and how it is logged
+// — is decided per lifecycle entry point.
+export type SandboxPreSleepCheck = (
+  sandbox: SandboxResource
+) => Promise<Result<void, Error>>;
+
 export type SandboxCreateOwner = SandboxLifecycleOwner & {
   createSandbox: (blob: SandboxCreateBlob) => Promise<SandboxResource>;
   envVars: Record<string, string>;
@@ -99,6 +107,18 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         "Failed to delete sandbox egress policy"
       )
     );
+  }
+
+  // No-op when there is no check or the sandbox is not running — a sleeping
+  // or pending_approval sandbox already passed the check when it paused.
+  private static async runPreSleepCheck(
+    beforeSleep: SandboxPreSleepCheck | undefined,
+    sandbox: SandboxResource
+  ): Promise<Result<void, Error>> {
+    if (!beforeSleep || sandbox.status !== "running") {
+      return new Ok(undefined);
+    }
+    return beforeSleep(sandbox);
   }
 
   private static async finalizeDestroyed(
@@ -433,10 +453,15 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * Ensure a running sandbox exists for the given owner.
    *
    * The provider is resolved internally — callers never touch it.
+   *
+   * `opts.beforeSleep` runs best-effort before the kill-requested
+   * destroy-and-recreate of a still-running sandbox: a failure is logged and
+   * recreation proceeds.
    */
   static async ensureActive(
     auth: Authenticator,
-    owner: SandboxCreateOwner
+    owner: SandboxCreateOwner,
+    opts: { beforeSleep?: SandboxPreSleepCheck } = {}
   ): Promise<Result<EnsureSandboxResult, Error>> {
     assert(
       auth.getNonNullableWorkspace().id !== undefined,
@@ -502,6 +527,21 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           { sandbox: existing.toLogJSON() },
           "Sandbox has killRequestedAt — destroying and recreating."
         );
+        // Best-effort pre-destroy flush. Unlike the reaper's kill sweep this
+        // PROCEEDS on failure: this branch is the user-facing
+        // recovery/rollout path, and refusing to recreate would wedge the pod
+        // behind the very failure (e.g. a dead replica mount) the recreation
+        // fixes.
+        const flushResult = await this.runPreSleepCheck(
+          opts.beforeSleep,
+          existing
+        );
+        if (flushResult.isErr()) {
+          logger.error(
+            { sandbox: existing.toLogJSON(), err: flushResult.error },
+            "Pre-destroy health check failed on kill-requested sandbox — proceeding with recreation."
+          );
+        }
         const destroyResult = await provider.destroy(
           existing.providerId,
           tracingOpts
@@ -637,10 +677,15 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * Sleep a running sandbox for the given owner. Acquires the lifecycle lock,
    * re-fetches the sandbox inside it, and only sleeps if still running. If the
    * provider reports the sandbox as gone, marks it deleted instead.
+   *
+   * An `opts.beforeSleep` Err aborts the sleep: status stays `running`, so
+   * the reaper retries the check on its next cycle instead of pausing a
+   * sandbox with unreplicated state.
    */
   static async dangerouslySleepIfRunning(
     auth: Authenticator,
-    owner: SandboxLifecycleOwner
+    owner: SandboxLifecycleOwner,
+    opts: { beforeSleep?: SandboxPreSleepCheck } = {}
   ): Promise<Result<void, Error>> {
     return this.withLifecycleLock(owner.lockKey, async (provider) => {
       const sandbox = await owner.fetchSandbox();
@@ -650,6 +695,20 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
       const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
       const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
+
+      const checkResult = await this.runPreSleepCheck(
+        opts.beforeSleep,
+        sandbox
+      );
+      if (checkResult.isErr()) {
+        // Status stays `running`, so the reaper retries the check on its next
+        // cycle instead of pausing a sandbox with unreplicated state.
+        logger.error(
+          { sandbox: sandbox.toLogJSON(), err: checkResult.error },
+          "Sandbox pre-sleep health check failed — not sleeping."
+        );
+        return checkResult;
+      }
 
       const result = await provider.sleep(sandbox.providerId, tracingOpts);
       if (result.isErr()) {
@@ -675,10 +734,13 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * Pause a running sandbox for tool approval. Calls sleep() on the
    * provider and sets the status to `pending_approval`. Unlike sleep, this
    * status prevents recreation on wake failure (frozen state is unrecoverable).
+   *
+   * An `opts.beforeSleep` Err aborts the pause.
    */
   static async pauseForApproval(
     auth: Authenticator,
-    owner: SandboxLifecycleOwner
+    owner: SandboxLifecycleOwner,
+    opts: { beforeSleep?: SandboxPreSleepCheck } = {}
   ): Promise<Result<void, Error>> {
     return this.withLifecycleLock(owner.lockKey, async (provider) => {
       const sandbox = await owner.fetchSandbox();
@@ -687,6 +749,26 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       }
 
       const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
+
+      // The health check runs BEFORE the pending_approval DB flip on purpose:
+      // a failure then leaves DB=running + SDK=running (nothing happened),
+      // instead of a pending_approval row for a sandbox that never paused.
+      const checkResult = await this.runPreSleepCheck(
+        opts.beforeSleep,
+        sandbox
+      );
+      if (checkResult.isErr()) {
+        // TODO(@jd 20260730: remove the panic true)
+        logger.error(
+          {
+            sandbox: sandbox.toLogJSON(),
+            err: checkResult.error,
+            panic: true,
+          },
+          "Sandbox pre-sleep health check failed — not pausing for approval."
+        );
+        return checkResult;
+      }
 
       // Flip the DB to `pending_approval` BEFORE the provider sleep.
       // If we slept first and the DB update then failed, we'd be stuck with
@@ -874,10 +956,14 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * status. Acquires the lifecycle lock, re-fetches the sandbox, and only
    * destroys if it is non-deleted and still has `killRequestedAt`. Treats
    * `SandboxNotFoundError` as success.
+   *
+   * An `opts.beforeSleep` Err skips the destroy for this sweep: the row keeps
+   * its `killRequestedAt`, so the reaper retries next cycle.
    */
   static async dangerouslyDestroyIfKillRequested(
     auth: Authenticator,
-    owner: SandboxLifecycleOwner
+    owner: SandboxLifecycleOwner,
+    opts: { beforeSleep?: SandboxPreSleepCheck } = {}
   ): Promise<Result<void, Error>> {
     return this.withLifecycleLock(owner.lockKey, async (provider) => {
       const sandbox = await owner.fetchSandbox();
@@ -891,6 +977,25 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
       const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
       const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
+
+      // Pre-destroy flush: kill-requested destroys (image rollouts) would
+      // otherwise lose state that never reached its replica.
+      const checkResult = await this.runPreSleepCheck(
+        opts.beforeSleep,
+        sandbox
+      );
+      if (checkResult.isErr()) {
+        // TODO(@jd 20260730: remove the panic true)
+        logger.error(
+          {
+            sandbox: sandbox.toLogJSON(),
+            err: checkResult.error,
+            panic: true,
+          },
+          "Kill-requested destroy: pre-destroy health check failed — skipping destroy this sweep."
+        );
+        return checkResult;
+      }
 
       const result = await provider.destroy(sandbox.providerId, tracingOpts);
       if (result.isErr()) {

--- a/front/temporal/sandbox_reaper/activities.test.ts
+++ b/front/temporal/sandbox_reaper/activities.test.ts
@@ -11,12 +11,14 @@ import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
 const {
+  mockEnsurePodStateHealthOnSleep,
   mockExecuteWithLock,
   mockGetSandboxImage,
   mockGetSandboxProvider,
   mockHeartbeat,
   mockProviderSleep,
 } = vi.hoisted(() => ({
+  mockEnsurePodStateHealthOnSleep: vi.fn(),
   mockExecuteWithLock: vi.fn(),
   mockGetSandboxImage: vi.fn(),
   mockGetSandboxProvider: vi.fn(),
@@ -35,6 +37,18 @@ vi.mock("@app/lib/api/sandbox", () => ({
 vi.mock("@app/lib/api/sandbox/image", () => ({
   getSandboxImage: mockGetSandboxImage,
 }));
+
+// The pod pre-sleep health check execs into the sandbox, and the provider
+// here is a stub. The reaper contract is only that the check gates the pod
+// sleep.
+vi.mock("@app/lib/api/sandbox/db", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/sandbox/db")>();
+  return {
+    ...actual,
+    ensurePodStateHealthOnSleep: mockEnsurePodStateHealthOnSleep,
+  };
+});
 
 vi.mock("@app/lib/lock", () => ({
   executeWithLock: mockExecuteWithLock,
@@ -62,6 +76,7 @@ describe("reapStaleSandboxesActivity", () => {
         .mockResolvedValueOnce(new Ok({ providerId: "pod-provider" })),
       sleep: mockProviderSleep.mockResolvedValue(new Ok(undefined)),
     });
+    mockEnsurePodStateHealthOnSleep.mockResolvedValue(new Ok(undefined));
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
@@ -109,5 +124,7 @@ describe("reapStaleSandboxesActivity", () => {
     expect(mockProviderSleep).toHaveBeenCalledWith("pod-provider", {
       workspaceId: workspace.sId,
     });
+    // Pod sleeps run the pre-sleep state health check; conversations don't.
+    expect(mockEnsurePodStateHealthOnSleep).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Description

Implement the new pod sandbox lifecycle hooks to on sleep, to do one last sync before.
 
* On cold start
   - restore all dbs in pod-state gcs folder to local sqlite dbs
   - start litestream replication
* On sleep
   - Do one last sync from litestream, on happy path it's a no-op, it's more of a sanity check to alert in case of data corruption than anything else.



## Tests

- Unit tests
- Tested locally (see #28596 )

## Risk

Risk: Low
Blast radius: conversation sandboxes (if we broken somehow their lifecycle)

## Deploy Plan

- [ ] Deploy front
- [ ] killswitch sandbox