### PR TITLE
[core] Drop idx_data_sources_documents_data_source_document_id_hash

### DIFF
--- a/core/src/stores/migrations/20260707_drop_index_data_sources_documents_data_source_document_id_hash.sql
+++ b/core/src/stores/migrations/20260707_drop_index_data_sources_documents_data_source_document_id_hash.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_data_sources_documents_data_source_document_id_hash;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -629,7 +629,7 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 35] = [
+pub const SQL_INDEXES: [&'static str; 34] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -668,9 +668,6 @@ pub const SQL_INDEXES: [&'static str; 35] = [
     "CREATE INDEX IF NOT EXISTS
        idx_data_sources_documents_data_source_status_timestamp
        ON data_sources_documents (data_source, status, timestamp);",
-    "CREATE INDEX IF NOT EXISTS
-       idx_data_sources_documents_data_source_document_id_hash
-       ON data_sources_documents (data_source, document_id, hash);",
     "CREATE INDEX IF NOT EXISTS
        idx_data_sources_documents_data_source_document_id_status
        ON data_sources_documents (data_source, document_id, status);",


### PR DESCRIPTION
## Description

Drops `idx_data_sources_documents_data_source_document_id_hash` on `data_sources_documents (data_source, document_id, hash)`.

The index is unused once #28620 removes hash-parameter filtering (`version_hash` / `latest_hash`). The remaining query touching `hash` — the exact-row match in `delete_data_source_document_version` — is served by `idx_data_sources_documents_data_source_document_id_created`.

- Removes the index from `SQL_INDEXES` so fresh databases don't create it.
- Adds a `DROP INDEX CONCURRENTLY IF EXISTS` migration for existing databases.

## Tests

- `cargo check --workspace --all-targets` passes.
- Migration is idempotent (`IF EXISTS`).

## Risk

Low once #28620 is deployed: dropping the index before #28620 is deployed would leave the hash-filter queries doing per-document scans. `DROP INDEX CONCURRENTLY` takes no long-lived lock. Rollback = recreate the index with `CREATE INDEX CONCURRENTLY` (definition preserved in #28620's `SQL_INDEXES`).

## Deploy Plan

1. Wait for #28620 to be merged and deployed to all core regions.
2. Merge this PR.
3. Run the migration against each core database: `DROP INDEX CONCURRENTLY` cannot run inside a transaction — execute the statement directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
