### PR TITLE
Fix: typechecking

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -713,7 +713,7 @@ export async function runModel(
     await publishAgentError({
       code: "model_not_available",
       message:
-        `The model you selected (${agentConfiguration.model.modelId}) ` +
+        `The model you selected (${model.modelId}) ` +
         `is not available. Please edit the agent to use another model ` +
         `(advanced settings in the Instructions panel).`,
       metadata: null,


### PR DESCRIPTION
## Description

Fixes a stale reference to `agentConfiguration.model.modelId` in the `model_not_available` error path of `runModel`. PR #28574 decoupled the runtime model from `AgentConfigurationType` — the model is now resolved once at loop start into `AgentLoopRunContextType` and passed as `model`. The error message was not updated, causing a TypeScript compile error.

## Tests

No behaviour change — error message text is identical. Verified locally via `tsc`.

## Risk

Low. Single-character diff, no logic change.

## Deploy Plan

Deploy front.
