### PR TITLE
feat(skill_authoring): add pagination to list_skills tool

### DIFF
--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -13,8 +13,22 @@ export const UPDATE_SKILL_TOOL_NAME = "update_skill" as const;
 export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
   [LIST_SKILLS_TOOL_NAME]: {
     description:
-      "List active custom Skills in this workspace. Returns lightweight summaries so you can find the skill id to inspect or update.",
-    schema: {},
+      "List active custom Skills in this workspace. Returns lightweight summaries (sId, name, agentFacingDescription) paginated. Pass the returned `nextCursor` to fetch the next page.",
+    schema: {
+      cursor: z
+        .string()
+        .optional()
+        .describe(
+          "Pagination cursor from a previous call. Omit for the first page."
+        ),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .max(50)
+        .optional()
+        .describe("Skills per page. Default 20, max 50."),
+    },
     stake: "never_ask",
     displayLabels: {
       running: "Listing skills",

--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -13,13 +13,13 @@ export const UPDATE_SKILL_TOOL_NAME = "update_skill" as const;
 export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
   [LIST_SKILLS_TOOL_NAME]: {
     description:
-      "List active custom Skills in this workspace. Returns lightweight summaries (sId, name, agentFacingDescription, canWrite) paginated",
+      "List active custom Skills in this workspace. Returns lightweight summaries (sId, name, agentFacingDescription, canWrite) paginated.",
     schema: {
       filter: z
         .enum(["all", "writable", "agent_discoverable"])
         .optional()
         .describe(
-          "Scope of skills to return. `all` (default): every skill in the workspace. `writable`: only skills the user can edit. `agent_discoverable`: only skills the agent can invoke in this conversation."
+          "Scope of skills to return. `writable` (default): only skills the user can edit. `all`: every skill in the workspace. `agent_discoverable`: only skills the agent can invoke in this conversation."
         ),
       cursor: z
         .string()

--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -13,8 +13,14 @@ export const UPDATE_SKILL_TOOL_NAME = "update_skill" as const;
 export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
   [LIST_SKILLS_TOOL_NAME]: {
     description:
-      "List active custom Skills in this workspace. Returns lightweight summaries (sId, name, agentFacingDescription) paginated. Pass the returned `nextCursor` to fetch the next page.",
+      "List active custom Skills in this workspace. Returns lightweight summaries (sId, name, agentFacingDescription, canWrite) paginated",
     schema: {
+      filter: z
+        .enum(["all", "writable", "agent_discoverable"])
+        .optional()
+        .describe(
+          "Scope of skills to return. `all` (default): every skill in the workspace. `writable`: only skills the user can edit. `agent_discoverable`: only skills the agent can invoke in this conversation."
+        ),
       cursor: z
         .string()
         .optional()

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
@@ -120,11 +120,11 @@ describe("skill_authoring tools", () => {
     if (listResult.isErr()) {
       throw listResult.error;
     }
-    expect(listResult.value[1]?.type).toBe("text");
-    if (listResult.value[1]?.type !== "text") {
+    expect(listResult.value[0]?.type).toBe("text");
+    if (listResult.value[0]?.type !== "text") {
       throw new Error("Expected JSON text output.");
     }
-    expect(JSON.parse(listResult.value[1].text)).toMatchObject({
+    expect(JSON.parse(listResult.value[0].text)).toMatchObject({
       skills: [
         expect.objectContaining({
           sId: output.resource.skillId,
@@ -168,11 +168,11 @@ describe("skill_authoring tools", () => {
     if (otherListResult.isErr()) {
       throw otherListResult.error;
     }
-    expect(otherListResult.value[1]?.type).toBe("text");
-    if (otherListResult.value[1]?.type !== "text") {
+    expect(otherListResult.value[0]?.type).toBe("text");
+    if (otherListResult.value[0]?.type !== "text") {
       throw new Error("Expected JSON text output.");
     }
-    expect(JSON.parse(otherListResult.value[1].text)).toMatchObject({
+    expect(JSON.parse(otherListResult.value[0].text)).toMatchObject({
       skills: [],
     });
 

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -218,35 +218,43 @@ function findDisallowedSpecialTagChanges(
 }
 
 const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
-  [LIST_SKILLS_TOOL_NAME]: async (_params, { auth }) => {
+  [LIST_SKILLS_TOOL_NAME]: async ({ cursor, limit }, { auth }) => {
     const user = requireInteractiveBuilder(auth);
     if (user.isErr()) {
       return new Err(user.error);
     }
 
-    const skills = await SkillResource.listByWorkspace(auth, {
+    const allSkills = await SkillResource.listByWorkspace(auth, {
       status: "active",
       onlyCustom: true,
       withInstructions: false,
       withTools: false,
     });
 
-    const summaries = skills
-      .filter((skill) => skill.canWrite(auth))
-      .map((skill) => ({
-        sId: skill.sId,
-        name: skill.name,
-        agentFacingDescription: skill.agentFacingDescription,
-        userFacingDescription: skill.userFacingDescription,
-        icon: skill.icon,
-      }));
+    const writable = allSkills.filter((skill) => skill.canWrite(auth));
+    const pageSize = Math.min(limit ?? 20, 50);
+    const offset = cursor
+      ? parseInt(Buffer.from(cursor, "base64").toString(), 10)
+      : 0;
+    const page = writable.slice(offset, offset + pageSize);
+    const nextOffset = offset + pageSize;
+    const nextCursor =
+      nextOffset < writable.length
+        ? Buffer.from(String(nextOffset)).toString("base64")
+        : null;
+
+    const summaries = page.map((skill) => ({
+      sId: skill.sId,
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+    }));
 
     return new Ok([
-      {
-        type: "text" as const,
-        text: `Found ${summaries.length} active custom skill${summaries.length === 1 ? "" : "s"}.`,
-      },
-      makeJsonText({ skills: summaries }),
+      makeJsonText({
+        total: writable.length,
+        skills: summaries,
+        nextCursor,
+      }),
     ]);
   },
 

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -218,28 +218,38 @@ function findDisallowedSpecialTagChanges(
 }
 
 const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
-  [LIST_SKILLS_TOOL_NAME]: async ({ cursor, limit }, { auth }) => {
+  [LIST_SKILLS_TOOL_NAME]: async ({ filter, cursor, limit }, { auth }) => {
     const user = requireInteractiveBuilder(auth);
     if (user.isErr()) {
       return new Err(user.error);
     }
 
-    const allSkills = await SkillResource.listByWorkspace(auth, {
-      status: "active",
-      onlyCustom: true,
-      withInstructions: false,
-      withTools: false,
-    });
+    const resolvedFilter = filter ?? "all";
 
-    const writable = allSkills.filter((skill) => skill.canWrite(auth));
+    let skills;
+    if (resolvedFilter === "agent_discoverable") {
+      skills = await SkillResource.listDiscoverable(auth);
+    } else {
+      const allSkills = await SkillResource.listByWorkspace(auth, {
+        status: "active",
+        onlyCustom: false,
+        withInstructions: false,
+        withTools: false,
+      });
+      skills =
+        resolvedFilter === "writable"
+          ? allSkills.filter((skill) => skill.canWrite(auth))
+          : allSkills;
+    }
+
     const pageSize = Math.min(limit ?? 20, 50);
     const offset = cursor
       ? parseInt(Buffer.from(cursor, "base64").toString(), 10)
       : 0;
-    const page = writable.slice(offset, offset + pageSize);
+    const page = skills.slice(offset, offset + pageSize);
     const nextOffset = offset + pageSize;
     const nextCursor =
-      nextOffset < writable.length
+      nextOffset < skills.length
         ? Buffer.from(String(nextOffset)).toString("base64")
         : null;
 
@@ -247,11 +257,12 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       sId: skill.sId,
       name: skill.name,
       agentFacingDescription: skill.agentFacingDescription,
+      canWrite: skill.canWrite(auth),
     }));
 
     return new Ok([
       makeJsonText({
-        total: writable.length,
+        total: skills.length,
         skills: summaries,
         nextCursor,
       }),

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -224,7 +224,7 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       return new Err(user.error);
     }
 
-    const resolvedFilter = filter ?? "all";
+    const resolvedFilter = filter ?? "writable";
 
     let skills;
     if (resolvedFilter === "agent_discoverable") {


### PR DESCRIPTION
## Summary

- This list_skills tool was failing in practice because the content was super bloated. Should just be a lightweight pagination and rely on the get_skill tool to get rest of details
- Adding ability to filter by writable, agent_discoverable. Previously it was hardcoded to included only writable skills, which is not helpful for all cases

## Testing

* Validated locally

## Risk

Low — additive change, existing callers that pass no args get the same first-page behavior as before.

## Deploy

1. deploy front
