### PR TITLE
fix(wakeups): delete cron schedule when a wake-up is cancelled at fire time

### DIFF
--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -658,10 +658,17 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     });
   }
 
-  async cleanupTemporalIfCronExpired(
+  async cleanupTemporalScheduleIfCronTerminal(
     auth: Authenticator
   ): Promise<Result<void, Error>> {
-    if (this.scheduleType !== "cron" || this.status !== "expired") {
+    // Once the wake-up reaches a terminal state (expired or cancelled) the
+    // schedule must be deleted, otherwise Temporal keeps spawning daily
+    // workflows that no-op forever. cancelTemporalWorkflow deletes the schedule
+    // for cron and is idempotent (ScheduleNotFound is treated as success).
+    if (
+      this.scheduleType !== "cron" ||
+      (this.status !== "expired" && this.status !== "cancelled")
+    ) {
       return new Ok(undefined);
     }
 

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -438,7 +438,7 @@ export async function runWakeUpActivity({
       { status: wakeUp.status, wakeUpId, workspaceId },
       "Cancelling wake-up: conversation not found."
     );
-    await wakeUp.markCancelled(auth);
+    await cancelWakeUpAndCleanupSchedule(auth, wakeUp);
     return;
   }
 
@@ -453,7 +453,7 @@ export async function runWakeUpActivity({
       },
       "Cancelling wake-up: conversation not accessible."
     );
-    await wakeUp.markCancelled(auth);
+    await cancelWakeUpAndCleanupSchedule(auth, wakeUp);
     return;
   }
 
@@ -494,7 +494,7 @@ export async function runWakeUpActivity({
         },
         "Cancelling wake-up: agent cannot be invoked."
       );
-      await wakeUp.markCancelled(auth);
+      await cancelWakeUpAndCleanupSchedule(auth, wakeUp);
       return;
     }
 
@@ -503,7 +503,7 @@ export async function runWakeUpActivity({
 
   await wakeUp.markFired(auth);
 
-  const cleanupRes = await wakeUp.cleanupTemporalIfCronExpired(auth);
+  const cleanupRes = await wakeUp.cleanupTemporalScheduleIfCronTerminal(auth);
   if (cleanupRes.isErr()) {
     logger.error(
       {
@@ -512,6 +512,29 @@ export async function runWakeUpActivity({
         error: normalizeError(cleanupRes.error),
       },
       "Failed cleaning up wake-up temporal state after fire."
+    );
+  }
+}
+
+// Marks a wake-up cancelled and, for cron wake-ups, deletes the backing
+// Temporal schedule so it stops firing. We do not use WakeUpResource.cancel
+// here: for one-shot wake-ups that would cancel the very workflow this activity
+// runs in. Deleting the cron schedule is safe from within a scheduled run.
+async function cancelWakeUpAndCleanupSchedule(
+  auth: Authenticator,
+  wakeUp: WakeUpResource
+): Promise<void> {
+  await wakeUp.markCancelled(auth);
+
+  const cleanupRes = await wakeUp.cleanupTemporalScheduleIfCronTerminal(auth);
+  if (cleanupRes.isErr()) {
+    logger.error(
+      {
+        wakeUpId: wakeUp.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        error: normalizeError(cleanupRes.error),
+      },
+      "Failed deleting wake-up schedule after cancelling."
     );
   }
 }
@@ -539,4 +562,16 @@ export async function expireWakeUpActivity({
   const { auth, wakeUp } = wakeUpAndAuthRes.value;
 
   await wakeUp.markExpired(auth);
+
+  const cleanupRes = await wakeUp.cleanupTemporalScheduleIfCronTerminal(auth);
+  if (cleanupRes.isErr()) {
+    logger.error(
+      {
+        wakeUpId,
+        workspaceId,
+        error: normalizeError(cleanupRes.error),
+      },
+      "Failed deleting wake-up schedule after expiring."
+    );
+  }
 }


### PR DESCRIPTION
## Description

When runWakeUpActivity hit a terminal condition (conversation gone/inaccessible, or agent_configuration_not_found / agent_inaccessible / model_disabled) it called markCancelled(), which only flips the DB row. For cron wake-ups the backing Temporal schedule was never deleted, so Temporal kept spawning daily workflows that no-op forever (until the maxFires cap).

The fire-time terminal paths now cancel the wake-up AND delete its cron schedule via cleanupTemporalScheduleIfCronTerminal (generalized from the former cleanupTemporalIfCronExpired to also cover the cancelled state). We deliberately do not use cancel(): for one-shot wake-ups that would cancel the very workflow this activity runs in. Deleting the cron schedule is safe from within a scheduled run.

Refs dust-tt/tasks#8477

## Tests

Unit
## Risk

Low

## Deploy Plan

Front