### PR TITLE
Pricing: cleaning the invoices tab in billing page

### DIFF
--- a/front/components/workspace/billing/RecentInvoices.tsx
+++ b/front/components/workspace/billing/RecentInvoices.tsx
@@ -2,8 +2,18 @@ import { getPriceAsString } from "@app/lib/client/subscription";
 import { useRecentBillingInvoices } from "@app/lib/swr/workspaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { BillingInvoice } from "@app/types/api/billing/invoices";
-import { Button, Spinner } from "@dust-tt/sparkle";
+import { Button, DataTable, Spinner } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
 import { useSubscriptionContext } from "./SubscriptionContext";
+
+interface InvoiceRow {
+  label: string;
+  dateLabel: string;
+  amountLabel: string;
+  invoiceUrl: string | null;
+  onClick?: () => void;
+  menuItems?: never[];
+}
 
 function getInvoiceLabel(invoice: BillingInvoice): string {
   return invoice.description ?? invoice.number ?? "Invoice";
@@ -13,6 +23,58 @@ function getInvoiceUrl(invoice: BillingInvoice): string | null {
   return invoice.hostedInvoiceUrl ?? invoice.invoicePdf;
 }
 
+const COLUMNS: ColumnDef<InvoiceRow>[] = [
+  {
+    accessorKey: "label",
+    header: "Invoice",
+    enableSorting: false,
+    meta: { className: "w-[45%]" },
+    cell: ({ row }) => (
+      <span className="block truncate text-sm">{row.original.label}</span>
+    ),
+  },
+  {
+    accessorKey: "dateLabel",
+    header: "Date",
+    enableSorting: false,
+    meta: { className: "w-[20%]" },
+    cell: ({ row }) => (
+      <span className="text-sm text-muted-foreground">
+        {row.original.dateLabel}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "amountLabel",
+    header: "Amount",
+    enableSorting: false,
+    meta: { headerAlign: "right", className: "w-[17%]" },
+    cell: ({ row }) => (
+      <span className="block text-right text-sm">
+        {row.original.amountLabel}
+      </span>
+    ),
+  },
+  {
+    id: "actions",
+    header: "",
+    enableSorting: false,
+    meta: { className: "w-[18%]" },
+    cell: ({ row }) => (
+      <div className="flex justify-end">
+        <Button
+          label="See invoice"
+          variant="ghost"
+          size="sm"
+          href={row.original.invoiceUrl ?? "target-blank-placeholder"}
+          target="_blank"
+          disabled={!row.original.invoiceUrl}
+        />
+      </div>
+    ),
+  },
+];
+
 export function RecentInvoices() {
   const { owner } = useSubscriptionContext();
   const { billingInvoices, isBillingInvoicesLoading } =
@@ -21,10 +83,20 @@ export function RecentInvoices() {
     });
   const portalHref = `/w/${owner.sId}/subscription/manage`;
 
+  const rows: InvoiceRow[] = billingInvoices.map((invoice) => ({
+    label: getInvoiceLabel(invoice),
+    dateLabel: formatTimestampToFriendlyDate(invoice.createdAtMs, "short"),
+    amountLabel: getPriceAsString({
+      currency: invoice.currency,
+      priceInCents: invoice.totalExcludingTaxCents ?? invoice.totalCents,
+    }),
+    invoiceUrl: getInvoiceUrl(invoice),
+  }));
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between gap-3">
-        <h2 className="text-xl font-semibold text-foreground">Invoices</h2>
+        <h2 className="text-xl font-semibold text-foreground">Past invoices</h2>
         {billingInvoices.length > 0 && (
           <Button
             label="See all"
@@ -44,44 +116,7 @@ export function RecentInvoices() {
           No invoices available.
         </div>
       ) : (
-        <div className="flex flex-col">
-          <div className="flex flex-col">
-            {billingInvoices.map((invoice) => {
-              const invoiceUrl = getInvoiceUrl(invoice);
-
-              return (
-                <div
-                  key={invoice.id}
-                  className="grid grid-cols-1 gap-2 border-b border-border py-2 text-sm text-muted-foreground last:border-b-0 md:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1fr)_auto] md:items-center md:gap-4"
-                >
-                  <div className="truncate">{getInvoiceLabel(invoice)}</div>
-                  <div>
-                    {formatTimestampToFriendlyDate(
-                      invoice.createdAtMs,
-                      "short"
-                    )}
-                  </div>
-                  <div>
-                    {getPriceAsString({
-                      currency: invoice.currency,
-                      priceInCents: invoice.totalCents,
-                    })}
-                  </div>
-                  <div className="md:justify-self-end">
-                    <Button
-                      label="See invoice"
-                      variant="ghost"
-                      size="sm"
-                      href={invoiceUrl ?? "target-blank-placeholder"}
-                      target="_blank"
-                      disabled={!invoiceUrl}
-                    />
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
+        <DataTable data={rows} columns={COLUMNS} hideRowDivider={false} />
       )}
     </div>
   );

--- a/front/lib/api/billing/invoices.ts
+++ b/front/lib/api/billing/invoices.ts
@@ -25,6 +25,9 @@ function serializeInvoice(invoice: Stripe.Invoice): BillingInvoice {
     description: invoice.description ?? null,
     currency: invoice.currency,
     totalCents: invoice.total,
+    // `total_excluding_tax` is null when Stripe computed no tax on the
+    // invoice, in which case `total` is already tax-free.
+    totalExcludingTaxCents: invoice.total_excluding_tax ?? invoice.total,
     amountPaidCents: invoice.amount_paid,
     createdAtMs: invoice.created * 1000,
     dueDateMs: invoice.due_date ? invoice.due_date * 1000 : null,

--- a/front/types/api/billing/invoices.ts
+++ b/front/types/api/billing/invoices.ts
@@ -7,6 +7,9 @@ export type BillingInvoice = {
   description: string | null;
   currency: string;
   totalCents: number;
+  // Optional for backward compatibility with servers deployed before the
+  // field was introduced.
+  totalExcludingTaxCents?: number;
   amountPaidCents: number;
   createdAtMs: number;
   dueDateMs: number | null;


### PR DESCRIPTION
## Description

 - Make all the prices excluding tax for consistency
 - turn the table of past invoices to a table to make it clear it is a different table than the previous one

## Tests

tested locally

<img width="3790" height="1614" alt="image" src="https://github.com/user-attachments/assets/ec43479a-df95-41a1-ba80-e0bfaa9240a9" />


## Risk

low, if amount without tax is too confusing we can always add a new column with the tax later

## Deploy Plan

deploy front
