### PR TITLE
Pricing bulk edit seat 3/3: usage page UI

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -2,6 +2,7 @@ import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { ConfirmContext } from "@app/components/Confirm";
 import { InviteEmailButtonWithModal } from "@app/components/members/InviteEmailButtonWithModal";
+import { BulkChangeSeatModal } from "@app/components/workspace/BulkChangeSeatModal";
 import { BulkEditSpendLimitModal } from "@app/components/workspace/BulkEditSpendLimitModal";
 import { BuyAwuCreditsDialog } from "@app/components/workspace/BuyAwuCreditsDialog";
 import { FreePlanUpgradeSection } from "@app/components/workspace/billing/FreePlanUpgradeSection";
@@ -58,6 +59,8 @@ import {
 import { useGroups } from "@app/lib/swr/groups";
 import type { BulkMemberSelectionBody } from "@app/lib/swr/memberships";
 import {
+  useBulkChangeSeatType,
+  useBulkSeatChangePreview,
   useBulkSetUserSpendLimit,
   useMembersUsage,
   useUpdateMemberSeatType,
@@ -75,6 +78,7 @@ import {
 import type {
   MembershipSeatType,
   MembershipUpgradeRequestType,
+  PaidSeatType,
 } from "@app/types/memberships";
 import {
   isMembershipSeatType,
@@ -554,6 +558,26 @@ export function UsagePage() {
     setIsBulkSpendLimitOpen(true);
   }, []);
 
+  const { doBulkChangeSeatType } = useBulkChangeSeatType({
+    workspaceId: owner.sId,
+  });
+  const { doFetchSeatChangePreview } = useBulkSeatChangePreview({
+    workspaceId: owner.sId,
+  });
+  const [isBulkChangeSeatOpen, setIsBulkChangeSeatOpen] = useState(false);
+
+  const handleBatchChangeSeat = useCallback(() => {
+    setIsBulkChangeSeatOpen(true);
+  }, []);
+
+  // Selected members visible on the current page, for the bulk seat modal's
+  // avatar row (with an "all across pages" selection this is the visible
+  // subset only).
+  const selectedVisibleMembers = useMemo(
+    () => membersUsage.filter((m) => selection.rowSelection[m.sId]),
+    [membersUsage, selection.rowSelection]
+  );
+
   // Translate the cross-page selection into the descriptor the bulk member
   // endpoints expect: explicit ids, or the current filter minus exclusions.
   const buildBulkSelectionBody = useCallback((): BulkMemberSelectionBody => {
@@ -661,6 +685,63 @@ export function UsagePage() {
       buildBulkSelectionBody,
       getBulkPendingMemberIds,
       doBulkSetSpendLimit,
+    ]
+  );
+
+  const handleBulkSeatChangePreview = useCallback(
+    (seatType: PaidSeatType) =>
+      doFetchSeatChangePreview({
+        selection: buildBulkSelectionBody(),
+        seatType,
+      }),
+    [doFetchSeatChangePreview, buildBulkSelectionBody]
+  );
+
+  const handleBulkChangeSeatValidate = useCallback(
+    async ({
+      seatType,
+      seatName,
+      hasDeferredChanges,
+    }: {
+      seatType: PaidSeatType;
+      seatName: string;
+      hasDeferredChanges: boolean;
+    }): Promise<boolean> => {
+      const pendingMemberIds = getBulkPendingMemberIds();
+      setSeatChangePendingMemberIds((prev) => {
+        const next = new Set(prev);
+        pendingMemberIds.forEach((id) => next.add(id));
+        return next;
+      });
+
+      try {
+        const body = await doBulkChangeSeatType({
+          selection: buildBulkSelectionBody(),
+          seatType,
+          seatName,
+          hasDeferredChanges,
+        });
+        if (!body) {
+          return false;
+        }
+
+        // Seat mutations can move members in or out of the currently filtered
+        // set, which makes the cross-page selection stale.
+        selection.clearSelection();
+        return true;
+      } finally {
+        setSeatChangePendingMemberIds((prev) => {
+          const next = new Set(prev);
+          pendingMemberIds.forEach((id) => next.delete(id));
+          return next;
+        });
+      }
+    },
+    [
+      selection,
+      buildBulkSelectionBody,
+      getBulkPendingMemberIds,
+      doBulkChangeSeatType,
     ]
   );
 
@@ -873,6 +954,9 @@ export function UsagePage() {
       onSelectAllAcrossPages={selection.selectAllAcrossPages}
       onClear={selection.clearSelection}
       onBatchEditSpendLimit={handleBatchEditSpendLimit}
+      onBatchChangeSeat={
+        isSeatBased && !isFreePlanWorkspace ? handleBatchChangeSeat : undefined
+      }
       disabled={isReadOnly}
     />
   );
@@ -1149,6 +1233,15 @@ export function UsagePage() {
         onClose={() => setIsBulkSpendLimitOpen(false)}
         memberCount={selection.selectedCount}
         onValidate={handleBulkSpendLimitValidate}
+      />
+      <BulkChangeSeatModal
+        isOpen={isBulkChangeSeatOpen}
+        onClose={() => setIsBulkChangeSeatOpen(false)}
+        memberCount={selection.selectedCount}
+        selectedMembers={selectedVisibleMembers}
+        seatPlans={seatPlans}
+        onFetchPreview={handleBulkSeatChangePreview}
+        onValidate={handleBulkChangeSeatValidate}
       />
       <EditAdvancedModelsModal
         isOpen={editAdvancedModelsTarget !== null}

--- a/front/components/workspace/BulkChangeSeatModal.tsx
+++ b/front/components/workspace/BulkChangeSeatModal.tsx
@@ -15,8 +15,8 @@ import type {
   SeatPlanResponseBody,
   SeatTypeInfo,
 } from "@app/lib/api/credits/seat_plan";
+import { formatCurrencyAmountCents } from "@app/lib/metronome/amounts";
 import type { BulkSeatChangePreviewBody } from "@app/lib/swr/memberships";
-import { CURRENCY_SYMBOLS } from "@app/types/currency";
 import type { MembershipSeatType, PaidSeatType } from "@app/types/memberships";
 import { isMembershipSeatType, isPaidSeatType } from "@app/types/memberships";
 import {
@@ -183,7 +183,10 @@ function SeatMoveSection({
         <p className="text-sm text-muted-foreground">
           This will {deltaMonthlyCents > 0 ? "add" : "remove"} an estimated{" "}
           <span className="font-semibold text-foreground">
-            {formatAmountCents(Math.abs(deltaMonthlyCents), preview.currency)}
+            {formatCurrencyAmountCents({
+              amountCents: Math.abs(deltaMonthlyCents),
+              currency: preview.currency,
+            })}
           </span>{" "}
           {deltaMonthlyCents > 0 ? "to" : "from"} your monthly invoice.
         </p>
@@ -260,8 +263,6 @@ function formatBillingPeriodDate(iso: string): string {
   });
 }
 
-// Amount without the "/mo" suffix (the sentence already says "monthly
-// invoice"), e.g. "$80" or "80€".
 // Price badge of a seat card in the pick step; annual seats show the
 // monthly-equivalent price.
 function getBadge(info: SeatTypeInfo): React.ReactNode {
@@ -279,23 +280,68 @@ function getBadge(info: SeatTypeInfo): React.ReactNode {
   );
 }
 
-function formatAmountCents(
-  cents: number,
-  currency: BulkSeatChangePreviewBody["currency"]
-): string {
-  const symbol = CURRENCY_SYMBOLS[currency];
-  const amount = (cents / 100).toFixed(2).replace(/\.00$/, "");
-  return currency === "eur" ? `${amount}${symbol}` : `${symbol}${amount}`;
+interface BulkChangeSeatModalHeaderProps {
+  // Selected members visible on the current page, for the avatar row.
+  selectedMembers: MemberUsageType[];
+  memberCount: number;
+  step: BulkChangeSeatStep;
 }
 
-function BulkChangeSeatForm({
-  onClose,
-  memberCount,
+function BulkChangeSeatModalHeader({
   selectedMembers,
+  memberCount,
+  step,
+}: BulkChangeSeatModalHeaderProps) {
+  return (
+    <DialogHeader>
+      <div className="flex flex-col gap-2">
+        {selectedMembers.length > 0 && (
+          <div className="flex flex-row items-center gap-2">
+            <Avatar.Stack
+              avatars={selectedMembers
+                .slice(0, MAX_HEADER_AVATARS)
+                .map((member) => ({
+                  name: member.name,
+                  visual: member.image ?? undefined,
+                  isRounded: true,
+                }))}
+              nbVisibleItems={MAX_HEADER_AVATARS}
+              size="md"
+            />
+            {memberCount > MAX_HEADER_AVATARS && (
+              <span className="flex h-8 min-w-8 items-center justify-center rounded-full bg-highlight-100 px-2 text-sm font-medium text-highlight-600">
+                {memberCount}
+              </span>
+            )}
+          </div>
+        )}
+        <div className="flex flex-col gap-1">
+          <DialogTitle>
+            Change seat for {memberCount.toLocaleString("en-US")} members
+          </DialogTitle>
+          <p className="text-sm text-muted-foreground">
+            {step === "pick"
+              ? "Choose a new seat to continue"
+              : "Review the changes before applying"}
+          </p>
+        </div>
+      </div>
+    </DialogHeader>
+  );
+}
+
+interface BulkChangeSeatModalPickSeatDialogContentProps {
+  seatPlans: SeatPlanResponseBody;
+  selectedSeat: PaidSeatType | null;
+  onSelectSeat: (seatType: PaidSeatType) => void;
+}
+
+// Pick step: the per-frequency seat cards with the monthly/yearly switch.
+function BulkChangeSeatModalPickSeatDialogContent({
   seatPlans,
-  onFetchPreview,
-  onValidate,
-}: BulkChangeSeatFormProps) {
+  selectedSeat,
+  onSelectSeat,
+}: BulkChangeSeatModalPickSeatDialogContentProps) {
   // "free" seats are one-shot starter seats and can never be assigned from
   // this modal; "none" (seat removal) has its own dedicated action.
   const seatTypes = sortSeatTypes(
@@ -305,9 +351,120 @@ function BulkChangeSeatForm({
   const seatTypesByFrequency = groupSeatTypesByFrequency(seatTypes, seatPlans);
   const availableFrequencies = getAvailableFrequencies(seatTypesByFrequency);
 
+  // Default the tab to the selected seat's frequency so coming Back from the
+  // preview step reopens on the tab holding the selection.
+  const initialFrequency = selectedSeat
+    ? (seatPlans[selectedSeat]?.billingFrequency ?? null)
+    : null;
   const [activeFrequency, setActiveFrequency] = useState<SeatBillingFrequency>(
-    availableFrequencies[0] ?? "monthly"
+    initialFrequency ?? availableFrequencies[0] ?? "monthly"
   );
+
+  return (
+    <div className="flex flex-col gap-3">
+      {availableFrequencies.length > 1 && (
+        <div className="mb-1 self-start">
+          <BillingPeriodSwitch
+            defaultValue={activeFrequency === "annual" ? "yearly" : "monthly"}
+            onValueChange={(period) =>
+              setActiveFrequency(period === "yearly" ? "annual" : "monthly")
+            }
+          />
+        </div>
+      )}
+
+      {seatTypesByFrequency[activeFrequency].map((seatType) => {
+        const info = seatPlans[seatType];
+        if (!info || !isPaidSeatType(seatType)) {
+          return null;
+        }
+        return (
+          <SeatCard
+            key={seatType}
+            seatType={seatType}
+            info={info}
+            isSelected={selectedSeat === seatType}
+            badge={getBadge(info)}
+            onClick={() => onSelectSeat(seatType)}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+interface BulkChangeSeatModalPreviewDialogContentProps {
+  preview: BulkSeatChangePreviewBody;
+  seatPlans: SeatPlanResponseBody;
+}
+
+// Confirm step: the immediate / next-billing-period move sections, the
+// unchanged-members note and the per-seat-type summary table.
+function BulkChangeSeatModalPreviewDialogContent({
+  preview,
+  seatPlans,
+}: BulkChangeSeatModalPreviewDialogContentProps) {
+  const immediateMoves = preview.moves.filter((m) => m.kind === "immediate");
+  const deferredMoves = preview.moves.filter((m) => m.kind === "deferred");
+  const unchangedCount = preview.moves
+    .filter((m) => m.kind === "unchanged")
+    .reduce((sum, m) => sum + m.count, 0);
+  const seatTotals = preview.seatTotals ?? [];
+  const hasAnyChange = immediateMoves.length > 0 || deferredMoves.length > 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {immediateMoves.length > 0 && (
+        <SeatMoveSection
+          title="Immediate changes"
+          moves={immediateMoves}
+          deltaMonthlyCents={preview.immediateDeltaMonthlyCents}
+          preview={preview}
+          seatPlans={seatPlans}
+        />
+      )}
+      {deferredMoves.length > 0 && (
+        <SeatMoveSection
+          title={
+            preview.nextBillingPeriodAt
+              ? `Changes on next billing period (${formatBillingPeriodDate(preview.nextBillingPeriodAt)})`
+              : "Changes on next billing period"
+          }
+          moves={deferredMoves}
+          deltaMonthlyCents={preview.deferredDeltaMonthlyCents}
+          preview={preview}
+          seatPlans={seatPlans}
+        />
+      )}
+      {unchangedCount > 0 && (
+        <p className="text-sm text-muted-foreground">
+          {unchangedCount.toLocaleString("en-US")}{" "}
+          {unchangedCount === 1 ? "member is" : "members are"} already on{" "}
+          {seatMoveLabel(
+            preview.targetSeatType,
+            preview.targetSeatName,
+            seatPlans
+          )}{" "}
+          and won&apos;t change.
+        </p>
+      )}
+      {seatTotals.length > 0 && hasAnyChange && (
+        <SeatSummarySection seatTotals={seatTotals} seatPlans={seatPlans} />
+      )}
+    </div>
+  );
+}
+
+type BulkChangeSeatStep = "pick" | "confirm";
+
+function BulkChangeSeatForm({
+  onClose,
+  memberCount,
+  selectedMembers,
+  seatPlans,
+  onFetchPreview,
+  onValidate,
+}: BulkChangeSeatFormProps) {
   const [selectedSeat, setSelectedSeat] = useState<PaidSeatType | null>(null);
   const [preview, setPreview] = useState<BulkSeatChangePreviewBody | null>(
     null
@@ -315,7 +472,7 @@ function BulkChangeSeatForm({
   const [isLoadingPreview, setIsLoadingPreview] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
-  const step: "pick" | "confirm" = preview === null ? "pick" : "confirm";
+  const step: BulkChangeSeatStep = preview === null ? "pick" : "confirm";
 
   async function handleNext() {
     if (!selectedSeat) {
@@ -351,132 +508,26 @@ function BulkChangeSeatForm({
     }
   }
 
-  const displayedMemberCount = preview?.memberCount ?? memberCount;
-  const immediateMoves =
-    preview?.moves.filter((m) => m.kind === "immediate") ?? [];
-  const deferredMoves =
-    preview?.moves.filter((m) => m.kind === "deferred") ?? [];
-  const unchangedCount = (preview?.moves ?? [])
-    .filter((m) => m.kind === "unchanged")
-    .reduce((sum, m) => sum + m.count, 0);
-  const seatTotals = preview?.seatTotals ?? [];
-  const hasAnyChange = immediateMoves.length > 0 || deferredMoves.length > 0;
-
   return (
     <>
-      <DialogHeader>
-        <div className="flex flex-col gap-2">
-          {selectedMembers.length > 0 && (
-            <div className="flex flex-row items-center gap-2">
-              <Avatar.Stack
-                avatars={selectedMembers
-                  .slice(0, MAX_HEADER_AVATARS)
-                  .map((member) => ({
-                    name: member.name,
-                    visual: member.image ?? undefined,
-                    isRounded: true,
-                  }))}
-                nbVisibleItems={MAX_HEADER_AVATARS}
-                size="md"
-              />
-              {displayedMemberCount > MAX_HEADER_AVATARS && (
-                <span className="flex h-8 min-w-8 items-center justify-center rounded-full bg-highlight-100 px-2 text-sm font-medium text-highlight-600">
-                  {displayedMemberCount}
-                </span>
-              )}
-            </div>
-          )}
-          <div className="flex flex-col gap-1">
-            <DialogTitle>
-              Change seat for {displayedMemberCount.toLocaleString("en-US")}{" "}
-              members
-            </DialogTitle>
-            <p className="text-sm text-muted-foreground">
-              {step === "pick"
-                ? "Choose a new seat to continue"
-                : "Review the changes before applying"}
-            </p>
-          </div>
-        </div>
-      </DialogHeader>
+      <BulkChangeSeatModalHeader
+        selectedMembers={selectedMembers}
+        memberCount={preview?.memberCount ?? memberCount}
+        step={step}
+      />
       <DialogContainer>
         {step === "pick" ? (
-          <div className="flex flex-col gap-3">
-            {availableFrequencies.length > 1 && (
-              <div className="mb-1 self-start">
-                <BillingPeriodSwitch
-                  defaultValue="monthly"
-                  onValueChange={(period) =>
-                    setActiveFrequency(
-                      period === "yearly" ? "annual" : "monthly"
-                    )
-                  }
-                />
-              </div>
-            )}
-
-            {seatTypesByFrequency[activeFrequency].map((seatType) => {
-              const info = seatPlans[seatType];
-              if (!info || !isPaidSeatType(seatType)) {
-                return null;
-              }
-              return (
-                <SeatCard
-                  key={seatType}
-                  seatType={seatType}
-                  info={info}
-                  isSelected={selectedSeat === seatType}
-                  badge={getBadge(info)}
-                  onClick={() => setSelectedSeat(seatType)}
-                />
-              );
-            })}
-          </div>
+          <BulkChangeSeatModalPickSeatDialogContent
+            seatPlans={seatPlans}
+            selectedSeat={selectedSeat}
+            onSelectSeat={setSelectedSeat}
+          />
         ) : (
           preview && (
-            <div className="flex flex-col gap-4">
-              {immediateMoves.length > 0 && (
-                <SeatMoveSection
-                  title="Immediate changes"
-                  moves={immediateMoves}
-                  deltaMonthlyCents={preview.immediateDeltaMonthlyCents}
-                  preview={preview}
-                  seatPlans={seatPlans}
-                />
-              )}
-              {deferredMoves.length > 0 && (
-                <SeatMoveSection
-                  title={
-                    preview.nextBillingPeriodAt
-                      ? `Changes on next billing period (${formatBillingPeriodDate(preview.nextBillingPeriodAt)})`
-                      : "Changes on next billing period"
-                  }
-                  moves={deferredMoves}
-                  deltaMonthlyCents={preview.deferredDeltaMonthlyCents}
-                  preview={preview}
-                  seatPlans={seatPlans}
-                />
-              )}
-              {unchangedCount > 0 && (
-                <p className="text-sm text-muted-foreground">
-                  {unchangedCount.toLocaleString("en-US")}{" "}
-                  {unchangedCount === 1 ? "member is" : "members are"} already
-                  on{" "}
-                  {seatMoveLabel(
-                    preview.targetSeatType,
-                    preview.targetSeatName,
-                    seatPlans
-                  )}{" "}
-                  and won&apos;t change.
-                </p>
-              )}
-              {seatTotals.length > 0 && hasAnyChange && (
-                <SeatSummarySection
-                  seatTotals={seatTotals}
-                  seatPlans={seatPlans}
-                />
-              )}
-            </div>
+            <BulkChangeSeatModalPreviewDialogContent
+              preview={preview}
+              seatPlans={seatPlans}
+            />
           )
         )}
       </DialogContainer>

--- a/front/components/workspace/BulkChangeSeatModal.tsx
+++ b/front/components/workspace/BulkChangeSeatModal.tsx
@@ -1,0 +1,513 @@
+import { BillingPeriodSwitch } from "@app/components/pages/onboarding/SubscriptionPlans";
+import {
+  formatPriceCents,
+  getAvailableFrequencies,
+  groupSeatTypesByFrequency,
+  SEAT_TYPE_ICONS,
+  SeatCard,
+  sortSeatTypes,
+  stripYearlySuffix,
+} from "@app/components/workspace/SeatCard";
+import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
+import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import type {
+  SeatBillingFrequency,
+  SeatPlanResponseBody,
+  SeatTypeInfo,
+} from "@app/lib/api/credits/seat_plan";
+import type { BulkSeatChangePreviewBody } from "@app/lib/swr/memberships";
+import { CURRENCY_SYMBOLS } from "@app/types/currency";
+import type { MembershipSeatType, PaidSeatType } from "@app/types/memberships";
+import { isMembershipSeatType, isPaidSeatType } from "@app/types/memberships";
+import {
+  ArrowRight,
+  Avatar,
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Icon,
+} from "@dust-tt/sparkle";
+import { Fragment, useState } from "react";
+
+const MAX_HEADER_AVATARS = 3;
+
+interface BulkChangeSeatModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  memberCount: number;
+  // Selected members visible on the current page, for the header avatar row.
+  // With an "all across pages" selection this is only the visible subset.
+  selectedMembers: MemberUsageType[];
+  seatPlans: SeatPlanResponseBody;
+  onFetchPreview: (
+    seatType: PaidSeatType
+  ) => Promise<BulkSeatChangePreviewBody | null>;
+  onValidate: (args: {
+    seatType: PaidSeatType;
+    seatName: string;
+    hasDeferredChanges: boolean;
+  }) => Promise<boolean>;
+}
+
+export function BulkChangeSeatModal({
+  isOpen,
+  onClose,
+  memberCount,
+  selectedMembers,
+  seatPlans,
+  onFetchPreview,
+  onValidate,
+}: BulkChangeSeatModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      {/* Without this, the dialog auto-focuses its first focusable element —
+          the Avatar.Stack tooltip trigger — which opens the members tooltip
+          as soon as the dialog appears. */}
+      <DialogContent size="md" onOpenAutoFocus={(e) => e.preventDefault()}>
+        {isOpen && (
+          <BulkChangeSeatForm
+            onClose={onClose}
+            memberCount={memberCount}
+            selectedMembers={selectedMembers}
+            seatPlans={seatPlans}
+            onFetchPreview={onFetchPreview}
+            onValidate={onValidate}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface BulkChangeSeatFormProps {
+  onClose: () => void;
+  memberCount: number;
+  selectedMembers: MemberUsageType[];
+  seatPlans: SeatPlanResponseBody;
+  onFetchPreview: (
+    seatType: PaidSeatType
+  ) => Promise<BulkSeatChangePreviewBody | null>;
+  onValidate: (args: {
+    seatType: PaidSeatType;
+    seatName: string;
+    hasDeferredChanges: boolean;
+  }) => Promise<boolean>;
+}
+
+const FREQUENCY_LABELS: Record<SeatBillingFrequency, string> = {
+  weekly: "weekly",
+  monthly: "monthly",
+  quarterly: "quarterly",
+  annual: "yearly",
+};
+
+// Compact seat label for the move rows: base tier name without the "Seat" /
+// yearly suffixes, plus the billing cadence for paid seats — e.g.
+// "Pro (monthly)", "Max (yearly)", "Free", "No seat".
+function seatMoveLabel(
+  seatType: MembershipSeatType,
+  name: string | null,
+  seatPlans: SeatPlanResponseBody
+): string {
+  if (seatType === "none") {
+    return "No seat";
+  }
+  const baseName = stripYearlySuffix(name ?? seatType).replace(/\s+Seat$/, "");
+  if (!isPaidSeatType(seatType)) {
+    return baseName;
+  }
+  const frequency = seatPlans[seatType]?.billingFrequency;
+  return frequency ? `${baseName} (${FREQUENCY_LABELS[frequency]})` : baseName;
+}
+
+interface SeatMoveSectionProps {
+  title: string;
+  moves: BulkSeatChangePreviewBody["moves"];
+  deltaMonthlyCents: number;
+  preview: BulkSeatChangePreviewBody;
+  seatPlans: SeatPlanResponseBody;
+}
+
+// One section of the confirmation step (immediate changes vs next billing
+// period): the move rows share a single grid so the arrows line up across
+// rows, followed by the section's invoice impact.
+function SeatMoveSection({
+  title,
+  moves,
+  deltaMonthlyCents,
+  preview,
+  seatPlans,
+}: SeatMoveSectionProps) {
+  const { targetSeatType, targetSeatName } = preview;
+  const targetLabel = seatMoveLabel(targetSeatType, targetSeatName, seatPlans);
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm font-semibold text-foreground">{title}</p>
+      <div className="grid grid-cols-[max-content_max-content_max-content_1fr] items-center gap-x-2 gap-y-1.5 text-sm text-foreground">
+        {moves.map((move) => (
+          <Fragment key={move.fromSeatType}>
+            <div className="flex items-center gap-1.5">
+              <Icon
+                visual={SEAT_TYPE_ICONS[move.fromSeatType]}
+                size="sm"
+                className={getSeatIconColorClass(move.fromSeatType)}
+              />
+              <span>
+                {seatMoveLabel(move.fromSeatType, move.fromSeatName, seatPlans)}
+              </span>
+            </div>
+            <Icon
+              visual={ArrowRight}
+              size="xs"
+              className="text-muted-foreground"
+            />
+            <div className="flex items-center gap-1.5">
+              <Icon
+                visual={SEAT_TYPE_ICONS[targetSeatType]}
+                size="sm"
+                className={getSeatIconColorClass(targetSeatType)}
+              />
+              <span>{targetLabel}</span>
+            </div>
+            <span className="justify-self-end font-medium text-muted-foreground">
+              ×{move.count.toLocaleString("en-US")}
+            </span>
+          </Fragment>
+        ))}
+      </div>
+      {deltaMonthlyCents !== 0 ? (
+        <p className="text-sm text-muted-foreground">
+          This will {deltaMonthlyCents > 0 ? "add" : "remove"} an estimated{" "}
+          <span className="font-semibold text-foreground">
+            {formatAmountCents(Math.abs(deltaMonthlyCents), preview.currency)}
+          </span>{" "}
+          {deltaMonthlyCents > 0 ? "to" : "from"} your monthly invoice.
+        </p>
+      ) : (
+        // Every move in the section is absorbed by committed (already paid)
+        // seats.
+        <p className="text-sm text-muted-foreground">
+          This will not change your invoice.
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface SeatSummarySectionProps {
+  seatTotals: NonNullable<BulkSeatChangePreviewBody["seatTotals"]>;
+  seatPlans: SeatPlanResponseBody;
+}
+
+// Per-seat-type recap table: committed pool size, assigned count today, and
+// assigned count once every move has landed.
+function SeatSummarySection({
+  seatTotals,
+  seatPlans,
+}: SeatSummarySectionProps) {
+  const headerClasses =
+    "justify-self-end text-xs font-medium text-muted-foreground";
+  const valueClasses = "justify-self-end font-medium text-muted-foreground";
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm font-semibold text-foreground">Summary</p>
+      <div className="grid grid-cols-[1fr_max-content_max-content_max-content] items-center gap-x-4 gap-y-1.5 text-sm text-foreground">
+        <span className="text-xs font-medium text-muted-foreground">
+          Seat type
+        </span>
+        <span className={headerClasses}>Committed</span>
+        <span className={headerClasses}>Before</span>
+        <span className={headerClasses}>After</span>
+        {seatTotals.map((total) => (
+          <Fragment key={total.seatType}>
+            <div className="flex items-center gap-1.5">
+              <Icon
+                visual={SEAT_TYPE_ICONS[total.seatType]}
+                size="sm"
+                className={getSeatIconColorClass(total.seatType)}
+              />
+              <span>
+                {seatMoveLabel(total.seatType, total.seatName, seatPlans)}
+              </span>
+            </div>
+            <span className={valueClasses}>
+              {total.committedSeats > 0
+                ? total.committedSeats.toLocaleString("en-US")
+                : "—"}
+            </span>
+            <span className={valueClasses}>
+              {total.assignedBefore.toLocaleString("en-US")}
+            </span>
+            <span className="justify-self-end font-medium text-foreground">
+              {total.assignedAfter.toLocaleString("en-US")}
+            </span>
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function formatBillingPeriodDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+// Amount without the "/mo" suffix (the sentence already says "monthly
+// invoice"), e.g. "$80" or "80€".
+// Price badge of a seat card in the pick step; annual seats show the
+// monthly-equivalent price.
+function getBadge(info: SeatTypeInfo): React.ReactNode {
+  return (
+    <span className="text-xs text-foreground">
+      {info.billingFrequency === "annual" ? (
+        <>
+          {formatPriceCents(info.priceCents / 12, info.currency, "monthly")} ·
+          billed annually
+        </>
+      ) : (
+        formatPriceCents(info.priceCents, info.currency, info.billingFrequency)
+      )}
+    </span>
+  );
+}
+
+function formatAmountCents(
+  cents: number,
+  currency: BulkSeatChangePreviewBody["currency"]
+): string {
+  const symbol = CURRENCY_SYMBOLS[currency];
+  const amount = (cents / 100).toFixed(2).replace(/\.00$/, "");
+  return currency === "eur" ? `${amount}${symbol}` : `${symbol}${amount}`;
+}
+
+function BulkChangeSeatForm({
+  onClose,
+  memberCount,
+  selectedMembers,
+  seatPlans,
+  onFetchPreview,
+  onValidate,
+}: BulkChangeSeatFormProps) {
+  // "free" seats are one-shot starter seats and can never be assigned from
+  // this modal; "none" (seat removal) has its own dedicated action.
+  const seatTypes = sortSeatTypes(
+    Object.keys(seatPlans).filter(isMembershipSeatType)
+  ).filter(isPaidSeatType);
+
+  const seatTypesByFrequency = groupSeatTypesByFrequency(seatTypes, seatPlans);
+  const availableFrequencies = getAvailableFrequencies(seatTypesByFrequency);
+
+  const [activeFrequency, setActiveFrequency] = useState<SeatBillingFrequency>(
+    availableFrequencies[0] ?? "monthly"
+  );
+  const [selectedSeat, setSelectedSeat] = useState<PaidSeatType | null>(null);
+  const [preview, setPreview] = useState<BulkSeatChangePreviewBody | null>(
+    null
+  );
+  const [isLoadingPreview, setIsLoadingPreview] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const step: "pick" | "confirm" = preview === null ? "pick" : "confirm";
+
+  async function handleNext() {
+    if (!selectedSeat) {
+      return;
+    }
+    setIsLoadingPreview(true);
+    try {
+      const fetched = await onFetchPreview(selectedSeat);
+      if (fetched) {
+        setPreview(fetched);
+      }
+    } finally {
+      setIsLoadingPreview(false);
+    }
+  }
+
+  async function handleValidate() {
+    if (!selectedSeat || !preview) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const ok = await onValidate({
+        seatType: selectedSeat,
+        seatName: stripYearlySuffix(preview.targetSeatName),
+        hasDeferredChanges: preview.moves.some((m) => m.kind === "deferred"),
+      });
+      if (ok) {
+        onClose();
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const displayedMemberCount = preview?.memberCount ?? memberCount;
+  const immediateMoves =
+    preview?.moves.filter((m) => m.kind === "immediate") ?? [];
+  const deferredMoves =
+    preview?.moves.filter((m) => m.kind === "deferred") ?? [];
+  const unchangedCount = (preview?.moves ?? [])
+    .filter((m) => m.kind === "unchanged")
+    .reduce((sum, m) => sum + m.count, 0);
+  const seatTotals = preview?.seatTotals ?? [];
+  const hasAnyChange = immediateMoves.length > 0 || deferredMoves.length > 0;
+
+  return (
+    <>
+      <DialogHeader>
+        <div className="flex flex-col gap-2">
+          {selectedMembers.length > 0 && (
+            <div className="flex flex-row items-center gap-2">
+              <Avatar.Stack
+                avatars={selectedMembers
+                  .slice(0, MAX_HEADER_AVATARS)
+                  .map((member) => ({
+                    name: member.name,
+                    visual: member.image ?? undefined,
+                    isRounded: true,
+                  }))}
+                nbVisibleItems={MAX_HEADER_AVATARS}
+                size="md"
+              />
+              {displayedMemberCount > MAX_HEADER_AVATARS && (
+                <span className="flex h-8 min-w-8 items-center justify-center rounded-full bg-highlight-100 px-2 text-sm font-medium text-highlight-600">
+                  {displayedMemberCount}
+                </span>
+              )}
+            </div>
+          )}
+          <div className="flex flex-col gap-1">
+            <DialogTitle>
+              Change seat for {displayedMemberCount.toLocaleString("en-US")}{" "}
+              members
+            </DialogTitle>
+            <p className="text-sm text-muted-foreground">
+              {step === "pick"
+                ? "Choose a new seat to continue"
+                : "Review the changes before applying"}
+            </p>
+          </div>
+        </div>
+      </DialogHeader>
+      <DialogContainer>
+        {step === "pick" ? (
+          <div className="flex flex-col gap-3">
+            {availableFrequencies.length > 1 && (
+              <div className="mb-1 self-start">
+                <BillingPeriodSwitch
+                  defaultValue="monthly"
+                  onValueChange={(period) =>
+                    setActiveFrequency(
+                      period === "yearly" ? "annual" : "monthly"
+                    )
+                  }
+                />
+              </div>
+            )}
+
+            {seatTypesByFrequency[activeFrequency].map((seatType) => {
+              const info = seatPlans[seatType];
+              if (!info || !isPaidSeatType(seatType)) {
+                return null;
+              }
+              return (
+                <SeatCard
+                  key={seatType}
+                  seatType={seatType}
+                  info={info}
+                  isSelected={selectedSeat === seatType}
+                  badge={getBadge(info)}
+                  onClick={() => setSelectedSeat(seatType)}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          preview && (
+            <div className="flex flex-col gap-4">
+              {immediateMoves.length > 0 && (
+                <SeatMoveSection
+                  title="Immediate changes"
+                  moves={immediateMoves}
+                  deltaMonthlyCents={preview.immediateDeltaMonthlyCents}
+                  preview={preview}
+                  seatPlans={seatPlans}
+                />
+              )}
+              {deferredMoves.length > 0 && (
+                <SeatMoveSection
+                  title={
+                    preview.nextBillingPeriodAt
+                      ? `Changes on next billing period (${formatBillingPeriodDate(preview.nextBillingPeriodAt)})`
+                      : "Changes on next billing period"
+                  }
+                  moves={deferredMoves}
+                  deltaMonthlyCents={preview.deferredDeltaMonthlyCents}
+                  preview={preview}
+                  seatPlans={seatPlans}
+                />
+              )}
+              {unchangedCount > 0 && (
+                <p className="text-sm text-muted-foreground">
+                  {unchangedCount.toLocaleString("en-US")}{" "}
+                  {unchangedCount === 1 ? "member is" : "members are"} already
+                  on{" "}
+                  {seatMoveLabel(
+                    preview.targetSeatType,
+                    preview.targetSeatName,
+                    seatPlans
+                  )}{" "}
+                  and won&apos;t change.
+                </p>
+              )}
+              {seatTotals.length > 0 && hasAnyChange && (
+                <SeatSummarySection
+                  seatTotals={seatTotals}
+                  seatPlans={seatPlans}
+                />
+              )}
+            </div>
+          )
+        )}
+      </DialogContainer>
+      {/* Plain buttons instead of DialogFooter's button props: those are
+          wrapped in a DialogClose, which would close the dialog on "Next" /
+          "Back" instead of switching steps. */}
+      <DialogFooter>
+        <Button
+          label={step === "pick" ? "Cancel" : "Back"}
+          variant="outline"
+          onClick={step === "pick" ? onClose : () => setPreview(null)}
+          disabled={isSaving}
+        />
+        {step === "pick" ? (
+          <Button
+            label="Review"
+            variant="primary"
+            disabled={!selectedSeat || isLoadingPreview}
+            isLoading={isLoadingPreview}
+            onClick={handleNext}
+          />
+        ) : (
+          <Button
+            label="Validate"
+            variant="primary"
+            disabled={isSaving}
+            isLoading={isSaving}
+            onClick={handleValidate}
+          />
+        )}
+      </DialogFooter>
+    </>
+  );
+}

--- a/front/components/workspace/BulkChangeSeatModal.tsx
+++ b/front/components/workspace/BulkChangeSeatModal.tsx
@@ -147,7 +147,9 @@ function SeatMoveSection({
   return (
     <div className="flex flex-col gap-2">
       <p className="text-sm font-semibold text-foreground">{title}</p>
-      <div className="grid grid-cols-[max-content_max-content_max-content_1fr] items-center gap-x-2 gap-y-1.5 text-sm text-foreground">
+      {/* The count column is max-content (shared across rows) with its
+          content left-aligned, so the × of ×1 / ×12 line up. */}
+      <div className="grid grid-cols-[max-content_max-content_1fr_max-content] items-center gap-x-2 gap-y-1.5 text-sm text-foreground">
         {moves.map((move) => (
           <Fragment key={move.fromSeatType}>
             <div className="flex items-center gap-1.5">
@@ -173,7 +175,7 @@ function SeatMoveSection({
               />
               <span>{targetLabel}</span>
             </div>
-            <span className="justify-self-end font-medium text-muted-foreground">
+            <span className="font-medium text-muted-foreground">
               ×{move.count.toLocaleString("en-US")}
             </span>
           </Fragment>

--- a/front/components/workspace/MembersSelectionBanner.tsx
+++ b/front/components/workspace/MembersSelectionBanner.tsx
@@ -13,6 +13,8 @@ interface MembersSelectionBannerProps {
   onSelectAllAcrossPages: () => void;
   onClear: () => void;
   onBatchEditSpendLimit: () => void;
+  // Absent when the workspace has no assignable seat tiers (non seat-based).
+  onBatchChangeSeat?: () => void;
   disabled?: boolean;
 }
 
@@ -29,6 +31,7 @@ export function MembersSelectionBanner({
   onSelectAllAcrossPages,
   onClear,
   onBatchEditSpendLimit,
+  onBatchChangeSeat,
   disabled = false,
 }: MembersSelectionBannerProps) {
   if (selectedCount === 0) {
@@ -64,6 +67,14 @@ export function MembersSelectionBanner({
         onClick={onClear}
         disabled={disabled}
       />
+      {onBatchChangeSeat && (
+        <ContentMessageAction
+          variant="primary"
+          label="Batch change seat"
+          onClick={onBatchChangeSeat}
+          disabled={disabled}
+        />
+      )}
       <ContentMessageAction
         variant="primary"
         label="Batch edit spend limit"

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -13,9 +13,11 @@ import type {
   GetUserSpendLimitResponseBody,
   PutUserSpendLimitResponseBody,
 } from "@app/types/api/users/spend_limit";
+import { SUPPORTED_CURRENCIES } from "@app/types/currency";
 import type { GroupKind } from "@app/types/groups";
 import { isGroupKind } from "@app/types/groups";
-import type { MembershipSeatType } from "@app/types/memberships";
+import type { MembershipSeatType, PaidSeatType } from "@app/types/memberships";
+import { MEMBERSHIP_SEAT_TYPES, PAID_SEAT_TYPES } from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type {
   LightUserTypeWithWorkspace,
@@ -227,7 +229,12 @@ function bulkSpendLimitUrl(workspaceId: string): string {
   return `/api/w/${workspaceId}/members/bulk-spend-limit`;
 }
 
-// Cross-page member selection descriptor shared by the bulk member endpoints.
+function bulkSeatTypeUrl(workspaceId: string): string {
+  return `/api/w/${workspaceId}/members/bulk-seat-type`;
+}
+
+// Cross-page member selection descriptor shared by the bulk member endpoints
+// (spend limit and seat type).
 export type BulkMemberSelectionBody =
   | { mode: "ids"; userIds: string[] }
   | {
@@ -289,6 +296,140 @@ export function useBulkSetUserSpendLimit({
   );
 
   return { doBulkSetSpendLimit };
+}
+
+const BulkSeatChangeMoveSchema = z.object({
+  fromSeatType: z.enum(MEMBERSHIP_SEAT_TYPES),
+  fromSeatName: z.string().nullable(),
+  kind: z.enum(["unchanged", "immediate", "deferred"]),
+  count: z.number().int(),
+});
+
+const BulkSeatChangeSeatTotalSchema = z.object({
+  seatType: z.enum(MEMBERSHIP_SEAT_TYPES),
+  seatName: z.string(),
+  committedSeats: z.number().int(),
+  assignedBefore: z.number().int(),
+  assignedAfter: z.number().int(),
+});
+
+const BulkSeatChangePreviewResponseSchema = z.object({
+  preview: z.object({
+    memberCount: z.number().int(),
+    targetSeatType: z.enum(PAID_SEAT_TYPES),
+    targetSeatName: z.string(),
+    currency: z.enum(SUPPORTED_CURRENCIES),
+    moves: z.array(BulkSeatChangeMoveSchema),
+    immediateDeltaMonthlyCents: z.number(),
+    deferredDeltaMonthlyCents: z.number(),
+    // Optional: tolerate an older server that doesn't send the fields yet.
+    nextBillingPeriodAt: z.string().nullable().optional(),
+    seatTotals: z.array(BulkSeatChangeSeatTotalSchema).optional(),
+  }),
+});
+
+export type BulkSeatChangePreviewBody = z.infer<
+  typeof BulkSeatChangePreviewResponseSchema
+>["preview"];
+
+export function useBulkSeatChangePreview({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const doFetchSeatChangePreview = useCallback(
+    async ({
+      selection,
+      seatType,
+    }: {
+      selection: BulkMemberSelectionBody;
+      seatType: PaidSeatType;
+    }): Promise<BulkSeatChangePreviewBody | null> => {
+      const res = await clientFetch(`${bulkSeatTypeUrl(workspaceId)}/preview`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selection, seatType }),
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        sendNotification({
+          type: "error",
+          title: "Failed to prepare seat change",
+          description: error?.error?.message ?? "An unexpected error occurred.",
+        });
+        return null;
+      }
+
+      return BulkSeatChangePreviewResponseSchema.parse(await res.json())
+        .preview;
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return { doFetchSeatChangePreview };
+}
+
+const BulkChangeSeatTypeResponseSchema = z.object({
+  workflowId: z.string(),
+  memberCount: z.number().int(),
+});
+
+export function useBulkChangeSeatType({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const doBulkChangeSeatType = useCallback(
+    async ({
+      selection,
+      seatType,
+      seatName,
+      hasDeferredChanges,
+    }: {
+      selection: BulkMemberSelectionBody;
+      seatType: PaidSeatType;
+      seatName: string;
+      // Whether some selected members are being downgraded — their change
+      // applies at the next credit refresh, so the notification says so.
+      hasDeferredChanges: boolean;
+    }): Promise<{ workflowId: string; memberCount: number } | null> => {
+      const res = await clientFetch(bulkSeatTypeUrl(workspaceId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selection, seatType }),
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        sendNotification({
+          type: "error",
+          title: "Failed to update seats",
+          description: error?.error?.message ?? "An unexpected error occurred.",
+        });
+        return null;
+      }
+
+      const body = BulkChangeSeatTypeResponseSchema.parse(await res.json());
+      sendNotification({
+        type: "success",
+        title: "Seats updated",
+        description: hasDeferredChanges
+          ? `Changed ${body.memberCount.toLocaleString("en-US")} members to ${seatName}. Downgrades take effect at the next credit refresh.`
+          : `Changed ${body.memberCount.toLocaleString("en-US")} members to ${seatName}.`,
+      });
+
+      await invalidateMembersUsage(workspaceId);
+      return body;
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return { doBulkChangeSeatType };
 }
 
 export async function invalidateMembersUsage(


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9315

UI for bulk seat-type change (PR 3/3, stacked on #28643).

When members are selected in the usage members table, the selection banner shows a **Batch change seat** action (seat-based, non-free-plan workspaces only). It opens `BulkChangeSeatModal`, a two-step dialog:

1. **Pick step** — same `SeatCard` picker as the single-user `ChangeSeatModal` (monthly/yearly switch, price per seat per month, `free` excluded), with a **Next** button that fetches the server-side preview.
2. **Confirm step** — avatar stack + member count, a full breakdown of the changes.

Implementation notes:
- New SWR hooks `useBulkSeatChangePreview` / `useBulkChangeSeatType` with success/error notifications and members-usage invalidation; affected rows spin while the bulk workflow runs.
- The footer uses plain `Button`s inside `DialogFooter` (the `leftButtonProps`/`rightButtonProps` variants are wrapped in `DialogClose` and would close the dialog on Next/Back) — same pattern as `BuyAwuCreditsDialog`.
- Selection is cleared after a successful change since seat mutations can move members in/out of the filtered set.

## Preview

<img width="1135" height="512" alt="Screenshot 2026-07-08 at 12 02 54" src="https://github.com/user-attachments/assets/960146e0-d9da-422f-8f80-81c4b5e63e33" />
<img width="1153" height="652" alt="Screenshot 2026-07-08 at 12 03 02" src="https://github.com/user-attachments/assets/c65adb22-5801-4f63-bbec-5c54b5053cd3" />
<img width="1236" height="675" alt="Screenshot 2026-07-08 at 12 03 14" src="https://github.com/user-attachments/assets/0189e598-6403-4280-8667-4188da59e4ab" />


## Tests

Manually tested on a dev workspace (ids selection and select-all-across-pages, upgrade and downgrade paths). tsgo clean.

## Risk

Low: new UI behind the `pricing_groups` flag; no existing flow modified.


## Stack

 1. Refactoring: https://github.com/dust-tt/dust/pull/28642
 2. Backend: https://github.com/dust-tt/dust/pull/28643
 3. UI: https://github.com/dust-tt/dust/pull/28644

## Deploy Plan

Deploy front