### PR TITLE
[front] feat: pod-state gcs prefix, replica mount profile and path helper

### DIFF
--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -608,18 +608,24 @@ export class GCSFileSystemBackend implements FileSystemBackend {
   ): SandboxMountAdapter {
     const bucket = fileStorageConfig.getGcsPrivateUploadsBucket();
     const targets: GCSMountTarget[] = [
-      ...mounts.map((mount) => ({
-        gcsPrefix: this.mountRootGCSPrefix(mount),
-        sandboxMountPoint: mount.sandboxMountPoint,
-        legacySandboxMountPoint: mount.legacySandboxMountPoint,
-        readOnly: false,
-      })),
-      ...sandboxOnlyMounts.map((mount) => ({
-        gcsPrefix: this.sandboxOnlyMountGCSPrefix(mount),
-        sandboxMountPoint: mount.sandboxMountPoint,
-        legacySandboxMountPoint: null,
-        readOnly: mount.readOnly,
-      })),
+      ...mounts.map(
+        (mount): GCSMountTarget => ({
+          gcsPrefix: this.mountRootGCSPrefix(mount),
+          sandboxMountPoint: mount.sandboxMountPoint,
+          legacySandboxMountPoint: mount.legacySandboxMountPoint,
+          readOnly: false,
+          mountProfile: "workload",
+        })
+      ),
+      ...sandboxOnlyMounts.map(
+        (mount): GCSMountTarget => ({
+          gcsPrefix: this.sandboxOnlyMountGCSPrefix(mount),
+          sandboxMountPoint: mount.sandboxMountPoint,
+          legacySandboxMountPoint: null,
+          readOnly: mount.readOnly,
+          mountProfile: this.sandboxOnlyMountProfile(mount),
+        })
+      ),
     ];
 
     return new GCSSandboxMountAdapter(bucket, targets);
@@ -629,6 +635,24 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     switch (mount.kind) {
       case "pod_sandbox_functions":
         return `w/${this.workspaceId}/pods/${mount.id}/sandbox-functions`;
+
+      case "pod_state":
+        return `w/${this.workspaceId}/pods/${mount.id}/state`;
+
+      default:
+        assertNever(mount.kind);
+    }
+  }
+
+  private sandboxOnlyMountProfile(
+    mount: SandboxOnlyMount
+  ): GCSMountTarget["mountProfile"] {
+    switch (mount.kind) {
+      case "pod_sandbox_functions":
+        return "workload";
+
+      case "pod_state":
+        return "pod_state_replica";
 
       default:
         assertNever(mount.kind);

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -12,6 +12,7 @@ import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import { concurrentExecutor } from "@app/temporal/workflow_utils";
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import type { SandboxMountAdapter } from "./sandbox_mount_adapter";
 
@@ -21,6 +22,22 @@ const TOKEN_SERVER_URL = "http://127.0.0.1:9876";
 const TOKEN_SERVER_POLL_ATTEMPTS = 100;
 const TOKEN_SERVER_POLL_INTERVAL_SECONDS = 0.05;
 const TOKEN_SERVER_EXEC_TIMEOUT_MS = 10_000;
+
+/**
+ * Per-target mount profile.
+ *
+ * - "workload": root-mounted with `allow_other` so the unprivileged sandbox
+ *   users can access it; permissive file/dir modes; 60s kernel list cache
+ *   (read-mostly workloads). All agent-facing mounts.
+ * - "pod_state_replica": mounted AS `dust-state` (via runuser) so the FUSE
+ *   default — only the mounting user can access the fs — makes it invisible to
+ *   every other uid, including the untrusted workload uid 1003 and root. No
+ *   `allow_other`, restrictive modes, and NO kernel list caching: litestream
+ *   restore must never see a stale LTX listing. Needs the dust-state user and
+ *   /pod-state layout in the image; targets with this profile are only ever
+ *   constructed when a pod sandbox (the sandbox-functions computer) boots.
+ */
+export type GCSMountProfile = "workload" | "pod_state_replica";
 
 export type GCSMountTarget = {
   /**
@@ -36,6 +53,7 @@ export type GCSMountTarget = {
   legacySandboxMountPoint: string | null;
   /** When set, the mount uses `-o ro` and a read-only-scoped token (see buildAccessBoundaryRules). */
   readOnly: boolean;
+  mountProfile: GCSMountProfile;
 };
 
 /**
@@ -142,12 +160,7 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
 
         const mountResult = await sandbox.execRoot(
           auth,
-          buildMountCommand({
-            bucket,
-            prefix: target.gcsPrefix,
-            mountPoint: target.sandboxMountPoint,
-            readOnly: target.readOnly,
-          }),
+          buildMountCommand({ bucket, target }),
           { timeoutMs: MOUNT_TIMEOUT_MS }
         );
 
@@ -221,9 +234,10 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       return new Ok(undefined);
     }
 
+    const { targets } = this;
     const tokenResult = await mintDownscopedGcsToken({
       bucket: this.bucket,
-      prefixes: this.targets.map((t) => ({
+      prefixes: targets.map((t) => ({
         prefix: t.gcsPrefix,
         readOnly: t.readOnly,
       })),
@@ -244,7 +258,7 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       {
         sandboxId: sandbox.sId,
         workspaceId: auth.getNonNullableWorkspace().sId,
-        prefixes: this.targets.map((t) => t.gcsPrefix),
+        prefixes: targets.map((t) => t.gcsPrefix),
       },
       "GCS sandbox mount: credential refreshed"
     );
@@ -261,26 +275,17 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
   }
 }
 
-function buildMountCommand({
+/** Exported for testing. */
+export function buildMountCommand({
   bucket,
-  prefix,
-  mountPoint,
-  readOnly,
+  target,
 }: {
   bucket: string;
-  prefix: string;
-  mountPoint: string;
-  readOnly: boolean;
+  target: GCSMountTarget;
 }): RootCommand {
-  // allow_other lets the unprivileged sandbox user read the root-mounted fs. `ro` is only
-  // defense-in-depth: the real write protection is the read-only token scope (see
-  // buildAccessBoundaryRules), not this flag.
-  const mountOptions = ["allow_other"];
-  if (readOnly) {
-    mountOptions.push("ro");
-  }
+  const { gcsPrefix: prefix, sandboxMountPoint: mountPoint } = target;
 
-  const flags = [
+  const commonFlags = [
     "--token-url",
     TOKEN_SERVER_URL,
     // Disable token caching so gcsfuse fetches a fresh credential on every GCS API request.
@@ -288,22 +293,69 @@ function buildMountCommand({
     "--only-dir",
     prefix,
     "--implicit-dirs",
-    "-o",
-    mountOptions.join(","),
-    "--file-mode=666",
-    "--dir-mode=777",
-    "--kernel-list-cache-ttl-secs=60",
     // Disable HNS: GetStorageLayout requires unrestricted objects.list which CAB cannot grant
     // per-prefix. With HNS disabled we scope list access via objectListPrefix conditions.
     "--enable-hns=false",
   ];
 
-  return rootCommand.stderrToStdout(
-    rootCommand.timeout(
-      rootCommand.exec("/usr/bin/gcsfuse", [...flags, bucket, mountPoint]),
-      MOUNT_TIMEOUT_MS / 1_000
-    )
-  );
+  switch (target.mountProfile) {
+    case "workload": {
+      // allow_other lets the unprivileged sandbox user read the root-mounted fs. `ro` is only
+      // defense-in-depth: the real write protection is the read-only token scope (see
+      // buildAccessBoundaryRules), not this flag.
+      const mountOptions = ["allow_other"];
+      if (target.readOnly) {
+        mountOptions.push("ro");
+      }
+
+      const flags = [
+        ...commonFlags,
+        "-o",
+        mountOptions.join(","),
+        "--file-mode=666",
+        "--dir-mode=777",
+        "--kernel-list-cache-ttl-secs=60",
+      ];
+
+      return rootCommand.stderrToStdout(
+        rootCommand.timeout(
+          rootCommand.exec("/usr/bin/gcsfuse", [...flags, bucket, mountPoint]),
+          MOUNT_TIMEOUT_MS / 1_000
+        )
+      );
+    }
+
+    case "pod_state_replica": {
+      // Mounted AS dust-state (runuser): with no allow_other, the FUSE layer
+      // denies every uid but the mounting one — the kernel-enforced version of
+      // "invisible to uid 1003". List caching is OFF: litestream restore reads
+      // the LTX listing at cold start and must never see a cached view.
+      const flags = [
+        ...commonFlags,
+        "--file-mode=600",
+        "--dir-mode=700",
+        "--kernel-list-cache-ttl-secs=0",
+      ];
+
+      return rootCommand.stderrToStdout(
+        rootCommand.timeout(
+          rootCommand.exec("/usr/sbin/runuser", [
+            "-u",
+            "dust-state",
+            "--",
+            "/usr/bin/gcsfuse",
+            ...flags,
+            bucket,
+            mountPoint,
+          ]),
+          MOUNT_TIMEOUT_MS / 1_000
+        )
+      );
+    }
+
+    default:
+      assertNever(target.mountProfile);
+  }
 }
 
 function buildTokenJson({

--- a/front/lib/api/file_system/types.ts
+++ b/front/lib/api/file_system/types.ts
@@ -53,9 +53,10 @@ export type FileSystemMount = {
 /**
  * A mount that exists only inside the sandbox filesystem and is never exposed through the
  * scoped-path API (the agent's file tools never see it). Used for prefixes the sandbox must read
- * but that are not an agent-visible namespace, e.g. published sandbox-function bundles.
+ * but that are not an agent-visible namespace, e.g. published sandbox-function bundles or the
+ * pod-state litestream replica.
  */
-export type SandboxOnlyMountKind = "pod_sandbox_functions";
+export type SandboxOnlyMountKind = "pod_sandbox_functions" | "pod_state";
 
 export type SandboxOnlyMount = {
   kind: SandboxOnlyMountKind;

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -5,6 +5,7 @@ import {
   getConversationFilesBasePath,
   getPodFilesBasePath,
   getPodSandboxFunctionsBasePath,
+  getPodStateBasePath,
   isAgentScopedPath,
   isCanonicalScopedPath,
   isLegacyScopedPath,
@@ -61,6 +62,14 @@ describe("mount_path helpers", () => {
       expect(
         getPodSandboxFunctionsBasePath({ workspaceId: "ws1", podId: "spc1" })
       ).toBe("w/ws1/pods/spc1/sandbox-functions/");
+    });
+  });
+
+  describe("getPodStateBasePath", () => {
+    it("should return a dedicated prefix separate from pod files and functions", () => {
+      expect(getPodStateBasePath({ workspaceId: "ws1", podId: "spc1" })).toBe(
+        "w/ws1/pods/spc1/state/"
+      );
     });
   });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -110,6 +110,22 @@ export function getPodSandboxFunctionsMountPoint(podId: string): string {
 export const POD_SANDBOX_DATABASES_DIR = "/pod-state/databases";
 
 /**
+ * Prefix for the pod's Litestream state replica (LTX chains for the pod's SQLite databases). The
+ * sandbox's litestream daemon is the only writer, through the dust-state-only gcsfuse mount at
+ * /pod-state/replica. Never mounted under /files, never a FileResource: cleanup is a wholesale
+ * prefix delete at pod deletion (see deletePodStatePrefix).
+ */
+export function getPodStateBasePath({
+  workspaceId,
+  podId,
+}: {
+  workspaceId: string;
+  podId: string;
+}): string {
+  return `${getBaseMountPathForWorkspace({ workspaceId })}pods/${podId}/state/`;
+}
+
+/**
  * Given a mount file path like "w/.../files/report.pdf",
  * returns "w/.../files/report.processed.pdf".
  * For files without extension: "w/.../files/Makefile" -> "w/.../files/Makefile.processed".

--- a/front/lib/api/sandbox/gcs/token.test.ts
+++ b/front/lib/api/sandbox/gcs/token.test.ts
@@ -185,6 +185,33 @@ describe("buildAccessBoundaryRules", () => {
     ).toBe(false);
   });
 
+  it("emits 7 rules for the full pod sandbox prefix set (files, functions, state)", () => {
+    // Pod sandboxes mount three prefixes; the CAB ceiling is 10 rules, so
+    // this must stay at 7 (1 unconditional + 2 per prefix).
+    const rules = buildAccessBoundaryRules("bucket-x", [
+      { prefix: "w/ws1/pods/spc1/files", readOnly: false },
+      { prefix: "w/ws1/pods/spc1/sandbox-functions", readOnly: true },
+      { prefix: "w/ws1/pods/spc1/state", readOnly: false },
+    ]);
+    expect(rules).toHaveLength(7);
+  });
+
+  it("grants read/write on the pod state prefix", () => {
+    const rules = buildAccessBoundaryRules("bucket-x", [
+      { prefix: "w/ws1/pods/spc1/state", readOnly: false },
+    ]);
+
+    const objectRule = rules.find((r) =>
+      r.availablePermissions[0].includes("objectUser")
+    );
+    expect(objectRule).toBeDefined();
+    expect(
+      objectRule &&
+        "availabilityCondition" in objectRule &&
+        objectRule.availabilityCondition.expression
+    ).toContain("projects/_/buckets/bucket-x/objects/w/ws1/pods/spc1/state/");
+  });
+
   it("references every prefix in list and resource.name conditions", () => {
     const prefixes = [
       { prefix: "w/ws1/conversations/c1/files", readOnly: false },

--- a/front/lib/api/sandbox/gcs/token.ts
+++ b/front/lib/api/sandbox/gcs/token.ts
@@ -168,7 +168,11 @@ function getStorageMountRole(): string {
  *     loopback-served token (gcsfuse fetches it over http) still cannot write there.
  *
  * Total rule count is `1 + 2 * prefixes.length`. CAB allows up to 10 rules, so we support up to 4
- * concurrent prefixes.
+ * concurrent prefixes. Current budget: a pod sandbox mounts files (rw) +
+ * sandbox-functions (ro) + state (rw, the litestream replica prefix) = 3 prefixes = 7 rules.
+ *
+ * Prefixes carry NO trailing slash: the conditions below append the '/' themselves, so a
+ * trailing-slash prefix would produce 'state//' and silently break listing.
  */
 export function buildAccessBoundaryRules(
   bucket: string,


### PR DESCRIPTION
## Description

Separate fuse mounting into two types
- workloads: everything we already have, no change
- pod_state: no caching

And we use pod_state type to mount the litestream LTX files
 
## Tests

Tested manually (see #28596 for tests)


## Risk

Standard
Blast radius: sandboxes

## Deploy Plan

Deploy front