### PR TITLE
Pricing bulk edit seat 1/3: generalize bulk member selection

### DIFF
--- a/front-api/routes/w/[wId]/members/bulk-spend-limit.ts
+++ b/front-api/routes/w/[wId]/members/bulk-spend-limit.ts
@@ -1,7 +1,7 @@
 import {
-  BulkSpendLimitSelectionSchema,
-  resolveBulkSpendLimitUserIds,
-} from "@app/lib/api/users/bulk_spend_limit";
+  BulkMemberSelectionSchema,
+  resolveBulkMemberSelectionUserIds,
+} from "@app/lib/api/users/bulk_member_selection";
 import {
   MAX_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_USER_SPEND_LIMIT_AWU_CREDITS,
@@ -27,7 +27,7 @@ const LimitSchema = z.discriminatedUnion("kind", [
 ]);
 
 const BodySchema = z.object({
-  selection: BulkSpendLimitSelectionSchema,
+  selection: BulkMemberSelectionSchema,
   limit: LimitSchema,
 });
 
@@ -70,7 +70,10 @@ app.post(
 
     const { selection, limit } = ctx.req.valid("json");
 
-    const userIdsResult = await resolveBulkSpendLimitUserIds(auth, selection);
+    const userIdsResult = await resolveBulkMemberSelectionUserIds(
+      auth,
+      selection
+    );
     if (userIdsResult.isErr()) {
       return apiError(ctx, {
         status_code: 500,

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -56,6 +56,7 @@ import {
   useSeatPlan,
 } from "@app/lib/swr/credits";
 import { useGroups } from "@app/lib/swr/groups";
+import type { BulkMemberSelectionBody } from "@app/lib/swr/memberships";
 import {
   useBulkSetUserSpendLimit,
   useMembersUsage,
@@ -553,6 +554,23 @@ export function UsagePage() {
     setIsBulkSpendLimitOpen(true);
   }, []);
 
+  // Translate the cross-page selection into the descriptor the bulk member
+  // endpoints expect: explicit ids, or the current filter minus exclusions.
+  const buildBulkSelectionBody = useCallback((): BulkMemberSelectionBody => {
+    const descriptor = selection.descriptor();
+    return descriptor.mode === "ids"
+      ? descriptor
+      : {
+          mode: "all" as const,
+          filter: {
+            seatType: seatTypeFilter ?? undefined,
+            groupId: groupFilter ?? undefined,
+            search: searchTerm.trim() || undefined,
+          },
+          excludeUserIds: descriptor.excludeUserIds,
+        };
+  }, [selection, seatTypeFilter, groupFilter, searchTerm]);
+
   const onRemoveSeat = useCallback(
     async (member: MemberUsageType) => {
       // Free seats carry no renewing allowance to preserve, so removing one is
@@ -598,31 +616,21 @@ export function UsagePage() {
     handleApproveOnModalSaved();
   }, [handleApproveOnModalSaved, clearSelection]);
 
+  // Rows to spin while a bulk update runs — the request returns once the bulk
+  // workflow has completed. For an "all matching" selection only the current
+  // page is visible, so spin its non-excluded rows.
+  const getBulkPendingMemberIds = useCallback((): string[] => {
+    const descriptor = selection.descriptor();
+    return descriptor.mode === "ids"
+      ? descriptor.userIds
+      : pageItemIds.filter((id) => !descriptor.excludeUserIds.includes(id));
+  }, [selection, pageItemIds]);
+
   const handleBulkSpendLimitValidate = useCallback(
     async (
       limit: { kind: "unlimited" } | { kind: "limited"; awuCredits: number }
     ): Promise<boolean> => {
-      const descriptor = selection.descriptor();
-      const selectionBody =
-        descriptor.mode === "ids"
-          ? descriptor
-          : {
-              mode: "all" as const,
-              filter: {
-                seatType: seatTypeFilter ?? undefined,
-                groupId: groupFilter ?? undefined,
-                search: searchTerm.trim() || undefined,
-              },
-              excludeUserIds: descriptor.excludeUserIds,
-            };
-
-      // Spin the affected rows while the update runs — the request returns
-      // once the bulk workflow has completed. For an "all matching" selection
-      // only the current page is visible, so spin its non-excluded rows.
-      const pendingMemberIds =
-        descriptor.mode === "ids"
-          ? descriptor.userIds
-          : pageItemIds.filter((id) => !descriptor.excludeUserIds.includes(id));
+      const pendingMemberIds = getBulkPendingMemberIds();
       setTotalAllowedUsagePendingMemberIds((prev) => {
         const next = new Set(prev);
         pendingMemberIds.forEach((id) => next.add(id));
@@ -631,7 +639,7 @@ export function UsagePage() {
 
       try {
         const body = await doBulkSetSpendLimit({
-          selection: selectionBody,
+          selection: buildBulkSelectionBody(),
           limit,
         });
         if (!body) {
@@ -650,11 +658,9 @@ export function UsagePage() {
     },
     [
       selection,
-      seatTypeFilter,
-      groupFilter,
-      searchTerm,
+      buildBulkSelectionBody,
+      getBulkPendingMemberIds,
       doBulkSetSpendLimit,
-      pageItemIds,
     ]
   );
 

--- a/front/lib/api/users/bulk_member_selection.ts
+++ b/front/lib/api/users/bulk_member_selection.ts
@@ -6,28 +6,30 @@ import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { z } from "zod";
 
-const BulkSpendLimitFilterSchema = z.object({
+const BulkMemberSelectionFilterSchema = z.object({
   seatType: z.enum(MEMBERSHIP_SEAT_TYPES).optional(),
   groupId: z.string().optional(),
   search: z.string().optional(),
 });
 
-export const BulkSpendLimitSelectionSchema = z.discriminatedUnion("mode", [
+// Descriptor of a cross-page member selection in the usage members table:
+// either an explicit list of user sIds, or "all members matching the current
+// filter" minus explicit exclusions. Shared by the bulk member actions
+// (spend-limit and seat-type updates).
+export const BulkMemberSelectionSchema = z.discriminatedUnion("mode", [
   z.object({ mode: z.literal("ids"), userIds: z.array(z.string()).min(1) }),
   z.object({
     mode: z.literal("all"),
-    filter: BulkSpendLimitFilterSchema,
+    filter: BulkMemberSelectionFilterSchema,
     excludeUserIds: z.array(z.string()),
   }),
 ]);
 
-export type BulkSpendLimitSelection = z.infer<
-  typeof BulkSpendLimitSelectionSchema
->;
+export type BulkMemberSelection = z.infer<typeof BulkMemberSelectionSchema>;
 
-export async function resolveBulkSpendLimitUserIds(
+export async function resolveBulkMemberSelectionUserIds(
   auth: Authenticator,
-  selection: BulkSpendLimitSelection
+  selection: BulkMemberSelection
 ): Promise<Result<string[], Error>> {
   if (selection.mode === "ids") {
     const uniqueIds = [...new Set(selection.userIds)];

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -227,7 +227,8 @@ function bulkSpendLimitUrl(workspaceId: string): string {
   return `/api/w/${workspaceId}/members/bulk-spend-limit`;
 }
 
-type BulkSpendLimitSelectionBody =
+// Cross-page member selection descriptor shared by the bulk member endpoints.
+export type BulkMemberSelectionBody =
   | { mode: "ids"; userIds: string[] }
   | {
       mode: "all";
@@ -252,7 +253,7 @@ export function useBulkSetUserSpendLimit({
       selection,
       limit,
     }: {
-      selection: BulkSpendLimitSelectionBody;
+      selection: BulkMemberSelectionBody;
       limit: { kind: "unlimited" } | { kind: "limited"; awuCredits: number };
     }): Promise<{ workflowId: string; memberCount: number } | null> => {
       const res = await clientFetch(bulkSpendLimitUrl(workspaceId), {

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -30,9 +30,9 @@ export function isMembershipOriginType(
   return MEMBERSHIP_ORIGIN_TYPES.includes(value as MembershipOriginType);
 }
 
-// Billable seat types — each maps to a Metronome product.
-export const BILLABLE_SEAT_TYPES = [
-  "free",
+// Paid seat types — billable seats excluding the one-shot `free` starter seat.
+// These are the seats a member can be moved to from the admin seat pickers.
+export const PAID_SEAT_TYPES = [
   "workspace",
   "workspace_yearly",
   "pro",
@@ -40,6 +40,11 @@ export const BILLABLE_SEAT_TYPES = [
   "max",
   "max_yearly",
 ] as const;
+
+export type PaidSeatType = (typeof PAID_SEAT_TYPES)[number];
+
+// Billable seat types — each maps to a Metronome product.
+export const BILLABLE_SEAT_TYPES = ["free", ...PAID_SEAT_TYPES] as const;
 
 export const MEMBERSHIP_SEAT_TYPES = [
   // `none` = no billable seat assigned; member cannot send messages.
@@ -171,7 +176,9 @@ export function isSeatBased(
   }
 }
 
-export function isPaidSeatType(seatType: MembershipSeatType): boolean {
+export function isPaidSeatType(
+  seatType: MembershipSeatType
+): seatType is PaidSeatType {
   switch (seatType) {
     case "workspace":
     case "workspace_yearly":


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9315

Preliminary refactor for the upcoming bulk seat-type change feature (PR 1/3). No behavior change.

- Rename `lib/api/users/bulk_spend_limit.ts` → `bulk_member_selection.ts` with generic names (`BulkMemberSelectionSchema`, `resolveBulkMemberSelectionUserIds`): the cross-page selection descriptor will be shared by the bulk spend-limit and bulk seat-type endpoints.
- Add `PAID_SEAT_TYPES` to `types/memberships.ts` and turn `isPaidSeatType` into a type guard.
- `UsagePage`: extract `buildBulkSelectionBody` / `getBulkPendingMemberIds` out of the spend-limit handler, and export `BulkMemberSelectionBody` from the SWR layer, so the next bulk action can reuse them.

## Tests

- `bulk-spend-limit.test.ts` (9 tests) passes.
- tsgo clean on front and front-api.

## Risk

Low — pure rename/extraction, no behavior change.

## Stack
 1. Refactoring: https://github.com/dust-tt/dust/pull/28642
 2. Backend: https://github.com/dust-tt/dust/pull/28643
 3. UI: https://github.com/dust-tt/dust/pull/28644

## Deploy Plan

Deploy front.