### PR TITLE
[CONVERSATIONS] bound content fragment POST concurrency to avoid lock timeouts

### DIFF
--- a/front/hooks/useSubmitMessage.ts
+++ b/front/hooks/useSubmitMessage.ts
@@ -1,5 +1,6 @@
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { PostMessagesResponseBody } from "@app/types/api/assistant/messages";
 import type {
   ClientMessageOrigin,
@@ -11,6 +12,11 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import { useCallback } from "react";
+
+// Bounded concurrency for content fragment POSTs: each grabs a per-conversation advisory lock
+// (getConversationRankVersionLock) that serializes inserts, so posting them unbounded races the
+// lock and times out (SequelizeDatabaseError).
+const CONTENT_FRAGMENT_POST_CONCURRENCY = 8;
 
 export function useSubmitMessage({
   owner,
@@ -55,8 +61,27 @@ export function useSubmitMessage({
         contentFragments.uploaded.length > 0 ||
         contentFragments.contentNodes.length > 0
       ) {
-        const contentFragmentsRes = await Promise.all([
-          ...contentFragments.uploaded.map((contentFragment) => {
+        const timezone =
+          Intl.DateTimeFormat().resolvedOptions().timeZone || "Etc/UTC";
+
+        const contentFragmentBodies = [
+          ...contentFragments.uploaded.map((cf) => ({
+            title: cf.title,
+            fileId: cf.fileId,
+            url: cf.url,
+            context: { timezone, profilePictureUrl: user.image },
+          })),
+          ...contentFragments.contentNodes.map((cf) => ({
+            title: cf.title,
+            nodeId: cf.internalId,
+            nodeDataSourceViewId: cf.dataSourceView.sId,
+            context: { timezone, profilePictureUrl: user.image },
+          })),
+        ];
+
+        const contentFragmentsRes = await concurrentExecutor(
+          contentFragmentBodies,
+          async (body) => {
             return clientFetch(
               `/api/w/${owner.sId}/assistant/conversations/${conversationId}/content_fragment`,
               {
@@ -64,43 +89,12 @@ export function useSubmitMessage({
                 headers: {
                   "Content-Type": "application/json",
                 },
-                body: JSON.stringify({
-                  title: contentFragment.title,
-                  fileId: contentFragment.fileId,
-                  url: contentFragment.url,
-                  context: {
-                    timezone:
-                      Intl.DateTimeFormat().resolvedOptions().timeZone ||
-                      "Etc/UTC",
-                    profilePictureUrl: user.image,
-                  },
-                }),
+                body: JSON.stringify(body),
               }
             );
-          }),
-          ...contentFragments.contentNodes.map((contentFragment) => {
-            return clientFetch(
-              `/api/w/${owner.sId}/assistant/conversations/${conversationId}/content_fragment`,
-              {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                  title: contentFragment.title,
-                  nodeId: contentFragment.internalId,
-                  nodeDataSourceViewId: contentFragment.dataSourceView.sId,
-                  context: {
-                    timezone:
-                      Intl.DateTimeFormat().resolvedOptions().timeZone ||
-                      "Etc/UTC",
-                    profilePictureUrl: user.image,
-                  },
-                }),
-              }
-            );
-          }),
-        ]);
+          },
+          { concurrency: CONTENT_FRAGMENT_POST_CONCURRENCY }
+        );
 
         for (const mcfRes of contentFragmentsRes) {
           if (!mcfRes.ok) {


### PR DESCRIPTION
## Description

Bound the `/content_fragment` POST fan-out in `useSubmitMessage` with `concurrentExecutor` (concurrency 8) instead of an unbounded `Promise.all`, so posting many attachments no longer races the per-conversation advisory lock (`getConversationRankVersionLock`) and times out with `SequelizeDatabaseError`.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`