### PR TITLE
Restore auto-advance invoice

### DIFF
--- a/front/lib/plans/stripe.test.ts
+++ b/front/lib/plans/stripe.test.ts
@@ -532,7 +532,9 @@ describe("finalizeInvoice", () => {
     if (result.isOk()) {
       expect(result.value.status).toBe("open");
     }
-    expect(mockInvoices.finalizeInvoice).toHaveBeenCalledWith("in_123");
+    expect(mockInvoices.finalizeInvoice).toHaveBeenCalledWith("in_123", {
+      auto_advance: true,
+    });
   });
 
   it("should return Err on Stripe failure", async () => {
@@ -946,7 +948,9 @@ describe("cleanAndFinalizeMetronomeDraftInvoice", () => {
       unit_amount: 1965,
     });
     expect(mockInvoiceItems.del).not.toHaveBeenCalled();
-    expect(mockInvoices.finalizeInvoice).toHaveBeenCalledWith("in_test");
+    expect(mockInvoices.finalizeInvoice).toHaveBeenCalledWith("in_test", {
+      auto_advance: true,
+    });
   });
 
   it("should keep a quantity > 1 when the total divides evenly by it", async () => {
@@ -1050,7 +1054,9 @@ describe("cleanAndFinalizeMetronomeDraftInvoice", () => {
 
     expect(result.isOk()).toBe(true);
     expect(mockInvoiceItems.update).not.toHaveBeenCalled();
-    expect(mockInvoices.finalizeInvoice).toHaveBeenCalledWith("in_test");
+    expect(mockInvoices.finalizeInvoice).toHaveBeenCalledWith("in_test", {
+      auto_advance: true,
+    });
   });
 
   it("should delete negative lines without normalizing them", async () => {

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1636,7 +1636,12 @@ export async function finalizeInvoice(
   const stripe = getStripeClient();
 
   try {
-    const finalizedInvoice = await stripe.invoices.finalizeInvoice(invoice.id);
+    // Explicitly re-enable auto_advance so Stripe proceeds with its
+    // post-finalization workflow (auto-charge or auto-send), in case the
+    // invoice had it disabled (e.g. frozen while editing a Metronome draft).
+    const finalizedInvoice = await stripe.invoices.finalizeInvoice(invoice.id, {
+      auto_advance: true,
+    });
     return new Ok(finalizedInvoice);
   } catch (error) {
     logger.error(


### PR DESCRIPTION
## Description

Restore auto_advance in stripe so that invoices are correctly sent by email after being finalized


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front
