### PR TITLE
Match eager tool promotion on configuration id instead of server view id

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -73,10 +73,20 @@ function makeConversation(
 
 function makeServerSideToolConfiguration(
   name: string,
-  { mcpServerViewId, eager }: { mcpServerViewId: string; eager?: boolean }
+  {
+    mcpServerViewId,
+    serverConfigurationId = -1,
+    eager,
+  }: {
+    mcpServerViewId: string;
+    // Persisted id of the originating server configuration; -1 for
+    // runtime-built servers (JIT, skills).
+    serverConfigurationId?: number;
+    eager?: boolean;
+  }
 ): MCPToolConfigurationType {
   return {
-    id: -1,
+    id: serverConfigurationId,
     sId: `tool_${name}`,
     type: "mcp_configuration",
     name,
@@ -121,11 +131,15 @@ function makeClientSideToolConfiguration(
   };
 }
 
-function makeAgentServerConfiguration(
-  mcpServerViewId: string
-): ServerSideMCPServerConfigurationType {
+function makeAgentServerConfiguration({
+  mcpServerViewId,
+  serverConfigurationId,
+}: {
+  mcpServerViewId: string;
+  serverConfigurationId: number;
+}): ServerSideMCPServerConfigurationType {
   return {
-    id: -1,
+    id: serverConfigurationId,
     sId: `action_${mcpServerViewId}`,
     type: "mcp_server_configuration",
     name: "server",
@@ -150,6 +164,7 @@ describe("buildBaseSpecifications", () => {
       [
         makeServerSideToolConfiguration("configured_tool", {
           mcpServerViewId: "view_configured",
+          serverConfigurationId: 100,
         }),
         makeServerSideToolConfiguration("jit_tool", {
           mcpServerViewId: "view_jit",
@@ -157,7 +172,12 @@ describe("buildBaseSpecifications", () => {
       ],
       {
         sId: "custom_agent",
-        actions: [makeAgentServerConfiguration("view_configured")],
+        actions: [
+          makeAgentServerConfiguration({
+            mcpServerViewId: "view_configured",
+            serverConfigurationId: 100,
+          }),
+        ],
       }
     );
 
@@ -169,16 +189,79 @@ describe("buildBaseSpecifications", () => {
     ).toBeUndefined();
   });
 
+  it("does not promote JIT tools that share a server view with configured actions", () => {
+    // Two configured actions can be instances of the same internal server and
+    // therefore share one server view (e.g. two query_tables actions), and the
+    // attachment-driven JIT query tables server reuses that same view. Only the
+    // configured tools, identified by their persisted configuration id, may be
+    // promoted; the JIT tool must stay deferred even though its view matches.
+    const specifications = buildBaseSpecifications(
+      [
+        makeServerSideToolConfiguration("glossary__execute_database_query", {
+          mcpServerViewId: "view_shared",
+          serverConfigurationId: 100,
+        }),
+        makeServerSideToolConfiguration(
+          "translations__execute_database_query",
+          {
+            mcpServerViewId: "view_shared",
+            serverConfigurationId: 101,
+          }
+        ),
+        makeServerSideToolConfiguration(
+          "query_conversation_tables__execute_database_query",
+          {
+            mcpServerViewId: "view_shared",
+          }
+        ),
+      ],
+      {
+        sId: "custom_agent",
+        actions: [
+          makeAgentServerConfiguration({
+            mcpServerViewId: "view_shared",
+            serverConfigurationId: 100,
+          }),
+          makeAgentServerConfiguration({
+            mcpServerViewId: "view_shared",
+            serverConfigurationId: 101,
+          }),
+        ],
+      }
+    );
+
+    expect(
+      specifications.find((s) => s.name === "glossary__execute_database_query")
+        ?.eager
+    ).toBe(true);
+    expect(
+      specifications.find(
+        (s) => s.name === "translations__execute_database_query"
+      )?.eager
+    ).toBe(true);
+    expect(
+      specifications.find(
+        (s) => s.name === "query_conversation_tables__execute_database_query"
+      )?.eager
+    ).toBeUndefined();
+  });
+
   it("does not promote configured tools of a global agent", () => {
     const specifications = buildBaseSpecifications(
       [
         makeServerSideToolConfiguration("configured_tool", {
           mcpServerViewId: "view_configured",
+          serverConfigurationId: 100,
         }),
       ],
       {
         sId: "dust",
-        actions: [makeAgentServerConfiguration("view_configured")],
+        actions: [
+          makeAgentServerConfiguration({
+            mcpServerViewId: "view_configured",
+            serverConfigurationId: 100,
+          }),
+        ],
       }
     );
 
@@ -202,10 +285,16 @@ describe("buildBaseSpecifications", () => {
   it("keeps skill tools deferred when a skill is enabled mid-conversation", () => {
     const agentConfiguration = {
       sId: "custom_agent",
-      actions: [makeAgentServerConfiguration("view_configured")],
+      actions: [
+        makeAgentServerConfiguration({
+          mcpServerViewId: "view_configured",
+          serverConfigurationId: 100,
+        }),
+      ],
     };
     const configuredTool = makeServerSideToolConfiguration("configured_tool", {
       mcpServerViewId: "view_configured",
+      serverConfigurationId: 100,
     });
 
     // Before the skill is enabled, its tools are not in the request at all.

--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -75,18 +75,18 @@ function makeServerSideToolConfiguration(
   name: string,
   {
     mcpServerViewId,
-    serverConfigurationId = -1,
+    serverConfigurationModelId = -1,
     eager,
   }: {
     mcpServerViewId: string;
     // Persisted id of the originating server configuration; -1 for
     // runtime-built servers (JIT, skills).
-    serverConfigurationId?: number;
+    serverConfigurationModelId?: number;
     eager?: boolean;
   }
 ): MCPToolConfigurationType {
   return {
-    id: serverConfigurationId,
+    id: serverConfigurationModelId,
     sId: `tool_${name}`,
     type: "mcp_configuration",
     name,
@@ -133,13 +133,13 @@ function makeClientSideToolConfiguration(
 
 function makeAgentServerConfiguration({
   mcpServerViewId,
-  serverConfigurationId,
+  serverConfigurationModelId,
 }: {
   mcpServerViewId: string;
-  serverConfigurationId: number;
+  serverConfigurationModelId: number;
 }): ServerSideMCPServerConfigurationType {
   return {
-    id: serverConfigurationId,
+    id: serverConfigurationModelId,
     sId: `action_${mcpServerViewId}`,
     type: "mcp_server_configuration",
     name: "server",
@@ -164,7 +164,7 @@ describe("buildBaseSpecifications", () => {
       [
         makeServerSideToolConfiguration("configured_tool", {
           mcpServerViewId: "view_configured",
-          serverConfigurationId: 100,
+          serverConfigurationModelId: 100,
         }),
         makeServerSideToolConfiguration("jit_tool", {
           mcpServerViewId: "view_jit",
@@ -175,7 +175,7 @@ describe("buildBaseSpecifications", () => {
         actions: [
           makeAgentServerConfiguration({
             mcpServerViewId: "view_configured",
-            serverConfigurationId: 100,
+            serverConfigurationModelId: 100,
           }),
         ],
       }
@@ -199,13 +199,13 @@ describe("buildBaseSpecifications", () => {
       [
         makeServerSideToolConfiguration("glossary__execute_database_query", {
           mcpServerViewId: "view_shared",
-          serverConfigurationId: 100,
+          serverConfigurationModelId: 100,
         }),
         makeServerSideToolConfiguration(
           "translations__execute_database_query",
           {
             mcpServerViewId: "view_shared",
-            serverConfigurationId: 101,
+            serverConfigurationModelId: 101,
           }
         ),
         makeServerSideToolConfiguration(
@@ -220,11 +220,11 @@ describe("buildBaseSpecifications", () => {
         actions: [
           makeAgentServerConfiguration({
             mcpServerViewId: "view_shared",
-            serverConfigurationId: 100,
+            serverConfigurationModelId: 100,
           }),
           makeAgentServerConfiguration({
             mcpServerViewId: "view_shared",
-            serverConfigurationId: 101,
+            serverConfigurationModelId: 101,
           }),
         ],
       }
@@ -251,7 +251,7 @@ describe("buildBaseSpecifications", () => {
       [
         makeServerSideToolConfiguration("configured_tool", {
           mcpServerViewId: "view_configured",
-          serverConfigurationId: 100,
+          serverConfigurationModelId: 100,
         }),
       ],
       {
@@ -259,7 +259,7 @@ describe("buildBaseSpecifications", () => {
         actions: [
           makeAgentServerConfiguration({
             mcpServerViewId: "view_configured",
-            serverConfigurationId: 100,
+            serverConfigurationModelId: 100,
           }),
         ],
       }
@@ -288,13 +288,13 @@ describe("buildBaseSpecifications", () => {
       actions: [
         makeAgentServerConfiguration({
           mcpServerViewId: "view_configured",
-          serverConfigurationId: 100,
+          serverConfigurationModelId: 100,
         }),
       ],
     };
     const configuredTool = makeServerSideToolConfiguration("configured_tool", {
       mcpServerViewId: "view_configured",
-      serverConfigurationId: 100,
+      serverConfigurationModelId: 100,
     });
 
     // Before the skill is enabled, its tools are not in the request at all.

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -223,10 +223,17 @@ export function buildBaseSpecifications(
   agentConfiguration: Pick<AgentConfigurationType, "sId" | "actions">
 ): AgentActionSpecification[] {
   const isCustomAgent = !isGlobalAgentId(agentConfiguration.sId);
-  const agentActionViewIds = new Set(
+  // Tools are matched to configured actions through the configuration's
+  // persisted id, not the server view id: several configurations of the same
+  // internal server share one view (e.g. two query_tables actions), and
+  // runtime-built JIT and skill servers reuse those views too with a synthetic
+  // id of -1. Matching on the view id would wrongly promote JIT tools that
+  // appear mid-conversation, rewriting the cached tool prefix.
+  const agentActionModelIds = new Set(
     agentConfiguration.actions
       .filter(isServerSideMCPServerConfiguration)
-      .map((action) => action.mcpServerViewId)
+      .map((action) => action.id)
+      .filter((id) => id !== -1)
   );
 
   return availableActions.map((action) => {
@@ -234,7 +241,7 @@ export function buildBaseSpecifications(
     if (
       isCustomAgent &&
       isServerSideMCPToolConfiguration(action) &&
-      agentActionViewIds.has(action.mcpServerViewId)
+      agentActionModelIds.has(action.id)
     ) {
       return { ...specification, eager: true };
     }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/28588.

The recent change that eagerly loads a custom agent's configured tools matched tools to their configured actions through the server view id. That key is not unique: several configurations of the same internal server share one view, and runtime-built conversation servers reuse those views too. In practice, an agent configured with table query tools saw the conversation-level table query tools, which appear as soon as a queryable file lands in the conversation, wrongly promoted to the eagerly loaded set mid-conversation, rewriting the cached tool prefix and defeating the purpose of the deferred catalog. The promotion now matches on the persisted id of the configuration, which runtime-built servers never carry, so only the tools the builder actually configured stay eager. A regression test covers the shared-view scenario observed in production.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
