### PR TITLE
Pricing bulk edit seat 2/3: backend (endpoints, preview, workflow)

### DIFF
--- a/front-api/routes/w/[wId]/members/bulk-seat-type.test.ts
+++ b/front-api/routes/w/[wId]/members/bulk-seat-type.test.ts
@@ -1,0 +1,245 @@
+import type { BulkSeatChangePreview } from "@app/lib/api/credits/bulk_seat_change";
+import { computeBulkSeatChangePreview } from "@app/lib/api/credits/bulk_seat_change";
+import { UserResource } from "@app/lib/resources/user_resource";
+import * as bulkClient from "@app/temporal/bulk_seat_change/client";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/temporal/bulk_seat_change/client", () => ({
+  runBulkChangeSeatTypeWorkflow: vi.fn(),
+}));
+
+vi.mock(
+  import("@app/lib/api/credits/bulk_seat_change"),
+  async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+      ...actual,
+      computeBulkSeatChangePreview: vi.fn(),
+    };
+  }
+);
+
+function bulkSeatTypeUrl(wId: string) {
+  return `/api/w/${wId}/members/bulk-seat-type`;
+}
+
+async function makeMetronomeWorkspace(): Promise<WorkspaceType> {
+  return WorkspaceFactory.metronome({ metronomeCustomerId: "cust_test_bulk" });
+}
+
+function post(wId: string, body: unknown, path = "") {
+  return honoApp.request(`${bulkSeatTypeUrl(wId)}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const PREVIEW: BulkSeatChangePreview = {
+  memberCount: 2,
+  targetSeatType: "max",
+  targetSeatName: "Max Seat",
+  currency: "usd",
+  moves: [
+    {
+      fromSeatType: "pro",
+      fromSeatName: "Pro Seat",
+      kind: "immediate",
+      count: 2,
+    },
+  ],
+  immediateDeltaMonthlyCents: 4000,
+  deferredDeltaMonthlyCents: 0,
+  nextBillingPeriodAt: null,
+  seatTotals: [
+    {
+      seatType: "max",
+      seatName: "Max Seat",
+      committedSeats: 0,
+      assignedBefore: 1,
+      assignedAfter: 3,
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.mocked(bulkClient.runBulkChangeSeatTypeWorkflow).mockResolvedValue(
+    new Ok({ workflowId: "wf_test_bulk_seat" })
+  );
+  vi.mocked(computeBulkSeatChangePreview).mockResolvedValue(new Ok(PREVIEW));
+  // The workspace-scoped search that validates membership. Default to "no
+  // match"; tests that need members override with real UserFactory users.
+  vi.spyOn(UserResource, "searchAllUsers").mockResolvedValue(
+    new Ok({ users: [], total: 0 })
+  );
+});
+
+describe("POST /api/w/[wId]/members/bulk-seat-type", () => {
+  it("returns 403 when the caller is a user", async () => {
+    const workspace = await makeMetronomeWorkspace();
+    await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+      workspace,
+    });
+
+    const response = await post(workspace.sId, {
+      selection: { mode: "ids", userIds: ["u1"] },
+      seatType: "max",
+    });
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+    expect(bulkClient.runBulkChangeSeatTypeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("allows a business admin to launch the workflow", async () => {
+    const workspace = await makeMetronomeWorkspace();
+    const { auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "business_admin",
+      workspace,
+    });
+    await FeatureFlagFactory.basic(auth, "pricing_groups");
+
+    const member = await UserFactory.basic();
+    vi.mocked(UserResource.searchAllUsers).mockResolvedValue(
+      new Ok({ users: [member], total: 1 })
+    );
+
+    const response = await post(workspace.sId, {
+      selection: { mode: "ids", userIds: [member.sId] },
+      seatType: "max",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      workflowId: "wf_test_bulk_seat",
+      memberCount: 1,
+    });
+    expect(bulkClient.runBulkChangeSeatTypeWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: workspace.sId,
+        userIds: [member.sId],
+        seatType: "max",
+      })
+    );
+  });
+
+  it("returns 403 when the pricing_groups flag is off", async () => {
+    const workspace = await makeMetronomeWorkspace();
+    await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+      workspace,
+    });
+
+    const response = await post(workspace.sId, {
+      selection: { mode: "ids", userIds: ["u1"] },
+      seatType: "max",
+    });
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("feature_flag_not_found");
+    expect(bulkClient.runBulkChangeSeatTypeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the target seat type is not a paid seat", async () => {
+    const workspace = await makeMetronomeWorkspace();
+    const { auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+      workspace,
+    });
+    await FeatureFlagFactory.basic(auth, "pricing_groups");
+
+    for (const seatType of ["free", "none"]) {
+      const response = await post(workspace.sId, {
+        selection: { mode: "ids", userIds: ["u1"] },
+        seatType,
+      });
+      expect(response.status).toBe(400);
+    }
+    expect(bulkClient.runBulkChangeSeatTypeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when no submitted ids are active members", async () => {
+    const workspace = await makeMetronomeWorkspace();
+    const { auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+      workspace,
+    });
+    await FeatureFlagFactory.basic(auth, "pricing_groups");
+
+    const response = await post(workspace.sId, {
+      selection: { mode: "ids", userIds: ["stale1", "stale2"] },
+      seatType: "max",
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+    expect(bulkClient.runBulkChangeSeatTypeWorkflow).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/w/[wId]/members/bulk-seat-type/preview", () => {
+  it("returns the computed preview for a business admin", async () => {
+    const workspace = await makeMetronomeWorkspace();
+    const { auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "business_admin",
+      workspace,
+    });
+    await FeatureFlagFactory.basic(auth, "pricing_groups");
+
+    const member = await UserFactory.basic();
+    vi.mocked(UserResource.searchAllUsers).mockResolvedValue(
+      new Ok({ users: [member], total: 1 })
+    );
+
+    const response = await post(
+      workspace.sId,
+      {
+        selection: { mode: "ids", userIds: [member.sId] },
+        seatType: "max",
+      },
+      "/preview"
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ preview: PREVIEW });
+    expect(computeBulkSeatChangePreview).toHaveBeenCalledWith(
+      expect.anything(),
+      { userIds: [member.sId], targetSeatType: "max" }
+    );
+  });
+
+  it("returns 403 when the caller is a user", async () => {
+    const workspace = await makeMetronomeWorkspace();
+    await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+      workspace,
+    });
+
+    const response = await post(
+      workspace.sId,
+      {
+        selection: { mode: "ids", userIds: ["u1"] },
+        seatType: "max",
+      },
+      "/preview"
+    );
+
+    expect(response.status).toBe(403);
+    expect(computeBulkSeatChangePreview).not.toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/w/[wId]/members/bulk-seat-type.ts
+++ b/front-api/routes/w/[wId]/members/bulk-seat-type.ts
@@ -1,0 +1,186 @@
+import type { BulkSeatChangePreview } from "@app/lib/api/credits/bulk_seat_change";
+import {
+  BulkSeatChangeTargetSeatTypeSchema,
+  computeBulkSeatChangePreview,
+} from "@app/lib/api/credits/bulk_seat_change";
+import {
+  BulkMemberSelectionSchema,
+  resolveBulkMemberSelectionUserIds,
+} from "@app/lib/api/users/bulk_member_selection";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { runBulkChangeSeatTypeWorkflow } from "@app/temporal/bulk_seat_change/client";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import type { Context } from "hono";
+import { z } from "zod";
+
+const BodySchema = z.object({
+  selection: BulkMemberSelectionSchema,
+  seatType: BulkSeatChangeTargetSeatTypeSchema,
+});
+
+export type BulkChangeSeatTypeResponseBody = {
+  workflowId: string;
+  memberCount: number;
+};
+
+export type BulkSeatChangePreviewResponseBody = {
+  preview: BulkSeatChangePreview;
+};
+
+// Shared guards for the apply and preview handlers. Returns the error
+// response when a guard fails, null when the request may proceed.
+async function checkBulkSeatTypeAccess(
+  ctx: Context,
+  auth: Authenticator
+): Promise<ReturnType<typeof apiError> | null> {
+  if (!(await hasFeatureFlag(auth, "pricing_groups"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "feature_flag_not_found",
+        message: "The pricing_groups feature is not enabled.",
+      },
+    });
+  }
+
+  if (!auth.getNonNullableSubscriptionResource().isMetronomeOnlyBilled) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "plan_limit_error",
+        message:
+          "Seat type management is only available for workspaces on Metronome billing.",
+      },
+    });
+  }
+
+  return null;
+}
+
+// Mounted at /api/w/:wId/members/bulk-seat-type.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsBusinessAdmin(),
+  validate("json", BodySchema),
+  async (ctx): HandlerResult<BulkChangeSeatTypeResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const accessError = await checkBulkSeatTypeAccess(ctx, auth);
+    if (accessError) {
+      return accessError;
+    }
+
+    const { selection, seatType } = ctx.req.valid("json");
+
+    const userIdsResult = await resolveBulkMemberSelectionUserIds(
+      auth,
+      selection
+    );
+    if (userIdsResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to resolve the selected members.",
+        },
+      });
+    }
+    const userIds = userIdsResult.value;
+    if (userIds.length === 0) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "No active members matched the selection.",
+        },
+      });
+    }
+
+    const result = await runBulkChangeSeatTypeWorkflow({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      actorUserId: auth.getNonNullableUser().sId,
+      userIds,
+      seatType,
+    });
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to start the bulk seat-type update.",
+        },
+      });
+    }
+
+    return ctx.json({
+      workflowId: result.value.workflowId,
+      memberCount: userIds.length,
+    });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/preview",
+  ensureIsBusinessAdmin(),
+  validate("json", BodySchema),
+  async (ctx): HandlerResult<BulkSeatChangePreviewResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const accessError = await checkBulkSeatTypeAccess(ctx, auth);
+    if (accessError) {
+      return accessError;
+    }
+
+    const { selection, seatType } = ctx.req.valid("json");
+
+    const userIdsResult = await resolveBulkMemberSelectionUserIds(
+      auth,
+      selection
+    );
+    if (userIdsResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to resolve the selected members.",
+        },
+      });
+    }
+    const userIds = userIdsResult.value;
+    if (userIds.length === 0) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "No active members matched the selection.",
+        },
+      });
+    }
+
+    const previewResult = await computeBulkSeatChangePreview(auth, {
+      userIds,
+      targetSeatType: seatType,
+    });
+    if (previewResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to compute the seat-change preview.",
+        },
+      });
+    }
+
+    return ctx.json({ preview: previewResult.value });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/members/index.ts
+++ b/front-api/routes/w/[wId]/members/index.ts
@@ -9,6 +9,7 @@ import type { Context } from "hono";
 import { z } from "zod";
 
 import member from "./[uId]";
+import bulkSeatType from "./bulk-seat-type";
 import bulkSpendLimit from "./bulk-spend-limit";
 import freeSeats from "./free-seats";
 import lookup from "./lookup";
@@ -82,6 +83,7 @@ app.get(
   }
 );
 
+app.route("/bulk-seat-type", bulkSeatType);
 app.route("/bulk-spend-limit", bulkSpendLimit);
 app.route("/free-seats", freeSeats);
 app.route("/lookup", lookup);

--- a/front/lib/api/credits/bulk_seat_change.ts
+++ b/front/lib/api/credits/bulk_seat_change.ts
@@ -1,0 +1,329 @@
+import type {
+  SeatBillingFrequency,
+  SeatPlanResponseBody,
+} from "@app/lib/api/credits/seat_plan";
+import { getSeatPlan, SeatPlanError } from "@app/lib/api/credits/seat_plan";
+import type { Authenticator } from "@app/lib/auth";
+import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { SupportedCurrency } from "@app/types/currency";
+import type { MembershipSeatType, PaidSeatType } from "@app/types/memberships";
+import {
+  isMembershipSeatType,
+  isPaidSeatType,
+  PAID_SEAT_TYPES,
+  SEAT_TYPE_ORDER,
+} from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { z } from "zod";
+
+export const BulkSeatChangeTargetSeatTypeSchema = z.enum(PAID_SEAT_TYPES);
+
+// How a member's transition to the target seat will be applied. Mirrors the
+// backend classifier (`classifySeatChange` in lib/metronome/seats.ts):
+// - `unchanged`: already on the target seat, nothing happens.
+// - `immediate`: the change (and its billing impact) applies right away.
+// - `deferred`: the change applies at the next credit refresh (downgrades and
+//   monthly→yearly switches).
+export type BulkSeatChangeMoveKind = "unchanged" | "immediate" | "deferred";
+
+export type BulkSeatChangeMove = {
+  fromSeatType: MembershipSeatType;
+  // Display name of the source seat from the seat plan; null for seats that
+  // have no plan entry (e.g. "none").
+  fromSeatName: string | null;
+  kind: BulkSeatChangeMoveKind;
+  count: number;
+};
+
+// Per-seat-type assignment totals around the bulk change, for the summary
+// table: how many members hold the seat now and once every move (immediate +
+// deferred) has landed, against the committed pool size (`minSeats`, 0 when
+// the seat type carries no commitment). Covers every billable seat type
+// (free included); "none" is not a seat and never appears.
+export type BulkSeatChangeSeatTotal = {
+  seatType: MembershipSeatType;
+  seatName: string;
+  committedSeats: number;
+  assignedBefore: number;
+  assignedAfter: number;
+};
+
+export type BulkSeatChangePreview = {
+  memberCount: number;
+  targetSeatType: PaidSeatType;
+  targetSeatName: string;
+  currency: SupportedCurrency;
+  moves: BulkSeatChangeMove[];
+  seatTotals: BulkSeatChangeSeatTotal[];
+  // Monthly-equivalent invoice delta (annual prices divided by 12) of the
+  // changes applying right away vs. at the next credit refresh.
+  immediateDeltaMonthlyCents: number;
+  deferredDeltaMonthlyCents: number;
+  // ISO date the deferred changes land on (start of the next billing period,
+  // i.e. the current cycle's end). Null when there are no deferred moves or
+  // the billing period couldn't be resolved.
+  nextBillingPeriodAt: string | null;
+};
+
+export class BulkSeatChangePreviewError extends Error {
+  constructor(
+    readonly type: "seat_plan_unavailable" | "members_resolution_failed",
+    readonly cause?: Error
+  ) {
+    super(type);
+  }
+}
+
+// Monthly-equivalent price of a seat, to sum deltas across mixed billing
+// cadences into a single "per month" figure.
+function monthlyEquivalentCents(
+  priceCents: number,
+  billingFrequency: SeatBillingFrequency
+): number {
+  switch (billingFrequency) {
+    case "weekly":
+      return (priceCents * 52) / 12;
+    case "monthly":
+      return priceCents;
+    case "quarterly":
+      return priceCents / 3;
+    case "annual":
+      return priceCents / 12;
+    default:
+      return assertNever(billingFrequency);
+  }
+}
+
+function classifyMove({
+  fromSeatType,
+  targetSeatType,
+  seatPlans,
+}: {
+  fromSeatType: MembershipSeatType;
+  targetSeatType: PaidSeatType;
+  seatPlans: SeatPlanResponseBody;
+}): BulkSeatChangeMoveKind {
+  if (fromSeatType === targetSeatType) {
+    return "unchanged";
+  }
+  // Mirrors `classifySeatChange`: a monthly paid seat committing to annual
+  // billing is always deferred, even when the target tier is higher.
+  const isMonthlyToYearlySwitch =
+    isPaidSeatType(fromSeatType) &&
+    !fromSeatType.endsWith("_yearly") &&
+    targetSeatType.endsWith("_yearly");
+  if (isMonthlyToYearlySwitch) {
+    return "deferred";
+  }
+  const fromAwuCredits = seatPlans[fromSeatType]?.awuCredits ?? 0;
+  const targetAwuCredits = seatPlans[targetSeatType]?.awuCredits ?? 0;
+  return targetAwuCredits >= fromAwuCredits ? "immediate" : "deferred";
+}
+
+/**
+ * Marginal monthly cost of applying the net per-seat-type headcount deltas on
+ * top of the current assignment, accounting for committed-seat floors: a seat
+ * type's billed quantity is `max(assigned, minSeats)` (the seat sync tops the
+ * subscription up to the floor with unassigned seats), so moving a member into
+ * a seat type with spare committed slots consumes an already-billed seat and
+ * costs nothing, and dropping below the floor saves nothing.
+ */
+function billedDeltaMonthlyCents({
+  assignedBySeatType,
+  headcountDeltaBySeatType,
+  seatPlans,
+}: {
+  assignedBySeatType: Map<MembershipSeatType, number>;
+  headcountDeltaBySeatType: Map<MembershipSeatType, number>;
+  seatPlans: SeatPlanResponseBody;
+}): number {
+  let totalCents = 0;
+  for (const [seatType, delta] of headcountDeltaBySeatType) {
+    const info = seatPlans[seatType];
+    // Seat types without a plan entry ("none", legacy) carry no billing.
+    if (!info || delta === 0) {
+      continue;
+    }
+    const assigned = assignedBySeatType.get(seatType) ?? info.assignedCount;
+    const billedBefore = Math.max(assigned, info.minSeats);
+    const billedAfter = Math.max(assigned + delta, info.minSeats);
+    totalCents +=
+      (billedAfter - billedBefore) *
+      monthlyEquivalentCents(info.priceCents, info.billingFrequency);
+  }
+  return totalCents;
+}
+
+/**
+ * Compute the impact summary of moving `userIds` to `targetSeatType`: how many
+ * members move from each seat type (and whether each move is immediate or
+ * deferred to the next credit refresh), plus the monthly-equivalent invoice
+ * delta. Prices come from the workspace seat plan, and the deltas account for
+ * committed-seat floors (`minSeats`): only the change in each seat type's
+ * billed quantity `max(assigned, minSeats)` costs or saves money. Deferred
+ * changes are priced on top of the post-immediate assignment.
+ */
+export async function computeBulkSeatChangePreview(
+  auth: Authenticator,
+  {
+    userIds,
+    targetSeatType,
+  }: {
+    userIds: string[];
+    targetSeatType: PaidSeatType;
+  }
+): Promise<Result<BulkSeatChangePreview, BulkSeatChangePreviewError>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const seatPlanResult = await getSeatPlan(auth);
+  if (seatPlanResult.isErr()) {
+    return new Err(
+      new BulkSeatChangePreviewError(
+        "seat_plan_unavailable",
+        seatPlanResult.error
+      )
+    );
+  }
+  const seatPlans = seatPlanResult.value;
+  const targetInfo = seatPlans[targetSeatType];
+  if (!targetInfo) {
+    return new Err(
+      new BulkSeatChangePreviewError(
+        "seat_plan_unavailable",
+        new SeatPlanError("not_configured")
+      )
+    );
+  }
+
+  const users = await UserResource.fetchByIds(userIds);
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+    users,
+  });
+  const seatTypeByUserModelId = new Map(
+    memberships.map((m) => [m.userId, m.seatType])
+  );
+
+  const countByFromSeatType = new Map<MembershipSeatType, number>();
+  for (const user of users) {
+    const fromSeatType = seatTypeByUserModelId.get(user.id);
+    if (fromSeatType === undefined) {
+      // No active membership (revoked between selection and preview) — the
+      // apply step will skip them too.
+      continue;
+    }
+    countByFromSeatType.set(
+      fromSeatType,
+      (countByFromSeatType.get(fromSeatType) ?? 0) + 1
+    );
+  }
+
+  // Classify the moves and accumulate the net headcount delta each phase
+  // applies to each seat type (members leave their current type and join the
+  // target type either immediately or at the next credit refresh).
+  const moves: BulkSeatChangeMove[] = [];
+  let memberCount = 0;
+  const immediateHeadcountDeltas = new Map<MembershipSeatType, number>();
+  const deferredHeadcountDeltas = new Map<MembershipSeatType, number>();
+  for (const [fromSeatType, count] of countByFromSeatType) {
+    memberCount += count;
+    const kind = classifyMove({ fromSeatType, targetSeatType, seatPlans });
+    moves.push({
+      fromSeatType,
+      fromSeatName: seatPlans[fromSeatType]?.name ?? null,
+      kind,
+      count,
+    });
+    if (kind === "unchanged") {
+      continue;
+    }
+    const deltas =
+      kind === "immediate" ? immediateHeadcountDeltas : deferredHeadcountDeltas;
+    deltas.set(fromSeatType, (deltas.get(fromSeatType) ?? 0) - count);
+    deltas.set(targetSeatType, (deltas.get(targetSeatType) ?? 0) + count);
+  }
+
+  const assignedBySeatType = new Map<MembershipSeatType, number>();
+  for (const [seatType, info] of Object.entries(seatPlans)) {
+    if (isMembershipSeatType(seatType)) {
+      assignedBySeatType.set(seatType, info.assignedCount);
+    }
+  }
+
+  // Per-seat-type totals before / after all changes have landed, restricted
+  // to billable seat types (free included) that hold members or carry a
+  // commitment. "none" never has a seat-plan entry so it can't appear here.
+  const seatTotals: BulkSeatChangeSeatTotal[] = [];
+  for (const [seatType, info] of Object.entries(seatPlans)) {
+    if (!isMembershipSeatType(seatType)) {
+      continue;
+    }
+    const assignedBefore = info.assignedCount;
+    const assignedAfter =
+      assignedBefore +
+      (immediateHeadcountDeltas.get(seatType) ?? 0) +
+      (deferredHeadcountDeltas.get(seatType) ?? 0);
+    if (assignedBefore === 0 && assignedAfter === 0 && info.minSeats === 0) {
+      continue;
+    }
+    seatTotals.push({
+      seatType,
+      seatName: info.name,
+      committedSeats: info.minSeats,
+      assignedBefore,
+      assignedAfter,
+    });
+  }
+  seatTotals.sort(
+    (a, b) =>
+      SEAT_TYPE_ORDER[a.seatType] - SEAT_TYPE_ORDER[b.seatType] ||
+      a.seatType.localeCompare(b.seatType)
+  );
+
+  const immediateDeltaMonthlyCents = billedDeltaMonthlyCents({
+    assignedBySeatType,
+    headcountDeltaBySeatType: immediateHeadcountDeltas,
+    seatPlans,
+  });
+  // Deferred changes land on an assignment that already includes the
+  // immediate moves.
+  for (const [seatType, delta] of immediateHeadcountDeltas) {
+    assignedBySeatType.set(
+      seatType,
+      (assignedBySeatType.get(seatType) ?? 0) + delta
+    );
+  }
+  const deferredDeltaMonthlyCents = billedDeltaMonthlyCents({
+    assignedBySeatType,
+    headcountDeltaBySeatType: deferredHeadcountDeltas,
+    seatPlans,
+  });
+
+  // Resolve when the deferred changes will land. Degrades to null (the UI
+  // then omits the date) rather than failing the whole preview.
+  let nextBillingPeriodAt: string | null = null;
+  if (moves.some((m) => m.kind === "deferred")) {
+    const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+      workspace.sId
+    );
+    if (periodResult.isOk()) {
+      nextBillingPeriodAt = periodResult.value?.cycleEnd.toISOString() ?? null;
+    }
+  }
+
+  return new Ok({
+    memberCount,
+    targetSeatType,
+    targetSeatName: targetInfo.name,
+    currency: targetInfo.currency,
+    moves: moves.toSorted((a, b) => b.count - a.count),
+    seatTotals,
+    immediateDeltaMonthlyCents: Math.round(immediateDeltaMonthlyCents),
+    deferredDeltaMonthlyCents: Math.round(deferredDeltaMonthlyCents),
+    nextBillingPeriodAt,
+  });
+}

--- a/front/temporal/bulk_seat_change/client.ts
+++ b/front/temporal/bulk_seat_change/client.ts
@@ -1,0 +1,56 @@
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { makeBulkSeatChangeWorkflowId } from "@app/temporal/bulk_seat_change/helpers";
+import { QUEUE_NAME } from "@app/temporal/metronome_events_queue/config";
+import { bulkChangeSeatTypeWorkflow } from "@app/temporal/metronome_events_queue/workflows";
+import type { PaidSeatType } from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+
+/**
+ * Start a bulk seat-change workflow and wait for it to complete, so callers
+ * (the members table) can refresh the updated seats as soon as the request
+ * returns. The wait is bounded by the caller's HTTP timeout — acceptable while
+ * selections stay in the hundreds of members (each seat change is a membership
+ * write plus a debounced Metronome sync); revisit with an async status-polling
+ * flow if that stops holding.
+ */
+export async function runBulkChangeSeatTypeWorkflow({
+  workspaceId,
+  actorUserId,
+  userIds,
+  seatType,
+}: {
+  workspaceId: string;
+  actorUserId: string;
+  userIds: string[];
+  seatType: PaidSeatType;
+}): Promise<Result<{ workflowId: string }, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = makeBulkSeatChangeWorkflowId({
+    workspaceId,
+    token: generateRandomModelSId(),
+  });
+
+  try {
+    const handle = await client.workflow.start(bulkChangeSeatTypeWorkflow, {
+      args: [{ workspaceId, actorUserId, userIds, seatType }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: { workspaceId, actorUserId, seatType, memberCount: userIds.length },
+    });
+    await handle.result();
+    return new Ok({ workflowId });
+  } catch (e) {
+    if (!(e instanceof WorkflowExecutionAlreadyStartedError)) {
+      logger.error(
+        { workflowId, workspaceId, err: e },
+        "[BulkSeatChange] Failed to run workflow"
+      );
+    }
+    return new Err(normalizeError(e));
+  }
+}

--- a/front/temporal/bulk_seat_change/helpers.ts
+++ b/front/temporal/bulk_seat_change/helpers.ts
@@ -1,0 +1,9 @@
+export function makeBulkSeatChangeWorkflowId({
+  workspaceId,
+  token,
+}: {
+  workspaceId: string;
+  token: string;
+}): string {
+  return `bulk-seat-change-${workspaceId}-${token}`;
+}

--- a/front/temporal/metronome_events_queue/activities.ts
+++ b/front/temporal/metronome_events_queue/activities.ts
@@ -1,4 +1,5 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
+import { updateMembershipSeatAndTrack } from "@app/lib/api/membership";
 import { processMetronomeWebhook } from "@app/lib/api/metronome/process_webhook";
 import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
 import { setUserSpendLimit } from "@app/lib/api/users/spend_limit";
@@ -6,11 +7,13 @@ import { Authenticator } from "@app/lib/auth";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { cleanAndFinalizeMetronomeDraftInvoice } from "@app/lib/plans/stripe";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { UserSpendLimit } from "@app/types/api/users/spend_limit";
+import type { PaidSeatType } from "@app/types/memberships";
 
 const SET_SPEND_LIMIT_CONCURRENCY = 1;
 
@@ -75,6 +78,84 @@ export async function setSpendLimitForUsersActivity({
   if (transientFailures.length > 0) {
     throw new Error(
       `[BulkSpendLimit] ${transientFailures.length} transient failure(s) setting spend limit; retrying. ` +
+        `First: ${transientFailures[0].userId}: ${transientFailures[0].message}`
+    );
+  }
+
+  return { succeeded, failures };
+}
+
+export type ChangeSeatTypeChunkResult = {
+  succeeded: number;
+  failures: { userId: string; message: string }[];
+};
+
+// Move a chunk of members to `seatType`. Permanent failures (member revoked
+// between selection and run, seat cap reached, free-plan workspace) are
+// recorded; transient Metronome failures throw so Temporal retries the chunk
+// (`updateMembershipSeatAndTrack` no-ops on members already on the target
+// seat, so re-running already-applied members is safe).
+export async function changeSeatTypeForUsersActivity({
+  workspaceId,
+  actorUserId,
+  userIds,
+  seatType,
+}: {
+  workspaceId: string;
+  actorUserId: string;
+  userIds: string[];
+  seatType: PaidSeatType;
+}): Promise<ChangeSeatTypeChunkResult> {
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    actorUserId,
+    workspaceId
+  );
+  const workspace = auth.getNonNullableWorkspace();
+  const author = auth.getNonNullableUser().toJSON();
+
+  const users = await UserResource.fetchByIds(userIds);
+  const userById = new Map(users.map((user) => [user.sId, user]));
+
+  const failures: { userId: string; message: string }[] = [];
+  const transientFailures: { userId: string; message: string }[] = [];
+  let succeeded = 0;
+
+  // TODO(fabien): consider adding a new method to do bulk update of the seats.
+  // The current updateMembershipSeatAndTrack cannot be called in parallel because
+  // it does not do the limit checks atomicly.
+  for (const userId of userIds) {
+    // Workspace membership is enforced by `updateMembershipSeatAndTrack`
+    // (`not_found` when the user holds no active membership here).
+    const user = userById.get(userId);
+    if (!user) {
+      failures.push({ userId, message: "not_found" });
+      continue;
+    }
+    const result = await updateMembershipSeatAndTrack({
+      user,
+      workspace,
+      newSeatType: seatType,
+      author,
+    });
+    if (result.isOk()) {
+      succeeded++;
+      continue;
+    }
+    const failure = { userId, message: result.error.type };
+    if (result.error.type === "metronome_error") {
+      transientFailures.push(failure);
+    } else {
+      failures.push(failure);
+    }
+    logger.error(
+      { workspaceId, userId, seatType, err: result.error },
+      "[BulkSeatChange] Failed to change seat type for member"
+    );
+  }
+
+  if (transientFailures.length > 0) {
+    throw new Error(
+      `[BulkSeatChange] ${transientFailures.length} transient failure(s) changing seat type; retrying. ` +
         `First: ${transientFailures[0].userId}: ${transientFailures[0].message}`
     );
   }

--- a/front/temporal/metronome_events_queue/workflows.ts
+++ b/front/temporal/metronome_events_queue/workflows.ts
@@ -1,6 +1,7 @@
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import type * as activities from "@app/temporal/metronome_events_queue/activities";
 import type { UserSpendLimit } from "@app/types/api/users/spend_limit";
+import type { PaidSeatType } from "@app/types/memberships";
 import { log, proxyActivities } from "@temporalio/workflow";
 
 const {
@@ -11,17 +12,19 @@ const {
   startToCloseTimeout: "5 minutes",
 });
 
-// Bulk per-user spend-limit runs on this (Metronome) worker. Its activity makes
-// Metronome calls, so it gets a tighter timeout and a retry policy of its own.
-const { setSpendLimitForUsersActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "2 minutes",
-  retry: {
-    maximumAttempts: 3,
-    initialInterval: "2s",
-    backoffCoefficient: 2,
-    maximumInterval: "1m",
-  },
-});
+// Bulk per-user spend-limit and seat-type updates run on this (Metronome)
+// worker. Their activities make Metronome calls, so they get a tighter timeout
+// and a retry policy of their own.
+const { setSpendLimitForUsersActivity, changeSeatTypeForUsersActivity } =
+  proxyActivities<typeof activities>({
+    startToCloseTimeout: "2 minutes",
+    retry: {
+      maximumAttempts: 3,
+      initialInterval: "2s",
+      backoffCoefficient: 2,
+      maximumInterval: "1m",
+    },
+  });
 
 export async function metronomeEventsWorkflow({
   event,
@@ -93,6 +96,43 @@ export async function bulkSetUserSpendLimitWorkflow({
 
   log.info("[BulkSpendLimit] Completed bulk spend-limit update", {
     workspaceId,
+    total: userIds.length,
+    succeeded,
+    failed,
+  });
+}
+
+const BULK_SEAT_CHANGE_CHUNK_SIZE = 25;
+
+export async function bulkChangeSeatTypeWorkflow({
+  workspaceId,
+  actorUserId,
+  userIds,
+  seatType,
+}: {
+  workspaceId: string;
+  actorUserId: string;
+  userIds: string[];
+  seatType: PaidSeatType;
+}): Promise<void> {
+  let succeeded = 0;
+  let failed = 0;
+
+  for (let i = 0; i < userIds.length; i += BULK_SEAT_CHANGE_CHUNK_SIZE) {
+    const chunk = userIds.slice(i, i + BULK_SEAT_CHANGE_CHUNK_SIZE);
+    const result = await changeSeatTypeForUsersActivity({
+      workspaceId,
+      actorUserId,
+      userIds: chunk,
+      seatType,
+    });
+    succeeded += result.succeeded;
+    failed += result.failures.length;
+  }
+
+  log.info("[BulkSeatChange] Completed bulk seat-type update", {
+    workspaceId,
+    seatType,
     total: userIds.length,
     succeeded,
     failed,


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9315

Backend for bulk seat-type change from the usage admin page (PR 2/3, stacked on #28642 — UI in the follow-up PR).

- **Apply endpoint** `POST /api/w/:wId/members/bulk-seat-type`: resolves the cross-page member selection (shared `BulkMemberSelectionSchema`), then runs a new `bulkChangeSeatTypeWorkflow` on the Metronome events queue. The chunked activity calls `updateMembershipSeatAndTrack` per member (concurrency 1): transient Metronome failures throw so Temporal retries the chunk (re-running applied members is a no-op), permanent failures (revoked member, seat cap reached, free plan) are recorded and skipped. The client waits for workflow completion like bulk-spend-limit, so the table refreshes with the result.
- **Preview endpoint** `POST /api/w/:wId/members/bulk-seat-type/preview` (`computeBulkSeatChangePreview`): resolves the selection server-side (accurate for "select all across pages"), batches the membership reads, and returns per-source-seat move counts classified `immediate`/`deferred`/`unchanged` — mirroring `classifySeatChange`, including the monthly→yearly-is-always-deferred rule — plus monthly-equivalent invoice deltas split into immediate vs deferred, from seat-plan prices.
- Target seat restricted to `PAID_SEAT_TYPES` (no `free`, no `none`).
- Guards mirror bulk-spend-limit: business admin + `pricing_groups` flag + Metronome-only billing.
- the price delta take into account the commitment

## Tests

- New `bulk-seat-type.test.ts` (10 tests) covering roles, flag, billing gating, invalid target seats, stale selections, resolution failure, preview success/failure.

## Risk

Low — new endpoints behind business-admin + feature flag; no existing path modified except sharing the workflow retry config with bulk-spend-limit.

## Stack

 1. Refactoring: https://github.com/dust-tt/dust/pull/28642
 2. Backend: https://github.com/dust-tt/dust/pull/28643
 3. UI: https://github.com/dust-tt/dust/pull/28644

## Deploy Plan

Deploy front