### PR TITLE
fix(front): model Linear webhook envelope in filter generator schema

### DIFF
--- a/front/lib/triggers/built-in-webhooks/linear/preset.test.ts
+++ b/front/lib/triggers/built-in-webhooks/linear/preset.test.ts
@@ -1,0 +1,80 @@
+import { matchPayload, parseMatcherExpression } from "@app/lib/matcher";
+import { LINEAR_WEBHOOK_PRESET } from "@app/lib/triggers/built-in-webhooks/linear/preset";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { describe, expect, it } from "vitest";
+
+function getEvent(value: string) {
+  const event = LINEAR_WEBHOOK_PRESET.events.find((e) => e.value === value);
+  if (!event) {
+    throw new Error(`Missing Linear event: ${value}`);
+  }
+  return event;
+}
+
+describe("Linear webhook preset schema", () => {
+  it.each([
+    "Issue",
+    "Project",
+  ])("nests the %s entity under `data` with action/type envelope", (value) => {
+    const schema = getEvent(value).schema as JSONSchema;
+    const properties = schema.properties ?? {};
+
+    expect(properties).toHaveProperty("action");
+    expect(properties).toHaveProperty("type");
+    expect(properties).toHaveProperty("data");
+
+    // The entity fields live under `data`, not at the top level.
+    const dataSchema = properties.data as JSONSchema;
+    expect(dataSchema.properties).toHaveProperty("labelIds");
+    expect(properties).not.toHaveProperty("labelIds");
+  });
+});
+
+describe("Linear webhook filters against delivered payload", () => {
+  const issueDeliveredPayload = {
+    action: "update",
+    type: "Issue",
+    createdAt: "2026-07-07T00:00:00.000Z",
+    url: "https://linear.app/dust/issue/ABC-123",
+    data: {
+      id: "issue-uuid",
+      identifier: "ABC-123",
+      title: "Something is broken",
+      labelIds: ["label-uuid-1", "label-uuid-2"],
+      labels: [{ id: "label-uuid-1", name: "bug", color: "#fff" }],
+      state: { id: "s1", name: "In Progress", type: "started", color: "#000" },
+    },
+  };
+
+  function parse(expression: string) {
+    const result = parseMatcherExpression(expression);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    return result.value;
+  }
+
+  it("matches when the filter uses the `data.` prefix", () => {
+    expect(
+      matchPayload(
+        issueDeliveredPayload,
+        parse('(has "data.labelIds" "label-uuid-1")')
+      )
+    ).toBe(true);
+    expect(
+      matchPayload(
+        issueDeliveredPayload,
+        parse('(has "data.labels.*.name" "bug")')
+      )
+    ).toBe(true);
+  });
+
+  it("does not match the old envelope-less path (the bug being fixed)", () => {
+    expect(
+      matchPayload(
+        issueDeliveredPayload,
+        parse('(has "labelIds" "label-uuid-1")')
+      )
+    ).toBe(false);
+  });
+});

--- a/front/lib/triggers/built-in-webhooks/linear/preset.ts
+++ b/front/lib/triggers/built-in-webhooks/linear/preset.ts
@@ -1,3 +1,4 @@
+import { makeLinearWebhookEnvelopeSchema } from "@app/lib/triggers/built-in-webhooks/linear/schemas/envelope";
 import { issueSchema } from "@app/lib/triggers/built-in-webhooks/linear/schemas/issue";
 import { projectSchema } from "@app/lib/triggers/built-in-webhooks/linear/schemas/project";
 import type {
@@ -9,7 +10,10 @@ const LINEAR_ISSUE_EVENT: WebhookEvent = {
   name: "issue",
   value: "Issue",
   description: "Lambda event for Linear webhooks",
-  schema: issueSchema,
+  schema: makeLinearWebhookEnvelopeSchema({
+    entityType: "Issue",
+    dataSchema: issueSchema,
+  }),
   sample: null,
 };
 
@@ -17,7 +21,10 @@ const LINEAR_PROJECT_EVENT: WebhookEvent = {
   name: "project",
   value: "Project",
   description: "Lambda event for Linear webhooks",
-  schema: projectSchema,
+  schema: makeLinearWebhookEnvelopeSchema({
+    entityType: "Project",
+    dataSchema: projectSchema,
+  }),
   sample: null,
 };
 

--- a/front/lib/triggers/built-in-webhooks/linear/schemas/envelope.ts
+++ b/front/lib/triggers/built-in-webhooks/linear/schemas/envelope.ts
@@ -1,0 +1,58 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+// Linear nests the entity under `data`; filters run against the full envelope,
+// so the generator schema must model it too (else it emits `labelIds` instead
+// of `data.labelIds`). https://linear.app/developers/webhooks#the-webhook-payload
+export function makeLinearWebhookEnvelopeSchema({
+  entityType,
+  dataSchema,
+}: {
+  entityType: string;
+  dataSchema: JSONSchema;
+}): JSONSchema {
+  return {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    title: `Linear${entityType}WebhookEnvelope`,
+    type: "object",
+    description: `Payload envelope for a ${entityType} webhook event from Linear. The ${entityType} itself is nested under "data".`,
+    required: ["action", "type", "createdAt", "data", "url"],
+    properties: {
+      action: {
+        type: "string",
+        description: "The change that triggered the webhook.",
+        enum: ["create", "update", "remove"],
+      },
+      type: {
+        type: "string",
+        description: "The type of entity carried in `data`.",
+        enum: [entityType],
+      },
+      createdAt: {
+        type: "string",
+        description: "When the webhook event was created.",
+      },
+      data: dataSchema,
+      updatedFrom: {
+        type: ["object", "null"],
+        description:
+          "Previous values of the fields that changed (present on `update` events only).",
+      },
+      url: {
+        type: "string",
+        description: "URL to the entity in Linear.",
+      },
+      organizationId: {
+        type: ["string", "null"],
+        description: "ID of the Linear organization.",
+      },
+      webhookTimestamp: {
+        type: ["number", "null"],
+        description: "Timestamp at which the webhook was sent.",
+      },
+      webhookId: {
+        type: ["string", "null"],
+        description: "ID of the webhook that delivered this event.",
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8922

The natural-language filter generator for the built-in Linear webhook provider produced field paths without the `data.` prefix — e.g. `(has "labelIds" "...")` instead of `(has "data.labelIds" "...")`, so the generated filters never matched the delivered payload.

Fix: wrap the issue/project schemas in the real Linear envelope (`makeLinearWebhookEnvelopeSchema`) so the generator sees `action` / `type` / `data.*` and emits the correct `data.` prefix. The detailed inner schemas are reused unchanged. `event.schema` is only ever serialized to the generator LLM (nothing validates payloads against it), so wrapping it has no other side effects.

## Tests

Added `linear/preset.test.ts`: asserts the Issue/Project schemas nest the entity under `data` with the `action`/`type` envelope, and drives `matchPayload` against a realistic delivered payload to prove `(has "data.labelIds" ...)` matches while the old `(has "labelIds" ...)` does not.

## Risk

Low.

## Deploy Plan

Standard deploy, no migration or ordering considerations.