### PR TITLE
feat(front): make Workspace Analyst available to all workspaces with opt-out

### DIFF
--- a/front-api/routes/w/[wId]/index.test.ts
+++ b/front-api/routes/w/[wId]/index.test.ts
@@ -143,3 +143,48 @@ describe("POST /api/w/:wId (workspace default agent)", () => {
     }
   });
 });
+
+describe("POST /api/w/:wId (workspace analytics opt-out)", () => {
+  it("sets disableWorkspaceAnalytics in workspace metadata", async () => {
+    const { workspace } = await setup();
+
+    const response = await post(workspace, {
+      disableWorkspaceAnalytics: true,
+    });
+
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.metadata?.disableWorkspaceAnalytics).toBe(true);
+  });
+
+  it("re-enables analytics and preserves other metadata", async () => {
+    const { workspace } = await setup();
+
+    await post(workspace, { reinforcementCapAwuCredits: 5_000 });
+    await post(workspace, { disableWorkspaceAnalytics: true });
+
+    const response = await post(workspace, {
+      disableWorkspaceAnalytics: false,
+    });
+
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.metadata?.disableWorkspaceAnalytics).toBe(false);
+    expect(updated?.metadata?.reinforcementCapAwuCredits).toBe(5_000);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    for (const role of ["builder", "user"] as const) {
+      const { workspace } = await setup(role);
+
+      const response = await post(workspace, {
+        disableWorkspaceAnalytics: true,
+      });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
+    }
+  });
+});

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -200,6 +200,10 @@ const WorkspaceAuditLogsUpdateBodySchema = z.object({
   disableAuditLogs: z.boolean(),
 });
 
+const WorkspaceAnalyticsUpdateBodySchema = z.object({
+  disableWorkspaceAnalytics: z.boolean(),
+});
+
 const WorkspaceSlackPersonalFooterRemovalUpdateBodySchema = z.object({
   slackPersonalAllowFooterRemoval: z.boolean(),
 });
@@ -234,6 +238,7 @@ const PostWorkspaceRequestBodySchema = z.union([
   WorkspaceReinforcementCapAwuCreditsUpdateBodySchema,
   WorkspaceSelfImprovementCapPerSkillAwuCreditsUpdateBodySchema,
   WorkspaceAuditLogsUpdateBodySchema,
+  WorkspaceAnalyticsUpdateBodySchema,
   WorkspaceDefaultAgentUpdateBodySchema,
   WorkspaceSlackPersonalFooterRemovalUpdateBodySchema,
 ]);
@@ -654,6 +659,23 @@ app.post(
         context: getAuditLogContext(auth),
         metadata: {
           enabled: String(!body.disableAuditLogs),
+        },
+      });
+    } else if ("disableWorkspaceAnalytics" in body) {
+      const previousMetadata = owner.metadata ?? {};
+      const newMetadata = {
+        ...previousMetadata,
+        disableWorkspaceAnalytics: body.disableWorkspaceAnalytics,
+      };
+      await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+      owner.metadata = newMetadata;
+      void emitAuditLogEvent({
+        auth,
+        action: "workspace.analytics_updated",
+        targets: [buildAuditLogTarget("workspace", owner)],
+        context: getAuditLogContext(auth),
+        metadata: {
+          enabled: String(!body.disableWorkspaceAnalytics),
         },
       });
     } else if ("workspaceDefaultAgentId" in body) {

--- a/front/admin/audit_log_schemas/workspace.analytics_updated.json
+++ b/front/admin/audit_log_schemas/workspace.analytics_updated.json
@@ -1,0 +1,13 @@
+{
+  "action": "workspace.analytics_updated",
+  "targets": [
+    {
+      "type": "workspace"
+    }
+  ],
+  "metadata": {
+    "enabled": "string",
+    "source": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -8,6 +8,7 @@ import { ProjectKnowledgePolicy } from "@app/components/workspace/settings/Proje
 import { RestrictAgentsPublishingCapability } from "@app/components/workspace/settings/RestrictAgentsPublishingCapability";
 import { SlackPersonalFooterRemovalToggle } from "@app/components/workspace/settings/SlackPersonalFooterRemovalToggle";
 import { VoiceTranscriptionToggle } from "@app/components/workspace/settings/VoiceTranscriptionToggle";
+import { WorkspaceAnalyticsToggle } from "@app/components/workspace/settings/WorkspaceAnalyticsToggle";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
 import { ContextItem, Page } from "@dust-tt/sparkle";
@@ -40,6 +41,7 @@ export function CapabilitiesSection({
         <EmailAgentsToggle owner={owner} />
         <PrivateConversationUrlsToggle owner={owner} />
         <SlackPersonalFooterRemovalToggle owner={owner} />
+        <WorkspaceAnalyticsToggle owner={owner} />
         <DustMcpServerSettingsItem owner={owner} />
         {hasAuditLogsAccess && <AuditLogsToggle owner={owner} />}
         {publishingRestrictionMessage && (

--- a/front/components/workspace/settings/WorkspaceAnalyticsToggle.tsx
+++ b/front/components/workspace/settings/WorkspaceAnalyticsToggle.tsx
@@ -1,0 +1,24 @@
+import { useWorkspaceAnalyticsToggle } from "@app/hooks/useWorkspaceAnalyticsToggle";
+import type { WorkspaceType } from "@app/types/user";
+import { BarChart01, ContextItem, SliderToggle } from "@dust-tt/sparkle";
+
+export function WorkspaceAnalyticsToggle({ owner }: { owner: WorkspaceType }) {
+  const { isEnabled, isChanging, doToggleWorkspaceAnalytics } =
+    useWorkspaceAnalyticsToggle({ owner });
+
+  return (
+    <ContextItem
+      title="Workspace Analyst"
+      subElement="Give workspace admins the Analyst agent and analytics tools to explore how the workspace is being used"
+      visual={<BarChart01 className="h-6 w-6" />}
+      hasSeparatorIfLast={true}
+      action={
+        <SliderToggle
+          selected={isEnabled}
+          disabled={isChanging}
+          onClick={doToggleWorkspaceAnalytics}
+        />
+      }
+    />
+  );
+}

--- a/front/components/workspace/settings/WorkspaceAnalyticsToggle.tsx
+++ b/front/components/workspace/settings/WorkspaceAnalyticsToggle.tsx
@@ -2,7 +2,13 @@ import { useWorkspaceAnalyticsToggle } from "@app/hooks/useWorkspaceAnalyticsTog
 import type { WorkspaceType } from "@app/types/user";
 import { BarChart01, ContextItem, SliderToggle } from "@dust-tt/sparkle";
 
-export function WorkspaceAnalyticsToggle({ owner }: { owner: WorkspaceType }) {
+interface WorkspaceAnalyticsToggleProps {
+  owner: WorkspaceType;
+}
+
+export function WorkspaceAnalyticsToggle({
+  owner,
+}: WorkspaceAnalyticsToggleProps) {
   const { isEnabled, isChanging, doToggleWorkspaceAnalytics } =
     useWorkspaceAnalyticsToggle({ owner });
 

--- a/front/hooks/useWorkspaceAnalyticsToggle.ts
+++ b/front/hooks/useWorkspaceAnalyticsToggle.ts
@@ -1,0 +1,54 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import type { LightWorkspaceType } from "@app/types/user";
+import { isWorkspaceAnalyticsEnabled } from "@app/types/user";
+import { useState } from "react";
+
+interface UseWorkspaceAnalyticsToggleProps {
+  owner: LightWorkspaceType;
+}
+
+export function useWorkspaceAnalyticsToggle({
+  owner,
+}: UseWorkspaceAnalyticsToggleProps) {
+  const [isChanging, setIsChanging] = useState(false);
+  const sendNotification = useSendNotification();
+  const [isEnabled, setIsEnabled] = useState(
+    isWorkspaceAnalyticsEnabled(owner)
+  );
+
+  const doToggleWorkspaceAnalytics = async () => {
+    setIsChanging(true);
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          disableWorkspaceAnalytics: isEnabled,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to update Workspace Analyst setting");
+      }
+      setIsEnabled(!isEnabled);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to update Workspace Analyst setting",
+        description: "Could not update the Workspace Analyst setting.",
+      });
+    }
+    setIsChanging(false);
+  };
+
+  return {
+    isEnabled,
+    isChanging,
+    doToggleWorkspaceAnalytics,
+  };
+}

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1156,13 +1156,13 @@ export const INTERNAL_MCP_SERVERS = {
   },
   workspace_analytics: {
     id: 1035,
-    // Gated by the workspace_analytics feature flag (off by default) and hidden
-    // from the builder tool-picker; the skill wires it by name. Data access is
-    // enforced per-tool via auth.isAdmin().
+    // Available to all workspaces unless the admin opts out, and hidden from the
+    // builder tool-picker; the skill wires it by name. Data access is enforced
+    // per-tool via auth.isAdmin().
     availability: "auto_hidden_builder",
     allowMultipleInstances: false,
-    isRestricted: ({ featureFlags }) =>
-      !featureFlags.includes("workspace_analytics"),
+    isRestricted: ({ isWorkspaceAnalyticsEnabled }) =>
+      !isWorkspaceAnalyticsEnabled,
     isPreview: false,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
@@ -1213,6 +1213,7 @@ type IsRestrictedCallback = (params: {
   plan: PlanType;
   featureFlags: WhitelistableFeature[];
   isDeepDiveDisabled: boolean;
+  isWorkspaceAnalyticsEnabled: boolean;
 }) => boolean;
 
 type RuntimeToolStakeLevelCallbackParams = {

--- a/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
@@ -1,21 +1,29 @@
 import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { describe, expect, it } from "vitest";
 
-async function fetchAnalyst(role: MembershipRoleType, flagOn: boolean) {
-  const { authenticator } = await createResourceTest({ role });
-  if (flagOn) {
-    await FeatureFlagFactory.basic(authenticator, "workspace_analytics");
+async function fetchAnalyst(role: MembershipRoleType, optedOut = false) {
+  const { authenticator, workspace, user } = await createResourceTest({ role });
+  if (optedOut) {
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      disableWorkspaceAnalytics: true,
+    });
+    const refreshedAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    return getGlobalAgents(refreshedAuth, [GLOBAL_AGENTS_SID.ANALYST], "light");
   }
   return getGlobalAgents(authenticator, [GLOBAL_AGENTS_SID.ANALYST], "light");
 }
 
 describe("analyst global agent visibility", () => {
-  it("is available to admins when the flag is on", async () => {
-    const agents = await fetchAnalyst("admin", true);
+  it("is available to admins by default", async () => {
+    const agents = await fetchAnalyst("admin");
     expect(agents).toHaveLength(1);
     expect(agents[0].sId).toBe(GLOBAL_AGENTS_SID.ANALYST);
     expect(agents[0].name).toBe("analyst");
@@ -23,15 +31,15 @@ describe("analyst global agent visibility", () => {
     expect(agents[0].skills).toContain("frames");
   });
 
-  it("is hidden from admins when the flag is off", async () => {
-    expect(await fetchAnalyst("admin", false)).toEqual([]);
+  it("is hidden from admins when the workspace opts out", async () => {
+    expect(await fetchAnalyst("admin", true)).toEqual([]);
   });
 
-  it("is hidden from builders even when the flag is on", async () => {
-    expect(await fetchAnalyst("builder", true)).toEqual([]);
+  it("is hidden from builders even by default", async () => {
+    expect(await fetchAnalyst("builder")).toEqual([]);
   });
 
-  it("is hidden from regular users even when the flag is on", async () => {
-    expect(await fetchAnalyst("user", true)).toEqual([]);
+  it("is hidden from regular users even by default", async () => {
+    expect(await fetchAnalyst("user")).toEqual([]);
   });
 });

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -134,6 +134,7 @@ import {
   isComputerFeatureEnabled,
   type WhitelistableFeature,
 } from "@app/types/shared/feature_flags";
+import { isWorkspaceAnalyticsEnabled } from "@app/types/user";
 
 // Exhaustive map of flags for each global agent. This is used to control which agents inject
 // per-user dynamic content (like the user profile) into the prompt context. This approach is not
@@ -1536,7 +1537,7 @@ export async function getGlobalAgents(
 
   const flags = await getFeatureFlags(auth);
 
-  if (!flags.includes("workspace_analytics")) {
+  if (!isWorkspaceAnalyticsEnabled(owner)) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) => sId !== GLOBAL_AGENTS_SID.ANALYST
     );

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -96,6 +96,7 @@
   "wake_up.expired": 1,
   "wake_up.fired": 1,
   "workspace.advanced_model_access_updated": 1,
+  "workspace.analytics_updated": 1,
   "workspace.audit_logs_updated": 1,
   "workspace.default_user_spend_limit_updated": 1,
   "workspace.deleted": 2,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -86,6 +86,7 @@ export const AUDIT_ACTIONS = [
   "sandbox_env_var.updated",
   // Workspace settings.
   "workspace.audit_logs_updated",
+  "workspace.analytics_updated",
   "workspace.advanced_model_access_updated",
   "workspace.default_user_spend_limit_updated",
   "workspace.programmatic_usage_limit_updated",

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -562,6 +562,7 @@ export interface WorkspaceMetadata {
   dustMcpServerAcceptAllRedirectUris?: boolean;
   dustMcpServerAllowedRedirectUris?: string[];
   disableAuditLogs?: boolean;
+  disableWorkspaceAnalytics?: boolean;
   isBusiness?: boolean;
   phoneCountry?: string;
   sandboxAllowAgentEgressRequests?: boolean;

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -41,6 +41,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { decrypt, encrypt } from "@app/types/shared/utils/encryption";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { redactString } from "@app/types/shared/utils/string_utils";
+import { isWorkspaceAnalyticsEnabled } from "@app/types/user";
 import { Op } from "sequelize";
 
 export class InternalMCPServerInMemoryResource {
@@ -89,6 +90,9 @@ export class InternalMCPServerInMemoryResource {
     const uniqueNames = [...new Set(names)];
     const featureFlags = await getFeatureFlags(auth);
     const isDeepDiveDisabled = await isDeepDiveDisabledByAdmin(auth);
+    const workspaceAnalyticsEnabled = isWorkspaceAnalyticsEnabled(
+      auth.getNonNullableWorkspace()
+    );
     const plan = auth.getNonNullablePlan();
 
     return new Set(
@@ -97,6 +101,7 @@ export class InternalMCPServerInMemoryResource {
           !INTERNAL_MCP_SERVERS[name].isRestricted?.({
             featureFlags,
             isDeepDiveDisabled,
+            isWorkspaceAnalyticsEnabled: workspaceAnalyticsEnabled,
             plan,
           })
       )
@@ -195,6 +200,9 @@ export class InternalMCPServerInMemoryResource {
       isEnabled = !mcpServer.isRestricted({
         featureFlags,
         isDeepDiveDisabled,
+        isWorkspaceAnalyticsEnabled: isWorkspaceAnalyticsEnabled(
+          auth.getNonNullableWorkspace()
+        ),
         plan: auth.getNonNullablePlan(),
       });
     }

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -43,7 +43,10 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
-import { formatUserFullName } from "@app/types/user";
+import {
+  formatUserFullName,
+  isWorkspaceAnalyticsEnabled,
+} from "@app/types/user";
 import assert from "assert";
 import uniq from "lodash/uniq";
 import type {
@@ -1110,10 +1113,12 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     {
       featureFlags,
       isDeepDiveDisabled,
+      isWorkspaceAnalyticsEnabled,
       plan,
     }: {
       featureFlags: WhitelistableFeature[];
       isDeepDiveDisabled: boolean;
+      isWorkspaceAnalyticsEnabled: boolean;
       plan: PlanType;
     }
   ): string[] {
@@ -1126,6 +1131,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       const isEnabled = !INTERNAL_MCP_SERVERS[name].isRestricted?.({
         featureFlags,
         isDeepDiveDisabled,
+        isWorkspaceAnalyticsEnabled,
         plan,
       });
       const availability = getAvailabilityOfInternalMCPServerByName(name);
@@ -1242,6 +1248,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         this.computeEnabledAutoInternalMCPServerIds(workspace.id, {
           featureFlags,
           isDeepDiveDisabled,
+          isWorkspaceAnalyticsEnabled: isWorkspaceAnalyticsEnabled(workspace),
           plan,
         });
 

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.test.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.test.ts
@@ -1,12 +1,12 @@
+import { Authenticator } from "@app/lib/auth";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { describe, expect, it } from "vitest";
 
 describe("workspace-analytics code-defined skill", () => {
-  it("is hidden from non-admins even when the flag is on", async () => {
+  it("is hidden from non-admins", async () => {
     const { authenticator } = await createResourceTest({ role: "builder" });
-    await FeatureFlagFactory.basic(authenticator, "workspace_analytics");
 
     const skill = await GlobalSkillsRegistry.getById(
       authenticator,
@@ -15,19 +15,27 @@ describe("workspace-analytics code-defined skill", () => {
     expect(skill).toBeNull();
   });
 
-  it("is hidden from admins when the flag is off", async () => {
-    const { authenticator } = await createResourceTest({ role: "admin" });
+  it("is hidden from admins when the workspace opts out", async () => {
+    const { workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      disableWorkspaceAnalytics: true,
+    });
+    const refreshedAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
 
     const skill = await GlobalSkillsRegistry.getById(
-      authenticator,
+      refreshedAuth,
       "workspace-analytics"
     );
     expect(skill).toBeNull();
   });
 
-  it("is visible to admins with the flag on and wires the workspace_analytics server", async () => {
+  it("is visible to admins by default and wires the workspace_analytics server", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
-    await FeatureFlagFactory.basic(authenticator, "workspace_analytics");
 
     const skill = await GlobalSkillsRegistry.getById(
       authenticator,

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import { isWorkspaceAnalyticsEnabled } from "@app/types/user";
 
 export const workspaceAnalyticsSkill = {
   sId: "workspace-analytics",
@@ -45,7 +45,6 @@ export const workspaceAnalyticsSkill = {
     if (!auth.isAdmin()) {
       return true;
     }
-    const flags = await getFeatureFlags(auth);
-    return !flags.includes("workspace_analytics");
+    return !isWorkspaceAnalyticsEnabled(auth.getNonNullableWorkspace());
   },
 } as const satisfies GlobalSkillDefinition;

--- a/front/migrations/20260707_delete_workspace_analytics_feature_flag.ts
+++ b/front/migrations/20260707_delete_workspace_analytics_feature_flag.ts
@@ -1,0 +1,62 @@
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { makeScript } from "@app/scripts/helpers";
+
+const FEATURE_FLAG_NAME = "workspace_analytics";
+
+makeScript({}, async ({ execute }, logger) => {
+  const [{ count }] = await frontSequelize.query<{ count: number }>(
+    `
+      SELECT COUNT(*)::int AS count
+      FROM feature_flags
+      WHERE name = :featureFlag
+    `,
+    {
+      replacements: { featureFlag: FEATURE_FLAG_NAME },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  logger.info(
+    {
+      execute,
+      featureFlag: FEATURE_FLAG_NAME,
+      workspaceCount: count,
+    },
+    "Found legacy workspace_analytics feature flags."
+  );
+
+  if (count === 0) {
+    return;
+  }
+
+  if (!execute) {
+    logger.info(
+      {
+        featureFlag: FEATURE_FLAG_NAME,
+        workspaceCount: count,
+      },
+      "Would delete legacy workspace_analytics feature flags."
+    );
+    return;
+  }
+
+  await frontSequelize.query(
+    `
+      DELETE FROM feature_flags
+      WHERE name = :featureFlag
+    `,
+    {
+      replacements: { featureFlag: FEATURE_FLAG_NAME },
+    }
+  );
+
+  logger.info(
+    {
+      featureFlag: FEATURE_FLAG_NAME,
+      workspaceCount: count,
+    },
+    "Deleted legacy workspace_analytics feature flags."
+  );
+});

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -153,11 +153,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "API for accessing usage data (Means that any builder with an API key can access usage data of the workspace from API)",
     stage: "on_demand",
   },
-  workspace_analytics: {
-    description:
-      "Admin-only workspace usage analytics: the workspace_analytics MCP server, its skill, and the Workspace Analyst agent.",
-    stage: "on_demand",
-  },
   usage_page_read_only: {
     description:
       "Allow legacy-contract workspaces to view the Usage page in read-only mode (analytics and member spend visible; all actions disabled).",

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -85,6 +85,15 @@ export function getWorkspaceDefaultAgentId(
   return typeof value === "string" ? value : null;
 }
 
+// The Workspace Analyst agent (and the workspace_analytics skill + MCP server it
+// relies on) are available to all workspaces by default. Admins can opt out via
+// the workspace settings, which sets `disableWorkspaceAnalytics` to true.
+export function isWorkspaceAnalyticsEnabled(
+  owner: LightWorkspaceType
+): boolean {
+  return owner.metadata?.disableWorkspaceAnalytics !== true;
+}
+
 /**
  * The default agent that should be pre-selected for new conversations.
  * A pod-level default agent takes precedence over the workspace-level default agent.


### PR DESCRIPTION
## Description

- Remove the workspace_analytics feature flag: the Workspace Analyst agent, the workspace_analytics skill, and its MCP server are now available to all workspaces (still admin-only via the existing "admins" audience).
- Gate the capability on a new per-workspace admin opt-out stored in workspace metadata (disableWorkspaceAnalytics), via a shared isWorkspaceAnalyticsEnabled helper used at every availability site.
- Add a "Workspace Analyst" toggle to the workspace settings Capabilities section (component + hook + POST /api/w/[wId] branch) with a workspace.analytics_updated audit log event.
- Add a migration to delete legacy workspace_analytics feature flag rows.

Ticket: https://github.com/dust-tt/tasks/issues/9448

## Tests

Unit + local

## Risk

Low

## Deploy Plan

Front + `npx tsx migrations/20260707_delete_workspace_analytics_feature_flag.ts` to clean the feature flag + `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed` to update the audit log schema