### PR TITLE
Remove sound alert feature flag 

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -16,7 +16,7 @@ import { AwuUsageBar } from "@app/components/workspace/MembersUsageTable";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useIsMac } from "@app/hooks/useKeyboardShortcutLabel";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
 import { useMyUsage, useSeatPlan } from "@app/lib/swr/credits";
 import {
@@ -577,7 +577,6 @@ function CustomizationSection() {
 
 function NotificationsSection({ owner }: { owner: WorkspaceType }) {
   const { user } = useUser();
-  const { hasFeature } = useFeatureFlags();
   const sendNotification = useSendNotification();
   const sound = useSoundNotificationPreferencesForm();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -630,18 +629,16 @@ function NotificationsSection({ owner }: { owner: WorkspaceType }) {
         </div>
       ) : (
         <>
-          {hasFeature("sound_notification") && (
-            <div className="flex flex-col gap-4">
-              <Page.SectionHeader
-                title="Inbox notifications"
-                description="Sound alerts for items that need your attention"
-              />
-              <SoundNotificationPreferences
-                control={sound.control}
-                disabled={sound.isLoading}
-              />
-            </div>
-          )}
+          <div className="flex flex-col gap-4">
+            <Page.SectionHeader
+              title="Inbox notifications"
+              description="Sound alerts for items that need your attention"
+            />
+            <SoundNotificationPreferences
+              control={sound.control}
+              disabled={sound.isLoading}
+            />
+          </div>
           {showNotificationPreferences && (
             <div className="flex flex-col gap-4">
               <Page.SectionHeader

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -311,11 +311,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Workspace default agent: admins can pre-select a workspace-wide default agent for new conversations.",
     stage: "on_demand",
   },
-  sound_notification: {
-    description:
-      "Play a sound notification when an agent requires manual input (approval/decline).",
-    stage: "dust_only",
-  },
   whitelabel_frames: {
     description:
       "Whitelabel frames: customize the workspace logo, favicon and OG image shown on shared Frames.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -771,7 +771,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "use_new_llm_router"
   | "live_speech_to_text"
   | "workspace_default_agent"
-  | "sound_notification"
   | "whitelabel_frames"
   | "workday_mcp"
 >();


### PR DESCRIPTION
## Description

Remove sound alert feature flag. 

## Tests

Tested locally that feature flag `sound_ notification` doesnt exist anymore and that the sound settings appear on the notification page. 

## Risk

Low, everything is turned off by default. 

## Deploy Plan

Standard 