### PR TITLE
fix: surface an agent error for unroutable models instead of hanging

### DIFF
--- a/front/lib/api/assistant/configuration/create_or_upgrade.ts
+++ b/front/lib/api/assistant/configuration/create_or_upgrade.ts
@@ -149,18 +149,25 @@ export async function createOrUpgradeAgentConfiguration({
 
   const featureFlags = await getFeatureFlags(auth);
   const modelConfig = getSupportedModelConfig(assistant.model);
-  if (modelConfig) {
-    const accessError = await getAdvancedModelAccessErrorForAgentConfiguration(
-      auth,
-      {
-        agentName: assistant.name,
-        model: modelConfig,
-        featureFlags,
-      }
+  if (!modelConfig) {
+    return new Err(
+      new Error(
+        `Unsupported model "${assistant.model.modelId}" for provider ` +
+          `"${assistant.model.providerId}".`
+      )
     );
-    if (accessError) {
-      return new Err(new Error(accessError.message));
+  }
+
+  const accessError = await getAdvancedModelAccessErrorForAgentConfiguration(
+    auth,
+    {
+      agentName: assistant.name,
+      model: modelConfig,
+      featureFlags,
     }
+  );
+  if (accessError) {
+    return new Err(new Error(accessError.message));
   }
 
   const agentConfigurationRes = await createAgentConfiguration(auth, {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -796,7 +796,7 @@ export async function postUserMessage(
 
     const supportedModelConfig = getSupportedModelConfig(agentConfig.model);
     if (
-      supportedModelConfig &&
+      !supportedModelConfig ||
       !isModelAvailable(supportedModelConfig, {
         featureFlags,
         plan,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -711,15 +711,18 @@ export async function runModel(
       !output.toolCalls?.length && output.content ? output.content : undefined,
   });
 
-  // Should not happen
+  // The model is listed as supported but no client (legacy or new router) can
+  // serve it. Surface an agent error instead of returning silently, which would
+  // leave the message pending and the UI stuck on "Thinking…" indefinitely.
   if (llm === null) {
-    localLogger.error(
-      {
-        conversationId: conversation.sId,
-        workspaceId: conversation.owner.sId,
-      },
-      "LLM is null in runModel, cannot proceed."
-    );
+    await publishAgentError({
+      code: "model_not_available",
+      message:
+        `The model you selected (${agentConfiguration.model.modelId}) ` +
+        `is not available. Please edit the agent to use another model ` +
+        `(advanced settings in the Instructions panel).`,
+      metadata: null,
+    });
 
     return null;
   }

--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -121,7 +121,7 @@ export const GEMINI_2_5_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   description: "Google's fast large context model (1m context).",
   shortDescription: "Google's fast model.",
   isLegacy: false,
-  isLatest: true,
+  isLatest: false,
   generationTokensCount: 64_000,
   supportsVision: true,
   supportsResponseFormat: false, // response format not compatible with tool use


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9277

Setting an agent's model (via `PATCH /api/v1/w/{wId}/assistant/agent_configurations/{sId}`) to one that is listed in `SUPPORTED_MODEL_CONFIGS` but that no LLM client can actually serve returned HTTP 200, but starting a conversation hung forever on "Thinking…".

Root cause: `runModel` treated `llm === null` as "should not happen", logged, and `return null` **without** emitting a terminal `agent_error` / `agent_message_success` event. The FE then waited on pubsub indefinitely.

- `run_model.ts`: publish a `model_not_available` agent error when `llm` is null, so the message resolves and the UI shows an actionable error. This also rescues models already stuck in this state (e.g. Haiku 3, `sonnet-3.5-0620`).
- `create_or_upgrade.ts` / `conversation.ts`: reject an unknown `(modelId, providerId)` pair at save/post time with a clear error, so bad pairs never reach the runtime.
- `gemini-2.5-flash`: drop the incorrect `isLatest: true` flag, newer gemini 3s supersede it.

No model configs are removed: unroutable-but-listed models stay in `SUPPORTED_MODEL_CONFIGS` so existing conversations keep resolving their metadata.

## Tests

Manual: reproduced the hang by patching an agent onto an unroutable model. Typecheck + biome clean.

## Risk

Low.

## Deploy Plan

Standard front + agent-loop worker deploy.