### PR TITLE
[front] feat: pod database manifest compat differ

### DIFF
--- a/front/lib/api/sandbox_functions/compat.test.ts
+++ b/front/lib/api/sandbox_functions/compat.test.ts
@@ -1,20 +1,20 @@
 import type {
   CompatDiff,
-  SiblingManifests,
+  SiblingState,
 } from "@app/lib/api/sandbox_functions/compat";
 import {
   computeStaleSiblings,
-  diffManifestsAgainstSiblings,
+  diffStateAgainstSiblings,
 } from "@app/lib/api/sandbox_functions/compat";
 import type {
-  FunctionStateManifest,
-  ManifestColumn,
-  ManifestIndex,
-  ManifestTable,
+  DatabaseColumn,
+  DatabaseIndex,
+  DatabaseTable,
+  FunctionState,
 } from "@app/lib/api/sandbox_functions/manifests";
 import { describe, expect, it } from "vitest";
 
-function col(overrides: Partial<ManifestColumn> = {}): ManifestColumn {
+function col(overrides: Partial<DatabaseColumn> = {}): DatabaseColumn {
   return {
     type: "text",
     mode: null,
@@ -26,7 +26,7 @@ function col(overrides: Partial<ManifestColumn> = {}): ManifestColumn {
   };
 }
 
-function idCol(): ManifestColumn {
+function idCol(): DatabaseColumn {
   return col({
     type: "integer",
     notNull: true,
@@ -37,15 +37,15 @@ function idCol(): ManifestColumn {
 }
 
 function table(
-  columns: Record<string, ManifestColumn>,
-  indexes: Record<string, ManifestIndex> = {}
-): ManifestTable {
+  columns: Record<string, DatabaseColumn>,
+  indexes: Record<string, DatabaseIndex> = {}
+): DatabaseTable {
   return { columns, indexes };
 }
 
-function manifests(
-  tablesByDb: Record<string, Record<string, ManifestTable>>
-): FunctionStateManifest {
+function state(
+  tablesByDb: Record<string, Record<string, DatabaseTable>>
+): FunctionState {
   return {
     version: 1,
     databases: Object.fromEntries(
@@ -58,8 +58,8 @@ function manifests(
 }
 
 // The design's canonical chat example: messages(id, body, created_at).
-function chatMessagesManifests(): FunctionStateManifest {
-  return manifests({
+function chatMessagesState(): FunctionState {
+  return state({
     chat: {
       messages: table({
         id: idCol(),
@@ -71,43 +71,43 @@ function chatMessagesManifests(): FunctionStateManifest {
 }
 
 function diff({
-  newManifests,
-  previousManifests = null,
+  newState,
+  previousState = null,
   siblings = [],
 }: {
-  newManifests: FunctionStateManifest | null;
-  previousManifests?: FunctionStateManifest | null;
-  siblings?: SiblingManifests[];
+  newState: FunctionState | null;
+  previousState?: FunctionState | null;
+  siblings?: SiblingState[];
 }): CompatDiff {
-  return diffManifestsAgainstSiblings({
-    newManifests,
-    previousManifests,
+  return diffStateAgainstSiblings({
+    newState,
+    previousState,
     siblings,
   });
 }
 
-describe("diffManifestsAgainstSiblings", () => {
+describe("diffStateAgainstSiblings", () => {
   it("is empty for a function declaring no databases", () => {
     const result = diff({
-      newManifests: null,
-      siblings: [{ slug: "other", manifests: chatMessagesManifests() }],
+      newState: null,
+      siblings: [{ slug: "other", state: chatMessagesState() }],
     });
     expect(result).toEqual({ blocks: [], warnings: [] });
   });
 
   it("is empty on a first publish with no siblings, even with NOT NULL columns", () => {
-    const result = diff({ newManifests: chatMessagesManifests() });
+    const result = diff({ newState: chatMessagesState() });
     expect(result).toEqual({ blocks: [], warnings: [] });
   });
 
-  it("ignores siblings without manifests or declaring other databases", () => {
+  it("ignores siblings without state or declaring other databases", () => {
     const result = diff({
-      newManifests: chatMessagesManifests(),
+      newState: chatMessagesState(),
       siblings: [
-        { slug: "no-db", manifests: null },
+        { slug: "no-db", state: null },
         {
           slug: "other-db",
-          manifests: manifests({
+          state: state({
             analytics: { events: table({ id: idCol() }) },
           }),
         },
@@ -118,7 +118,7 @@ describe("diffManifestsAgainstSiblings", () => {
 
   it("blocks the design's rename example: body -> content removes a referenced column", () => {
     // `content` is added nullable (the additive way); the block is purely about `body`.
-    const renamed = manifests({
+    const renamed = state({
       chat: {
         messages: table({
           id: idCol(),
@@ -133,8 +133,8 @@ describe("diffManifestsAgainstSiblings", () => {
     });
 
     const result = diff({
-      newManifests: renamed,
-      siblings: [{ slug: "list-messages", manifests: chatMessagesManifests() }],
+      newState: renamed,
+      siblings: [{ slug: "list-messages", state: chatMessagesState() }],
     });
 
     expect(result.blocks).toHaveLength(1);
@@ -151,8 +151,8 @@ describe("diffManifestsAgainstSiblings", () => {
 
   it("blocks removing a table a sibling references", () => {
     const result = diff({
-      newManifests: manifests({ chat: { other: table({ id: idCol() }) } }),
-      siblings: [{ slug: "list-messages", manifests: chatMessagesManifests() }],
+      newState: state({ chat: { other: table({ id: idCol() }) } }),
+      siblings: [{ slug: "list-messages", state: chatMessagesState() }],
     });
 
     expect(
@@ -166,15 +166,15 @@ describe("diffManifestsAgainstSiblings", () => {
   });
 
   it("blocks a type change on a referenced column", () => {
-    const changed = chatMessagesManifests();
+    const changed = chatMessagesState();
     changed.databases.chat.tables.messages.columns.body = col({
       type: "integer",
       notNull: true,
     });
 
     const result = diff({
-      newManifests: changed,
-      siblings: [{ slug: "post-message", manifests: chatMessagesManifests() }],
+      newState: changed,
+      siblings: [{ slug: "post-message", state: chatMessagesState() }],
     });
 
     expect(result.blocks).toHaveLength(1);
@@ -182,34 +182,34 @@ describe("diffManifestsAgainstSiblings", () => {
   });
 
   it("blocks notNull changes in both directions", () => {
-    const relaxed = chatMessagesManifests();
+    const relaxed = chatMessagesState();
     relaxed.databases.chat.tables.messages.columns.body = col({
       notNull: false,
     });
     const relaxedDiff = diff({
-      newManifests: relaxed,
-      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+      newState: relaxed,
+      siblings: [{ slug: "sib", state: chatMessagesState() }],
     });
     expect(relaxedDiff.blocks).toHaveLength(1);
     expect(relaxedDiff.blocks[0]?.reason).toContain("removes NOT NULL");
 
-    const tightened = chatMessagesManifests();
+    const tightened = chatMessagesState();
     tightened.databases.chat.tables.messages.columns.created_at = col({
       type: "integer",
       mode: "timestamp",
       notNull: false,
     });
-    const base = chatMessagesManifests();
+    const base = chatMessagesState();
     const tightenedDiff = diff({
-      newManifests: base,
-      siblings: [{ slug: "sib", manifests: tightened }],
+      newState: base,
+      siblings: [{ slug: "sib", state: tightened }],
     });
     expect(tightenedDiff.blocks).toHaveLength(1);
     expect(tightenedDiff.blocks[0]?.reason).toContain("adds NOT NULL");
   });
 
   it("blocks primaryKey and autoIncrement changes", () => {
-    const noAutoIncrement = chatMessagesManifests();
+    const noAutoIncrement = chatMessagesState();
     noAutoIncrement.databases.chat.tables.messages.columns.id = col({
       type: "integer",
       notNull: true,
@@ -218,13 +218,13 @@ describe("diffManifestsAgainstSiblings", () => {
       autoIncrement: false,
     });
     const autoIncrementDiff = diff({
-      newManifests: noAutoIncrement,
-      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+      newState: noAutoIncrement,
+      siblings: [{ slug: "sib", state: chatMessagesState() }],
     });
     expect(autoIncrementDiff.blocks).toHaveLength(1);
     expect(autoIncrementDiff.blocks[0]?.reason).toContain("autoincrement");
 
-    const noPk = chatMessagesManifests();
+    const noPk = chatMessagesState();
     noPk.databases.chat.tables.messages.columns.id = col({
       type: "integer",
       notNull: true,
@@ -233,8 +233,8 @@ describe("diffManifestsAgainstSiblings", () => {
       autoIncrement: false,
     });
     const pkDiff = diff({
-      newManifests: noPk,
-      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+      newState: noPk,
+      siblings: [{ slug: "sib", state: chatMessagesState() }],
     });
     // The pk flip is reported (autoIncrement differs too; primary key wins the description).
     expect(pkDiff.blocks).toHaveLength(1);
@@ -242,14 +242,14 @@ describe("diffManifestsAgainstSiblings", () => {
   });
 
   it("blocks the design's NOT NULL addition example (no default, existing table)", () => {
-    const withChannel = chatMessagesManifests();
+    const withChannel = chatMessagesState();
     withChannel.databases.chat.tables.messages.columns.channel = col({
       notNull: true,
     });
 
     const result = diff({
-      newManifests: withChannel,
-      siblings: [{ slug: "list-messages", manifests: chatMessagesManifests() }],
+      newState: withChannel,
+      siblings: [{ slug: "list-messages", state: chatMessagesState() }],
     });
 
     expect(result.blocks).toHaveLength(1);
@@ -263,7 +263,7 @@ describe("diffManifestsAgainstSiblings", () => {
   });
 
   it("allows a NOT NULL addition with a default, and a nullable addition", () => {
-    const withDefault = chatMessagesManifests();
+    const withDefault = chatMessagesState();
     withDefault.databases.chat.tables.messages.columns.channel = col({
       notNull: true,
       hasDefault: true,
@@ -271,21 +271,21 @@ describe("diffManifestsAgainstSiblings", () => {
     withDefault.databases.chat.tables.messages.columns.topic = col({});
 
     const result = diff({
-      newManifests: withDefault,
-      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+      newState: withDefault,
+      siblings: [{ slug: "sib", state: chatMessagesState() }],
     });
     expect(result.blocks).toEqual([]);
   });
 
-  it("blocks a NOT NULL addition against the function's own previous manifests", () => {
-    const withChannel = chatMessagesManifests();
+  it("blocks a NOT NULL addition against the function's own previous state", () => {
+    const withChannel = chatMessagesState();
     withChannel.databases.chat.tables.messages.columns.channel = col({
       notNull: true,
     });
 
     const result = diff({
-      newManifests: withChannel,
-      previousManifests: chatMessagesManifests(),
+      newState: withChannel,
+      previousState: chatMessagesState(),
     });
 
     expect(result.blocks).toHaveLength(1);
@@ -295,16 +295,16 @@ describe("diffManifestsAgainstSiblings", () => {
   });
 
   it("does not block a NOT NULL column on a brand-new table", () => {
-    const withNewTable = chatMessagesManifests();
+    const withNewTable = chatMessagesState();
     withNewTable.databases.chat.tables.reactions = table({
       id: idCol(),
       emoji: col({ notNull: true }),
     });
 
     const result = diff({
-      newManifests: withNewTable,
-      previousManifests: chatMessagesManifests(),
-      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+      newState: withNewTable,
+      previousState: chatMessagesState(),
+      siblings: [{ slug: "sib", state: chatMessagesState() }],
     });
     expect(result.blocks).toEqual([]);
   });
@@ -312,17 +312,17 @@ describe("diffManifestsAgainstSiblings", () => {
   it("warns on the design's mode-drift example instead of blocking", () => {
     // report-activity declares created_at as plain integer (no mode); the siblings declare
     // integer mode=timestamp. Same storage type -> warning, publish proceeds.
-    const noMode = chatMessagesManifests();
+    const noMode = chatMessagesState();
     noMode.databases.chat.tables.messages.columns.created_at = col({
       type: "integer",
       notNull: true,
     });
 
     const result = diff({
-      newManifests: noMode,
+      newState: noMode,
       siblings: [
-        { slug: "post-message", manifests: chatMessagesManifests() },
-        { slug: "list-messages", manifests: chatMessagesManifests() },
+        { slug: "post-message", state: chatMessagesState() },
+        { slug: "list-messages", state: chatMessagesState() },
       ],
     });
 
@@ -342,15 +342,15 @@ describe("diffManifestsAgainstSiblings", () => {
   });
 
   it("warns on unique tightening for a table a sibling uses", () => {
-    const withUnique = chatMessagesManifests();
+    const withUnique = chatMessagesState();
     withUnique.databases.chat.tables.messages = table(
       withUnique.databases.chat.tables.messages.columns,
       { messages_body_idx: { unique: true, columns: ["body"] } }
     );
 
     const result = diff({
-      newManifests: withUnique,
-      siblings: [{ slug: "post-message", manifests: chatMessagesManifests() }],
+      newState: withUnique,
+      siblings: [{ slug: "post-message", state: chatMessagesState() }],
     });
 
     expect(result.blocks).toEqual([]);
@@ -363,21 +363,21 @@ describe("diffManifestsAgainstSiblings", () => {
   });
 
   it("does not warn when the sibling already carries the same unique index", () => {
-    const withUnique = chatMessagesManifests();
+    const withUnique = chatMessagesState();
     withUnique.databases.chat.tables.messages = table(
       withUnique.databases.chat.tables.messages.columns,
       { messages_body_idx: { unique: true, columns: ["body"] } }
     );
 
     const result = diff({
-      newManifests: withUnique,
-      siblings: [{ slug: "sib", manifests: withUnique }],
+      newState: withUnique,
+      siblings: [{ slug: "sib", state: withUnique }],
     });
     expect(result.warnings).toEqual([]);
   });
 
   it("never blocks on indexes or hasDefault changes", () => {
-    const changed = chatMessagesManifests();
+    const changed = chatMessagesState();
     // New non-unique index + hasDefault flip on body.
     changed.databases.chat.tables.messages = table(
       {
@@ -388,15 +388,15 @@ describe("diffManifestsAgainstSiblings", () => {
     );
 
     const result = diff({
-      newManifests: changed,
-      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+      newState: changed,
+      siblings: [{ slug: "sib", state: chatMessagesState() }],
     });
     expect(result.blocks).toEqual([]);
     expect(result.warnings).toEqual([]);
   });
 
   it("merges the affected functions of one breaking change across siblings", () => {
-    const renamed = manifests({
+    const renamed = state({
       chat: {
         messages: table({
           id: idCol(),
@@ -411,10 +411,10 @@ describe("diffManifestsAgainstSiblings", () => {
     });
 
     const result = diff({
-      newManifests: renamed,
+      newState: renamed,
       siblings: [
-        { slug: "list-messages", manifests: chatMessagesManifests() },
-        { slug: "post-message", manifests: chatMessagesManifests() },
+        { slug: "list-messages", state: chatMessagesState() },
+        { slug: "post-message", state: chatMessagesState() },
       ],
     });
 
@@ -428,16 +428,16 @@ describe("diffManifestsAgainstSiblings", () => {
 
 describe("computeStaleSiblings", () => {
   it("flags siblings whose stored manifest for a shared database differs", () => {
-    const evolved = chatMessagesManifests();
+    const evolved = chatMessagesState();
     evolved.databases.chat.tables.messages.columns.topic = col({});
 
     const notes = computeStaleSiblings(evolved, [
-      { slug: "list-messages", manifests: chatMessagesManifests() },
-      { slug: "up-to-date", manifests: evolved },
-      { slug: "no-db", manifests: null },
+      { slug: "list-messages", state: chatMessagesState() },
+      { slug: "up-to-date", state: evolved },
+      { slug: "no-db", state: null },
       {
         slug: "other-db",
-        manifests: manifests({ analytics: { events: table({ id: idCol() }) } }),
+        state: state({ analytics: { events: table({ id: idCol() }) } }),
       },
     ]);
 
@@ -446,9 +446,7 @@ describe("computeStaleSiblings", () => {
 
   it("is empty when the publish declares no databases", () => {
     expect(
-      computeStaleSiblings(null, [
-        { slug: "sib", manifests: chatMessagesManifests() },
-      ])
+      computeStaleSiblings(null, [{ slug: "sib", state: chatMessagesState() }])
     ).toEqual([]);
   });
 });

--- a/front/lib/api/sandbox_functions/compat.test.ts
+++ b/front/lib/api/sandbox_functions/compat.test.ts
@@ -1,0 +1,454 @@
+import type {
+  CompatDiff,
+  SiblingManifests,
+} from "@app/lib/api/sandbox_functions/compat";
+import {
+  computeStaleSiblings,
+  diffManifestsAgainstSiblings,
+} from "@app/lib/api/sandbox_functions/compat";
+import type {
+  FunctionManifests,
+  ManifestColumn,
+  ManifestIndex,
+  ManifestTable,
+} from "@app/lib/api/sandbox_functions/manifests";
+import { describe, expect, it } from "vitest";
+
+function col(overrides: Partial<ManifestColumn> = {}): ManifestColumn {
+  return {
+    type: "text",
+    mode: null,
+    notNull: false,
+    hasDefault: false,
+    primaryKey: false,
+    autoIncrement: false,
+    ...overrides,
+  };
+}
+
+function idCol(): ManifestColumn {
+  return col({
+    type: "integer",
+    notNull: true,
+    hasDefault: true,
+    primaryKey: true,
+    autoIncrement: true,
+  });
+}
+
+function table(
+  columns: Record<string, ManifestColumn>,
+  indexes: Record<string, ManifestIndex> = {}
+): ManifestTable {
+  return { columns, indexes };
+}
+
+function manifests(
+  tablesByDb: Record<string, Record<string, ManifestTable>>
+): FunctionManifests {
+  return {
+    version: 1,
+    databases: Object.fromEntries(
+      Object.entries(tablesByDb).map(([db, tables]) => [
+        db,
+        { schemaFile: `databases/${db}.db.ts`, tables },
+      ])
+    ),
+  };
+}
+
+// The design's canonical chat example: messages(id, body, created_at).
+function chatMessagesManifests(): FunctionManifests {
+  return manifests({
+    chat: {
+      messages: table({
+        id: idCol(),
+        body: col({ notNull: true }),
+        created_at: col({ type: "integer", mode: "timestamp", notNull: true }),
+      }),
+    },
+  });
+}
+
+function diff({
+  newManifests,
+  previousManifests = null,
+  siblings = [],
+}: {
+  newManifests: FunctionManifests | null;
+  previousManifests?: FunctionManifests | null;
+  siblings?: SiblingManifests[];
+}): CompatDiff {
+  return diffManifestsAgainstSiblings({
+    newManifests,
+    previousManifests,
+    siblings,
+  });
+}
+
+describe("diffManifestsAgainstSiblings", () => {
+  it("is empty for a function declaring no databases", () => {
+    const result = diff({
+      newManifests: null,
+      siblings: [{ slug: "other", manifests: chatMessagesManifests() }],
+    });
+    expect(result).toEqual({ blocks: [], warnings: [] });
+  });
+
+  it("is empty on a first publish with no siblings, even with NOT NULL columns", () => {
+    const result = diff({ newManifests: chatMessagesManifests() });
+    expect(result).toEqual({ blocks: [], warnings: [] });
+  });
+
+  it("ignores siblings without manifests or declaring other databases", () => {
+    const result = diff({
+      newManifests: chatMessagesManifests(),
+      siblings: [
+        { slug: "no-db", manifests: null },
+        {
+          slug: "other-db",
+          manifests: manifests({
+            analytics: { events: table({ id: idCol() }) },
+          }),
+        },
+      ],
+    });
+    expect(result).toEqual({ blocks: [], warnings: [] });
+  });
+
+  it("blocks the design's rename example: body -> content removes a referenced column", () => {
+    // `content` is added nullable (the additive way); the block is purely about `body`.
+    const renamed = manifests({
+      chat: {
+        messages: table({
+          id: idCol(),
+          content: col(),
+          created_at: col({
+            type: "integer",
+            mode: "timestamp",
+            notNull: true,
+          }),
+        }),
+      },
+    });
+
+    const result = diff({
+      newManifests: renamed,
+      siblings: [{ slug: "list-messages", manifests: chatMessagesManifests() }],
+    });
+
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0]).toMatchObject({
+      database: "chat",
+      table: "messages",
+      column: "body",
+      affectedFunctions: ["list-messages"],
+    });
+    expect(result.blocks[0]?.reason).toContain(
+      "removes column chat.messages.body"
+    );
+  });
+
+  it("blocks removing a table a sibling references", () => {
+    const result = diff({
+      newManifests: manifests({ chat: { other: table({ id: idCol() }) } }),
+      siblings: [{ slug: "list-messages", manifests: chatMessagesManifests() }],
+    });
+
+    expect(
+      result.blocks.some(
+        (block) =>
+          block.table === "messages" &&
+          block.column === null &&
+          block.reason.includes("removes table chat.messages")
+      )
+    ).toBe(true);
+  });
+
+  it("blocks a type change on a referenced column", () => {
+    const changed = chatMessagesManifests();
+    changed.databases.chat.tables.messages.columns.body = col({
+      type: "integer",
+      notNull: true,
+    });
+
+    const result = diff({
+      newManifests: changed,
+      siblings: [{ slug: "post-message", manifests: chatMessagesManifests() }],
+    });
+
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0]?.reason).toContain("type text -> integer");
+  });
+
+  it("blocks notNull changes in both directions", () => {
+    const relaxed = chatMessagesManifests();
+    relaxed.databases.chat.tables.messages.columns.body = col({
+      notNull: false,
+    });
+    const relaxedDiff = diff({
+      newManifests: relaxed,
+      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+    });
+    expect(relaxedDiff.blocks).toHaveLength(1);
+    expect(relaxedDiff.blocks[0]?.reason).toContain("removes NOT NULL");
+
+    const tightened = chatMessagesManifests();
+    tightened.databases.chat.tables.messages.columns.created_at = col({
+      type: "integer",
+      mode: "timestamp",
+      notNull: false,
+    });
+    const base = chatMessagesManifests();
+    const tightenedDiff = diff({
+      newManifests: base,
+      siblings: [{ slug: "sib", manifests: tightened }],
+    });
+    expect(tightenedDiff.blocks).toHaveLength(1);
+    expect(tightenedDiff.blocks[0]?.reason).toContain("adds NOT NULL");
+  });
+
+  it("blocks primaryKey and autoIncrement changes", () => {
+    const noAutoIncrement = chatMessagesManifests();
+    noAutoIncrement.databases.chat.tables.messages.columns.id = col({
+      type: "integer",
+      notNull: true,
+      hasDefault: true,
+      primaryKey: true,
+      autoIncrement: false,
+    });
+    const autoIncrementDiff = diff({
+      newManifests: noAutoIncrement,
+      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+    });
+    expect(autoIncrementDiff.blocks).toHaveLength(1);
+    expect(autoIncrementDiff.blocks[0]?.reason).toContain("autoincrement");
+
+    const noPk = chatMessagesManifests();
+    noPk.databases.chat.tables.messages.columns.id = col({
+      type: "integer",
+      notNull: true,
+      hasDefault: true,
+      primaryKey: false,
+      autoIncrement: false,
+    });
+    const pkDiff = diff({
+      newManifests: noPk,
+      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+    });
+    // The pk flip is reported (autoIncrement differs too; primary key wins the description).
+    expect(pkDiff.blocks).toHaveLength(1);
+    expect(pkDiff.blocks[0]?.reason).toContain("primary key");
+  });
+
+  it("blocks the design's NOT NULL addition example (no default, existing table)", () => {
+    const withChannel = chatMessagesManifests();
+    withChannel.databases.chat.tables.messages.columns.channel = col({
+      notNull: true,
+    });
+
+    const result = diff({
+      newManifests: withChannel,
+      siblings: [{ slug: "list-messages", manifests: chatMessagesManifests() }],
+    });
+
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0]).toMatchObject({
+      database: "chat",
+      table: "messages",
+      column: "channel",
+      affectedFunctions: ["list-messages"],
+    });
+    expect(result.blocks[0]?.reason).toContain("without a default");
+  });
+
+  it("allows a NOT NULL addition with a default, and a nullable addition", () => {
+    const withDefault = chatMessagesManifests();
+    withDefault.databases.chat.tables.messages.columns.channel = col({
+      notNull: true,
+      hasDefault: true,
+    });
+    withDefault.databases.chat.tables.messages.columns.topic = col({});
+
+    const result = diff({
+      newManifests: withDefault,
+      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+    });
+    expect(result.blocks).toEqual([]);
+  });
+
+  it("blocks a NOT NULL addition against the function's own previous manifests", () => {
+    const withChannel = chatMessagesManifests();
+    withChannel.databases.chat.tables.messages.columns.channel = col({
+      notNull: true,
+    });
+
+    const result = diff({
+      newManifests: withChannel,
+      previousManifests: chatMessagesManifests(),
+    });
+
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0]?.affectedFunctions).toEqual([
+      "(this function's previous publish)",
+    ]);
+  });
+
+  it("does not block a NOT NULL column on a brand-new table", () => {
+    const withNewTable = chatMessagesManifests();
+    withNewTable.databases.chat.tables.reactions = table({
+      id: idCol(),
+      emoji: col({ notNull: true }),
+    });
+
+    const result = diff({
+      newManifests: withNewTable,
+      previousManifests: chatMessagesManifests(),
+      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+    });
+    expect(result.blocks).toEqual([]);
+  });
+
+  it("warns on the design's mode-drift example instead of blocking", () => {
+    // report-activity declares created_at as plain integer (no mode); the siblings declare
+    // integer mode=timestamp. Same storage type -> warning, publish proceeds.
+    const noMode = chatMessagesManifests();
+    noMode.databases.chat.tables.messages.columns.created_at = col({
+      type: "integer",
+      notNull: true,
+    });
+
+    const result = diff({
+      newManifests: noMode,
+      siblings: [
+        { slug: "post-message", manifests: chatMessagesManifests() },
+        { slug: "list-messages", manifests: chatMessagesManifests() },
+      ],
+    });
+
+    expect(result.blocks).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    const warning = result.warnings[0];
+    expect(warning).toMatchObject({
+      kind: "mode_drift",
+      database: "chat",
+      table: "messages",
+      subject: "created_at",
+    });
+    expect(warning?.message).toContain("(no mode)");
+    expect(warning?.message).toContain("mode=timestamp");
+    expect(warning?.message).toContain("list-messages, post-message");
+    expect(warning?.message).toContain("databases/chat.db.ts");
+  });
+
+  it("warns on unique tightening for a table a sibling uses", () => {
+    const withUnique = chatMessagesManifests();
+    withUnique.databases.chat.tables.messages = table(
+      withUnique.databases.chat.tables.messages.columns,
+      { messages_body_idx: { unique: true, columns: ["body"] } }
+    );
+
+    const result = diff({
+      newManifests: withUnique,
+      siblings: [{ slug: "post-message", manifests: chatMessagesManifests() }],
+    });
+
+    expect(result.blocks).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatchObject({
+      kind: "unique_tightening",
+      subject: "messages_body_idx",
+    });
+    expect(result.warnings[0]?.message).toContain("post-message");
+  });
+
+  it("does not warn when the sibling already carries the same unique index", () => {
+    const withUnique = chatMessagesManifests();
+    withUnique.databases.chat.tables.messages = table(
+      withUnique.databases.chat.tables.messages.columns,
+      { messages_body_idx: { unique: true, columns: ["body"] } }
+    );
+
+    const result = diff({
+      newManifests: withUnique,
+      siblings: [{ slug: "sib", manifests: withUnique }],
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("never blocks on indexes or hasDefault changes", () => {
+    const changed = chatMessagesManifests();
+    // New non-unique index + hasDefault flip on body.
+    changed.databases.chat.tables.messages = table(
+      {
+        ...changed.databases.chat.tables.messages.columns,
+        body: col({ notNull: true, hasDefault: true }),
+      },
+      { messages_created_idx: { unique: false, columns: ["created_at"] } }
+    );
+
+    const result = diff({
+      newManifests: changed,
+      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+    });
+    expect(result.blocks).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("merges the affected functions of one breaking change across siblings", () => {
+    const renamed = manifests({
+      chat: {
+        messages: table({
+          id: idCol(),
+          content: col(),
+          created_at: col({
+            type: "integer",
+            mode: "timestamp",
+            notNull: true,
+          }),
+        }),
+      },
+    });
+
+    const result = diff({
+      newManifests: renamed,
+      siblings: [
+        { slug: "list-messages", manifests: chatMessagesManifests() },
+        { slug: "post-message", manifests: chatMessagesManifests() },
+      ],
+    });
+
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0]?.affectedFunctions).toEqual([
+      "list-messages",
+      "post-message",
+    ]);
+  });
+});
+
+describe("computeStaleSiblings", () => {
+  it("flags siblings whose stored manifest for a shared database differs", () => {
+    const evolved = chatMessagesManifests();
+    evolved.databases.chat.tables.messages.columns.topic = col({});
+
+    const notes = computeStaleSiblings(evolved, [
+      { slug: "list-messages", manifests: chatMessagesManifests() },
+      { slug: "up-to-date", manifests: evolved },
+      { slug: "no-db", manifests: null },
+      {
+        slug: "other-db",
+        manifests: manifests({ analytics: { events: table({ id: idCol() }) } }),
+      },
+    ]);
+
+    expect(notes).toEqual([{ slug: "list-messages", databases: ["chat"] }]);
+  });
+
+  it("is empty when the publish declares no databases", () => {
+    expect(
+      computeStaleSiblings(null, [
+        { slug: "sib", manifests: chatMessagesManifests() },
+      ])
+    ).toEqual([]);
+  });
+});

--- a/front/lib/api/sandbox_functions/compat.test.ts
+++ b/front/lib/api/sandbox_functions/compat.test.ts
@@ -7,7 +7,7 @@ import {
   diffManifestsAgainstSiblings,
 } from "@app/lib/api/sandbox_functions/compat";
 import type {
-  FunctionManifests,
+  FunctionStateManifest,
   ManifestColumn,
   ManifestIndex,
   ManifestTable,
@@ -45,7 +45,7 @@ function table(
 
 function manifests(
   tablesByDb: Record<string, Record<string, ManifestTable>>
-): FunctionManifests {
+): FunctionStateManifest {
   return {
     version: 1,
     databases: Object.fromEntries(
@@ -58,7 +58,7 @@ function manifests(
 }
 
 // The design's canonical chat example: messages(id, body, created_at).
-function chatMessagesManifests(): FunctionManifests {
+function chatMessagesManifests(): FunctionStateManifest {
   return manifests({
     chat: {
       messages: table({
@@ -75,8 +75,8 @@ function diff({
   previousManifests = null,
   siblings = [],
 }: {
-  newManifests: FunctionManifests | null;
-  previousManifests?: FunctionManifests | null;
+  newManifests: FunctionStateManifest | null;
+  previousManifests?: FunctionStateManifest | null;
   siblings?: SiblingManifests[];
 }): CompatDiff {
   return diffManifestsAgainstSiblings({

--- a/front/lib/api/sandbox_functions/compat.ts
+++ b/front/lib/api/sandbox_functions/compat.ts
@@ -1,5 +1,5 @@
 import type {
-  FunctionManifests,
+  FunctionStateManifest,
   ManifestColumn,
 } from "@app/lib/api/sandbox_functions/manifests";
 import isEqual from "lodash/isEqual";
@@ -19,7 +19,7 @@ import isEqual from "lodash/isEqual";
 
 export interface SiblingManifests {
   slug: string;
-  manifests: FunctionManifests | null;
+  manifests: FunctionStateManifest | null;
 }
 
 export interface CompatBlock {
@@ -62,8 +62,8 @@ export function diffManifestsAgainstSiblings({
   previousManifests,
   siblings,
 }: {
-  newManifests: FunctionManifests | null;
-  previousManifests: FunctionManifests | null;
+  newManifests: FunctionStateManifest | null;
+  previousManifests: FunctionStateManifest | null;
   siblings: SiblingManifests[];
 }): CompatDiff {
   if (newManifests === null) {
@@ -359,7 +359,7 @@ function formatMode(mode: string | null): string {
  * files are stale until republished.
  */
 export function computeStaleSiblings(
-  newManifests: FunctionManifests | null,
+  newManifests: FunctionStateManifest | null,
   siblings: SiblingManifests[]
 ): StaleSiblingNote[] {
   if (newManifests === null) {

--- a/front/lib/api/sandbox_functions/compat.ts
+++ b/front/lib/api/sandbox_functions/compat.ts
@@ -1,25 +1,25 @@
 import type {
-  FunctionStateManifest,
-  ManifestColumn,
+  DatabaseColumn,
+  FunctionState,
 } from "@app/lib/api/sandbox_functions/manifests";
 import isEqual from "lodash/isEqual";
 
-// Pure manifest compatibility diff (manifest.v1 compat semantics): the new manifests of the
-// function being published are compared against the stored manifests of every other function
+// Pure function state compatibility diff: the new state of the
+// function being published is compared against the stored state of every other function
 // of the same pod declaring the same database ("siblings"), plus the publishing function's own
-// previous manifests for the additive-but-breaking check.
+// previous state for the additive-but-breaking check.
 //
-// - BLOCK (structural): a sibling references something the new manifests remove or change
+// - BLOCK (structural): a sibling references something the new state removes or changes
 //   (table missing; column missing; type/notNull/primaryKey/autoIncrement differ).
 // - BLOCK (additive-but-breaking): a new NOT NULL column without default on a table that
-//   already exists in any sibling manifest or in this function's own previous manifests.
+//   already exists in any sibling state or in this function's own previous state.
 // - WARN (mode drift): same column, same type, different mode.
-// - WARN (unique tightening): new unique index on a table present in a sibling manifest.
+// - WARN (unique tightening): new unique index on a table present in a sibling state.
 // - Indexes never block; hasDefault changes never block.
 
-export interface SiblingManifests {
+export interface SiblingState {
   slug: string;
-  manifests: FunctionStateManifest | null;
+  state: FunctionState | null;
 }
 
 export interface CompatBlock {
@@ -57,16 +57,16 @@ interface BlockAccumulatorEntry {
   reason: string;
 }
 
-export function diffManifestsAgainstSiblings({
-  newManifests,
-  previousManifests,
+export function diffStateAgainstSiblings({
+  newState,
+  previousState,
   siblings,
 }: {
-  newManifests: FunctionStateManifest | null;
-  previousManifests: FunctionStateManifest | null;
-  siblings: SiblingManifests[];
+  newState: FunctionState | null;
+  previousState: FunctionState | null;
+  siblings: SiblingState[];
 }): CompatDiff {
-  if (newManifests === null) {
+  if (newState === null) {
     // A function declaring no databases cannot break siblings: its bundle opens nothing, and
     // no DDL runs. (Tables it used to declare stay live; reconcile never drops.)
     return { blocks: [], warnings: [] };
@@ -111,9 +111,9 @@ export function diffManifestsAgainstSiblings({
     }
   };
 
-  for (const [database, newDb] of Object.entries(newManifests.databases)) {
+  for (const [database, newDb] of Object.entries(newState.databases)) {
     for (const sibling of siblings) {
-      const siblingDb = sibling.manifests?.databases[database];
+      const siblingDb = sibling.state?.databases[database];
       if (siblingDb === undefined) {
         continue;
       }
@@ -202,7 +202,7 @@ export function diffManifestsAgainstSiblings({
           addBlock,
         });
 
-        // Unique tightening: a unique index the sibling's manifest does not carry.
+        // Unique tightening: a unique index the sibling's state does not carry.
         for (const [indexName, index] of Object.entries(newTable.indexes)) {
           if (!index.unique) {
             continue;
@@ -227,9 +227,9 @@ export function diffManifestsAgainstSiblings({
       }
     }
 
-    // Own previous manifests participate in the additive-but-breaking check only: live rows
+    // Own previous state participates in the additive-but-breaking check only: live rows
     // predate the new column, so NOT NULL without default breaks even without siblings.
-    const previousDb = previousManifests?.databases[database];
+    const previousDb = previousState?.databases[database];
     if (previousDb !== undefined) {
       for (const [tableName, previousTable] of Object.entries(
         previousDb.tables
@@ -303,8 +303,8 @@ function addNotNullAdditionBlocks({
 }: {
   database: string;
   tableName: string;
-  newColumns: Record<string, ManifestColumn>;
-  existingColumns: Record<string, ManifestColumn>;
+  newColumns: Record<string, DatabaseColumn>;
+  existingColumns: Record<string, DatabaseColumn>;
   affectedSlug: string;
   addBlock: (
     entry: { database: string; table: string; column: string; reason: string },
@@ -331,8 +331,8 @@ function addNotNullAdditionBlocks({
 }
 
 function describeStructuralChange(
-  siblingColumn: ManifestColumn,
-  newColumn: ManifestColumn
+  siblingColumn: DatabaseColumn,
+  newColumn: DatabaseColumn
 ): string | null {
   if (newColumn.type !== siblingColumn.type) {
     return `type ${siblingColumn.type} -> ${newColumn.type}`;
@@ -354,26 +354,26 @@ function formatMode(mode: string | null): string {
 }
 
 /**
- * After a compatible publish: siblings whose stored manifest for a shared database differs from
+ * After a compatible publish: siblings whose stored state for a shared database differs from
  * the newly stored one. Their bundles keep working (the diff said so), but their embedded schema
  * files are stale until republished.
  */
 export function computeStaleSiblings(
-  newManifests: FunctionStateManifest | null,
-  siblings: SiblingManifests[]
+  newState: FunctionState | null,
+  siblings: SiblingState[]
 ): StaleSiblingNote[] {
-  if (newManifests === null) {
+  if (newState === null) {
     return [];
   }
 
   const notes: StaleSiblingNote[] = [];
   for (const sibling of siblings) {
-    if (sibling.manifests === null || sibling.manifests === undefined) {
+    if (sibling.state === null || sibling.state === undefined) {
       continue;
     }
     const staleDatabases: string[] = [];
-    for (const [database, newDb] of Object.entries(newManifests.databases)) {
-      const siblingDb = sibling.manifests.databases[database];
+    for (const [database, newDb] of Object.entries(newState.databases)) {
+      const siblingDb = sibling.state.databases[database];
       if (siblingDb !== undefined && !isEqual(siblingDb, newDb)) {
         staleDatabases.push(database);
       }

--- a/front/lib/api/sandbox_functions/compat.ts
+++ b/front/lib/api/sandbox_functions/compat.ts
@@ -1,0 +1,386 @@
+import type {
+  FunctionManifests,
+  ManifestColumn,
+} from "@app/lib/api/sandbox_functions/manifests";
+import isEqual from "lodash/isEqual";
+
+// Pure manifest compatibility diff (manifest.v1 compat semantics): the new manifests of the
+// function being published are compared against the stored manifests of every other function
+// of the same pod declaring the same database ("siblings"), plus the publishing function's own
+// previous manifests for the additive-but-breaking check.
+//
+// - BLOCK (structural): a sibling references something the new manifests remove or change
+//   (table missing; column missing; type/notNull/primaryKey/autoIncrement differ).
+// - BLOCK (additive-but-breaking): a new NOT NULL column without default on a table that
+//   already exists in any sibling manifest or in this function's own previous manifests.
+// - WARN (mode drift): same column, same type, different mode.
+// - WARN (unique tightening): new unique index on a table present in a sibling manifest.
+// - Indexes never block; hasDefault changes never block.
+
+export interface SiblingManifests {
+  slug: string;
+  manifests: FunctionManifests | null;
+}
+
+export interface CompatBlock {
+  database: string;
+  table: string;
+  column: string | null;
+  // Slugs whose published bundles (or, for the additive check, whose live rows) break.
+  affectedFunctions: string[];
+  reason: string;
+}
+
+export interface CompatWarning {
+  kind: "mode_drift" | "unique_tightening";
+  database: string;
+  table: string;
+  subject: string; // column name (mode_drift) or index name (unique_tightening)
+  message: string;
+}
+
+export interface CompatDiff {
+  blocks: CompatBlock[];
+  warnings: CompatWarning[];
+}
+
+export interface StaleSiblingNote {
+  slug: string;
+  databases: string[];
+}
+
+interface BlockAccumulatorEntry {
+  database: string;
+  table: string;
+  column: string | null;
+  affectedFunctions: Set<string>;
+  reason: string;
+}
+
+export function diffManifestsAgainstSiblings({
+  newManifests,
+  previousManifests,
+  siblings,
+}: {
+  newManifests: FunctionManifests | null;
+  previousManifests: FunctionManifests | null;
+  siblings: SiblingManifests[];
+}): CompatDiff {
+  if (newManifests === null) {
+    // A function declaring no databases cannot break siblings: its bundle opens nothing, and
+    // no DDL runs. (Tables it used to declare stay live; reconcile never drops.)
+    return { blocks: [], warnings: [] };
+  }
+
+  const blocks = new Map<string, BlockAccumulatorEntry>();
+  const modeDrifts = new Map<
+    string,
+    {
+      database: string;
+      table: string;
+      column: string;
+      type: string;
+      newMode: string | null;
+      siblingMode: string | null;
+      slugs: Set<string>;
+    }
+  >();
+  const uniqueTightenings = new Map<
+    string,
+    {
+      database: string;
+      table: string;
+      indexName: string;
+      columns: string[];
+      slugs: Set<string>;
+    }
+  >();
+
+  const addBlock = (
+    entry: Omit<BlockAccumulatorEntry, "affectedFunctions">,
+    affectedSlug: string
+  ) => {
+    const key = [entry.database, entry.table, entry.column, entry.reason].join(
+      "\u0000"
+    );
+    const existing = blocks.get(key);
+    if (existing) {
+      existing.affectedFunctions.add(affectedSlug);
+    } else {
+      blocks.set(key, { ...entry, affectedFunctions: new Set([affectedSlug]) });
+    }
+  };
+
+  for (const [database, newDb] of Object.entries(newManifests.databases)) {
+    for (const sibling of siblings) {
+      const siblingDb = sibling.manifests?.databases[database];
+      if (siblingDb === undefined) {
+        continue;
+      }
+
+      for (const [tableName, siblingTable] of Object.entries(
+        siblingDb.tables
+      )) {
+        const newTable = newDb.tables[tableName];
+        if (newTable === undefined) {
+          addBlock(
+            {
+              database,
+              table: tableName,
+              column: null,
+              reason: `removes table ${database}.${tableName}`,
+            },
+            sibling.slug
+          );
+          continue;
+        }
+
+        // Structural checks: everything the sibling references must survive unchanged.
+        for (const [columnName, siblingColumn] of Object.entries(
+          siblingTable.columns
+        )) {
+          const newColumn = newTable.columns[columnName];
+          if (newColumn === undefined) {
+            addBlock(
+              {
+                database,
+                table: tableName,
+                column: columnName,
+                reason: `removes column ${database}.${tableName}.${columnName}`,
+              },
+              sibling.slug
+            );
+            continue;
+          }
+          const structuralChange = describeStructuralChange(
+            siblingColumn,
+            newColumn
+          );
+          if (structuralChange !== null) {
+            addBlock(
+              {
+                database,
+                table: tableName,
+                column: columnName,
+                reason: `changes ${database}.${tableName}.${columnName}: ${structuralChange}`,
+              },
+              sibling.slug
+            );
+          } else if (newColumn.mode !== siblingColumn.mode) {
+            // Same storage type, different (de)serialization contract: warn, never block.
+            const key = [
+              database,
+              tableName,
+              columnName,
+              newColumn.mode,
+              siblingColumn.mode,
+            ].join("\u0000");
+            const drift = modeDrifts.get(key);
+            if (drift) {
+              drift.slugs.add(sibling.slug);
+            } else {
+              modeDrifts.set(key, {
+                database,
+                table: tableName,
+                column: columnName,
+                type: newColumn.type,
+                newMode: newColumn.mode,
+                siblingMode: siblingColumn.mode,
+                slugs: new Set([sibling.slug]),
+              });
+            }
+          }
+        }
+
+        // Additive-but-breaking: new NOT NULL column without default on a pre-existing table.
+        addNotNullAdditionBlocks({
+          database,
+          tableName,
+          newColumns: newTable.columns,
+          existingColumns: siblingTable.columns,
+          affectedSlug: sibling.slug,
+          addBlock,
+        });
+
+        // Unique tightening: a unique index the sibling's manifest does not carry.
+        for (const [indexName, index] of Object.entries(newTable.indexes)) {
+          if (!index.unique) {
+            continue;
+          }
+          const siblingIndex = siblingTable.indexes[indexName];
+          if (siblingIndex === undefined || !siblingIndex.unique) {
+            const key = [database, tableName, indexName].join("\u0000");
+            const tightening = uniqueTightenings.get(key);
+            if (tightening) {
+              tightening.slugs.add(sibling.slug);
+            } else {
+              uniqueTightenings.set(key, {
+                database,
+                table: tableName,
+                indexName,
+                columns: index.columns,
+                slugs: new Set([sibling.slug]),
+              });
+            }
+          }
+        }
+      }
+    }
+
+    // Own previous manifests participate in the additive-but-breaking check only: live rows
+    // predate the new column, so NOT NULL without default breaks even without siblings.
+    const previousDb = previousManifests?.databases[database];
+    if (previousDb !== undefined) {
+      for (const [tableName, previousTable] of Object.entries(
+        previousDb.tables
+      )) {
+        const newTable = newDb.tables[tableName];
+        if (newTable === undefined) {
+          continue;
+        }
+        addNotNullAdditionBlocks({
+          database,
+          tableName,
+          newColumns: newTable.columns,
+          existingColumns: previousTable.columns,
+          affectedSlug: "(this function's previous publish)",
+          addBlock,
+        });
+      }
+    }
+  }
+
+  const warnings: CompatWarning[] = [
+    ...[...modeDrifts.values()].map((drift): CompatWarning => {
+      const slugs = [...drift.slugs].sort();
+      return {
+        kind: "mode_drift",
+        database: drift.database,
+        table: drift.table,
+        subject: drift.column,
+        message:
+          `${drift.database}.${drift.table}.${drift.column}: this publish declares ` +
+          `${drift.type}${formatMode(drift.newMode)}; ${slugs.join(", ")} ` +
+          `declare${slugs.length === 1 ? "s" : ""} ${drift.type}${formatMode(drift.siblingMode)}. ` +
+          `Align on the shared databases/${drift.database}.db.ts and republish, ` +
+          `or republish the siblings if the new mode is intended.`,
+      };
+    }),
+    ...[...uniqueTightenings.values()].map((tightening): CompatWarning => {
+      const slugs = [...tightening.slugs].sort();
+      return {
+        kind: "unique_tightening",
+        database: tightening.database,
+        table: tightening.table,
+        subject: tightening.indexName,
+        message:
+          `${tightening.database}.${tightening.table}: new unique index ` +
+          `"${tightening.indexName}" (${tightening.columns.join(", ")}) tightens a table ` +
+          `other functions use (${slugs.join(", ")}); writes violating uniqueness will now fail.`,
+      };
+    }),
+  ];
+
+  return {
+    blocks: [...blocks.values()].map((entry) => ({
+      database: entry.database,
+      table: entry.table,
+      column: entry.column,
+      affectedFunctions: [...entry.affectedFunctions].sort(),
+      reason: entry.reason,
+    })),
+    warnings,
+  };
+}
+
+function addNotNullAdditionBlocks({
+  database,
+  tableName,
+  newColumns,
+  existingColumns,
+  affectedSlug,
+  addBlock,
+}: {
+  database: string;
+  tableName: string;
+  newColumns: Record<string, ManifestColumn>;
+  existingColumns: Record<string, ManifestColumn>;
+  affectedSlug: string;
+  addBlock: (
+    entry: { database: string; table: string; column: string; reason: string },
+    affectedSlug: string
+  ) => void;
+}): void {
+  for (const [columnName, newColumn] of Object.entries(newColumns)) {
+    if (
+      existingColumns[columnName] === undefined &&
+      newColumn.notNull &&
+      !newColumn.hasDefault
+    ) {
+      addBlock(
+        {
+          database,
+          table: tableName,
+          column: columnName,
+          reason: `adds NOT NULL column ${database}.${tableName}.${columnName} without a default on a table that already exists`,
+        },
+        affectedSlug
+      );
+    }
+  }
+}
+
+function describeStructuralChange(
+  siblingColumn: ManifestColumn,
+  newColumn: ManifestColumn
+): string | null {
+  if (newColumn.type !== siblingColumn.type) {
+    return `type ${siblingColumn.type} -> ${newColumn.type}`;
+  }
+  if (newColumn.notNull !== siblingColumn.notNull) {
+    return newColumn.notNull ? "adds NOT NULL" : "removes NOT NULL";
+  }
+  if (newColumn.primaryKey !== siblingColumn.primaryKey) {
+    return "changes the primary key";
+  }
+  if (newColumn.autoIncrement !== siblingColumn.autoIncrement) {
+    return "changes autoincrement";
+  }
+  return null;
+}
+
+function formatMode(mode: string | null): string {
+  return mode === null ? " (no mode)" : ` mode=${mode}`;
+}
+
+/**
+ * After a compatible publish: siblings whose stored manifest for a shared database differs from
+ * the newly stored one. Their bundles keep working (the diff said so), but their embedded schema
+ * files are stale until republished.
+ */
+export function computeStaleSiblings(
+  newManifests: FunctionManifests | null,
+  siblings: SiblingManifests[]
+): StaleSiblingNote[] {
+  if (newManifests === null) {
+    return [];
+  }
+
+  const notes: StaleSiblingNote[] = [];
+  for (const sibling of siblings) {
+    if (sibling.manifests === null || sibling.manifests === undefined) {
+      continue;
+    }
+    const staleDatabases: string[] = [];
+    for (const [database, newDb] of Object.entries(newManifests.databases)) {
+      const siblingDb = sibling.manifests.databases[database];
+      if (siblingDb !== undefined && !isEqual(siblingDb, newDb)) {
+        staleDatabases.push(database);
+      }
+    }
+    if (staleDatabases.length > 0) {
+      notes.push({ slug: sibling.slug, databases: staleDatabases.sort() });
+    }
+  }
+  return notes.sort((a, b) => a.slug.localeCompare(b.slug));
+}


### PR DESCRIPTION
## Description

**Stack 7/10 (pod-state).** The pure manifest compatibility differ — the heart of the publish gate (design: "How to handle breaking changes? … we do NOT handle breaking changes by forbidding them, raising errors to the agent").

`diffManifestsAgainstSiblings` compares the manifests being published against the stored manifests of every other function of the pod declaring the same database, plus the function's own previous manifests. Semantics (frozen in manifest.v1):

- **BLOCK (structural)** — a sibling references something removed/changed: table missing, column missing, `type`/`notNull`/`primaryKey`/`autoIncrement` differ.
- **BLOCK (additive-but-breaking)** — new `NOT NULL` column without default on a table that already exists in any sibling manifest **or in this function's own previous manifests** (live rows predate the column even with no siblings).
- **WARN (mode drift)** — same column, same storage type, different mode: value-level divergence only (stored bytes identical), which is exactly why manifests carry modes — SQLite can't see this. Warn, never block; publish proceeds.
- **WARN (unique tightening)** — new `unique: true` index on a table a sibling uses (UNIQUE is allowed per the manifest.v1 deviation; tightening makes sibling writes fail, so it warns).
- **Indexes never block** (queries don't reference indexes); `hasDefault` changes never block.
- `computeStaleSiblings` — post-publish notes: siblings whose stored manifest for a shared db now differs (their bundles keep working; their embedded schema files are stale until republished — the design's accepted no-transactional-publish tradeoff).

Pure function, no I/O — blocks dedupe across siblings and carry the affected function list so the publish error can say *"removes chat.messages.body (breaks: list-messages)"*.

## Tests

18 vitest cases at this commit (`compat.test.ts`), deliberately including the design doc's worked examples: the `body → content` rename (blocked, names the sibling), the `report-activity` mode-drift warning (proceeds with the alignment message), and the `channel NOT NULL` addition (blocked with the additive-migrate hint). `tsgo` clean.

## Risk

None standalone — nothing calls it until the next PR.

## Deploy Plan

Standard front deploy (inert until wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
