### PR TITLE
feat: add governance admin only section and update copy

### DIFF
--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -53,7 +53,6 @@ export const GovernancePage = () => {
 
   const sections: {
     label: string;
-    description?: string;
     icon: ComponentType;
     governancePermissions: GovernancePermission[];
   }[] = [
@@ -69,7 +68,6 @@ export const GovernancePage = () => {
     },
     {
       label: "Frame sharing",
-      description: "Choose how members can share frames outside the workspace.",
       icon: ActionFrame,
       governancePermissions: governancePermissionsMap.frame ?? [],
     },
@@ -103,7 +101,7 @@ export const GovernancePage = () => {
     <Page>
       <Page.Header
         title="Governance"
-        description="Control what members can access, create, publish and share."
+        description="Manage what members can do in your workspace."
         icon={Toggle01Left}
       />
       <div className="flex w-full flex-col gap-8">
@@ -111,7 +109,6 @@ export const GovernancePage = () => {
           <GovernanceSettingSection
             key={section.label}
             label={section.label}
-            description={section.description}
             icon={section.icon}
             governancePermissions={section.governancePermissions}
             groups={groups}

--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -1,17 +1,26 @@
 import { GovernanceSettingSection } from "@app/components/pages/workspace/governance/GovernanceSettingSection";
-import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { useGovernancePermissions } from "@app/lib/swr/governance";
 import { useGroups } from "@app/lib/swr/groups";
-import type { GovernancePermission } from "@app/types/group_permissions";
+import type {
+  GovernancePermission,
+  GroupPermissionResourceType,
+} from "@app/types/group_permissions";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   ActionFrame,
+  Lock01,
   Page,
   PuzzlePiece01,
   Robot,
   Toggle01Left,
 } from "@dust-tt/sparkle";
 import groupBy from "lodash/groupBy";
+import type { ComponentType } from "react";
 
 function useUpdateGovernancePermission(owner: LightWorkspaceType) {
   return (input: GovernancePermission) => {
@@ -24,6 +33,7 @@ export const GovernancePage = () => {
   const hasAdminGovernanceFeature = hasFeature("admin_governance");
 
   const owner = useWorkspace();
+  const { isAdmin } = useAuth();
   const { groups, isGroupsLoading } = useGroups({
     owner,
     kinds: ["provisioned"],
@@ -34,12 +44,19 @@ export const GovernancePage = () => {
 
   const isLoading = isGroupsLoading || isGovernancePermissionsLoading;
 
-  const governancePermissionsMap = groupBy(
-    governancePermissions,
-    "resourceType"
-  );
+  const governancePermissionsMap: Partial<
+    Record<GroupPermissionResourceType, GovernancePermission[]>
+  > = groupBy(governancePermissions, "resourceType");
 
-  const sections = [
+  const billingPermissions = governancePermissionsMap.billing ?? [];
+  const identityPermissions = governancePermissionsMap.identity ?? [];
+
+  const sections: {
+    label: string;
+    description?: string;
+    icon: ComponentType;
+    governancePermissions: GovernancePermission[];
+  }[] = [
     {
       label: "Agents",
       icon: Robot,
@@ -51,10 +68,23 @@ export const GovernancePage = () => {
       governancePermissions: governancePermissionsMap.skill ?? [],
     },
     {
-      label: "Frames",
+      label: "Frame sharing",
+      description: "Choose how members can share frames outside the workspace.",
       icon: ActionFrame,
       governancePermissions: governancePermissionsMap.frame ?? [],
     },
+    ...(isAdmin
+      ? [
+          {
+            label: "Billing and security",
+            icon: Lock01,
+            governancePermissions: [
+              ...billingPermissions,
+              ...identityPermissions,
+            ],
+          },
+        ]
+      : []),
   ];
 
   if (!hasAdminGovernanceFeature) {
@@ -73,7 +103,7 @@ export const GovernancePage = () => {
     <Page>
       <Page.Header
         title="Governance"
-        description="Control what members can create and publish. Use groups to grant exceptions."
+        description="Control what members can access, create, publish and share."
         icon={Toggle01Left}
       />
       <div className="flex w-full flex-col gap-8">
@@ -81,6 +111,7 @@ export const GovernancePage = () => {
           <GovernanceSettingSection
             key={section.label}
             label={section.label}
+            description={section.description}
             icon={section.icon}
             governancePermissions={section.governancePermissions}
             groups={groups}

--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -1,4 +1,7 @@
 import { GovernanceSettingSection } from "@app/components/pages/workspace/governance/GovernanceSettingSection";
+import { AuditLogsToggle } from "@app/components/workspace/settings/AuditLogsToggle";
+import { InteractiveContentSharing } from "@app/components/workspace/settings/InteractiveContentSharingToggle";
+import { useFrameSharingToggle } from "@app/hooks/useFrameSharingToggle";
 import {
   useAuth,
   useFeatureFlags,
@@ -9,14 +12,20 @@ import { useGroups } from "@app/lib/swr/groups";
 import type {
   GovernancePermission,
   GroupPermissionResourceType,
+  PermissionType,
 } from "@app/types/group_permissions";
-import type { LightWorkspaceType } from "@app/types/user";
+import type {
+  LightWorkspaceType,
+  WorkspaceSharingPolicy,
+} from "@app/types/user";
 import {
   ActionFrame,
+  Icon,
   Lock01,
   Page,
   PuzzlePiece01,
   Robot,
+  ShapesPlus,
   Toggle01Left,
 } from "@dust-tt/sparkle";
 import groupBy from "lodash/groupBy";
@@ -26,6 +35,26 @@ function useUpdateGovernancePermission(owner: LightWorkspaceType) {
   return (input: GovernancePermission) => {
     return true;
   };
+}
+
+// Frame governance permissions are only relevant when the workspace sharing policy actually
+// enables the underlying capability: email invites require external email sharing, and public
+// links require unrestricted sharing.
+function isFrameCapabilityEnabled(
+  permissionType: PermissionType,
+  sharingPolicy: WorkspaceSharingPolicy
+): boolean {
+  switch (permissionType) {
+    case "invite":
+      return (
+        sharingPolicy === "workspace_and_emails" ||
+        sharingPolicy === "all_scopes"
+      );
+    case "publish":
+      return sharingPolicy === "all_scopes";
+    default:
+      return true;
+  }
 }
 
 export const GovernancePage = () => {
@@ -42,6 +71,9 @@ export const GovernancePage = () => {
     useGovernancePermissions(owner);
   const onPermissionChange = useUpdateGovernancePermission(owner);
 
+  const { sharingPolicy, doUpdateSharingPolicy, isChanging } =
+    useFrameSharingToggle({ owner });
+
   const isLoading = isGroupsLoading || isGovernancePermissionsLoading;
 
   const governancePermissionsMap: Partial<
@@ -50,6 +82,11 @@ export const GovernancePage = () => {
 
   const billingPermissions = governancePermissionsMap.billing ?? [];
   const identityPermissions = governancePermissionsMap.identity ?? [];
+
+  const framePermissions = (governancePermissionsMap.frame ?? []).filter(
+    (permission) =>
+      isFrameCapabilityEnabled(permission.permissionType, sharingPolicy)
+  );
 
   const sections: {
     label: string;
@@ -66,11 +103,15 @@ export const GovernancePage = () => {
       icon: PuzzlePiece01,
       governancePermissions: governancePermissionsMap.skill ?? [],
     },
-    {
-      label: "Frame sharing",
-      icon: ActionFrame,
-      governancePermissions: governancePermissionsMap.frame ?? [],
-    },
+    ...(framePermissions.length > 0
+      ? [
+          {
+            label: "Frame sharing",
+            icon: ActionFrame,
+            governancePermissions: framePermissions,
+          },
+        ]
+      : []),
     ...(isAdmin
       ? [
           {
@@ -115,6 +156,22 @@ export const GovernancePage = () => {
             onPermissionChange={onPermissionChange}
           />
         ))}
+        {isAdmin && (
+          <>
+            <div className="flex items-center gap-2">
+              <Icon visual={ShapesPlus} className="text-muted-foreground" />
+              <Page.H variant="h5">Capabilities</Page.H>
+            </div>
+            <div className="w-full rounded-xl border border-border">
+              <InteractiveContentSharing
+                sharingPolicy={sharingPolicy}
+                doUpdateSharingPolicy={doUpdateSharingPolicy}
+                isChanging={isChanging}
+              />
+              <AuditLogsToggle owner={owner} />
+            </div>
+          </>
+        )}
       </div>
     </Page>
   );

--- a/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
@@ -4,6 +4,7 @@ import {
   type GovernancePermissionConfiguration,
   type GroupPermissionResourceType,
   isValidPermissionConfigurationScope,
+  type PermissionConfigurationScope,
   type PermissionType,
 } from "@app/types/group_permissions";
 import type { GroupType } from "@app/types/groups";
@@ -66,6 +67,15 @@ const GOVERNANCE_SETTING_METADATA: Partial<
     isGroupsOnly: true,
   },
 };
+
+const PERMISSION_SCOPE_OPTIONS: {
+  value: PermissionConfigurationScope;
+  label: string;
+}[] = [
+  { value: "everyone", label: "Everyone" },
+  { value: "groups", label: "Groups" },
+  { value: "admins_only", label: "Admins only" },
+];
 
 function getGovernancePermissionMetadata(
   permissions: GovernancePermission
@@ -161,9 +171,9 @@ export const GovernanceSettingRow = ({
             defaultValue={configuration.scope}
             onValueChange={(value) => handlePermissionChange({ scope: value })}
           >
-            <ButtonsSwitch value="everyone" label="Everyone" />
-            <ButtonsSwitch value="groups" label="Groups" />
-            <ButtonsSwitch value="disabled" label="Disabled" />
+            {PERMISSION_SCOPE_OPTIONS.map(({ value, label }) => (
+              <ButtonsSwitch key={value} value={value} label={label} />
+            ))}
           </ButtonsSwitchList>
         )}
       </div>

--- a/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
@@ -12,7 +12,6 @@ import {
   ButtonsSwitch,
   ButtonsSwitchList,
   ContentMessage,
-  cn,
   Page,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -96,14 +95,12 @@ interface GovernanceSettingRowProps {
   governancePermission: GovernancePermission;
   groups: GroupType[];
   onChange: (permission: GovernancePermissionConfiguration) => void;
-  className?: string;
 }
 
 export const GovernanceSettingRow = ({
   governancePermission,
   groups,
   onChange,
-  className,
 }: GovernanceSettingRowProps) => {
   const [configuration, setConfiguration] =
     useState<GovernancePermissionConfiguration>(
@@ -157,7 +154,7 @@ export const GovernanceSettingRow = ({
   }
 
   return (
-    <div className={cn("w-full flex flex-col gap-3 p-4", className)}>
+    <div className="w-full flex flex-col gap-3 p-4">
       <div className="flex w-full items-center gap-4 justify-between">
         <Page.Vertical gap="xs" sizing="grow">
           <Page.H variant="h6">{metadata.label}</Page.H>

--- a/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
@@ -11,42 +11,65 @@ import {
   ButtonsSwitch,
   ButtonsSwitchList,
   ContentMessage,
+  cn,
   Page,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+type GovernanceSettingMetadata = {
+  label: string;
+  description: string;
+  isGroupsOnly?: boolean;
+};
+
 const GOVERNANCE_SETTING_METADATA: Partial<
   Record<
     `${PermissionType}:${GroupPermissionResourceType}`,
-    { label: string; description: string }
+    GovernanceSettingMetadata
   >
 > = {
   "create:agent": {
-    label: "Members can create agents",
-    description: "Build new agents in the Agent Builder",
+    label: "Create agents",
+    description: "Choose who can build agents in the Agent Builder.",
   },
   "publish:agent": {
-    label: "Members can publish agents",
-    description: "Publish agents in the Agent Builder",
+    label: "Publish agents",
+    description: "Choose who can publish agents to the whole workspace.",
   },
   "create:skill": {
-    label: "Members can create skills",
-    description: "Build custom Skills",
+    label: "Create skills",
+    description: "Choose who can build custom skills.",
   },
   "publish:skill": {
-    label: "Members can publish skills",
-    description: "Publish Skills workspace-wide for all members to use",
+    label: "Publish skills",
+    description: "Choose who can publish Skills to the whole workspace.",
   },
   "invite:frame": {
-    label: "Members + email invites",
+    label: "Invite people by email",
     description:
-      "Frames can be shared with workspace members or via email invite",
+      "Choose who can share frames by email with people outside your organization.",
+  },
+  "publish:frame": {
+    label: "Share by public link",
+    description: "Choose who can create public links to frames.",
+  },
+  "admin:billing": {
+    label: "Billing access",
+    description:
+      "Choose who can manage billing settings, invoices, and payment methods.",
+    isGroupsOnly: true,
+  },
+  "admin:identity": {
+    label: "Security access",
+    description:
+      "Choose who can manage user access, identities, and provisioning.",
+    isGroupsOnly: true,
   },
 };
 
 function getGovernancePermissionMetadata(
   permissions: GovernancePermission
-): { label: string; description: string } | null {
+): GovernanceSettingMetadata | null {
   const metadata =
     GOVERNANCE_SETTING_METADATA[
       `${permissions.permissionType}:${permissions.resourceType}`
@@ -63,12 +86,14 @@ interface GovernanceSettingRowProps {
   governancePermission: GovernancePermission;
   groups: GroupType[];
   onChange: (permission: GovernancePermissionConfiguration) => void;
+  className?: string;
 }
 
 export const GovernanceSettingRow = ({
   governancePermission,
   groups,
   onChange,
+  className,
 }: GovernanceSettingRowProps) => {
   const [configuration, setConfiguration] =
     useState<GovernancePermissionConfiguration>(
@@ -122,7 +147,7 @@ export const GovernanceSettingRow = ({
   }
 
   return (
-    <div className="w-full flex flex-col gap-3 p-4">
+    <div className={cn("w-full flex flex-col gap-3 p-4", className)}>
       <div className="flex w-full items-center gap-4 justify-between">
         <Page.Vertical gap="xs" sizing="grow">
           <Page.H variant="h6">{metadata.label}</Page.H>
@@ -130,17 +155,19 @@ export const GovernanceSettingRow = ({
             {metadata.description}
           </Page.P>
         </Page.Vertical>
-        <ButtonsSwitchList
-          size="xs"
-          defaultValue={configuration.scope}
-          onValueChange={(value) => handlePermissionChange({ scope: value })}
-        >
-          <ButtonsSwitch value="everyone" label="Everyone" />
-          <ButtonsSwitch value="groups" label="Groups" />
-          <ButtonsSwitch value="disabled" label="Disabled" />
-        </ButtonsSwitchList>
+        {!metadata.isGroupsOnly && (
+          <ButtonsSwitchList
+            size="xs"
+            defaultValue={configuration.scope}
+            onValueChange={(value) => handlePermissionChange({ scope: value })}
+          >
+            <ButtonsSwitch value="everyone" label="Everyone" />
+            <ButtonsSwitch value="groups" label="Groups" />
+            <ButtonsSwitch value="disabled" label="Disabled" />
+          </ButtonsSwitchList>
+        )}
       </div>
-      {configuration.scope === "groups" && (
+      {(metadata.isGroupsOnly || configuration.scope === "groups") && (
         <GroupSelector
           selectedGroups={selectedGroups}
           selectableGroups={selectableGroups}

--- a/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
@@ -30,39 +30,39 @@ const GOVERNANCE_SETTING_METADATA: Partial<
 > = {
   "create:agent": {
     label: "Create agents",
-    description: "Choose who can build agents in the Agent Builder.",
+    description: "Controls who can build agents in the Agent Builder.",
   },
   "publish:agent": {
     label: "Publish agents",
-    description: "Choose who can publish agents to the whole workspace.",
+    description: "Controls who can publish agents to the whole workspace.",
   },
   "create:skill": {
     label: "Create skills",
-    description: "Choose who can build custom skills.",
+    description: "Controls who can build custom skills.",
   },
   "publish:skill": {
     label: "Publish skills",
-    description: "Choose who can publish Skills to the whole workspace.",
+    description: "Controls who can publish skills to the whole workspace.",
   },
   "invite:frame": {
     label: "Invite people by email",
     description:
-      "Choose who can share frames by email with people outside your organization.",
+      "Controls who can share frames by email with people outside your organization.",
   },
   "publish:frame": {
     label: "Share by public link",
-    description: "Choose who can create public links to frames.",
+    description: "Controls who can create public links to frames.",
   },
   "admin:billing": {
     label: "Billing access",
     description:
-      "Choose who can manage billing settings, invoices, and payment methods.",
+      "Controls who can manage billing settings, invoices, and payment methods.",
     isGroupsOnly: true,
   },
   "admin:identity": {
     label: "Security access",
     description:
-      "Choose who can manage user access, identities, and provisioning.",
+      "Controls who can manage user access, identities, and provisioning.",
     isGroupsOnly: true,
   },
 };

--- a/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
@@ -6,7 +6,6 @@ import type { ComponentType } from "react";
 
 interface GovernanceSettingSectionProps {
   label: string;
-  description?: string;
   icon: ComponentType;
   governancePermissions: GovernancePermission[];
   groups: GroupType[];
@@ -15,7 +14,6 @@ interface GovernanceSettingSectionProps {
 
 export const GovernanceSettingSection = ({
   label,
-  description,
   icon,
   governancePermissions,
   groups,
@@ -28,11 +26,6 @@ export const GovernanceSettingSection = ({
           <Icon visual={icon} className="text-muted-foreground" />
           <Page.H variant="h5">{label}</Page.H>
         </div>
-        {!!description && (
-          <Page.P variant="secondary" size="sm">
-            {description}
-          </Page.P>
-        )}
       </div>
       <div className="w-full rounded-xl border border-border">
         {governancePermissions.map((governancePermission, idx) => (

--- a/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
@@ -6,6 +6,7 @@ import type { ComponentType } from "react";
 
 interface GovernanceSettingSectionProps {
   label: string;
+  description?: string;
   icon: ComponentType;
   governancePermissions: GovernancePermission[];
   groups: GroupType[];
@@ -14,6 +15,7 @@ interface GovernanceSettingSectionProps {
 
 export const GovernanceSettingSection = ({
   label,
+  description,
   icon,
   governancePermissions,
   groups,
@@ -21,18 +23,26 @@ export const GovernanceSettingSection = ({
 }: GovernanceSettingSectionProps) => {
   return (
     <div className="flex w-full flex-col gap-4">
-      <div className="flex items-center gap-2">
-        <Icon visual={icon} className="text-muted-foreground" />
-        <Page.H variant="h5">{label}</Page.H>
+      <div className="flex flex-col">
+        <div className="flex items-center gap-2">
+          <Icon visual={icon} className="text-muted-foreground" />
+          <Page.H variant="h5">{label}</Page.H>
+        </div>
+        {!!description && (
+          <Page.P variant="secondary" size="sm">
+            {description}
+          </Page.P>
+        )}
       </div>
       <div className="w-full rounded-xl border border-border">
-        {governancePermissions.map((governancePermission) => (
+        {governancePermissions.map((governancePermission, idx) => (
           <GovernanceSettingRow
             key={
               governancePermission.permissionType +
               ":" +
               governancePermission.resourceType
             }
+            className={idx < governancePermissions.length - 1 ? "border-b" : ""}
             governancePermission={governancePermission}
             groups={groups}
             onChange={(newConfiguration) =>

--- a/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
@@ -27,15 +27,14 @@ export const GovernanceSettingSection = ({
           <Page.H variant="h5">{label}</Page.H>
         </div>
       </div>
-      <div className="w-full rounded-xl border border-border">
-        {governancePermissions.map((governancePermission, idx) => (
+      <div className="w-full rounded-xl border border-border divide-y divide-border">
+        {governancePermissions.map((governancePermission) => (
           <GovernanceSettingRow
             key={
               governancePermission.permissionType +
               ":" +
               governancePermission.resourceType
             }
-            className={idx < governancePermissions.length - 1 ? "border-b" : ""}
             governancePermission={governancePermission}
             groups={groups}
             onChange={(newConfiguration) =>

--- a/front/components/workspace/settings/AuditLogsToggle.tsx
+++ b/front/components/workspace/settings/AuditLogsToggle.tsx
@@ -1,15 +1,44 @@
 import { useAuditLogsToggle } from "@app/hooks/useAuditLogsToggle";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
-import { ContextItem, File04, SliderToggle } from "@dust-tt/sparkle";
+import { ContextItem, File04, Page, SliderToggle } from "@dust-tt/sparkle";
 
 interface AuditLogsToggleProps {
   owner: WorkspaceType;
 }
 
 export function AuditLogsToggle({ owner }: AuditLogsToggleProps) {
+  const { subscription } = useAuth();
   const { isEnabled, isChanging, doToggleAuditLogs } = useAuditLogsToggle({
     owner,
   });
+  const { hasFeature } = useFeatureFlags();
+
+  const hasAuditLogsAccess =
+    subscription.plan.isAuditLogsAllowed || hasFeature("audit_logs");
+
+  if (!hasAuditLogsAccess) {
+    return null;
+  }
+
+  if (hasFeature("admin_governance")) {
+    return (
+      <div className="flex w-full items-center gap-4 p-4 justify-between">
+        <Page.Vertical gap="xs" sizing="grow">
+          <Page.H variant="h6">Audit logs</Page.H>
+          <Page.P variant="secondary" size="sm">
+            Emit audit events to WorkOS and expose the audit logs section in IT
+            & Security.
+          </Page.P>
+        </Page.Vertical>
+        <SliderToggle
+          selected={isEnabled}
+          disabled={isChanging}
+          onClick={doToggleAuditLogs}
+        />
+      </div>
+    );
+  }
 
   return (
     <ContextItem

--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -24,15 +24,16 @@ export function CapabilitiesSection({
 }: CapabilitiesSectionProps) {
   const { subscription } = useAuth();
   const { hasFeature } = useFeatureFlags();
-  const hasAuditLogsAccess =
-    subscription.plan.isAuditLogsAllowed || hasFeature("audit_logs");
+  const isAdminGovernanceEnabled = hasFeature("admin_governance");
 
   return (
     <Page.Vertical align="stretch" gap="md">
       <Page.H variant="h4">Capabilities</Page.H>
       <ContextItem.List>
         <div className="h-full border-b border-border" />
-        <InteractiveContentSharingToggle owner={owner} />
+        {!isAdminGovernanceEnabled && (
+          <InteractiveContentSharingToggle owner={owner} />
+        )}
         {!subscription.plan.isByok && (
           <VoiceTranscriptionToggle owner={owner} />
         )}
@@ -43,7 +44,7 @@ export function CapabilitiesSection({
         <SlackPersonalFooterRemovalToggle owner={owner} />
         <WorkspaceAnalyticsToggle owner={owner} />
         <DustMcpServerSettingsItem owner={owner} />
-        {hasAuditLogsAccess && <AuditLogsToggle owner={owner} />}
+        {!isAdminGovernanceEnabled && <AuditLogsToggle owner={owner} />}
         {publishingRestrictionMessage && (
           <RestrictAgentsPublishingCapability
             subElement={publishingRestrictionMessage}

--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -1,4 +1,5 @@
 import { useFrameSharingToggle } from "@app/hooks/useFrameSharingToggle";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceSharingPolicy, WorkspaceType } from "@app/types/user";
 import {
   ActionFrame,
@@ -17,6 +18,7 @@ import {
   DropdownMenuTrigger,
   Globe01,
   Lock01,
+  Page,
   Users01,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -56,8 +58,30 @@ interface InteractiveContentSharingToggleProps {
 export function InteractiveContentSharingToggle({
   owner,
 }: InteractiveContentSharingToggleProps) {
-  const { isChanging, sharingPolicy, doUpdateSharingPolicy } =
+  const { sharingPolicy, doUpdateSharingPolicy, isChanging } =
     useFrameSharingToggle({ owner });
+
+  return (
+    <InteractiveContentSharing
+      sharingPolicy={sharingPolicy}
+      doUpdateSharingPolicy={doUpdateSharingPolicy}
+      isChanging={isChanging}
+    />
+  );
+}
+
+interface InteractiveContentSharingProps {
+  isChanging: boolean;
+  sharingPolicy: WorkspaceSharingPolicy;
+  doUpdateSharingPolicy: (policy: WorkspaceSharingPolicy) => Promise<void>;
+}
+
+export function InteractiveContentSharing({
+  isChanging,
+  sharingPolicy,
+  doUpdateSharingPolicy,
+}: InteractiveContentSharingProps) {
+  const { hasFeature } = useFeatureFlags();
   const [pendingPolicy, setPendingPolicy] =
     useState<WorkspaceSharingPolicy | null>(null);
 
@@ -84,41 +108,38 @@ export function InteractiveContentSharingToggle({
 
   return (
     <>
-      <ContextItem
-        title="Frame sharing policy"
-        subElement="Control how Frames can be shared in this workspace"
-        visual={<ActionFrame className="h-6 w-6" />}
-        hasSeparatorIfLast={true}
-        action={
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                isSelect
-                label={selectedOption?.label}
-                icon={selectedOption?.icon}
-                disabled={isChanging}
-                className="grid grid-cols-[auto_1fr_auto] truncate"
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="max-w-[400px]" align="end">
-              <DropdownMenuRadioGroup value={sharingPolicy}>
-                {SHARING_POLICY_OPTIONS.map((option) => (
-                  <DropdownMenuRadioItem
-                    key={option.value}
-                    value={option.value}
-                    label={option.label}
-                    description={option.description}
-                    icon={option.icon}
-                    onClick={() => handlePolicyChange(option.value)}
-                  />
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        }
-      />
+      {hasFeature("admin_governance") ? (
+        <div className="flex w-full items-center gap-4 p-4 justify-between">
+          <Page.Vertical gap="xs" sizing="grow">
+            <Page.H variant="h6">Frame sharing policy</Page.H>
+            <Page.P variant="secondary" size="sm">
+              Control how frames can be shared in this workspace
+            </Page.P>
+          </Page.Vertical>
+          <InteractiveContentSharingDropdown
+            selectedOption={selectedOption}
+            onPolicyChange={handlePolicyChange}
+            isChanging={isChanging}
+            sharingPolicy={sharingPolicy}
+          />
+        </div>
+      ) : (
+        <ContextItem
+          title="Frame sharing policy"
+          subElement="Control how Frames can be shared in this workspace"
+          visual={<ActionFrame className="h-6 w-6" />}
+          hasSeparatorIfLast={true}
+          action={
+            <InteractiveContentSharingDropdown
+              selectedOption={selectedOption}
+              onPolicyChange={handlePolicyChange}
+              isChanging={isChanging}
+              sharingPolicy={sharingPolicy}
+            />
+          }
+        />
+      )}
+
       <Dialog
         open={!!pendingPolicy}
         onOpenChange={(open) => {
@@ -176,3 +197,50 @@ export function InteractiveContentSharingToggle({
     </>
   );
 }
+
+interface InteractiveContentSharingDropdownProps {
+  selectedOption?: {
+    icon: typeof Lock01;
+    label: string;
+  };
+  isChanging: boolean;
+  sharingPolicy: WorkspaceSharingPolicy;
+  onPolicyChange: (newPolicy: WorkspaceSharingPolicy) => void;
+}
+
+const InteractiveContentSharingDropdown = ({
+  selectedOption,
+  isChanging,
+  sharingPolicy,
+  onPolicyChange,
+}: InteractiveContentSharingDropdownProps) => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          isSelect
+          label={selectedOption?.label}
+          icon={selectedOption?.icon}
+          disabled={isChanging}
+          className="grid grid-cols-[auto_1fr_auto] truncate"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="max-w-100" align="end">
+        <DropdownMenuRadioGroup value={sharingPolicy}>
+          {SHARING_POLICY_OPTIONS.map((option) => (
+            <DropdownMenuRadioItem
+              key={option.value}
+              value={option.value}
+              label={option.label}
+              description={option.description}
+              icon={option.icon}
+              onClick={() => onPolicyChange(option.value)}
+            />
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/front/lib/swr/governance.ts
+++ b/front/lib/swr/governance.ts
@@ -25,22 +25,22 @@ const TEST_GOVERNANCE_PERMISSIONS: GovernancePermission[] = [
   {
     permissionType: "invite",
     resourceType: "frame",
-    configuration: { scope: "disabled" },
+    configuration: { scope: "admins_only" },
   },
   {
     permissionType: "publish",
     resourceType: "frame",
-    configuration: { scope: "disabled" },
+    configuration: { scope: "admins_only" },
   },
   {
     permissionType: "admin",
     resourceType: "billing",
-    configuration: { scope: "disabled" },
+    configuration: { scope: "admins_only" },
   },
   {
     permissionType: "admin",
     resourceType: "identity",
-    configuration: { scope: "disabled" },
+    configuration: { scope: "admins_only" },
   },
 ];
 

--- a/front/lib/swr/governance.ts
+++ b/front/lib/swr/governance.ts
@@ -27,6 +27,21 @@ const TEST_GOVERNANCE_PERMISSIONS: GovernancePermission[] = [
     resourceType: "frame",
     configuration: { scope: "disabled" },
   },
+  {
+    permissionType: "publish",
+    resourceType: "frame",
+    configuration: { scope: "disabled" },
+  },
+  {
+    permissionType: "admin",
+    resourceType: "billing",
+    configuration: { scope: "disabled" },
+  },
+  {
+    permissionType: "admin",
+    resourceType: "identity",
+    configuration: { scope: "disabled" },
+  },
 ];
 
 export function useGovernancePermissions(owner: LightWorkspaceType): {

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -55,10 +55,10 @@ export function isGroupPermissionResourceType(
 const PERMISSION_CONFIGURATION_SCOPES = [
   "everyone",
   "groups",
-  "disabled",
+  "admins_only",
 ] as const;
 
-type PermissionConfigurationScope =
+export type PermissionConfigurationScope =
   (typeof PERMISSION_CONFIGURATION_SCOPES)[number];
 
 export const isValidPermissionConfigurationScope = (


### PR DESCRIPTION
## Description

This PR adds an admin-only "Billing and security" section and an admin-only "Capabilities" section to the governance page and updates copy for all governance permission labels and descriptions.


https://github.com/user-attachments/assets/72d6e090-0a41-4cf2-a2a9-373ca4086769



## Tests

Manually.

## Risks
Low.

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan
Standard deployment.

<!-- Outline the deployment steps. -->
