### PR TITLE
[front] feat: pod-state gcs prefix, replica mount profile and path helper

### DIFF
--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -608,18 +608,24 @@ export class GCSFileSystemBackend implements FileSystemBackend {
   ): SandboxMountAdapter {
     const bucket = fileStorageConfig.getGcsPrivateUploadsBucket();
     const targets: GCSMountTarget[] = [
-      ...mounts.map((mount) => ({
-        gcsPrefix: this.mountRootGCSPrefix(mount),
-        sandboxMountPoint: mount.sandboxMountPoint,
-        legacySandboxMountPoint: mount.legacySandboxMountPoint,
-        readOnly: false,
-      })),
-      ...sandboxOnlyMounts.map((mount) => ({
-        gcsPrefix: this.sandboxOnlyMountGCSPrefix(mount),
-        sandboxMountPoint: mount.sandboxMountPoint,
-        legacySandboxMountPoint: null,
-        readOnly: mount.readOnly,
-      })),
+      ...mounts.map(
+        (mount): GCSMountTarget => ({
+          gcsPrefix: this.mountRootGCSPrefix(mount),
+          sandboxMountPoint: mount.sandboxMountPoint,
+          legacySandboxMountPoint: mount.legacySandboxMountPoint,
+          readOnly: false,
+          mountProfile: "workload",
+        })
+      ),
+      ...sandboxOnlyMounts.map(
+        (mount): GCSMountTarget => ({
+          gcsPrefix: this.sandboxOnlyMountGCSPrefix(mount),
+          sandboxMountPoint: mount.sandboxMountPoint,
+          legacySandboxMountPoint: null,
+          readOnly: mount.readOnly,
+          mountProfile: this.sandboxOnlyMountProfile(mount),
+        })
+      ),
     ];
 
     return new GCSSandboxMountAdapter(bucket, targets);
@@ -629,6 +635,24 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     switch (mount.kind) {
       case "pod_sandbox_functions":
         return `w/${this.workspaceId}/pods/${mount.id}/sandbox-functions`;
+
+      case "pod_state":
+        return `w/${this.workspaceId}/pods/${mount.id}/state`;
+
+      default:
+        assertNever(mount.kind);
+    }
+  }
+
+  private sandboxOnlyMountProfile(
+    mount: SandboxOnlyMount
+  ): GCSMountTarget["mountProfile"] {
+    switch (mount.kind) {
+      case "pod_sandbox_functions":
+        return "workload";
+
+      case "pod_state":
+        return "pod_state_replica";
 
       default:
         assertNever(mount.kind);

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -12,6 +12,7 @@ import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import { concurrentExecutor } from "@app/temporal/workflow_utils";
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import type { SandboxMountAdapter } from "./sandbox_mount_adapter";
 
@@ -21,6 +22,21 @@ const TOKEN_SERVER_URL = "http://127.0.0.1:9876";
 const TOKEN_SERVER_POLL_ATTEMPTS = 100;
 const TOKEN_SERVER_POLL_INTERVAL_SECONDS = 0.05;
 const TOKEN_SERVER_EXEC_TIMEOUT_MS = 10_000;
+
+/**
+ * Per-target mount profile.
+ *
+ * - "workload": root-mounted with `allow_other` so the unprivileged sandbox
+ *   users can access it; permissive file/dir modes; 60s kernel list cache
+ *   (read-mostly workloads). All agent-facing mounts.
+ * - "pod_state_replica": mounted AS `dust-state` (via runuser) so the FUSE
+ *   default — only the mounting user can access the fs — makes it invisible to
+ *   every other uid, including the untrusted workload uid 1003 and root. No
+ *   `allow_other`, restrictive modes, and NO kernel list caching: litestream
+ *   restore must never see a stale LTX listing. Requires the image's
+ *   `pod_state` capability (dust-state user + /pod-state layout).
+ */
+export type GCSMountProfile = "workload" | "pod_state_replica";
 
 export type GCSMountTarget = {
   /**
@@ -36,6 +52,7 @@ export type GCSMountTarget = {
   legacySandboxMountPoint: string | null;
   /** When set, the mount uses `-o ro` and a read-only-scoped token (see buildAccessBoundaryRules). */
   readOnly: boolean;
+  mountProfile: GCSMountProfile;
 };
 
 /**
@@ -68,7 +85,8 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       return new Ok(undefined);
     }
 
-    const { bucket, targets } = this;
+    const { bucket } = this;
+    const targets = this.activeTargets(image);
     const prefixes = targets.map((t) => t.gcsPrefix);
     const workspaceId = auth.getNonNullableWorkspace().sId;
 
@@ -142,12 +160,7 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
 
         const mountResult = await sandbox.execRoot(
           auth,
-          buildMountCommand({
-            bucket,
-            prefix: target.gcsPrefix,
-            mountPoint: target.sandboxMountPoint,
-            readOnly: target.readOnly,
-          }),
+          buildMountCommand({ bucket, target }),
           { timeoutMs: MOUNT_TIMEOUT_MS }
         );
 
@@ -221,9 +234,10 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       return new Ok(undefined);
     }
 
+    const targets = this.activeTargets(image);
     const tokenResult = await mintDownscopedGcsToken({
       bucket: this.bucket,
-      prefixes: this.targets.map((t) => ({
+      prefixes: targets.map((t) => ({
         prefix: t.gcsPrefix,
         readOnly: t.readOnly,
       })),
@@ -244,12 +258,27 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       {
         sandboxId: sandbox.sId,
         workspaceId: auth.getNonNullableWorkspace().sId,
-        prefixes: this.targets.map((t) => t.gcsPrefix),
+        prefixes: targets.map((t) => t.gcsPrefix),
       },
       "GCS sandbox mount: credential refreshed"
     );
 
     return new Ok(undefined);
+  }
+
+  /**
+   * Targets applicable to the given image. pod_state_replica targets need the
+   * dust-state user and the /pod-state layout, both introduced with the
+   * `pod_state` capability — on older images they are skipped entirely (no
+   * mount, no CAB rules) so existing sandboxes keep working untouched.
+   */
+  private activeTargets(image: SandboxImage): GCSMountTarget[] {
+    if (image.hasCapability("pod_state")) {
+      return [...this.targets];
+    }
+    return this.targets.filter(
+      (target) => target.mountProfile !== "pod_state_replica"
+    );
   }
 
   /** Exposed for testing and diagnostics. */
@@ -261,26 +290,17 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
   }
 }
 
-function buildMountCommand({
+/** Exported for testing. */
+export function buildMountCommand({
   bucket,
-  prefix,
-  mountPoint,
-  readOnly,
+  target,
 }: {
   bucket: string;
-  prefix: string;
-  mountPoint: string;
-  readOnly: boolean;
+  target: GCSMountTarget;
 }): RootCommand {
-  // allow_other lets the unprivileged sandbox user read the root-mounted fs. `ro` is only
-  // defense-in-depth: the real write protection is the read-only token scope (see
-  // buildAccessBoundaryRules), not this flag.
-  const mountOptions = ["allow_other"];
-  if (readOnly) {
-    mountOptions.push("ro");
-  }
+  const { gcsPrefix: prefix, sandboxMountPoint: mountPoint } = target;
 
-  const flags = [
+  const commonFlags = [
     "--token-url",
     TOKEN_SERVER_URL,
     // Disable token caching so gcsfuse fetches a fresh credential on every GCS API request.
@@ -288,22 +308,69 @@ function buildMountCommand({
     "--only-dir",
     prefix,
     "--implicit-dirs",
-    "-o",
-    mountOptions.join(","),
-    "--file-mode=666",
-    "--dir-mode=777",
-    "--kernel-list-cache-ttl-secs=60",
     // Disable HNS: GetStorageLayout requires unrestricted objects.list which CAB cannot grant
     // per-prefix. With HNS disabled we scope list access via objectListPrefix conditions.
     "--enable-hns=false",
   ];
 
-  return rootCommand.stderrToStdout(
-    rootCommand.timeout(
-      rootCommand.exec("/usr/bin/gcsfuse", [...flags, bucket, mountPoint]),
-      MOUNT_TIMEOUT_MS / 1_000
-    )
-  );
+  switch (target.mountProfile) {
+    case "workload": {
+      // allow_other lets the unprivileged sandbox user read the root-mounted fs. `ro` is only
+      // defense-in-depth: the real write protection is the read-only token scope (see
+      // buildAccessBoundaryRules), not this flag.
+      const mountOptions = ["allow_other"];
+      if (target.readOnly) {
+        mountOptions.push("ro");
+      }
+
+      const flags = [
+        ...commonFlags,
+        "-o",
+        mountOptions.join(","),
+        "--file-mode=666",
+        "--dir-mode=777",
+        "--kernel-list-cache-ttl-secs=60",
+      ];
+
+      return rootCommand.stderrToStdout(
+        rootCommand.timeout(
+          rootCommand.exec("/usr/bin/gcsfuse", [...flags, bucket, mountPoint]),
+          MOUNT_TIMEOUT_MS / 1_000
+        )
+      );
+    }
+
+    case "pod_state_replica": {
+      // Mounted AS dust-state (runuser): with no allow_other, the FUSE layer
+      // denies every uid but the mounting one — the kernel-enforced version of
+      // "invisible to uid 1003". List caching is OFF: litestream restore reads
+      // the LTX listing at cold start and must never see a cached view.
+      const flags = [
+        ...commonFlags,
+        "--file-mode=600",
+        "--dir-mode=700",
+        "--kernel-list-cache-ttl-secs=0",
+      ];
+
+      return rootCommand.stderrToStdout(
+        rootCommand.timeout(
+          rootCommand.exec("/usr/sbin/runuser", [
+            "-u",
+            "dust-state",
+            "--",
+            "/usr/bin/gcsfuse",
+            ...flags,
+            bucket,
+            mountPoint,
+          ]),
+          MOUNT_TIMEOUT_MS / 1_000
+        )
+      );
+    }
+
+    default:
+      assertNever(target.mountProfile);
+  }
 }
 
 function buildTokenJson({

--- a/front/lib/api/file_system/types.ts
+++ b/front/lib/api/file_system/types.ts
@@ -53,9 +53,10 @@ export type FileSystemMount = {
 /**
  * A mount that exists only inside the sandbox filesystem and is never exposed through the
  * scoped-path API (the agent's file tools never see it). Used for prefixes the sandbox must read
- * but that are not an agent-visible namespace, e.g. published sandbox-function bundles.
+ * but that are not an agent-visible namespace, e.g. published sandbox-function bundles or the
+ * pod-state litestream replica.
  */
-export type SandboxOnlyMountKind = "pod_sandbox_functions";
+export type SandboxOnlyMountKind = "pod_sandbox_functions" | "pod_state";
 
 export type SandboxOnlyMount = {
   kind: SandboxOnlyMountKind;

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -5,6 +5,7 @@ import {
   getConversationFilesBasePath,
   getPodFilesBasePath,
   getPodSandboxFunctionsBasePath,
+  getPodStateBasePath,
   isAgentScopedPath,
   isCanonicalScopedPath,
   isLegacyScopedPath,
@@ -60,6 +61,14 @@ describe("mount_path helpers", () => {
       expect(
         getPodSandboxFunctionsBasePath({ workspaceId: "ws1", podId: "spc1" })
       ).toBe("w/ws1/pods/spc1/sandbox-functions/");
+    });
+  });
+
+  describe("getPodStateBasePath", () => {
+    it("should return a dedicated prefix separate from pod files and functions", () => {
+      expect(getPodStateBasePath({ workspaceId: "ws1", podId: "spc1" })).toBe(
+        "w/ws1/pods/spc1/state/"
+      );
     });
   });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -97,6 +97,22 @@ export function getPodSandboxFunctionsMountPoint(podId: string): string {
 }
 
 /**
+ * Prefix for the pod's Litestream state replica (LTX chains for the pod's SQLite databases). The
+ * sandbox's litestream daemon is the only writer, through the dust-state-only gcsfuse mount at
+ * /pod-state/replica. Never mounted under /files, never a FileResource: cleanup is a wholesale
+ * prefix delete at pod deletion (see deletePodStatePrefix).
+ */
+export function getPodStateBasePath({
+  workspaceId,
+  podId,
+}: {
+  workspaceId: string;
+  podId: string;
+}): string {
+  return `${getBaseMountPathForWorkspace({ workspaceId })}pods/${podId}/state/`;
+}
+
+/**
  * Given a mount file path like "w/.../files/report.pdf",
  * returns "w/.../files/report.processed.pdf".
  * For files without extension: "w/.../files/Makefile" -> "w/.../files/Makefile.processed".

--- a/front/lib/api/sandbox/gcs/token.test.ts
+++ b/front/lib/api/sandbox/gcs/token.test.ts
@@ -185,6 +185,33 @@ describe("buildAccessBoundaryRules", () => {
     ).toBe(false);
   });
 
+  it("emits 7 rules for the full pod sandbox prefix set (files, functions, state)", () => {
+    // Pod sandboxes mount three prefixes; the CAB ceiling is 10 rules, so
+    // this must stay at 7 (1 unconditional + 2 per prefix).
+    const rules = buildAccessBoundaryRules("bucket-x", [
+      { prefix: "w/ws1/pods/spc1/files", readOnly: false },
+      { prefix: "w/ws1/pods/spc1/sandbox-functions", readOnly: true },
+      { prefix: "w/ws1/pods/spc1/state", readOnly: false },
+    ]);
+    expect(rules).toHaveLength(7);
+  });
+
+  it("grants read/write on the pod state prefix", () => {
+    const rules = buildAccessBoundaryRules("bucket-x", [
+      { prefix: "w/ws1/pods/spc1/state", readOnly: false },
+    ]);
+
+    const objectRule = rules.find((r) =>
+      r.availablePermissions[0].includes("objectUser")
+    );
+    expect(objectRule).toBeDefined();
+    expect(
+      objectRule &&
+        "availabilityCondition" in objectRule &&
+        objectRule.availabilityCondition.expression
+    ).toContain("projects/_/buckets/bucket-x/objects/w/ws1/pods/spc1/state/");
+  });
+
   it("references every prefix in list and resource.name conditions", () => {
     const prefixes = [
       { prefix: "w/ws1/conversations/c1/files", readOnly: false },

--- a/front/lib/api/sandbox/gcs/token.ts
+++ b/front/lib/api/sandbox/gcs/token.ts
@@ -168,7 +168,11 @@ function getStorageMountRole(): string {
  *     loopback-served token (gcsfuse fetches it over http) still cannot write there.
  *
  * Total rule count is `1 + 2 * prefixes.length`. CAB allows up to 10 rules, so we support up to 4
- * concurrent prefixes.
+ * concurrent prefixes. Current budget: a pod sandbox mounts files (rw) +
+ * sandbox-functions (ro) + state (rw, the litestream replica prefix) = 3 prefixes = 7 rules.
+ *
+ * Prefixes carry NO trailing slash: the conditions below append the '/' themselves, so a
+ * trailing-slash prefix would produce 'state//' and silently break listing.
  */
 export function buildAccessBoundaryRules(
   bucket: string,

--- a/front/lib/api/sandbox/hardening.ts
+++ b/front/lib/api/sandbox/hardening.ts
@@ -40,6 +40,9 @@ export const SANDBOX_STATIC_ROOT_CONSUMED_DIRS = [
 export const SANDBOX_ROOT_INVOKED_HELPERS = [
   "/opt/bin/dsbx",
   "/usr/local/bin/dust-install-trust-bundle",
+  // Root invokes litestream on the pod-state sleep barrier (`litestream sync
+  // -wait`) and cold-start restore, so it must stay root-owned/non-writable.
+  "/opt/bin/litestream",
 ] as const;
 
 const ROOT_SAFE_PATH_PROFILE = "/etc/profile.d/zz-dust-root-safe-path.sh";

--- a/front/lib/api/sandbox/image/litestream/litestream.service
+++ b/front/lib/api/sandbox/image/litestream/litestream.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Dust Litestream replication daemon for pod state
+After=network.target
+
+[Service]
+User=dust-state
+Group=dust-state
+ExecStart=/opt/bin/litestream replicate -config /etc/litestream.yml
+Restart=always
+RestartSec=2s
+
+# Control socket directory (/run/litestream), created by systemd as
+# dust-state. The pre-sleep barrier runs `litestream sync -wait` against the
+# socket in there; the socket is enabled by the static /etc/litestream.yml
+# baked at image build (directory-watcher config over /pod-state/databases).
+RuntimeDirectory=litestream
+RuntimeDirectoryMode=0755
+
+# Defense in depth, modeled on dust-egress-resolver.service. The daemon only
+# needs rw under /pod-state (live databases + replica gcsfuse mount); the
+# control socket is AF_UNIX and the file replica needs no network.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ReadWritePaths=/pod-state
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/front/lib/api/sandbox/image/litestream/litestream.yml
+++ b/front/lib/api/sandbox/image/litestream/litestream.yml
@@ -1,0 +1,25 @@
+# Managed by Dust. Static config: every path is a fixed constant of the
+# pod-state contract (design_docs/pod_state_progress/contracts/paths-env.v2.md),
+# so it is baked at image build. The litestream.service unit stays disabled at
+# build and is started by front at runtime AFTER the replica gcsfuse mount and
+# the cold-start restore — starting at boot would let the daemon write to the
+# unmounted local directory and manage files mid-restore.
+
+# Control socket for the pre-sleep `litestream sync -wait` barrier. Lives in
+# the unit's RuntimeDirectory (unix socket paths are capped ~104 chars).
+socket:
+  enabled: true
+  path: /run/litestream/litestream.sock
+
+# Directory watcher (verified on v0.5.13): databases created after daemon
+# start — e.g. by a publish-time `dsbx db reconcile` — are discovered and
+# replicated within seconds. Non-SQLite files matching the pattern are
+# ignored by the watcher (header validation). Replica subdirectories are
+# named by database FILENAME: /pod-state/replica/{db}.db/ltx/...
+dbs:
+  - dir: /pod-state/databases
+    pattern: "*.db"
+    watch: true
+    replica:
+      type: file
+      path: /pod-state/replica

--- a/front/lib/api/sandbox/image/pod_package.test.ts
+++ b/front/lib/api/sandbox/image/pod_package.test.ts
@@ -1,0 +1,32 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import {
+  POD_PACKAGE_IMAGE_DIR,
+  POD_PACKAGE_SRC_DIR,
+} from "@app/lib/api/sandbox/image/pod_package";
+import { describe, expect, test } from "vitest";
+
+describe("pod package build paths", () => {
+  test("resolves the @dust/pod source dir under the repo root", () => {
+    // cli/dust-sandbox/pod itself lands in a parallel stack, so assert the
+    // repo-root resolution through markers that exist in every checkout: the
+    // repo root must contain front/ (where this test runs from) and
+    // cli/dust-sandbox/ (the parent of the pod package). This catches the
+    // path.resolve off-by-one class of bug without depending on the other
+    // stack's files.
+    // pod → dust-sandbox → cli → repo root.
+    const repoRoot = path.dirname(
+      path.dirname(path.dirname(POD_PACKAGE_SRC_DIR))
+    );
+
+    expect(POD_PACKAGE_SRC_DIR.endsWith("cli/dust-sandbox/pod")).toBe(true);
+    expect(existsSync(path.join(repoRoot, "front", "package.json"))).toBe(true);
+    expect(existsSync(path.join(repoRoot, "cli", "dust-sandbox"))).toBe(true);
+  });
+
+  test("targets the @dust scope inside the global node_modules", () => {
+    expect(POD_PACKAGE_IMAGE_DIR).toBe(
+      "/opt/npm-global/lib/node_modules/@dust/pod"
+    );
+  });
+});

--- a/front/lib/api/sandbox/image/pod_package.ts
+++ b/front/lib/api/sandbox/image/pod_package.ts
@@ -1,0 +1,140 @@
+import { spawnSync } from "child_process";
+import { createHash } from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// @dust/pod is the pod-state runtime package (db(name) over bun:sqlite; see
+// design_docs/pod_state_progress/contracts/paths-env.v1.md). Its source lives
+// as a standalone bun package in cli/dust-sandbox/pod. The @dust scope is a
+// Dust-owned virtual namespace that is never published to npm, so the package
+// is vendored into the image at build time: bun-bundle the entrypoint
+// (packages stay external and resolve through NODE_PATH at invocation, like
+// zod) and copy a flat {package.json, index.js} into
+// /opt/npm-global/lib/node_modules/@dust/pod.
+// __dirname is front/lib/api/sandbox/image → 4 up is front, 5 up is the repo
+// root (compare FRONT_ROOT_DIR in image/profile/build.ts, which is 5 up from
+// one directory deeper). Pinned by pod_package.test.ts against repo-root
+// markers so an off-by-one cannot silently point outside the repo.
+const REPO_ROOT_DIR = path.resolve(__dirname, "../../../../..");
+export const POD_PACKAGE_SRC_DIR = path.join(
+  REPO_ROOT_DIR,
+  "cli/dust-sandbox/pod"
+);
+const POD_PACKAGE_ENTRYPOINT = path.join(POD_PACKAGE_SRC_DIR, "index.ts");
+const POD_PACKAGE_CACHE = new Map<string, Map<string, Buffer | string>>();
+
+export const POD_PACKAGE_NAME = "@dust/pod";
+export const POD_PACKAGE_VERSION = "0.1.0";
+export const POD_PACKAGE_IMAGE_DIR = `/opt/npm-global/lib/node_modules/${POD_PACKAGE_NAME}`;
+
+function isENOENT(err: Error | undefined): err is NodeJS.ErrnoException {
+  return err !== undefined && "code" in err && err.code === "ENOENT";
+}
+
+function walkFiles(dir: string): string[] {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules") {
+          return [];
+        }
+        return walkFiles(entryPath);
+      }
+      return [entryPath];
+    })
+    .sort();
+}
+
+function getPodPackageBuildHash(): string {
+  const hash = createHash("sha256");
+  for (const filePath of walkFiles(POD_PACKAGE_SRC_DIR)) {
+    hash.update(path.relative(POD_PACKAGE_SRC_DIR, filePath));
+    hash.update("\0");
+    hash.update(fs.readFileSync(filePath));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+function buildPackageJson(): string {
+  return `${JSON.stringify(
+    {
+      name: POD_PACKAGE_NAME,
+      version: POD_PACKAGE_VERSION,
+      private: true,
+      type: "module",
+      main: "index.js",
+    },
+    null,
+    2
+  )}\n`;
+}
+
+export function buildPodPackage(): Map<string, Buffer | string> {
+  // The source dir is written by a parallel track (pod 1); the path is
+  // contract-frozen. This generator only runs at image build time (content
+  // generators are lazy), so a missing dir must fail the build loudly rather
+  // than ship an image without the package.
+  if (!fs.existsSync(POD_PACKAGE_ENTRYPOINT)) {
+    throw new Error(
+      `@dust/pod source not found at ${POD_PACKAGE_ENTRYPOINT}. The package ` +
+        "lives in cli/dust-sandbox/pod (see " +
+        "design_docs/pod_state_progress/contracts/paths-env.v1.md)."
+    );
+  }
+
+  const buildHash = getPodPackageBuildHash();
+  const cached = POD_PACKAGE_CACHE.get(buildHash);
+  if (cached) {
+    return cached;
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dust-pod-build-"));
+  const outputPath = path.join(tempDir, "index.js");
+
+  try {
+    const result = spawnSync(
+      "bun",
+      [
+        "build",
+        POD_PACKAGE_ENTRYPOINT,
+        "--bundle",
+        "--target=bun",
+        "--packages=external",
+        "--outfile",
+        outputPath,
+      ],
+      {
+        cwd: POD_PACKAGE_SRC_DIR,
+        encoding: "utf8",
+      }
+    );
+
+    if (isENOENT(result.error)) {
+      throw new Error(
+        "bun is required to build the sandbox @dust/pod package, but it was not found on PATH"
+      );
+    }
+
+    if (result.status !== 0) {
+      throw new Error(
+        `Failed to build sandbox @dust/pod package with bun: ${
+          result.stderr || result.stdout || "unknown error"
+        }`
+      );
+    }
+
+    const bundle = fs.readFileSync(outputPath);
+    const files = new Map<string, Buffer | string>([
+      ["package.json", buildPackageJson()],
+      ["index.js", bundle],
+    ]);
+    POD_PACKAGE_CACHE.set(buildHash, files);
+    return files;
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.50",
+      tag: "0.8.51",
     });
   });
 
@@ -167,7 +167,7 @@ describe("sandbox image registry", () => {
       expect(command).toContain("/usr/bin/systemd-analyze unit-paths");
       expect(command).toContain("systemd unit path must be absolute");
       expect(command).toContain(
-        "for path in /opt/bin/dsbx /usr/local/bin/dust-install-trust-bundle"
+        "for path in /opt/bin/dsbx /usr/local/bin/dust-install-trust-bundle /opt/bin/litestream"
       );
       expect(command).toContain("empty-password local accounts must not exist");
       expect(command).toContain("privileged primary group");
@@ -348,6 +348,181 @@ describe("sandbox image registry", () => {
         ),
       ])
     );
+  });
+
+  test("installs the pinned litestream release to /opt/bin", () => {
+    const runCommands = getRunCommands(getDustBaseImageOperations());
+    const installCommand = runCommands.find((command) =>
+      command.includes("benbjohnson/litestream/releases/download")
+    );
+
+    expect(installCommand).toBeDefined();
+    expect(installCommand).toContain(
+      "https://github.com/benbjohnson/litestream/releases/download/v0.5.13/litestream-0.5.13-linux-x86_64.tar.gz"
+    );
+    // sha256-pinned against the digest hardcoded in registry.ts, not against
+    // a checksums file fetched at build time.
+    expect(installCommand).toContain(
+      'echo "fc3420fea7d2f92d4d604aceeb0d7c63dc2c91f6ee5c1547cc05e25629e70f9f  /tmp/litestream.tar.gz" | sha256sum -c -'
+    );
+    expect(installCommand).toContain(
+      "chown root:root /opt/bin/litestream && chmod 755 /opt/bin/litestream"
+    );
+  });
+
+  test("creates the dust-state user and the pod-state directory layout", () => {
+    const runCommands = getRunCommands(getDustBaseImageOperations());
+
+    expect(runCommands).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "useradd --system --no-create-home --gid dust-state --groups agent --shell /usr/sbin/nologin dust-state"
+        ),
+        expect.stringContaining("install -d -o root -g root -m 755 /pod-state"),
+        expect.stringContaining(
+          "install -d -o dust-state -g agent -m 2770 /pod-state/databases"
+        ),
+        expect.stringContaining("setfacl -R -d -m g::rwx /pod-state/databases"),
+        expect.stringContaining("setfacl -R -m g::rwx /pod-state/databases"),
+        expect.stringContaining(
+          "install -d -o dust-state -g dust-state -m 700 /pod-state/replica"
+        ),
+      ])
+    );
+  });
+
+  test("copies the litestream systemd unit for runtime start only", () => {
+    const operations = getDustBaseImageOperations();
+    const runCommands = getRunCommands(operations);
+    const copyOperations = getCopyOperations(operations);
+    const litestreamUnit = getCopiedContent(
+      copyOperations,
+      "/etc/systemd/system/litestream.service"
+    );
+
+    expect(litestreamUnit).toContain(
+      "Description=Dust Litestream replication daemon for pod state"
+    );
+    expect(litestreamUnit).toContain("User=dust-state");
+    expect(litestreamUnit).toContain("Group=dust-state");
+    expect(litestreamUnit).toContain(
+      "ExecStart=/opt/bin/litestream replicate -config /etc/litestream.yml"
+    );
+    expect(litestreamUnit).toContain("Restart=always");
+    expect(litestreamUnit).toContain("RuntimeDirectory=litestream");
+    expect(litestreamUnit).toContain("NoNewPrivileges=yes");
+    expect(litestreamUnit).toContain("ProtectSystem=strict");
+    expect(litestreamUnit).toContain("ReadWritePaths=/pod-state");
+    expect(litestreamUnit).toContain("RestrictAddressFamilies=AF_UNIX");
+    expect(litestreamUnit).toContain("MemoryDenyWriteExecute=yes");
+
+    // The unit must NOT be enabled at build: front starts the daemon at
+    // runtime AFTER the replica mount + restore. Enabled at boot, the daemon
+    // would write to the unmounted local replica dir (the silent-unmount
+    // failure mode) and manage files mid-restore.
+    const enableCommands = runCommands.filter((command) =>
+      command.includes("systemctl enable")
+    );
+    expect(enableCommands.length).toBeGreaterThan(0);
+    for (const command of enableCommands) {
+      expect(command).not.toContain("litestream");
+    }
+  });
+
+  test("bakes the static litestream directory-watcher config", () => {
+    const copyOperations = getCopyOperations(getDustBaseImageOperations());
+    const litestreamConfig = getCopiedContent(
+      copyOperations,
+      "/etc/litestream.yml"
+    );
+
+    // Control socket for the pre-sleep sync barrier.
+    expect(litestreamConfig).toContain("socket:");
+    expect(litestreamConfig).toContain("enabled: true");
+    expect(litestreamConfig).toContain("path: /run/litestream/litestream.sock");
+
+    // Directory watcher (paths-env.v2): post-cold-start databases are
+    // discovered automatically; the replica subdir is named by db FILENAME
+    // ({db}.db).
+    expect(litestreamConfig).toContain("dir: /pod-state/databases");
+    expect(litestreamConfig).toContain('pattern: "*.db"');
+    expect(litestreamConfig).toContain("watch: true");
+    expect(litestreamConfig).toContain("type: file");
+    expect(litestreamConfig).toContain("path: /pod-state/replica");
+  });
+
+  test("pins drizzle packages and vendors @dust/pod", () => {
+    const operations = getDustBaseImageOperations();
+    const runCommands = getRunCommands(operations);
+    const copyOperations = getCopyOperations(operations);
+    const image = getDustBaseImage();
+
+    expect(runCommands).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "npm install -g typescript tsx pptxgenjs@4.0.1 zod@4.4.3 drizzle-orm@0.45.2 drizzle-kit@0.31.10"
+        ),
+        expect.stringContaining(
+          "mkdir -p /opt/npm-global/lib/node_modules/@dust"
+        ),
+      ])
+    );
+
+    // Vendored copy of @dust/pod. Do NOT materialize the content here: the
+    // generator bun-builds cli/dust-sandbox/pod, which is written by a
+    // parallel track and may be absent in this checkout.
+    const podCopy = copyOperations.find(
+      (operation) =>
+        operation.dest === "/opt/npm-global/lib/node_modules/@dust/pod"
+    );
+    expect(podCopy).toBeDefined();
+    expect(podCopy?.src.type).toBe("content");
+
+    expect(image.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "drizzle-orm", version: "0.45.2" }),
+        expect.objectContaining({ name: "drizzle-kit", version: "0.31.10" }),
+        expect.objectContaining({ name: "@dust/pod", version: "0.1.0" }),
+      ])
+    );
+  });
+
+  test("declares the pod_state capability", () => {
+    expect(getDustBaseImage().hasCapability("pod_state")).toBe(true);
+  });
+
+  test("runs pod-state install ops before the final hardening re-run", () => {
+    const runCommands = getRunCommands(getDustBaseImageOperations());
+    const lastHardeningIndex = runCommands.reduce(
+      (last, command, index) =>
+        command.includes("sudo must not be installed in sandbox images")
+          ? index
+          : last,
+      -1
+    );
+    const litestreamIndex = runCommands.findIndex((command) =>
+      command.includes("benbjohnson/litestream/releases/download")
+    );
+    const podStateIndex = runCommands.findIndex((command) =>
+      command.includes("install -d -o dust-state -g agent -m 2770")
+    );
+    const drizzleIndex = runCommands.findIndex((command) =>
+      command.includes("drizzle-orm@0.45.2")
+    );
+    const podPackageMkdirIndex = runCommands.findIndex((command) =>
+      command.includes("mkdir -p /opt/npm-global/lib/node_modules/@dust")
+    );
+
+    expect(lastHardeningIndex).toBeGreaterThanOrEqual(0);
+    for (const index of [
+      litestreamIndex,
+      podStateIndex,
+      drizzleIndex,
+      podPackageMkdirIndex,
+    ]) {
+      expect(index).toBeGreaterThanOrEqual(0);
+      expect(index).toBeLessThan(lastHardeningIndex);
+    }
   });
 
   test("keeps the nftables UID filter aligned with untrusted sandbox UIDs", () => {

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -2,6 +2,12 @@ import {
   getLocalAccountPrivilegeHardeningCommand,
   getRootConsumedPathHardeningCommand,
 } from "@app/lib/api/sandbox/hardening";
+import {
+  buildPodPackage,
+  POD_PACKAGE_IMAGE_DIR,
+  POD_PACKAGE_NAME,
+  POD_PACKAGE_VERSION,
+} from "@app/lib/api/sandbox/image/pod_package";
 import { PROFILE_DIR } from "@app/lib/api/sandbox/image/profile";
 import { buildDustToolsBinary } from "@app/lib/api/sandbox/image/profile/build";
 import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
@@ -19,7 +25,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.50";
+const DUST_BASE_IMAGE_VERSION = "0.8.51";
 const DSBX_CLI_VERSION = "0.1.32";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
@@ -39,7 +45,16 @@ const BUN_VERSION = "1.3.14";
 // machine and not another. This assumes an Ubuntu base and build-time egress to
 // launchpad.net; if PPAs are blocked, install the TDF .deb bundle instead.
 const LIBREOFFICE_PPA = "ppa:libreoffice/ppa";
+// Litestream (Apache-2.0) replicates pod-state SQLite databases to the GCS
+// replica mount. Pinned per design_docs/pod_state_progress/contracts/
+// paths-env.v1.md. The sha256 is the digest of the upstream release artifact
+// litestream-<version>-linux-x86_64.tar.gz, verified against the checksums.txt
+// published at https://github.com/benbjohnson/litestream/releases/tag/v0.5.13.
+const LITESTREAM_VERSION = "0.5.13";
+const LITESTREAM_SHA256 =
+  "fc3420fea7d2f92d4d604aceeb0d7c63dc2c91f6ee5c1547cc05e25629e70f9f";
 const EGRESS_LOCAL_DIR = path.resolve(__dirname, "egress");
+const LITESTREAM_LOCAL_DIR = path.resolve(__dirname, "litestream");
 const PROFILE_LOCAL_DIR = path.resolve(__dirname, "profile");
 const TELEMETRY_LOCAL_DIR = path.resolve(__dirname, "telemetry");
 
@@ -199,6 +214,35 @@ function getEgressResolverUserSetupCommand(): string {
   ].join(" && ");
 }
 
+function getDustStateUserSetupCommand(): string {
+  // dust-state runs the litestream replication daemon (pod state). Primary
+  // group dust-state owns the replica mount point; supplementary membership
+  // in `agent` grants rw on the live databases dir shared with agent-proxied
+  // function code. Deliberately NOT in SANDBOX_UNTRUSTED_UIDS: it never
+  // executes workload code.
+  return [
+    "groupadd --system dust-state",
+    "useradd --system --no-create-home --gid dust-state --groups agent --shell /usr/sbin/nologin dust-state",
+  ].join(" && ");
+}
+
+function getPodStateSetupCommand(): string {
+  // Pod-state layout per design_docs/pod_state_progress/contracts/
+  // paths-env.v1.md. /pod-state/databases holds the live SQLite files: both
+  // agent-proxied function code (group agent) and litestream (dust-state)
+  // need rw, so it gets the same setgid + default-ACL treatment as /files.
+  // /pod-state/replica is the gcsfuse mount point for the litestream file
+  // replica: dust-state only, and it must stay invisible to uid 1003 (0700
+  // here, no allow_other on the runtime mount).
+  return [
+    "install -d -o root -g root -m 755 /pod-state",
+    "install -d -o dust-state -g agent -m 2770 /pod-state/databases",
+    "setfacl -R -d -m g::rwx /pod-state/databases",
+    "setfacl -R -m g::rwx /pod-state/databases",
+    "install -d -o dust-state -g dust-state -m 700 /pod-state/replica",
+  ].join(" && ");
+}
+
 function getSshHardeningCommand(): string {
   // Layered on purpose, not redundant. `AllowUsers agent` is the load-bearing
   // lock (whitelist). The other lines defend the case where a future bedrock
@@ -279,6 +323,8 @@ SHELLEOF`,
   )
   .runCmd("chmod 755 /home/agent/.bin/token-server.sh", { user: "root" })
   .runCmd(getEgressResolverUserSetupCommand(), { user: "root" })
+  .runCmd(getDustStateUserSetupCommand(), { user: "root" })
+  .runCmd(getPodStateSetupCommand(), { user: "root" })
   // Hidden tools: installed but not in manifest (back profile functions)
   .runCmd("apt-get update && apt-get install -y ripgrep fd-find sd", {
     user: "root",
@@ -372,8 +418,25 @@ SHELLEOF`,
         description: "Schema validation (sandbox function contracts)",
         runtime: "node",
       },
+      {
+        name: "drizzle-orm",
+        version: "0.45.2",
+        description:
+          "SQLite ORM (pod database schema files and function queries)",
+        runtime: "node",
+      },
+      {
+        name: "drizzle-kit",
+        version: "0.31.10",
+        description:
+          "Schema push/pull engine (used by dsbx db commands, not function code)",
+        runtime: "node",
+      },
     ],
-    { installCmd: "npm install -g typescript tsx pptxgenjs@4.0.1 zod@4.4.3" }
+    {
+      installCmd:
+        "npm install -g typescript tsx pptxgenjs@4.0.1 zod@4.4.3 drizzle-orm@0.45.2 drizzle-kit@0.31.10",
+    }
   )
   .runCmd(
     `curl -fsSL https://github.com/dust-tt/dust/releases/download/dsbx-v${DSBX_CLI_VERSION}/dsbx-linux-x86_64 -o /tmp/dsbx && ` +
@@ -420,6 +483,44 @@ SHELLEOF`,
   .registerTool({
     name: "bun",
     description: "Fast JavaScript/TypeScript runtime and package manager",
+    runtime: "node",
+  })
+  .runCmd(
+    `curl -fsSL https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-${LITESTREAM_VERSION}-linux-x86_64.tar.gz -o /tmp/litestream.tar.gz && ` +
+      `echo "${LITESTREAM_SHA256}  /tmp/litestream.tar.gz" | sha256sum -c - && ` +
+      "tar -xzf /tmp/litestream.tar.gz -C /tmp litestream && " +
+      "rm /tmp/litestream.tar.gz && " +
+      "mv /tmp/litestream /opt/bin/litestream && " +
+      "chown root:root /opt/bin/litestream && chmod 755 /opt/bin/litestream",
+    { user: "root" }
+  )
+  // Litestream unit + STATIC config (all paths are pod-state contract
+  // constants), both baked at build. The unit is deliberately NOT enabled:
+  // front starts it at runtime AFTER the replica gcsfuse mount and the
+  // cold-start restore — at boot the daemon would write to the unmounted
+  // local directory (the silent-unmount failure mode) and manage files
+  // mid-restore.
+  .copy(
+    getLocalContent(LITESTREAM_LOCAL_DIR, "litestream.service"),
+    "/etc/systemd/system/litestream.service",
+    { user: "root" }
+  )
+  .copy(
+    getLocalContent(LITESTREAM_LOCAL_DIR, "litestream.yml"),
+    "/etc/litestream.yml",
+    { user: "root" }
+  )
+  // Vendor @dust/pod into the global node_modules (see pod_package.ts for why
+  // this is a build-time copy rather than an npm install).
+  .runCmd(`mkdir -p ${path.posix.dirname(POD_PACKAGE_IMAGE_DIR)}`, {
+    user: "root",
+  })
+  .copy(buildPodPackage, POD_PACKAGE_IMAGE_DIR, { user: "root" })
+  .registerTool({
+    name: POD_PACKAGE_NAME,
+    version: POD_PACKAGE_VERSION,
+    description:
+      "Pod database access: db(name) returns a drizzle instance over the pod's SQLite database",
     runtime: "node",
   })
   .runCmd(`mkdir -p ${PROFILE_DIR}`, { user: "root" })
@@ -673,6 +774,7 @@ SHELLEOF`,
     runtime: "system",
   })
   .withCapability("gcsfuse")
+  .withCapability("pod_state")
   .withResources({ vcpu: 2, memoryMb: 2048 })
   .withNetwork(PROXY_ONLY_NETWORK_POLICY)
   .setWorkdir("/home/agent")

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -154,8 +154,14 @@ export interface ToolManifest {
  * Declarative tags describing what a sandbox template supports.
  * The Docker image must actually have the corresponding tooling installed. The capability tag tells
  * orchestration it is safe to attempt the feature.
+ *
+ * - "gcsfuse": gcsfuse binary + token server, GCS mounts can be attempted.
+ * - "pod_state": litestream binary + dust-state user + /pod-state layout;
+ *   pod-state runtime touchpoints (state mount, restore, daemon start, sleep
+ *   barrier, probes) early-return when the image lacks it, so sandboxes on
+ *   older images keep working untouched.
  */
-export type SandboxCapability = "gcsfuse";
+export type SandboxCapability = "gcsfuse" | "pod_state";
 
 // ---------------------------------------------------------------------------
 // Base Image

--- a/front/scripts/sandbox_security_check.test.ts
+++ b/front/scripts/sandbox_security_check.test.ts
@@ -7,6 +7,7 @@ import {
   assertNoEmptyPasswordAccounts,
   assertNoPasswordlessSudoers,
   assertNoPrivilegedGroupMembers,
+  assertPodStateDirsSafe,
   assertRootInvokedHelpersSafe,
   assertRootPathSafe,
   assertStaticRootConsumedDirsSafe,
@@ -146,19 +147,57 @@ describe("sandbox security check assertions", () => {
   test("detects unsafe root-invoked helper ownership or modes", () => {
     expect(() =>
       assertRootInvokedHelpersSafe(
-        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x"
+        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x\n/opt/bin/litestream root:root 755 -rwxr-xr-x"
       )
     ).not.toThrow();
     expect(() =>
       assertRootInvokedHelpersSafe(
-        "/opt/bin/dsbx root:root 777 -rwxrwxrwx\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x"
+        "/opt/bin/dsbx root:root 777 -rwxrwxrwx\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x\n/opt/bin/litestream root:root 755 -rwxr-xr-x"
       )
     ).toThrow("root-invoked helper is not root-owned");
     expect(() =>
-      assertRootInvokedHelpersSafe("/opt/bin/dsbx root:root 755 -rwxr-xr-x")
+      assertRootInvokedHelpersSafe(
+        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/opt/bin/litestream root:root 755 -rwxr-xr-x"
+      )
     ).toThrow(
       "missing root-invoked helper audit for /usr/local/bin/dust-install-trust-bundle"
     );
+    expect(() =>
+      assertRootInvokedHelpersSafe(
+        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x"
+      )
+    ).toThrow("missing root-invoked helper audit for /opt/bin/litestream");
+  });
+
+  test("detects unsafe pod-state directory ownership or modes", () => {
+    const safeOutput = [
+      "POD_STATE_DIR=/pod-state root:root 755 drwxr-xr-x",
+      "POD_STATE_DIR=/pod-state/databases dust-state:agent 2770 drwxrws---",
+      "POD_STATE_DIR=/pod-state/replica dust-state:dust-state 700 drwx------",
+    ].join("\n");
+
+    expect(() => assertPodStateDirsSafe(safeOutput)).not.toThrow();
+    expect(() =>
+      assertPodStateDirsSafe(
+        safeOutput.replace(
+          "/pod-state/replica dust-state:dust-state 700",
+          "/pod-state/replica dust-state:dust-state 755"
+        )
+      )
+    ).toThrow("pod-state directory /pod-state/replica");
+    expect(() =>
+      assertPodStateDirsSafe(
+        safeOutput.replace(
+          "/pod-state/databases dust-state:agent 2770",
+          "/pod-state/databases agent:agent 2770"
+        )
+      )
+    ).toThrow("pod-state directory /pod-state/databases");
+    expect(() =>
+      assertPodStateDirsSafe(
+        "POD_STATE_DIR=/pod-state root:root 755 drwxr-xr-x"
+      )
+    ).toThrow("missing pod-state directory audit for /pod-state/databases");
   });
 
   test("detects root PATH entries that can resolve agent-writable binaries", () => {

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -567,6 +567,45 @@ export function assertRootInvokedHelpersSafe(output: string): void {
   }
 }
 
+const POD_STATE_DIR_EXPECTATIONS = [
+  { path: "/pod-state", owner: "root:root", mode: "755" },
+  { path: "/pod-state/databases", owner: "dust-state:agent", mode: "2770" },
+  { path: "/pod-state/replica", owner: "dust-state:dust-state", mode: "700" },
+] as const;
+
+export function assertPodStateDirsSafe(output: string): void {
+  const lineByPath = new Map<string, string>();
+  for (const line of output.split("\n")) {
+    if (!line.startsWith("POD_STATE_DIR=")) {
+      continue;
+    }
+    const [path] = line.replace("POD_STATE_DIR=", "").split(/\s+/, 1);
+    if (path) {
+      lineByPath.set(path, line);
+    }
+  }
+
+  for (const expectation of POD_STATE_DIR_EXPECTATIONS) {
+    const line = lineByPath.get(expectation.path);
+    if (!line) {
+      throw new Error(
+        `missing pod-state directory audit for ${expectation.path}:\n${output}`
+      );
+    }
+
+    const fields = line.replace("POD_STATE_DIR=", "").split(/\s+/);
+    const owner = fields[1];
+    const mode = fields[2];
+
+    if (owner !== expectation.owner || mode !== expectation.mode) {
+      throw new Error(
+        `pod-state directory ${expectation.path} must be ${expectation.owner} ` +
+          `mode ${expectation.mode}:\n${line}`
+      );
+    }
+  }
+}
+
 export function assertRootPathSafe(output: string): void {
   const rootPathLines = output
     .split("\n")
@@ -654,6 +693,12 @@ for path in ${SANDBOX_ROOT_INVOKED_HELPERS.map((path) => shellQuote(path)).join(
     stat -c '%n %U:%G %a %A' "$path"
   fi
 done
+echo "--- pod-state-dirs ---"
+for dir in ${POD_STATE_DIR_EXPECTATIONS.map((expectation) =>
+      shellQuote(expectation.path)
+    ).join(" ")}; do
+  stat -c 'POD_STATE_DIR=%n %U:%G %a %A' "$dir"
+done
 echo "--- root-path ---"
 printf 'ROOT_EXEC_PATH=%s\n' "$PATH"
 /bin/bash --noprofile --norc -c 'source /etc/profile; printf "ROOT_LOGIN_PATH=%s\n" "$PATH"'
@@ -669,6 +714,7 @@ printf 'ROOT_EXEC_PATH=%s\n' "$PATH"
   assertStaticRootConsumedDirsSafe(output);
   assertSystemdUnitPathsSafe(output);
   assertRootInvokedHelpersSafe(output);
+  assertPodStateDirsSafe(output);
   assertRootPathSafe(output);
 }
 
@@ -843,6 +889,63 @@ fi
   }
 }
 
+async function checkPodStateWorkloadAccess(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  // The live databases dir must be read-write for the workload user (function
+  // code opens SQLite files there), exercising the setgid + default-ACL
+  // inheritance like the /files smoke test does.
+  const databasesAccess = await runBashScript(
+    provider,
+    providerId,
+    `
+set -euo pipefail
+test -d /pod-state/databases
+proof=$(mktemp /pod-state/databases/dust-security-smoke-XXXXXX)
+printf 'db-ok' > "$proof"
+test "$(cat "$proof")" = "db-ok"
+rm -f "$proof"
+`,
+    { user: AGENT_PROXIED_USER }
+  );
+  assertCommandSucceeded(
+    "pod-state databases workload access",
+    databasesAccess
+  );
+
+  // The replica dir (gcsfuse mount point for the litestream file replica),
+  // the litestream binary, and the litestream unit must all be untouchable by
+  // uid 1003. This sandbox has no gcsfuse mount, so the replica probe covers
+  // the underlying 0700 directory; the mounted case is additionally protected
+  // by mounting without allow_other.
+  const denials = await runBashScript(
+    provider,
+    providerId,
+    `
+set -euo pipefail
+if ls /pod-state/replica >/dev/null 2>&1; then
+  echo "CRITICAL: workload user can list /pod-state/replica"
+  exit 1
+fi
+if touch /pod-state/replica/dust-security-proof 2>/dev/null; then
+  echo "CRITICAL: workload user can write /pod-state/replica"
+  exit 1
+fi
+if [ -w /opt/bin/litestream ]; then
+  echo "CRITICAL: workload user can write /opt/bin/litestream"
+  exit 1
+fi
+if printf '' >> /etc/systemd/system/litestream.service 2>/dev/null; then
+  echo "CRITICAL: workload user can write the litestream systemd unit"
+  exit 1
+fi
+`,
+    { user: AGENT_PROXIED_USER }
+  );
+  assertCommandSucceeded("pod-state workload denial probes", denials);
+}
+
 function assertSshAndDnsHardening(output: string): void {
   if (!output.includes("SSH_PORT_22_LISTENING=0")) {
     throw new Error(`sshd appears to be listening on port 22:\n${output}`);
@@ -950,6 +1053,7 @@ async function checkImage(image: SandboxImage): Promise<void> {
     await checkSshAndDnsHardening(provider, providerId);
     await checkRootExecPathHijack(provider, providerId);
     await checkSystemdUnitSearchPathShadow(provider, providerId);
+    await checkPodStateWorkloadAccess(provider, providerId);
 
     logger.info(
       { imageId, providerId },


### PR DESCRIPTION
## Description

**PR 2/4 of the pod-state stack** (`design_docs/POD_STATE_DESIGN.md`, "GCS architecture and auth"): the GCS plumbing for the litestream replica — token scope, mount profile, path helper.

**What & why:**
- New **`pod_state` SandboxOnlyMount kind** → rw CAB prefix `w/{wId}/pods/{podId}/state` (no trailing slash: the CAB conditions append the `/` themselves). Pod sandboxes now mint **7 rules** (1 unconditional + 2×3 prefixes: files rw, sandbox-functions ro, state rw) of the CAB ceiling of 10 / adapter cap of 4 targets.
- **`GCSMountTarget.mountProfile`** (`"workload" | "pod_state_replica"`). The replica profile is mounted **as `dust-state` via runuser** instead of root-with-`allow_other`: with no `allow_other`, the FUSE layer only admits the *mounting* user — one mechanism that simultaneously keeps the replica usable by the litestream daemon and kernel-denied to the untrusted workload uid 1003 (and even root). A root-made mount without `allow_other` would lock out the daemon itself. Also per-profile: `--kernel-list-cache-ttl-secs=0` (restore must never see a stale LTX listing — design failure mode 3), file/dir modes 600/700.
- `pod_state_replica` targets are **skipped entirely (mount + CAB rules) on images without the `pod_state` capability**, so existing paused sandboxes keep refreshing tokens exactly as today.
- `getPodStateBasePath` path helper (trailing-slash form for object writers/prefix deletes, consistent with its siblings).

Stack (bottom-up): #28596 image → **this** → restore → sleep barrier (#28597).

## Tests

- `token.test.ts` (8 + manual CAB suite): rule shape, the 7-rule pod set, rw scope on the state prefix.
- `mount_path.test.ts` (52): helper family incl. the new state prefix.
- (The end-to-end wiring test that derives the CAB set from the real pod mount set lands with the barrier PR, which introduces the shared mount factory.)

## Risk

Pure plumbing, inert until the follow-ups: the state target only materializes for pod sandboxes on the `pod_state`-capable image. CAB budget checked twice (comment'd formula + adapter constructor throw above 4 targets).

## Deploy Plan

No ordering constraints; deploy with the rest of front. Does nothing until the restore/barrier PRs and the 0.8.51 image exist.
