### PR TITLE
[dsbx] feat: add @dust/pod package

### DIFF
--- a/.github/workflows/build-dust-sandbox.yml
+++ b/.github/workflows/build-dust-sandbox.yml
@@ -95,3 +95,18 @@ jobs:
         # so its bun:test suite is the only coverage of protocol/invoke/schema/runner.
         working-directory: cli/dust-sandbox/functions-runner
         run: bun test
+
+      - name: Test pod package
+        # @dust/pod ships into the sandbox image as a bun bundle; its bun:test
+        # suite is the only coverage of db()'s open/pragma/quota/error logic.
+        working-directory: cli/dust-sandbox/pod
+        run: |
+          bun install --frozen-lockfile
+          bun test
+
+      - name: Build pod package bundle
+        # Mirrors the sandbox-image vendor step (bun build index.ts --bundle
+        # --target=bun --packages=external) so bundle regressions surface here
+        # instead of at image build time.
+        working-directory: cli/dust-sandbox/pod
+        run: bun run build

--- a/biome.json
+++ b/biome.json
@@ -56,7 +56,8 @@
       "front/**",
       "front-api/**",
       "marketing/**",
-      "cli/dust-sandbox/functions-runner/**"
+      "cli/dust-sandbox/functions-runner/**",
+      "cli/dust-sandbox/pod/**"
     ],
     "rules": {
       "preset": "none",
@@ -254,7 +255,8 @@
       "front-spa/**",
       "front/**",
       "front-api/**",
-      "cli/dust-sandbox/functions-runner/**"
+      "cli/dust-sandbox/functions-runner/**",
+      "cli/dust-sandbox/pod/**"
     ],
     "enabled": true,
     "actions": {

--- a/cli/dust-sandbox/pod/.gitignore
+++ b/cli/dust-sandbox/pod/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+# Generated bundle — built via `bun run build` (the image vendor step bundles index.ts itself).
+dist/

--- a/cli/dust-sandbox/pod/bun.lock
+++ b/cli/dust-sandbox/pod/bun.lock
@@ -1,0 +1,26 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@dust/pod",
+      "dependencies": {
+        "drizzle-orm": "0.45.2",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "prisma": "*", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "prisma", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -67,7 +67,12 @@ export const POD_DATABASE_BUSY_TIMEOUT_MS = 5000;
 /** Valid database names (also the manifest/publish contract). */
 export const POD_DATABASE_NAME_REGEX = /^[a-z][a-z0-9_]{0,63}$/;
 
-export class PodDatabaseError extends Error {}
+export class PodDatabaseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PodDatabaseError";
+  }
+}
 
 export class PodDatabaseInvalidNameError extends PodDatabaseError {
   constructor(name: string) {

--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -1,0 +1,338 @@
+import type { Changes, SQLQueryBindings, Statement } from "bun:sqlite";
+import { Database } from "bun:sqlite";
+import type { BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+/**
+ * Pod state databases.
+ *
+ * `db(name)` returns a cached Drizzle instance over the pod's live SQLite
+ * database at `${DUST_POD_DATABASES_DIR}/{name}.db`. Databases are created by
+ * the publish pipeline (`dsbx db reconcile`), never here: the file is opened
+ * must-exist so a typo'd name errors clearly instead of minting an empty
+ * database. Functions that never call `db()` pay nothing.
+ *
+ * Disk guardrails — pod state must not fill the sandbox disk by accident:
+ *
+ * - `db()` cannot create database files (must-exist open), so the set of
+ *   databases is fixed at publish time. Total pod-state footprint is the
+ *   number of declared databases times the per-database cap; bounding the
+ *   count is the publish pipeline's job.
+ * - Each database is capped at {@link DEFAULT_POD_DATABASE_MAX_SIZE_BYTES}
+ *   (1 GiB) via `PRAGMA max_page_count`. Writes past the cap fail with
+ *   {@link PodDatabaseFullError}; the database stays readable and rows can
+ *   still be deleted, so the agent recovers in place by reclaiming space.
+ * - The cap override env var is clamped down-only, since it is readable and
+ *   writable by the workload itself (see
+ *   {@link POD_DATABASE_MAX_SIZE_BYTES_ENV}).
+ * - The WAL is not counted by `max_page_count`: Litestream owns checkpointing
+ *   and truncates the WAL as frames are replicated (see `applyPragmas`).
+ *
+ * The cap turns runaway state growth into an actionable error well before the
+ * disk is full, instead of unrecoverable ENOSPC everywhere. It is not a
+ * security boundary — workload code can write to the filesystem directly; the
+ * sandbox's own disk is the hard limit, and filling it breaks only this pod's
+ * sandbox.
+ */
+
+/**
+ * Env var pointing at the live databases directory, required. The location is
+ * hardcoded once, in front (`POD_SANDBOX_DATABASES_DIR`), passed per-exec to
+ * `dsbx function run`, which forwards it here — no layer below front carries
+ * its own copy of the path.
+ */
+export const POD_DATABASES_DIR_ENV = "DUST_POD_DATABASES_DIR";
+
+/**
+ * Sandbox-global env var carrying the pod sId — set at sandbox creation for
+ * pod-owned sandboxes only. Its absence means this is not a pod sandbox
+ * (e.g. a conversation sandbox), where pod databases do not exist.
+ */
+export const POD_SPACE_ID_ENV = "SPACE_ID";
+
+/**
+ * Optional env override for the per-database size quota, in bytes. Clamped to
+ * the default: this env var lives in the (untrusted) workload's own process,
+ * so it can only LOWER the quota (a test/ops seam), never raise it.
+ */
+export const POD_DATABASE_MAX_SIZE_BYTES_ENV =
+  "DUST_POD_DATABASE_MAX_SIZE_BYTES";
+
+/** Per-database size quota default: 1 GiB, enforced via `PRAGMA max_page_count`. */
+export const DEFAULT_POD_DATABASE_MAX_SIZE_BYTES = 1024 * 1024 * 1024;
+
+/** How long a connection waits on a locked database before failing. */
+export const POD_DATABASE_BUSY_TIMEOUT_MS = 5000;
+
+/** Valid database names (also the manifest/publish contract). */
+export const POD_DATABASE_NAME_REGEX = /^[a-z][a-z0-9_]{0,63}$/;
+
+export class PodDatabaseError extends Error {}
+
+export class PodDatabaseInvalidNameError extends PodDatabaseError {
+  constructor(name: string) {
+    super(
+      `Invalid pod database name ${JSON.stringify(name)}: names must match ` +
+        `${POD_DATABASE_NAME_REGEX.source} (lowercase letter first, then lowercase ` +
+        `letters, digits or underscores, 64 characters max).`
+    );
+    this.name = "PodDatabaseInvalidNameError";
+  }
+}
+
+export class PodDatabasesUnavailableError extends PodDatabaseError {
+  constructor() {
+    super(
+      `Pod databases are not available in this sandbox: ${POD_SPACE_ID_ENV} ` +
+        `is not set, which means this sandbox does not belong to a pod ` +
+        `(conversation sandboxes have no pod databases). db() only works in ` +
+        `functions running in a pod sandbox.`
+    );
+    this.name = "PodDatabasesUnavailableError";
+  }
+}
+
+export class PodDatabaseNotDeclaredError extends PodDatabaseError {
+  constructor(dbName: string, path: string) {
+    super(
+      `Pod database "${dbName}" does not exist (no database file at ${path}). ` +
+        `Databases are created by the first publish that declares them: add ` +
+        `"${dbName}" to a function's schema.databases, define its tables in ` +
+        `databases/${dbName}.db.ts, and publish that function.`
+    );
+    this.name = "PodDatabaseNotDeclaredError";
+  }
+}
+
+export class PodDatabaseFullError extends PodDatabaseError {
+  constructor(dbName: string, maxSizeBytes: number) {
+    super(
+      `Pod database "${dbName}" is full: it reached its size quota of ` +
+        `${maxSizeBytes} bytes. Delete unneeded rows to reclaim space before ` +
+        `writing more data.`
+    );
+    this.name = "PodDatabaseFullError";
+  }
+}
+
+/** The Drizzle handle returned by {@link db}. */
+export type PodDatabase = BunSQLiteDatabase<Record<string, never>> & {
+  $client: Database;
+};
+
+function isSqliteErrorWithCode(err: unknown, code: string): boolean {
+  return err instanceof Error && "code" in err && err.code === code;
+}
+
+/**
+ * Statement methods that execute SQL and can therefore surface `SQLITE_FULL`.
+ * (Also covers commit-time errors: bun:sqlite's `Database.transaction()` builds
+ * its BEGIN/COMMIT statements through `Database.prepare`.)
+ */
+const EXECUTING_STATEMENT_METHODS = new Set<PropertyKey>([
+  "run",
+  "get",
+  "all",
+  "values",
+  "iterate",
+]);
+
+function translateSqliteError(
+  err: unknown,
+  dbName: string,
+  maxSizeBytes: number
+): unknown {
+  if (isSqliteErrorWithCode(err, "SQLITE_FULL")) {
+    return new PodDatabaseFullError(dbName, maxSizeBytes);
+  }
+  return err;
+}
+
+/** Wrap a prepared statement so executing it translates `SQLITE_FULL`. */
+function wrapStatement<T extends object>(
+  stmt: T,
+  dbName: string,
+  maxSizeBytes: number
+): T {
+  return new Proxy(stmt, {
+    get(target, prop) {
+      const value = Reflect.get(target, prop, target);
+      if (typeof value !== "function") {
+        return value;
+      }
+      if (!EXECUTING_STATEMENT_METHODS.has(prop)) {
+        return value.bind(target);
+      }
+      return (...args: unknown[]) => {
+        try {
+          return value.apply(target, args);
+        } catch (err) {
+          throw translateSqliteError(err, dbName, maxSizeBytes);
+        }
+      };
+    },
+  });
+}
+
+/**
+ * A bun:sqlite Database that translates `SQLITE_FULL` (the quota surface of
+ * `PRAGMA max_page_count`) into {@link PodDatabaseFullError} on every
+ * execution path Drizzle uses: `exec`/`run` directly, and statements obtained
+ * through `prepare` (which `query()` and `transaction()` also go through).
+ */
+class PodSqliteDatabase extends Database {
+  readonly #dbName: string;
+  readonly #maxSizeBytes: number;
+
+  constructor(path: string, dbName: string, maxSizeBytes: number) {
+    // readwrite without create: opening a missing file throws SQLITE_CANTOPEN
+    // instead of minting an empty database (verified against bun 1.3.14).
+    super(path, { readwrite: true });
+    this.#dbName = dbName;
+    this.#maxSizeBytes = maxSizeBytes;
+  }
+
+  run<ParamsType extends SQLQueryBindings[]>(
+    sql: string,
+    ...bindings: ParamsType[]
+  ): Changes {
+    try {
+      return super.run(sql, ...bindings);
+    } catch (err) {
+      throw translateSqliteError(err, this.#dbName, this.#maxSizeBytes);
+    }
+  }
+
+  exec<ParamsType extends SQLQueryBindings[]>(
+    sql: string,
+    ...bindings: ParamsType[]
+  ): Changes {
+    try {
+      return super.exec(sql, ...bindings);
+    } catch (err) {
+      throw translateSqliteError(err, this.#dbName, this.#maxSizeBytes);
+    }
+  }
+
+  prepare<ReturnType, ParamsType extends SQLQueryBindings | SQLQueryBindings[]>(
+    sql: string,
+    params?: ParamsType
+    // The `any[]` conditional mirrors bun:sqlite's own Database.prepare signature.
+  ): Statement<
+    ReturnType,
+    ParamsType extends any[] ? ParamsType : [ParamsType]
+  > {
+    const stmt = super.prepare<ReturnType, ParamsType>(sql, params);
+    return wrapStatement(stmt, this.#dbName, this.#maxSizeBytes);
+  }
+}
+
+function podDatabasesDir(): string {
+  const dir = process.env[POD_DATABASES_DIR_ENV];
+  if (dir === undefined || dir.length === 0) {
+    throw new PodDatabaseError(
+      `${POD_DATABASES_DIR_ENV} is not set: the databases directory is ` +
+        `chosen by front and passed through dsbx function run, so db() only ` +
+        `works in functions launched that way.`
+    );
+  }
+  return dir;
+}
+
+function podDatabaseMaxSizeBytes(): number {
+  const raw = process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV];
+  if (raw === undefined || raw.length === 0) {
+    return DEFAULT_POD_DATABASE_MAX_SIZE_BYTES;
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return DEFAULT_POD_DATABASE_MAX_SIZE_BYTES;
+  }
+  // Clamp: the override is workload-settable, so it can only lower the quota.
+  return Math.min(parsed, DEFAULT_POD_DATABASE_MAX_SIZE_BYTES);
+}
+
+/**
+ * Per-connection settings, re-applied on every open. `journal_mode = WAL` is
+ * not set here: it is a persistent per-database setting, applied once when
+ * the publish pipeline creates the file.
+ */
+function applyPragmas(sqlite: PodSqliteDatabase, maxSizeBytes: number): void {
+  // WAL allows a single writer at a time: concurrent function invocations —
+  // and Litestream, which briefly takes the write lock to checkpoint — must
+  // wait for it instead of failing instantly with SQLITE_BUSY. 5s is the
+  // value the Litestream docs recommend and comfortably covers the short
+  // transactions functions are expected to run.
+  sqlite.exec(`PRAGMA busy_timeout = ${POD_DATABASE_BUSY_TIMEOUT_MS}`);
+  // Under WAL, NORMAL fsyncs at checkpoint time instead of on every commit:
+  // a host crash can lose the most recent commits but cannot corrupt the
+  // database. Commits happen inside function calls, so FULL's per-commit
+  // fsync would be paid as agent-visible latency for durability we get from
+  // replication anyway.
+  sqlite.exec("PRAGMA synchronous = NORMAL");
+  // Litestream replicates by tailing the WAL and owns checkpointing: it
+  // holds a long-running read lock and checkpoints itself once frames are
+  // replicated, truncating the WAL (which is what bounds WAL growth, since
+  // max_page_count below does not count WAL pages). An application
+  // checkpoint slipping in between Litestream's own can make it miss WAL
+  // frames and force a full re-snapshot, so SQLite must never checkpoint on
+  // its own.
+  sqlite.exec("PRAGMA wal_autocheckpoint = 0");
+  const row = sqlite.query<{ page_size: number }, []>("PRAGMA page_size").get();
+  if (row === null) {
+    throw new PodDatabaseError("PRAGMA page_size returned no row");
+  }
+  // The per-database size cap (see the module doc). max_page_count counts
+  // pages, so the byte quota is converted using this database's actual page
+  // size. It is per-connection state, hence re-applied on every open. If the
+  // database already exceeds the cap, SQLite clamps the value up to the
+  // current page count: reads and deletes keep working, growth doesn't.
+  const maxPageCount = Math.max(1, Math.floor(maxSizeBytes / row.page_size));
+  sqlite.exec(`PRAGMA max_page_count = ${maxPageCount}`);
+}
+
+// One instance per resolved database file path, opened lazily on first db().
+const instances = new Map<string, PodDatabase>();
+
+/**
+ * Get the pod's Drizzle handle for database `name`.
+ *
+ * @throws PodDatabaseInvalidNameError when `name` does not match the contract.
+ * @throws PodDatabasesUnavailableError when SPACE_ID is absent — this sandbox
+ *   is not pod-owned (conversation sandboxes have no pod databases).
+ * @throws PodDatabaseError when DUST_POD_DATABASES_DIR is absent — db() only
+ *   works in functions launched by `dsbx function run`.
+ * @throws PodDatabaseNotDeclaredError when no database file exists — databases
+ *   are created by the first publish that declares them.
+ * @throws PodDatabaseFullError (from queries) when the database hits its quota.
+ */
+export function db(name: string): PodDatabase {
+  if (!POD_DATABASE_NAME_REGEX.test(name)) {
+    throw new PodDatabaseInvalidNameError(name);
+  }
+  const spaceId = process.env[POD_SPACE_ID_ENV];
+  if (spaceId === undefined || spaceId.length === 0) {
+    throw new PodDatabasesUnavailableError();
+  }
+  const path = `${podDatabasesDir()}/${name}.db`;
+  const cached = instances.get(path);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const maxSizeBytes = podDatabaseMaxSizeBytes();
+  let sqlite: PodSqliteDatabase;
+  try {
+    sqlite = new PodSqliteDatabase(path, name, maxSizeBytes);
+  } catch (err) {
+    if (isSqliteErrorWithCode(err, "SQLITE_CANTOPEN")) {
+      throw new PodDatabaseNotDeclaredError(name, path);
+    }
+    throw err;
+  }
+  applyPragmas(sqlite, maxSizeBytes);
+
+  const instance = drizzle(sqlite);
+  instances.set(path, instance);
+  return instance;
+}

--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -18,13 +18,11 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
  *   databases is fixed at publish time. Total pod-state footprint is the
  *   number of declared databases times the per-database cap; bounding the
  *   count is the publish pipeline's job.
- * - Each database is capped at {@link DEFAULT_POD_DATABASE_MAX_SIZE_BYTES}
- *   (1 GiB) via `PRAGMA max_page_count`. Writes past the cap fail with
+ * - Each database is capped via `PRAGMA max_page_count` at the byte quota
+ *   front chooses and passes per exec (1 GiB in production — see
+ *   {@link POD_DATABASE_MAX_SIZE_BYTES_ENV}). Writes past the cap fail with
  *   {@link PodDatabaseFullError}; the database stays readable and rows can
  *   still be deleted, so the agent recovers in place by reclaiming space.
- * - The cap override env var is clamped down-only, since it is readable and
- *   writable by the workload itself (see
- *   {@link POD_DATABASE_MAX_SIZE_BYTES_ENV}).
  * - The WAL is not counted by `max_page_count`: Litestream owns checkpointing
  *   and truncates the WAL as frames are replicated (see `applyPragmas`).
  *
@@ -51,15 +49,15 @@ export const POD_DATABASES_DIR_ENV = "DUST_POD_DATABASES_DIR";
 export const POD_SPACE_ID_ENV = "SPACE_ID";
 
 /**
- * Optional env override for the per-database size quota, in bytes. Clamped to
- * the default: this env var lives in the (untrusted) workload's own process,
- * so it can only LOWER the quota (a test/ops seam), never raise it.
+ * Env var carrying the per-database size quota in bytes, required. Like the
+ * databases directory, the value is owned by front (1 GiB in production) and
+ * passed per-exec through dsbx — no copy of the number lives below front.
+ * It lives in the (untrusted) workload's own process, so workload code can
+ * rewrite it — acceptable because the cap is not a security boundary (see
+ * the module doc).
  */
 export const POD_DATABASE_MAX_SIZE_BYTES_ENV =
   "DUST_POD_DATABASE_MAX_SIZE_BYTES";
-
-/** Per-database size quota default: 1 GiB, enforced via `PRAGMA max_page_count`. */
-export const DEFAULT_POD_DATABASE_MAX_SIZE_BYTES = 1024 * 1024 * 1024;
 
 /** How long a connection waits on a locked database before failing. */
 export const POD_DATABASE_BUSY_TIMEOUT_MS = 5000;
@@ -247,14 +245,22 @@ function podDatabasesDir(): string {
 function podDatabaseMaxSizeBytes(): number {
   const raw = process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV];
   if (raw === undefined || raw.length === 0) {
-    return DEFAULT_POD_DATABASE_MAX_SIZE_BYTES;
+    throw new PodDatabaseError(
+      `${POD_DATABASE_MAX_SIZE_BYTES_ENV} is not set: the per-database size ` +
+        `quota is chosen by front and passed through dsbx function run, so ` +
+        `db() only works in functions launched that way.`
+    );
   }
-  const parsed = Number(raw);
+  // Decimal digits only: Number() alone would also accept "1e3" or "0x10".
+  const parsed = /^[0-9]+$/.test(raw) ? Number(raw) : Number.NaN;
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    return DEFAULT_POD_DATABASE_MAX_SIZE_BYTES;
+    // No default to fall back to; failing loudly beats masking a broken quota.
+    throw new PodDatabaseError(
+      `${POD_DATABASE_MAX_SIZE_BYTES_ENV} is not a positive integer byte ` +
+        `count: ${JSON.stringify(raw)}.`
+    );
   }
-  // Clamp: the override is workload-settable, so it can only lower the quota.
-  return Math.min(parsed, DEFAULT_POD_DATABASE_MAX_SIZE_BYTES);
+  return parsed;
 }
 
 /**
@@ -305,8 +311,9 @@ const instances = new Map<string, PodDatabase>();
  * @throws PodDatabaseInvalidNameError when `name` does not match the contract.
  * @throws PodDatabasesUnavailableError when SPACE_ID is absent — this sandbox
  *   is not pod-owned (conversation sandboxes have no pod databases).
- * @throws PodDatabaseError when DUST_POD_DATABASES_DIR is absent — db() only
- *   works in functions launched by `dsbx function run`.
+ * @throws PodDatabaseError when DUST_POD_DATABASES_DIR or
+ *   DUST_POD_DATABASE_MAX_SIZE_BYTES is absent or invalid — db() only works
+ *   in functions launched by `dsbx function run`.
  * @throws PodDatabaseNotDeclaredError when no database file exists — databases
  *   are created by the first publish that declares them.
  * @throws PodDatabaseFullError (from queries) when the database hits its quota.

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -1,0 +1,328 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { blob, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+import {
+  DEFAULT_POD_DATABASE_MAX_SIZE_BYTES,
+  db,
+  POD_DATABASE_BUSY_TIMEOUT_MS,
+  POD_DATABASE_MAX_SIZE_BYTES_ENV,
+  POD_DATABASES_DIR_ENV,
+  POD_SPACE_ID_ENV,
+  PodDatabaseError,
+  PodDatabaseFullError,
+  PodDatabaseInvalidNameError,
+  PodDatabaseNotDeclaredError,
+  PodDatabasesUnavailableError,
+} from "./index.ts";
+
+const messages = sqliteTable("messages", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  body: text("body").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }),
+});
+
+const blobs = sqliteTable("blobs", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  data: blob("data", { mode: "buffer" }),
+});
+
+let databasesDir: string;
+
+// Simulate `dsbx db reconcile` creating a database: WAL + DDL, then close.
+function createDatabaseFile(name: string, ...ddl: string[]): string {
+  const path = join(databasesDir, `${name}.db`);
+  const sqlite = new Database(path, { create: true });
+  sqlite.exec("PRAGMA journal_mode = WAL");
+  for (const statement of ddl) {
+    sqlite.exec(statement);
+  }
+  sqlite.close();
+  return path;
+}
+
+// Each test gets a unique database name: db() caches instances per resolved
+// path for the process lifetime, and temp dirs make paths unique anyway.
+let uniqueNameCounter = 0;
+function uniqueName(prefix: string): string {
+  uniqueNameCounter += 1;
+  return `${prefix}_${uniqueNameCounter}`;
+}
+
+let originalSpaceId: string | undefined;
+
+beforeEach(() => {
+  databasesDir = mkdtempSync(join(tmpdir(), "dust-pod-test-"));
+  process.env[POD_DATABASES_DIR_ENV] = databasesDir;
+  delete process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV];
+  // Pod sandboxes carry SPACE_ID as a sandbox-global env var.
+  originalSpaceId = process.env[POD_SPACE_ID_ENV];
+  process.env[POD_SPACE_ID_ENV] = "spc_test_pod";
+});
+
+afterEach(() => {
+  delete process.env[POD_DATABASES_DIR_ENV];
+  delete process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV];
+  if (originalSpaceId === undefined) {
+    delete process.env[POD_SPACE_ID_ENV];
+  } else {
+    process.env[POD_SPACE_ID_ENV] = originalSpaceId;
+  }
+  rmSync(databasesDir, { recursive: true, force: true });
+});
+
+describe("pod sandbox guard", () => {
+  test("SPACE_ID absent throws PodDatabasesUnavailableError even when the file exists", () => {
+    const name = uniqueName("guard");
+    createDatabaseFile(name);
+    delete process.env[POD_SPACE_ID_ENV];
+    expect(() => db(name)).toThrow(PodDatabasesUnavailableError);
+    expect(() => db(name)).toThrow(/does not belong to a pod/);
+  });
+
+  test("empty SPACE_ID is treated as absent", () => {
+    const name = uniqueName("guard");
+    createDatabaseFile(name);
+    process.env[POD_SPACE_ID_ENV] = "";
+    expect(() => db(name)).toThrow(PodDatabasesUnavailableError);
+  });
+
+  test("the guard runs before the missing-file check", () => {
+    delete process.env[POD_SPACE_ID_ENV];
+    expect(() => db(uniqueName("guard"))).toThrow(PodDatabasesUnavailableError);
+  });
+});
+
+describe("name validation", () => {
+  test("accepts contract-conforming names", () => {
+    for (const name of ["chat", "a", "a1", "a_b_c", `a${"b".repeat(63)}`]) {
+      createDatabaseFile(name);
+      expect(() => db(name)).not.toThrow();
+    }
+  });
+
+  test("rejects invalid names with PodDatabaseInvalidNameError", () => {
+    const invalid = [
+      "",
+      "Chat",
+      "1chat",
+      "_chat",
+      "chat-log",
+      "chat.db",
+      "a/b",
+      "../escape",
+      `a${"b".repeat(64)}`, // 65 chars
+    ];
+    for (const name of invalid) {
+      expect(() => db(name)).toThrow(PodDatabaseInvalidNameError);
+    }
+  });
+
+  test("validates the name before touching the filesystem", () => {
+    delete process.env[POD_DATABASES_DIR_ENV];
+    expect(() => db("NOT_VALID")).toThrow(PodDatabaseInvalidNameError);
+  });
+});
+
+describe("must-exist open", () => {
+  test("missing database file throws PodDatabaseNotDeclaredError", () => {
+    const name = uniqueName("missing");
+    expect(() => db(name)).toThrow(PodDatabaseNotDeclaredError);
+  });
+
+  test("the error tells the agent databases are created by publish", () => {
+    const name = uniqueName("missing");
+    expect(() => db(name)).toThrow(/created by the first publish/);
+    expect(() => db(name)).toThrow(new RegExp(`databases/${name}\\.db\\.ts`));
+  });
+
+  test("a failed open does not mint an empty database file", () => {
+    const name = uniqueName("missing");
+    expect(() => db(name)).toThrow(PodDatabaseNotDeclaredError);
+    expect(existsSync(join(databasesDir, `${name}.db`))).toBe(false);
+  });
+
+  test("throws when the databases dir env var is absent", () => {
+    // No fallback path lives here: front owns the location and passes it
+    // through dsbx. Unset means a broken launch context, not an empty pod.
+    delete process.env[POD_DATABASES_DIR_ENV];
+    const name = uniqueName("nodir");
+    expect(() => db(name)).toThrow(PodDatabaseError);
+    expect(() => db(name)).toThrow(/DUST_POD_DATABASES_DIR is not set/);
+  });
+});
+
+describe("queries through drizzle", () => {
+  test("insert and select round-trip, modes applied", () => {
+    const name = uniqueName("chat");
+    createDatabaseFile(
+      name,
+      "CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, body TEXT NOT NULL, created_at INTEGER)"
+    );
+
+    const handle = db(name);
+    const createdAt = new Date(1700000000000);
+    handle.insert(messages).values({ body: "hello", createdAt }).run();
+    handle.insert(messages).values({ body: "world", createdAt: null }).run();
+
+    const rows = handle.select().from(messages).all();
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.body).toBe("hello");
+    expect(rows[0]?.createdAt).toEqual(createdAt);
+    expect(rows[1]?.createdAt).toBeNull();
+  });
+
+  test("writes are durable across instances (readwrite open)", () => {
+    const name = uniqueName("chat");
+    const path = createDatabaseFile(
+      name,
+      "CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, body TEXT NOT NULL, created_at INTEGER)"
+    );
+    db(name).insert(messages).values({ body: "persisted" }).run();
+
+    const raw = new Database(path, { readonly: true });
+    const row = raw
+      .query<{ body: string }, []>("SELECT body FROM messages")
+      .get();
+    raw.close();
+    expect(row?.body).toBe("persisted");
+  });
+
+  test("non-quota SQLite errors pass through untranslated", () => {
+    const name = uniqueName("chat");
+    createDatabaseFile(
+      name,
+      "CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, body TEXT NOT NULL, created_at INTEGER)"
+    );
+    let thrown: unknown;
+    try {
+      // NOT NULL violation on body.
+      db(name).$client.exec("INSERT INTO messages (body) VALUES (NULL)");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).not.toBeInstanceOf(PodDatabaseError);
+  });
+});
+
+describe("pragmas", () => {
+  test("busy_timeout, synchronous, wal_autocheckpoint and max_page_count are applied", () => {
+    const name = uniqueName("pragmas");
+    createDatabaseFile(name);
+
+    const client = db(name).$client;
+    const pragma = <T>(sql: string): T | null => client.query<T, []>(sql).get();
+
+    expect(pragma<{ timeout: number }>("PRAGMA busy_timeout")?.timeout).toBe(
+      POD_DATABASE_BUSY_TIMEOUT_MS
+    );
+    // 1 = NORMAL.
+    expect(
+      pragma<{ synchronous: number }>("PRAGMA synchronous")?.synchronous
+    ).toBe(1);
+    expect(
+      pragma<{ wal_autocheckpoint: number }>("PRAGMA wal_autocheckpoint")
+        ?.wal_autocheckpoint
+    ).toBe(0);
+
+    const pageSize = pragma<{ page_size: number }>("PRAGMA page_size");
+    expect(pageSize).not.toBeNull();
+    const expectedPages = Math.floor(
+      DEFAULT_POD_DATABASE_MAX_SIZE_BYTES / (pageSize?.page_size ?? 0)
+    );
+    expect(
+      pragma<{ max_page_count: number }>("PRAGMA max_page_count")
+        ?.max_page_count
+    ).toBe(expectedPages);
+  });
+
+  test("the quota env override drives max_page_count", () => {
+    const name = uniqueName("quota");
+    createDatabaseFile(name);
+    process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = "20480"; // 5 pages of 4096.
+
+    const client = db(name).$client;
+    expect(
+      client
+        .query<{ max_page_count: number }, []>("PRAGMA max_page_count")
+        .get()?.max_page_count
+    ).toBe(5);
+  });
+
+  test("the quota env override cannot raise the quota above the default", () => {
+    const name = uniqueName("quota");
+    createDatabaseFile(name);
+    // The env var is workload-settable: a value above the default is clamped.
+    process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = String(
+      DEFAULT_POD_DATABASE_MAX_SIZE_BYTES * 2
+    );
+
+    const client = db(name).$client;
+    const pageSize = client
+      .query<{ page_size: number }, []>("PRAGMA page_size")
+      .get();
+    expect(pageSize).not.toBeNull();
+    expect(
+      client
+        .query<{ max_page_count: number }, []>("PRAGMA max_page_count")
+        .get()?.max_page_count
+    ).toBe(
+      Math.floor(
+        DEFAULT_POD_DATABASE_MAX_SIZE_BYTES / (pageSize?.page_size ?? 0)
+      )
+    );
+  });
+});
+
+describe("instance caching", () => {
+  test("db(name) returns the same instance for the same database", () => {
+    const name = uniqueName("cached");
+    createDatabaseFile(name);
+    expect(db(name)).toBe(db(name));
+  });
+
+  test("different databases get different instances", () => {
+    const a = uniqueName("cached");
+    const b = uniqueName("cached");
+    createDatabaseFile(a);
+    createDatabaseFile(b);
+    expect(db(a)).not.toBe(db(b));
+  });
+});
+
+describe("size quota enforcement", () => {
+  test("writes past the quota throw PodDatabaseFullError", () => {
+    const name = uniqueName("full");
+    createDatabaseFile(
+      name,
+      "CREATE TABLE blobs (id INTEGER PRIMARY KEY AUTOINCREMENT, data BLOB)"
+    );
+    process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = "20480"; // 5 pages of 4096.
+
+    const handle = db(name);
+    let thrown: unknown;
+    try {
+      // Each row carries a page-sized payload; 5 pages fill up fast. The loop
+      // bound only guards against the quota silently not applying.
+      for (let i = 0; i < 1000; i++) {
+        handle
+          .insert(blobs)
+          .values({ data: Buffer.alloc(4096, 1) })
+          .run();
+      }
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(PodDatabaseFullError);
+    expect(thrown).toBeInstanceOf(PodDatabaseError);
+    if (thrown instanceof PodDatabaseFullError) {
+      expect(thrown.message).toContain(`"${name}" is full`);
+      expect(thrown.message).toContain("20480");
+    }
+  });
+});

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -7,7 +7,6 @@ import { join } from "node:path";
 import { blob, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 import {
-  DEFAULT_POD_DATABASE_MAX_SIZE_BYTES,
   db,
   POD_DATABASE_BUSY_TIMEOUT_MS,
   POD_DATABASE_MAX_SIZE_BYTES_ENV,
@@ -19,6 +18,9 @@ import {
   PodDatabaseNotDeclaredError,
   PodDatabasesUnavailableError,
 } from "./index.ts";
+
+// The production quota front passes per exec.
+const ONE_GIB_BYTES = 1024 * 1024 * 1024;
 
 const messages = sqliteTable("messages", {
   id: integer("id").primaryKey({ autoIncrement: true }),
@@ -58,7 +60,8 @@ let originalSpaceId: string | undefined;
 beforeEach(() => {
   databasesDir = mkdtempSync(join(tmpdir(), "dust-pod-test-"));
   process.env[POD_DATABASES_DIR_ENV] = databasesDir;
-  delete process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV];
+  // Both env vars are required and normally set by front through dsbx.
+  process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = String(ONE_GIB_BYTES);
   // Pod sandboxes carry SPACE_ID as a sandbox-global env var.
   originalSpaceId = process.env[POD_SPACE_ID_ENV];
   process.env[POD_SPACE_ID_ENV] = "spc_test_pod";
@@ -242,7 +245,7 @@ describe("pragmas", () => {
     const pageSize = pragma<{ page_size: number }>("PRAGMA page_size");
     expect(pageSize).not.toBeNull();
     const expectedPages = Math.floor(
-      DEFAULT_POD_DATABASE_MAX_SIZE_BYTES / (pageSize?.page_size ?? 0)
+      ONE_GIB_BYTES / (pageSize?.page_size ?? 0)
     );
     expect(
       pragma<{ max_page_count: number }>("PRAGMA max_page_count")
@@ -250,7 +253,7 @@ describe("pragmas", () => {
     ).toBe(expectedPages);
   });
 
-  test("the quota env override drives max_page_count", () => {
+  test("the quota env var drives max_page_count", () => {
     const name = uniqueName("quota");
     createDatabaseFile(name);
     process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = "20480"; // 5 pages of 4096.
@@ -263,13 +266,10 @@ describe("pragmas", () => {
     ).toBe(5);
   });
 
-  test("the quota env override cannot raise the quota above the default", () => {
+  test("quotas above 1 GiB are honored, not clamped", () => {
     const name = uniqueName("quota");
     createDatabaseFile(name);
-    // The env var is workload-settable: a value above the default is clamped.
-    process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = String(
-      DEFAULT_POD_DATABASE_MAX_SIZE_BYTES * 2
-    );
+    process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = String(2 * ONE_GIB_BYTES);
 
     const client = db(name).$client;
     const pageSize = client
@@ -280,11 +280,30 @@ describe("pragmas", () => {
       client
         .query<{ max_page_count: number }, []>("PRAGMA max_page_count")
         .get()?.max_page_count
-    ).toBe(
-      Math.floor(
-        DEFAULT_POD_DATABASE_MAX_SIZE_BYTES / (pageSize?.page_size ?? 0)
-      )
+    ).toBe(Math.floor((2 * ONE_GIB_BYTES) / (pageSize?.page_size ?? 0)));
+  });
+
+  test("throws when the quota env var is absent", () => {
+    // No default lives here: front owns the quota and passes it through dsbx.
+    const name = uniqueName("quota");
+    createDatabaseFile(name);
+    delete process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV];
+    expect(() => db(name)).toThrow(PodDatabaseError);
+    expect(() => db(name)).toThrow(
+      /DUST_POD_DATABASE_MAX_SIZE_BYTES is not set/
     );
+  });
+
+  test("throws when the quota env var is not a positive integer", () => {
+    const name = uniqueName("quota");
+    createDatabaseFile(name);
+    // Canonical decimal digits only: Number() alone would accept "1e3",
+    // "0x10" or " 42 ".
+    const invalid = ["0", "-1", "1.5", "abc", "1e100", "1e3", "0x10", " 42 "];
+    for (const raw of invalid) {
+      process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = raw;
+      expect(() => db(name)).toThrow(/not a positive integer byte count/);
+    }
   });
 });
 

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -154,6 +154,15 @@ describe("must-exist open", () => {
     expect(() => db(name)).toThrow(PodDatabaseError);
     expect(() => db(name)).toThrow(/DUST_POD_DATABASES_DIR is not set/);
   });
+
+  test("an empty databases dir env var is treated as absent", () => {
+    // dsbx passes env through verbatim; empty means the same broken launch
+    // context as unset, and this is the one layer that normalizes it.
+    process.env[POD_DATABASES_DIR_ENV] = "";
+    const name = uniqueName("nodir");
+    expect(() => db(name)).toThrow(PodDatabaseError);
+    expect(() => db(name)).toThrow(/DUST_POD_DATABASES_DIR is not set/);
+  });
 });
 
 describe("queries through drizzle", () => {

--- a/cli/dust-sandbox/pod/index.ts
+++ b/cli/dust-sandbox/pod/index.ts
@@ -1,0 +1,7 @@
+/**
+ * `@dust/pod` — the runtime library for code running in a Dust pod sandbox.
+ *
+ * Surfaces:
+ * - `db(name)`: the pod's SQLite state databases, through Drizzle (./db.ts).
+ */
+export * from "./db.ts";

--- a/cli/dust-sandbox/pod/package.json
+++ b/cli/dust-sandbox/pod/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@dust/pod",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Runtime library for code running in a Dust pod sandbox.",
+  "type": "module",
+  "main": "index.ts",
+  "scripts": {
+    "test": "bun test",
+    "build": "bun build index.ts --bundle --target=bun --packages=external --outfile dist/index.js"
+  },
+  "dependencies": { "drizzle-orm": "0.45.2" },
+  "devDependencies": { "@types/bun": "latest" }
+}

--- a/cli/dust-sandbox/pod/tsconfig.json
+++ b/cli/dust-sandbox/pod/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Description

Adds `@dust/pod`, the runtime library for code running in a pod sandbox. First surface: `db(name)` — a cached Drizzle handle over the pod's live SQLite database at `${DUST_POD_DATABASES_DIR}/{name}.db`.

Design decisions:

- **Must-exist open** — `db()` never creates database files; the set of databases is fixed at publish time (`dsbx db reconcile`), so a typo'd name errors clearly instead of minting an empty database.
- **Per-database size cap** (1 GiB in production) via `PRAGMA max_page_count`, with `SQLITE_FULL` translated to `PodDatabaseFullError` on every execution path Drizzle uses. The database stays readable and rows can still be deleted, so the agent recovers in place by reclaiming space. *Not* a security boundary — workload code can write to the filesystem directly (or rewrite the env var); the sandbox's own disk is the hard limit.
- **Required env contract, no defaults below front** — front owns both the databases dir and the quota and passes them per exec through dsbx; `db()` fails loudly when either is absent or the quota is not a canonical positive decimal, instead of masking a broken launch context with a baked-in value.
- **`wal_autocheckpoint = 0`** — Litestream owns checkpointing: an application checkpoint slipping in between Litestream's own can make it miss WAL frames and force a full re-snapshot.

## Tests

`bun test` in `cli/dust-sandbox/pod` (pod guard, name contract, must-exist open, pragmas, quota clamp, instance caching, error translation), wired into `build-dust-sandbox.yml` along with the bundle build.

## Risk

It's a no-op

## Deploy Plan

- Merge