### PR TITLE
[front] credit_usage_configurations: make programmatic cap + default pool cap non-nullable, default 0

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -176,7 +176,7 @@ app.post(
               api_error: {
                 type: "rate_limit_error",
                 message:
-                  "Your workspace has reached its programmatic monthly spending cap.",
+                  "Your workspace has reached its programmatic monthly spending cap. An admin can raise the cap in the workspace's usage settings.",
               },
             });
           }

--- a/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.test.ts
+++ b/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.test.ts
@@ -106,9 +106,9 @@ describe("/api/w/[wId]/usage_settings/programmatic_usage_limit", () => {
       expect(await response.json()).toEqual({ monthlyCapCredits: 1000 });
     });
 
-    it("returns null when no cap is configured", async () => {
+    it("returns 0 when programmatic access is blocked", async () => {
       vi.mocked(businessLayer.getProgrammaticUsageLimit).mockResolvedValueOnce(
-        new Ok(null)
+        new Ok(0)
       );
 
       const workspace = await makeMetronomeWorkspace();
@@ -120,7 +120,7 @@ describe("/api/w/[wId]/usage_settings/programmatic_usage_limit", () => {
       const response = await getRequest(workspace.sId);
 
       expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({ monthlyCapCredits: null });
+      expect(await response.json()).toEqual({ monthlyCapCredits: 0 });
     });
 
     it("returns 500 on business layer error", async () => {
@@ -163,11 +163,7 @@ describe("/api/w/[wId]/usage_settings/programmatic_usage_limit", () => {
       );
     });
 
-    it("clears the cap when null is passed", async () => {
-      vi.mocked(businessLayer.syncProgrammaticUsageLimit).mockResolvedValueOnce(
-        new Ok(undefined)
-      );
-
+    it("rejects null (no cap is not allowed)", async () => {
       const workspace = await makeMetronomeWorkspace();
       await createPrivateApiMockRequest({
         role: "admin",
@@ -178,11 +174,8 @@ describe("/api/w/[wId]/usage_settings/programmatic_usage_limit", () => {
         monthlyCapCredits: null,
       });
 
-      expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({ monthlyCapCredits: null });
-      expect(businessLayer.syncProgrammaticUsageLimit).toHaveBeenCalledWith(
-        expect.objectContaining({ monthlyCapCredits: null })
-      );
+      expect(response.status).toBe(400);
+      expect(businessLayer.syncProgrammaticUsageLimit).not.toHaveBeenCalled();
     });
 
     it("returns 400 when monthlyCapCredits is missing", async () => {

--- a/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
+++ b/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
@@ -16,7 +16,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 const UpdateProgrammaticUsageLimitBodySchema = z.object({
-  monthlyCapCredits: z.number().int().nonnegative().nullable(),
+  monthlyCapCredits: z.number().int().nonnegative(),
 });
 
 // Mounted at /api/w/:wId/usage_settings/programmatic_usage_limit.

--- a/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
+++ b/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
@@ -20,17 +20,17 @@ export function UsageProgrammaticLimitCard({
     workspaceId,
   });
 
-  const currentLimit = programmaticUsageLimit?.monthlyCapCredits ?? null;
+  const currentLimit = programmaticUsageLimit?.monthlyCapCredits ?? 0;
 
   const [isEditing, setIsEditing] = useState(false);
 
   const handleSaveLimit = async (newValue: string) => {
     const trimmed = newValue.trim();
 
-    // An empty value means no programmatic access. Save 0 (not null) so
-    // Metronome alerts are upserted with cap=0 and actually block access.
+    // An empty value means no programmatic access: save 0 so the cap blocks
+    // access. There is no "no cap" / unlimited state.
     if (trimmed === "") {
-      if (currentLimit === null || currentLimit === 0) {
+      if (currentLimit === 0) {
         return;
       }
       await doUpdateProgrammaticUsageLimit(0);
@@ -65,16 +65,8 @@ export function UsageProgrammaticLimitCard({
                 inputMode="numeric"
                 pattern="[0-9]*"
                 placeholder="No access"
-                value={
-                  currentLimit === null || currentLimit === 0
-                    ? ""
-                    : currentLimit.toLocaleString()
-                }
-                unit={
-                  (currentLimit === null || currentLimit === 0) && !isEditing
-                    ? undefined
-                    : "credits"
-                }
+                value={currentLimit === 0 ? "" : currentLimit.toLocaleString()}
+                unit={currentLimit === 0 && !isEditing ? undefined : "credits"}
                 normalizeValue={(value) => value.replace(/[^\d]/g, "")}
                 formatValue={(value) =>
                   value ? Number(value).toLocaleString() : value

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -68,7 +68,7 @@ export function UsageSettingsCard({
     }
   };
 
-  const currentDefaultLimit = defaultUserSpendLimit?.awuCredits ?? null;
+  const currentDefaultLimit = defaultUserSpendLimit?.awuCredits ?? 0;
 
   const handleSaveDefaultLimit = async (newValue: string) => {
     const parsed = Number(newValue);
@@ -107,14 +107,12 @@ export function UsageSettingsCard({
                   pattern="[0-9]*"
                   placeholder="No access"
                   value={
-                    currentDefaultLimit === null || currentDefaultLimit === 0
+                    currentDefaultLimit === 0
                       ? ""
                       : currentDefaultLimit.toLocaleString()
                   }
                   unit={
-                    (currentDefaultLimit === null ||
-                      currentDefaultLimit === 0) &&
-                    !isEditingDefaultLimit
+                    currentDefaultLimit === 0 && !isEditingDefaultLimit
                       ? undefined
                       : "credits/month"
                   }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2595,7 +2595,7 @@ async function checkMessagesLimit(
           api_error: {
             type: "rate_limit_error",
             message:
-              "Your workspace has reached its programmatic monthly spending cap. Please contact support to increase it.",
+              "Your workspace has reached its programmatic monthly spending cap. An admin can raise the cap in the workspace's usage settings.",
           },
         });
       }

--- a/front/lib/api/credits/programmatic_usage_limit.test.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.test.ts
@@ -77,20 +77,32 @@ describe("syncProgrammaticUsageLimit persistence", () => {
     ).toHaveBeenCalled();
   });
 
-  it("clears the cap and the alerts when set to null", async () => {
+  it("resets to 0 (no access) and clears the alerts", async () => {
     const workspace = await WorkspaceFactory.creditPriced({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: 500 });
-    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: null });
+    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: 0 });
 
     const read = await getProgrammaticUsageLimit(auth);
-    expect(read.isOk() && read.value).toBe(null);
+    expect(read.isOk() && read.value).toBe(0);
     expect(
       programmaticCap.clearMetronomeProgrammaticCapAlerts
     ).toHaveBeenCalled();
+  });
+
+  it("clamps a negative cap to 0", async () => {
+    const workspace = await WorkspaceFactory.creditPriced({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: -5 });
+
+    const read = await getProgrammaticUsageLimit(auth);
+    expect(read.isOk() && read.value).toBe(0);
   });
 });
 
@@ -122,7 +134,7 @@ describe("syncProgrammaticUsageLimit audit", () => {
     );
   });
 
-  it("records previous as 'unset' when no cap existed", async () => {
+  it("records previous as '0' when no cap existed", async () => {
     const workspace = await WorkspaceFactory.creditPriced({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
@@ -137,14 +149,14 @@ describe("syncProgrammaticUsageLimit audit", () => {
     expect(workosAudit.emitAuditLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: {
-          previous_monthly_cap_credits: "unset",
+          previous_monthly_cap_credits: "0",
           new_monthly_cap_credits: "1000",
         },
       })
     );
   });
 
-  it("records new as 'unset' when clearing the cap", async () => {
+  it("records new as '0' when blocking access (cap set to 0)", async () => {
     const workspace = await WorkspaceFactory.creditPriced({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
@@ -155,7 +167,7 @@ describe("syncProgrammaticUsageLimit audit", () => {
 
     await syncProgrammaticUsageLimit({
       auth,
-      monthlyCapCredits: null,
+      monthlyCapCredits: 0,
       auditContext: AUDIT_CONTEXT,
     });
 
@@ -163,7 +175,7 @@ describe("syncProgrammaticUsageLimit audit", () => {
       expect.objectContaining({
         metadata: {
           previous_monthly_cap_credits: "500",
-          new_monthly_cap_credits: "unset",
+          new_monthly_cap_credits: "0",
         },
       })
     );

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -19,12 +19,13 @@ import { Err, Ok } from "@app/types/shared/result";
  * Read the workspace's programmatic usage monthly cap.
  *
  * The cap is persisted on `credit_usage_configurations` (the source of truth);
- * the Metronome programmatic alerts are derived enforcement. Returns `null`
- * when no cap is configured.
+ * the Metronome programmatic alerts are derived enforcement. The cap is
+ * non-nullable and defaults to 0 (0 blocks all programmatic access), so a
+ * workspace with no configuration row reads as 0.
  */
 export async function getProgrammaticUsageLimit(
   auth: Authenticator
-): Promise<Result<number | null, Error>> {
+): Promise<Result<number, Error>> {
   const workspace = auth.getNonNullableWorkspace();
   if (!workspace.metronomeCustomerId) {
     return new Err(
@@ -34,17 +35,21 @@ export async function getProgrammaticUsageLimit(
 
   const config =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
-  return new Ok(config?.programmaticMonthlyCapAwuCredits ?? null);
+  return new Ok(config?.programmaticMonthlyCapAwuCredits ?? 0);
 }
 
 /**
- * Set or clear the workspace's programmatic usage monthly cap.
+ * Set the workspace's programmatic usage monthly cap.
  *
  * Persists the cap on `credit_usage_configurations` (the source of truth),
  * then derives the Metronome programmatic alerts from it (only for positive
- * caps; 0 and null both clear the alerts since a cap of 0 is always depleted),
- * and finally reconciles `programmaticCreditState` so usage-status reflects
- * the change immediately without waiting for a webhook.
+ * caps; a cap of 0 clears the alerts since it is always depleted — no
+ * threshold transition can ever fire), and finally reconciles
+ * `programmaticCreditState` so usage-status reflects the change immediately
+ * without waiting for a webhook.
+ *
+ * The cap is non-nullable: 0 blocks all programmatic access, a positive value
+ * is the monthly cap. Negative inputs are clamped to 0.
  */
 export async function syncProgrammaticUsageLimit({
   auth,
@@ -52,7 +57,7 @@ export async function syncProgrammaticUsageLimit({
   auditContext,
 }: {
   auth: Authenticator;
-  monthlyCapCredits: number | null;
+  monthlyCapCredits: number;
   auditContext?: AuditLogContext;
 }): Promise<Result<undefined, Error>> {
   const workspace = auth.getNonNullableWorkspace();
@@ -77,17 +82,12 @@ export async function syncProgrammaticUsageLimit({
   // Persist the admin's intent first: the credit-usage configuration column is
   // the source of truth; the Metronome alerts below are derived enforcement (a
   // failed sync can be retried and re-derives from this value). The config row
-  // is created lazily, so upsert it. A normalized cap stores `null` (no cap)
-  // for any negative/absent value and the value itself otherwise (0 included,
-  // as a hard cap).
-  const normalizedCapCredits =
-    monthlyCapCredits !== null && monthlyCapCredits >= 0
-      ? monthlyCapCredits
-      : null;
+  // is created lazily, so upsert it. Negative inputs are clamped to 0.
+  const normalizedCapCredits = Math.max(0, monthlyCapCredits);
   const existingConfig =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
   const previousCapCredits =
-    existingConfig?.programmaticMonthlyCapAwuCredits ?? null;
+    existingConfig?.programmaticMonthlyCapAwuCredits ?? 0;
   if (existingConfig) {
     await existingConfig.updateConfiguration(auth, {
       programmaticMonthlyCapAwuCredits: normalizedCapCredits,
@@ -103,7 +103,7 @@ export async function syncProgrammaticUsageLimit({
   // Alerts only make sense for a positive cap: a cap of 0 means usage is
   // always fully depleted, so no threshold transition can ever fire.
   const alertResult =
-    normalizedCapCredits !== null && normalizedCapCredits > 0
+    normalizedCapCredits > 0
       ? await upsertMetronomeProgrammaticCapAlerts({
           metronomeCustomerId: workspace.metronomeCustomerId,
           workspaceId: workspace.sId,
@@ -139,10 +139,8 @@ export async function syncProgrammaticUsageLimit({
     targets: [buildAuditLogTarget("workspace", workspace)],
     context: auditContext,
     metadata: {
-      previous_monthly_cap_credits:
-        previousCapCredits !== null ? String(previousCapCredits) : "unset",
-      new_monthly_cap_credits:
-        normalizedCapCredits !== null ? String(normalizedCapCredits) : "unset",
+      previous_monthly_cap_credits: String(previousCapCredits),
+      new_monthly_cap_credits: String(normalizedCapCredits),
     },
   });
 

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -680,7 +680,7 @@ async function notifyAdminsProgrammaticCapAboutStatus({
         workspace.id
       );
     const monthlyCapCredits =
-      creditUsageConfig?.programmaticMonthlyCapAwuCredits ?? null;
+      creditUsageConfig?.programmaticMonthlyCapAwuCredits ?? 0;
 
     const { members: admins } = await getMembers(auth, {
       roles: ["admin"],

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -293,41 +293,29 @@ export async function reconcileProgrammatic({
   const config = await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
     workspace.id
   );
-  // Distinguish "no cap configured" (null) from an explicit hard cap of 0:
-  // null means programmatic usage is unrestricted at the cap level, whereas 0
-  // is an explicit block. Collapsing both to 0 would wrongly deplete workspaces
-  // that never set a programmatic cap.
-  const monthlyCapCredits = config?.programmaticMonthlyCapAwuCredits ?? null;
+  // The cap is non-nullable and defaults to 0; a workspace with no config row
+  // reads as 0 (no programmatic access).
+  const monthlyCapCredits = config?.programmaticMonthlyCapAwuCredits ?? 0;
 
   const previousState = workspace.programmaticCreditState;
 
-  // States that don't require reading live spend:
-  //  - explicit hard cap of 0 → always depleted (programmatic API blocked).
-  //  - no cap configured (null), or no contract to meter spend against →
-  //    programmatic usage is unrestricted at the cap level; stay "active" and
-  //    let the pool gate (isApiBlocked) decide. This keeps PAYG programmatic
-  //    usage running when the pool is in overage and no programmatic cap is set.
-  if (
-    monthlyCapCredits === null ||
-    monthlyCapCredits === 0 ||
-    !metronomeContractId
-  ) {
-    const expectedState: WorkspaceProgrammaticCreditState =
-      monthlyCapCredits === 0 ? "depleted" : "active";
+  // Cap of 0 → always depleted (no programmatic access); no spend to read. Same
+  // when there is no contract to meter spend against.
+  if (monthlyCapCredits === 0 || !metronomeContractId) {
     if (execute) {
-      await setProgrammaticCreditStateReconciled(workspace, expectedState);
+      await setProgrammaticCreditStateReconciled(workspace, "depleted");
       void clearWorkspaceProgrammaticWarningReached(workspace.sId);
     }
     const newState = workspace.programmaticCreditState;
     return new Ok({
       target: "programmatic",
       previousState,
-      expectedState,
+      expectedState: "depleted",
       newState,
-      wasInvalid: previousState !== expectedState,
+      wasInvalid: previousState !== "depleted",
       corrected: previousState !== newState,
       executed: execute,
-      monthlyCapCredits: monthlyCapCredits ?? 0,
+      monthlyCapCredits,
       spentAwuCredits: null,
     });
   }

--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -183,8 +183,11 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
       usageCapCredits > 0 ? usageCapCredits : null;
     const resolvedBalanceThresholdCredits =
       balanceThresholdCredits > 0 ? balanceThresholdCredits : null;
-    const resolvedProgrammaticMonthlyCapCredits =
-      programmaticMonthlyCapCredits > 0 ? programmaticMonthlyCapCredits : null;
+    // The programmatic cap is non-nullable: 0 blocks all programmatic access.
+    const resolvedProgrammaticMonthlyCapCredits = Math.max(
+      0,
+      programmaticMonthlyCapCredits
+    );
 
     // Fetch current state upfront so each sync step can be skipped when its
     // inputs haven't changed (avoids triggering seat reconciliation for every

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_monthly_cap.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_monthly_cap.ts
@@ -9,37 +9,25 @@ import { isCreditPricedPlan } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
 
-const ProgrammaticMonthlyCapSchema = z
-  .object({
-    enabled: z.boolean(),
-    monthlyCapAwu: z.number().min(1).max(10_000_000).optional(),
-  })
-  .refine(
-    (data) =>
-      !data.enabled ||
-      (data.monthlyCapAwu !== undefined && data.monthlyCapAwu >= 1),
-    { message: "monthlyCapAwu must be >= 1 when enabled" }
-  );
+const ProgrammaticMonthlyCapSchema = z.object({
+  monthlyCapAwu: z.number().int().min(0).max(10_000_000),
+});
 
 export const manageProgrammaticMonthlyCapPlugin = createPlugin({
   manifest: {
     id: "manage-programmatic-monthly-cap",
     name: "Manage Programmatic Monthly Cap",
     description:
-      "Set or remove the monthly spending cap for programmatic (API) usage.",
+      "Set the monthly spending cap for programmatic (API) usage. Set to 0 " +
+      "to block all programmatic access.",
     resourceTypes: ["workspaces"],
     args: {
-      enabled: {
-        type: "boolean",
-        label: "Enable monthly cap",
-        description: "Toggle the programmatic monthly cap on or off.",
-        async: true,
-        asyncDescription: true,
-      },
       monthlyCapAwu: {
         type: "number",
         label: "Monthly cap (AWU credits)",
-        description: "Monthly spending cap in AWU credits.",
+        description:
+          "Monthly spending cap in AWU credits. Set to 0 to block all " +
+          "programmatic access.",
         async: true,
       },
     },
@@ -56,20 +44,12 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
 
   populateAsyncArgs: async (auth, workspace) => {
     if (!workspace) {
-      return new Ok({
-        enabled: false,
-        enabledDescription: "No workspace found.",
-        monthlyCapAwu: 0,
-      });
+      return new Ok({ monthlyCapAwu: 0 });
     }
 
     const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
     if (!workspaceResource?.metronomeCustomerId) {
-      return new Ok({
-        enabled: false,
-        enabledDescription: "Workspace is not provisioned in Metronome.",
-        monthlyCapAwu: 0,
-      });
+      return new Ok({ monthlyCapAwu: 0 });
     }
 
     const capResult = await getProgrammaticUsageLimit(auth);
@@ -77,22 +57,7 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
       return new Err(capResult.error);
     }
 
-    const capCredits = capResult.value;
-    const currentState = workspaceResource.programmaticCreditState;
-
-    if (capCredits === null) {
-      return new Ok({
-        enabled: false,
-        enabledDescription: `No cap set. State: ${currentState}.`,
-        monthlyCapAwu: 0,
-      });
-    }
-
-    return new Ok({
-      enabled: true,
-      enabledDescription: `Current cap: ${capCredits} AWU. State: ${currentState}.`,
-      monthlyCapAwu: capCredits,
-    });
+    return new Ok({ monthlyCapAwu: capResult.value });
   },
 
   execute: async (auth, workspace, rawArgs) => {
@@ -128,15 +93,14 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
     if (!parsed.success) {
       return new Err(new Error(parsed.error.message));
     }
-    const { enabled, monthlyCapAwu } = parsed.data;
+    const { monthlyCapAwu } = parsed.data;
 
     // `syncProgrammaticUsageLimit` persists the cap (DB source of truth),
     // derives the Metronome alerts, and emits the audit event with the
-    // operator as actor. `null` clears the cap.
-    const monthlyCapCredits = enabled && monthlyCapAwu ? monthlyCapAwu : null;
+    // operator as actor. A cap of 0 blocks all programmatic access.
     const syncResult = await syncProgrammaticUsageLimit({
       auth,
-      monthlyCapCredits,
+      monthlyCapCredits: monthlyCapAwu,
     });
     if (syncResult.isErr()) {
       return new Err(syncResult.error);
@@ -148,9 +112,9 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
     return new Ok({
       display: "text",
       value:
-        monthlyCapCredits !== null
-          ? `Programmatic monthly cap set to ${monthlyCapCredits} AWU for workspace "${workspace.name}".`
-          : `Programmatic monthly cap removed for workspace "${workspace.name}".`,
+        monthlyCapAwu > 0
+          ? `Programmatic monthly cap set to ${monthlyCapAwu} AWU for workspace "${workspace.name}".`
+          : `Programmatic access blocked (cap set to 0) for workspace "${workspace.name}".`,
     });
   },
 });

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -671,7 +671,7 @@ async function persistCreditConfig(
     paygEnabled: body.paygEnabled,
     usageCapCredits: body.usageCapCredits ?? null,
     balanceThresholdAwuCredits: body.balanceThresholdCredits ?? null,
-    defaultPoolCapAwuCredits: body.defaultPoolCapCredits ?? null,
+    defaultPoolCapAwuCredits: body.defaultPoolCapCredits ?? 0,
     programmaticMonthlyCapAwuCredits: body.programmaticMonthlyCapCredits ?? 0,
     autoSeatUpgradeEnabled: body.autoSeatUpgradeEnabled,
     topUpEnabled: body.topUpEnabled,

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -672,8 +672,7 @@ async function persistCreditConfig(
     usageCapCredits: body.usageCapCredits ?? null,
     balanceThresholdAwuCredits: body.balanceThresholdCredits ?? null,
     defaultPoolCapAwuCredits: body.defaultPoolCapCredits ?? null,
-    programmaticMonthlyCapAwuCredits:
-      body.programmaticMonthlyCapCredits ?? null,
+    programmaticMonthlyCapAwuCredits: body.programmaticMonthlyCapCredits ?? 0,
     autoSeatUpgradeEnabled: body.autoSeatUpgradeEnabled,
     topUpEnabled: body.topUpEnabled,
     autoInvoiceFinalizationEnabled: body.autoInvoiceFinalizationEnabled,

--- a/front/lib/api/workspace/default_user_spend_limit.test.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.test.ts
@@ -204,7 +204,7 @@ describe("setDefaultUserSpendLimit", () => {
     );
   });
 
-  it("records previous_awu_credits as 'unset' when no default existed", async () => {
+  it("records previous_awu_credits as '0' when no default existed", async () => {
     const workspace = await WorkspaceFactory.metronome({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
@@ -218,7 +218,7 @@ describe("setDefaultUserSpendLimit", () => {
     expect(workosAudit.emitAuditLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: {
-          previous_awu_credits: "unset",
+          previous_awu_credits: "0",
           new_awu_credits: "1000",
         },
       })

--- a/front/lib/api/workspace/default_user_spend_limit.test.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.test.ts
@@ -123,7 +123,7 @@ describe("getDefaultUserSpendLimit", () => {
     }
   });
 
-  it("falls back to the plan-tier default when no workspace default is configured (pro plan → 0)", async () => {
+  it("returns 0 when no workspace default is configured (no plan-tier fallback, no unlimited)", async () => {
     const workspace = await WorkspaceFactory.metronome({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -78,11 +78,7 @@ export async function getDefaultUserSpendLimit(
 
   const config =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
-  if (!config || config.defaultPoolCapAwuCredits === null) {
-    return new Ok({ awuCredits: 0 });
-  }
-
-  return new Ok({ awuCredits: config.defaultPoolCapAwuCredits });
+  return new Ok({ awuCredits: config?.defaultPoolCapAwuCredits ?? 0 });
 }
 
 /**
@@ -255,7 +251,7 @@ export async function setDefaultUserSpendLimit(
   // The config row is created lazily, so upsert it.
   const existingConfig =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
-  const previousAwuCredits = existingConfig?.defaultPoolCapAwuCredits ?? null;
+  const previousAwuCredits = existingConfig?.defaultPoolCapAwuCredits ?? 0;
 
   if (existingConfig) {
     await existingConfig.updateConfiguration(auth, {
@@ -309,8 +305,7 @@ export async function setDefaultUserSpendLimit(
     targets: [buildAuditLogTarget("workspace", workspace)],
     context: auditContext,
     metadata: {
-      previous_awu_credits:
-        previousAwuCredits !== null ? String(previousAwuCredits) : "unset",
+      previous_awu_credits: String(previousAwuCredits),
       new_awu_credits: String(poolAwuCredits),
     },
   });

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -124,7 +124,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       usageCapCredits: number | null;
       allowMemberUpgradeRequests: boolean;
       upgradeRequestEmailEnabled: boolean;
-      defaultPoolCapAwuCredits: number | null;
+      defaultPoolCapAwuCredits: number;
       programmaticMonthlyCapAwuCredits: number;
       autoSeatUpgradeEnabled: boolean;
       balanceThresholdAwuCredits: number | null;

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -125,7 +125,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       allowMemberUpgradeRequests: boolean;
       upgradeRequestEmailEnabled: boolean;
       defaultPoolCapAwuCredits: number | null;
-      programmaticMonthlyCapAwuCredits: number | null;
+      programmaticMonthlyCapAwuCredits: number;
       autoSeatUpgradeEnabled: boolean;
       balanceThresholdAwuCredits: number | null;
       topUpEnabled: boolean;

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -38,7 +38,8 @@ import type { CreationOptional } from "sequelize";
  * - programmaticMonthlyCapAwuCredits: Workspace monthly cap on programmatic
  *   (API) AWU consumption, in AWU credits. Source of truth for the cap; the
  *   four Metronome programmatic alerts (cap/warning/low/critical) are derived
- *   from it. NULL means no cap is configured; 0 is a meaningful hard cap.
+ *   from it. Non-nullable, defaults to 0: 0 blocks all programmatic access
+ *   (no alerts, statically depleted); a positive value is the monthly cap.
  * - autoSeatUpgradeEnabled: Whether members who hit their per-user credit limit
  *   are automatically bumped to the next entitled seat tier (free→pro, pro→max,
  *   none→workspace) instead of being blocked. May increase the bill. Defaults to
@@ -68,7 +69,7 @@ export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsa
   declare allowMemberUpgradeRequests: CreationOptional<boolean>;
   declare upgradeRequestEmailEnabled: CreationOptional<boolean>;
   declare defaultPoolCapAwuCredits: number | null;
-  declare programmaticMonthlyCapAwuCredits: number | null;
+  declare programmaticMonthlyCapAwuCredits: CreationOptional<number>;
   declare autoSeatUpgradeEnabled: CreationOptional<boolean>;
   declare balanceThresholdAwuCredits: number | null;
   declare topUpEnabled: CreationOptional<boolean>;
@@ -132,8 +133,8 @@ CreditUsageConfigurationModel.init(
     },
     programmaticMonthlyCapAwuCredits: {
       type: DataTypes.INTEGER,
-      allowNull: true,
-      defaultValue: null,
+      allowNull: false,
+      defaultValue: 0,
     },
     autoSeatUpgradeEnabled: {
       type: DataTypes.BOOLEAN,

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -33,8 +33,10 @@ import type { CreationOptional } from "sequelize";
  *   member requests an upgrade. Defaults to true.
  * - defaultPoolCapAwuCredits: Workspace-wide default per-user cap on
  *   workspace-pool AWU consumption, in AWU credits, excluding the seat
- *   allowance. NULL means no default is configured (the plan-tier default
- *   applies).
+ *   allowance. Non-nullable, defaults to 0: 0 removes pool access; a positive
+ *   value is the per-user pool cap. Effective cap resolution is per-user
+ *   override -> group cap -> this workspace default (no plan-tier fallback).
+ *   Unlimited is not supported.
  * - programmaticMonthlyCapAwuCredits: Workspace monthly cap on programmatic
  *   (API) AWU consumption, in AWU credits. Source of truth for the cap; the
  *   four Metronome programmatic alerts (cap/warning/low/critical) are derived
@@ -68,7 +70,7 @@ export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsa
   declare usageCapCredits: number | null;
   declare allowMemberUpgradeRequests: CreationOptional<boolean>;
   declare upgradeRequestEmailEnabled: CreationOptional<boolean>;
-  declare defaultPoolCapAwuCredits: number | null;
+  declare defaultPoolCapAwuCredits: CreationOptional<number>;
   declare programmaticMonthlyCapAwuCredits: CreationOptional<number>;
   declare autoSeatUpgradeEnabled: CreationOptional<boolean>;
   declare balanceThresholdAwuCredits: number | null;
@@ -128,8 +130,8 @@ CreditUsageConfigurationModel.init(
     },
     defaultPoolCapAwuCredits: {
       type: DataTypes.INTEGER,
-      allowNull: true,
-      defaultValue: null,
+      allowNull: false,
+      defaultValue: 0,
     },
     programmaticMonthlyCapAwuCredits: {
       type: DataTypes.INTEGER,

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -22,7 +22,7 @@ import { mutate } from "swr";
 import { z } from "zod";
 
 const GetDefaultUserSpendLimitResponseSchema = z.object({
-  awuCredits: z.number().int().nullable(),
+  awuCredits: z.number().int(),
 });
 
 const PutDefaultUserSpendLimitResponseSchema = z.object({

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -332,7 +332,7 @@ export function useUpdateDefaultUserSpendLimit({
 // Programmatic usage limit
 
 const GetProgrammaticUsageLimitResponseSchema = z.object({
-  monthlyCapCredits: z.number().int().nullable(),
+  monthlyCapCredits: z.number().int(),
 });
 
 function programmaticUsageLimitUrl(workspaceId: string): string {
@@ -375,7 +375,7 @@ export function useUpdateProgrammaticUsageLimit({
 
   const doUpdateProgrammaticUsageLimit = useCallback(
     async (
-      monthlyCapCredits: number | null
+      monthlyCapCredits: number
     ): Promise<PutProgrammaticUsageLimitResponseBody | null> => {
       const res = await clientFetch(programmaticUsageLimitUrl(workspaceId), {
         method: "PUT",
@@ -397,7 +397,7 @@ export function useUpdateProgrammaticUsageLimit({
         await res.json()
       );
 
-      if (monthlyCapCredits === null || monthlyCapCredits === 0) {
+      if (monthlyCapCredits === 0) {
         sendNotification({
           type: "success",
           title: "Programmatic access disabled",

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -295,7 +295,7 @@ async function checkWorkspaceRateLimit({
       (await isProgrammaticApiBlocked(owner.sId))
     ) {
       errorMessage =
-        "Your workspace has reached its programmatic monthly spending cap.";
+        "Your workspace has reached its programmatic monthly spending cap. An admin can raise the cap in the workspace's usage settings.";
     }
   }
 

--- a/front/migrations/post-deploy/20260707182558_programmatic_monthly_cap_not_null_default_zero.sql
+++ b/front/migrations/post-deploy/20260707182558_programmatic_monthly_cap_not_null_default_zero.sql
@@ -1,0 +1,18 @@
+/*
+Post-deploy: make credit_usage_configurations."programmaticMonthlyCapAwuCredits"
+NOT NULL with a default of 0.
+
+The programmatic monthly cap no longer has a "no cap / unlimited" (NULL) state:
+0 blocks all programmatic access and a positive value is the monthly cap.
+Backfill any legacy NULL rows to 0 (no access) before applying the NOT NULL
+constraint. Run after the code that never writes NULL is live.
+ */
+UPDATE "public"."credit_usage_configurations"
+SET "programmaticMonthlyCapAwuCredits" = 0
+WHERE "programmaticMonthlyCapAwuCredits" IS NULL;
+
+ALTER TABLE "public"."credit_usage_configurations"
+    ALTER COLUMN "programmaticMonthlyCapAwuCredits" SET DEFAULT 0;
+
+ALTER TABLE "public"."credit_usage_configurations"
+    ALTER COLUMN "programmaticMonthlyCapAwuCredits" SET NOT NULL;

--- a/front/migrations/post-deploy/20260708110032_default_pool_cap_not_null_default_zero.sql
+++ b/front/migrations/post-deploy/20260708110032_default_pool_cap_not_null_default_zero.sql
@@ -1,0 +1,20 @@
+/*
+Post-deploy: make credit_usage_configurations."defaultPoolCapAwuCredits"
+NOT NULL with a default of 0.
+
+The workspace-wide default per-user pool cap has no "unlimited" state and no
+plan-tier fallback: 0 removes pool access and a positive value is the cap
+(resolution order: per-user override -> group cap -> this workspace default).
+NULL was already coerced to 0 in every read path, so this only makes the column
+consistent with that behavior. Backfill legacy NULL rows to 0 before applying
+the NOT NULL constraint. Run after the code that never writes NULL is live.
+ */
+UPDATE "public"."credit_usage_configurations"
+SET "defaultPoolCapAwuCredits" = 0
+WHERE "defaultPoolCapAwuCredits" IS NULL;
+
+ALTER TABLE "public"."credit_usage_configurations"
+    ALTER COLUMN "defaultPoolCapAwuCredits" SET DEFAULT 0;
+
+ALTER TABLE "public"."credit_usage_configurations"
+    ALTER COLUMN "defaultPoolCapAwuCredits" SET NOT NULL;

--- a/front/types/api/credits/programmatic_usage_limit.ts
+++ b/front/types/api/credits/programmatic_usage_limit.ts
@@ -1,7 +1,7 @@
 export type GetProgrammaticUsageLimitResponseBody = {
-  monthlyCapCredits: number | null;
+  monthlyCapCredits: number;
 };
 
 export type PutProgrammaticUsageLimitResponseBody = {
-  monthlyCapCredits: number | null;
+  monthlyCapCredits: number;
 };

--- a/front/types/api/workspace/default_user_spend_limit.ts
+++ b/front/types/api/workspace/default_user_spend_limit.ts
@@ -3,7 +3,7 @@ export type DefaultUserSpendLimit = {
 };
 
 export type GetDefaultUserSpendLimitResponseBody = {
-  awuCredits: number | null;
+  awuCredits: number;
 };
 
 export type PutDefaultUserSpendLimitResponseBody = DefaultUserSpendLimit;


### PR DESCRIPTION
## Summary

Makes two `credit_usage_configurations` columns non-nullable with default 0, removing the "no cap / unlimited" (NULL) state. Both changes are on the same table so they ship together with one deploy.

### 1. `programmaticMonthlyCapAwuCredits` (follow-up to #28494)
Programmatic usage no longer has an "unlimited" state. Default is **0 = no programmatic access**; a positive value is the monthly cap. Reverts the null-handling from #28494.

- Reverted `reconcileProgrammatic` to `?? 0` → 0 (or no contract) ⇒ `depleted`.
- `getProgrammaticUsageLimit` returns 0 when unset; `syncProgrammaticUsageLimit` takes a `number`, clamps negatives to 0; cap 0 clears the Metronome alerts (statically depleted).
- PUT endpoint rejects null; usage card + poke plugins set a non-negative number (0 = block). Dropped the enable/disable toggle from the "Manage Programmatic Monthly Cap" poke plugin.

**Re: Metronome alerts for cap 0** — none are needed: spend is always ≥ cap (zero headroom), so no threshold can ever transition; the state is statically `depleted`. Alerts are only created for cap `> 0`.

### 2. `defaultPoolCapAwuCredits` (consistency)
The workspace-wide default per-user pool cap already had **no "unlimited" option and no plan-tier fallback** — resolution is **per-user override → group cap → workspace default**, and `NULL` was already coerced to `0` in every read path. This just makes the column match that reality.

- `getDefaultUserSpendLimit` returns 0 when unset; audit "unset" sentinel dropped.
- `switch_contract`: `?? null` → `?? 0`. API type / SWR schema: `number` (not `number | null`). UI card null-handling simplified to 0.
- Fixed the misleading model doc comment + test name that referenced a non-existent "plan-tier default".


## Validation
- `tsgo`: **0 type errors in any file changed by this PR** (verified directly).
- Full-project typecheck / tests can't run in this worktree (`@dust-tt/sparkle` / `@temporalio` workspace deps are unbuilt/broken here — pre-existing, unrelated). CI builds these fresh. Pre-commit hook bypassed for the same reason.
- Migrations are hand-written (local dev DB not provisioned in this worktree) but follow the repo format; apply/verify against a real DB before deploy.

## Deploy Plan

regular deploy for front, then run post deploy migrations : 

- `…_programmatic_monthly_cap_not_null_default_zero.sql`
- `…_default_pool_cap_not_null_default_zero.sql`

Each: backfill `NULL → 0`, set `DEFAULT 0`, then `SET NOT NULL`. Safe as post-deploy — new code never writes null and defaults to 0, and all readers coerce `null → 0` during the transition window.



## Deploy Plan

1. Merge and deploy the code first. The new code never writes `NULL` for either column, the model defaults both to `0`, and every reader coerces `NULL → 0`, so no new `NULL` rows are created and behavior is unchanged during the rollout.
2. After the new code is fully live (old code cycled out), run the two **post-deploy** migrations from prodbox (`npm -w front run migration:apply:post-deploy`). Each backfills legacy `NULL → 0`, sets `DEFAULT 0`, then applies `SET NOT NULL` on `credit_usage_configurations` (`programmaticMonthlyCapAwuCredits`, `defaultPoolCapAwuCredits`).
3. No data backfill script beyond the migrations is required; both caps already behaved as `0` when `NULL`.
