### PR TITLE
[core] Remove version_hash/latest_hash document filtering

### DIFF
--- a/core/bin/qdrant/delete_orphaned_points.rs
+++ b/core/bin/qdrant/delete_orphaned_points.rs
@@ -15,10 +15,7 @@ async fn delete_orphaned_points_for_document_id(
     qdrant_client: &DustQdrantClient,
     document_id: &str,
 ) -> Result<()> {
-    match ds
-        .retrieve(store.clone(), &document_id, &None, true, &None)
-        .await
-    {
+    match ds.retrieve(store.clone(), &document_id, &None, true).await {
         Err(e) => Err(e),
         Ok(None) => Ok(()),
         Ok(Some(_)) => Err(anyhow!("Document still exists. Won't delete.")),

--- a/core/src/api/data_sources.rs
+++ b/core/src/api/data_sources.rs
@@ -904,7 +904,6 @@ pub async fn data_sources_documents_update_parents(
 pub struct DataSourcesDocumentsVersionsListQuery {
     offset: usize,
     limit: usize,
-    latest_hash: Option<String>, // Hash of the latest version to retrieve.
     view_filter: Option<String>, // Parsed as JSON.
 }
 
@@ -942,7 +941,6 @@ pub async fn data_sources_documents_versions_list(
                 Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
                 None => None,
             },
-            &query.latest_hash,
             true,
         )
         .await
@@ -1284,7 +1282,6 @@ pub async fn data_sources_documents_list(
 /// Retrieve document from a data source.
 #[derive(serde::Deserialize)]
 pub struct DataSourcesDocumentsRetrieveQuery {
-    version_hash: Option<String>,
     view_filter: Option<String>, // Parsed as JSON.
 }
 
@@ -1337,7 +1334,6 @@ pub async fn data_sources_documents_retrieve(
                         None => None,
                     },
                     true,
-                    &query.version_hash,
                 )
                 .await
             {
@@ -1379,7 +1375,6 @@ pub struct DataSourcesDocumentsRetrieveTextQuery {
     offset: Option<usize>,
     limit: Option<usize>,
     grep: Option<String>,
-    version_hash: Option<String>,
     view_filter: Option<String>, // Parsed as JSON.
 }
 
@@ -1391,7 +1386,6 @@ pub async fn data_sources_documents_retrieve_text(
     // Call the existing retrieve function
     let now = utils::now();
     let retrieve_query = DataSourcesDocumentsRetrieveQuery {
-        version_hash: query.version_hash,
         view_filter: query.view_filter,
     };
 

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -532,7 +532,6 @@ impl DataSource {
                 &self.project,
                 &self.data_source_id(),
                 &document_id.to_string(),
-                &None,
             )
             .await?;
 
@@ -710,7 +709,6 @@ impl DataSource {
                     &self.project,
                     &self.data_source_id(),
                     &document_id.to_string(),
-                    &None,
                 )
                 .await?;
 
@@ -1391,7 +1389,7 @@ impl DataSource {
 
                 tokio::spawn(async move {
                     match store
-                        .load_data_source_document(&project, &data_source_id, &document_id, &None)
+                        .load_data_source_document(&project, &data_source_id, &document_id)
                         .await?
                     {
                         Some(mut d) => {
@@ -1810,17 +1808,11 @@ impl DataSource {
         document_id: &str,
         view_filter: &Option<SearchFilter>,
         remove_system_tags: bool,
-        version_hash: &Option<String>,
     ) -> Result<Option<Document>> {
         let store = store.clone();
 
         let mut d = match store
-            .load_data_source_document(
-                &self.project,
-                &self.data_source_id,
-                document_id,
-                version_hash,
-            )
+            .load_data_source_document(&self.project, &self.data_source_id, document_id)
             .await?
         {
             Some(d) => d,
@@ -1863,7 +1855,7 @@ impl DataSource {
         document_id: &str,
     ) -> Result<()> {
         let document = match store
-            .load_data_source_document(&self.project, &self.data_source_id, document_id, &None)
+            .load_data_source_document(&self.project, &self.data_source_id, document_id)
             .await?
         {
             Some(document) => document,
@@ -2000,7 +1992,6 @@ impl DataSource {
                 document_id,
                 None,
                 &None,
-                &None,
                 false,
             )
             .await?;
@@ -2056,7 +2047,6 @@ impl DataSource {
                 &self.data_source_id,
                 document_id,
                 None,
-                &None,
                 &None,
                 false,
             )
@@ -2220,9 +2210,8 @@ impl DataSource {
     ) -> Result<Option<DocumnentBlobPayload>> {
         let store = store.clone();
 
-        // Only fetch latest version by passing None as version_hash.
         let d = match store
-            .load_data_source_document(&self.project, &self.data_source_id, document_id, &None)
+            .load_data_source_document(&self.project, &self.data_source_id, document_id)
             .await?
         {
             Some(d) => d,

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1423,7 +1423,6 @@ impl Store for PostgresStore {
         project: &Project,
         data_source_id: &str,
         document_id: &str,
-        version_hash: &Option<String>,
     ) -> Result<Option<Document>> {
         let project_id = project.project_id();
         let data_source_id = data_source_id.to_string();
@@ -1445,34 +1444,18 @@ impl Store for PostgresStore {
             _ => unreachable!(),
         };
         // TODO(Thomas-020425): Read tags from nodes table.
-        let r = match version_hash {
-            None => {
-                c.query(
-                    "SELECT dsd.id, dsd.created, dsd.timestamp, dsn.tags_array, dsn.parents, \
-                       dsn.source_url, dsd.hash, dsd.text_size, dsd.chunk_count, dsn.title, \
-                       dsn.mime_type, dsn.provider_visibility \
-                       FROM data_sources_documents dsd \
-                       INNER JOIN data_sources_nodes dsn ON dsn.document=dsd.id \
-                       WHERE dsd.data_source = $1 AND dsd.document_id = $2 \
-                       AND dsd.status='latest' LIMIT 1",
-                    &[&data_source_row_id, &document_id],
-                )
-                .await?
-            }
-            Some(version_hash) => {
-                c.query(
-                    "SELECT dsd.id, dsd.created, dsd.timestamp, dsn.tags_array, dsn.parents, \
-                       dsn.source_url, dsd.hash, dsd.text_size, dsd.chunk_count, dsn.title, \
-                       dsn.mime_type, dsn.provider_visibility \
-                       FROM data_sources_documents dsd \
-                       INNER JOIN data_sources_nodes dsn ON dsn.document=dsd.id \
-                       WHERE dsd.data_source = $1 AND dsd.document_id = $2 \
-                       AND dsd.hash = $3 LIMIT 1",
-                    &[&data_source_row_id, &document_id, &version_hash],
-                )
-                .await?
-            }
-        };
+        let r = c
+            .query(
+                "SELECT dsd.id, dsd.created, dsd.timestamp, dsn.tags_array, dsn.parents, \
+                   dsn.source_url, dsd.hash, dsd.text_size, dsd.chunk_count, dsn.title, \
+                   dsn.mime_type, dsn.provider_visibility \
+                   FROM data_sources_documents dsd \
+                   INNER JOIN data_sources_nodes dsn ON dsn.document=dsd.id \
+                   WHERE dsd.data_source = $1 AND dsd.document_id = $2 \
+                   AND dsd.status='latest' LIMIT 1",
+                &[&data_source_row_id, &document_id],
+            )
+            .await?;
 
         let d: Option<(
             i64,
@@ -1696,7 +1679,6 @@ impl Store for PostgresStore {
         document_id: &str,
         limit_offset: Option<(usize, usize)>,
         view_filter: &Option<SearchFilter>,
-        latest_hash: &Option<String>,
         include_count: bool,
     ) -> Result<(Vec<DocumentVersion>, usize)> {
         let project_id = project.project_id();
@@ -1719,46 +1701,6 @@ impl Store for PostgresStore {
             _ => unreachable!(),
         };
 
-        // The `created` timestamp of the version specified by `latest_hash`
-        // (if `latest_hash` is `None`, then this is the latest version's `created` timestamp).
-        let latest_hash_created: i64 = match latest_hash {
-            Some(latest_hash) => {
-                let stmt = c
-                    .prepare(
-                        "SELECT created FROM data_sources_documents \
-                           WHERE data_source = $1 AND document_id = $2 AND hash = $3 LIMIT 1",
-                    )
-                    .await?;
-                let r = c
-                    .query(&stmt, &[&data_source_row_id, &document_id, &latest_hash])
-                    .await?;
-                match r.len() {
-                    0 => Err(anyhow!("Unknown document hash"))?,
-                    1 => r[0].get(0),
-                    _ => unreachable!(),
-                }
-            }
-
-            // Get the latest version's created timestamp (accepting deleted versions).
-            None => {
-                let stmt = c
-                    .prepare(
-                        "SELECT created FROM data_sources_documents \
-                           WHERE data_source = $1 AND document_id = $2 \
-                           ORDER BY created DESC LIMIT 1",
-                    )
-                    .await?;
-                let r = c.query(&stmt, &[&data_source_row_id, &document_id]).await?;
-                match r.len() {
-                    // If no hash was specified and there are no versions, just return an empty
-                    // array.
-                    0 => return Ok((vec![], 0)),
-                    1 => r[0].get(0),
-                    _ => unreachable!(),
-                }
-            }
-        };
-
         let mut where_clauses: Vec<String> = vec![];
         let mut params: Vec<&(dyn ToSql + Sync)> = vec![];
 
@@ -1766,8 +1708,6 @@ impl Store for PostgresStore {
         params.push(&data_source_row_id);
         where_clauses.push("dsd.document_id = $2".to_string());
         params.push(&document_id);
-        where_clauses.push("dsd.created <= $3".to_string());
-        params.push(&latest_hash_created);
 
         let (filter_clauses, filter_params, p_idx) = Self::where_clauses_and_params_for_filter(
             view_filter,

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -194,7 +194,6 @@ pub trait Store {
         project: &Project,
         data_source_id: &str,
         document_id: &str,
-        version_hash: &Option<String>,
     ) -> Result<Option<Document>>;
     async fn find_data_source_document_ids(
         &self,
@@ -233,7 +232,6 @@ pub trait Store {
         document_id: &str,
         limit_offset: Option<(usize, usize)>,
         view_filter: &Option<SearchFilter>,
-        latest_hash: &Option<String>,
         include_count: bool,
     ) -> Result<(Vec<DocumentVersion>, usize)>;
     async fn list_data_source_documents(

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1150,13 +1150,11 @@ export class CoreAPI {
     dataSourceId,
     documentId,
     projectId,
-    versionHash,
     viewFilter,
   }: {
     dataSourceId: string;
     documentId: string;
     projectId: string;
-    versionHash?: string | null;
     viewFilter?: CoreAPISearchFilter | null;
   }): Promise<
     CoreAPIResponse<{
@@ -1165,10 +1163,6 @@ export class CoreAPI {
     }>
   > {
     const queryParams = new URLSearchParams();
-
-    if (versionHash) {
-      queryParams.append("version_hash", versionHash);
-    }
 
     if (viewFilter) {
       queryParams.append("view_filter", JSON.stringify(viewFilter));
@@ -1197,7 +1191,6 @@ export class CoreAPI {
     offset,
     limit,
     grep,
-    versionHash,
     viewFilter,
   }: {
     dataSourceId: string;
@@ -1206,7 +1199,6 @@ export class CoreAPI {
     offset?: number | null;
     limit?: number | null;
     grep?: string | null;
-    versionHash?: string | null;
     viewFilter?: CoreAPISearchFilter | null;
   }): Promise<
     CoreAPIResponse<{
@@ -1228,10 +1220,6 @@ export class CoreAPI {
 
     if (grep) {
       queryParams.append("grep", grep);
-    }
-
-    if (versionHash) {
-      queryParams.append("version_hash", versionHash);
     }
 
     if (viewFilter) {
@@ -1258,7 +1246,6 @@ export class CoreAPI {
     projectId,
     dataSourceId,
     documentId,
-    latest_hash,
     limit = 10,
     offset = 0,
   }: {
@@ -1267,7 +1254,6 @@ export class CoreAPI {
     documentId: string;
     limit: number;
     offset: number;
-    latest_hash?: string | null;
   }): Promise<
     CoreAPIResponse<{
       versions: CoreAPIDocumentVersion[];
@@ -1280,10 +1266,6 @@ export class CoreAPI {
       limit: String(limit),
       offset: String(offset),
     });
-
-    if (latest_hash) {
-      params.append("latest_hash", latest_hash);
-    }
 
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(


### PR DESCRIPTION
## Description

Removes the ability to filter `data_sources_documents` by content hash, in preparation for dropping `idx_data_sources_documents_data_source_document_id_hash` (stacked PR #28621):

- The document retrieve (`GET .../documents/{id}`) and retrieve-text (`GET .../documents/{id}/text`) endpoints no longer accept `version_hash`; they always return the `status='latest'` version.
- The versions list endpoint (`GET .../documents/{id}/versions`) no longer accepts `latest_hash`. The `created <= x` clause it drove was vacuous when `latest_hash` was unset (it compared against the max `created`), so behavior is unchanged for all remaining callers.
- `Store::load_data_source_document` and `Store::list_data_source_document_versions` lose the corresponding parameters (trait, Postgres impl, all call sites).
- The front `CoreAPI` client loses the dead `versionHash` / `latest_hash` options — no caller in front, connectors, or the SDK ever passed them.

Deliberately kept: `delete_data_source_document_version` still matches on `hash`, but only to pin an exact version row alongside `created` and `status`; that query is served by `idx_data_sources_documents_data_source_document_id_created`.

## Tests

- `cargo check --workspace --all-targets` passes.
- `npx tsgo --noEmit` on front passes.
- Repo-wide sweep confirms no remaining reference to `version_hash` / `latest_hash` / `versionHash` outside a one-off 2024 migration binary and log field names.

## Risk

Low. The removed query parameters had no in-repo callers. Axum/serde ignores unknown query params, so any out-of-date client still sending them gets latest-version semantics instead of a 400. Safe to rollback (revert).

## Deploy Plan

1. Deploy core (and front) normally.
2. Only then merge/deploy the stacked index-drop PR (#28621) — the index must outlive the last code that issues bare `(data_source, document_id, hash)` lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
