### PR TITLE
Tool context: carry the MCP action resource in the agent loop run context

### DIFF
--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -8,7 +8,7 @@ import type {
 import { isAgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
 import { useConversationContextUsage } from "@app/hooks/conversations";
 import { useEventSource } from "@app/hooks/useEventSource";
-import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
+import type { AgentLoopToolNotificationEvent } from "@app/lib/actions/mcp";
 import { getActionOneLineLabel } from "@app/lib/api/assistant/activity_steps";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
@@ -174,7 +174,7 @@ export function updateMessageWithAction(
 
 export function updateProgress(
   agentMessage: AgentMessageWithStreaming,
-  event: ToolNotificationEvent
+  event: AgentLoopToolNotificationEvent
 ): AgentMessageWithStreaming {
   const actionId = event.action.id;
   const currentProgress = agentMessage.streaming.actionProgress.get(actionId);

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -28,6 +28,7 @@ import type {
   ToolDisplayLabels,
 } from "@app/lib/api/mcp";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { SandboxFunctionMCPActionType } from "@app/types/api/sandbox_functions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
@@ -255,11 +256,10 @@ export type AgentLoopToolNotificationEvent = ToolNotificationEventBase & {
 };
 
 // Tool notification emitted when running a tool within a sandbox function invocation.
-// TODO(SANDBOX_FUNCTIONS): carry the sandbox function action once SandboxFunctionMCPActionResource
-// is available.
 export type SandboxFunctionToolNotificationEvent = ToolNotificationEventBase & {
   sandboxFunctionId: string;
   invocationId: string;
+  action: SandboxFunctionMCPActionType;
 };
 
 export type ToolNotificationEvent =

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -242,7 +242,6 @@ export type MCPErrorEvent = {
 type ToolNotificationEventBase = {
   type: "tool_notification";
   created: number;
-  action: AgentMCPActionWithOutputType;
   notification: ProgressNotificationContentType;
 };
 
@@ -252,9 +251,12 @@ export type AgentLoopToolNotificationEvent = ToolNotificationEventBase & {
   configurationId: string;
   conversationId: string;
   messageId: string;
+  action: AgentMCPActionWithOutputType;
 };
 
 // Tool notification emitted when running a tool within a sandbox function invocation.
+// TODO(SANDBOX_FUNCTIONS): carry the sandbox function action once SandboxFunctionMCPActionResource
+// is available.
 export type SandboxFunctionToolNotificationEvent = ToolNotificationEventBase & {
   sandboxFunctionId: string;
   invocationId: string;

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -29,6 +29,7 @@ import {
   AgentMessageModel,
   MessageModel,
 } from "@app/lib/models/agent/conversation";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
@@ -731,7 +732,8 @@ describe("tryCallMCPTool", () => {
         resumeState: null,
         websearchResultCount: 0,
       },
-      currentAction: mockAction,
+      // The action resource is never read by tryCallMCPTool; a plain mock is enough here.
+      action: mockAction as unknown as AgentMCPActionResource,
       toolConfiguration,
       userMessage,
     };

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -121,7 +121,7 @@ async function setupTest({
         ...modelConfig,
       },
       agentMessage,
-      currentAction: action.toJSON(),
+      action,
       conversation,
       stepContext: action.stepContext,
       toolConfiguration,
@@ -253,13 +253,12 @@ describe("getAugmentedInputs", () => {
 
 describe("processToolResults", () => {
   it("should store snippet in DB when text exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES", async () => {
-    const { auth, action, toolContext } = await setupTest();
+    const { auth, toolContext } = await setupTest();
 
     // Generate text that exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES (20KB).
     const largeText = "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
 
     const { outputItems, generatedFiles } = await processToolResults(auth, {
-      action,
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [{ type: "text", text: largeText }],
@@ -282,13 +281,12 @@ describe("processToolResults", () => {
   });
 
   it("should store snippet for large resource text", async () => {
-    const { auth, action, toolContext } = await setupTest();
+    const { auth, toolContext } = await setupTest();
 
     // Generate resource text that exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES (20KB).
     const largeResourceText = "y".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
 
     const { outputItems, generatedFiles } = await processToolResults(auth, {
-      action,
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [
@@ -315,12 +313,11 @@ describe("processToolResults", () => {
   });
 
   it("should keep small text content as-is", async () => {
-    const { auth, action, toolContext } = await setupTest();
+    const { auth, toolContext } = await setupTest();
 
     const smallText = "hello world";
 
     const { outputItems } = await processToolResults(auth, {
-      action,
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [{ type: "text", text: smallText }],
@@ -336,14 +333,13 @@ describe("processToolResults", () => {
   });
 
   it("should keep large sandbox text content as-is", async () => {
-    const { auth, action, toolContext } = await setupTest({
+    const { auth, toolContext } = await setupTest({
       mcpServerName: "sandbox",
     });
 
     const largeText = "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
 
     const { outputItems } = await processToolResults(auth, {
-      action,
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [{ type: "text", text: largeText }],
@@ -359,12 +355,11 @@ describe("processToolResults", () => {
   });
 
   it("should keep small resource text as-is", async () => {
-    const { auth, action, toolContext } = await setupTest();
+    const { auth, toolContext } = await setupTest();
 
     const smallText = "small resource text";
 
     const { outputItems } = await processToolResults(auth, {
-      action,
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [
@@ -385,7 +380,7 @@ describe("processToolResults", () => {
   });
 
   it(`should persist DATA_SOURCE_NODE_CONTENT block to ${TOOL_OUTPUTS_FOLDER_NAME}/`, async () => {
-    const { auth, action, toolContext } = await setupTest();
+    const { auth, toolContext } = await setupTest();
 
     fileStorageMock.reset();
 
@@ -407,7 +402,6 @@ describe("processToolResults", () => {
     };
 
     await processToolResults(auth, {
-      action,
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [
@@ -431,14 +425,13 @@ describe("processToolResults", () => {
   });
 
   it(`should persist large plain text block to ${TOOL_OUTPUTS_FOLDER_NAME}/ as .txt`, async () => {
-    const { auth, action, toolContext } = await setupTest();
+    const { auth, toolContext } = await setupTest();
 
     fileStorageMock.reset();
 
     const largeText = "hello world ".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES);
 
     await processToolResults(auth, {
-      action,
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [{ type: "text", text: largeText }],
@@ -455,7 +448,7 @@ describe("processToolResults", () => {
   });
 
   it(`should persist large JSON text block to ${TOOL_OUTPUTS_FOLDER_NAME}/ as .json`, async () => {
-    const { auth, action, toolContext } = await setupTest();
+    const { auth, toolContext } = await setupTest();
 
     fileStorageMock.reset();
 
@@ -464,7 +457,6 @@ describe("processToolResults", () => {
     });
 
     await processToolResults(auth, {
-      action,
       localLogger: logger.child({ test: true }),
       toolContext,
       toolCallResultContent: [{ type: "text", text: largeJson }],

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -105,12 +105,12 @@ export async function processToolNotification(
 
   // Specific handling for run_agent notifications indicating the tool has
   // started and can be resumed: the action is updated to save the resumeState.
-  if (isRunAgentQueryProgressOutput(output)) {
-    // Sandbox function actions carry no step context to persist a resume state on.
-    assert(
-      isAgentLoopRunContext(runContext),
-      "run_agent notifications require an agent loop run context."
-    );
+  // Sandbox function actions carry no step context to persist a resume state on, so this only
+  // applies to agent loop run contexts.
+  if (
+    isRunAgentQueryProgressOutput(output) &&
+    isAgentLoopRunContext(runContext)
+  ) {
     await runContext.action.updateStepContext({
       ...runContext.action.stepContext,
       resumeState: {

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -19,13 +19,15 @@ import type {
   ActionGeneratedFileType,
   ToolContextType,
 } from "@app/lib/actions/types";
-import { isAgentLoopRunContext } from "@app/lib/actions/types";
+import {
+  getMCPActionFromRunContext,
+  isAgentLoopRunContext,
+} from "@app/lib/actions/types";
 import { isInternalServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { persistToolOutput } from "@app/lib/api/files/action_output_fs";
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
-import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
@@ -74,10 +76,8 @@ export async function processToolNotification(
   auth: Authenticator,
   notification: MCPProgressNotificationType,
   {
-    action,
     toolContext,
   }: {
-    action: AgentMCPActionResource;
     toolContext: ToolContextType;
   }
 ): Promise<{
@@ -86,6 +86,7 @@ export async function processToolNotification(
 }> {
   const { runContext } = toolContext;
   assert(runContext, "processToolNotification requires a tool run context.");
+  const action = getMCPActionFromRunContext(runContext);
 
   const output = notification.params._meta.data.output;
 
@@ -113,12 +114,6 @@ export async function processToolNotification(
     });
   }
 
-  const actionWithOutput = {
-    ...action.toJSON(),
-    output: null,
-    generatedFiles: [],
-  };
-
   // Regular notifications, we yield them as is with the type "tool_notification", scoped to the
   // run context they were emitted from.
   switch (runContext.contextType) {
@@ -130,7 +125,11 @@ export async function processToolNotification(
           configurationId: runContext.agentConfiguration.sId,
           conversationId: runContext.conversation.sId,
           messageId: runContext.agentMessage.sId,
-          action: actionWithOutput,
+          action: {
+            ...action.toJSON(),
+            output: null,
+            generatedFiles: [],
+          },
           notification: notification.params,
         },
         storedItems,
@@ -142,7 +141,6 @@ export async function processToolNotification(
           created: Date.now(),
           sandboxFunctionId: runContext.invocation.sandboxFunction.sId,
           invocationId: runContext.invocation.sId,
-          action: actionWithOutput,
           notification: notification.params,
         },
         storedItems,
@@ -159,12 +157,10 @@ export async function processToolNotification(
 export async function processToolResults(
   auth: Authenticator,
   {
-    action,
     localLogger,
     toolCallResultContent,
     toolContext,
   }: {
-    action: AgentMCPActionResource;
     localLogger: Logger;
     toolCallResultContent: CallToolResult["content"];
     toolContext: ToolContextType;
@@ -176,6 +172,7 @@ export async function processToolResults(
   const { runContext } = toolContext;
   assert(runContext, "processToolResults requires a tool run context.");
   const { toolConfiguration } = runContext;
+  const action = getMCPActionFromRunContext(runContext);
 
   const timestamp = Date.now();
   const cleanContent: {

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -90,7 +90,8 @@ export async function processToolNotification(
 
   // Handle store_resource notifications by creating output items immediately (fire-and-forget GCS).
   if (isStoreResourceProgressOutput(output)) {
-    // Sandbox function actions have no per-block output items (single output at completion).
+    // TODO(SANDBOX_FUNCTIONS): persist sandbox function outputs (writeOutput) when running in a
+    // sandbox function run context.
     assert(
       isAgentLoopRunContext(runContext),
       "store_resource notifications require an agent loop run context."
@@ -441,8 +442,6 @@ export async function processToolResults(
     }
   );
 
-  // Sandbox function actions have no per-block output items (single output written at
-  // completion); their persistence will be wired in the sandbox function runner.
   // TODO(SANDBOX_FUNCTIONS): persist sandbox function outputs (writeOutput) when running in a
   // sandbox function run context.
   assert(

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -19,10 +19,7 @@ import type {
   ActionGeneratedFileType,
   ToolContextType,
 } from "@app/lib/actions/types";
-import {
-  getMCPActionFromRunContext,
-  isAgentLoopRunContext,
-} from "@app/lib/actions/types";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { isInternalServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { persistToolOutput } from "@app/lib/api/files/action_output_fs";
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
@@ -86,7 +83,6 @@ export async function processToolNotification(
 }> {
   const { runContext } = toolContext;
   assert(runContext, "processToolNotification requires a tool run context.");
-  const action = getMCPActionFromRunContext(runContext);
 
   const output = notification.params._meta.data.output;
 
@@ -94,7 +90,12 @@ export async function processToolNotification(
 
   // Handle store_resource notifications by creating output items immediately (fire-and-forget GCS).
   if (isStoreResourceProgressOutput(output)) {
-    storedItems = await action.createOutputItems(
+    // Sandbox function actions have no per-block output items (single output at completion).
+    assert(
+      isAgentLoopRunContext(runContext),
+      "store_resource notifications require an agent loop run context."
+    );
+    storedItems = await runContext.action.createOutputItems(
       auth,
       output.contents.map((content) => ({
         content: sanitizeStringsDeep(content),
@@ -105,8 +106,13 @@ export async function processToolNotification(
   // Specific handling for run_agent notifications indicating the tool has
   // started and can be resumed: the action is updated to save the resumeState.
   if (isRunAgentQueryProgressOutput(output)) {
-    await action.updateStepContext({
-      ...action.stepContext,
+    // Sandbox function actions carry no step context to persist a resume state on.
+    assert(
+      isAgentLoopRunContext(runContext),
+      "run_agent notifications require an agent loop run context."
+    );
+    await runContext.action.updateStepContext({
+      ...runContext.action.stepContext,
       resumeState: {
         userMessageId: output.userMessageId,
         conversationId: output.conversationId,
@@ -126,7 +132,7 @@ export async function processToolNotification(
           conversationId: runContext.conversation.sId,
           messageId: runContext.agentMessage.sId,
           action: {
-            ...action.toJSON(),
+            ...runContext.action.toJSON(),
             output: null,
             generatedFiles: [],
           },
@@ -141,6 +147,7 @@ export async function processToolNotification(
           created: Date.now(),
           sandboxFunctionId: runContext.invocation.sandboxFunction.sId,
           invocationId: runContext.invocation.sId,
+          action: runContext.action.toJSON(),
           notification: notification.params,
         },
         storedItems,
@@ -172,7 +179,6 @@ export async function processToolResults(
   const { runContext } = toolContext;
   assert(runContext, "processToolResults requires a tool run context.");
   const { toolConfiguration } = runContext;
-  const action = getMCPActionFromRunContext(runContext);
 
   const timestamp = Date.now();
   const cleanContent: {
@@ -435,7 +441,15 @@ export async function processToolResults(
     }
   );
 
-  const outputItems = await action.createOutputItems(
+  // Sandbox function actions have no per-block output items (single output written at
+  // completion); their persistence will be wired in the sandbox function runner.
+  // TODO(SANDBOX_FUNCTIONS): persist sandbox function outputs (writeOutput) when running in a
+  // sandbox function run context.
+  assert(
+    isAgentLoopRunContext(runContext),
+    "processToolResults requires an agent loop run context to store output items."
+  );
+  const outputItems = await runContext.action.createOutputItems(
     auth,
     cleanContent.map((c) => ({
       content: sanitizeStringsDeep(c.content),

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -3,8 +3,8 @@ import type {
   LightMCPToolConfigurationType,
   MCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
-import type { AgentMCPActionType } from "@app/types/actions";
 import type {
   AgentConfigurationWithoutModelType,
   AgentModelConfigurationType,
@@ -16,6 +16,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { AllSupportedFileContentType } from "@app/types/files";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { z } from "zod";
 
 const FileAuthorizationInfoSchema = z.object({
@@ -152,10 +153,10 @@ export type ActionGeneratedFileType =
 
 export type AgentLoopRunContextType = {
   contextType: "agent_loop";
+  action: AgentMCPActionResource;
   agentConfiguration: AgentConfigurationWithoutModelType;
   model: AgentModelConfigurationType & ModelConfigurationType;
   agentMessage: AgentMessageType;
-  currentAction: AgentMCPActionType;
   conversation: ConversationType;
   stepContext: StepContext;
   toolConfiguration: LightMCPToolConfigurationType;
@@ -186,6 +187,26 @@ export function isAgentLoopRunContext(
   value: AgentLoopRunContextType | SandboxFunctionRunContextType | undefined
 ): value is AgentLoopRunContextType {
   return value?.contextType === "agent_loop";
+}
+
+/**
+ * Returns the MCP action resource associated with a tool run context.
+ */
+export function getMCPActionFromRunContext(
+  runContext: AgentLoopRunContextType | SandboxFunctionRunContextType
+): AgentMCPActionResource {
+  switch (runContext.contextType) {
+    case "agent_loop":
+      return runContext.action;
+    case "sandbox_function":
+      // TODO(SANDBOX_FUNCTIONS): return the invocation's SandboxFunctionMCPActionResource once
+      // available.
+      throw new Error(
+        "MCP actions are not available in sandbox function run contexts yet."
+      );
+    default:
+      return assertNever(runContext);
+  }
 }
 
 export type ToolContextType =

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -5,6 +5,7 @@ import type {
 } from "@app/lib/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import type { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import type {
   AgentConfigurationWithoutModelType,
   AgentModelConfigurationType,
@@ -16,7 +17,6 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { AllSupportedFileContentType } from "@app/types/files";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { z } from "zod";
 
 const FileAuthorizationInfoSchema = z.object({
@@ -165,6 +165,7 @@ export type AgentLoopRunContextType = {
 
 export type SandboxFunctionRunContextType = {
   contextType: "sandbox_function";
+  action: SandboxFunctionMCPActionResource;
   invocation: SandboxFunctionInvocationResource;
   toolConfiguration: LightMCPToolConfigurationType;
 };
@@ -187,26 +188,6 @@ export function isAgentLoopRunContext(
   value: AgentLoopRunContextType | SandboxFunctionRunContextType | undefined
 ): value is AgentLoopRunContextType {
   return value?.contextType === "agent_loop";
-}
-
-/**
- * Returns the MCP action resource associated with a tool run context.
- */
-export function getMCPActionFromRunContext(
-  runContext: AgentLoopRunContextType | SandboxFunctionRunContextType
-): AgentMCPActionResource {
-  switch (runContext.contextType) {
-    case "agent_loop":
-      return runContext.action;
-    case "sandbox_function":
-      // TODO(SANDBOX_FUNCTIONS): return the invocation's SandboxFunctionMCPActionResource once
-      // available.
-      throw new Error(
-        "MCP actions are not available in sandbox function run contexts yet."
-      );
-    default:
-      return assertNever(runContext);
-  }
 }
 
 export type ToolContextType =

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -243,7 +243,10 @@ describe("runSandboxBashTool", () => {
           model: { providerId: "openai" },
           agentMessage: { sId: "message-id", agentMessageId: 1 },
           conversation: { sId: "conversation-id" },
-          currentAction: { sId: "sandbox-action-id" },
+          action: {
+            sId: "sandbox-action-id",
+            toJSON: () => ({ sId: "sandbox-action-id" }),
+          },
           stepContext: {
             citationsCount: 0,
             citationsOffset: 0,
@@ -680,7 +683,10 @@ describe("runSandboxBashTool", () => {
             model: { providerId: "openai" },
             agentMessage: { sId: "message-id", agentMessageId: 1 },
             conversation: { sId: "conversation-id" },
-            currentAction: { sId: "sandbox-action-id" },
+            action: {
+              sId: "sandbox-action-id",
+              toJSON: () => ({ sId: "sandbox-action-id" }),
+            },
             stepContext: {
               citationsCount: 0,
               citationsOffset: 0,

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -314,7 +314,7 @@ export async function runSandboxBashTool(
     agentConfiguration,
     model,
     agentMessage,
-    currentAction: sandboxAction,
+    action: sandboxAction,
     stepContext,
   } = runContext;
 
@@ -367,7 +367,7 @@ export async function runSandboxBashTool(
     // Token must outlive the longest plausible pause/resume cycle. Redis
     // revocation list bounds the real lifetime.
     expiryMs: DEFAULT_EXEC_TIMEOUT_MS,
-    sandboxAction,
+    sandboxAction: sandboxAction.toJSON(),
   });
 
   const metricsCtx = { workspaceId: auth.getNonNullableWorkspace().sId };

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -87,10 +87,10 @@ export async function* runToolWithStreaming(
 
   const agentLoopRunContext: AgentLoopRunContextType = {
     contextType: "agent_loop",
+    action,
     agentConfiguration,
     model,
     agentMessage,
-    currentAction: action.toJSON(),
     conversation,
     stepContext: action.stepContext,
     toolConfiguration,
@@ -112,7 +112,7 @@ export async function* runToolWithStreaming(
         const { event, storedItems } = await processToolNotification(
           auth,
           notification,
-          { action, toolContext: { runContext: agentLoopRunContext } }
+          { toolContext: { runContext: agentLoopRunContext } }
         );
         intermediateOutputItems.push(...storedItems);
         return event;
@@ -142,7 +142,6 @@ export async function* runToolWithStreaming(
   const { outputItems, generatedFiles } = await withPeriodicHeartbeat(
     () =>
       processToolResults(auth, {
-        action,
         localLogger,
         toolCallResultContent: toolCallResult.content,
         toolContext: { runContext: agentLoopRunContext },

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -70,7 +70,7 @@ to dynamically express that a server is not usable.
 - [x] run_tool/mcp_execution: introduce pod tool_outputs (action_output_fs, persistToolOutput)
 - [ ] make runToolWithStreaming conversation-free
   - [x] make processToolNotification conversation-free
-  - [ ] make processToolResults conversation-free
+  - [x] make processToolResults conversation-free
   - [ ] make getExitOrPauseEvents conversation-free
 - [ ] data_warehouse: flow to tool_outputs if in sandbox function
 - [ ] image_generation: flow to tool_outputs if in sandbox function


### PR DESCRIPTION
## Description

Step towards conversation-free tool execution (sandbox function invocations).

- `AgentLoopRunContextType.currentAction: AgentMCPActionType` becomes `action: AgentMCPActionResource`: the run context carries the action resource itself instead of its serialized form.
- `SandboxFunctionRunContextType` gains `action: SandboxFunctionMCPActionResource`, so `runContext.action` resolves the right resource on both context types.
- `processToolNotification` and `processToolResults` no longer take an `action` parameter; they resolve it from the tool context. Agent-loop-only behaviors (per-block output items, step-context resume state) assert an agent loop run context; sandbox output persistence (`writeOutput`) is left as a `TODO(SANDBOX_FUNCTIONS)` for the sandbox function runner.
- `ToolNotificationEvent`: `action` moves from the shared base onto each variant — `AgentMCPActionWithOutputType` on the agent loop event, `SandboxFunctionMCPActionType` on the sandbox function event.
- The sandbox bash tool (sole reader of `currentAction`) now destructures the resource and passes `sandboxAction.toJSON()` to `generateSandboxExecToken`, whose signature is unchanged.

## Tests

`lib/actions/mcp_execution.test.ts`, `lib/actions/mcp_actions.test.ts`, `lib/api/actions/servers/sandbox/tools/index.test.ts`, `lib/api/sandbox/access_tokens.test.ts`, `lib/resources/sandbox_function_mcp_action_resource.test.ts` pass.

## Risk

Low. Agent loop behavior unchanged: the same resource flows through, just via the context. The sandbox function paths assert until the sandbox runner lands.

## Deploy Plan

- deploy `front`

🤖 Generated with [Claude Code](https://claude.com/claude-code)