### PR TITLE
Add columns for resolved models

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -598,9 +598,9 @@ export async function postUserMessage(
   const featureFlags = await getFeatureFlags(auth);
 
   // Resolve the picker selection to a concrete model for this workspace. If it
-  // cannot be honored (unknown/disabled model), we leave `requestedModel` null
+  // cannot be honored (unknown/disabled model), we leave `resolvedModel` null
   // and the agent's configured model is used.
-  const requestedModel: ResolvedRequestedModel | null = modelSelection
+  const resolvedModel: ResolvedRequestedModel | null = modelSelection
     ? resolveModelSelection(auth, modelSelection, { featureFlags })
     : null;
 
@@ -1045,7 +1045,7 @@ export async function postUserMessage(
             skipToolsValidation,
             nextMessageRank,
             userMessage: userMessageWithoutMentions,
-            requestedModel,
+            resolvedModel,
           },
           transaction: t,
         });

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -5,7 +5,7 @@ import {
 } from "@app/lib/api/assistant/conversation/permissions";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import {
-  requestedAgentModelFromColumns,
+  resolvedModelFromAgentMessageRow,
   resolveModelSelection,
 } from "@app/lib/api/assistant/models";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
@@ -268,7 +268,7 @@ export const createAgentMessages = async (
           skipToolsValidation: boolean;
           nextMessageRank: number;
           userMessage: UserMessageTypeWithoutMentions;
-          requestedModel?: ResolvedRequestedModel | null;
+          resolvedModel?: ResolvedRequestedModel | null;
         };
     transaction?: Transaction;
   }
@@ -308,9 +308,10 @@ export const createAgentMessages = async (
             agentConfigurationVersion: agentConfiguration.version,
             workspaceId: owner.id,
             skipToolsValidation: metadata.agentMessage.skipToolsValidation,
-            requestedProviderId: revalidatedModel?.providerId ?? null,
-            requestedModelId: revalidatedModel?.modelId ?? null,
-            requestedReasoningEffort: revalidatedModel?.reasoningEffort ?? null,
+            resolvedProviderId: revalidatedModel?.providerId ?? null,
+            resolvedModelId: revalidatedModel?.modelId ?? null,
+            resolvedReasoningEffort: revalidatedModel?.reasoningEffort ?? null,
+            modelResolutionMethod: "auto", // TODO(models_picker): carry over the method from the original message
           },
           { transaction }
         );
@@ -471,11 +472,11 @@ export const createAgentMessages = async (
                 agentConfigurationVersion: configuration.version,
                 workspaceId: owner.id,
                 skipToolsValidation: metadata.skipToolsValidation,
-                requestedProviderId:
-                  metadata.requestedModel?.providerId ?? null,
-                requestedModelId: metadata.requestedModel?.modelId ?? null,
-                requestedReasoningEffort:
-                  metadata.requestedModel?.reasoningEffort ?? null,
+                resolvedProviderId: metadata.resolvedModel?.providerId ?? null,
+                resolvedModelId: metadata.resolvedModel?.modelId ?? null,
+                resolvedReasoningEffort:
+                  metadata.resolvedModel?.reasoningEffort ?? null,
+                modelResolutionMethod: "auto", // TODO(models_picker): carry over the method from the original message
               },
               { transaction }
             );
@@ -576,7 +577,7 @@ export const createAgentMessages = async (
             richMentions: [],
             reactions: [],
             costCredits: null,
-            requestedModel: requestedAgentModelFromColumns(agentMessageRow),
+            requestedModel: resolvedModelFromAgentMessageRow(agentMessageRow),
           };
         }
       }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -1,7 +1,7 @@
 import { renderAgentMessageContentView } from "@app/lib/api/assistant/activity_steps";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { requestedAgentModelFromColumns } from "@app/lib/api/assistant/models";
+import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
 import { getMessagesReactions } from "@app/lib/api/assistant/reaction";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -824,7 +824,7 @@ async function renderSingleAgentMessage(
     // Aggregated only when rendering a single agent message (see
     // batchRenderAgentMessages), so it is `null` for bulk conversation rendering.
     subAgentCostCredits,
-    requestedModel: requestedAgentModelFromColumns(agentMessage),
+    requestedModel: resolvedModelFromAgentMessageRow(agentMessage),
   } satisfies AgentMessageType;
 
   if (viewType === "full") {

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -1,6 +1,7 @@
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { isModelEnabled } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import type { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
@@ -278,28 +279,25 @@ export function reconcileModelSettings<T extends { responseFormat?: string }>(
 // Rebuilds a `ResolvedRequestedModel` from the raw agent-message columns, or null
 // when no override was stored (or the stored values fail validation). Values are
 // written by the resolver above, so validation is defensive.
-export function requestedAgentModelFromColumns(row: {
-  requestedProviderId: string | null;
-  requestedModelId: string | null;
-  requestedReasoningEffort: string | null;
-}): ResolvedRequestedModel | null {
-  const { requestedProviderId, requestedModelId, requestedReasoningEffort } =
-    row;
+export function resolvedModelFromAgentMessageRow(
+  row: AgentMessageModel
+): ResolvedRequestedModel | null {
+  const { resolvedProviderId, resolvedModelId, resolvedReasoningEffort } = row;
 
   if (
-    !requestedProviderId ||
-    !requestedModelId ||
-    !requestedReasoningEffort ||
-    !isModelProviderId(requestedProviderId) ||
-    !isModelId(requestedModelId) ||
-    !isReasoningEffort(requestedReasoningEffort)
+    !resolvedProviderId ||
+    !resolvedModelId ||
+    !resolvedReasoningEffort ||
+    !isModelProviderId(resolvedProviderId) ||
+    !isModelId(resolvedModelId) ||
+    !isReasoningEffort(resolvedReasoningEffort)
   ) {
     return null;
   }
 
   return {
-    providerId: requestedProviderId,
-    modelId: requestedModelId,
-    reasoningEffort: requestedReasoningEffort,
+    providerId: resolvedProviderId,
+    modelId: resolvedModelId,
+    reasoningEffort: resolvedReasoningEffort,
   };
 }

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -433,6 +433,10 @@ UserMessageModel.belongsTo(KeyModel, {
   onDelete: "RESTRICT",
 });
 
+const MODEL_RESOLUTION_METHODS = ["agent", "user", "auto"] as const;
+
+type ModelResolutionMethod = (typeof MODEL_RESOLUTION_METHODS)[number];
+
 export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -459,12 +463,12 @@ export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
   declare prunedContext: boolean | null;
   declare costCredits: number | null;
 
-  // Per-message model override from the input-bar model picker: the concrete
-  // provider/model/effort triplet the user picked at send time. All null when
-  // the message runs the agent's configured model.
-  declare requestedProviderId: string | null;
-  declare requestedModelId: string | null;
-  declare requestedReasoningEffort: string | null;
+  // The concrete provider/model/effort triplet used by the message when
+  // running the agent. Legacy: null when the message runs the agent's configured model.
+  declare resolvedProviderId: string | null;
+  declare resolvedModelId: string | null;
+  declare resolvedReasoningEffort: string | null;
+  declare modelResolutionMethod: ModelResolutionMethod | null;
 }
 
 AgentMessageModel.init(
@@ -555,20 +559,28 @@ AgentMessageModel.init(
       allowNull: true,
       defaultValue: null,
     },
-    requestedProviderId: {
+    resolvedProviderId: {
       type: DataTypes.STRING,
       allowNull: true,
       defaultValue: null,
     },
-    requestedModelId: {
+    resolvedModelId: {
       type: DataTypes.STRING,
       allowNull: true,
       defaultValue: null,
     },
-    requestedReasoningEffort: {
+    resolvedReasoningEffort: {
       type: DataTypes.STRING,
       allowNull: true,
       defaultValue: null,
+    },
+    modelResolutionMethod: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+      validate: {
+        isIn: [MODEL_RESOLUTION_METHODS],
+      },
     },
   },
   {

--- a/front/migrations/post-deploy/20260707183547_remove_old_model_requested_model_columns_on_agent_message.sql
+++ b/front/migrations/post-deploy/20260707183547_remove_old_model_requested_model_columns_on_agent_message.sql
@@ -1,0 +1,14 @@
+SET
+  SESSION statement_timeout = 3000;
+
+SET
+  SESSION lock_timeout = 3000;
+
+ALTER TABLE "public"."agent_messages"
+DROP COLUMN "requestedModelId";
+
+ALTER TABLE "public"."agent_messages"
+DROP COLUMN "requestedProviderId";
+
+ALTER TABLE "public"."agent_messages"
+DROP COLUMN "requestedReasoningEffort";

--- a/front/migrations/pre-deploy/20260707183300_add_model_resolution_methods_on_agent_message.sql
+++ b/front/migrations/pre-deploy/20260707183300_add_model_resolution_methods_on_agent_message.sql
@@ -1,0 +1,17 @@
+SET
+  SESSION statement_timeout = 3000;
+
+SET
+  SESSION lock_timeout = 3000;
+
+ALTER TABLE "public"."agent_messages"
+ADD COLUMN "modelResolutionMethod" character varying(255) DEFAULT NULL;
+
+ALTER TABLE "public"."agent_messages"
+ADD COLUMN "resolvedModelId" character varying(255) DEFAULT NULL;
+
+ALTER TABLE "public"."agent_messages"
+ADD COLUMN "resolvedProviderId" character varying(255) DEFAULT NULL;
+
+ALTER TABLE "public"."agent_messages"
+ADD COLUMN "resolvedReasoningEffort" character varying(255) DEFAULT NULL;


### PR DESCRIPTION
## Description

Renames `requestedProviderId/ModelId/ReasoningEffort` → `resolvedProviderId/ModelId/ReasoningEffort` on `AgentMessageModel` and `agent_messages`, and adds a new `modelResolutionMethod` column (`"agent" | "user" | "auto"`). The rename reflects that these fields record the *resolved* model actually used at run time (which can diverge from what was requested, e.g. when `auto` picks the model). The new `modelResolutionMethod` column tracks which path determined the model choice for each message.

## Tests

Tested locally via model picker flows. Schema changes are purely additive in pre-deploy; the Sequelize `validate.isIn` guard prevents invalid values at the ORM layer.

## Risk

Medium — schema migration on `agent_messages`. Pre-deploy adds new columns (safe, nullable with DEFAULT NULL). Old columns coexist until post-deploy drop, so no backward-compat gap during the rollout window. Rollback before post-deploy is safe; after post-deploy, a rollback would need the columns re-added.

## Deploy Plan

1. Run pre-deploy SQL on front DB: `front/migrations/pre-deploy/20260707183300_add_model_resolution_methods_on_agent_message.sql`
2. Deploy front
3. Run post-deploy SQL on front DB: `front/migrations/post-deploy/20260707183547_remove_old_model_requested_model_columns_on_agent_message.sql`
