### PR TITLE
Show checkout steps

### DIFF
--- a/front-api/routes/metronome/webhook.ts
+++ b/front-api/routes/metronome/webhook.ts
@@ -1,4 +1,5 @@
 import apiConfig from "@app/lib/api/config";
+import { markCheckoutPaymentActivating } from "@app/lib/credits/checkout_payment_status";
 import { unwrapMetronomeWebhook } from "@app/lib/metronome/client";
 import {
   getCustomerIdFromEvent,
@@ -109,6 +110,21 @@ app.post("/", async (ctx): HandlerResult<ResponseBody> => {
 
   if (!workspace) {
     return ctx.json({ success: true });
+  }
+
+  // Payment has cleared. The activation itself is deferred to the Temporal
+  // workflow below and can take several seconds (workflow scheduling + contract
+  // swap, seat sync, ...), during which the checkout polling UI would otherwise
+  // still show "processing payment". Advance it to "activating" here, at the
+  // earliest reliable point. No-op unless a checkout is pending on this contract.
+  if (
+    event.type === "payment_gate.payment_status" &&
+    event.properties.payment_status === "paid"
+  ) {
+    await markCheckoutPaymentActivating({
+      workspaceId: workspace.sId,
+      contractId: event.properties.contract_id,
+    });
   }
 
   // Hand the event off to a Temporal workflow for durable processing.

--- a/front-api/routes/metronome/webhook.ts
+++ b/front-api/routes/metronome/webhook.ts
@@ -1,5 +1,4 @@
 import apiConfig from "@app/lib/api/config";
-import { markCheckoutPaymentActivating } from "@app/lib/credits/checkout_payment_status";
 import { unwrapMetronomeWebhook } from "@app/lib/metronome/client";
 import {
   getCustomerIdFromEvent,
@@ -110,21 +109,6 @@ app.post("/", async (ctx): HandlerResult<ResponseBody> => {
 
   if (!workspace) {
     return ctx.json({ success: true });
-  }
-
-  // Payment has cleared. The activation itself is deferred to the Temporal
-  // workflow below and can take several seconds (workflow scheduling + contract
-  // swap, seat sync, ...), during which the checkout polling UI would otherwise
-  // still show "processing payment". Advance it to "activating" here, at the
-  // earliest reliable point. No-op unless a checkout is pending on this contract.
-  if (
-    event.type === "payment_gate.payment_status" &&
-    event.properties.payment_status === "paid"
-  ) {
-    await markCheckoutPaymentActivating({
-      workspaceId: workspace.sId,
-      contractId: event.properties.contract_id,
-    });
   }
 
   // Hand the event off to a Temporal workflow for durable processing.

--- a/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
@@ -34,8 +34,16 @@ app.get(
       });
     }
 
+    // The polling UI omits `receipt`; only the success screen requests the
+    // (slow) Stripe hosted invoice URL, so status polls stay fast.
+    const includeReceiptUrl = ctx.req.query("receipt") === "true";
+
     const workspace = auth.getNonNullableWorkspace();
-    return ctx.json(await getBusinessActivationStatus(workspace, contractId));
+    return ctx.json(
+      await getBusinessActivationStatus(workspace, contractId, {
+        includeReceiptUrl,
+      })
+    );
   }
 );
 

--- a/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
@@ -23,13 +23,23 @@ app.get(
   async (ctx): HandlerResult<GetBusinessActivationResponseBody> => {
     const auth = ctx.get("auth");
 
+    // The record can be looked up by contract id or by Stripe setup session id.
+    // The polling UI uses the session id so it can poll from the first step,
+    // before the contract id exists.
     const contractId = ctx.req.query("contract_id");
-    if (!contractId) {
+    const setupSessionId = ctx.req.query("setup_session_id");
+    const identifier = contractId
+      ? { contractId }
+      : setupSessionId
+        ? { setupSessionId }
+        : null;
+    if (!identifier) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: "Missing required query parameter: contract_id.",
+          message:
+            "Missing required query parameter: contract_id or setup_session_id.",
         },
       });
     }
@@ -40,7 +50,7 @@ app.get(
 
     const workspace = auth.getNonNullableWorkspace();
     return ctx.json(
-      await getBusinessActivationStatus(workspace, contractId, {
+      await getBusinessActivationStatus(workspace, identifier, {
         includeReceiptUrl,
       })
     );

--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -108,7 +108,8 @@ export function CheckoutPage() {
   const [phase, setPhase] = useState<CheckoutPhase>("card_capture");
   const [phaseError, setPhaseError] = useState<PhaseError | null>(null);
   const [setupSessionId, setSetupSessionId] = useState<string | null>(null);
-  // For the waiting_for_payment phase: contract id to poll.
+  // Contract id returned by the activation POST, used as a fallback key for the
+  // receipt fetch (polling itself is keyed by setup session id).
   const [pendingContractId, setPendingContractId] = useState<string | null>(
     null
   );
@@ -169,27 +170,33 @@ export function CheckoutPage() {
     }
   }, [livePreparePayment]);
 
-  // Poll checkout payment status while in waiting_for_payment phase. Status only
-  // (no receipt URL) so the poll stays fast and we transition on `succeeded`
-  // without waiting on the slow Stripe invoice-URL fetch.
+  // Poll the checkout status (by setup session id) from the confirming step
+  // onward, so the stepper advances live — including the coupon (zero-payment)
+  // flow, whose whole activation happens inside the confirming request. Status
+  // only (no receipt URL) so the poll stays fast and we transition on
+  // `succeeded` without waiting on the slow Stripe invoice-URL fetch.
+  const isActivating =
+    phase === "confirming" || phase === "waiting_for_payment";
   const { checkoutPayment } = useCheckBusinessActivation({
     workspaceId: owner.sId,
-    contractId: pendingContractId,
-    disabled: phase !== "waiting_for_payment",
-    pollIntervalMs: phase === "waiting_for_payment" ? 1500 : 0,
+    setupSessionId,
+    disabled: !isActivating,
+    pollIntervalMs: 1500,
   });
 
   // Lazily fetch the Stripe receipt URL once on the success screen, so the "View
   // receipt" button appears when ready without blocking the success transition.
   const { receiptUrl } = useCheckoutReceiptUrl({
     workspaceId: owner.sId,
-    contractId: pendingContractId,
+    contractId: checkoutPayment?.contractId ?? pendingContractId,
     disabled: phase !== "checkout_success",
   });
 
-  // React to Redis activation status.
+  // React to Redis activation status. Runs from the confirming step too: for a
+  // coupon checkout the record can reach `succeeded` before the confirming POST
+  // resolves (see handleConfirmPayment, which won't clobber this transition).
   useEffect(() => {
-    if (phase !== "waiting_for_payment" || !checkoutPayment) {
+    if (!isActivating || !checkoutPayment) {
       return;
     }
     if (checkoutPayment.status === "succeeded") {
@@ -200,7 +207,7 @@ export function CheckoutPage() {
       setPhase("error");
     }
     // pending: keep polling
-  }, [phase, checkoutPayment, mutateAuthContext]);
+  }, [isActivating, checkoutPayment, mutateAuthContext]);
 
   const {
     register: registerCoupon,
@@ -321,7 +328,10 @@ export function CheckoutPage() {
       return;
     }
     setPendingContractId(result.contractId);
-    setPhase("waiting_for_payment");
+    // Only advance to waiting_for_payment if the poll hasn't already moved us on
+    // (a coupon activation can reach succeeded/failed while this POST is still
+    // in flight). Overwriting would flicker success → waiting → success.
+    setPhase((prev) => (prev === "confirming" ? "waiting_for_payment" : prev));
   }, [setupSessionId, initiateBusinessActivation]);
 
   const handleCardCaptureComplete = useCallback(() => {
@@ -391,18 +401,20 @@ export function CheckoutPage() {
     ? CHECKOUT_STEPS_NO_PAYMENT
     : CHECKOUT_STEPS;
 
-  // Active step, driven by the phase and the polled checkout record's state:
-  // - confirming (POST provisioning the contract / writing the pending record
-  //   via setCheckoutPaymentPending): "Setting up your subscription" (step 0).
+  // Active step, driven by the polled checkout record's state (which we now poll
+  // from the confirming step onward):
+  // - record progress "activating" (markCheckoutPaymentActivating): the final
+  //   "Activating your workspace" step — checked first so it wins even while the
+  //   confirming POST is still in flight (the coupon flow activates in there).
+  // - confirming, record still pending (setCheckoutPaymentPending): "Setting up
+  //   your subscription" (step 0).
   // - waiting_for_payment, record still pending: "Processing payment" for a paid
   //   checkout; still "Setting up" for a zero-payment one (nothing to charge).
-  // - record progress "activating" (markCheckoutPaymentActivating): the final
-  //   "Activating your workspace" step, for both paths.
   const activeStepIndex =
-    phase === "confirming"
-      ? 0
-      : checkoutPayment?.progress === "activating"
-        ? checkoutSteps.length - 1
+    checkoutPayment?.progress === "activating"
+      ? checkoutSteps.length - 1
+      : phase === "confirming"
+        ? 0
         : isZeroPaymentCheckout
           ? 0
           : 1;

--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -391,20 +391,21 @@ export function CheckoutPage() {
     ? CHECKOUT_STEPS_NO_PAYMENT
     : CHECKOUT_STEPS;
 
-  // Progress step shown during the confirming / waiting_for_payment phases.
-  // - Paid checkout: waiting_for_payment starts on "Processing payment" (step 1)
-  //   and advances to "Activating your workspace" (step 2) once the payment
-  //   webhook reports activation has begun (surfaced through the polled record).
-  // - Zero-payment (coupon) checkout: activation runs inside the confirming
-  //   request, so we show the "Activating your workspace" step (the last of the
-  //   two-step list) throughout instead of a payment step that never happens.
-  const activeStepIndex = isZeroPaymentCheckout
-    ? checkoutSteps.length - 1
-    : phase === "confirming"
+  // Active step, driven by the phase and the polled checkout record's state:
+  // - confirming (POST provisioning the contract / writing the pending record
+  //   via setCheckoutPaymentPending): "Setting up your subscription" (step 0).
+  // - waiting_for_payment, record still pending: "Processing payment" for a paid
+  //   checkout; still "Setting up" for a zero-payment one (nothing to charge).
+  // - record progress "activating" (markCheckoutPaymentActivating): the final
+  //   "Activating your workspace" step, for both paths.
+  const activeStepIndex =
+    phase === "confirming"
       ? 0
       : checkoutPayment?.progress === "activating"
-        ? 2
-        : 1;
+        ? checkoutSteps.length - 1
+        : isZeroPaymentCheckout
+          ? 0
+          : 1;
 
   const showActualTax = preparePayment !== null;
 

--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -108,11 +108,6 @@ export function CheckoutPage() {
   const [phase, setPhase] = useState<CheckoutPhase>("card_capture");
   const [phaseError, setPhaseError] = useState<PhaseError | null>(null);
   const [setupSessionId, setSetupSessionId] = useState<string | null>(null);
-  // Contract id returned by the activation POST, used as a fallback key for the
-  // receipt fetch (polling itself is keyed by setup session id).
-  const [pendingContractId, setPendingContractId] = useState<string | null>(
-    null
-  );
   // Prevents initSession from firing before URL params have been read on mount.
   const [isInitialized, setIsInitialized] = useState(false);
 
@@ -188,7 +183,7 @@ export function CheckoutPage() {
   // receipt" button appears when ready without blocking the success transition.
   const { receiptUrl } = useCheckoutReceiptUrl({
     workspaceId: owner.sId,
-    contractId: checkoutPayment?.contractId ?? pendingContractId,
+    setupSessionId,
     disabled: phase !== "checkout_success",
   });
 
@@ -327,7 +322,6 @@ export function CheckoutPage() {
       setPhase("error");
       return;
     }
-    setPendingContractId(result.contractId);
     // Only advance to waiting_for_payment if the poll hasn't already moved us on
     // (a coupon activation can reach succeeded/failed while this POST is still
     // in flight). Overwriting would flicker success → waiting → success.
@@ -345,7 +339,6 @@ export function CheckoutPage() {
     setPhaseError(null);
     setAppliedCoupon(null);
     setPreparePayment(null);
-    setPendingContractId(null);
     pendingCouponForRestartRef.current = undefined;
     resetCoupon();
     confirmCalledRef.current = false;
@@ -359,7 +352,6 @@ export function CheckoutPage() {
     setClientSecret(null);
     setSetupSessionId(null);
     setPhaseError(null);
-    setPendingContractId(null);
     pendingCouponForRestartRef.current = appliedCoupon?.code;
     confirmCalledRef.current = false;
     setPreparePayment(null);

--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -378,12 +378,29 @@ export function CheckoutPage() {
     setIsSessionRefreshing(false);
   });
 
+  // When a coupon fully covers the cost there is nothing to charge: the backend
+  // skips the payment-gated commit and activates directly, so we drop the
+  // "Processing payment" step and go straight to "Activating your workspace".
+  // Detected from the prepared total (available during confirming) or, once
+  // polling, from the server-computed amount on the checkout record.
+  const isZeroPaymentCheckout =
+    preparePayment?.totalCents === 0 ||
+    checkoutPayment?.initialAmountCents === 0;
+
+  const checkoutSteps = isZeroPaymentCheckout
+    ? CHECKOUT_STEPS_NO_PAYMENT
+    : CHECKOUT_STEPS;
+
   // Progress step shown during the confirming / waiting_for_payment phases.
-  // waiting_for_payment starts on "Processing payment" (step 1) and advances to
-  // "Activating your workspace" (step 2) once the webhook reports activation has
-  // begun (surfaced through the polled checkout payment record).
-  const activeStepIndex =
-    phase === "confirming"
+  // - Paid checkout: waiting_for_payment starts on "Processing payment" (step 1)
+  //   and advances to "Activating your workspace" (step 2) once the payment
+  //   webhook reports activation has begun (surfaced through the polled record).
+  // - Zero-payment (coupon) checkout: activation runs inside the confirming
+  //   request, so we show the "Activating your workspace" step (the last of the
+  //   two-step list) throughout instead of a payment step that never happens.
+  const activeStepIndex = isZeroPaymentCheckout
+    ? checkoutSteps.length - 1
+    : phase === "confirming"
       ? 0
       : checkoutPayment?.progress === "activating"
         ? 2
@@ -639,6 +656,7 @@ export function CheckoutPage() {
         <RightPane
           phase={phase}
           phaseError={phaseError}
+          checkoutSteps={checkoutSteps}
           activeStepIndex={activeStepIndex}
           clientSecret={clientSecret}
           isCreating={isCreating}
@@ -711,6 +729,7 @@ function CheckoutSuccessPage({
 interface RightPaneProps {
   phase: CheckoutPhase;
   phaseError: PhaseError | null;
+  checkoutSteps: readonly string[];
   activeStepIndex: number;
   clientSecret: string | null;
   isCreating: boolean;
@@ -728,6 +747,7 @@ interface RightPaneProps {
 function RightPane({
   phase,
   phaseError,
+  checkoutSteps,
   activeStepIndex,
   clientSecret,
   isCreating,
@@ -825,7 +845,12 @@ function RightPane({
 
     case "confirming":
     case "waiting_for_payment":
-      return <CheckoutProgress activeStepIndex={activeStepIndex} />;
+      return (
+        <CheckoutProgress
+          steps={checkoutSteps}
+          activeStepIndex={activeStepIndex}
+        />
+      );
 
     case "checkout_success":
       return null;
@@ -905,14 +930,22 @@ const CHECKOUT_STEPS = [
   "Activating your workspace",
 ] as const;
 
+// Zero-payment (coupon covers the full cost): no charge happens, so the
+// "Processing payment" step is dropped.
+const CHECKOUT_STEPS_NO_PAYMENT = [
+  "Setting up your subscription",
+  "Activating your workspace",
+] as const;
+
 interface CheckoutProgressProps {
+  steps: readonly string[];
   activeStepIndex: number;
 }
 
-function CheckoutProgress({ activeStepIndex }: CheckoutProgressProps) {
+function CheckoutProgress({ steps, activeStepIndex }: CheckoutProgressProps) {
   return (
     <div className="flex flex-col gap-4">
-      {CHECKOUT_STEPS.map((label, index) => {
+      {steps.map((label, index) => {
         const isDone = index < activeStepIndex;
         const isActive = index === activeStepIndex;
         return (

--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -14,6 +14,7 @@ import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import {
   useAuthContext,
   useCheckBusinessActivation,
+  useCheckoutReceiptUrl,
   useCreateCheckoutSession,
   useInitiateBusinessActivation,
   usePreparePayment,
@@ -111,7 +112,6 @@ export function CheckoutPage() {
   const [pendingContractId, setPendingContractId] = useState<string | null>(
     null
   );
-  const [receiptUrl, setReceiptUrl] = useState<string | null>(null);
   // Prevents initSession from firing before URL params have been read on mount.
   const [isInitialized, setIsInitialized] = useState(false);
 
@@ -169,12 +169,22 @@ export function CheckoutPage() {
     }
   }, [livePreparePayment]);
 
-  // Poll checkout payment status while in waiting_for_payment phase.
-  const { checkoutPayment, invoiceUrl } = useCheckBusinessActivation({
+  // Poll checkout payment status while in waiting_for_payment phase. Status only
+  // (no receipt URL) so the poll stays fast and we transition on `succeeded`
+  // without waiting on the slow Stripe invoice-URL fetch.
+  const { checkoutPayment } = useCheckBusinessActivation({
     workspaceId: owner.sId,
     contractId: pendingContractId,
     disabled: phase !== "waiting_for_payment",
     pollIntervalMs: phase === "waiting_for_payment" ? 1500 : 0,
+  });
+
+  // Lazily fetch the Stripe receipt URL once on the success screen, so the "View
+  // receipt" button appears when ready without blocking the success transition.
+  const { receiptUrl } = useCheckoutReceiptUrl({
+    workspaceId: owner.sId,
+    contractId: pendingContractId,
+    disabled: phase !== "checkout_success",
   });
 
   // React to Redis activation status.
@@ -183,7 +193,6 @@ export function CheckoutPage() {
       return;
     }
     if (checkoutPayment.status === "succeeded") {
-      setReceiptUrl(invoiceUrl);
       setPhase("checkout_success");
       void mutateAuthContext();
     } else if (checkoutPayment.status === "failed") {
@@ -191,7 +200,7 @@ export function CheckoutPage() {
       setPhase("error");
     }
     // pending: keep polling
-  }, [phase, checkoutPayment, invoiceUrl, mutateAuthContext]);
+  }, [phase, checkoutPayment, mutateAuthContext]);
 
   const {
     register: registerCoupon,
@@ -368,6 +377,17 @@ export function CheckoutPage() {
     await initSession(couponCode.trim());
     setIsSessionRefreshing(false);
   });
+
+  // Progress step shown during the confirming / waiting_for_payment phases.
+  // waiting_for_payment starts on "Processing payment" (step 1) and advances to
+  // "Activating your workspace" (step 2) once the webhook reports activation has
+  // begun (surfaced through the polled checkout payment record).
+  const activeStepIndex =
+    phase === "confirming"
+      ? 0
+      : checkoutPayment?.progress === "activating"
+        ? 2
+        : 1;
 
   const showActualTax = preparePayment !== null;
 
@@ -600,14 +620,18 @@ export function CheckoutPage() {
       </div>
 
       {/* Right pane: phase-dependent content.
-          payment_review + error: top padding of 296px aligns content with the "Price per seat" row in the left pane.
+          payment_review + error + confirming/waiting_for_payment (progress steps): top padding of 296px aligns
+          content with the "Price per seat" row in the left pane.
           card_capture (with Stripe iframe): uniform p-24 with no centering so the iframe fills from the top.
           All other phases (spinners): centered. */}
       <div
         className={`flex w-1/2 flex-col overflow-y-auto bg-white ${
           phase === "card_capture" && clientSecret
             ? "p-24"
-            : phase === "payment_review" || phase === "error"
+            : phase === "payment_review" ||
+                phase === "error" ||
+                phase === "confirming" ||
+                phase === "waiting_for_payment"
               ? "px-24 pb-24 pt-[296px]"
               : "items-center justify-center p-24"
         }`}
@@ -615,6 +639,7 @@ export function CheckoutPage() {
         <RightPane
           phase={phase}
           phaseError={phaseError}
+          activeStepIndex={activeStepIndex}
           clientSecret={clientSecret}
           isCreating={isCreating}
           isPreparePaymentLoading={isPreparePaymentLoading}
@@ -686,6 +711,7 @@ function CheckoutSuccessPage({
 interface RightPaneProps {
   phase: CheckoutPhase;
   phaseError: PhaseError | null;
+  activeStepIndex: number;
   clientSecret: string | null;
   isCreating: boolean;
   isPreparePaymentLoading: boolean;
@@ -702,6 +728,7 @@ interface RightPaneProps {
 function RightPane({
   phase,
   phaseError,
+  activeStepIndex,
   clientSecret,
   isCreating,
   isPreparePaymentLoading,
@@ -797,20 +824,8 @@ function RightPane({
       );
 
     case "confirming":
-      return (
-        <div className="flex flex-col items-center gap-4">
-          <Spinner size="lg" />
-          <p className="text-sm text-muted-foreground">Processing payment…</p>
-        </div>
-      );
-
     case "waiting_for_payment":
-      return (
-        <div className="flex flex-col items-center gap-4">
-          <Spinner size="lg" />
-          <p className="text-sm text-muted-foreground">Processing payment…</p>
-        </div>
-      );
+      return <CheckoutProgress activeStepIndex={activeStepIndex} />;
 
     case "checkout_success":
       return null;
@@ -878,6 +893,55 @@ function RightPane({
       assertNeverAndIgnore(phase);
       return null;
   }
+}
+
+// Steps shown during the confirming / waiting_for_payment phases, in the order
+// they happen server-side: the subscription (Metronome customer + contract) is
+// set up while confirming, then payment is charged and the workspace activated
+// while polling for the webhook result.
+const CHECKOUT_STEPS = [
+  "Setting up your subscription",
+  "Processing payment",
+  "Activating your workspace",
+] as const;
+
+interface CheckoutProgressProps {
+  activeStepIndex: number;
+}
+
+function CheckoutProgress({ activeStepIndex }: CheckoutProgressProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      {CHECKOUT_STEPS.map((label, index) => {
+        const isDone = index < activeStepIndex;
+        const isActive = index === activeStepIndex;
+        return (
+          <div key={label} className="flex items-center gap-3">
+            <div className="flex h-6 w-6 items-center justify-center">
+              {isDone ? (
+                <Icon
+                  visual={CheckCircle}
+                  size="sm"
+                  className="text-success-500"
+                />
+              ) : isActive ? (
+                <Spinner size="xs" />
+              ) : (
+                <div className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
+              )}
+            </div>
+            <span
+              className={`text-sm ${
+                isDone || isActive ? "text-foreground" : "text-muted-foreground"
+              }`}
+            >
+              {label}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 interface CheckoutErrorProps {

--- a/front/lib/api/checkout/business_activation.test.ts
+++ b/front/lib/api/checkout/business_activation.test.ts
@@ -11,6 +11,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockSetCheckoutPaymentPending,
   mockGetCheckoutPaymentStatus,
+  mockGetCheckoutPaymentStatusBySession,
   mockMarkCheckoutPaymentSucceeded,
   mockMarkCheckoutPaymentFailed,
   mockMarkCheckoutPaymentActivating,
@@ -28,6 +29,7 @@ const {
 } = vi.hoisted(() => ({
   mockSetCheckoutPaymentPending: vi.fn(),
   mockGetCheckoutPaymentStatus: vi.fn(),
+  mockGetCheckoutPaymentStatusBySession: vi.fn(),
   mockMarkCheckoutPaymentSucceeded: vi.fn(),
   mockMarkCheckoutPaymentFailed: vi.fn(),
   mockMarkCheckoutPaymentActivating: vi.fn(),
@@ -47,6 +49,7 @@ const {
 vi.mock("@app/lib/credits/checkout_payment_status", () => ({
   setCheckoutPaymentPending: mockSetCheckoutPaymentPending,
   getCheckoutPaymentStatus: mockGetCheckoutPaymentStatus,
+  getCheckoutPaymentStatusBySession: mockGetCheckoutPaymentStatusBySession,
   markCheckoutPaymentSucceeded: mockMarkCheckoutPaymentSucceeded,
   markCheckoutPaymentFailed: mockMarkCheckoutPaymentFailed,
   markCheckoutPaymentActivating: mockMarkCheckoutPaymentActivating,
@@ -260,6 +263,9 @@ beforeEach(() => {
   mockAddPaymentGatedCommit.mockResolvedValue(new Ok({ editId: "edit_1" }));
   mockScheduleContractEnd.mockResolvedValue(new Ok(undefined));
   mockGetCheckoutPaymentStatus.mockResolvedValue(CHECKOUT_PAYMENT_PENDING);
+  mockGetCheckoutPaymentStatusBySession.mockResolvedValue(
+    CHECKOUT_PAYMENT_PENDING
+  );
   mockMarkCheckoutPaymentSucceeded.mockResolvedValue(undefined);
   mockMarkCheckoutPaymentFailed.mockResolvedValue(undefined);
   mockMarkCheckoutPaymentActivating.mockResolvedValue(undefined);

--- a/front/lib/api/checkout/business_activation.test.ts
+++ b/front/lib/api/checkout/business_activation.test.ts
@@ -13,6 +13,7 @@ const {
   mockGetCheckoutPaymentStatus,
   mockMarkCheckoutPaymentSucceeded,
   mockMarkCheckoutPaymentFailed,
+  mockMarkCheckoutPaymentActivating,
   mockRecordCheckoutPaymentSyncFailure,
   mockSwapMetronomeContract,
   mockFetchActiveSubscription,
@@ -29,6 +30,7 @@ const {
   mockGetCheckoutPaymentStatus: vi.fn(),
   mockMarkCheckoutPaymentSucceeded: vi.fn(),
   mockMarkCheckoutPaymentFailed: vi.fn(),
+  mockMarkCheckoutPaymentActivating: vi.fn(),
   mockRecordCheckoutPaymentSyncFailure: vi.fn(),
   mockSwapMetronomeContract: vi.fn(),
   mockFetchActiveSubscription: vi.fn(),
@@ -47,6 +49,7 @@ vi.mock("@app/lib/credits/checkout_payment_status", () => ({
   getCheckoutPaymentStatus: mockGetCheckoutPaymentStatus,
   markCheckoutPaymentSucceeded: mockMarkCheckoutPaymentSucceeded,
   markCheckoutPaymentFailed: mockMarkCheckoutPaymentFailed,
+  markCheckoutPaymentActivating: mockMarkCheckoutPaymentActivating,
   recordCheckoutPaymentSyncFailure: mockRecordCheckoutPaymentSyncFailure,
 }));
 
@@ -259,6 +262,7 @@ beforeEach(() => {
   mockGetCheckoutPaymentStatus.mockResolvedValue(CHECKOUT_PAYMENT_PENDING);
   mockMarkCheckoutPaymentSucceeded.mockResolvedValue(undefined);
   mockMarkCheckoutPaymentFailed.mockResolvedValue(undefined);
+  mockMarkCheckoutPaymentActivating.mockResolvedValue(undefined);
   mockRecordCheckoutPaymentSyncFailure.mockResolvedValue(undefined);
   mockSwapMetronomeContract.mockResolvedValue(undefined);
   mockInvalidateCache.mockResolvedValue(undefined);

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -9,6 +9,7 @@ import { Authenticator } from "@app/lib/auth";
 import {
   type CheckoutPayment,
   getCheckoutPaymentStatus,
+  getCheckoutPaymentStatusBySession,
   markCheckoutPaymentActivating,
   markCheckoutPaymentFailed,
   markCheckoutPaymentSucceeded,
@@ -258,6 +259,7 @@ export async function createPaymentGatedBusinessActivation({
   // handler can update it even if it races ahead of this function returning.
   await setCheckoutPaymentPending({
     workspaceId: workspace.sId,
+    setupSessionId,
     metronomeCustomerId,
     contractId: metronomeContractId,
     userId,
@@ -893,6 +895,11 @@ export type GetBusinessActivationResponseBody = {
  * Returns the checkout payment status and, only when explicitly requested via
  * `includeReceiptUrl`, the Stripe hosted invoice URL.
  *
+ * The record is looked up either by contract id or by Stripe setup session id.
+ * The polling UI uses the session id so it can start polling from the first
+ * step (the contract id only exists once provisioning has run inside the
+ * confirming request).
+ *
  * The invoice-URL fetch is a slow (~seconds) Stripe round-trip, so the polling
  * UI does NOT request it: it polls only for status and transitions to the
  * success screen immediately on `succeeded`. The success screen then fetches the
@@ -901,18 +908,27 @@ export type GetBusinessActivationResponseBody = {
  */
 export async function getBusinessActivationStatus(
   workspace: LightWorkspaceType,
-  contractId: string,
+  identifier: { contractId: string } | { setupSessionId: string },
   { includeReceiptUrl = false }: { includeReceiptUrl?: boolean } = {}
 ): Promise<GetBusinessActivationResponseBody> {
-  const checkoutPayment = await getCheckoutPaymentStatus({
-    workspaceId: workspace.sId,
-    contractId,
-  });
+  const checkoutPayment =
+    "contractId" in identifier
+      ? await getCheckoutPaymentStatus({
+          workspaceId: workspace.sId,
+          contractId: identifier.contractId,
+        })
+      : await getCheckoutPaymentStatusBySession({
+          workspaceId: workspace.sId,
+          setupSessionId: identifier.setupSessionId,
+        });
 
   let invoiceUrl: string | undefined;
   if (
     includeReceiptUrl &&
     checkoutPayment?.status === "succeeded" &&
+    // Zero-amount (coupon) activations have no Stripe invoice — the invoiceId is
+    // a "free-activation" placeholder — so there is no receipt to fetch.
+    checkoutPayment.initialAmountCents > 0 &&
     checkoutPayment.invoiceId &&
     workspace.metronomeCustomerId
   ) {

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -9,6 +9,7 @@ import { Authenticator } from "@app/lib/auth";
 import {
   type CheckoutPayment,
   getCheckoutPaymentStatus,
+  markCheckoutPaymentActivating,
   markCheckoutPaymentFailed,
   markCheckoutPaymentSucceeded,
   recordCheckoutPaymentSyncFailure,
@@ -447,6 +448,17 @@ export async function handleSubscriptionActivationSuccess({
     );
     return;
   }
+
+  // Payment has cleared and activation is starting. Surface it to the polling UI
+  // as early as possible so the long-running work below (contract swap, workspace
+  // restore, seat update, seat sync, ending the previous contract, ...) shows as
+  // "activating your workspace" rather than still "processing payment". Marked
+  // here — the single entry point for both the webhook and the zero-amount fast
+  // path — so every activation route advances the UI consistently.
+  await markCheckoutPaymentActivating({
+    workspaceId: workspace.sId,
+    contractId,
+  });
 
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   const lightWorkspace = renderLightWorkspaceType({ workspace });

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -878,13 +878,19 @@ export type GetBusinessActivationResponseBody = {
 };
 
 /**
- * Returns the checkout payment status and, when payment has succeeded, the
- * Stripe hosted invoice URL. Coordinates the two sequential external-service
- * calls so the GET handler stays thin.
+ * Returns the checkout payment status and, only when explicitly requested via
+ * `includeReceiptUrl`, the Stripe hosted invoice URL.
+ *
+ * The invoice-URL fetch is a slow (~seconds) Stripe round-trip, so the polling
+ * UI does NOT request it: it polls only for status and transitions to the
+ * success screen immediately on `succeeded`. The success screen then fetches the
+ * receipt URL lazily (a single call with `includeReceiptUrl`) for its "View
+ * receipt" button, without blocking the transition.
  */
 export async function getBusinessActivationStatus(
   workspace: LightWorkspaceType,
-  contractId: string
+  contractId: string,
+  { includeReceiptUrl = false }: { includeReceiptUrl?: boolean } = {}
 ): Promise<GetBusinessActivationResponseBody> {
   const checkoutPayment = await getCheckoutPaymentStatus({
     workspaceId: workspace.sId,
@@ -893,6 +899,7 @@ export async function getBusinessActivationStatus(
 
   let invoiceUrl: string | undefined;
   if (
+    includeReceiptUrl &&
     checkoutPayment?.status === "succeeded" &&
     checkoutPayment.invoiceId &&
     workspace.metronomeCustomerId

--- a/front/lib/credits/checkout_payment_status.test.ts
+++ b/front/lib/credits/checkout_payment_status.test.ts
@@ -19,6 +19,7 @@ vi.mock("@app/lib/api/redis", () => ({
 
 import {
   getCheckoutPaymentStatus,
+  getCheckoutPaymentStatusBySession,
   markCheckoutPaymentFailed,
   markCheckoutPaymentSucceeded,
   recordCheckoutPaymentSyncFailure,
@@ -28,6 +29,7 @@ import { BUSINESS_USD_PACKAGE_ALIAS } from "@app/lib/metronome/types";
 
 const BASE_INPUT = {
   workspaceId: "ws_test",
+  setupSessionId: "seti_test",
   metronomeCustomerId: "cst_abc",
   contractId: "contract_abc",
   userId: "user_1",
@@ -92,6 +94,29 @@ describe("checkout_payment_status Redis helpers", () => {
       const result = await getCheckoutPaymentStatus({
         workspaceId: "ws_test",
         contractId: "contract_nonexistent",
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getCheckoutPaymentStatusBySession", () => {
+    it("resolves the record via the setup session id", async () => {
+      await setCheckoutPaymentPending(BASE_INPUT);
+
+      const result = await getCheckoutPaymentStatusBySession({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.contractId).toBe(BASE_INPUT.contractId);
+      expect(result!.status).toBe("pending");
+    });
+
+    it("returns null when the session pointer does not exist", async () => {
+      const result = await getCheckoutPaymentStatusBySession({
+        workspaceId: "ws_test",
+        setupSessionId: "seti_nonexistent",
       });
       expect(result).toBeNull();
     });

--- a/front/lib/credits/checkout_payment_status.ts
+++ b/front/lib/credits/checkout_payment_status.ts
@@ -46,18 +46,34 @@ function redisKey(workspaceId: string, contractId: string): string {
   return `checkout_payment:${workspaceId}:${contractId}`;
 }
 
+// Secondary index: maps the Stripe setup session id (known to the client before
+// the contract id is) to the contract id, so the polling UI can look up the
+// record from the very first step, while the activation contract is still being
+// provisioned inside the confirming request.
+function sessionKey(workspaceId: string, setupSessionId: string): string {
+  return `checkout_payment_session:${workspaceId}:${setupSessionId}`;
+}
+
 export async function setCheckoutPaymentPending(
-  input: Omit<CheckoutPayment, "status" | "createdAtMs">
+  input: Omit<CheckoutPayment, "status" | "createdAtMs"> & {
+    setupSessionId: string;
+  }
 ): Promise<void> {
+  const { setupSessionId, ...record } = input;
   const payment: CheckoutPayment = {
-    ...input,
+    ...record,
     status: "pending",
     createdAtMs: Date.now(),
   };
   await runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
     await cli.set(
-      redisKey(input.workspaceId, input.contractId),
+      redisKey(record.workspaceId, record.contractId),
       JSON.stringify(payment),
+      { EX: TTL_SECONDS }
+    );
+    await cli.set(
+      sessionKey(record.workspaceId, setupSessionId),
+      record.contractId,
       { EX: TTL_SECONDS }
     );
   });
@@ -85,6 +101,26 @@ export async function getCheckoutPaymentStatus({
     }
     return parsed.data;
   });
+}
+
+// Resolve the checkout record from a Stripe setup session id via the secondary
+// index. Returns null until the pending record (and its pointer) has been
+// written — i.e. during the very first moments of the confirming request.
+export async function getCheckoutPaymentStatusBySession({
+  workspaceId,
+  setupSessionId,
+}: {
+  workspaceId: string;
+  setupSessionId: string;
+}): Promise<CheckoutPayment | null> {
+  const contractId = await runOnRedisCache(
+    { origin: REDIS_ORIGIN },
+    async (cli) => cli.get(sessionKey(workspaceId, setupSessionId))
+  );
+  if (!contractId) {
+    return null;
+  }
+  return getCheckoutPaymentStatus({ workspaceId, contractId });
 }
 
 async function updatePayment(

--- a/front/lib/credits/checkout_payment_status.ts
+++ b/front/lib/credits/checkout_payment_status.ts
@@ -31,6 +31,10 @@ export const CheckoutPaymentSchema = z.object({
   invoiceId: z.string().optional(),
   errorMessage: z.string().optional(),
   previousMetronomeContractId: z.string().optional(),
+  // Coarse activation progress surfaced to the polling UI. While pending the
+  // record is either awaiting payment (no progress set) or being activated once
+  // payment cleared. Optional for records written before this field existed.
+  progress: z.literal("activating").optional(),
 });
 
 export type CheckoutPayment = z.infer<typeof CheckoutPaymentSchema>;
@@ -108,6 +112,23 @@ async function updatePayment(
     });
     return updated;
   });
+}
+
+// Marks the pending activation as "activating" so the polling UI can advance
+// from "processing payment" to "activating your workspace" once payment cleared
+// and the webhook has started the (multi-step) activation work. No-op if the
+// record is missing or already succeeded.
+export async function markCheckoutPaymentActivating({
+  workspaceId,
+  contractId,
+}: {
+  workspaceId: string;
+  contractId: string;
+}): Promise<void> {
+  await updatePayment(workspaceId, contractId, (current) => ({
+    ...current,
+    progress: "activating",
+  }));
 }
 
 export async function markCheckoutPaymentSucceeded({

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -1261,10 +1261,38 @@ export function useCheckBusinessActivation({
 
   return {
     checkoutPayment: data?.checkoutPayment ?? null,
-    invoiceUrl: data?.invoiceUrl ?? null,
     isCheckoutPaymentLoading: !error && !data && !disabled && !!contractId,
     isCheckoutPaymentError: !!error,
   };
+}
+
+// Fetches the Stripe hosted invoice (receipt) URL for a completed checkout. Kept
+// separate from `useCheckBusinessActivation` because the underlying Stripe
+// round-trip is slow (~seconds): the status poll must stay fast so the success
+// screen shows immediately, and this fetches the receipt URL lazily afterwards
+// (only enabled once the checkout has succeeded).
+export function useCheckoutReceiptUrl({
+  workspaceId,
+  contractId,
+  disabled,
+}: {
+  workspaceId: string;
+  contractId: string | null;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const statusFetcher: Fetcher<GetBusinessActivationResponseBody> = fetcher;
+
+  const url =
+    disabled || !contractId
+      ? null
+      : `/api/w/${workspaceId}/subscriptions/checkout/business-activation?contract_id=${contractId}&receipt=true`;
+
+  const { data } = useSWRWithDefaults(url, statusFetcher, {
+    revalidateOnFocus: false,
+  });
+
+  return { receiptUrl: data?.invoiceUrl ?? null };
 }
 
 export function useInitiateBusinessActivation({

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -1235,14 +1235,18 @@ export function useCreateCheckoutSession({
   return { createSession, isCreating };
 }
 
+// Polls the checkout activation status by Stripe setup session id. The session
+// id is known to the client from the first step, so polling can start while the
+// activation contract is still being provisioned (the contract id only exists
+// once that provisioning completes server-side).
 export function useCheckBusinessActivation({
   workspaceId,
-  contractId,
+  setupSessionId,
   disabled,
   pollIntervalMs = 0,
 }: {
   workspaceId: string;
-  contractId: string | null;
+  setupSessionId: string | null;
   disabled?: boolean;
   pollIntervalMs?: number;
 }) {
@@ -1250,9 +1254,9 @@ export function useCheckBusinessActivation({
   const statusFetcher: Fetcher<GetBusinessActivationResponseBody> = fetcher;
 
   const url =
-    disabled || !contractId
+    disabled || !setupSessionId
       ? null
-      : `/api/w/${workspaceId}/subscriptions/checkout/business-activation?contract_id=${contractId}`;
+      : `/api/w/${workspaceId}/subscriptions/checkout/business-activation?setup_session_id=${setupSessionId}`;
 
   const { data, error } = useSWRWithDefaults(url, statusFetcher, {
     refreshInterval: pollIntervalMs,
@@ -1261,7 +1265,7 @@ export function useCheckBusinessActivation({
 
   return {
     checkoutPayment: data?.checkoutPayment ?? null,
-    isCheckoutPaymentLoading: !error && !data && !disabled && !!contractId,
+    isCheckoutPaymentLoading: !error && !data && !disabled && !!setupSessionId,
     isCheckoutPaymentError: !!error,
   };
 }

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -1277,20 +1277,20 @@ export function useCheckBusinessActivation({
 // (only enabled once the checkout has succeeded).
 export function useCheckoutReceiptUrl({
   workspaceId,
-  contractId,
+  setupSessionId,
   disabled,
 }: {
   workspaceId: string;
-  contractId: string | null;
+  setupSessionId: string | null;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const statusFetcher: Fetcher<GetBusinessActivationResponseBody> = fetcher;
 
   const url =
-    disabled || !contractId
+    disabled || !setupSessionId
       ? null
-      : `/api/w/${workspaceId}/subscriptions/checkout/business-activation?contract_id=${contractId}&receipt=true`;
+      : `/api/w/${workspaceId}/subscriptions/checkout/business-activation?setup_session_id=${setupSessionId}&receipt=true`;
 
   const { data } = useSWRWithDefaults(url, statusFetcher, {
     revalidateOnFocus: false,


### PR DESCRIPTION
## Description

Improves the checkout waiting experience. Previously the whole activation showed a single static "Processing payment…" spinner for ~30s, so users had no sense of progress and often thought it had stalled.

<img width="272" height="163" alt="Screenshot 2026-07-07 at 17 23 03" src="https://github.com/user-attachments/assets/b44a8a58-751a-4ca9-931f-15a9ef186feb" />



**Multi-step progress indicator.** The `confirming` / `waiting_for_payment` phases now render a 3-step checklist that reflects the real backend phases, each advancing with a spinner → checkmark:
1. **Setting up your subscription** — the `POST /business-activation` (Metronome customer + contract + commit creation).
2. **Processing payment** — waiting for the Stripe charge + Metronome `payment_gate.payment_status: paid` webhook.
3. **Activating your workspace** — the (workflow-driven) plan swap, seat update, and seat sync.

**Real "activating" signal via polling.** Added an optional `progress: "activating"` field to the polled checkout-payment Redis record. The Metronome webhook endpoint marks it the moment a `payment_gate.payment_status: paid` event is received — the earliest reliable "payment cleared" point — so the UI advances to step 3 instead of showing "Processing payment" for the whole post-payment window (which is dominated by deferred Temporal activation work).

**Non-blocking receipt URL.** The Stripe hosted invoice ("View receipt") URL is a slow (~3s) round-trip. The status poll no longer fetches it, so the success screen appears immediately on `succeeded`; the receipt URL is fetched lazily afterwards (`?receipt=true`) and the button appears when ready.

## Tests

- Manual: ran a full checkout and inspected server logs to confirm the phase timings and that the stepper advances (confirming → processing payment → activating your workspace → success).
- `front/lib/credits/checkout_payment_status.test.ts` passes (covers the Redis record incl. the new optional `progress` field).
- `tsgo` clean in `front` and `front-api`.

## Risk

Low.
- The `progress` field is additive and optional on a private, onboarding-only endpoint (`GetBusinessActivationResponseBody`); older records without it are handled.
- Marking `activating` in the webhook endpoint is idempotent and a no-op unless a checkout is pending on that contract; it does not replace the workflow that performs (and completes) the real activation.
- Frontend uses `assertNeverAndIgnore` on the phase switch, so unknown values won't crash.
- Safe to roll back — no schema/data migration.

## Deploy Plan

Standard. `front` (webhook endpoint + status lib) and `front-api` (route) deploy together; no migration, no worker/queue changes.
