### PR TITLE
fix(front): resolve conversation files in convert_file_format

### DIFF
--- a/front/lib/api/actions/servers/file_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/file_generation/tools/index.ts
@@ -3,6 +3,7 @@ import { Readable } from "node:stream";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { resolveConversationFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
   getContentTypeFromOutputFormat,
   isBinaryFormat,
@@ -13,13 +14,11 @@ import {
   OUTPUT_FORMATS,
 } from "@app/lib/api/actions/servers/file_generation/metadata";
 import config from "@app/lib/api/config";
-import { FileResource } from "@app/lib/resources/file_resource";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { validateUrl } from "@app/types/shared/utils/url_utils";
-import type { UploadResult } from "convertapi";
 import ConvertAPI from "convertapi";
 import { marked } from "marked";
 
@@ -55,43 +54,34 @@ const handlers: ToolHandlers<typeof FILE_GENERATION_TOOLS_METADATA> = {
   },
 
   convert_file_format: async (
-    { file_name, file_id_or_url, source_format, output_format },
-    { auth }
+    { file_id_or_url, source_format, output_format },
+    { auth, toolContext }
   ) => {
     const convertAPIKey = config.getConvertAPIKey();
     const contentType = getContentTypeFromOutputFormat(output_format);
 
     const convertapi = new ConvertAPI(convertAPIKey);
-    let url: string | UploadResult = file_id_or_url;
+    let url = file_id_or_url;
 
+    // When the input is not a URL it references a conversation file: either a
+    // legacy `fil_` id or a canonical scoped path (e.g. `conversation-{id}/x.csv`)
+    // as returned by generate_file for text outputs. Resolve it to a signed URL
+    // that ConvertAPI can fetch.
     if (!validateUrl(file_id_or_url).valid) {
-      const r = getResourceNameAndIdFromSId(file_id_or_url);
-
-      if (r && r.resourceName === "file") {
-        const { resourceModelId } = r;
-
-        const file = await FileResource.fetchByModelIdWithAuth(
-          auth,
-          resourceModelId
-        );
-        if (!file) {
-          return new Err(
-            new MCPError(`File not found: ${file_id_or_url}`, {
-              tracked: false,
-            })
-          );
-        }
-
-        url = await convertapi.upload(
-          file.getReadStream({ auth, version: "original" }),
-          `${file_name}.${source_format}`
-        );
-      } else {
-        url = await convertapi.upload(
-          Readable.from(file_id_or_url),
-          `${file_name}.${source_format}`
+      const refResult = await resolveConversationFileRef(
+        auth,
+        file_id_or_url,
+        toolContext
+      );
+      if (refResult.isErr()) {
+        return new Err(
+          new MCPError(`File not found: ${file_id_or_url}`, {
+            tracked: false,
+          })
         );
       }
+
+      url = await refResult.value.getSignedUrl();
     }
 
     try {


### PR DESCRIPTION
## Description

`convert_file_format` only knew how to handle two kinds of input: a URL or a `fil_` sId. But `generate_file` writes text/CSV outputs straight to GCS via `DustFileSystem` and creates no `FileResource` row, so those files are referenced only by a canonical scoped path (`conversation-{id}/x.csv`) with a null `fileId`.

That path matched neither `validateUrl` nor `getResourceNameAndIdFromSId`, so it fell into the else branch that uploaded the raw `file_id_or_url` **string** to ConvertAPI as the file body. Result: the converted file contained the path text (e.g. `conversation-<id>/x.csv` in cell A1) instead of the actual data. User-uploaded files (real `fil_` sIds) hit the working branch and were unaffected.

Fix: resolve any non-URL input through `resolveConversationFileRef` (the same resolver already used by `image_generation` and the mail tools) which handles legacy fileIds, legacy scoped paths, and canonical scoped paths. We then hand ConvertAPI a signed URL via the existing `{ File: url }` convert call. Unresolvable inputs now return a proper "File not found" error instead of silently producing garbage.

Fixes dust-tt/tasks#9342

## Tests

- `npx tsgo --noEmit` and biome clean (pre-commit hooks pass).

## Risk

Low.

## Deploy Plan

Standard `front` deploy. 