### PR TITLE
fix(connectors): bound Google Drive file downloads to prevent OOM

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file/handle_file_export.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/handle_file_export.ts
@@ -2,6 +2,7 @@ import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/
 import {
   getDriveClient,
   getInternalId,
+  isFileTooLargeToDownloadError,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import {
   handleCsvFile,
@@ -10,6 +11,7 @@ import {
 } from "@connectors/connectors/shared/file";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
 import {
+  MAX_FILE_SIZE_TO_DOWNLOAD,
   renderDocumentTitleAndContent,
   renderMarkdownSection,
 } from "@connectors/lib/data_sources";
@@ -43,6 +45,10 @@ export async function handleFileExport(
       },
       {
         responseType: "arraybuffer",
+        // Google-native files report no size in their metadata, so the pre-download guard cannot
+        // catch them. Cap the download itself so a huge file is aborted mid-stream instead of being
+        // fully buffered in memory (a source of OOMs).
+        maxContentLength: MAX_FILE_SIZE_TO_DOWNLOAD,
       }
     );
   } catch (e) {
@@ -81,8 +87,7 @@ export async function handleFileExport(
       }
     }
 
-    const maybeErrorWithCode = e as { code: string };
-    if (maybeErrorWithCode.code === "ERR_OUT_OF_RANGE") {
+    if (isFileTooLargeToDownloadError(e)) {
       localLogger.info({}, "File too big to be downloaded. Skipping");
       return null;
     }

--- a/connectors/src/connectors/google_drive/temporal/file/handle_google_drive_export.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/handle_google_drive_export.ts
@@ -160,10 +160,7 @@ export async function handleGoogleDriveExport(
       }
 
       if (isFileTooLargeToDownloadError(e)) {
-        localLogger.info(
-          {},
-          "Google document too large to be exported, skipping."
-        );
+        localLogger.info("Google document too large to be exported, skipping.");
         return { content: null };
       }
 

--- a/connectors/src/connectors/google_drive/temporal/file/handle_google_drive_export.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/handle_google_drive_export.ts
@@ -1,6 +1,10 @@
 import { MIME_TYPES_TO_EXPORT } from "@connectors/connectors/google_drive/temporal/mime_types";
-import { getDriveClient } from "@connectors/connectors/google_drive/temporal/utils";
+import {
+  getDriveClient,
+  isFileTooLargeToDownloadError,
+} from "@connectors/connectors/google_drive/temporal/utils";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
+import { MAX_FILE_SIZE_TO_DOWNLOAD } from "@connectors/lib/data_sources";
 import type { Logger } from "@connectors/logger/logger";
 import type { GoogleDriveObjectType } from "@connectors/types";
 import { Context } from "@temporalio/activity";
@@ -27,10 +31,18 @@ export async function handleGoogleDriveExport(
 
   for (;;) {
     try {
-      const res = await drive.files.export({
-        fileId: file.id,
-        mimeType: MIME_TYPES_TO_EXPORT[file.mimeType],
-      });
+      const res = await drive.files.export(
+        {
+          fileId: file.id,
+          mimeType: MIME_TYPES_TO_EXPORT[file.mimeType],
+        },
+        {
+          // Google-native docs report no size in their metadata, so the pre-download guard cannot
+          // catch them. Cap the export so a huge document is aborted mid-stream instead of being
+          // fully buffered in memory (a source of OOMs).
+          maxContentLength: MAX_FILE_SIZE_TO_DOWNLOAD,
+        }
+      );
       if (res.status !== 200) {
         localLogger.error({}, "Error exporting Google document");
         throw new Error(
@@ -145,6 +157,14 @@ export async function handleGoogleDriveExport(
             continue;
           }
         }
+      }
+
+      if (isFileTooLargeToDownloadError(e)) {
+        localLogger.info(
+          {},
+          "Google document too large to be exported, skipping."
+        );
+        return { content: null };
       }
 
       localLogger.error({ error: e }, "Error exporting Google document");

--- a/connectors/src/connectors/google_drive/temporal/utils.test.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.test.ts
@@ -1,0 +1,34 @@
+import { isFileTooLargeToDownloadError } from "@connectors/connectors/google_drive/temporal/utils";
+import { describe, expect, it } from "vitest";
+
+describe("isFileTooLargeToDownloadError", () => {
+  it("detects the node-fetch max-size error raised when maxContentLength is exceeded", () => {
+    // Shape of the error node-fetch throws once the response body goes over the
+    // configured `size` (set from gaxios `maxContentLength`).
+    const err = Object.assign(
+      new Error("content size at https://example.com over limit: 268435456"),
+      { name: "FetchError", type: "max-size" }
+    );
+
+    expect(isFileTooLargeToDownloadError(err)).toBe(true);
+  });
+
+  it("detects the Node ERR_OUT_OF_RANGE error raised when buffering a huge file", () => {
+    const err = Object.assign(new Error("Array buffer allocation failed"), {
+      code: "ERR_OUT_OF_RANGE",
+    });
+
+    expect(isFileTooLargeToDownloadError(err)).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isFileTooLargeToDownloadError(new Error("boom"))).toBe(false);
+    expect(
+      isFileTooLargeToDownloadError(
+        Object.assign(new Error("nope"), { type: "system" })
+      )
+    ).toBe(false);
+    expect(isFileTooLargeToDownloadError("not an error")).toBe(false);
+    expect(isFileTooLargeToDownloadError(null)).toBe(false);
+  });
+});

--- a/connectors/src/connectors/google_drive/temporal/utils.test.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.test.ts
@@ -13,6 +13,26 @@ describe("isFileTooLargeToDownloadError", () => {
     expect(isFileTooLargeToDownloadError(err)).toBe(true);
   });
 
+  it("detects the max-size error when gaxios wraps it in a GaxiosError", () => {
+    // gaxios 6.x (used via google-auth-library) wraps the underlying fetch error in a GaxiosError
+    // whose top-level `type` is undefined; the original FetchError (with `type: "max-size"`) is
+    // nested on `.error`.
+    const wrapped = Object.assign(
+      new Error("content size at https://example.com over limit: 268435456"),
+      {
+        name: "GaxiosError",
+        error: Object.assign(
+          new Error(
+            "content size at https://example.com over limit: 268435456"
+          ),
+          { name: "FetchError", type: "max-size" }
+        ),
+      }
+    );
+
+    expect(isFileTooLargeToDownloadError(wrapped)).toBe(true);
+  });
+
   it("detects the Node ERR_OUT_OF_RANGE error raised when buffering a huge file", () => {
     const err = Object.assign(new Error("Array buffer allocation failed"), {
       code: "ERR_OUT_OF_RANGE",

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -348,6 +348,27 @@ export async function _getLabels(
   return [];
 }
 
+// Detects the errors raised when a file exceeds the download size cap. Google-native docs
+// (Slides/Docs) report no size in their metadata, so the pre-download guard cannot catch them; we
+// cap the download itself via gaxios `maxContentLength`, which makes node-fetch abort mid-stream
+// with a `max-size` error. `ERR_OUT_OF_RANGE` is the older reactive case where Node fails to
+// allocate a buffer/string for a huge response.
+export function isFileTooLargeToDownloadError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if ("type" in error && error.type === "max-size") {
+    return true;
+  }
+
+  if ("code" in error && error.code === "ERR_OUT_OF_RANGE") {
+    return true;
+  }
+
+  return false;
+}
+
 export function isSharedDriveNotFoundError(error: unknown): boolean {
   if (!(error instanceof GaxiosError)) {
     return false;

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -348,22 +348,37 @@ export async function _getLabels(
   return [];
 }
 
-// Detects the errors raised when a file exceeds the download size cap. Google-native docs
-// (Slides/Docs) report no size in their metadata, so the pre-download guard cannot catch them; we
-// cap the download itself via gaxios `maxContentLength`, which makes node-fetch abort mid-stream
-// with a `max-size` error. `ERR_OUT_OF_RANGE` is the older reactive case where Node fails to
-// allocate a buffer/string for a huge response.
-export function isFileTooLargeToDownloadError(error: unknown): boolean {
+function hasFileTooLargeMarker(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
   }
 
+  // `max-size` is what node-fetch/fetch aborts with once the response body exceeds `maxContentLength`.
   if ("type" in error && error.type === "max-size") {
     return true;
   }
 
+  // `ERR_OUT_OF_RANGE` is the older reactive case where Node fails to allocate a buffer/string for a
+  // huge response.
   if ("code" in error && error.code === "ERR_OUT_OF_RANGE") {
     return true;
+  }
+
+  return false;
+}
+
+// Detects the errors raised when a file exceeds the download size cap. Google-native docs
+// (Slides/Docs) report no size in their metadata, so the pre-download guard cannot catch them; we
+// cap the download itself via gaxios `maxContentLength`, which makes fetch abort mid-stream with a
+// `max-size` error. gaxios wraps that in a GaxiosError whose top-level `type` is undefined and
+// stores the original error on `.error`, so we check both the error itself and that nested cause.
+export function isFileTooLargeToDownloadError(error: unknown): boolean {
+  if (hasFileTooLargeMarker(error)) {
+    return true;
+  }
+
+  if (error instanceof Error && "error" in error) {
+    return hasFileTooLargeMarker(error.error);
   }
 
   return false;

--- a/connectors/src/lib/async_utils.test.ts
+++ b/connectors/src/lib/async_utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { getAdaptiveConcurrency } from "./async_utils";
+
+describe("getAdaptiveConcurrency", () => {
+  const MAX_FILE_SIZE = 256 * 1024 * 1024; // 256 MB
+  const DEFAULT_CONCURRENCY = 8;
+
+  it("returns the default concurrency when all files are small", () => {
+    const files = [{ size: 1024 }, { size: 2048 }, { size: 4096 }];
+
+    expect(
+      getAdaptiveConcurrency(files, MAX_FILE_SIZE, DEFAULT_CONCURRENCY)
+    ).toBe(DEFAULT_CONCURRENCY);
+  });
+
+  it("lowers concurrency as the largest file approaches the max size", () => {
+    const files = [{ size: MAX_FILE_SIZE / 2 }, { size: 1024 }];
+
+    // maxFileSize / (maxFileSize / 2) === 2
+    expect(
+      getAdaptiveConcurrency(files, MAX_FILE_SIZE, DEFAULT_CONCURRENCY)
+    ).toBe(2);
+  });
+
+  it("returns the default concurrency for an empty list", () => {
+    expect(getAdaptiveConcurrency([], MAX_FILE_SIZE, DEFAULT_CONCURRENCY)).toBe(
+      DEFAULT_CONCURRENCY
+    );
+  });
+
+  it("treats files with unknown size as worst-case", () => {
+    // Google-native Docs/Slides come back with no size from the Drive API. They
+    // must not silently get maximum concurrency, since they can be huge once
+    // exported and are fully buffered in memory.
+    const files = [{ size: null }, { size: undefined }, { size: 1024 }];
+
+    expect(
+      getAdaptiveConcurrency(files, MAX_FILE_SIZE, DEFAULT_CONCURRENCY)
+    ).toBe(1);
+  });
+
+  it("treats a mix of known-small and unknown-size files as worst-case", () => {
+    const files = [{ size: 1024 }, { size: 2048 }, { size: null }];
+
+    expect(
+      getAdaptiveConcurrency(files, MAX_FILE_SIZE, DEFAULT_CONCURRENCY)
+    ).toBe(1);
+  });
+
+  it("ignores files already over the max size (they are skipped before download)", () => {
+    const files = [{ size: MAX_FILE_SIZE * 2 }, { size: 1024 }];
+
+    expect(
+      getAdaptiveConcurrency(files, MAX_FILE_SIZE, DEFAULT_CONCURRENCY)
+    ).toBe(DEFAULT_CONCURRENCY);
+  });
+});

--- a/connectors/src/lib/async_utils.ts
+++ b/connectors/src/lib/async_utils.ts
@@ -52,9 +52,23 @@ export function getAdaptiveConcurrency(
   maxFileSize: number,
   defaultConcurrency: number
 ): number {
-  const maxFoundFileSize = files
-    .filter((file) => file.size && file.size <= maxFileSize)
-    .reduce((max, file) => Math.max(max, file.size ?? 0), 0);
+  const maxFoundFileSize = files.reduce((max, file) => {
+    // Files with a known size over the limit are skipped before download, so they
+    // consume no memory and should not lower concurrency.
+    if (file.size && file.size > maxFileSize) {
+      return max;
+    }
+    // Files with an unknown size (e.g. Google-native Docs/Slides, which the Drive
+    // API does not report a size for) are treated as worst-case: they can be huge
+    // once exported and are fully buffered in memory, so they must not silently
+    // get maximum concurrency.
+    const effectiveSize = file.size ?? maxFileSize;
+    return Math.max(max, effectiveSize);
+  }, 0);
+
+  if (maxFoundFileSize === 0) {
+    return defaultConcurrency;
+  }
 
   return Math.min(
     Math.floor(maxFileSize / maxFoundFileSize),

--- a/connectors/src/lib/async_utils.ts
+++ b/connectors/src/lib/async_utils.ts
@@ -52,23 +52,14 @@ export function getAdaptiveConcurrency(
   maxFileSize: number,
   defaultConcurrency: number
 ): number {
-  const maxFoundFileSize = files.reduce((max, file) => {
+  const maxFoundFileSize = files
     // Files with a known size over the limit are skipped before download, so they
-    // consume no memory and should not lower concurrency.
-    if (file.size && file.size > maxFileSize) {
-      return max;
-    }
-    // Files with an unknown size (e.g. Google-native Docs/Slides, which the Drive
-    // API does not report a size for) are treated as worst-case: they can be huge
-    // once exported and are fully buffered in memory, so they must not silently
+    // consume no memory and should not lower concurrency. Files with an unknown
+    // size (e.g. Google-native Docs/Slides, which the Drive API does not report a
+    // size for) are kept and treated as worst-case below, so they don't silently
     // get maximum concurrency.
-    const effectiveSize = file.size ?? maxFileSize;
-    return Math.max(max, effectiveSize);
-  }, 0);
-
-  if (maxFoundFileSize === 0) {
-    return defaultConcurrency;
-  }
+    .filter((file) => !file.size || file.size <= maxFileSize)
+    .reduce((max, file) => Math.max(max, file.size ?? maxFileSize), 0);
 
   return Math.min(
     Math.floor(maxFileSize / maxFoundFileSize),


### PR DESCRIPTION
## Problem

The Google Drive connector worker was OOM-restarting. Investigation of a killed pod showed multiple 300–524 MB presentations being **fully buffered in memory** before being rejected, several at once. Two independent gaps let this happen, both rooted in the fact that **Google-native files (Docs/Slides) report no `size` in their Drive metadata**:

1. **`getAdaptiveConcurrency` gave unknown-size files maximum concurrency.** It filtered out files with no `size` before computing the largest file in a batch. A page of only Google-native docs therefore yielded `maxFoundFileSize = 0` → `Math.floor(maxFileSize / 0) = Infinity` → the default concurrency (8). So up to 8 large exports were held in memory simultaneously per activity.

2. **The pre-download size guard never fires for native docs.** `sync_one_file.ts` skips files over `MAX_FILE_SIZE_TO_DOWNLOAD` only `if (file.size && ...)`, which is always false for Docs/Slides. They went straight to `drive.files.export`, whose entire response was buffered in memory with only a reactive "too large to export" catch.

## Changes

- **`getAdaptiveConcurrency`** (`lib/async_utils.ts`): treat unknown-size files as worst-case (`maxFileSize`) so batches containing them drop to low concurrency instead of getting the default. Files with a known size *over* the limit are still ignored (they're skipped before download). This also fixes the same latent bug in the Microsoft connector, which shares this helper.

- **Cap the download/export itself** (`handle_file_export.ts`, `handle_google_drive_export.ts`): pass `maxContentLength: MAX_FILE_SIZE_TO_DOWNLOAD` to both `drive.files.get({alt:"media"})` and `drive.files.export(...)`. This maps to node-fetch's `size` limit, which **aborts the stream mid-download** — an oversized file never fully lands in memory. Matches the existing `maxContentLength` pattern in `dust_project`.

- **`isFileTooLargeToDownloadError`** (`temporal/utils.ts`): a type-safe helper that detects the resulting `max-size` error (and the older `ERR_OUT_OF_RANGE` case), so oversized files are **skipped gracefully** instead of throwing and triggering ~20 Temporal retries that each re-download. It also replaces a non-type-safe `e as { code: string }` cast (rule GEN4).

## Testing

- New unit tests, written test-first: `async_utils.test.ts` (6) and `utils.test.ts` (3).
- `incremental_sync.test.ts` (6) re-run to confirm no regression.
- **15/15 passing**, `tsgo --noEmit` clean.