### PR TITLE
Add the resource for `SandboxFunctionMCPActionModel`

### DIFF
--- a/front/lib/models/agent/actions/mcp_server_view_helper.ts
+++ b/front/lib/models/agent/actions/mcp_server_view_helper.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/models/agent/actions/mcp";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
-import { SandboxFunctionMCPActionModel } from "@app/lib/resources/storage/models/sandbox_function_mcp_action";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
@@ -89,14 +89,9 @@ export async function destroyMCPServerViewDependencies(
   });
 
   // Sandbox-function tool calls FK the view with RESTRICT, so their rows must go before the view.
-  // TODO(2026-07-03 sandbox-functions): route through SandboxFunctionMCPActionResource once it
-  // exists so `outputGcsPath` objects are deleted too — rows destroyed here would orphan their GCS
-  // output objects (none are written yet; the resource lands in the next PR).
-  await SandboxFunctionMCPActionModel.destroy({
-    where: {
-      workspaceId: auth.getNonNullableWorkspace().id,
-      mcpServerViewId: mcpServerViewIds,
-    },
+  // Routed through the resource so the output GCS objects are deleted alongside the rows.
+  await SandboxFunctionMCPActionResource.deleteAllForMCPServerViews(auth, {
+    mcpServerViewIds,
     transaction,
   });
 }

--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -11,7 +11,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
-const MCP_OUTPUT_ITEMS_PREFIX = "mcp_output_items";
+export const MCP_OUTPUT_ITEMS_PREFIX = "mcp_output_items";
 const GCS_CONCURRENCY = 4;
 
 export const GCS_CONTENT_CACHE_TTL_MS = 15 * 60 * 1000;

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionInvocationModel } from "@app/lib/resources/storage/models/sandbox_function";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -134,10 +135,12 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     sandboxFunction: SandboxFunctionResource,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<number> {
-    // SandboxFunctionMCPActionModel FKs invocations with RESTRICT, but has no writer yet.
-    // TODO(2026-07-03 sandbox-functions): delete actions (rows + `outputGcsPath` GCS objects)
-    // before invocations, through SandboxFunctionMCPActionResource — lands with the resource,
-    // before any writer exists.
+    // MCP actions FK invocations with RESTRICT: delete them (rows + output GCS objects) first.
+    await SandboxFunctionMCPActionResource.deleteAllForSandboxFunction(
+      sandboxFunction,
+      { transaction }
+    );
+
     return this.model.destroy({
       where: {
         sandboxFunctionId: sandboxFunction.id,
@@ -152,10 +155,14 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
     try {
-      // SandboxFunctionMCPActionModel FKs invocations with RESTRICT, but has no writer yet.
-      // TODO(2026-07-03 sandbox-functions): delete actions (rows + `outputGcsPath` GCS objects)
-      // first, through SandboxFunctionMCPActionResource — lands with the resource, before any
-      // writer exists.
+      // MCP actions FK this invocation with RESTRICT: delete them (rows + output GCS objects)
+      // first.
+      await SandboxFunctionMCPActionResource.deleteAllForInvocation(
+        auth,
+        this,
+        { transaction }
+      );
+
       await this.model.destroy({
         where: {
           id: this.id,

--- a/front/lib/resources/sandbox_function_mcp_action_resource.test.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.test.ts
@@ -1,0 +1,267 @@
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { sandboxFunctionContentType } from "@app/types/files";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory GCS mock: writes persist content that reads can return.
+const gcsStore = new Map<string, Buffer>();
+
+vi.mock("@app/lib/file_storage", () => ({
+  getPrivateUploadBucket: vi.fn(() => ({
+    file: vi.fn((path: string) => ({
+      save: vi.fn(async (data: Buffer) => {
+        gcsStore.set(path, data);
+      }),
+      download: vi.fn(async () => {
+        const buf = gcsStore.get(path);
+        if (!buf) {
+          throw new Error(`GCS file not found: ${path}`);
+        }
+        return [buf];
+      }),
+    })),
+    delete: vi.fn(async (path: string, opts?: { ignoreNotFound?: boolean }) => {
+      if (!gcsStore.has(path) && !opts?.ignoreNotFound) {
+        throw new Error(`GCS file not found: ${path}`);
+      }
+      gcsStore.delete(path);
+    }),
+  })),
+}));
+
+const inputSchema: JSONSchema = {
+  type: "object",
+  properties: { message: { type: "string" } },
+  required: ["message"],
+};
+
+const outputSchema: JSONSchema = {
+  type: "object",
+  properties: { greeting: { type: "string" } },
+  required: ["greeting"],
+};
+
+async function setup() {
+  const { authenticator, workspace, globalSpace } = await createResourceTest({
+    role: "admin",
+  });
+
+  const podSpace = await SpaceFactory.project(workspace);
+  const file = await FileFactory.create(authenticator, null, {
+    contentType: sandboxFunctionContentType,
+    fileName: "greet.ts",
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: podSpace.sId },
+  });
+  const sandboxFunction = await SandboxFunctionResource.makeNew(authenticator, {
+    space: podSpace,
+    file,
+    slug: "greet",
+    description: "Greet someone.",
+    inputSchema,
+    outputSchema,
+  });
+  const invocation = await SandboxFunctionInvocationResource.makeNew(
+    authenticator,
+    { sandboxFunction }
+  );
+
+  const server = await RemoteMCPServerFactory.create(workspace);
+  const mcpServerView = await MCPServerViewFactory.create(
+    workspace,
+    server.sId,
+    globalSpace
+  );
+
+  return {
+    authenticator,
+    workspace,
+    sandboxFunction,
+    invocation,
+    mcpServerView,
+  };
+}
+
+describe("SandboxFunctionMCPActionResource", () => {
+  beforeEach(() => {
+    gcsStore.clear();
+  });
+
+  it("creates an action in running status and fetches it back by sId", async () => {
+    const { authenticator, invocation, mcpServerView } = await setup();
+
+    const action = await SandboxFunctionMCPActionFactory.create(authenticator, {
+      invocation,
+      mcpServerView,
+      toolName: "math_operation",
+      inputs: { expression: "1+1" },
+    });
+
+    expect(action.sId).toMatch(/^sfa_/);
+    expect(action.status).toBe("running");
+
+    const fetched = await SandboxFunctionMCPActionResource.fetchById(
+      authenticator,
+      action.sId
+    );
+    expect(fetched).not.toBeNull();
+    expect(fetched?.toolName).toBe("math_operation");
+    expect(fetched?.inputs).toEqual({ expression: "1+1" });
+    expect(fetched?.sandboxFunctionInvocationId).toBe(invocation.id);
+    expect(fetched?.outputGcsPath).toBeNull();
+  });
+
+  it("returns null when fetching with a foreign or invalid sId", async () => {
+    const { authenticator } = await setup();
+
+    expect(
+      await SandboxFunctionMCPActionResource.fetchById(authenticator, "sfa_x")
+    ).toBeNull();
+    expect(
+      await SandboxFunctionMCPActionResource.fetchById(
+        authenticator,
+        "not_an_sid"
+      )
+    ).toBeNull();
+  });
+
+  it("writes the output to a single GCS object and reads it back", async () => {
+    const { authenticator, invocation, mcpServerView } = await setup();
+    const action = await SandboxFunctionMCPActionFactory.create(authenticator, {
+      invocation,
+      mcpServerView,
+    });
+
+    const before = await action.readOutput();
+    expect(before.isOk()).toBe(true);
+    if (before.isOk()) {
+      expect(before.value).toBeNull();
+    }
+
+    const content = [{ type: "text" as const, text: "4" }];
+    const writeResult = await action.writeOutput(authenticator, content);
+    expect(writeResult.isOk()).toBe(true);
+    expect(action.outputGcsPath).toContain(action.sId);
+
+    const readBack = await action.readOutput();
+    expect(readBack.isOk()).toBe(true);
+    if (readBack.isOk()) {
+      expect(readBack.value).toEqual(content);
+    }
+  });
+
+  it("marks the action as succeeded or errored with a duration", async () => {
+    const { authenticator, invocation, mcpServerView } = await setup();
+    const action = await SandboxFunctionMCPActionFactory.create(authenticator, {
+      invocation,
+      mcpServerView,
+    });
+
+    await action.markAsSucceeded({ executionDurationMs: 1_234 });
+    expect(action.status).toBe("succeeded");
+    expect(action.executionDurationMs).toBe(1_234);
+  });
+
+  it("deletes actions and their GCS outputs when the invocation is deleted", async () => {
+    const { authenticator, invocation, mcpServerView } = await setup();
+    const action = await SandboxFunctionMCPActionFactory.create(authenticator, {
+      invocation,
+      mcpServerView,
+    });
+    await action.writeOutput(authenticator, [{ type: "text", text: "4" }]);
+    expect(gcsStore.size).toBe(1);
+
+    // The action FKs the invocation with RESTRICT: deletion must not throw.
+    const deleteResult = await invocation.delete(authenticator);
+    expect(deleteResult.isOk()).toBe(true);
+
+    expect(
+      await SandboxFunctionMCPActionResource.fetchById(
+        authenticator,
+        action.sId
+      )
+    ).toBeNull();
+    expect(gcsStore.size).toBe(0);
+  });
+
+  it("deletes actions across invocations when the sandbox function is deleted", async () => {
+    const { authenticator, sandboxFunction, invocation, mcpServerView } =
+      await setup();
+    const action = await SandboxFunctionMCPActionFactory.create(authenticator, {
+      invocation,
+      mcpServerView,
+    });
+    await action.writeOutput(authenticator, [{ type: "text", text: "4" }]);
+
+    const deleteResult = await sandboxFunction.delete(authenticator);
+    expect(deleteResult.isOk()).toBe(true);
+
+    expect(
+      await SandboxFunctionMCPActionResource.fetchById(
+        authenticator,
+        action.sId
+      )
+    ).toBeNull();
+    expect(gcsStore.size).toBe(0);
+  });
+
+  it("keeps rows and GCS outputs when the enclosing transaction rolls back", async () => {
+    const { authenticator, invocation, mcpServerView } = await setup();
+    const action = await SandboxFunctionMCPActionFactory.create(authenticator, {
+      invocation,
+      mcpServerView,
+    });
+    await action.writeOutput(authenticator, [{ type: "text", text: "4" }]);
+    expect(gcsStore.size).toBe(1);
+
+    // GCS deletion is deferred to afterCommit: on rollback, neither the rows nor the objects go.
+    await expect(
+      frontSequelize.transaction(async (transaction) => {
+        await invocation.delete(authenticator, { transaction });
+        throw new Error("rollback");
+      })
+    ).rejects.toThrow("rollback");
+
+    expect(
+      await SandboxFunctionMCPActionResource.fetchById(
+        authenticator,
+        action.sId
+      )
+    ).not.toBeNull();
+    expect(gcsStore.size).toBe(1);
+  });
+
+  it("deletes actions and their GCS outputs when the MCP server view is hard-deleted", async () => {
+    const { authenticator, invocation, mcpServerView } = await setup();
+    const action = await SandboxFunctionMCPActionFactory.create(authenticator, {
+      invocation,
+      mcpServerView,
+    });
+    await action.writeOutput(authenticator, [{ type: "text", text: "4" }]);
+    expect(gcsStore.size).toBe(1);
+
+    // The action FKs the view with RESTRICT: hard-deleting the view (e.g. sharing a server to
+    // the company space, remote server deletion) must not throw.
+    const deleteResult = await mcpServerView.hardDelete(authenticator);
+    expect(deleteResult.isOk()).toBe(true);
+
+    expect(
+      await SandboxFunctionMCPActionResource.fetchById(
+        authenticator,
+        action.sId
+      )
+    ).toBeNull();
+    expect(gcsStore.size).toBe(0);
+  });
+});

--- a/front/lib/resources/sandbox_function_mcp_action_resource.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.ts
@@ -1,0 +1,390 @@
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import {
+  deleteContentsFromGcs,
+  MCP_OUTPUT_ITEMS_PREFIX,
+} from "@app/lib/resources/agent_mcp_action/output_storage";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SandboxFunctionInvocationModel } from "@app/lib/resources/storage/models/sandbox_function";
+import { SandboxFunctionMCPActionModel } from "@app/lib/resources/storage/models/sandbox_function_mcp_action";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import {
+  getResourceIdFromSId,
+  isResourceSId,
+  makeSId,
+} from "@app/lib/resources/string_ids";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { withRetry } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { SandboxFunctionMCPActionType } from "@app/types/api/sandbox_functions";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import assert from "assert";
+import type { Attributes, Transaction } from "sequelize";
+import { Op } from "sequelize";
+
+// Outputs share the agent MCP output items GCS prefix (`w/<wsId>/...` so workspace relocation
+// transfers the objects), but with one object per action holding the full content array — dsbx
+// consumes the output exactly once as a whole, there is no per-block rendering.
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface SandboxFunctionMCPActionResource
+  extends ReadonlyAttributesType<SandboxFunctionMCPActionModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFunctionMCPActionModel> {
+  static model: ModelStaticWorkspaceAware<SandboxFunctionMCPActionModel> =
+    SandboxFunctionMCPActionModel;
+
+  constructor(
+    model: ModelStaticWorkspaceAware<SandboxFunctionMCPActionModel>,
+    blob: Attributes<SandboxFunctionMCPActionModel>
+  ) {
+    super(model, blob);
+  }
+
+  get sId(): string {
+    return SandboxFunctionMCPActionResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("sandbox_function_mcp_action", { id, workspaceId });
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    {
+      invocation,
+      mcpServerView,
+      toolName,
+      inputs,
+      toolConfiguration,
+    }: {
+      invocation: SandboxFunctionInvocationResource;
+      mcpServerView: MCPServerViewResource;
+      toolName: string;
+      inputs: Record<string, unknown>;
+      toolConfiguration: LightMCPToolConfigurationType;
+    },
+    transaction?: Transaction
+  ): Promise<SandboxFunctionMCPActionResource> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    // Cross-workspace resources would make the workspace-scoped deletion paths miss the row,
+    // leaving the RESTRICT FKs to fire on invocation/view deletion.
+    assert(
+      invocation.workspaceId === workspaceId &&
+        mcpServerView.workspaceId === workspaceId,
+      "Invocation and MCP server view must belong to the authenticated workspace."
+    );
+
+    const action = await this.model.create(
+      {
+        workspaceId,
+        sandboxFunctionInvocationId: invocation.id,
+        mcpServerViewId: mcpServerView.id,
+        toolName,
+        inputs,
+        toolConfiguration,
+        status: "running",
+      },
+      { transaction }
+    );
+
+    return new this(this.model, action.get());
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    options?: ResourceFindOptions<SandboxFunctionMCPActionModel>
+  ): Promise<SandboxFunctionMCPActionResource[]> {
+    const { where, ...rest } = options ?? {};
+    const actions = await this.model.findAll({
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      ...rest,
+    });
+
+    return actions.map((action) => new this(this.model, action.get()));
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    actionId: string
+  ): Promise<SandboxFunctionMCPActionResource | null> {
+    if (!isResourceSId("sandbox_function_mcp_action", actionId)) {
+      return null;
+    }
+
+    const actionModelId = getResourceIdFromSId(actionId);
+    if (actionModelId === null) {
+      return null;
+    }
+
+    const [action] = await this.baseFetch(auth, {
+      where: { id: actionModelId },
+    });
+
+    return action ?? null;
+  }
+
+  static async fetchByModelIdWithAuth(
+    auth: Authenticator,
+    id: ModelId
+  ): Promise<SandboxFunctionMCPActionResource | null> {
+    const [action] = await this.baseFetch(auth, { where: { id } });
+
+    return action ?? null;
+  }
+
+  async markAsSucceeded({
+    executionDurationMs,
+  }: {
+    executionDurationMs: number;
+  }): Promise<void> {
+    await this.update({ status: "succeeded", executionDurationMs });
+  }
+
+  async markAsErrored({
+    executionDurationMs,
+  }: {
+    executionDurationMs: number;
+  }): Promise<void> {
+    await this.update({ status: "errored", executionDurationMs });
+  }
+
+  private outputGcsPathFor(auth: Authenticator): string {
+    return `w/${auth.getNonNullableWorkspace().sId}/${MCP_OUTPUT_ITEMS_PREFIX}/${this.sId}/output.json`;
+  }
+
+  // Writes the full content array to a single GCS object and records its path on the row. Written
+  // exactly once, at tool completion.
+  async writeOutput(
+    auth: Authenticator,
+    content: CallToolResult["content"]
+  ): Promise<Result<undefined, Error>> {
+    const gcsPath = this.outputGcsPathFor(auth);
+    const file = getPrivateUploadBucket().file(gcsPath);
+    const json = JSON.stringify(content);
+
+    const writeResult = await withRetry(() =>
+      file.save(Buffer.from(json, "utf-8"), {
+        contentType: "application/json",
+      })
+    );
+    if (writeResult.isErr()) {
+      logger.error(
+        { err: writeResult.error, actionId: this.sId, gcsPath },
+        "Failed to write sandbox function MCP action output to GCS"
+      );
+      return new Err(writeResult.error);
+    }
+
+    // When the row never got the path (update threw, or the row was deleted concurrently and
+    // update affected 0 rows): best-effort delete the just-written object so the later row-driven
+    // GCS cleanup does not miss it.
+    const deleteOrphanedOutput = async () => {
+      const gcsResult = await deleteContentsFromGcs([gcsPath]);
+      if (gcsResult.isErr()) {
+        logger.error(
+          { err: gcsResult.error, actionId: this.sId, gcsPath },
+          "Failed to delete orphaned sandbox function MCP action output from GCS"
+        );
+      }
+    };
+
+    try {
+      const [affectedCount] = await this.update({ outputGcsPath: gcsPath });
+      if (affectedCount === 0) {
+        await deleteOrphanedOutput();
+        return new Err(
+          new Error("Sandbox function MCP action row no longer exists.")
+        );
+      }
+    } catch (err) {
+      await deleteOrphanedOutput();
+      return new Err(normalizeError(err));
+    }
+
+    return new Ok(undefined);
+  }
+
+  async readOutput(): Promise<Result<CallToolResult["content"] | null, Error>> {
+    if (!this.outputGcsPath) {
+      return new Ok(null);
+    }
+
+    try {
+      const file = getPrivateUploadBucket().file(this.outputGcsPath);
+      const [buffer] = await file.download();
+
+      return new Ok(JSON.parse(buffer.toString("utf-8")));
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  // GCS objects are deleted best-effort AFTER the rows (post-commit when a transaction is
+  // provided): a failed or rolled-back row deletion must not leave rows pointing at deleted
+  // objects, while a failed GCS deletion only logs — the orphaned object is harmless.
+  private static async deleteAllWithOutputs(
+    where: {
+      workspaceId: ModelId;
+      id?: ModelId;
+      sandboxFunctionInvocationId?: ModelId | ModelId[];
+      mcpServerViewId?: ModelId[];
+    },
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<number> {
+    const actions = await this.model.findAll({
+      attributes: ["outputGcsPath"],
+      where: {
+        ...where,
+        outputGcsPath: { [Op.ne]: null },
+      },
+      transaction,
+    });
+
+    const gcsPaths = removeNulls(actions.map((action) => action.outputGcsPath));
+
+    const destroyedCount = await this.model.destroy({ where, transaction });
+
+    const deleteFromGcs = async () => {
+      const gcsResult = await deleteContentsFromGcs(gcsPaths);
+      if (gcsResult.isErr()) {
+        logger.error(
+          { err: gcsResult.error, pathCount: gcsPaths.length },
+          "Failed to delete sandbox function MCP action outputs from GCS"
+        );
+      }
+    };
+
+    if (transaction) {
+      // Same shape as `invalidateAfterCommit` in `lib/utils/cache.ts`: the callback never rejects
+      // today, but an unhandled rejection post-commit would be unattributable.
+      transaction.afterCommit(() =>
+        deleteFromGcs().catch((err) => {
+          logger.error(
+            { err: normalizeError(err), pathCount: gcsPaths.length },
+            "Failed to delete sandbox function MCP action outputs from GCS after commit"
+          );
+        })
+      );
+    } else {
+      await deleteFromGcs();
+    }
+
+    return destroyedCount;
+  }
+
+  static async deleteAllForInvocation(
+    auth: Authenticator,
+    invocation: SandboxFunctionInvocationResource,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<number> {
+    return this.deleteAllWithOutputs(
+      {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        sandboxFunctionInvocationId: invocation.id,
+      },
+      { transaction }
+    );
+  }
+
+  static async deleteAllForSandboxFunction(
+    sandboxFunction: SandboxFunctionResource,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<number> {
+    const invocationIds = (
+      await SandboxFunctionInvocationModel.findAll({
+        attributes: ["id"],
+        where: {
+          sandboxFunctionId: sandboxFunction.id,
+          workspaceId: sandboxFunction.workspaceId,
+        },
+        transaction,
+      })
+    ).map((invocation) => invocation.id);
+
+    if (invocationIds.length === 0) {
+      return 0;
+    }
+
+    return this.deleteAllWithOutputs(
+      {
+        workspaceId: sandboxFunction.workspaceId,
+        sandboxFunctionInvocationId: invocationIds,
+      },
+      { transaction }
+    );
+  }
+
+  static async deleteAllForMCPServerViews(
+    auth: Authenticator,
+    {
+      mcpServerViewIds,
+      transaction,
+    }: { mcpServerViewIds: ModelId[]; transaction?: Transaction }
+  ): Promise<number> {
+    return this.deleteAllWithOutputs(
+      {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        mcpServerViewId: mcpServerViewIds,
+      },
+      { transaction }
+    );
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await SandboxFunctionMCPActionResource.deleteAllWithOutputs(
+        {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          id: this.id,
+        },
+        { transaction }
+      );
+
+      return new Ok(undefined);
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
+  }
+
+  toJSON(): SandboxFunctionMCPActionType {
+    return {
+      sId: this.sId,
+      createdAt: this.createdAt.getTime(),
+      updatedAt: this.updatedAt.getTime(),
+      invocationId: makeSId("sandbox_function_invocation", {
+        id: this.sandboxFunctionInvocationId,
+        workspaceId: this.workspaceId,
+      }),
+      toolName: this.toolName,
+      inputs: this.inputs,
+      status: this.status,
+      executionDurationMs: this.executionDurationMs,
+    };
+  }
+}

--- a/front/tests/utils/SandboxFunctionMCPActionFactory.ts
+++ b/front/tests/utils/SandboxFunctionMCPActionFactory.ts
@@ -1,0 +1,58 @@
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+
+export class SandboxFunctionMCPActionFactory {
+  static async create(
+    auth: Authenticator,
+    {
+      invocation,
+      mcpServerView,
+      toolName = "math_operation",
+      inputs = { expression: "2+2" },
+    }: {
+      invocation: SandboxFunctionInvocationResource;
+      mcpServerView: MCPServerViewResource;
+      toolName?: string;
+      inputs?: Record<string, unknown>;
+    }
+  ): Promise<SandboxFunctionMCPActionResource> {
+    const serverName = mcpServerView.toJSON().server.name;
+
+    // Minimal synthesized snapshot, mirroring what creation derives from the view + manifest.
+    const toolConfiguration: LightMCPToolConfigurationType = {
+      id: -1,
+      sId: generateRandomModelSId(),
+      type: "mcp_configuration",
+      name: toolName,
+      originalName: toolName,
+      mcpServerName: serverName,
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: mcpServerView.sId,
+      dustAppConfiguration: null,
+      internalMCPServerId: null,
+      secretName: null,
+      dustProject: null,
+      availability: "manual",
+      permission: "never_ask",
+      toolServerId: mcpServerView.mcpServerId,
+      retryPolicy: "no_retry",
+    };
+
+    return SandboxFunctionMCPActionResource.makeNew(auth, {
+      invocation,
+      mcpServerView,
+      toolName,
+      inputs,
+      toolConfiguration,
+    });
+  }
+}

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -1,3 +1,5 @@
+import type { ToolExecutionBaseStatus } from "@app/lib/actions/statuses";
+
 export const SANDBOX_FUNCTION_INVOCATION_STATUSES = ["created"] as const;
 
 export type SandboxFunctionInvocationStatus =
@@ -15,6 +17,18 @@ export type SandboxFunctionInvocationType = {
   functionId: string;
   status: SandboxFunctionInvocationStatus;
   createdAt: string;
+};
+
+export type SandboxFunctionMCPActionType = {
+  sId: string;
+  createdAt: number;
+  updatedAt: number;
+
+  invocationId: string;
+  toolName: string;
+  inputs: Record<string, unknown>;
+  status: ToolExecutionBaseStatus;
+  executionDurationMs: number | null;
 };
 
 export type SandboxFunctionInvocationCreatedEvent = {


### PR DESCRIPTION
## Description

Follow up of #28446. Adds the resource for `SandboxFunctionMCPActionModel`:

- `makeNew` / `fetchById` / `markAsSucceeded` / `markAsErrored` — the row is born `running`,  executed from its persisted `toolConfiguration` snapshot.
- `writeOutput` / `readOutput`: the full `CallToolResult` content array goes to a **single GCS object** (`w/{wId}/mcp_output_items/{sId}/output.json`), written once at tool completion.
- Deletion with GCS cleanup as a single owner (`deleteAllForInvocation` / `deleteAllForSandboxFunction` / `deleteAllForMCPServerViews`), wired into the two paths that were TODO'd in #28446: invocation/function deletion and MCP server view hard-delete. The RESTRICT FKs are now safe ahead of any writer.
- GCS objects are deleted **after** the rows, post-commit via `transaction.afterCommit` when a transaction is provided (same shape as `invalidateAfterCommit` in `lib/utils/cache.ts`). A rollback leaves rows and objects consistent. Overkill??

Tests cover the GCS round trip, both RESTRICT regressions (invocation delete + view hard-delete with actions present → no FK violation, no orphaned GCS object) and transaction rollback (rows and objects both survive).


Follow-ups
- PR3: endpoints + Temporal execution, first e2e with `common_utilities`
- PR4: pod file outputs, flipping real servers

## Tests

Tests cover the GCS round trip and both RESTRICT regressions (invocation delete + view hard-delete with actions present → no FK violation, no orphaned GCS object).

## Risk

No caller creates actions yet. Safe to rollback.

## Deploy Plan

- [ ] Deploy front