### PR TITLE
[front] feat: pod_databases MCP server

### DIFF
--- a/cli/dust-sandbox/functions-runner/db.test.ts
+++ b/cli/dust-sandbox/functions-runner/db.test.ts
@@ -1,0 +1,517 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { existsSync, statSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DbCommandError } from "./db_common.ts";
+import {
+  QUERY_PAYLOAD_CAP_BYTES,
+  QUERY_ROW_CAP,
+  queryReadonly,
+} from "./db_query.ts";
+import { reconcile } from "./db_reconcile.ts";
+import { generateSchemaFileText } from "./db_schema.ts";
+
+const fx = (n: string) => join(import.meta.dir, "fixtures", "databases", n);
+
+async function withDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "dsbx-db-test-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function expectDbError(
+  fn: () => Promise<unknown>,
+  kind: string,
+  messagePattern: RegExp
+): Promise<void> {
+  let caught: unknown;
+  try {
+    await fn();
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(DbCommandError);
+  if (caught instanceof DbCommandError) {
+    expect(caught.kind).toBe(kind);
+    expect(caught.message).toMatch(messagePattern);
+  }
+}
+
+function tableNames(dbPath: string): string[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return (
+      db
+        .query(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        )
+        .all() as { name: string }[]
+    ).map((row) => row.name);
+  } finally {
+    db.close();
+  }
+}
+
+describe("db reconcile", () => {
+  test("creates the database on first claim with WAL mode, group-writable, and applies the schema", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "chat.db");
+      const result = await reconcile(dbPath, fx("chat.db.ts"));
+
+      expect(result.ok).toBe(true);
+      expect(result.created).toBe(true);
+      expect(result.statements.length).toBeGreaterThan(0);
+
+      // Group-writable per paths-env.v1: litestream (dust-state, group agent) must write the
+      // file it replicates; -wal/-shm inherit this mode.
+      expect(statSync(dbPath).mode & 0o777).toBe(0o660);
+
+      const db = new Database(dbPath, { readonly: true });
+      try {
+        const mode = db.query("PRAGMA journal_mode").get() as {
+          journal_mode: string;
+        };
+        expect(mode.journal_mode).toBe("wal");
+      } finally {
+        db.close();
+      }
+      expect(tableNames(dbPath)).toEqual(["messages", "settings", "users"]);
+    });
+  });
+
+  test("a failed first claim leaves no database file behind", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "dup.db");
+      await expectDbError(
+        () => reconcile(dbPath, fx("dup_index.db.ts")),
+        "apply_failed",
+        /rolled back/
+      );
+      for (const suffix of ["", "-wal", "-shm"]) {
+        expect(existsSync(`${dbPath}${suffix}`)).toBe(false);
+      }
+    });
+  });
+
+  test("a failed reconcile on an EXISTING database keeps the file", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "chat.db");
+      await reconcile(dbPath, fx("chat.db.ts"));
+      await expectDbError(
+        () => reconcile(dbPath, fx("chat_reduced.db.ts")),
+        "destructive_change",
+        /would be dropped/
+      );
+      expect(existsSync(dbPath)).toBe(true);
+    });
+  });
+
+  test("is idempotent: a second reconcile applies nothing", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "chat.db");
+      await reconcile(dbPath, fx("chat.db.ts"));
+      const second = await reconcile(dbPath, fx("chat.db.ts"));
+
+      expect(second.created).toBe(false);
+      expect(second.statements).toEqual([]);
+    });
+  });
+
+  test("applies additive evolution (new column, new index, new table) and keeps data", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "chat.db");
+      await reconcile(dbPath, fx("chat.db.ts"));
+
+      const db = new Database(dbPath);
+      db.exec(
+        "INSERT INTO users (handle, created_at) VALUES ('alice', 1700000000)"
+      );
+      db.close();
+
+      const result = await reconcile(dbPath, fx("chat_v2.db.ts"));
+      expect(result.statements.join("\n")).toMatch(/ALTER TABLE .users. ADD/);
+      expect(result.statements.join("\n")).toMatch(/CREATE TABLE .reactions./);
+      expect(result.statements.join("\n")).toMatch(/users_bio_idx/);
+
+      const after = new Database(dbPath, { readonly: true });
+      try {
+        const row = after.query("SELECT handle, bio FROM users").get() as {
+          handle: string;
+          bio: unknown;
+        };
+        expect(row.handle).toBe("alice");
+        expect(row.bio).toBeNull();
+      } finally {
+        after.close();
+      }
+    });
+  });
+
+  test("refuses destructive changes (dropped column/tables) with a typed error", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "chat.db");
+      await reconcile(dbPath, fx("chat.db.ts"));
+
+      await expectDbError(
+        () => reconcile(dbPath, fx("chat_reduced.db.ts")),
+        "destructive_change",
+        /display_name.*would be dropped|would be dropped/
+      );
+      // Nothing was applied.
+      expect(tableNames(dbPath)).toEqual(["messages", "settings", "users"]);
+    });
+  });
+
+  test("refuses a type change (table recreate plan) with a typed error", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "notes.db");
+      await reconcile(dbPath, fx("notes.db.ts"));
+
+      await expectDbError(
+        () => reconcile(dbPath, fx("notes_typechange.db.ts")),
+        "disallowed_statement",
+        /additive DDL/
+      );
+
+      // The live column type is unchanged.
+      const db = new Database(dbPath, { readonly: true });
+      try {
+        const info = db.query("PRAGMA table_xinfo(notes)").all() as {
+          name: string;
+          type: string;
+        }[];
+        const label = info.find((column) => column.name === "label");
+        expect(label?.type.toUpperCase()).toContain("TEXT");
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  test("refuses a missing schema file with a typed error", async () => {
+    await withDir(async (dir) => {
+      await expectDbError(
+        () => reconcile(join(dir, "chat.db"), join(dir, "nope.db.ts")),
+        "schema_unresolvable",
+        /schema file not found/
+      );
+    });
+  });
+
+  test("refuses a schema file with foreign keys (same gate as build)", async () => {
+    await withDir(async (dir) => {
+      await expectDbError(
+        () => reconcile(join(dir, "fk.db"), fx("fk.db.ts")),
+        "schema_invalid",
+        /foreign keys/
+      );
+    });
+  });
+});
+
+describe("db schema", () => {
+  test("regenerates a schema file that reconciles cleanly against the same database", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "chat.db");
+      await reconcile(dbPath, fx("chat.db.ts"));
+
+      const text = generateSchemaFileText(dbPath);
+      expect(text).toContain('from "drizzle-orm/sqlite-core"');
+      expect(text).toContain("export const users = sqliteTable(");
+      expect(text).toContain(".primaryKey({ autoIncrement: true })");
+      expect(text).toContain('uniqueIndex("users_handle_idx")');
+      expect(text).toContain("modes");
+
+      // Roundtrip: the regenerated file must be a no-op plan against the live database. It is
+      // written inside the package tree so its `drizzle-orm` import resolves by node_modules
+      // walk-up (the sandbox resolves it via NODE_PATH instead).
+      const scratch = await mkdtemp(join(import.meta.dir, ".db-test-"));
+      try {
+        const regenerated = join(scratch, "chat.regenerated.db.ts");
+        await writeFile(regenerated, text);
+        const roundtrip = await reconcile(dbPath, regenerated);
+        expect(roundtrip.statements).toEqual([]);
+      } finally {
+        await rm(scratch, { recursive: true, force: true });
+      }
+    });
+  });
+
+  test("errors with database_not_found on a missing database", async () => {
+    await withDir(async (dir) => {
+      let caught: unknown;
+      try {
+        generateSchemaFileText(join(dir, "nope.db"));
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(DbCommandError);
+      if (caught instanceof DbCommandError) {
+        expect(caught.kind).toBe("database_not_found");
+      }
+    });
+  });
+});
+
+describe("db query", () => {
+  async function seeded(dir: string): Promise<string> {
+    const dbPath = join(dir, "chat.db");
+    await reconcile(dbPath, fx("chat.db.ts"));
+    const db = new Database(dbPath);
+    db.exec(
+      "INSERT INTO users (handle, created_at) VALUES ('alice', 1), ('bob', 2)"
+    );
+    db.close();
+    return dbPath;
+  }
+
+  test("returns rows with columns", async () => {
+    await withDir(async (dir) => {
+      const dbPath = await seeded(dir);
+      const result = queryReadonly(
+        dbPath,
+        "SELECT handle FROM users ORDER BY handle"
+      );
+      expect(result.ok).toBe(true);
+      expect(result.columns).toEqual(["handle"]);
+      expect(result.rows).toEqual([{ handle: "alice" }, { handle: "bob" }]);
+      expect(result.row_count).toBe(2);
+      expect(result.truncated).toBe(false);
+    });
+  });
+
+  test("caps rows and sets the truncated flag", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "notes.db");
+      await reconcile(dbPath, fx("notes.db.ts"));
+      const db = new Database(dbPath);
+      const insert = db.prepare("INSERT INTO notes (label) VALUES (?)");
+      db.exec("BEGIN");
+      for (let i = 0; i < QUERY_ROW_CAP + 1; i++) {
+        insert.run(`row-${i}`);
+      }
+      db.exec("COMMIT");
+      db.close();
+
+      const result = queryReadonly(dbPath, "SELECT label FROM notes");
+      expect(result.rows.length).toBe(QUERY_ROW_CAP);
+      expect(result.truncated).toBe(true);
+    });
+  });
+
+  test("rejects writes (read-only + query_only)", async () => {
+    await withDir(async (dir) => {
+      const dbPath = await seeded(dir);
+      let caught: unknown;
+      try {
+        queryReadonly(
+          dbPath,
+          "INSERT INTO users (handle, created_at) VALUES ('eve', 3)"
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(DbCommandError);
+      if (caught instanceof DbCommandError) {
+        expect(caught.kind).toBe("query_failed");
+      }
+      // Nothing was written.
+      const check = queryReadonly(dbPath, "SELECT count(*) AS n FROM users");
+      expect(check.rows).toEqual([{ n: 2 }]);
+    });
+  });
+
+  test("rejects multi-statement SQL (bun:sqlite would silently run only the first)", async () => {
+    await withDir(async (dir) => {
+      const dbPath = await seeded(dir);
+      let caught: unknown;
+      try {
+        queryReadonly(dbPath, "SELECT handle FROM users; DELETE FROM users");
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(DbCommandError);
+      if (caught instanceof DbCommandError) {
+        expect(caught.kind).toBe("query_failed");
+        expect(caught.message).toMatch(/multiple SQL statements/);
+      }
+
+      // A trailing semicolon (and semicolons inside string literals) are fine.
+      const trailing = queryReadonly(
+        dbPath,
+        "SELECT count(*) AS n FROM users WHERE handle != 'a;b';"
+      );
+      expect(trailing.rows).toEqual([{ n: 2 }]);
+    });
+  });
+
+  test("caps the total payload bytes and sets the truncated flag", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "notes.db");
+      await reconcile(dbPath, fx("notes.db.ts"));
+      const db = new Database(dbPath);
+      const insert = db.prepare("INSERT INTO notes (label) VALUES (?)");
+      // Three ~600KB rows: well under the row cap, over the 1MiB payload cap after row one.
+      const big = "x".repeat(600 * 1024);
+      db.exec("BEGIN");
+      for (let i = 0; i < 3; i++) {
+        insert.run(big);
+      }
+      db.exec("COMMIT");
+      db.close();
+
+      const result = queryReadonly(dbPath, "SELECT label FROM notes");
+      expect(result.rows.length).toBe(1);
+      expect(result.truncated).toBe(true);
+    });
+  });
+
+  test("rejects a single row exceeding the payload cap", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "notes.db");
+      await reconcile(dbPath, fx("notes.db.ts"));
+      const db = new Database(dbPath);
+      db.prepare("INSERT INTO notes (label) VALUES (?)").run(
+        "x".repeat(QUERY_PAYLOAD_CAP_BYTES + 1024)
+      );
+      db.close();
+
+      let caught: unknown;
+      try {
+        queryReadonly(dbPath, "SELECT label FROM notes");
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(DbCommandError);
+      if (caught instanceof DbCommandError) {
+        expect(caught.kind).toBe("query_failed");
+        expect(caught.message).toMatch(/payload cap/);
+      }
+    });
+  });
+
+  test("errors on an empty SQL input", async () => {
+    await withDir(async (dir) => {
+      const dbPath = await seeded(dir);
+      let caught: unknown;
+      try {
+        queryReadonly(dbPath, "   \n ");
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(DbCommandError);
+      if (caught instanceof DbCommandError) {
+        expect(caught.kind).toBe("empty_sql");
+      }
+    });
+  });
+
+  test("errors with database_not_found on a missing database", async () => {
+    await withDir(async (dir) => {
+      let caught: unknown;
+      try {
+        queryReadonly(join(dir, "nope.db"), "SELECT 1");
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(DbCommandError);
+      if (caught instanceof DbCommandError) {
+        expect(caught.kind).toBe("database_not_found");
+      }
+    });
+  });
+});
+
+describe("runner db-* envelopes", () => {
+  const runner = join(import.meta.dir, "runner.ts");
+
+  async function run(args: string[], stdin?: string) {
+    const proc = Bun.spawn(["bun", runner, ...args], {
+      stdin: stdin === undefined ? "ignore" : new Blob([stdin]),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      proc.exited,
+    ]);
+    return { stdout, code };
+  }
+
+  test("db-reconcile prints a one-line ok envelope", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "chat.db");
+      const { stdout, code } = await run([
+        "db-reconcile",
+        dbPath,
+        fx("chat.db.ts"),
+      ]);
+      expect(code).toBe(0);
+      const lines = stdout.split("\n").filter((line) => line.trim().length > 0);
+      const envelope = JSON.parse(lines.at(-1) ?? "");
+      expect(envelope.ok).toBe(true);
+      expect(envelope.created).toBe(true);
+      // The whole stdout is the envelope: drizzle-kit's spinner is suppressed.
+      expect(lines).toHaveLength(1);
+    });
+  });
+
+  test("db-reconcile prints a typed error envelope and exits 1", async () => {
+    await withDir(async (dir) => {
+      const { stdout, code } = await run([
+        "db-reconcile",
+        join(dir, "fk.db"),
+        fx("fk.db.ts"),
+      ]);
+      expect(code).toBe(1);
+      const envelope = JSON.parse(stdout.trim().split("\n").at(-1) ?? "");
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error.kind).toBe("schema_invalid");
+    });
+  });
+
+  test("db-schema writes the file and prints ok", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "chat.db");
+      await run(["db-reconcile", dbPath, fx("chat.db.ts")]);
+      const outPath = join(dir, "chat.db.ts");
+      const { stdout, code } = await run(["db-schema", dbPath, outPath]);
+      expect(code).toBe(0);
+      expect(JSON.parse(stdout.trim())).toEqual({ ok: true });
+      const text = await Bun.file(outPath).text();
+      expect(text).toContain("export const users = sqliteTable(");
+    });
+  });
+
+  test("db-query reads SQL from stdin", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "chat.db");
+      await run(["db-reconcile", dbPath, fx("chat.db.ts")]);
+      const { stdout, code } = await run(
+        ["db-query", dbPath],
+        "SELECT count(*) AS n FROM users"
+      );
+      expect(code).toBe(0);
+      const envelope = JSON.parse(stdout.trim());
+      expect(envelope.ok).toBe(true);
+      expect(envelope.rows).toEqual([{ n: 0 }]);
+    });
+  });
+
+  test("db-* subcommands exit 2 with bad_args on missing arguments", async () => {
+    for (const args of [
+      ["db-reconcile"],
+      ["db-schema", "/tmp/x.db"],
+      ["db-query"],
+    ]) {
+      const { stdout, code } = await run(args);
+      expect(code).toBe(2);
+      expect(JSON.parse(stdout.trim()).error.kind).toBe("bad_args");
+    }
+  });
+});

--- a/cli/dust-sandbox/functions-runner/db_query.ts
+++ b/cli/dust-sandbox/functions-runner/db_query.ts
@@ -1,0 +1,135 @@
+// `dsbx db query` runner backend: read-only SQL against a live pod database.
+//
+// The database is opened read-only AND with `PRAGMA query_only = ON` (defense in depth), so
+// any write attempt fails. Rows are returned in the stdout envelope, capped (+ truncated flag):
+// this backs the pod_databases `query` MCP tool.
+
+import { DbCommandError, openReadonly } from "./db_common.ts";
+
+export const QUERY_ROW_CAP = 1000;
+// Total payload cap alongside the row cap: a single crafted large row must not buffer an
+// unbounded result through the runner into front memory.
+export const QUERY_PAYLOAD_CAP_BYTES = 1024 * 1024;
+
+export interface QuerySuccess {
+  ok: true;
+  columns: string[];
+  rows: Record<string, unknown>[];
+  row_count: number;
+  truncated: boolean;
+}
+
+// bun:sqlite's query()/prepare() compiles only the FIRST statement and silently ignores the
+// rest, so multi-statement input would return partial results with no error. v1 limitation:
+// reject it up front with a pragmatic top-level-';' scan (quotes respected; comments containing
+// ';' after a statement are also rejected — send a single clean statement).
+function assertSingleStatement(sql: string): void {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < sql.length; i++) {
+    const char = sql[i];
+    if (inSingle) {
+      if (char === "'") {
+        inSingle = false;
+      }
+    } else if (inDouble) {
+      if (char === '"') {
+        inDouble = false;
+      }
+    } else if (char === "'") {
+      inSingle = true;
+    } else if (char === '"') {
+      inDouble = true;
+    } else if (char === ";" && sql.slice(i + 1).trim().length > 0) {
+      throw new DbCommandError(
+        "query_failed",
+        "multiple SQL statements are not supported; send a single statement"
+      );
+    }
+  }
+}
+
+export function queryReadonly(dbPath: string, sql: string): QuerySuccess {
+  const trimmed = sql.trim();
+  if (trimmed.length === 0) {
+    throw new DbCommandError("empty_sql", "no SQL statement provided on stdin");
+  }
+  assertSingleStatement(trimmed);
+
+  const db = openReadonly(dbPath);
+  try {
+    let statement;
+    try {
+      statement = db.query(trimmed);
+    } catch (e) {
+      throw new DbCommandError(
+        "query_failed",
+        e instanceof Error ? e.message : String(e)
+      );
+    }
+
+    const rows: Record<string, unknown>[] = [];
+    let truncated = false;
+    let payloadBytes = 0;
+    try {
+      for (const row of statement.iterate()) {
+        if (rows.length >= QUERY_ROW_CAP) {
+          truncated = true;
+          break;
+        }
+        const sanitized = sanitizeRow(row);
+        const rowBytes = Buffer.byteLength(JSON.stringify(sanitized), "utf8");
+        if (rowBytes > QUERY_PAYLOAD_CAP_BYTES) {
+          throw new DbCommandError(
+            "query_failed",
+            `a single row exceeds the ${QUERY_PAYLOAD_CAP_BYTES}-byte payload cap; select fewer or smaller columns`
+          );
+        }
+        if (payloadBytes + rowBytes > QUERY_PAYLOAD_CAP_BYTES) {
+          truncated = true;
+          break;
+        }
+        payloadBytes += rowBytes;
+        rows.push(sanitized);
+      }
+    } catch (e) {
+      throw new DbCommandError(
+        "query_failed",
+        e instanceof Error ? e.message : String(e)
+      );
+    }
+
+    return {
+      ok: true,
+      columns: statement.columnNames,
+      rows,
+      row_count: rows.length,
+      truncated,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+// Rows must survive JSON.stringify: blobs become base64 strings, bigints (safeIntegers off, so
+// only via user-defined functions) become decimal strings.
+function sanitizeRow(row: unknown): Record<string, unknown> {
+  if (typeof row !== "object" || row === null) {
+    return { value: sanitizeValue(row) };
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(row)) {
+    out[key] = sanitizeValue(value);
+  }
+  return out;
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value).toString("base64");
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  return value;
+}

--- a/cli/dust-sandbox/functions-runner/db_schema.ts
+++ b/cli/dust-sandbox/functions-runner/db_schema.ts
@@ -1,0 +1,227 @@
+// `dsbx db schema` runner backend: regenerate a drizzle `{db}.db.ts` schema file from a live
+// pod database.
+//
+// Introspection is PRAGMA-based (sqlite_master + table_xinfo + index_list/index_info):
+// drizzle-kit's `pull` requires a better-sqlite3/@libsql driver and cannot reuse bun:sqlite
+// (E2 verdict). Column modes (timestamp/json/boolean/...) are a drizzle-level concept that
+// SQLite does not store — they are NOT regenerated here; front merges them from the stored
+// manifests on its side (pod_databases.get_schema).
+
+import type { LiveColumn, LiveTable } from "./db_common.ts";
+import { introspectLiveTables, openReadonly } from "./db_common.ts";
+
+const GENERATED_HEADER = `// Regenerated from the live database by \`dsbx db schema\`.
+// NOTE: column modes (e.g. { mode: "timestamp" | "json" | "boolean" }) are not stored in
+// SQLite and are NOT recovered here — re-add them from the modes reported by the
+// pod_databases get_schema tool before using this file as the shared schema source.
+`;
+
+export function generateSchemaFileText(dbPath: string): string {
+  const db = openReadonly(dbPath);
+  try {
+    const tables = introspectLiveTables(db);
+    const usedImports = new Set<string>(["sqliteTable"]);
+    const tableBlocks = tables.map((table) =>
+      generateTableBlock(table, usedImports)
+    );
+
+    const sqliteCoreImports = [...usedImports]
+      .filter((name) => name !== "sql")
+      .sort()
+      .join(", ");
+    const importLines = [
+      `import { ${sqliteCoreImports} } from "drizzle-orm/sqlite-core";`,
+    ];
+    if (usedImports.has("sql")) {
+      importLines.unshift(`import { sql } from "drizzle-orm";`);
+    }
+
+    return [
+      GENERATED_HEADER,
+      importLines.join("\n"),
+      "",
+      tableBlocks.join("\n\n"),
+      "",
+    ].join("\n");
+  } finally {
+    db.close();
+  }
+}
+
+function generateTableBlock(
+  table: LiveTable,
+  usedImports: Set<string>
+): string {
+  const pkColumns = table.columns
+    .filter((column) => column.pkOrdinal > 0 && column.hidden === 0)
+    .sort((a, b) => a.pkOrdinal - b.pkOrdinal);
+  // Column-level .primaryKey() implies NOT NULL in drizzle's schema model, but a live
+  // non-INTEGER `PRIMARY KEY` column is nullable in SQLite (legacy quirk) — regenerating it
+  // inline would make drizzle-kit plan a table recreate. Only the INTEGER single-pk (rowid
+  // alias, which drizzle-kit treats as equivalent) regenerates inline; every other primary
+  // key becomes a table-level primaryKey({ ... }).
+  const singlePk =
+    pkColumns.length === 1 &&
+    pkColumns[0] !== undefined &&
+    builderForDeclaredType(pkColumns[0].declaredType) === "integer"
+      ? pkColumns[0]
+      : undefined;
+  const singlePkName = singlePk?.name;
+  const hasAutoIncrement = /\bAUTOINCREMENT\b/i.test(table.createSql);
+
+  // Single-column UNIQUE-constraint auto-indexes render as column-level .unique(); everything
+  // else renders in the table-level extras list.
+  const uniqueSingleColumns = new Set<string>();
+  const extras: string[] = [];
+
+  for (const index of table.indexes) {
+    if (index.origin === "pk") {
+      continue;
+    }
+    const memberNames = index.columns.filter(
+      (name): name is string => name !== null
+    );
+    if (memberNames.length !== index.columns.length) {
+      extras.push(
+        `// index ${JSON.stringify(index.name)} uses rowid or an expression and cannot be regenerated`
+      );
+      continue;
+    }
+    if (index.origin === "u") {
+      if (memberNames.length === 1 && memberNames[0] !== undefined) {
+        uniqueSingleColumns.add(memberNames[0]);
+      } else {
+        // Multi-column UNIQUE constraint: auto-index names (sqlite_autoindex_*) are reserved,
+        // regenerate as an unnamed table-level unique().
+        usedImports.add("unique");
+        extras.push(
+          `unique().on(${memberNames.map((name) => `t.${propertyName(name)}`).join(", ")})`
+        );
+      }
+      continue;
+    }
+    const builder = index.unique ? "uniqueIndex" : "index";
+    usedImports.add(builder);
+    extras.push(
+      `${builder}(${JSON.stringify(index.name)}).on(${memberNames
+        .map((name) => `t.${propertyName(name)}`)
+        .join(", ")})`
+    );
+  }
+
+  if (singlePk === undefined && pkColumns.length > 0) {
+    usedImports.add("primaryKey");
+    extras.push(
+      `primaryKey({ columns: [${pkColumns
+        .map((column) => `t.${propertyName(column.name)}`)
+        .join(", ")}] })`
+    );
+  }
+
+  const columnLines = table.columns
+    .filter((column) => column.hidden === 0)
+    .map((column) =>
+      generateColumnLine(column, {
+        isSinglePk: column.name === singlePkName,
+        autoIncrement: column.name === singlePkName && hasAutoIncrement,
+        unique: uniqueSingleColumns.has(column.name),
+        usedImports,
+      })
+    );
+
+  const exportName = propertyName(table.name);
+  const head = `export const ${exportName} = sqliteTable(\n  ${JSON.stringify(table.name)},\n  {\n${columnLines.join("\n")}\n  }`;
+  if (extras.length === 0) {
+    return `${head}\n);`;
+  }
+  return `${head},\n  (t) => [\n${extras.map((extra) => `    ${extra},`).join("\n")}\n  ]\n);`;
+}
+
+function generateColumnLine(
+  column: LiveColumn,
+  {
+    isSinglePk,
+    autoIncrement,
+    unique,
+    usedImports,
+  }: {
+    isSinglePk: boolean;
+    autoIncrement: boolean;
+    unique: boolean;
+    usedImports: Set<string>;
+  }
+): string {
+  const builder = builderForDeclaredType(column.declaredType);
+  usedImports.add(builder);
+
+  let line = `    ${propertyName(column.name)}: ${builder}(${JSON.stringify(column.name)})`;
+  if (isSinglePk) {
+    line += autoIncrement
+      ? ".primaryKey({ autoIncrement: true })"
+      : ".primaryKey()";
+  }
+  // INTEGER PRIMARY KEY is NOT NULL by construction; drizzle's .primaryKey() implies notNull.
+  if (column.notNull && !isSinglePk) {
+    line += ".notNull()";
+  }
+  if (unique) {
+    line += ".unique()";
+  }
+  if (column.defaultValue !== null && !isSinglePk) {
+    line += `.default(${renderDefault(column.defaultValue, usedImports)})`;
+  }
+  return `${line},`;
+}
+
+// SQLite type-affinity rules (https://sqlite.org/datatype3.html#determination_of_column_affinity)
+// mapped onto drizzle sqlite-core builders.
+function builderForDeclaredType(declaredType: string): string {
+  const upper = declaredType.toUpperCase();
+  if (upper.includes("INT")) {
+    return "integer";
+  }
+  if (
+    upper.includes("CHAR") ||
+    upper.includes("CLOB") ||
+    upper.includes("TEXT")
+  ) {
+    return "text";
+  }
+  if (upper === "" || upper.includes("BLOB")) {
+    return "blob";
+  }
+  if (
+    upper.includes("REAL") ||
+    upper.includes("FLOA") ||
+    upper.includes("DOUB")
+  ) {
+    return "real";
+  }
+  return "numeric";
+}
+
+// PRAGMA table_xinfo reports defaults as SQL text: numbers verbatim, strings quoted, and
+// keywords/expressions raw. Renders literals natively and falls back to a sql`` template.
+function renderDefault(defaultSql: string, usedImports: Set<string>): string {
+  const trimmed = defaultSql.trim();
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+    return trimmed;
+  }
+  // Boolean-mode columns render `DEFAULT true|false`; emit the bare literal so the DDL text
+  // (and thus the drizzle-kit push plan) stays identical.
+  if (/^(true|false)$/i.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+  if (trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return JSON.stringify(trimmed.slice(1, -1).replaceAll("''", "'"));
+  }
+  usedImports.add("sql");
+  return `sql\`${trimmed.replaceAll("`", "\\`")}\``;
+}
+
+// Table/column names become TS identifiers. Pod-created names already match
+// ^[a-z][a-z0-9_]*$; anything else (hand-made databases) is sanitized.
+function propertyName(sqlName: string): string {
+  const sanitized = sqlName.replaceAll(/[^A-Za-z0-9_$]/g, "_");
+  return /^[A-Za-z_$]/.test(sanitized) ? sanitized : `_${sanitized}`;
+}

--- a/cli/dust-sandbox/functions-runner/fixtures/databases/chat_reduced.db.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/databases/chat_reduced.db.ts
@@ -1,0 +1,31 @@
+// Destructive evolution of chat.db.ts: drops the display_name column and the messages and
+// settings tables. Reconcile must refuse it.
+import {
+  blob,
+  index,
+  integer,
+  real,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+export const users = sqliteTable(
+  "users",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    handle: text("handle").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).$defaultFn(
+      () => new Date()
+    ),
+    attachments: text("attachments", { mode: "json" }).$type<string[]>(),
+    active: integer("active", { mode: "boolean" }).default(true),
+    score: real("score"),
+    counter: blob("counter", { mode: "bigint" }),
+  },
+  (t) => [
+    uniqueIndex("users_handle_idx").on(t.handle),
+    index("users_created_idx").on(t.createdAt, t.handle),
+  ]
+);

--- a/cli/dust-sandbox/functions-runner/fixtures/databases/chat_v2.db.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/databases/chat_v2.db.ts
@@ -1,0 +1,61 @@
+// Additive evolution of chat.db.ts: one new column, one new index, one new table.
+import {
+  blob,
+  index,
+  integer,
+  primaryKey,
+  real,
+  sqliteTable,
+  text,
+  unique,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+export const users = sqliteTable(
+  "users",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    handle: text("handle").notNull(),
+    displayName: text("display_name"),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).$defaultFn(
+      () => new Date()
+    ),
+    attachments: text("attachments", { mode: "json" }).$type<string[]>(),
+    active: integer("active", { mode: "boolean" }).default(true),
+    score: real("score"),
+    counter: blob("counter", { mode: "bigint" }),
+    bio: text("bio"),
+  },
+  (t) => [
+    uniqueIndex("users_handle_idx").on(t.handle),
+    index("users_created_idx").on(t.createdAt, t.handle),
+    index("users_bio_idx").on(t.bio),
+  ]
+);
+
+export const messages = sqliteTable("messages", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  body: text("body").notNull(),
+  authorId: integer("author_id"),
+  slug: text("slug").unique(),
+});
+
+export const settings = sqliteTable(
+  "settings",
+  {
+    key: text("key"),
+    scope: text("scope").notNull(),
+    value: text("value"),
+  },
+  (t) => [
+    primaryKey({ columns: [t.key] }),
+    unique("settings_scope_value_unique").on(t.scope, t.value),
+  ]
+);
+
+export const reactions = sqliteTable("reactions", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  messageId: integer("message_id").notNull(),
+  emoji: text("emoji").notNull(),
+});

--- a/cli/dust-sandbox/functions-runner/fixtures/databases/dup_index.db.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/databases/dup_index.db.ts
@@ -1,0 +1,22 @@
+// Apply-failure fixture: two tables declare the same index name. Per-table manifest validation
+// passes and both CREATE INDEX statements classify as additive, but SQLite rejects the second
+// at apply time — exercising the transaction rollback (and first-claim cleanup) path.
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const alpha = sqliteTable(
+  "alpha",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    label: text("label"),
+  },
+  (t) => [index("dup_idx").on(t.label)]
+);
+
+export const beta = sqliteTable(
+  "beta",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    label: text("label"),
+  },
+  (t) => [index("dup_idx").on(t.label)]
+);

--- a/cli/dust-sandbox/functions-runner/fixtures/databases/notes.db.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/databases/notes.db.ts
@@ -1,0 +1,7 @@
+// Minimal fixture for reconcile type-change tests.
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const notes = sqliteTable("notes", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  label: text("label"),
+});

--- a/cli/dust-sandbox/functions-runner/fixtures/databases/notes_typechange.db.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/databases/notes_typechange.db.ts
@@ -1,0 +1,8 @@
+// Type-change fixture for reconcile tests: `label` flips text -> integer relative to
+// notes.db.ts, which forces a table recreate-and-copy plan that must be refused.
+import { integer, sqliteTable } from "drizzle-orm/sqlite-core";
+
+export const notes = sqliteTable("notes", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  label: integer("label"),
+});

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -1,10 +1,17 @@
 #!/usr/bin/env bun
-// Embedded runner for `dsbx function`. Subcommands:
+// Embedded runner for `dsbx function` and `dsbx db`. Subcommands:
 //   runner run <path>                            stdin request envelope -> stdout Output JSON
 //   runner get <path>                            -> stdout FunctionSchema JSON (or {error})
 //   runner build <src> <outBundle> <outSchema>   bundle + extract schema to files
+//   runner db-reconcile <dbPath> <schemaFile>    additive-only DDL reconcile -> stdout envelope
+//   runner db-schema <dbPath> <outSchemaTs>      regenerate drizzle schema file -> file + envelope
+//   runner db-query <dbPath>                     stdin SQL -> stdout rows envelope (read-only)
 
 import { build } from "./build.ts";
+import { errorEnvelope } from "./db_common.ts";
+import { queryReadonly } from "./db_query.ts";
+import { reconcile } from "./db_reconcile.ts";
+import { generateSchemaFileText } from "./db_schema.ts";
 import { invoke } from "./invoke.ts";
 import { BadInputError, parseInput, type RequestInput } from "./protocol.ts";
 import { getFunctionSchema } from "./schema.ts";
@@ -58,10 +65,76 @@ async function buildHandler(args: string[]): Promise<number> {
   return result.ok ? 0 : 1;
 }
 
+function emitDbBadArgs(usage: string): number {
+  process.stdout.write(
+    `${JSON.stringify({
+      ok: false,
+      error: { kind: "bad_args", message: usage },
+    })}\n`
+  );
+  return 2;
+}
+
+async function dbReconcileHandler(args: string[]): Promise<number> {
+  const [dbPath, schemaFile] = args;
+  if (!dbPath || !schemaFile) {
+    return emitDbBadArgs("usage: runner db-reconcile <dbPath> <schemaFile>");
+  }
+  try {
+    const result = await reconcile(dbPath, schemaFile);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  } catch (e) {
+    process.stdout.write(`${JSON.stringify(errorEnvelope(e))}\n`);
+    return 1;
+  }
+}
+
+async function dbSchemaHandler(args: string[]): Promise<number> {
+  const [dbPath, outSchemaTs] = args;
+  if (!dbPath || !outSchemaTs) {
+    return emitDbBadArgs("usage: runner db-schema <dbPath> <outSchemaTs>");
+  }
+  try {
+    const text = generateSchemaFileText(dbPath);
+    await Bun.write(outSchemaTs, text);
+    process.stdout.write(`${JSON.stringify({ ok: true })}\n`);
+    return 0;
+  } catch (e) {
+    process.stdout.write(`${JSON.stringify(errorEnvelope(e))}\n`);
+    return 1;
+  }
+}
+
+async function dbQueryHandler(args: string[]): Promise<number> {
+  const [dbPath] = args;
+  if (!dbPath) {
+    return emitDbBadArgs("usage: runner db-query <dbPath> (SQL on stdin)");
+  }
+  try {
+    const sql = await Bun.stdin.text();
+    const result = queryReadonly(dbPath, sql);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  } catch (e) {
+    process.stdout.write(`${JSON.stringify(errorEnvelope(e))}\n`);
+    return 1;
+  }
+}
+
 async function main(): Promise<number> {
   const [command, ...rest] = process.argv.slice(2);
   if (command === "build") {
     return buildHandler(rest);
+  }
+  if (command === "db-reconcile") {
+    return dbReconcileHandler(rest);
+  }
+  if (command === "db-schema") {
+    return dbSchemaHandler(rest);
+  }
+  if (command === "db-query") {
+    return dbQueryHandler(rest);
   }
 
   const [handlerPath] = rest;

--- a/cli/dust-sandbox/src/commands/db/list.rs
+++ b/cli/dust-sandbox/src/commands/db/list.rs
@@ -1,0 +1,108 @@
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+use serde::Serialize;
+
+use super::{databases_dir, emit_error};
+
+#[derive(Serialize, Debug, PartialEq)]
+struct DatabaseEntry {
+    name: String,
+    size_bytes: u64,
+}
+
+/// List the live pod databases (`*.db` files in the databases directory) with
+/// their sizes as a one-line JSON envelope. A missing directory is an empty
+/// list: it is created by the first reconcile that claims a database.
+pub fn cmd_db_list() -> Result<()> {
+    let dir = databases_dir();
+    let databases = enumerate_databases(&dir)
+        .map_err(|e| emit_error(anyhow!("cannot read {}: {e}", dir.display())))?;
+
+    println!(
+        "{}",
+        serde_json::json!({ "ok": true, "databases": databases })
+    );
+    Ok(())
+}
+
+fn enumerate_databases(dir: &Path) -> std::io::Result<Vec<DatabaseEntry>> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Vec::new());
+        }
+        Err(e) => return Err(e),
+    };
+
+    let mut databases: Vec<DatabaseEntry> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("db") {
+            continue;
+        }
+        let Some(name) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        // Hostile-name allowlist: only names satisfying the frozen contract are pod databases
+        // (consistent with db_file_path and Track 1's replica-name filtering).
+        if !super::is_valid_db_name(name) {
+            continue;
+        }
+        // Include the -wal sibling: @dust/pod runs with wal_autocheckpoint=0, so recent data
+        // lives in the WAL until litestream checkpoints it.
+        let mut size_bytes = entry.metadata().map(|m| m.len()).unwrap_or(0);
+        let wal_path = dir.join(format!("{name}.db-wal"));
+        if let Ok(wal_metadata) = std::fs::metadata(&wal_path) {
+            size_bytes += wal_metadata.len();
+        }
+        databases.push(DatabaseEntry {
+            name: name.to_string(),
+            size_bytes,
+        });
+    }
+    databases.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(databases)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lists_db_files_only_sorted_with_wal_inclusive_sizes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("notes.db"), b"y").unwrap();
+        std::fs::write(dir.path().join("chat.db"), "x".repeat(42)).unwrap();
+        // WAL size is folded into the database's size (wal_autocheckpoint=0 keeps data there);
+        // SHM and stray files are not databases and never listed on their own.
+        std::fs::write(dir.path().join("chat.db-wal"), "w".repeat(8)).unwrap();
+        std::fs::write(dir.path().join("chat.db-shm"), b"s").unwrap();
+        std::fs::write(dir.path().join("readme.txt"), b"t").unwrap();
+        std::fs::create_dir(dir.path().join("subdir.db")).unwrap();
+        // Names outside the frozen ^[a-z][a-z0-9_]{0,63}$ contract are not pod databases.
+        std::fs::write(dir.path().join("Weird Name.db"), b"n").unwrap();
+        std::fs::write(dir.path().join("UPPER.db"), b"n").unwrap();
+
+        let databases = enumerate_databases(dir.path()).unwrap();
+        assert_eq!(
+            databases,
+            vec![
+                DatabaseEntry {
+                    name: "chat".to_string(),
+                    size_bytes: 50
+                },
+                DatabaseEntry {
+                    name: "notes".to_string(),
+                    size_bytes: 1
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_dir_is_an_empty_list() {
+        let databases = enumerate_databases(Path::new("/nonexistent/dsbx-db-list-test")).unwrap();
+        assert!(databases.is_empty());
+    }
+}

--- a/cli/dust-sandbox/src/commands/db/mod.rs
+++ b/cli/dust-sandbox/src/commands/db/mod.rs
@@ -1,0 +1,221 @@
+//! `dsbx db` — pod database subcommands (reconcile/schema/list/query).
+//!
+//! Databases are per-pod SQLite files `{name}.db` under `$DUST_POD_DATABASES_DIR`
+//! (falling back to the image's `/pod-state/databases`, per the frozen paths-env.v1
+//! contract). This Rust layer owns name validation and path resolution; the DDL/SQL
+//! work runs in the embedded Bun runner (same privilege-drop machinery as
+//! `dsbx function`: dropped to `agent-proxied` via `runuser` whenever dsbx runs as
+//! root, NODE_PATH pointed at the image's global npm modules so `drizzle-kit`
+//! resolves at run time).
+
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use anyhow::{anyhow, Result};
+use clap::Subcommand;
+use tokio::process::Command;
+
+use super::function::{ensure_runner, harness_node_path, running_as_root, set_mode, AGENT_USER};
+
+mod list;
+mod query;
+mod reconcile;
+mod schema;
+
+pub use list::cmd_db_list;
+pub use query::cmd_db_query;
+pub use reconcile::cmd_db_reconcile;
+pub use schema::cmd_db_schema;
+
+pub(crate) use super::function::emit_error;
+
+/// Directory holding the live pod databases. Set by front on `function run` /
+/// `db *` execs; the constant fallback matches the image layout (paths-env.v1).
+/// TODO(pod-state): Track 3's parallel stack adds identically-named consts plus a
+/// `pod_databases_dir()` helper to src/commands/function/mod.rs for `function run` — after the
+/// stacks merge, dedup onto a single shared definition (these here are the superset:
+/// PathBuf-typed helper + empty-value fallback).
+pub(crate) const POD_DATABASES_DIR_ENV: &str = "DUST_POD_DATABASES_DIR";
+pub(crate) const DEFAULT_POD_DATABASES_DIR: &str = "/pod-state/databases";
+
+#[derive(Subcommand)]
+pub enum DbCommand {
+    /// Reconcile a pod database with a drizzle schema file (additive DDL only)
+    Reconcile {
+        /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
+        name: String,
+        /// Path to the drizzle schema file (databases/{db}.db.ts)
+        schema_file: String,
+    },
+    /// Regenerate a drizzle schema file from a live pod database
+    Schema {
+        /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
+        name: String,
+        /// Output path for the regenerated schema file
+        out_schema: String,
+    },
+    /// List pod databases with sizes
+    List,
+    /// Execute read-only SQL (from stdin) against a pod database
+    Query {
+        /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
+        name: String,
+    },
+}
+
+/// The configured pod databases directory, falling back to the image constant.
+pub(crate) fn databases_dir() -> PathBuf {
+    std::env::var_os(POD_DATABASES_DIR_ENV)
+        .filter(|dir| !dir.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_POD_DATABASES_DIR))
+}
+
+/// Database name contract (paths-env.v1): `^[a-z][a-z0-9_]{0,63}$`. Also blocks
+/// path traversal — names never contain separators.
+pub(crate) fn is_valid_db_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    first.is_ascii_lowercase()
+        && name.len() <= 64
+        && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+/// Resolve a database name to its `{name}.db` file path, or emit a typed error.
+pub(crate) fn db_file_path(name: &str) -> Result<PathBuf> {
+    if !is_valid_db_name(name) {
+        return Err(emit_error(anyhow!(
+            "invalid database name {name:?}: must match ^[a-z][a-z0-9_]{{0,63}}$"
+        )));
+    }
+    Ok(databases_dir().join(format!("{name}.db")))
+}
+
+/// Spawn the embedded runner under `bun` for a `db-*` subcommand. Mirrors
+/// `function`'s privilege model: dropped to `agent-proxied` via `runuser` whenever
+/// dsbx runs privileged, NODE_PATH prepended with the global npm modules (where
+/// drizzle-kit lives in the sandbox image), and stdout inherited so the runner's
+/// one-line JSON envelope reaches the caller. Returns the exit code.
+pub(crate) async fn spawn_db_runner(
+    subcommand: &str,
+    args: &[&OsStr],
+    inherit_stdin: bool,
+) -> Result<i32> {
+    let runner = ensure_runner()?;
+    let as_agent = running_as_root();
+    if as_agent {
+        // The dropped child must read the runner dsbx wrote as root (0600).
+        set_mode(&runner, 0o644)
+            .map_err(|e| emit_error(anyhow!("failed to prepare runner: {e}")))?;
+    }
+
+    let mut cmd = if as_agent {
+        let mut c = Command::new("runuser");
+        c.arg("-u")
+            .arg(AGENT_USER)
+            .arg("--")
+            .arg("bun")
+            .arg(&*runner);
+        c
+    } else {
+        let mut c = Command::new("bun");
+        c.arg(&*runner);
+        c
+    };
+    cmd.arg(subcommand).args(args);
+    cmd.env("NODE_PATH", harness_node_path())
+        // Threaded to the bun child for consistency with the paths-env.v1 contract
+        // (the runner itself receives resolved paths and does not read it today).
+        .env(POD_DATABASES_DIR_ENV, databases_dir())
+        .stdin(if inherit_stdin {
+            Stdio::inherit()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    let status = cmd
+        .status()
+        .await
+        .map_err(|e| emit_error(anyhow!("failed to run bun: {e}")))?;
+
+    runner.close().ok();
+
+    Ok(status.code().unwrap_or(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The crate-shared env lock (commands/mod.rs): DUST_POD_DATABASES_DIR is process-global
+    // and other modules' tests (Track 3's function::tests post-merge) mutate it too.
+    use crate::commands::ENV_LOCK;
+
+    #[test]
+    fn accepts_contract_names() {
+        assert!(is_valid_db_name("chat"));
+        assert!(is_valid_db_name("a"));
+        assert!(is_valid_db_name("chat_v2"));
+        assert!(is_valid_db_name("a0123456789_z"));
+        // 64 chars total (1 + 63) is the maximum.
+        assert!(is_valid_db_name(&format!("a{}", "b".repeat(63))));
+    }
+
+    #[test]
+    fn rejects_names_outside_the_contract() {
+        assert!(!is_valid_db_name(""));
+        assert!(!is_valid_db_name("Chat"));
+        assert!(!is_valid_db_name("0chat"));
+        assert!(!is_valid_db_name("_chat"));
+        assert!(!is_valid_db_name("chat-db"));
+        assert!(!is_valid_db_name("chat.db"));
+        assert!(!is_valid_db_name("a/b"));
+        assert!(!is_valid_db_name(".."));
+        assert!(!is_valid_db_name(&format!("a{}", "b".repeat(64))));
+    }
+
+    #[test]
+    fn databases_dir_defaults_to_the_image_constant() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var(POD_DATABASES_DIR_ENV);
+        assert_eq!(databases_dir(), PathBuf::from(DEFAULT_POD_DATABASES_DIR));
+    }
+
+    #[test]
+    fn databases_dir_honors_the_env_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(POD_DATABASES_DIR_ENV, "/tmp/pod-dbs");
+        assert_eq!(databases_dir(), PathBuf::from("/tmp/pod-dbs"));
+        std::env::remove_var(POD_DATABASES_DIR_ENV);
+    }
+
+    #[test]
+    fn empty_env_override_falls_back_to_the_constant() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(POD_DATABASES_DIR_ENV, "");
+        assert_eq!(databases_dir(), PathBuf::from(DEFAULT_POD_DATABASES_DIR));
+        std::env::remove_var(POD_DATABASES_DIR_ENV);
+    }
+
+    #[test]
+    fn db_file_path_joins_name_and_dir() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(POD_DATABASES_DIR_ENV, "/tmp/pod-dbs");
+        assert_eq!(
+            db_file_path("chat").unwrap(),
+            PathBuf::from("/tmp/pod-dbs/chat.db")
+        );
+        std::env::remove_var(POD_DATABASES_DIR_ENV);
+    }
+
+    #[test]
+    fn db_file_path_rejects_invalid_names() {
+        assert!(db_file_path("../escape").is_err());
+        assert!(db_file_path("Chat").is_err());
+    }
+}

--- a/cli/dust-sandbox/src/commands/db/query.rs
+++ b/cli/dust-sandbox/src/commands/db/query.rs
@@ -1,0 +1,14 @@
+use anyhow::Result;
+
+use super::{db_file_path, spawn_db_runner};
+
+/// Execute read-only SQL (from stdin) against the pod database `name`. The
+/// runner opens the database read-only with `PRAGMA query_only=ON` and returns
+/// capped rows in the stdout JSON envelope. Runs as `agent-proxied` like
+/// `function run`.
+pub async fn cmd_db_query(name: &str) -> Result<()> {
+    let db_path = db_file_path(name)?;
+
+    let code = spawn_db_runner("db-query", &[db_path.as_os_str()], true).await?;
+    std::process::exit(code);
+}

--- a/cli/dust-sandbox/src/commands/db/reconcile.rs
+++ b/cli/dust-sandbox/src/commands/db/reconcile.rs
@@ -1,0 +1,27 @@
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+
+use super::{db_file_path, emit_error, spawn_db_runner};
+
+/// Reconcile the pod database `name` with the drizzle schema file at
+/// `schema_file`: the runner plans via drizzle-kit, applies ADDITIVE statements
+/// only (CREATE TABLE / ADD COLUMN / CREATE [UNIQUE] INDEX / DROP INDEX) in one
+/// transaction, and rejects anything destructive with a typed error. The
+/// database file is created on first claim. stdout carries the runner's
+/// one-line JSON envelope; exit code passes through.
+pub async fn cmd_db_reconcile(name: &str, schema_file: &str) -> Result<()> {
+    let db_path = db_file_path(name)?;
+    let schema_path = Path::new(schema_file);
+    if !schema_path.is_file() {
+        return Err(emit_error(anyhow!("schema file not found: {schema_file}")));
+    }
+
+    let code = spawn_db_runner(
+        "db-reconcile",
+        &[db_path.as_os_str(), schema_path.as_os_str()],
+        false,
+    )
+    .await?;
+    std::process::exit(code);
+}

--- a/cli/dust-sandbox/src/commands/db/schema.rs
+++ b/cli/dust-sandbox/src/commands/db/schema.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use super::{db_file_path, spawn_db_runner};
+
+/// Regenerate a drizzle `{db}.db.ts` schema file from the live pod database
+/// `name`, writing it to `out_schema` (file-output pattern: the file is the
+/// payload, stdout only carries the `{ok}` envelope). Column modes are not
+/// recoverable from SQLite — front merges them from the stored manifests.
+pub async fn cmd_db_schema(name: &str, out_schema: &str) -> Result<()> {
+    let db_path = db_file_path(name)?;
+
+    let code = spawn_db_runner(
+        "db-schema",
+        &[db_path.as_os_str(), Path::new(out_schema).as_os_str()],
+        false,
+    )
+    .await?;
+    std::process::exit(code);
+}

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -37,7 +37,7 @@ const RUNNER_JS: &str = include_str!("../../../functions-runner/runner.js");
 /// `agent-proxied` user created in the sandbox image; its `skuid` is what
 /// `dsbx healthcheck`'s nftables rules force through the egress proxy). Untrusted
 /// function code must run as this user too.
-const AGENT_USER: &str = "agent-proxied";
+pub(crate) const AGENT_USER: &str = "agent-proxied";
 const DEFAULT_FUNCTION_WORKING_DIR: &str = "/home/agent";
 
 #[derive(Subcommand)]
@@ -71,7 +71,7 @@ pub enum FunctionCommand {
 /// like agent code. When `dsbx` is already unprivileged (local dev), there is
 /// nothing to contain and no privilege to drop, so the function runs as the
 /// current user.
-fn running_as_root() -> bool {
+pub(crate) fn running_as_root() -> bool {
     rustix::process::geteuid().is_root()
 }
 
@@ -228,7 +228,7 @@ pub(crate) async fn spawn_build(src: &Path, out_bundle: &Path, out_schema: &Path
 /// NODE_PATH for the runner child: the global npm modules first, then any
 /// inherited entries. NODE_PATH is additive, so a missing dir (local dev) falls
 /// back to normal node_modules resolution.
-fn harness_node_path() -> String {
+pub(crate) fn harness_node_path() -> String {
     match std::env::var("NODE_PATH") {
         Ok(existing) if !existing.is_empty() => {
             format!("{FUNCTIONS_GLOBAL_NODE_MODULES}:{existing}")
@@ -251,7 +251,7 @@ fn function_working_dir() -> PathBuf {
 
 /// Set a path's permission bits (used to make the runner temp file readable by
 /// the dropped child without a uid lookup).
-fn set_mode(path: impl AsRef<Path>, mode: u32) -> std::io::Result<()> {
+pub(crate) fn set_mode(path: impl AsRef<Path>, mode: u32) -> std::io::Result<()> {
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
 }
 

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod db;
 pub mod env;
 pub mod forward;
 pub mod function;
@@ -6,6 +7,7 @@ pub mod resolve;
 pub mod tools;
 mod version;
 
+pub use db::{cmd_db_list, cmd_db_query, cmd_db_reconcile, cmd_db_schema};
 pub use env::cmd_env;
 pub use forward::cmd_forward;
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
@@ -13,3 +15,12 @@ pub use healthcheck::cmd_healthcheck;
 pub use resolve::cmd_resolve;
 pub use tools::{cmd_exec, cmd_list_servers, cmd_list_tools};
 pub use version::cmd_version;
+
+/// Serializes tests that mutate process-global environment variables (e.g.
+/// DUST_POD_DATABASES_DIR). Env vars are shared across the whole test binary, so every module
+/// whose tests touch them must take this ONE lock — two module-local mutexes guarding the same
+/// variable would not exclude each other under parallel test threads.
+/// TODO(pod-state): function::tests currently keeps its own ENV_LOCK (and, post Track 3 merge,
+/// also mutates DUST_POD_DATABASES_DIR) — migrate it to this shared lock after the stacks merge.
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -29,6 +29,11 @@ enum Commands {
         #[command(subcommand)]
         command: commands::function::FunctionCommand,
     },
+    /// Manage pod databases
+    Db {
+        #[command(subcommand)]
+        command: commands::db::DbCommand,
+    },
     /// Interact with MCP servers and tools
     Tools {
         /// Emit the tool execution result as JSON (`{ content, isError }`)
@@ -77,6 +82,16 @@ async fn run() -> anyhow::Result<()> {
                 out_bundle,
                 out_schema,
             } => commands::cmd_function_build(&src, &out_bundle, &out_schema).await?,
+        },
+        Commands::Db { command } => match command {
+            commands::db::DbCommand::Reconcile { name, schema_file } => {
+                commands::cmd_db_reconcile(&name, &schema_file).await?
+            }
+            commands::db::DbCommand::Schema { name, out_schema } => {
+                commands::cmd_db_schema(&name, &out_schema).await?
+            }
+            commands::db::DbCommand::List => commands::cmd_db_list()?,
+            commands::db::DbCommand::Query { name } => commands::cmd_db_query(&name).await?,
         },
         Commands::Tools {
             json,
@@ -187,6 +202,73 @@ mod tests {
             },
             _ => panic!("expected function"),
         }
+    }
+
+    #[test]
+    fn db_reconcile_parses() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "db",
+            "reconcile",
+            "chat",
+            "/files/pod-x/databases/chat.db.ts",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Db { command } => match command {
+                commands::db::DbCommand::Reconcile { name, schema_file } => {
+                    assert_eq!(name, "chat");
+                    assert_eq!(schema_file, "/files/pod-x/databases/chat.db.ts");
+                }
+                _ => panic!("expected reconcile"),
+            },
+            _ => panic!("expected db"),
+        }
+    }
+
+    #[test]
+    fn db_schema_parses() {
+        let cli = Cli::try_parse_from(["dsbx", "db", "schema", "chat", "/tmp/out/chat.db.ts"])
+            .expect("parse");
+        match cli.command {
+            Commands::Db { command } => match command {
+                commands::db::DbCommand::Schema { name, out_schema } => {
+                    assert_eq!(name, "chat");
+                    assert_eq!(out_schema, "/tmp/out/chat.db.ts");
+                }
+                _ => panic!("expected schema"),
+            },
+            _ => panic!("expected db"),
+        }
+    }
+
+    #[test]
+    fn db_list_parses() {
+        let cli = Cli::try_parse_from(["dsbx", "db", "list"]).expect("parse");
+        match cli.command {
+            Commands::Db { command } => match command {
+                commands::db::DbCommand::List => {}
+                _ => panic!("expected list"),
+            },
+            _ => panic!("expected db"),
+        }
+    }
+
+    #[test]
+    fn db_query_parses() {
+        let cli = Cli::try_parse_from(["dsbx", "db", "query", "chat"]).expect("parse");
+        match cli.command {
+            Commands::Db { command } => match command {
+                commands::db::DbCommand::Query { name } => assert_eq!(name, "chat"),
+                _ => panic!("expected query"),
+            },
+            _ => panic!("expected db"),
+        }
+    }
+
+    #[test]
+    fn db_reconcile_requires_schema_file() {
+        assert!(Cli::try_parse_from(["dsbx", "db", "reconcile", "chat"]).is_err());
     }
 
     #[test]

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -1705,6 +1705,20 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "toolCostCategory": "basic",
     },
   },
+  "pod_databases": {
+    "get_schema": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_databases": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "query": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
   "pod_manager": {
     "add_content_node": {
       "freeUsage": true,
@@ -2980,6 +2994,11 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "close_plan": "never_ask",
     "create_plan": "never_ask",
     "edit_plan": "never_ask",
+  },
+  "pod_databases": {
+    "get_schema": "never_ask",
+    "list_databases": "never_ask",
+    "query": "never_ask",
   },
   "pod_manager": {
     "add_content_node": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -51,6 +51,7 @@ import { OPENAI_USAGE_SERVER } from "@app/lib/api/actions/servers/openai_usage/m
 import { OUTLOOK_CALENDAR_SERVER } from "@app/lib/api/actions/servers/outlook/calendar_metadata";
 import { OUTLOOK_MAIL_SERVER } from "@app/lib/api/actions/servers/outlook/mail_metadata";
 import { PLAN_MODE_SERVER } from "@app/lib/api/actions/servers/plan_mode/metadata";
+import { POD_DATABASES_SERVER } from "@app/lib/api/actions/servers/pod_databases/metadata";
 import { POD_MANAGER_SERVER } from "@app/lib/api/actions/servers/pod_manager/metadata";
 import { POD_TASKS_SERVER } from "@app/lib/api/actions/servers/pod_tasks/metadata";
 import { POKE_SERVER } from "@app/lib/api/actions/servers/poke/metadata";
@@ -221,6 +222,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   SKILL_AUTHORING_SERVER_NAME,
   "skill_management",
   "schedules_management",
+  "pod_databases",
   "pod_manager",
   "pod_tasks",
   "poke",
@@ -1064,6 +1066,21 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: SANDBOX_FUNCTIONS_SERVER,
+  },
+  pod_databases: {
+    // 1039 was taken by user_analytics upstream while this stack was in flight.
+    id: 1040,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isPreview: true,
+    // Same gate as sandbox_functions: pod databases only exist through published functions.
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("sandbox_functions");
+    },
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: POD_DATABASES_SERVER,
   },
   user_mentions: {
     id: 1026,

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -34,7 +34,8 @@
     { "name": "skill_authoring", "id": 1034 },
     { "name": "workspace_analytics", "id": 1035 },
     { "name": "sandbox_functions", "id": 1037 },
-    { "name": "user_analytics", "id": 1039 }
+    { "name": "user_analytics", "id": 1039 },
+    { "name": "pod_databases", "id": 1040 }
   ],
   "manual": [
     { "name": "github", "id": 1 },

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -49,6 +49,7 @@ import { default as openaiUsageServer } from "@app/lib/api/actions/servers/opena
 import { default as outlookCalendarServer } from "@app/lib/api/actions/servers/outlook/calendar_server";
 import { default as outlookMailServer } from "@app/lib/api/actions/servers/outlook/mail_server";
 import { default as planModeServer } from "@app/lib/api/actions/servers/plan_mode";
+import { default as podDatabasesServer } from "@app/lib/api/actions/servers/pod_databases";
 import { default as podManagerServer } from "@app/lib/api/actions/servers/pod_manager";
 import { default as podTasksServer } from "@app/lib/api/actions/servers/pod_tasks";
 import { default as pokeServer } from "@app/lib/api/actions/servers/poke";
@@ -274,6 +275,8 @@ export async function getInternalMCPServer(
       return sandboxServer(auth, toolContext);
     case "sandbox_functions":
       return sandboxFunctionsServer(auth, toolContext);
+    case "pod_databases":
+      return podDatabasesServer(auth, toolContext);
     case "wakeups":
       return wakeupsServer(auth, toolContext);
     case "plan_mode":

--- a/front/lib/api/actions/servers/pod_databases/index.ts
+++ b/front/lib/api/actions/servers/pod_databases/index.ts
@@ -1,0 +1,24 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { ToolContextType } from "@app/lib/actions/types";
+import { POD_DATABASES_SERVER_NAME } from "@app/lib/api/actions/servers/pod_databases/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/pod_databases/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  toolContext?: ToolContextType
+): McpServer {
+  const server = makeInternalMCPServer(POD_DATABASES_SERVER_NAME);
+
+  for (const tool of TOOLS) {
+    registerTool(auth, toolContext, server, tool, {
+      monitoringName: POD_DATABASES_SERVER_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/pod_databases/metadata.ts
+++ b/front/lib/api/actions/servers/pod_databases/metadata.ts
@@ -1,0 +1,93 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { POD_DATABASE_NAME_REGEX } from "@app/lib/api/sandbox_functions/manifests";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const POD_DATABASES_SERVER_NAME = "pod_databases" as const;
+
+const databaseParam = z
+  .string()
+  .regex(POD_DATABASE_NAME_REGEX)
+  .describe(
+    "The database name, as shown by the list_databases tool (lowercase letters, digits and " +
+      "underscores, e.g. `chat`)."
+  );
+
+export const POD_DATABASES_TOOLS_METADATA = createToolsRecord({
+  list_databases: {
+    description:
+      "List the pod's live databases with their size, which published sandbox functions " +
+      "declare each one, and any untracked leftover databases no function declares anymore.",
+    schema: {},
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing pod databases...",
+      done: "Listed pod databases",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  get_schema: {
+    description:
+      "Get a pod database's schema as a regenerated drizzle `{db}.db.ts` file (introspected " +
+      "from the live database) together with the column modes declared by the published " +
+      "functions' manifests. SQLite does not store modes, so re-add them from the modes " +
+      "section when using the regenerated file as the shared schema source.",
+    schema: { database: databaseParam },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Introspecting pod database...",
+      done: "Introspected pod database",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  query: {
+    description:
+      "Execute a read-only SQL query against a pod database and get the rows back as JSON. " +
+      "Writes are rejected (the database is opened read-only); results are capped at 1000 " +
+      "rows with a truncated flag.",
+    schema: {
+      database: databaseParam,
+      sql: z
+        .string()
+        .min(1)
+        .describe(
+          "The SQL to execute (a single SELECT-style statement; writes are rejected)."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Querying pod database...",
+      done: "Queried pod database",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+});
+
+export const POD_DATABASES_SERVER = {
+  serverInfo: {
+    name: POD_DATABASES_SERVER_NAME,
+    version: "1.0.0",
+    description:
+      "Pod databases: inspect and query the shared SQLite databases that the pod's sandbox " +
+      "functions declare and use.",
+    icon: "CommandLineIcon",
+    authorization: null,
+    documentationUrl: null,
+  },
+  tools: Object.values(POD_DATABASES_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(POD_DATABASES_TOOLS_METADATA).map((t) => [t.name, t.stake])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/pod_databases/tools/get_schema.test.ts
+++ b/front/lib/api/actions/servers/pod_databases/tools/get_schema.test.ts
@@ -1,0 +1,67 @@
+import { formatManifestModes } from "@app/lib/api/actions/servers/pod_databases/tools/get_schema";
+import type { FunctionManifests } from "@app/lib/api/sandbox_functions/manifests";
+import { describe, expect, it } from "vitest";
+
+function manifestsWithMode(mode: string | null): FunctionManifests {
+  return {
+    version: 1,
+    databases: {
+      chat: {
+        schemaFile: "databases/chat.db.ts",
+        tables: {
+          messages: {
+            columns: {
+              created_at: {
+                type: "integer",
+                mode,
+                notNull: true,
+                hasDefault: false,
+                primaryKey: false,
+                autoIncrement: false,
+              },
+            },
+            indexes: {},
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("formatManifestModes", () => {
+  it("reports when no modes are declared", () => {
+    const out = formatManifestModes("chat", [
+      { slug: "no-db", manifests: null },
+      { slug: "plain", manifests: manifestsWithMode(null) },
+    ]);
+    expect(out).toContain("No column modes declared");
+  });
+
+  it("lists modes with their declaring functions", () => {
+    const out = formatManifestModes("chat", [
+      { slug: "post-message", manifests: manifestsWithMode("timestamp") },
+      { slug: "list-messages", manifests: manifestsWithMode("timestamp") },
+    ]);
+    expect(out).toContain(
+      "- messages.created_at: mode=timestamp (declared by list-messages, post-message)"
+    );
+    expect(out).not.toContain("DISAGREEMENT");
+  });
+
+  it("surfaces mode disagreements between functions", () => {
+    const out = formatManifestModes("chat", [
+      { slug: "post-message", manifests: manifestsWithMode("timestamp") },
+      { slug: "report-activity", manifests: manifestsWithMode("timestamp_ms") },
+    ]);
+    expect(out).toContain("mode=timestamp (declared by post-message)");
+    expect(out).toContain("mode=timestamp_ms (declared by report-activity)");
+    expect(out).toContain("DISAGREEMENT");
+  });
+
+  it("ignores other databases in the manifests", () => {
+    const out = formatManifestModes("analytics", [
+      { slug: "post-message", manifests: manifestsWithMode("timestamp") },
+    ]);
+    expect(out).toContain("No column modes declared");
+  });
+});

--- a/front/lib/api/actions/servers/pod_databases/tools/get_schema.ts
+++ b/front/lib/api/actions/servers/pod_databases/tools/get_schema.ts
@@ -1,0 +1,90 @@
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { dbErrorToMCPError } from "@app/lib/api/actions/servers/pod_databases/tools/shared";
+import { getPod } from "@app/lib/api/actions/servers/pod_manager/helpers";
+import { generateSchemaOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
+import type { FunctionManifests } from "@app/lib/api/sandbox_functions/manifests";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { Err, Ok } from "@app/types/shared/result";
+
+// SQLite stores no column modes; they live in the published functions' manifests. Collects
+// `table.column -> mode (declared by ...)` lines, surfacing disagreements between functions.
+export function formatManifestModes(
+  database: string,
+  functions: { slug: string; manifests: FunctionManifests | null }[]
+): string {
+  // column key -> mode -> slugs
+  const modes = new Map<string, Map<string, string[]>>();
+  for (const fn of functions) {
+    const dbManifest = fn.manifests?.databases[database];
+    if (dbManifest === undefined) {
+      continue;
+    }
+    for (const [tableName, tableManifest] of Object.entries(
+      dbManifest.tables
+    )) {
+      for (const [columnName, column] of Object.entries(
+        tableManifest.columns
+      )) {
+        if (column.mode === null) {
+          continue;
+        }
+        const key = `${tableName}.${columnName}`;
+        const byMode = modes.get(key) ?? new Map<string, string[]>();
+        const slugs = byMode.get(column.mode) ?? [];
+        slugs.push(fn.slug);
+        byMode.set(column.mode, slugs);
+        modes.set(key, byMode);
+      }
+    }
+  }
+
+  if (modes.size === 0) {
+    return "No column modes declared by the published functions for this database.";
+  }
+
+  const lines = [...modes.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, byMode]) => {
+      const parts = [...byMode.entries()].map(
+        ([mode, slugs]) =>
+          `mode=${mode} (declared by ${[...new Set(slugs)].sort().join(", ")})`
+      );
+      const disagreement =
+        byMode.size > 1 ? " — DISAGREEMENT: align the shared schema file" : "";
+      return `- ${key}: ${parts.join("; ")}${disagreement}`;
+    });
+
+  return `Column modes from the published functions' manifests (re-add them to the schema file):\n${lines.join("\n")}`;
+}
+
+export async function getSchemaHandler(
+  { database }: { database: string },
+  { auth, toolContext }: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const podResult = await getPod(auth, { toolContext });
+  if (podResult.isErr()) {
+    return new Err(podResult.error);
+  }
+  const pod = podResult.value.pod;
+
+  const schemaResult = await generateSchemaOnSandbox(auth, {
+    space: pod,
+    database,
+  });
+  if (schemaResult.isErr()) {
+    return new Err(dbErrorToMCPError(schemaResult.error));
+  }
+
+  const functions = await SandboxFunctionResource.listBySpace(auth, pod);
+
+  return new Ok([
+    {
+      type: "text",
+      text: `Regenerated drizzle schema for "${database}" (from the live database):\n\n${schemaResult.value}`,
+    },
+    { type: "text", text: formatManifestModes(database, functions) },
+  ]);
+}

--- a/front/lib/api/actions/servers/pod_databases/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_databases/tools/index.ts
@@ -1,0 +1,13 @@
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { POD_DATABASES_TOOLS_METADATA } from "@app/lib/api/actions/servers/pod_databases/metadata";
+import { getSchemaHandler } from "@app/lib/api/actions/servers/pod_databases/tools/get_schema";
+import { listDatabasesHandler } from "@app/lib/api/actions/servers/pod_databases/tools/list_databases";
+import { queryHandler } from "@app/lib/api/actions/servers/pod_databases/tools/query";
+
+const HANDLERS = {
+  list_databases: listDatabasesHandler,
+  get_schema: getSchemaHandler,
+  query: queryHandler,
+};
+
+export const TOOLS = buildTools(POD_DATABASES_TOOLS_METADATA, HANDLERS);

--- a/front/lib/api/actions/servers/pod_databases/tools/list_databases.test.ts
+++ b/front/lib/api/actions/servers/pod_databases/tools/list_databases.test.ts
@@ -1,0 +1,44 @@
+import { formatDatabasesList } from "@app/lib/api/actions/servers/pod_databases/tools/list_databases";
+import { describe, expect, it } from "vitest";
+
+describe("formatDatabasesList", () => {
+  it("returns an explicit empty message", () => {
+    expect(formatDatabasesList([], new Map())).toContain("no databases yet");
+  });
+
+  it("lists live databases with sizes and declaring functions", () => {
+    const out = formatDatabasesList(
+      [
+        { name: "chat", sizeBytes: 4096 },
+        { name: "notes", sizeBytes: 2 * 1024 * 1024 },
+      ],
+      new Map([
+        ["chat", ["list-messages", "post-message"]],
+        ["notes", ["take-note"]],
+      ])
+    );
+
+    expect(out).toContain(
+      "- chat (4.0 KB) — declared by: list-messages, post-message"
+    );
+    expect(out).toContain("- notes (2.0 MB) — declared by: take-note");
+    expect(out).toContain("get_schema");
+  });
+
+  it("flags untracked leftovers", () => {
+    const out = formatDatabasesList(
+      [{ name: "old_db", sizeBytes: 12 }],
+      new Map()
+    );
+    expect(out).toContain(
+      "- old_db (12 B) — UNTRACKED: no published function declares it anymore"
+    );
+  });
+
+  it("flags declared databases without a live file", () => {
+    const out = formatDatabasesList([], new Map([["chat", ["post-message"]]]));
+    expect(out).toContain(
+      "- chat — declared by post-message but no live database file exists yet"
+    );
+  });
+});

--- a/front/lib/api/actions/servers/pod_databases/tools/list_databases.ts
+++ b/front/lib/api/actions/servers/pod_databases/tools/list_databases.ts
@@ -1,0 +1,78 @@
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  dbErrorToMCPError,
+  declaringFunctionsByDatabase,
+} from "@app/lib/api/actions/servers/pod_databases/tools/shared";
+import { getPod } from "@app/lib/api/actions/servers/pod_manager/helpers";
+import type { LiveDatabaseEntry } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { listDatabasesOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { Err, Ok } from "@app/types/shared/result";
+
+export function formatDatabasesList(
+  live: LiveDatabaseEntry[],
+  declaredBy: Map<string, string[]>
+): string {
+  const liveNames = new Set(live.map((db) => db.name));
+  const declaredOnly = [...declaredBy.keys()]
+    .filter((name) => !liveNames.has(name))
+    .sort();
+
+  if (live.length === 0 && declaredOnly.length === 0) {
+    return "This pod has no databases yet. A database is created the first time a function declaring it is published.";
+  }
+
+  const lines = live.map((db) => {
+    const slugs = declaredBy.get(db.name);
+    const declaration = slugs
+      ? `declared by: ${slugs.join(", ")}`
+      : "UNTRACKED: no published function declares it anymore";
+    return `- ${db.name} (${formatSize(db.sizeBytes)}) — ${declaration}`;
+  });
+  for (const name of declaredOnly) {
+    lines.push(
+      `- ${name} — declared by ${declaredBy.get(name)?.join(", ") ?? ""} but no live database file exists yet`
+    );
+  }
+
+  return (
+    `Pod databases:\n${lines.join("\n")}\n\n` +
+    "Use get_schema for a database's structure and query for read-only SQL."
+  );
+}
+
+function formatSize(sizeBytes: number): string {
+  if (sizeBytes >= 1024 * 1024) {
+    return `${(sizeBytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (sizeBytes >= 1024) {
+    return `${(sizeBytes / 1024).toFixed(1)} KB`;
+  }
+  return `${sizeBytes} B`;
+}
+
+export async function listDatabasesHandler(
+  _params: Record<string, never>,
+  { auth, toolContext }: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const podResult = await getPod(auth, { toolContext });
+  if (podResult.isErr()) {
+    return new Err(podResult.error);
+  }
+  const pod = podResult.value.pod;
+
+  const liveResult = await listDatabasesOnSandbox(auth, { space: pod });
+  if (liveResult.isErr()) {
+    return new Err(dbErrorToMCPError(liveResult.error));
+  }
+
+  const functions = await SandboxFunctionResource.listBySpace(auth, pod);
+  const declaredBy = declaringFunctionsByDatabase(functions);
+
+  return new Ok([
+    { type: "text", text: formatDatabasesList(liveResult.value, declaredBy) },
+  ]);
+}

--- a/front/lib/api/actions/servers/pod_databases/tools/query.ts
+++ b/front/lib/api/actions/servers/pod_databases/tools/query.ts
@@ -1,0 +1,39 @@
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { dbErrorToMCPError } from "@app/lib/api/actions/servers/pod_databases/tools/shared";
+import { getPod } from "@app/lib/api/actions/servers/pod_manager/helpers";
+import { queryDatabaseOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { Err, Ok } from "@app/types/shared/result";
+
+export async function queryHandler(
+  { database, sql }: { database: string; sql: string },
+  { auth, toolContext }: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const podResult = await getPod(auth, { toolContext });
+  if (podResult.isErr()) {
+    return new Err(podResult.error);
+  }
+
+  const queryResult = await queryDatabaseOnSandbox(auth, {
+    space: podResult.value.pod,
+    database,
+    sql,
+  });
+  if (queryResult.isErr()) {
+    return new Err(dbErrorToMCPError(queryResult.error));
+  }
+  const { columns, rows, rowCount, truncated } = queryResult.value;
+
+  const summary = `${rowCount} row${rowCount === 1 ? "" : "s"} (columns: ${columns.join(", ") || "none"})${
+    truncated
+      ? " — TRUNCATED at the row cap; narrow the query for the full result"
+      : ""
+  }`;
+
+  return new Ok([
+    { type: "text", text: summary },
+    { type: "text", text: JSON.stringify(rows) },
+  ]);
+}

--- a/front/lib/api/actions/servers/pod_databases/tools/shared.ts
+++ b/front/lib/api/actions/servers/pod_databases/tools/shared.ts
@@ -1,0 +1,46 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { FunctionManifests } from "@app/lib/api/sandbox_functions/manifests";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+// Maps the dsbx-db domain errors to MCP errors: model-correctable refusals (unknown database,
+// bad SQL, destructive schema) are tracked:false so the model self-corrects without alerting.
+export function dbErrorToMCPError(error: SandboxFunctionError): MCPError {
+  switch (error.code) {
+    case "reconcile_blocked":
+    case "invalid_path":
+    case "invalid_contract":
+    case "compat_blocked":
+    case "build_failed":
+    case "schema_extraction_failed":
+    case "publish_conflict":
+      return new MCPError(error.message, { tracked: false });
+    case "sandbox_unavailable":
+    case "reconcile_failed":
+    case "internal":
+      return new MCPError(error.message);
+    default:
+      return assertNever(error.code);
+  }
+}
+
+// db -> sorted slugs of the published functions declaring it.
+export function declaringFunctionsByDatabase(
+  functions: { slug: string; manifests: FunctionManifests | null }[]
+): Map<string, string[]> {
+  const byDatabase = new Map<string, string[]>();
+  for (const fn of functions) {
+    for (const database of Object.keys(fn.manifests?.databases ?? {})) {
+      const slugs = byDatabase.get(database);
+      if (slugs) {
+        slugs.push(fn.slug);
+      } else {
+        byDatabase.set(database, [fn.slug]);
+      }
+    }
+  }
+  for (const slugs of byDatabase.values()) {
+    slugs.sort();
+  }
+  return byDatabase;
+}

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -37,12 +37,24 @@ export async function publishHandler(
   if (result.isErr()) {
     return new Err(toMCPError(result.error));
   }
+  const { sandboxFunction, warnings, staleSiblings } = result.value;
 
   return new Ok([
     {
       type: "text",
-      text: `Published sandbox function "${result.value.slug}".`,
+      text: `Published sandbox function "${sandboxFunction.slug}".`,
     },
+    ...warnings.map((warning): { type: "text"; text: string } => ({
+      type: "text",
+      text: `Warning — ${warning.message}`,
+    })),
+    ...staleSiblings.map((note): { type: "text"; text: string } => ({
+      type: "text",
+      text:
+        `Note — "${note.slug}" was published against an older schema of ` +
+        `${note.databases.join(", ")}. It keeps working, but republish it once its code is ` +
+        `aligned with the shared schema file${note.databases.length > 1 ? "s" : ""}.`,
+    })),
   ]);
 }
 
@@ -52,9 +64,16 @@ function toMCPError(error: SandboxFunctionError): MCPError {
     case "build_failed":
     case "schema_extraction_failed":
     case "invalid_contract":
+    // Compat blocks and reconcile refusals are model-correctable: the message carries the
+    // (function, table.column) list and the additive migrate path.
+    case "compat_blocked":
+    case "reconcile_blocked":
+    // Another publish holds the pod's lock; the model can simply retry.
+    case "publish_conflict":
       // The model controls the path and the function source, so surface the detail to let it fix.
       return new MCPError(error.message, { tracked: false });
     case "sandbox_unavailable":
+    case "reconcile_failed":
     case "internal":
       return new MCPError(error.message);
     default:

--- a/front/lib/api/sandbox_functions/compat.test.ts
+++ b/front/lib/api/sandbox_functions/compat.test.ts
@@ -1,0 +1,454 @@
+import type {
+  CompatDiff,
+  SiblingManifests,
+} from "@app/lib/api/sandbox_functions/compat";
+import {
+  computeStaleSiblings,
+  diffManifestsAgainstSiblings,
+} from "@app/lib/api/sandbox_functions/compat";
+import type {
+  FunctionManifests,
+  ManifestColumn,
+  ManifestIndex,
+  ManifestTable,
+} from "@app/lib/api/sandbox_functions/manifests";
+import { describe, expect, it } from "vitest";
+
+function col(overrides: Partial<ManifestColumn> = {}): ManifestColumn {
+  return {
+    type: "text",
+    mode: null,
+    notNull: false,
+    hasDefault: false,
+    primaryKey: false,
+    autoIncrement: false,
+    ...overrides,
+  };
+}
+
+function idCol(): ManifestColumn {
+  return col({
+    type: "integer",
+    notNull: true,
+    hasDefault: true,
+    primaryKey: true,
+    autoIncrement: true,
+  });
+}
+
+function table(
+  columns: Record<string, ManifestColumn>,
+  indexes: Record<string, ManifestIndex> = {}
+): ManifestTable {
+  return { columns, indexes };
+}
+
+function manifests(
+  tablesByDb: Record<string, Record<string, ManifestTable>>
+): FunctionManifests {
+  return {
+    version: 1,
+    databases: Object.fromEntries(
+      Object.entries(tablesByDb).map(([db, tables]) => [
+        db,
+        { schemaFile: `databases/${db}.db.ts`, tables },
+      ])
+    ),
+  };
+}
+
+// The design's canonical chat example: messages(id, body, created_at).
+function chatMessagesManifests(): FunctionManifests {
+  return manifests({
+    chat: {
+      messages: table({
+        id: idCol(),
+        body: col({ notNull: true }),
+        created_at: col({ type: "integer", mode: "timestamp", notNull: true }),
+      }),
+    },
+  });
+}
+
+function diff({
+  newManifests,
+  previousManifests = null,
+  siblings = [],
+}: {
+  newManifests: FunctionManifests | null;
+  previousManifests?: FunctionManifests | null;
+  siblings?: SiblingManifests[];
+}): CompatDiff {
+  return diffManifestsAgainstSiblings({
+    newManifests,
+    previousManifests,
+    siblings,
+  });
+}
+
+describe("diffManifestsAgainstSiblings", () => {
+  it("is empty for a function declaring no databases", () => {
+    const result = diff({
+      newManifests: null,
+      siblings: [{ slug: "other", manifests: chatMessagesManifests() }],
+    });
+    expect(result).toEqual({ blocks: [], warnings: [] });
+  });
+
+  it("is empty on a first publish with no siblings, even with NOT NULL columns", () => {
+    const result = diff({ newManifests: chatMessagesManifests() });
+    expect(result).toEqual({ blocks: [], warnings: [] });
+  });
+
+  it("ignores siblings without manifests or declaring other databases", () => {
+    const result = diff({
+      newManifests: chatMessagesManifests(),
+      siblings: [
+        { slug: "no-db", manifests: null },
+        {
+          slug: "other-db",
+          manifests: manifests({
+            analytics: { events: table({ id: idCol() }) },
+          }),
+        },
+      ],
+    });
+    expect(result).toEqual({ blocks: [], warnings: [] });
+  });
+
+  it("blocks the design's rename example: body -> content removes a referenced column", () => {
+    // `content` is added nullable (the additive way); the block is purely about `body`.
+    const renamed = manifests({
+      chat: {
+        messages: table({
+          id: idCol(),
+          content: col(),
+          created_at: col({
+            type: "integer",
+            mode: "timestamp",
+            notNull: true,
+          }),
+        }),
+      },
+    });
+
+    const result = diff({
+      newManifests: renamed,
+      siblings: [{ slug: "list-messages", manifests: chatMessagesManifests() }],
+    });
+
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0]).toMatchObject({
+      database: "chat",
+      table: "messages",
+      column: "body",
+      affectedFunctions: ["list-messages"],
+    });
+    expect(result.blocks[0]?.reason).toContain(
+      "removes column chat.messages.body"
+    );
+  });
+
+  it("blocks removing a table a sibling references", () => {
+    const result = diff({
+      newManifests: manifests({ chat: { other: table({ id: idCol() }) } }),
+      siblings: [{ slug: "list-messages", manifests: chatMessagesManifests() }],
+    });
+
+    expect(
+      result.blocks.some(
+        (block) =>
+          block.table === "messages" &&
+          block.column === null &&
+          block.reason.includes("removes table chat.messages")
+      )
+    ).toBe(true);
+  });
+
+  it("blocks a type change on a referenced column", () => {
+    const changed = chatMessagesManifests();
+    changed.databases.chat.tables.messages.columns.body = col({
+      type: "integer",
+      notNull: true,
+    });
+
+    const result = diff({
+      newManifests: changed,
+      siblings: [{ slug: "post-message", manifests: chatMessagesManifests() }],
+    });
+
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0]?.reason).toContain("type text -> integer");
+  });
+
+  it("blocks notNull changes in both directions", () => {
+    const relaxed = chatMessagesManifests();
+    relaxed.databases.chat.tables.messages.columns.body = col({
+      notNull: false,
+    });
+    const relaxedDiff = diff({
+      newManifests: relaxed,
+      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+    });
+    expect(relaxedDiff.blocks).toHaveLength(1);
+    expect(relaxedDiff.blocks[0]?.reason).toContain("removes NOT NULL");
+
+    const tightened = chatMessagesManifests();
+    tightened.databases.chat.tables.messages.columns.created_at = col({
+      type: "integer",
+      mode: "timestamp",
+      notNull: false,
+    });
+    const base = chatMessagesManifests();
+    const tightenedDiff = diff({
+      newManifests: base,
+      siblings: [{ slug: "sib", manifests: tightened }],
+    });
+    expect(tightenedDiff.blocks).toHaveLength(1);
+    expect(tightenedDiff.blocks[0]?.reason).toContain("adds NOT NULL");
+  });
+
+  it("blocks primaryKey and autoIncrement changes", () => {
+    const noAutoIncrement = chatMessagesManifests();
+    noAutoIncrement.databases.chat.tables.messages.columns.id = col({
+      type: "integer",
+      notNull: true,
+      hasDefault: true,
+      primaryKey: true,
+      autoIncrement: false,
+    });
+    const autoIncrementDiff = diff({
+      newManifests: noAutoIncrement,
+      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+    });
+    expect(autoIncrementDiff.blocks).toHaveLength(1);
+    expect(autoIncrementDiff.blocks[0]?.reason).toContain("autoincrement");
+
+    const noPk = chatMessagesManifests();
+    noPk.databases.chat.tables.messages.columns.id = col({
+      type: "integer",
+      notNull: true,
+      hasDefault: true,
+      primaryKey: false,
+      autoIncrement: false,
+    });
+    const pkDiff = diff({
+      newManifests: noPk,
+      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+    });
+    // The pk flip is reported (autoIncrement differs too; primary key wins the description).
+    expect(pkDiff.blocks).toHaveLength(1);
+    expect(pkDiff.blocks[0]?.reason).toContain("primary key");
+  });
+
+  it("blocks the design's NOT NULL addition example (no default, existing table)", () => {
+    const withChannel = chatMessagesManifests();
+    withChannel.databases.chat.tables.messages.columns.channel = col({
+      notNull: true,
+    });
+
+    const result = diff({
+      newManifests: withChannel,
+      siblings: [{ slug: "list-messages", manifests: chatMessagesManifests() }],
+    });
+
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0]).toMatchObject({
+      database: "chat",
+      table: "messages",
+      column: "channel",
+      affectedFunctions: ["list-messages"],
+    });
+    expect(result.blocks[0]?.reason).toContain("without a default");
+  });
+
+  it("allows a NOT NULL addition with a default, and a nullable addition", () => {
+    const withDefault = chatMessagesManifests();
+    withDefault.databases.chat.tables.messages.columns.channel = col({
+      notNull: true,
+      hasDefault: true,
+    });
+    withDefault.databases.chat.tables.messages.columns.topic = col({});
+
+    const result = diff({
+      newManifests: withDefault,
+      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+    });
+    expect(result.blocks).toEqual([]);
+  });
+
+  it("blocks a NOT NULL addition against the function's own previous manifests", () => {
+    const withChannel = chatMessagesManifests();
+    withChannel.databases.chat.tables.messages.columns.channel = col({
+      notNull: true,
+    });
+
+    const result = diff({
+      newManifests: withChannel,
+      previousManifests: chatMessagesManifests(),
+    });
+
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0]?.affectedFunctions).toEqual([
+      "(this function's previous publish)",
+    ]);
+  });
+
+  it("does not block a NOT NULL column on a brand-new table", () => {
+    const withNewTable = chatMessagesManifests();
+    withNewTable.databases.chat.tables.reactions = table({
+      id: idCol(),
+      emoji: col({ notNull: true }),
+    });
+
+    const result = diff({
+      newManifests: withNewTable,
+      previousManifests: chatMessagesManifests(),
+      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+    });
+    expect(result.blocks).toEqual([]);
+  });
+
+  it("warns on the design's mode-drift example instead of blocking", () => {
+    // report-activity declares created_at as plain integer (no mode); the siblings declare
+    // integer mode=timestamp. Same storage type -> warning, publish proceeds.
+    const noMode = chatMessagesManifests();
+    noMode.databases.chat.tables.messages.columns.created_at = col({
+      type: "integer",
+      notNull: true,
+    });
+
+    const result = diff({
+      newManifests: noMode,
+      siblings: [
+        { slug: "post-message", manifests: chatMessagesManifests() },
+        { slug: "list-messages", manifests: chatMessagesManifests() },
+      ],
+    });
+
+    expect(result.blocks).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    const warning = result.warnings[0];
+    expect(warning).toMatchObject({
+      kind: "mode_drift",
+      database: "chat",
+      table: "messages",
+      subject: "created_at",
+    });
+    expect(warning?.message).toContain("(no mode)");
+    expect(warning?.message).toContain("mode=timestamp");
+    expect(warning?.message).toContain("list-messages, post-message");
+    expect(warning?.message).toContain("databases/chat.db.ts");
+  });
+
+  it("warns on unique tightening for a table a sibling uses", () => {
+    const withUnique = chatMessagesManifests();
+    withUnique.databases.chat.tables.messages = table(
+      withUnique.databases.chat.tables.messages.columns,
+      { messages_body_idx: { unique: true, columns: ["body"] } }
+    );
+
+    const result = diff({
+      newManifests: withUnique,
+      siblings: [{ slug: "post-message", manifests: chatMessagesManifests() }],
+    });
+
+    expect(result.blocks).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatchObject({
+      kind: "unique_tightening",
+      subject: "messages_body_idx",
+    });
+    expect(result.warnings[0]?.message).toContain("post-message");
+  });
+
+  it("does not warn when the sibling already carries the same unique index", () => {
+    const withUnique = chatMessagesManifests();
+    withUnique.databases.chat.tables.messages = table(
+      withUnique.databases.chat.tables.messages.columns,
+      { messages_body_idx: { unique: true, columns: ["body"] } }
+    );
+
+    const result = diff({
+      newManifests: withUnique,
+      siblings: [{ slug: "sib", manifests: withUnique }],
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("never blocks on indexes or hasDefault changes", () => {
+    const changed = chatMessagesManifests();
+    // New non-unique index + hasDefault flip on body.
+    changed.databases.chat.tables.messages = table(
+      {
+        ...changed.databases.chat.tables.messages.columns,
+        body: col({ notNull: true, hasDefault: true }),
+      },
+      { messages_created_idx: { unique: false, columns: ["created_at"] } }
+    );
+
+    const result = diff({
+      newManifests: changed,
+      siblings: [{ slug: "sib", manifests: chatMessagesManifests() }],
+    });
+    expect(result.blocks).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("merges the affected functions of one breaking change across siblings", () => {
+    const renamed = manifests({
+      chat: {
+        messages: table({
+          id: idCol(),
+          content: col(),
+          created_at: col({
+            type: "integer",
+            mode: "timestamp",
+            notNull: true,
+          }),
+        }),
+      },
+    });
+
+    const result = diff({
+      newManifests: renamed,
+      siblings: [
+        { slug: "list-messages", manifests: chatMessagesManifests() },
+        { slug: "post-message", manifests: chatMessagesManifests() },
+      ],
+    });
+
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0]?.affectedFunctions).toEqual([
+      "list-messages",
+      "post-message",
+    ]);
+  });
+});
+
+describe("computeStaleSiblings", () => {
+  it("flags siblings whose stored manifest for a shared database differs", () => {
+    const evolved = chatMessagesManifests();
+    evolved.databases.chat.tables.messages.columns.topic = col({});
+
+    const notes = computeStaleSiblings(evolved, [
+      { slug: "list-messages", manifests: chatMessagesManifests() },
+      { slug: "up-to-date", manifests: evolved },
+      { slug: "no-db", manifests: null },
+      {
+        slug: "other-db",
+        manifests: manifests({ analytics: { events: table({ id: idCol() }) } }),
+      },
+    ]);
+
+    expect(notes).toEqual([{ slug: "list-messages", databases: ["chat"] }]);
+  });
+
+  it("is empty when the publish declares no databases", () => {
+    expect(
+      computeStaleSiblings(null, [
+        { slug: "sib", manifests: chatMessagesManifests() },
+      ])
+    ).toEqual([]);
+  });
+});

--- a/front/lib/api/sandbox_functions/compat.ts
+++ b/front/lib/api/sandbox_functions/compat.ts
@@ -1,0 +1,386 @@
+import type {
+  FunctionManifests,
+  ManifestColumn,
+} from "@app/lib/api/sandbox_functions/manifests";
+import isEqual from "lodash/isEqual";
+
+// Pure manifest compatibility diff (manifest.v1 compat semantics): the new manifests of the
+// function being published are compared against the stored manifests of every other function
+// of the same pod declaring the same database ("siblings"), plus the publishing function's own
+// previous manifests for the additive-but-breaking check.
+//
+// - BLOCK (structural): a sibling references something the new manifests remove or change
+//   (table missing; column missing; type/notNull/primaryKey/autoIncrement differ).
+// - BLOCK (additive-but-breaking): a new NOT NULL column without default on a table that
+//   already exists in any sibling manifest or in this function's own previous manifests.
+// - WARN (mode drift): same column, same type, different mode.
+// - WARN (unique tightening): new unique index on a table present in a sibling manifest.
+// - Indexes never block; hasDefault changes never block.
+
+export interface SiblingManifests {
+  slug: string;
+  manifests: FunctionManifests | null;
+}
+
+export interface CompatBlock {
+  database: string;
+  table: string;
+  column: string | null;
+  // Slugs whose published bundles (or, for the additive check, whose live rows) break.
+  affectedFunctions: string[];
+  reason: string;
+}
+
+export interface CompatWarning {
+  kind: "mode_drift" | "unique_tightening";
+  database: string;
+  table: string;
+  subject: string; // column name (mode_drift) or index name (unique_tightening)
+  message: string;
+}
+
+export interface CompatDiff {
+  blocks: CompatBlock[];
+  warnings: CompatWarning[];
+}
+
+export interface StaleSiblingNote {
+  slug: string;
+  databases: string[];
+}
+
+interface BlockAccumulatorEntry {
+  database: string;
+  table: string;
+  column: string | null;
+  affectedFunctions: Set<string>;
+  reason: string;
+}
+
+export function diffManifestsAgainstSiblings({
+  newManifests,
+  previousManifests,
+  siblings,
+}: {
+  newManifests: FunctionManifests | null;
+  previousManifests: FunctionManifests | null;
+  siblings: SiblingManifests[];
+}): CompatDiff {
+  if (newManifests === null) {
+    // A function declaring no databases cannot break siblings: its bundle opens nothing, and
+    // no DDL runs. (Tables it used to declare stay live; reconcile never drops.)
+    return { blocks: [], warnings: [] };
+  }
+
+  const blocks = new Map<string, BlockAccumulatorEntry>();
+  const modeDrifts = new Map<
+    string,
+    {
+      database: string;
+      table: string;
+      column: string;
+      type: string;
+      newMode: string | null;
+      siblingMode: string | null;
+      slugs: Set<string>;
+    }
+  >();
+  const uniqueTightenings = new Map<
+    string,
+    {
+      database: string;
+      table: string;
+      indexName: string;
+      columns: string[];
+      slugs: Set<string>;
+    }
+  >();
+
+  const addBlock = (
+    entry: Omit<BlockAccumulatorEntry, "affectedFunctions">,
+    affectedSlug: string
+  ) => {
+    const key = [entry.database, entry.table, entry.column, entry.reason].join(
+      "\u0000"
+    );
+    const existing = blocks.get(key);
+    if (existing) {
+      existing.affectedFunctions.add(affectedSlug);
+    } else {
+      blocks.set(key, { ...entry, affectedFunctions: new Set([affectedSlug]) });
+    }
+  };
+
+  for (const [database, newDb] of Object.entries(newManifests.databases)) {
+    for (const sibling of siblings) {
+      const siblingDb = sibling.manifests?.databases[database];
+      if (siblingDb === undefined) {
+        continue;
+      }
+
+      for (const [tableName, siblingTable] of Object.entries(
+        siblingDb.tables
+      )) {
+        const newTable = newDb.tables[tableName];
+        if (newTable === undefined) {
+          addBlock(
+            {
+              database,
+              table: tableName,
+              column: null,
+              reason: `removes table ${database}.${tableName}`,
+            },
+            sibling.slug
+          );
+          continue;
+        }
+
+        // Structural checks: everything the sibling references must survive unchanged.
+        for (const [columnName, siblingColumn] of Object.entries(
+          siblingTable.columns
+        )) {
+          const newColumn = newTable.columns[columnName];
+          if (newColumn === undefined) {
+            addBlock(
+              {
+                database,
+                table: tableName,
+                column: columnName,
+                reason: `removes column ${database}.${tableName}.${columnName}`,
+              },
+              sibling.slug
+            );
+            continue;
+          }
+          const structuralChange = describeStructuralChange(
+            siblingColumn,
+            newColumn
+          );
+          if (structuralChange !== null) {
+            addBlock(
+              {
+                database,
+                table: tableName,
+                column: columnName,
+                reason: `changes ${database}.${tableName}.${columnName}: ${structuralChange}`,
+              },
+              sibling.slug
+            );
+          } else if (newColumn.mode !== siblingColumn.mode) {
+            // Same storage type, different (de)serialization contract: warn, never block.
+            const key = [
+              database,
+              tableName,
+              columnName,
+              newColumn.mode,
+              siblingColumn.mode,
+            ].join("\u0000");
+            const drift = modeDrifts.get(key);
+            if (drift) {
+              drift.slugs.add(sibling.slug);
+            } else {
+              modeDrifts.set(key, {
+                database,
+                table: tableName,
+                column: columnName,
+                type: newColumn.type,
+                newMode: newColumn.mode,
+                siblingMode: siblingColumn.mode,
+                slugs: new Set([sibling.slug]),
+              });
+            }
+          }
+        }
+
+        // Additive-but-breaking: new NOT NULL column without default on a pre-existing table.
+        addNotNullAdditionBlocks({
+          database,
+          tableName,
+          newColumns: newTable.columns,
+          existingColumns: siblingTable.columns,
+          affectedSlug: sibling.slug,
+          addBlock,
+        });
+
+        // Unique tightening: a unique index the sibling's manifest does not carry.
+        for (const [indexName, index] of Object.entries(newTable.indexes)) {
+          if (!index.unique) {
+            continue;
+          }
+          const siblingIndex = siblingTable.indexes[indexName];
+          if (siblingIndex === undefined || !siblingIndex.unique) {
+            const key = [database, tableName, indexName].join("\u0000");
+            const tightening = uniqueTightenings.get(key);
+            if (tightening) {
+              tightening.slugs.add(sibling.slug);
+            } else {
+              uniqueTightenings.set(key, {
+                database,
+                table: tableName,
+                indexName,
+                columns: index.columns,
+                slugs: new Set([sibling.slug]),
+              });
+            }
+          }
+        }
+      }
+    }
+
+    // Own previous manifests participate in the additive-but-breaking check only: live rows
+    // predate the new column, so NOT NULL without default breaks even without siblings.
+    const previousDb = previousManifests?.databases[database];
+    if (previousDb !== undefined) {
+      for (const [tableName, previousTable] of Object.entries(
+        previousDb.tables
+      )) {
+        const newTable = newDb.tables[tableName];
+        if (newTable === undefined) {
+          continue;
+        }
+        addNotNullAdditionBlocks({
+          database,
+          tableName,
+          newColumns: newTable.columns,
+          existingColumns: previousTable.columns,
+          affectedSlug: "(this function's previous publish)",
+          addBlock,
+        });
+      }
+    }
+  }
+
+  const warnings: CompatWarning[] = [
+    ...[...modeDrifts.values()].map((drift): CompatWarning => {
+      const slugs = [...drift.slugs].sort();
+      return {
+        kind: "mode_drift",
+        database: drift.database,
+        table: drift.table,
+        subject: drift.column,
+        message:
+          `${drift.database}.${drift.table}.${drift.column}: this publish declares ` +
+          `${drift.type}${formatMode(drift.newMode)}; ${slugs.join(", ")} ` +
+          `declare${slugs.length === 1 ? "s" : ""} ${drift.type}${formatMode(drift.siblingMode)}. ` +
+          `Align on the shared databases/${drift.database}.db.ts and republish, ` +
+          `or republish the siblings if the new mode is intended.`,
+      };
+    }),
+    ...[...uniqueTightenings.values()].map((tightening): CompatWarning => {
+      const slugs = [...tightening.slugs].sort();
+      return {
+        kind: "unique_tightening",
+        database: tightening.database,
+        table: tightening.table,
+        subject: tightening.indexName,
+        message:
+          `${tightening.database}.${tightening.table}: new unique index ` +
+          `"${tightening.indexName}" (${tightening.columns.join(", ")}) tightens a table ` +
+          `other functions use (${slugs.join(", ")}); writes violating uniqueness will now fail.`,
+      };
+    }),
+  ];
+
+  return {
+    blocks: [...blocks.values()].map((entry) => ({
+      database: entry.database,
+      table: entry.table,
+      column: entry.column,
+      affectedFunctions: [...entry.affectedFunctions].sort(),
+      reason: entry.reason,
+    })),
+    warnings,
+  };
+}
+
+function addNotNullAdditionBlocks({
+  database,
+  tableName,
+  newColumns,
+  existingColumns,
+  affectedSlug,
+  addBlock,
+}: {
+  database: string;
+  tableName: string;
+  newColumns: Record<string, ManifestColumn>;
+  existingColumns: Record<string, ManifestColumn>;
+  affectedSlug: string;
+  addBlock: (
+    entry: { database: string; table: string; column: string; reason: string },
+    affectedSlug: string
+  ) => void;
+}): void {
+  for (const [columnName, newColumn] of Object.entries(newColumns)) {
+    if (
+      existingColumns[columnName] === undefined &&
+      newColumn.notNull &&
+      !newColumn.hasDefault
+    ) {
+      addBlock(
+        {
+          database,
+          table: tableName,
+          column: columnName,
+          reason: `adds NOT NULL column ${database}.${tableName}.${columnName} without a default on a table that already exists`,
+        },
+        affectedSlug
+      );
+    }
+  }
+}
+
+function describeStructuralChange(
+  siblingColumn: ManifestColumn,
+  newColumn: ManifestColumn
+): string | null {
+  if (newColumn.type !== siblingColumn.type) {
+    return `type ${siblingColumn.type} -> ${newColumn.type}`;
+  }
+  if (newColumn.notNull !== siblingColumn.notNull) {
+    return newColumn.notNull ? "adds NOT NULL" : "removes NOT NULL";
+  }
+  if (newColumn.primaryKey !== siblingColumn.primaryKey) {
+    return "changes the primary key";
+  }
+  if (newColumn.autoIncrement !== siblingColumn.autoIncrement) {
+    return "changes autoincrement";
+  }
+  return null;
+}
+
+function formatMode(mode: string | null): string {
+  return mode === null ? " (no mode)" : ` mode=${mode}`;
+}
+
+/**
+ * After a compatible publish: siblings whose stored manifest for a shared database differs from
+ * the newly stored one. Their bundles keep working (the diff said so), but their embedded schema
+ * files are stale until republished.
+ */
+export function computeStaleSiblings(
+  newManifests: FunctionManifests | null,
+  siblings: SiblingManifests[]
+): StaleSiblingNote[] {
+  if (newManifests === null) {
+    return [];
+  }
+
+  const notes: StaleSiblingNote[] = [];
+  for (const sibling of siblings) {
+    if (sibling.manifests === null || sibling.manifests === undefined) {
+      continue;
+    }
+    const staleDatabases: string[] = [];
+    for (const [database, newDb] of Object.entries(newManifests.databases)) {
+      const siblingDb = sibling.manifests.databases[database];
+      if (siblingDb !== undefined && !isEqual(siblingDb, newDb)) {
+        staleDatabases.push(database);
+      }
+    }
+    if (staleDatabases.length > 0) {
+      notes.push({ slug: sibling.slug, databases: staleDatabases.sort() });
+    }
+  }
+  return notes.sort((a, b) => a.slug.localeCompare(b.slug));
+}

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -1,0 +1,179 @@
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { shellEscape } from "@app/lib/api/sandbox/shell";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { z } from "zod";
+
+const DSBX_BIN_PATH = "/opt/bin/dsbx";
+const DB_EXEC_TIMEOUT_MS = 60 * 1000;
+
+// Mirrors DEFAULT_POD_DATABASES_DIR in cli/dust-sandbox/src/commands/db/mod.rs (paths-env.v1).
+// Passed explicitly on every `dsbx db` exec, like DUST_FUNCTIONS_DIR on `function run`.
+export const DUST_POD_DATABASES_DIR = "/pod-state/databases";
+
+// Mirrors the runner envelopes in cli/dust-sandbox/functions-runner/db_reconcile.ts /
+// db_common.ts, plus dsbx's own `{error}` shape (emit_error in
+// cli/dust-sandbox/src/commands/function/mod.rs).
+const dbErrorEnvelopeSchema = z.union([
+  z.object({
+    ok: z.literal(false),
+    error: z.object({ kind: z.string(), message: z.string() }),
+  }),
+  z.object({ error: z.string() }),
+]);
+
+const reconcileEnvelopeSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    created: z.boolean(),
+    statements: z.array(z.string()),
+  }),
+  dbErrorEnvelopeSchema,
+]);
+
+export interface ReconcileDatabaseResult {
+  created: boolean;
+  statements: string[];
+}
+
+// Runner error kinds the model can fix by editing its schema file — surfaced verbatim.
+const MODEL_CORRECTABLE_RECONCILE_KINDS = new Set([
+  "schema_unresolvable",
+  "schema_invalid",
+  "destructive_change",
+  "disallowed_statement",
+]);
+
+/**
+ * Run `dsbx db reconcile <name> <schema-file>` on the pod sandbox: plan the DDL for the
+ * database's drizzle schema file, apply it when strictly additive, refuse anything destructive
+ * with a typed error. Runs as `agent-proxied` (the schema file is model-written code that gets
+ * imported).
+ */
+export async function reconcileDatabaseOnSandbox(
+  auth: Authenticator,
+  {
+    space,
+    database,
+    schemaFileSandboxPath,
+  }: {
+    space: SpaceResource;
+    database: string;
+    schemaFileSandboxPath: string;
+  }
+): Promise<Result<ReconcileDatabaseResult, SandboxFunctionError>> {
+  const ensureResult = await ensurePodSandboxReady(auth, space);
+  if (ensureResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError(
+        "sandbox_unavailable",
+        ensureResult.error.message
+      )
+    );
+  }
+  const { sandbox } = ensureResult.value;
+
+  const command = [
+    "set -euo pipefail",
+    // `--` stops the model-influenced database name and schema path from being read as flags.
+    `${DSBX_BIN_PATH} db reconcile -- ${shellEscape(database)} ${shellEscape(schemaFileSandboxPath)}`,
+  ].join("\n");
+
+  const execResult = await sandbox.exec(auth, command, {
+    timeoutMs: DB_EXEC_TIMEOUT_MS,
+    envVars: { DUST_POD_DATABASES_DIR },
+    user: "agent-proxied",
+  });
+  if (execResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("internal", execResult.error.message)
+    );
+  }
+
+  const envelope = parseDbEnvelope(
+    execResult.value.stdout,
+    reconcileEnvelopeSchema,
+    `dsbx db reconcile ${database}`
+  );
+  if (envelope.isErr()) {
+    return envelope;
+  }
+  const parsed = envelope.value;
+
+  if ("ok" in parsed && parsed.ok === true) {
+    return new Ok({ created: parsed.created, statements: parsed.statements });
+  }
+
+  if ("ok" in parsed) {
+    const { kind, message } = parsed.error;
+    if (MODEL_CORRECTABLE_RECONCILE_KINDS.has(kind)) {
+      return new Err(
+        new SandboxFunctionError(
+          "reconcile_blocked",
+          `Database "${database}": ${message}`
+        )
+      );
+    }
+    return new Err(
+      new SandboxFunctionError(
+        "reconcile_failed",
+        `Database "${database}": ${message}`
+      )
+    );
+  }
+
+  // dsbx-level `{error}`: bad database name or missing schema file.
+  return new Err(
+    new SandboxFunctionError(
+      "reconcile_blocked",
+      `Database "${database}": ${parsed.error}`
+    )
+  );
+}
+
+/**
+ * Parse the one-line JSON envelope a `dsbx db` command prints as its last non-empty stdout
+ * line (sandbox stdout can carry shell noise and be truncated; files carry big payloads).
+ */
+export function parseDbEnvelope<S extends z.ZodTypeAny>(
+  stdout: string,
+  schema: S,
+  what: string
+): Result<z.infer<S>, SandboxFunctionError> {
+  const lastLine =
+    stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .at(-1) ?? "";
+  if (lastLine.length === 0) {
+    return new Err(
+      new SandboxFunctionError("internal", `${what} produced no output.`)
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(lastLine);
+  } catch (err) {
+    return new Err(
+      new SandboxFunctionError(
+        "internal",
+        `Unparseable ${what} output: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return new Err(
+      new SandboxFunctionError("internal", `Unexpected ${what} output shape.`)
+    );
+  }
+
+  return new Ok(parsed.data);
+}

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
@@ -10,6 +12,8 @@ import { z } from "zod";
 
 const DSBX_BIN_PATH = "/opt/bin/dsbx";
 const DB_EXEC_TIMEOUT_MS = 60 * 1000;
+// Non-mounted scratch root for regenerated schema files (file-output pattern).
+const DB_SCHEMA_STAGING_ROOT = "/tmp/dust-pod-db-schema";
 
 // Mirrors DEFAULT_POD_DATABASES_DIR in cli/dust-sandbox/src/commands/db/mod.rs (paths-env.v1).
 // Passed explicitly on every `dsbx db` exec, like DUST_FUNCTIONS_DIR on `function run`.
@@ -40,13 +44,48 @@ export interface ReconcileDatabaseResult {
   statements: string[];
 }
 
-// Runner error kinds the model can fix by editing its schema file — surfaced verbatim.
-const MODEL_CORRECTABLE_RECONCILE_KINDS = new Set([
+// Runner error kinds the model can fix itself (bad schema file, destructive DDL, bad SQL,
+// unknown database) — mapped to `reconcile_blocked` (surfaced verbatim, tracked:false at the
+// MCP boundary). Everything else maps to `reconcile_failed`.
+const MODEL_CORRECTABLE_DB_KINDS = new Set([
   "schema_unresolvable",
   "schema_invalid",
   "destructive_change",
   "disallowed_statement",
+  "database_not_found",
+  "query_failed",
+  "empty_sql",
 ]);
+
+function dbErrorToSandboxFunctionError(
+  database: string,
+  envelope: z.infer<typeof dbErrorEnvelopeSchema>
+): SandboxFunctionError {
+  if ("ok" in envelope) {
+    const { kind, message } = envelope.error;
+    // A destructive refusal can also mean the live schema drifted AHEAD of every stored
+    // manifest (a previous publish reconciled its DDL but failed before storing): the schema
+    // file then looks like it drops columns it simply never declared. Spell out the recovery.
+    const driftHint =
+      kind === "destructive_change"
+        ? " If you did not remove anything, the live database may be ahead of the stored " +
+          "schemas from a previously failed publish: republish the function that declares " +
+          "the wider schema, or regenerate the schema file with the pod_databases get_schema " +
+          "tool and declare everything it shows."
+        : "";
+    return new SandboxFunctionError(
+      MODEL_CORRECTABLE_DB_KINDS.has(kind)
+        ? "reconcile_blocked"
+        : "reconcile_failed",
+      `Database "${database}": ${message}${driftHint}`
+    );
+  }
+  // dsbx-level `{error}`: bad database name or missing schema file — model-correctable.
+  return new SandboxFunctionError(
+    "reconcile_blocked",
+    `Database "${database}": ${envelope.error}`
+  );
+}
 
 /**
  * Run `dsbx db reconcile <name> <schema-file>` on the pod sandbox: plan the DDL for the
@@ -108,38 +147,225 @@ export async function reconcileDatabaseOnSandbox(
     return new Ok({ created: parsed.created, statements: parsed.statements });
   }
 
-  if ("ok" in parsed) {
-    const { kind, message } = parsed.error;
-    if (MODEL_CORRECTABLE_RECONCILE_KINDS.has(kind)) {
-      return new Err(
-        new SandboxFunctionError(
-          "reconcile_blocked",
-          `Database "${database}": ${message}`
-        )
-      );
-    }
+  return new Err(dbErrorToSandboxFunctionError(database, parsed));
+}
+
+// Mirrors the `dsbx db list` envelope in cli/dust-sandbox/src/commands/db/list.rs.
+const listEnvelopeSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    databases: z.array(z.object({ name: z.string(), size_bytes: z.number() })),
+  }),
+  dbErrorEnvelopeSchema,
+]);
+
+export interface LiveDatabaseEntry {
+  name: string;
+  sizeBytes: number;
+}
+
+/**
+ * Run `dsbx db list` on the pod sandbox: enumerate the live `{db}.db` files with sizes.
+ */
+export async function listDatabasesOnSandbox(
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<Result<LiveDatabaseEntry[], SandboxFunctionError>> {
+  const ensureResult = await ensurePodSandboxReady(auth, space);
+  if (ensureResult.isErr()) {
     return new Err(
       new SandboxFunctionError(
-        "reconcile_failed",
-        `Database "${database}": ${message}`
+        "sandbox_unavailable",
+        ensureResult.error.message
       )
     );
   }
+  const { sandbox } = ensureResult.value;
 
-  // dsbx-level `{error}`: bad database name or missing schema file.
-  return new Err(
-    new SandboxFunctionError(
-      "reconcile_blocked",
-      `Database "${database}": ${parsed.error}`
-    )
+  const execResult = await sandbox.exec(auth, `${DSBX_BIN_PATH} db list`, {
+    timeoutMs: DB_EXEC_TIMEOUT_MS,
+    envVars: { DUST_POD_DATABASES_DIR },
+    user: "agent-proxied",
+  });
+  if (execResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("internal", execResult.error.message)
+    );
+  }
+
+  const envelope = parseDbEnvelope(
+    execResult.value.stdout,
+    listEnvelopeSchema,
+    "dsbx db list"
   );
+  if (envelope.isErr()) {
+    return envelope;
+  }
+  const parsed = envelope.value;
+  if ("ok" in parsed && parsed.ok === true) {
+    return new Ok(
+      parsed.databases.map((db) => ({
+        name: db.name,
+        sizeBytes: db.size_bytes,
+      }))
+    );
+  }
+  return new Err(dbErrorToSandboxFunctionError("(list)", parsed));
+}
+
+// Mirrors the `db-schema` envelope in cli/dust-sandbox/functions-runner/runner.ts.
+const schemaEnvelopeSchema = z.union([
+  z.object({ ok: z.literal(true) }),
+  dbErrorEnvelopeSchema,
+]);
+
+/**
+ * Run `dsbx db schema` on the pod sandbox: regenerate the database's drizzle schema file from
+ * the live SQLite file and read it back. Column modes are NOT in the output (SQLite does not
+ * store them) — the caller merges them from the stored manifests.
+ */
+export async function generateSchemaOnSandbox(
+  auth: Authenticator,
+  { space, database }: { space: SpaceResource; database: string }
+): Promise<Result<string, SandboxFunctionError>> {
+  const ensureResult = await ensurePodSandboxReady(auth, space);
+  if (ensureResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError(
+        "sandbox_unavailable",
+        ensureResult.error.message
+      )
+    );
+  }
+  const { sandbox } = ensureResult.value;
+
+  const outDir = path.posix.join(DB_SCHEMA_STAGING_ROOT, randomUUID());
+  const outPath = path.posix.join(outDir, `${database}.db.ts`);
+  const command = [
+    "set -euo pipefail",
+    `rm -rf -- ${shellEscape(outDir)}`,
+    `mkdir -p -- ${shellEscape(outDir)}`,
+    // `--` stops the model-influenced database name from being read as a flag.
+    `${DSBX_BIN_PATH} db schema -- ${shellEscape(database)} ${shellEscape(outPath)}`,
+  ].join("\n");
+
+  const execResult = await sandbox.exec(auth, command, {
+    timeoutMs: DB_EXEC_TIMEOUT_MS,
+    envVars: { DUST_POD_DATABASES_DIR },
+    user: "agent-proxied",
+  });
+  if (execResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("internal", execResult.error.message)
+    );
+  }
+
+  const envelope = parseDbEnvelope(
+    execResult.value.stdout,
+    schemaEnvelopeSchema,
+    `dsbx db schema ${database}`
+  );
+  if (envelope.isErr()) {
+    return envelope;
+  }
+  const parsed = envelope.value;
+  if (!("ok" in parsed) || parsed.ok !== true) {
+    return new Err(dbErrorToSandboxFunctionError(database, parsed));
+  }
+
+  const fileResult = await sandbox.readFile(auth, outPath);
+  if (fileResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("internal", fileResult.error.message)
+    );
+  }
+
+  return new Ok(fileResult.value.toString("utf8"));
+}
+
+// Mirrors QuerySuccess in cli/dust-sandbox/functions-runner/db_query.ts.
+const queryEnvelopeSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    columns: z.array(z.string()),
+    rows: z.array(z.record(z.unknown())),
+    row_count: z.number(),
+    truncated: z.boolean(),
+  }),
+  dbErrorEnvelopeSchema,
+]);
+
+export interface QueryDatabaseResult {
+  columns: string[];
+  rows: Record<string, unknown>[];
+  rowCount: number;
+  truncated: boolean;
+}
+
+/**
+ * Run `dsbx db query` on the pod sandbox: read-only SQL (passed on stdin, never in the command
+ * line) against the live database, rows capped runner-side.
+ */
+export async function queryDatabaseOnSandbox(
+  auth: Authenticator,
+  {
+    space,
+    database,
+    sql,
+  }: { space: SpaceResource; database: string; sql: string }
+): Promise<Result<QueryDatabaseResult, SandboxFunctionError>> {
+  const ensureResult = await ensurePodSandboxReady(auth, space);
+  if (ensureResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError(
+        "sandbox_unavailable",
+        ensureResult.error.message
+      )
+    );
+  }
+  const { sandbox } = ensureResult.value;
+
+  const execResult = await sandbox.exec(
+    auth,
+    `${DSBX_BIN_PATH} db query -- ${shellEscape(database)}`,
+    {
+      timeoutMs: DB_EXEC_TIMEOUT_MS,
+      envVars: { DUST_POD_DATABASES_DIR },
+      stdin: sql,
+      user: "agent-proxied",
+    }
+  );
+  if (execResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("internal", execResult.error.message)
+    );
+  }
+
+  const envelope = parseDbEnvelope(
+    execResult.value.stdout,
+    queryEnvelopeSchema,
+    `dsbx db query ${database}`
+  );
+  if (envelope.isErr()) {
+    return envelope;
+  }
+  const parsed = envelope.value;
+  if ("ok" in parsed && parsed.ok === true) {
+    return new Ok({
+      columns: parsed.columns,
+      rows: parsed.rows,
+      rowCount: parsed.row_count,
+      truncated: parsed.truncated,
+    });
+  }
+  return new Err(dbErrorToSandboxFunctionError(database, parsed));
 }
 
 /**
  * Parse the one-line JSON envelope a `dsbx db` command prints as its last non-empty stdout
  * line (sandbox stdout can carry shell noise and be truncated; files carry big payloads).
  */
-export function parseDbEnvelope<S extends z.ZodTypeAny>(
+function parseDbEnvelope<S extends z.ZodTypeAny>(
   stdout: string,
   schema: S,
   what: string

--- a/front/lib/api/sandbox_functions/errors.ts
+++ b/front/lib/api/sandbox_functions/errors.ts
@@ -4,6 +4,14 @@ export type SandboxFunctionErrorCode =
   | "build_failed"
   | "schema_extraction_failed"
   | "invalid_contract"
+  // The manifest diff found a change that would break a sibling function's published bundle.
+  | "compat_blocked"
+  // `dsbx db reconcile` refused the schema (destructive/disallowed DDL, bad schema file).
+  | "reconcile_blocked"
+  // `dsbx db reconcile` failed for a non-model-correctable reason (plan/apply error).
+  | "reconcile_failed"
+  // Another publish holds this pod's publish lock.
+  | "publish_conflict"
   | "internal";
 
 export class SandboxFunctionError extends Error {

--- a/front/lib/api/sandbox_functions/errors.ts
+++ b/front/lib/api/sandbox_functions/errors.ts
@@ -6,9 +6,10 @@ export type SandboxFunctionErrorCode =
   | "invalid_contract"
   // The manifest diff found a change that would break a sibling function's published bundle.
   | "compat_blocked"
-  // `dsbx db reconcile` refused the schema (destructive/disallowed DDL, bad schema file).
+  // A `dsbx db` command refused a model-correctable input (destructive/disallowed DDL, bad
+  // schema file, unknown database, bad SQL).
   | "reconcile_blocked"
-  // `dsbx db reconcile` failed for a non-model-correctable reason (plan/apply error).
+  // A `dsbx db` command failed for a non-model-correctable reason (plan/apply error).
   | "reconcile_failed"
   // Another publish holds this pod's publish lock.
   | "publish_conflict"

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -1,5 +1,7 @@
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import { reconcileDatabaseOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { FunctionManifests } from "@app/lib/api/sandbox_functions/manifests";
 import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
 import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -27,6 +29,23 @@ vi.mock(
   }
 );
 
+vi.mock("@app/lib/api/sandbox_functions/dsbx_db", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/dsbx_db")
+    >();
+
+  return { ...actual, reconcileDatabaseOnSandbox: vi.fn() };
+});
+
+// Mock the distributed lock to avoid a Redis dependency (established pattern, see
+// lib/api/data_sources.test.ts / lib/resources/sandbox_resource.test.ts).
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: vi.fn(
+    async (_lockName: string, fn: () => Promise<unknown>) => fn()
+  ),
+}));
+
 const inputSchema: JSONSchema = {
   type: "object",
   properties: { name: { type: "string" } },
@@ -37,6 +56,49 @@ const outputSchema: JSONSchema = {
   type: "object",
   properties: { greeting: { type: "string" } },
   required: ["greeting"],
+};
+
+function chatManifests(
+  columns: Record<
+    string,
+    {
+      type: string;
+      mode: string | null;
+      notNull: boolean;
+      hasDefault: boolean;
+      primaryKey: boolean;
+      autoIncrement: boolean;
+    }
+  >
+): FunctionManifests {
+  return {
+    version: 1,
+    databases: {
+      chat: {
+        schemaFile: "databases/chat.db.ts",
+        tables: { messages: { columns, indexes: {} } },
+      },
+    },
+  };
+}
+
+const baseColumns = {
+  id: {
+    type: "integer",
+    mode: null,
+    notNull: true,
+    hasDefault: true,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  body: {
+    type: "text",
+    mode: null,
+    notNull: true,
+    hasDefault: false,
+    primaryKey: false,
+    autoIncrement: false,
+  },
 };
 
 // The publisher must be a pod member so DustFileSystem.forPod grants read access, matching the
@@ -60,6 +122,9 @@ async function setupPod(): Promise<{
 beforeEach(() => {
   vi.clearAllMocks();
   fileStorageMock.reset();
+  vi.mocked(reconcileDatabaseOnSandbox).mockResolvedValue(
+    new Ok({ created: false, statements: [] })
+  );
 });
 
 describe("publishSandboxFunction", () => {
@@ -85,16 +150,21 @@ describe("publishSandboxFunction", () => {
     if (result.isErr()) {
       return;
     }
-    const fn = result.value;
+    const fn = result.value.sandboxFunction;
     expect(fn.slug).toBe("greet");
     expect(fn.description).toBe("Greet someone.");
     expect(fn.inputSchema).toEqual(inputSchema);
     expect(fn.outputSchema).toEqual(outputSchema);
+    expect(fn.manifests).toBeNull();
+    expect(result.value.warnings).toEqual([]);
+    expect(result.value.staleSiblings).toEqual([]);
 
     expect(buildSandboxFunctionOnSandbox).toHaveBeenCalledWith(auth, {
       space,
       srcSandboxPath: `/files/pod-${space.sId}/greet.ts`,
     });
+    // No databases declared -> no reconcile.
+    expect(reconcileDatabaseOnSandbox).not.toHaveBeenCalled();
 
     // The source stays on the mount, so the bundle is the only FileResource.
     const files = await FileModel.findAll({
@@ -131,7 +201,7 @@ describe("publishSandboxFunction", () => {
     if (first.isErr()) {
       return;
     }
-    const firstFileId = first.value.fileId;
+    const firstFileId = first.value.sandboxFunction.fileId;
     const [firstBundle] = await FileModel.findAll({
       where: { workspaceId: workspace.id },
     });
@@ -161,12 +231,14 @@ describe("publishSandboxFunction", () => {
       return;
     }
 
-    expect(second.value.id).toBe(first.value.id);
-    expect(second.value.description).toBe("v2");
-    expect(second.value.outputSchema).toEqual(newOutputSchema);
+    expect(second.value.sandboxFunction.id).toBe(
+      first.value.sandboxFunction.id
+    );
+    expect(second.value.sandboxFunction.description).toBe("v2");
+    expect(second.value.sandboxFunction.outputSchema).toEqual(newOutputSchema);
     // The bundle file is reused in place, not replaced: same row, canonical mount path retained, and
     // its version bumped by the re-upload.
-    expect(second.value.fileId).toBe(firstFileId);
+    expect(second.value.sandboxFunction.fileId).toBe(firstFileId);
 
     const listed = await SandboxFunctionResource.listBySpace(auth, space);
     expect(listed).toHaveLength(1);
@@ -249,5 +321,210 @@ describe("publishSandboxFunction", () => {
     expect(files).toHaveLength(0);
     const listed = await SandboxFunctionResource.listBySpace(auth, space);
     expect(listed).toHaveLength(0);
+  });
+
+  it("stores manifests and reconciles each declared database", async () => {
+    const { space, auth } = await setupPod();
+    const manifests = chatManifests(baseColumns);
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({ bundleCode: "b", inputSchema, outputSchema, manifests })
+    );
+
+    const result = await publishSandboxFunction(auth, {
+      space,
+      slug: "post-message",
+      description: "Post a message.",
+      path: `pod-${space.sId}/post-message.ts`,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.sandboxFunction.manifests).toEqual(manifests);
+
+    expect(reconcileDatabaseOnSandbox).toHaveBeenCalledTimes(1);
+    expect(reconcileDatabaseOnSandbox).toHaveBeenCalledWith(auth, {
+      space,
+      database: "chat",
+      // The schema file resolves relative to the function source directory.
+      schemaFileSandboxPath: `/files/pod-${space.sId}/databases/chat.db.ts`,
+    });
+  });
+
+  it("blocks a publish that removes a column a sibling references, before any reconcile", async () => {
+    const { space, auth } = await setupPod();
+
+    // Publish the sibling first, with a manifest referencing chat.messages.body.
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({
+        bundleCode: "sib",
+        inputSchema,
+        outputSchema,
+        manifests: chatManifests(baseColumns),
+      })
+    );
+    const sibling = await publishSandboxFunction(auth, {
+      space,
+      slug: "list-messages",
+      description: "List messages.",
+      path: `pod-${space.sId}/list-messages.ts`,
+    });
+    expect(sibling.isOk()).toBe(true);
+    vi.mocked(reconcileDatabaseOnSandbox).mockClear();
+
+    // The new publish renames body -> content (drops body).
+    const { body: _dropped, ...withoutBody } = baseColumns;
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({
+        bundleCode: "new",
+        inputSchema,
+        outputSchema,
+        manifests: chatManifests({
+          ...withoutBody,
+          content: {
+            type: "text",
+            mode: null,
+            notNull: false,
+            hasDefault: false,
+            primaryKey: false,
+            autoIncrement: false,
+          },
+        }),
+      })
+    );
+
+    const result = await publishSandboxFunction(auth, {
+      space,
+      slug: "post-message",
+      description: "Post a message.",
+      path: `pod-${space.sId}/post-message.ts`,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("compat_blocked");
+    expect(result.error.message).toContain("chat.messages.body");
+    expect(result.error.message).toContain("list-messages");
+    // Blocked before touching the live database, and nothing was stored.
+    expect(reconcileDatabaseOnSandbox).not.toHaveBeenCalled();
+    const listed = await SandboxFunctionResource.listBySpace(auth, space);
+    expect(listed.map((fn) => fn.slug)).toEqual(["list-messages"]);
+  });
+
+  it("propagates a reconcile refusal and stores nothing", async () => {
+    const { space, auth } = await setupPod();
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({
+        bundleCode: "b",
+        inputSchema,
+        outputSchema,
+        manifests: chatManifests(baseColumns),
+      })
+    );
+    vi.mocked(reconcileDatabaseOnSandbox).mockResolvedValue(
+      new Err(
+        new SandboxFunctionError("reconcile_blocked", "destructive change")
+      )
+    );
+
+    const result = await publishSandboxFunction(auth, {
+      space,
+      slug: "post-message",
+      description: "Post a message.",
+      path: `pod-${space.sId}/post-message.ts`,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("reconcile_blocked");
+
+    const listed = await SandboxFunctionResource.listBySpace(auth, space);
+    expect(listed).toHaveLength(0);
+  });
+
+  it("returns mode-drift warnings and stale-sibling notes on a compatible publish", async () => {
+    const { space, auth } = await setupPod();
+
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({
+        bundleCode: "sib",
+        inputSchema,
+        outputSchema,
+        manifests: chatManifests({
+          ...baseColumns,
+          created_at: {
+            type: "integer",
+            mode: "timestamp",
+            notNull: true,
+            hasDefault: false,
+            primaryKey: false,
+            autoIncrement: false,
+          },
+        }),
+      })
+    );
+    const sibling = await publishSandboxFunction(auth, {
+      space,
+      slug: "list-messages",
+      description: "List messages.",
+      path: `pod-${space.sId}/list-messages.ts`,
+    });
+    expect(sibling.isOk()).toBe(true);
+
+    // Same storage shape but created_at loses its mode and a column is added: compatible,
+    // with a mode-drift warning and a stale-sibling note.
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({
+        bundleCode: "new",
+        inputSchema,
+        outputSchema,
+        manifests: chatManifests({
+          ...baseColumns,
+          created_at: {
+            type: "integer",
+            mode: null,
+            notNull: true,
+            hasDefault: false,
+            primaryKey: false,
+            autoIncrement: false,
+          },
+          topic: {
+            type: "text",
+            mode: null,
+            notNull: false,
+            hasDefault: false,
+            primaryKey: false,
+            autoIncrement: false,
+          },
+        }),
+      })
+    );
+
+    const result = await publishSandboxFunction(auth, {
+      space,
+      slug: "report-activity",
+      description: "Report activity.",
+      path: `pod-${space.sId}/report-activity.ts`,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.warnings).toHaveLength(1);
+    expect(result.value.warnings[0]).toMatchObject({
+      kind: "mode_drift",
+      database: "chat",
+      table: "messages",
+      subject: "created_at",
+    });
+    expect(result.value.staleSiblings).toEqual([
+      { slug: "list-messages", databases: ["chat"] },
+    ]);
   });
 });

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -1,23 +1,58 @@
+import path from "node:path";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import type {
+  CompatBlock,
+  CompatWarning,
+  SiblingManifests,
+  StaleSiblingNote,
+} from "@app/lib/api/sandbox_functions/compat";
+import {
+  computeStaleSiblings,
+  diffManifestsAgainstSiblings,
+} from "@app/lib/api/sandbox_functions/compat";
+import { reconcileDatabaseOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { FunctionManifests } from "@app/lib/api/sandbox_functions/manifests";
 import type { Authenticator } from "@app/lib/auth";
+import { executeWithLock } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
+import logger from "@app/logger/logger";
 import { sandboxFunctionContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+// The Redis lock is a 5s-TTL best-effort mutex (front/lib/lock.ts) with a 30s acquisition
+// wait: the ~2min build runs OUTSIDE it, and the critical section re-reads Postgres state
+// (fencing re-check) immediately before storing.
+const PUBLISH_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
+// Mirrors lockTimeout in front/lib/lock.ts (not exported there): sections slower than this ran
+// partially unlocked — the fencing re-read + optimistic store guard carry correctness, this
+// value only feeds the observability check.
+const PUBLISH_LOCK_TTL_MS = 5_000;
+
+export interface PublishSandboxFunctionOutcome {
+  sandboxFunction: SandboxFunctionResource;
+  // Non-blocking compat findings (mode drift, unique tightening).
+  warnings: CompatWarning[];
+  // Siblings whose stored manifest for a shared database now differs from this publish.
+  staleSiblings: StaleSiblingNote[];
+}
 
 /**
- * Publish a sandbox function: build the source the model wrote to the pod mount, then store the
- * bundle and its extracted contract.
+ * Publish a sandbox function: build the source the model wrote to the pod mount, gate the
+ * publish on manifest compatibility with the pod's other functions, reconcile each declared
+ * database's live SQLite file (additive DDL only), then store the bundle and its contract.
  *
- * The bundle is stored as a single `project_context` FileResource with the sandbox-function content
- * type, which FileResource routes into the dedicated, front-only sandbox-functions prefix. The
- * SandboxFunctionResource is upserted on (space, slug): re-publish swaps the bundle, otherwise a new
- * row is created. Returns a domain Result, no HTTP shapes (BACK18).
+ * The bundle is stored as a single `project_context` FileResource with the sandbox-function
+ * content type, which FileResource routes into the dedicated, front-only sandbox-functions
+ * prefix. The SandboxFunctionResource is upserted on (space, slug): re-publish swaps the bundle,
+ * otherwise a new row is created. Returns a domain Result, no HTTP shapes (BACK18).
  */
 export async function publishSandboxFunction(
   auth: Authenticator,
@@ -32,7 +67,7 @@ export async function publishSandboxFunction(
     description: string;
     path: string;
   }
-): Promise<Result<SandboxFunctionResource, SandboxFunctionError>> {
+): Promise<Result<PublishSandboxFunctionOutcome, SandboxFunctionError>> {
   // Resolve the model-supplied scoped path (e.g. `pod-{id}/greet.ts`) to its absolute path inside
   // the sandbox, reusing DustFileSystem's traversal and mount checks rather than rebuilding them.
   const fsResult = await DustFileSystem.forPod(auth, space);
@@ -47,10 +82,12 @@ export async function publishSandboxFunction(
       new SandboxFunctionError("invalid_path", srcResult.error.message)
     );
   }
+  const srcSandboxPath = srcResult.value;
 
+  // Build outside the publish lock: it can take minutes and holds no shared state.
   const buildResult = await buildSandboxFunctionOnSandbox(auth, {
     space,
-    srcSandboxPath: srcResult.value,
+    srcSandboxPath,
   });
   if (buildResult.isErr()) {
     return buildResult;
@@ -58,14 +95,227 @@ export async function publishSandboxFunction(
   const { bundleCode, inputSchema, outputSchema, manifests } =
     buildResult.value;
 
-  // Re-publish overwrites the existing bundle in place so its mount path (<prefix>/<slug>.ts) stays
-  // stable; only a first publish creates the backing file.
-  const existing = await SandboxFunctionResource.fetchBySpaceAndSlug(
-    auth,
+  // Serialize the compat-check -> reconcile -> store section per pod. The Redis lock helper
+  // throws on acquisition timeout; that throw is mapped to a typed conflict error, while
+  // anything thrown from inside the critical section propagates (ERR1: genuine bugs 500).
+  let lockAcquired = false;
+  try {
+    return await executeWithLock(
+      `sandbox_function:publish:${space.sId}`,
+      async () => {
+        lockAcquired = true;
+        return publishCriticalSection(auth, {
+          space,
+          slug,
+          description,
+          srcSandboxPath,
+          bundleCode,
+          inputSchema,
+          outputSchema,
+          manifests,
+        });
+      },
+      PUBLISH_LOCK_ACQUIRE_TIMEOUT_MS,
+      { traceAcquireResource: "sandbox_function.publish" }
+    );
+  } catch (err) {
+    if (!lockAcquired) {
+      return new Err(
+        new SandboxFunctionError(
+          "publish_conflict",
+          `Another publish is in progress for this pod; retry shortly. (${normalizeError(err).message})`
+        )
+      );
+    }
+    throw err;
+  }
+}
+
+async function publishCriticalSection(
+  auth: Authenticator,
+  {
     space,
-    slug
-  );
+    slug,
+    description,
+    srcSandboxPath,
+    bundleCode,
+    inputSchema,
+    outputSchema,
+    manifests,
+  }: {
+    space: SpaceResource;
+    slug: string;
+    description: string;
+    srcSandboxPath: string;
+    bundleCode: string;
+    inputSchema: JSONSchema;
+    outputSchema: JSONSchema;
+    manifests: FunctionManifests | null;
+  }
+): Promise<Result<PublishSandboxFunctionOutcome, SandboxFunctionError>> {
+  const sectionStartMs = Date.now();
+
+  // Compat gate against the current Postgres state (one query for all sibling manifests).
+  const firstRead = await readPodManifests(auth, space, slug);
+  const diff = diffManifestsAgainstSiblings({
+    newManifests: manifests,
+    previousManifests: firstRead.previousManifests,
+    siblings: firstRead.siblings,
+  });
+  if (diff.blocks.length > 0) {
+    return new Err(
+      new SandboxFunctionError("compat_blocked", formatBlocks(diff.blocks))
+    );
+  }
+
+  // Reconcile each declared database against its live SQLite file (additive DDL only). The
+  // schema files live next to the function source, at the canonical databases/{db}.db.ts.
+  if (manifests !== null) {
+    const sourceDir = path.posix.dirname(srcSandboxPath);
+    for (const [database, manifest] of Object.entries(manifests.databases)) {
+      const reconcileResult = await reconcileDatabaseOnSandbox(auth, {
+        space,
+        database,
+        schemaFileSandboxPath: path.posix.join(sourceDir, manifest.schemaFile),
+      });
+      if (reconcileResult.isErr()) {
+        return reconcileResult;
+      }
+      // No replication wiring needed for a freshly created database: litestream (>= 0.5.13)
+      // runs in directory-watch mode and picks it up automatically within seconds; the
+      // pre-sleep sync barrier is the durability backstop.
+    }
+  }
+
+  // Fencing re-check: the 5s-TTL lock may have silently expired during the reconcile execs, so
+  // re-read the sibling manifests and re-run the (pure) diff immediately before storing. The
+  // GCS bundle upload cannot move out of the section: re-publish overwrites the live bundle in
+  // place, so uploading before the gates pass would corrupt the published function on a block.
+  const secondRead = await readPodManifests(auth, space, slug);
+  const fencingDiff = diffManifestsAgainstSiblings({
+    newManifests: manifests,
+    previousManifests: secondRead.previousManifests,
+    siblings: secondRead.siblings,
+  });
+  if (fencingDiff.blocks.length > 0) {
+    return new Err(
+      new SandboxFunctionError(
+        "compat_blocked",
+        formatBlocks(fencingDiff.blocks)
+      )
+    );
+  }
+
+  const storeResult = await storePublishedFunction(auth, {
+    space,
+    slug,
+    description,
+    bundleCode,
+    inputSchema,
+    outputSchema,
+    manifests,
+    existing: secondRead.existing,
+  });
+  if (storeResult.isErr()) {
+    return storeResult;
+  }
+
+  // Observability for the residual race: the Redis lock's 5s TTL is not renewed, so a section
+  // slower than the TTL ran partially unlocked (the fencing re-read + optimistic store guard
+  // are the real protection). Emit a metric + warn so we can see how often it happens.
+  const sectionElapsedMs = Date.now() - sectionStartMs;
+  if (sectionElapsedMs > PUBLISH_LOCK_TTL_MS) {
+    getStatsDClient().increment(
+      "sandbox_functions.publish_lock_ttl_exceeded.count"
+    );
+    logger.warn(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        podId: space.sId,
+        slug,
+        sectionElapsedMs,
+        lockTtlMs: PUBLISH_LOCK_TTL_MS,
+      },
+      "Sandbox function publish: critical section outlived the lock TTL"
+    );
+  }
+
+  return new Ok({
+    sandboxFunction: storeResult.value,
+    warnings: fencingDiff.warnings,
+    staleSiblings: computeStaleSiblings(manifests, secondRead.siblings),
+  });
+}
+
+async function readPodManifests(
+  auth: Authenticator,
+  space: SpaceResource,
+  slug: string
+): Promise<{
+  existing: SandboxFunctionResource | null;
+  previousManifests: FunctionManifests | null;
+  siblings: SiblingManifests[];
+}> {
+  // One query: manifests live on the sandbox_functions rows themselves (GEN14).
+  const functions = await SandboxFunctionResource.listBySpace(auth, space);
+  const existing = functions.find((fn) => fn.slug === slug) ?? null;
+
+  return {
+    existing,
+    previousManifests: existing?.manifests ?? null,
+    siblings: functions
+      .filter((fn) => fn.slug !== slug)
+      .map((fn) => ({ slug: fn.slug, manifests: fn.manifests ?? null })),
+  };
+}
+
+interface PublishStoreArgs {
+  space: SpaceResource;
+  slug: string;
+  description: string;
+  bundleCode: string;
+  inputSchema: JSONSchema;
+  outputSchema: JSONSchema;
+  manifests: FunctionManifests | null;
+  existing: SandboxFunctionResource | null;
+}
+
+async function storePublishedFunction(
+  auth: Authenticator,
+  {
+    space,
+    slug,
+    description,
+    bundleCode,
+    inputSchema,
+    outputSchema,
+    manifests,
+    existing,
+  }: PublishStoreArgs
+): Promise<Result<SandboxFunctionResource, SandboxFunctionError>> {
+  // Re-publish overwrites the existing bundle in place so its mount path (<prefix>/<slug>.ts)
+  // stays stable; only a first publish creates the backing file.
   if (existing) {
+    // Optimistic guard: the 5s lock TTL may have expired mid-section, so verify no concurrent
+    // publish stored a newer version since the fenced re-read (updatedAt compare). A first
+    // publish is protected by the unique (workspaceId, spaceId, slug) index instead.
+    const current = await SandboxFunctionResource.fetchBySpaceAndSlug(
+      auth,
+      space,
+      slug
+    );
+    if (
+      current === null ||
+      current.updatedAt.getTime() !== existing.updatedAt.getTime()
+    ) {
+      return new Err(
+        new SandboxFunctionError(
+          "publish_conflict",
+          "A concurrent publish updated this function while this one was being checked; retry."
+        )
+      );
+    }
+
     const updateResult = await existing.updateContent(auth, {
       bundleCode,
       description,
@@ -98,6 +348,20 @@ export async function publishSandboxFunction(
   });
 
   return new Ok(created);
+}
+
+function formatBlocks(blocks: CompatBlock[]): string {
+  const lines = blocks.map(
+    (block) =>
+      `- ${block.reason} (breaks: ${block.affectedFunctions.join(", ")})`
+  );
+  return [
+    "Publish blocked: this schema change would break published functions of this pod.",
+    ...lines,
+    "Fix additively instead: keep the existing tables and columns declared in the shared " +
+      "databases/{db}.db.ts, add new columns/tables alongside (nullable or with a default), " +
+      "dual-write during the transition, and republish the affected functions.",
+  ].join("\n");
 }
 
 async function createBundleFile(

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -55,7 +55,8 @@ export async function publishSandboxFunction(
   if (buildResult.isErr()) {
     return buildResult;
   }
-  const { bundleCode, inputSchema, outputSchema } = buildResult.value;
+  const { bundleCode, inputSchema, outputSchema, manifests } =
+    buildResult.value;
 
   // Re-publish overwrites the existing bundle in place so its mount path (<prefix>/<slug>.ts) stays
   // stable; only a first publish creates the backing file.
@@ -70,6 +71,7 @@ export async function publishSandboxFunction(
       description,
       inputSchema,
       outputSchema,
+      manifests,
     });
     if (updateResult.isErr()) {
       return new Err(
@@ -92,6 +94,7 @@ export async function publishSandboxFunction(
     description,
     inputSchema,
     outputSchema,
+    manifests,
   });
 
   return new Ok(created);

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -621,6 +621,7 @@ describe("SandboxFunctionResource", () => {
       description: "Second.",
       inputSchema: newInputSchema,
       outputSchema: newOutputSchema,
+      manifests: null,
     });
     expect(result.isOk()).toBe(true);
 

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/lib/api/sandbox/access_tokens";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
+import type { FunctionManifests } from "@app/lib/api/sandbox_functions/manifests";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -105,6 +106,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       description,
       inputSchema,
       outputSchema,
+      manifests,
     }: {
       space: SpaceResource;
       file: FileResource;
@@ -112,6 +114,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       description: string;
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
+      manifests?: FunctionManifests | null;
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionResource> {
@@ -150,6 +153,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         description,
         inputSchema,
         outputSchema,
+        manifests: manifests ?? null,
       },
       { transaction }
     );
@@ -170,16 +174,18 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       description,
       inputSchema,
       outputSchema,
+      manifests,
     }: {
       bundleCode: string;
       description: string;
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
+      manifests: FunctionManifests | null;
     }
   ): Promise<Result<undefined, Error>> {
     try {
       await this.file.uploadContent(auth, bundleCode);
-      await this.update({ description, inputSchema, outputSchema });
+      await this.update({ description, inputSchema, outputSchema, manifests });
     } catch (error) {
       return new Err(normalizeError(error));
     }

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -1,3 +1,5 @@
+import type { FunctionManifests } from "@app/lib/api/sandbox_functions/manifests";
+import { functionManifestsSchema } from "@app/lib/api/sandbox_functions/manifests";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { FileModel } from "@app/lib/resources/storage/models/files";
@@ -31,6 +33,19 @@ function validateSandboxFunctionSlug(value: unknown): void {
   }
 }
 
+function validateSandboxFunctionManifests(value: unknown): void {
+  // Null means the function declares no databases (custom validators also run on null).
+  if (value === null) {
+    return;
+  }
+  const validationResult = functionManifestsSchema.safeParse(value);
+  if (!validationResult.success) {
+    throw new Error(
+      `Invalid function manifests: ${validationResult.error.message}`
+    );
+  }
+}
+
 export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -41,6 +56,9 @@ export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionMod
   declare description: string;
   declare inputSchema: JSONSchema;
   declare outputSchema: JSONSchema;
+  // Per-database manifests (manifest.v1), stored verbatim at publish; null when the function
+  // declares no databases.
+  declare manifests: FunctionManifests | null;
 
   declare space: NonAttribute<SpaceModel>;
   declare file: NonAttribute<FileModel>;
@@ -99,6 +117,13 @@ SandboxFunctionModel.init(
       allowNull: false,
       validate: {
         isValidJSONSchema: validateSandboxFunctionJsonSchema,
+      },
+    },
+    manifests: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      validate: {
+        isValidManifests: validateSandboxFunctionManifests,
       },
     },
   },

--- a/front/migrations/pre-deploy/20260707110553_add_manifests_to_sandbox_functions.sql
+++ b/front/migrations/pre-deploy/20260707110553_add_manifests_to_sandbox_functions.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions" ADD COLUMN "manifests" jsonb;


### PR DESCRIPTION
## Description

**Stack 9/11 (pod-state), first of the MCP sub-stack.** New `pod_databases` internal MCP server — the agent's window into the pod's live databases (design "front - MCP server & skill 2").

- **Stable id 1040** — 1039 was the natural next id when this stack started, but `user_analytics` took it upstream mid-flight; 1040 verified free (source comment records the story). Gated on the same `sandbox_functions` feature flag as its sibling server; `auto_hidden_builder`; pod resolved from conversation context via the pod_manager `getPod` helper (works from both pod conversations and sandbox-function run contexts).
- Tools (all read-only, `never_ask`):
  - `list_databases` — `dsbx db list` (wal-inclusive sizes) merged with declaring-functions from stored manifests; flags **untracked leftovers** (live db no function declares) and declared-but-missing databases.
  - `get_schema` — `dsbx db schema` regenerated file (file-output pattern, read back from a scratch path — sandbox stdout can truncate) **plus a manifest-modes section merged front-side**: SQLite doesn't store column modes, so the tool appends `table.column → mode (declared by …)` lines with explicit DISAGREEMENT flags. Text merge, not TS injection — the agent re-applies modes when adopting the regenerated file (the file's header says so too).
  - `query` — `dsbx db query` with SQL passed via **stdin** (never argv), runner-side read-only + row/byte caps; misuse (unknown db, bad SQL) maps `tracked:false` so agents self-correct without paging.
- `dsbx_db.ts` gains the three exec helpers (same shellEscape/`--`/agent-proxied/envelope pattern as reconcile); both MCP snapshots regenerated (availability snapshot kept in the repo's compact one-line format — the diff is 1 entry).

## Tests

`tsgo` clean at this commit; `npm run test -- lib/api/actions/servers/pod_databases lib/actions/mcp_internal_actions/constants.test.ts lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts` — 16/16 (formatter units incl. untracked/missing flags + mode disagreements, both snapshot suites).

## Risk

Low: read-only tools, feature-flagged, sandbox execs as `agent-proxied` with the established injection guards.

## Deploy Plan

Standard front deploy; tools degrade to typed errors on images without the new dsbx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
