### PR TITLE
[front] feat: pod-state cold-start restore and litestream daemon start

### DIFF
--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -54,7 +54,14 @@ export type SandboxStartupPhase =
   // the token, starts the token server, and polls it ready (was three execs).
   | "gcs.mint_token"
   | "gcs.token_server"
-  | "gcs.gcsfuse_mount";
+  | "gcs.gcsfuse_mount"
+  // Pod state bring-up (cold start only, after gcs_mount): restore replicated
+  // SQLite databases, then start the daemon (its static directory-watcher
+  // config is baked in the image).
+  | "pod_state_setup"
+  | "pod_state.enumerate"
+  | "pod_state.restore_db"
+  | "pod_state.start_daemon";
 
 // Opens a parent APM span for a startup phase. The provider.* child spans nest
 // underneath automatically, so this adds semantic grouping (and a per-phase
@@ -128,5 +135,19 @@ export function recordToolDuration(
     ...buildTags(ctx),
     `tool:${tool}`,
     `status:${status}`,
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Pod state (litestream replication) metrics. "Alerting" for pod state means
+// Datadog monitors over these counters + the stable logger.error messages next
+// to them — a failure counter that stays at 0 is the healthy state.
+// ---------------------------------------------------------------------------
+
+// No workspace tag: the gate runs without a per-workspace failure mode — an
+// anomalous sandbox image identity is a fleet-wide code/rollout bug.
+export function recordPodStateCapabilityGateError(): void {
+  getStatsDClient().increment("sandbox.pod_state.capability_gate_error", 1, [
+    `region:${regionConfig.getCurrentRegion()}`,
   ]);
 }

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -1,6 +1,4 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import type { SandboxOnlyMount } from "@app/lib/api/file_system/types";
-import { getPodSandboxFunctionsMountPoint } from "@app/lib/api/files/mount_path";
 import {
   ensureSandboxEgressOnExec,
   prepareSandboxEgressBeforeMount,
@@ -11,6 +9,8 @@ import {
   traceSandboxStartupPhase,
 } from "@app/lib/api/sandbox/instrumentation";
 import type { SandboxRuntimeOwner } from "@app/lib/api/sandbox/owner";
+import { podSandboxOnlyMounts } from "@app/lib/api/sandbox/pod_mounts";
+import { setupPodStateOnColdStart } from "@app/lib/api/sandbox/pod_state";
 import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
@@ -128,6 +128,34 @@ async function ensureOwnerSandboxReady(
         }
       }
 
+      // Pod state bring-up must run strictly AFTER the mounts (restore reads
+      // through the replica mount) and is awaited: `invoke` awaits
+      // ensurePodSandboxReady, which is what guarantees no function runs
+      // before the restore + daemon start completed. No-op for non-pod owners
+      // and for images without the `pod_state` capability.
+      if (freshlyCreated && runtimeOwner.kind === "pod") {
+        const podStateResult = await setupPodStateOnColdStart(
+          auth,
+          sandbox,
+          image
+        );
+        if (podStateResult.isErr()) {
+          // status=running was already committed by ensureActive, and this
+          // block only runs when freshlyCreated — a plain Err would make the
+          // NEXT call take the warm path and happily serve a half-initialized
+          // sandbox (unrestored databases, no litestream daemon). Request a
+          // kill instead: ensureActive's kill-requested branch destroys and
+          // recreates on the next access, re-running this setup from scratch.
+          logger.error(
+            { err: podStateResult.error, sandboxId: sandbox.sId },
+            "Pod state cold start failed — requesting sandbox kill so the next access recreates it."
+          );
+          await sandbox.requestKill();
+          status = "error";
+          return podStateResult;
+        }
+      }
+
       const ensureEgressResult = await traceSandboxStartupPhase(
         "egress_on_exec",
         () =>
@@ -163,17 +191,6 @@ export async function ensureConversationSandboxReady(
   });
 }
 
-// A pod's published function bundles are mounted read-only so the sandbox can execute them while
-// front stays the sole writer of bundles.
-function podSandboxFunctionsMount(pod: SpaceResource): SandboxOnlyMount {
-  return {
-    kind: "pod_sandbox_functions",
-    id: pod.sId,
-    sandboxMountPoint: getPodSandboxFunctionsMountPoint(pod.sId),
-    readOnly: true,
-  };
-}
-
 export async function ensurePodSandboxReady(
   auth: Authenticator,
   pod: SpaceResource
@@ -182,7 +199,7 @@ export async function ensurePodSandboxReady(
     ensureActive: () => PodSandboxAdapter.ensureSandboxActive(auth, pod),
     getFileSystem: () =>
       DustFileSystem.forPod(auth, pod, {
-        sandboxOnlyMounts: [podSandboxFunctionsMount(pod)],
+        sandboxOnlyMounts: podSandboxOnlyMounts(pod),
       }),
     runtimeOwner: {
       kind: "pod",

--- a/front/lib/api/sandbox/pod_mounts.ts
+++ b/front/lib/api/sandbox/pod_mounts.ts
@@ -1,0 +1,43 @@
+import type { SandboxOnlyMount } from "@app/lib/api/file_system/types";
+import { getPodSandboxFunctionsMountPoint } from "@app/lib/api/files/mount_path";
+import { POD_STATE_REPLICA_MOUNT_POINT } from "@app/lib/api/sandbox/pod_state";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+
+/**
+ * The pod sandbox's sandbox-only mounts, shared by the bring-up path
+ * (ensurePodSandboxReady) and the pre-sleep credential refresh
+ * (PodSandboxAdapter) so both always operate on the same target set — the CAB
+ * token covers every prefix of the sandbox at once.
+ *
+ * The parameter is `Pick<SpaceResource, "sId">` (only the sId is used) so the
+ * wiring can be exercised in tests without constructing a full resource.
+ */
+type PodRef = Pick<SpaceResource, "sId">;
+
+// A pod's published function bundles are mounted read-only so the sandbox can execute them while
+// front stays the sole writer of bundles.
+export function podSandboxFunctionsMount(pod: PodRef): SandboxOnlyMount {
+  return {
+    kind: "pod_sandbox_functions",
+    id: pod.sId,
+    sandboxMountPoint: getPodSandboxFunctionsMountPoint(pod.sId),
+    readOnly: true,
+  };
+}
+
+// The pod's litestream replica prefix, mounted dust-state-only (no
+// allow_other) at /pod-state/replica. rw: the in-sandbox litestream daemon is
+// the writer. Skipped by the mount adapter on images without the `pod_state`
+// capability.
+export function podStateReplicaMount(pod: PodRef): SandboxOnlyMount {
+  return {
+    kind: "pod_state",
+    id: pod.sId,
+    sandboxMountPoint: POD_STATE_REPLICA_MOUNT_POINT,
+    readOnly: false,
+  };
+}
+
+export function podSandboxOnlyMounts(pod: PodRef): SandboxOnlyMount[] {
+  return [podSandboxFunctionsMount(pod), podStateReplicaMount(pod)];
+}

--- a/front/lib/api/sandbox/pod_state.test.ts
+++ b/front/lib/api/sandbox/pod_state.test.ts
@@ -1,0 +1,96 @@
+import {
+  compareDottedVersions,
+  isValidPodDatabaseName,
+  parseLiveDatabaseNames,
+  parseReplicaDatabaseNames,
+  podStateVersionSupported,
+} from "@app/lib/api/sandbox/pod_state";
+import { describe, expect, test } from "vitest";
+
+describe("pod state helpers", () => {
+  test("validates database names against the contract shape", () => {
+    expect(isValidPodDatabaseName("chat")).toBe(true);
+    expect(isValidPodDatabaseName("a")).toBe(true);
+    expect(isValidPodDatabaseName("chat_v2")).toBe(true);
+    expect(isValidPodDatabaseName("a".repeat(64))).toBe(true);
+
+    expect(isValidPodDatabaseName("a".repeat(65))).toBe(false);
+    expect(isValidPodDatabaseName("")).toBe(false);
+    expect(isValidPodDatabaseName("Chat")).toBe(false);
+    expect(isValidPodDatabaseName("1chat")).toBe(false);
+    expect(isValidPodDatabaseName("_chat")).toBe(false);
+    expect(isValidPodDatabaseName("chat-db")).toBe(false);
+    expect(isValidPodDatabaseName(".restore-chat")).toBe(false);
+    expect(isValidPodDatabaseName("-o")).toBe(false);
+    expect(isValidPodDatabaseName("chat db")).toBe(false);
+  });
+
+  test("parses replica enumeration output (watcher {db}.db layout), dropping non-conforming entries", () => {
+    const findOutput = [
+      // The directory watcher names replica subdirs by database FILENAME.
+      "/pod-state/replica/chat.db",
+      "/pod-state/replica/tasks.db",
+      // Hostile or accidental entries a workload could plant elsewhere or a
+      // partial write could leave behind: all dropped by the name allowlist.
+      "/pod-state/replica/.hidden.db",
+      "/pod-state/replica/Invalid-Name.db",
+      "/pod-state/replica/-o.db",
+      "/pod-state/replica/no-db-suffix",
+      "",
+      "  ",
+    ].join("\n");
+
+    expect(parseReplicaDatabaseNames(findOutput)).toEqual(["chat", "tasks"]);
+    expect(parseReplicaDatabaseNames("")).toEqual([]);
+  });
+
+  test("parses live database enumeration output", () => {
+    const findOutput = [
+      "/pod-state/databases/chat.db",
+      "/pod-state/databases/tasks.db",
+      "/pod-state/databases/.restore-chat.db",
+      "/pod-state/databases/UPPER.db",
+      "/pod-state/databases/not-a-db.txt",
+    ].join("\n");
+
+    expect(parseLiveDatabaseNames(findOutput)).toEqual(["chat", "tasks"]);
+    expect(parseLiveDatabaseNames("")).toEqual([]);
+  });
+
+  test("compares dotted versions numerically", () => {
+    expect(compareDottedVersions("0.8.51", "0.8.51")).toBe(0);
+    expect(compareDottedVersions("0.8.52", "0.8.51")).toBeGreaterThan(0);
+    expect(compareDottedVersions("0.8.50", "0.8.51")).toBeLessThan(0);
+    expect(compareDottedVersions("0.9.0", "0.8.51")).toBeGreaterThan(0);
+    expect(compareDottedVersions("1.0.0", "0.8.51")).toBeGreaterThan(0);
+    // Numeric compare, not lexicographic.
+    expect(compareDottedVersions("0.8.100", "0.8.51")).toBeGreaterThan(0);
+    // Length mismatch pads with zeros.
+    expect(compareDottedVersions("0.8", "0.8.0")).toBe(0);
+
+    expect(compareDottedVersions("0.8.51-rc1", "0.8.51")).toBeNull();
+    expect(compareDottedVersions("", "0.8.51")).toBeNull();
+    expect(compareDottedVersions("abc", "0.8.51")).toBeNull();
+  });
+
+  test("gates pod state on the image version that introduced it", () => {
+    // The registry only holds the CURRENT image, so this must be a version
+    // threshold, not an exact lookup: sandboxes on 0.8.51 must keep their
+    // barrier after the registry moves to 0.8.52+.
+    expect(podStateVersionSupported("dust-base", "0.8.51")).toBe(true);
+    expect(podStateVersionSupported("dust-base", "0.8.52")).toBe(true);
+    expect(podStateVersionSupported("dust-base", "0.9.0")).toBe(true);
+
+    // 0.8.50 is the last upstream image WITHOUT the pod-state bits.
+    expect(podStateVersionSupported("dust-base", "0.8.50")).toBe(false);
+    expect(podStateVersionSupported("dust-base", "0.8.45")).toBe(false);
+    // Pre-versioning rows are legitimately pre-pod-state.
+    expect(podStateVersionSupported(null, null)).toBe(false);
+    expect(podStateVersionSupported("dust-base", null)).toBe(false);
+
+    // Anomalies must surface as null (the caller alerts), never a silent
+    // false.
+    expect(podStateVersionSupported("other-image", "0.8.51")).toBeNull();
+    expect(podStateVersionSupported("dust-base", "not-a-version")).toBeNull();
+  });
+});

--- a/front/lib/api/sandbox/pod_state.ts
+++ b/front/lib/api/sandbox/pod_state.ts
@@ -1,0 +1,505 @@
+import { getPodStateBasePath } from "@app/lib/api/files/mount_path";
+import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import {
+  recordPodStateCapabilityGateError,
+  traceSandboxStartupPhase,
+} from "@app/lib/api/sandbox/instrumentation";
+import {
+  type RootCommand,
+  type RootCommandArg,
+  rootCommand,
+} from "@app/lib/api/sandbox/root_command";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+/**
+ * Pod state runtime plumbing: SQLite databases under /pod-state/databases,
+ * continuously replicated by a litestream daemon (running as dust-state) to a
+ * gcsfuse-mounted GCS prefix at /pod-state/replica.
+ *
+ * Layout and users are contract-frozen in
+ * design_docs/pod_state_progress/contracts/paths-env.v2.md. Everything here is
+ * gated on the `pod_state` SandboxCapability so sandboxes created from older
+ * images keep working untouched.
+ *
+ * The daemon runs litestream's directory watcher over /pod-state/databases
+ * (static /etc/litestream.yml baked at image build): databases created at any
+ * point — including publish-time `dsbx db reconcile` — are discovered and
+ * replicated automatically within seconds. Replica subdirectories are named
+ * by database FILENAME: /pod-state/replica/{db}.db/ltx/...
+ *
+ * Lifecycle:
+ *  - Cold start (`setupPodStateOnColdStart`, after the gcsfuse mounts): restore
+ *    each replicated database (temp file + PRAGMA quick_check + atomic rename),
+ *    then start the litestream systemd unit — strictly in that order, so the
+ *    watcher never manages files mid-restore or writes to an unmounted
+ *    replica dir.
+ *  - Wake from pause needs nothing: the Firecracker snapshot preserves the
+ *    daemon, its control socket, the mounts and the database files.
+ */
+
+export const POD_STATE_DATABASES_DIR = "/pod-state/databases";
+export const POD_STATE_REPLICA_DIR = "/pod-state/replica";
+/** In-sandbox mount point of the state replica gcsfuse mount. */
+export const POD_STATE_REPLICA_MOUNT_POINT = POD_STATE_REPLICA_DIR;
+/** System user running the litestream daemon and owning the replica mount. */
+export const POD_STATE_USER = "dust-state";
+
+const LITESTREAM_BIN = "/opt/bin/litestream";
+const LITESTREAM_UNIT_NAME = "litestream";
+
+const RUNUSER_BIN = "/usr/sbin/runuser";
+const SYSTEMCTL_BIN = "/usr/bin/systemctl";
+const SQLITE3_BIN = "/usr/bin/sqlite3";
+const FIND_BIN = "/usr/bin/find";
+const MV_BIN = "/usr/bin/mv";
+const RM_BIN = "/usr/bin/rm";
+const CHMOD_BIN = "/usr/bin/chmod";
+const TEST_BIN = "/usr/bin/test";
+
+// Contract-frozen database name shape (paths-env.v1). Doubles as an
+// allowlist: enumeration outputs are workload-influenced, so anything not
+// matching (dotfiles, litestream sidecar dirs, hostile names) is skipped.
+const POD_DATABASE_NAME_REGEX = /^[a-z][a-z0-9_]{0,63}$/;
+
+// The dust-base version that first shipped the pod-state image bits
+// (litestream binary, dust-state user, /pod-state layout, systemd unit).
+// NEVER lower this, and never gate by exact registry lookup: the registry only
+// holds the single CURRENT image, so an exact (name, tag) match would silently
+// turn the barrier OFF for every existing pod-state sandbox at the next
+// version bump.
+const POD_STATE_BASE_IMAGE_NAME = "dust-base";
+const POD_STATE_MIN_DUST_BASE_VERSION = "0.8.51";
+
+// Cheap probes and file operations stay tightly bounded.
+const PROBE_EXEC_TIMEOUT_MS = 10_000;
+// Cold-start restore may pull a large snapshot + LTX chain through gcsfuse.
+const RESTORE_EXEC_TIMEOUT_MS = 120_000;
+
+export function isValidPodDatabaseName(name: string): boolean {
+  return POD_DATABASE_NAME_REGEX.test(name);
+}
+
+/**
+ * True when the image supports pod state. For running sandboxes use
+ * `sandboxSupportsPodState`: the current registry image may be newer than the
+ * image the sandbox was created from.
+ */
+export function imageSupportsPodState(image: SandboxImage): boolean {
+  return image.hasCapability("pod_state");
+}
+
+/**
+ * Compare two dotted numeric versions ("0.8.51"). Returns a negative/zero/
+ * positive number like a comparator, or null when either side is not a dotted
+ * numeric version.
+ */
+export function compareDottedVersions(a: string, b: string): number | null {
+  const parse = (version: string): number[] | null => {
+    const parts = version.split(".");
+    const numbers: number[] = [];
+    for (const part of parts) {
+      if (!/^\d+$/.test(part)) {
+        return null;
+      }
+      numbers.push(Number.parseInt(part, 10));
+    }
+    return numbers.length > 0 ? numbers : null;
+  };
+
+  const left = parse(a);
+  const right = parse(b);
+  if (left === null || right === null) {
+    return null;
+  }
+
+  const length = Math.max(left.length, right.length);
+  for (let i = 0; i < length; i++) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Pure capability check for a sandbox's recorded (baseImage, version).
+ * Returns null when the inputs are anomalous (unknown image name or
+ * unparsable version) — the caller must alert, never silently treat that as
+ * unsupported.
+ */
+export function podStateVersionSupported(
+  baseImage: string | null,
+  version: string | null
+): boolean | null {
+  // Pre-versioning rows are legitimately pre-pod-state.
+  if (baseImage === null || version === null) {
+    return false;
+  }
+  // A renamed/second base image would land here: loud, so the gate cannot
+  // silently disable the barrier for a future image family.
+  if (baseImage !== POD_STATE_BASE_IMAGE_NAME) {
+    return null;
+  }
+  const cmp = compareDottedVersions(version, POD_STATE_MIN_DUST_BASE_VERSION);
+  if (cmp === null) {
+    return null;
+  }
+  return cmp >= 0;
+}
+
+/**
+ * Capability gate for sandboxes that may run an OLDER image than the current
+ * registry one (sleep/wake paths). Compares the version recorded at creation
+ * against the version that introduced pod state; pre-pod-state versions
+ * resolve to false so existing sandboxes are left untouched, and anomalous
+ * values alert loudly instead of silently disabling the barrier.
+ */
+export function sandboxSupportsPodState(sandbox: SandboxResource): boolean {
+  const supported = podStateVersionSupported(
+    sandbox.baseImage,
+    sandbox.version
+  );
+  if (supported === null) {
+    logger.error(
+      {
+        sandboxId: sandbox.sId,
+        baseImage: sandbox.baseImage,
+        version: sandbox.version,
+      },
+      "Pod state capability gate: unrecognized sandbox image identity — treating as unsupported"
+    );
+    recordPodStateCapabilityGateError();
+    return false;
+  }
+  return supported;
+}
+
+/**
+ * Parse `find <replica-dir> -mindepth 1 -maxdepth 1 -type d` output into
+ * database names. The directory watcher names replica subdirectories by
+ * database FILENAME (`{db}.db/`, paths-env.v2), so the `.db` suffix is
+ * stripped before validation. Non-conforming entries are dropped (see the
+ * name regex).
+ */
+export function parseReplicaDatabaseNames(findOutput: string): string[] {
+  return parseFindBasenames(findOutput)
+    .filter((name) => name.endsWith(".db"))
+    .map((name) => name.slice(0, -".db".length))
+    .filter(isValidPodDatabaseName)
+    .sort();
+}
+
+/**
+ * Parse `find <databases-dir> -mindepth 1 -maxdepth 1 -type f -name '*.db'`
+ * output into database names.
+ */
+export function parseLiveDatabaseNames(findOutput: string): string[] {
+  return parseFindBasenames(findOutput)
+    .filter((name) => name.endsWith(".db"))
+    .map((name) => name.slice(0, -".db".length))
+    .filter(isValidPodDatabaseName)
+    .sort();
+}
+
+function parseFindBasenames(findOutput: string): string[] {
+  return findOutput
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => line.slice(line.lastIndexOf("/") + 1));
+}
+
+/**
+ * Run a command as dust-state. Everything touching the replica mount must run
+ * as dust-state: the mount has no allow_other, so even root is denied by the
+ * FUSE layer.
+ */
+function asPodStateUser(
+  executable: string,
+  args: readonly RootCommandArg[]
+): RootCommand {
+  if (!executable.startsWith("/")) {
+    throw new Error(
+      `pod-state command executable must be absolute: ${executable}`
+    );
+  }
+  return rootCommand.exec(RUNUSER_BIN, [
+    "-u",
+    POD_STATE_USER,
+    "--",
+    executable,
+    ...args,
+  ]);
+}
+
+function execFailure(
+  label: string,
+  result: { exitCode: number; stdout: string; stderr: string }
+): Error {
+  return new Error(
+    `${label} failed (exit ${result.exitCode}): ${result.stderr || result.stdout || "no output"}`
+  );
+}
+
+/**
+ * Cold-start bring-up, called from the freshlyCreated lifecycle branch AFTER
+ * the gcsfuse mounts are up (the restore reads through the replica mount).
+ * Failures block sandbox readiness on purpose: `invoke` awaits
+ * `ensurePodSandboxReady`, which is what guarantees no function ever runs
+ * against a half-restored database.
+ */
+export async function setupPodStateOnColdStart(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  image: SandboxImage
+): Promise<Result<void, Error>> {
+  if (!imageSupportsPodState(image)) {
+    return new Ok(undefined);
+  }
+
+  const childLogger = logger.child({
+    sandboxId: sandbox.sId,
+    workspaceId: auth.getNonNullableWorkspace().sId,
+  });
+
+  return traceSandboxStartupPhase("pod_state_setup", async () => {
+    // 1. Enumerate replicated databases (as dust-state, through the mount).
+    const namesResult = await traceSandboxStartupPhase(
+      "pod_state.enumerate",
+      () => listReplicaDatabases(auth, sandbox)
+    );
+    if (namesResult.isErr()) {
+      childLogger.error(
+        { err: namesResult.error },
+        "Pod state cold start: replica enumeration failed"
+      );
+      return namesResult;
+    }
+    const names = namesResult.value;
+
+    // 2. Restore each database: temp file + quick_check + atomic rename.
+    for (const name of names) {
+      const restoreResult = await traceSandboxStartupPhase(
+        "pod_state.restore_db",
+        () => restorePodDatabase(auth, sandbox, name),
+        { database: name }
+      );
+      if (restoreResult.isErr()) {
+        childLogger.error(
+          { err: restoreResult.error, database: name },
+          "Pod state cold start: database restore failed"
+        );
+        return restoreResult;
+      }
+    }
+
+    // 3. Start the daemon (unit + static directory-watcher config baked into
+    // the image; the unit is deliberately not enabled at boot so it cannot
+    // write to the unmounted replica dir or manage files mid-restore). The
+    // watcher discovers the restored files and any database created later.
+    // Awaited: a sandbox whose replication never started must not become
+    // ready.
+    const startResult = await traceSandboxStartupPhase(
+      "pod_state.start_daemon",
+      () => startLitestreamDaemon(auth, sandbox)
+    );
+    if (startResult.isErr()) {
+      childLogger.error(
+        { err: startResult.error },
+        "Pod state cold start: litestream daemon start failed"
+      );
+      return startResult;
+    }
+
+    childLogger.info(
+      { databases: names },
+      "Pod state cold start: restore complete, litestream started"
+    );
+    return new Ok(undefined);
+  });
+}
+
+async function listReplicaDatabases(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<string[], Error>> {
+  const result = await sandbox.execRoot(
+    auth,
+    asPodStateUser(FIND_BIN, [
+      POD_STATE_REPLICA_DIR,
+      "-mindepth",
+      "1",
+      "-maxdepth",
+      "1",
+      "-type",
+      "d",
+    ]),
+    { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
+  );
+  if (result.isErr()) {
+    return result;
+  }
+  if (result.value.exitCode !== 0) {
+    return new Err(execFailure("pod state replica enumeration", result.value));
+  }
+  return new Ok(parseReplicaDatabaseNames(result.value.stdout));
+}
+
+async function restorePodDatabase(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  name: string
+): Promise<Result<void, Error>> {
+  const dbPath = `${POD_STATE_DATABASES_DIR}/${name}.db`;
+  const tmpPath = `${POD_STATE_DATABASES_DIR}/.restore-${name}.db`;
+  // Replica subdir named by database FILENAME (directory watcher layout).
+  const replicaUrl = `file://${POD_STATE_REPLICA_DIR}/${name}.db`;
+
+  const failAndCleanup = async (err: Error): Promise<Result<void, Error>> => {
+    // Best effort: a leftover temp file is invisible to enumeration (dotfile)
+    // and overwritten by the next restore attempt anyway.
+    await sandbox.execRoot(
+      auth,
+      rootCommand.exec(RM_BIN, ["-f", "--", tmpPath]),
+      {
+        timeoutMs: PROBE_EXEC_TIMEOUT_MS,
+      }
+    );
+    return new Err(err);
+  };
+
+  // Restore into a temp file in the SAME directory so the final rename is an
+  // atomic same-filesystem move. Runs as dust-state (replica mount access).
+  // -if-replica-exists tolerates a replica directory with no restorable
+  // backup (e.g. a crash during the very first LTX upload leaving only a
+  // stray .tmp object): litestream then exits 0 WITHOUT writing the output
+  // file, and we skip the database instead of bricking every cold start of
+  // the pod.
+  const restoreResult = await sandbox.execRoot(
+    auth,
+    asPodStateUser(LITESTREAM_BIN, [
+      "restore",
+      "-if-replica-exists",
+      "-o",
+      tmpPath,
+      replicaUrl,
+    ]),
+    { timeoutMs: RESTORE_EXEC_TIMEOUT_MS }
+  );
+  if (restoreResult.isErr()) {
+    return restoreResult;
+  }
+  if (restoreResult.value.exitCode !== 0) {
+    return failAndCleanup(
+      execFailure(`litestream restore of ${name}`, restoreResult.value)
+    );
+  }
+
+  const restoredResult = await sandbox.execRoot(
+    auth,
+    rootCommand.exec(TEST_BIN, ["-f", tmpPath]),
+    { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
+  );
+  if (restoredResult.isErr()) {
+    return restoredResult;
+  }
+  if (restoredResult.value.exitCode !== 0) {
+    logger.warn(
+      { database: name },
+      "Pod state cold start: replica directory has no restorable backup — skipping database"
+    );
+    return new Ok(undefined);
+  }
+
+  // Integrity gate: corrupt LTX chains fail the restore itself loudly, but
+  // quick_check also catches page-level corruption that slipped through.
+  const checkResult = await sandbox.execRoot(
+    auth,
+    asPodStateUser(SQLITE3_BIN, ["--", tmpPath, "PRAGMA quick_check;"]),
+    { timeoutMs: RESTORE_EXEC_TIMEOUT_MS }
+  );
+  if (checkResult.isErr()) {
+    return checkResult;
+  }
+  if (
+    checkResult.value.exitCode !== 0 ||
+    checkResult.value.stdout.trim() !== "ok"
+  ) {
+    return failAndCleanup(
+      new Error(
+        `PRAGMA quick_check failed for restored database ${name}: ${
+          checkResult.value.stdout || checkResult.value.stderr || "no output"
+        }`
+      )
+    );
+  }
+
+  // 660: the restored file must be writable by group `agent` (function code
+  // runs as agent-proxied) as well as by dust-state; the databases dir is
+  // setgid so the group is already `agent`.
+  const finalizeResult = await sandbox.execRoot(
+    auth,
+    rootCommand.and([
+      rootCommand.exec(CHMOD_BIN, ["660", "--", tmpPath]),
+      rootCommand.exec(MV_BIN, ["-f", "--", tmpPath, dbPath]),
+    ]),
+    { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
+  );
+  if (finalizeResult.isErr()) {
+    return finalizeResult;
+  }
+  if (finalizeResult.value.exitCode !== 0) {
+    return failAndCleanup(
+      execFailure(`pod state restore finalize of ${name}`, finalizeResult.value)
+    );
+  }
+
+  return new Ok(undefined);
+}
+
+async function startLitestreamDaemon(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<void, Error>> {
+  const result = await sandbox.execRoot(
+    auth,
+    rootCommand.exec(SYSTEMCTL_BIN, ["start", LITESTREAM_UNIT_NAME]),
+    { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
+  );
+  if (result.isErr()) {
+    return result;
+  }
+  if (result.value.exitCode !== 0) {
+    return new Err(execFailure("litestream daemon start", result.value));
+  }
+  return new Ok(undefined);
+}
+
+/**
+ * Delete the pod's whole GCS state prefix. State objects are litestream LTX
+ * files, never FileResources, so per-file deletion paths never touch them —
+ * without this, deleting a pod leaks its replica chain forever.
+ */
+export async function deletePodStatePrefix(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<Result<void, Error>> {
+  try {
+    await getPrivateUploadBucket().deleteByPrefix(
+      getPodStateBasePath({
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        podId: space.sId,
+      })
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -274,6 +274,18 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     return this.update({ lastActivityAt: new Date() }, transaction);
   }
 
+  /**
+   * Mark this sandbox for destruction: the reaper's kill sweep destroys it,
+   * and ensureActive's kill-requested branch destroys-and-recreates it on the
+   * next access. Used when runtime bring-up left the sandbox half-initialized
+   * (e.g. pod-state restore failed after status=running was committed), so
+   * the failure self-heals through a fresh cold start instead of the warm
+   * path silently serving a broken sandbox.
+   */
+  async requestKill(): Promise<void> {
+    await this.update({ killRequestedAt: new Date() });
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -2,6 +2,7 @@ import { hardDeleteApp } from "@app/lib/api/apps";
 import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
 import config from "@app/lib/api/config";
 import { hardDeleteDataSource } from "@app/lib/api/data_sources";
+import { deletePodStatePrefix } from "@app/lib/api/sandbox/pod_state";
 import { hardDeleteSpace } from "@app/lib/api/spaces";
 import { deleteWebhookSource } from "@app/lib/api/webhook_source";
 import { deleteWorksOSOrganizationWithWorkspace } from "@app/lib/api/workos/organization";
@@ -165,6 +166,14 @@ export async function scrubSpaceActivity({
       await SandboxFunctionResource.deleteAllForSpace(auth, space);
     if (deleteSandboxFunctionsResult.isErr()) {
       throw deleteSandboxFunctionsResult.error;
+    }
+
+    // Pod state (litestream replica) objects are never FileResources, so the
+    // per-function deletes above cannot reach them — scrub the whole GCS
+    // prefix or the replica chain leaks forever.
+    const deletePodStateResult = await deletePodStatePrefix(auth, space);
+    if (deletePodStateResult.isErr()) {
+      throw deletePodStateResult.error;
     }
   }
 


### PR DESCRIPTION
## Description

**PR 3/4 of the pod-state stack** (`design_docs/POD_STATE_DESIGN.md`, "Cold start: create, or destroy → recreate"): restore the pod's SQLite databases from the GCS replica on fresh sandbox creation, then start the litestream daemon.

**What & why:**
- **Cold-start sequence** (`setupPodStateOnColdStart`, wired in `ensureOwnerSandboxReady`'s freshlyCreated branch, strictly AFTER the gcsfuse mounts, awaited — `invoke` awaits readiness, which is what keeps functions off half-restored databases): enumerate `{db}.db` replica subdirs (the directory watcher names them by database *filename*) → per DB: `litestream restore` into a **same-dir temp file** (atomic rename at the end), `PRAGMA quick_check` integrity gate, `chmod 660` (group `agent` = function code rw) → `mv` into place → **then** start `litestream.service` (the watcher discovers the restored files and everything created later).
- `-if-replica-exists` + an explicit output-file check: a replica dir with **no restorable backup** (crash during the very first LTX upload leaving a stray `.tmp` object — design failure mode 5) skips the database with a warning instead of bricking every cold start of the pod.
- Everything touching the replica mount runs **as `dust-state` via runuser** (no `allow_other` ⇒ FUSE denies all other uids, including root); all root execs use `execRoot` + `RootCommand` absolute paths with `--` before workload-influenced operands (SEC3); enumeration output is filtered through the contract name regex (drops dotfiles/hostile names).
- **Failure self-heals via `requestKill()`**: `status=running` is committed before this step, so a plain error would make the next call take the warm path and silently serve a half-initialized sandbox (no restored DBs, no daemon). Kill-requesting instead makes the next access destroy + recreate and re-run setup from scratch.
- **Capability gate is a version threshold** (`dust-base` ≥ 0.8.51), NOT a registry lookup: the registry only holds the single *current* image, so exact-tag matching would silently turn pod-state handling OFF for every existing sandbox at the next image bump. Anomalous image identities alert (statsd + `logger.error`) rather than silently gating off; null/pre-versioning rows are legitimately pre-pod-state.
- Pod deletion / workspace scrub now delete the GCS state prefix (`deletePodStatePrefix` in `scrubSpaceActivity`): LTX objects are never FileResources, so per-file deletion paths can't reach them — without this the replica chain leaks forever.
- New startup phases (`pod_state_setup` + enumerate/restore_db/start_daemon) follow the existing `traceSandboxStartupPhase` pattern.

Known v1 tradeoff: a *concurrent* invoke against a cold pod can reach exec while the first caller is still mid-restore (no in-sandbox readiness sentinel); worst case is a transient must-exist-open failure. Accepted for v1.

Stack (bottom-up): #28596 image → mounts → **this** → sleep barrier (#28597).

## Tests

- `pod_state.test.ts`: name allowlist, replica/live enumeration parsers ({db}.db layout), dotted-version compare + threshold gate (incl. "0.8.50 = last image without pod state" and bump-survival cases).
- `sandbox_resource.test.ts` (28): lifecycle behavior unchanged with the new `requestKill`.
- Boundary typechecks standalone (`tsgo --noEmit`).

## Risk

Gated on `runtimeOwner.kind === "pod"` + the `pod_state` capability ⇒ strict no-op until 0.8.51 pod sandboxes exist. Restore failures block pod readiness by design (fail-loud, then self-heal via recreate); the empty-replica tolerance removes the main persistent-failure cause.

## Deploy Plan

Deploy with front, before or after the image build (no-op without the 0.8.51 template). No migration.
