### PR TITLE
Tool events: make MCPSuccessEvent generic, rename MCPParamsEvent to AgentLoopToolParamsEvent

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -18,6 +18,7 @@ import { hideInternalConfiguration } from "@app/lib/actions/mcp_internal_actions
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import type {
+  ActionGeneratedFileType,
   FileAuthorizationInfo,
   UserQuestion,
 } from "@app/lib/actions/types";
@@ -30,6 +31,7 @@ import type {
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type { SandboxFunctionMCPActionType } from "@app/types/api/sandbox_functions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 export type ActionApprovalStateType =
@@ -211,7 +213,9 @@ export function getMCPApprovalStateFromUserApprovalState(
   }
 }
 
-export type MCPParamsEvent = {
+// Emitted by the agent loop once tool arguments have been generated and the action created.
+// Published on the conversation message channel, hence the conversation-scoped identifiers.
+export type AgentLoopToolParamsEvent = {
   type: "tool_params";
   created: number;
   configurationId: string;
@@ -220,12 +224,13 @@ export type MCPParamsEvent = {
   runIds?: string[];
 };
 
+// Emitted by the tool runner when the tool execution completed. Generic across run contexts: it
+// carries the processed output only, consumers scope it to their own run context.
 export type MCPSuccessEvent = {
   type: "tool_success";
   created: number;
-  configurationId: string;
-  messageId: string;
-  action: AgentMCPActionWithOutputType;
+  output: CallToolResult["content"];
+  generatedFiles: ActionGeneratedFileType[];
 };
 
 export type MCPErrorEvent = {
@@ -274,7 +279,7 @@ export function isAgentLoopToolNotificationEvent(
 
 // AgentActionRunningEvents are events related action execution within an agent loop.
 export type AgentActionRunningEvents =
-  | MCPParamsEvent
+  | AgentLoopToolParamsEvent
   | MCPApproveExecutionEvent
   | AgentLoopToolNotificationEvent;
 

--- a/front/lib/api/mcp/error.ts
+++ b/front/lib/api/mcp/error.ts
@@ -3,13 +3,10 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 type HandleErrorParams = {
   action: AgentMCPActionResource;
-  agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
-  agentMessage: AgentLoopExecutionData["agentMessage"];
   errorContent: CallToolResult["content"];
   status: ToolExecutionStatus;
   executionDurationMs: number;
@@ -20,14 +17,7 @@ type HandleErrorParams = {
  */
 export async function handleMCPActionError(
   auth: Authenticator,
-  {
-    action,
-    agentConfiguration,
-    agentMessage,
-    errorContent,
-    status,
-    executionDurationMs,
-  }: HandleErrorParams
+  { action, errorContent, status, executionDurationMs }: HandleErrorParams
 ): Promise<MCPErrorEvent | MCPSuccessEvent> {
   await action.createOutputItems(
     auth,
@@ -43,12 +33,7 @@ export async function handleMCPActionError(
   return {
     type: "tool_success",
     created: Date.now(),
-    configurationId: agentConfiguration.sId,
-    messageId: agentMessage.sId,
-    action: {
-      ...action.toJSON(),
-      output: errorContent,
-      generatedFiles: [],
-    },
+    output: errorContent,
+    generatedFiles: [],
   };
 }

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -1,6 +1,5 @@
 import type {
   MCPErrorEvent,
-  MCPParamsEvent,
   MCPSuccessEvent,
   ToolNotificationEvent,
 } from "@app/lib/actions/mcp";
@@ -64,7 +63,6 @@ export async function* runToolWithStreaming(
 ): AsyncGenerator<
   | MCPApproveExecutionEvent
   | MCPErrorEvent
-  | MCPParamsEvent
   | MCPSuccessEvent
   | ToolNotificationEvent
   | ToolFileAuthRequiredEvent
@@ -128,8 +126,6 @@ export async function* runToolWithStreaming(
     const endDate = performance.now();
     yield await handleMCPActionError(auth, {
       action,
-      agentConfiguration,
-      agentMessage,
       status,
       errorContent: toolCallResult.content,
       executionDurationMs: endDate - startDate,
@@ -178,16 +174,9 @@ export async function* runToolWithStreaming(
   yield {
     type: "tool_success",
     created: Date.now(),
-    configurationId: agentConfiguration.sId,
-    messageId: agentMessage.sId,
-    action: {
-      ...action.toJSON(),
-      output: removeNulls(
-        [...intermediateOutputItems, ...outputItems].map(
-          hideFileFromActionOutput
-        )
-      ),
-      generatedFiles,
-    },
+    output: removeNulls(
+      [...intermediateOutputItems, ...outputItems].map(hideFileFromActionOutput)
+    ),
+    generatedFiles,
   };
 }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -462,16 +462,15 @@ async function executeToolStreaming(
             created: event.created,
             configurationId: agentConfiguration.sId,
             messageId: agentMessage.sId,
-            action: event.action,
+            // The generic tool runner event only carries the processed output; the agent loop
+            // action payload is rebuilt from the action resource, which reflects the final status
+            // (updated in place during execution).
+            action: {
+              ...action.toJSON(),
+              output: event.output,
+              generatedFiles: event.generatedFiles,
+            },
           },
-          agentMessage,
-          conversation,
-          step,
-        });
-        break;
-      case "tool_params":
-        await handleNonDeferredEvents(auth, {
-          event,
           agentMessage,
           conversation,
           step,


### PR DESCRIPTION
## Description

Step towards conversation-free tool execution (sandbox function invocations): the generic tool runner events no longer reference `AgentMCPActionWithOutputType`.

- `MCPSuccessEvent` (`tool_success`) is process-internal (yielded by `runToolWithStreaming`, consumed only by `executeToolStreaming`). It now carries `{ created, output, generatedFiles }` only (generic); the agent loop activity rebuilds the `agent_action_success` payload from the action resource, which reflects the final status (updated in place during execution). `handleMCPActionError` drops its now-unneeded `agentConfiguration` / `agentMessage` parameters.
- `MCPParamsEvent` (`tool_params`) is not a runner event: it is produced only by the agent loop (`create_tool_actions.ts`) and published on the conversation channel where its `action` payload is consumed (web client, Slack connector, public v1). Renamed to `AgentLoopToolParamsEvent` (matching `AgentLoopToolNotificationEvent`) and removed from `runToolWithStreaming`'s yield union, where it was never yielded.

No wire shape changes: `tool_params` and `agent_action_success` payloads are byte-identical; `tool_success` never leaves the process.

## Tests

- `lib/actions/mcp_execution.test.ts`, `lib/actions/mcp_actions.test.ts`, `temporal/agent_loop/activities/common.test.ts` pass.
- tested locally

## Risk

Low. Internal event plumbing only, published event payloads unchanged.

## Deploy Plan

- deploy `front`
