### PR TITLE
feat(activation): add action_card directive and recommendation card UI

### DIFF
--- a/front/components/assistant/AgentMessageMarkdown.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.tsx
@@ -13,6 +13,7 @@ import {
   preprocessInstructionBlocks,
 } from "@app/components/markdown/InstructionBlock";
 import { quickReplyDirective } from "@app/components/markdown/QuickReplyBlock";
+import { actionCardDirective } from "@app/components/markdown/ActionCardDirective";
 import {
   getTaskDirectiveBlock,
   taskDirective,
@@ -87,6 +88,7 @@ export const AgentMessageMarkdown = ({
       filePreviewDirective,
       toolDirective,
       quickReplyDirective,
+      actionCardDirective,
       ...additionalMarkdownPlugins,
     ];
 

--- a/front/components/assistant/AgentMessageMarkdown.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.tsx
@@ -1,3 +1,4 @@
+import { actionCardDirective } from "@app/components/markdown/ActionCardDirective";
 import {
   CiteBlock,
   getCiteDirective,
@@ -13,7 +14,6 @@ import {
   preprocessInstructionBlocks,
 } from "@app/components/markdown/InstructionBlock";
 import { quickReplyDirective } from "@app/components/markdown/QuickReplyBlock";
-import { actionCardDirective } from "@app/components/markdown/ActionCardDirective";
 import {
   getTaskDirectiveBlock,
   taskDirective,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -38,6 +38,7 @@ import {
 } from "@app/components/markdown/CiteBlock";
 import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
 import { getQuickReplyPlugin } from "@app/components/markdown/QuickReplyBlock";
+import { getActionCardPlugin } from "@app/components/markdown/ActionCardDirective";
 import { getToolSetupPlugin } from "@app/components/markdown/tool/tool";
 import {
   getVisualizationPlugin,
@@ -1263,6 +1264,17 @@ function AgentMessageContent({
       sup: CiteBlock,
       quickReply: getQuickReplyPlugin(onQuickReplySend, isLastMessage),
       toolSetup: getToolSetupPlugin(owner, handleToolSetupComplete),
+      action_card: getActionCardPlugin(
+        {
+          onAction: async (message) => {
+            await onQuickReplySend(message);
+          },
+          onDismiss: async (message) => {
+            await onQuickReplySend(message);
+          },
+        },
+        isLastMessage
+      ),
       ...propsAdditionalMarkdownComponents,
     }),
     [

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1264,17 +1264,7 @@ function AgentMessageContent({
       sup: CiteBlock,
       quickReply: getQuickReplyPlugin(onQuickReplySend, isLastMessage),
       toolSetup: getToolSetupPlugin(owner, handleToolSetupComplete),
-      action_card: getActionCardPlugin(
-        {
-          onAction: async (message) => {
-            await onQuickReplySend(message);
-          },
-          onDismiss: async (message) => {
-            await onQuickReplySend(message);
-          },
-        },
-        isLastMessage
-      ),
+      action_card: getActionCardPlugin(onQuickReplySend, isLastMessage),
       ...propsAdditionalMarkdownComponents,
     }),
     [

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -32,13 +32,13 @@ import {
   useCreditCostMenuItem,
 } from "@app/components/assistant/conversation/useCreditCostMenuItem";
 import { ConfirmContext } from "@app/components/Confirm";
+import { getActionCardPlugin } from "@app/components/markdown/ActionCardDirective";
 import {
   CitationsContext,
   CiteBlock,
 } from "@app/components/markdown/CiteBlock";
 import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
 import { getQuickReplyPlugin } from "@app/components/markdown/QuickReplyBlock";
-import { getActionCardPlugin } from "@app/components/markdown/ActionCardDirective";
 import { getToolSetupPlugin } from "@app/components/markdown/tool/tool";
 import {
   getVisualizationPlugin,

--- a/front/components/markdown/ActionCardDirective.tsx
+++ b/front/components/markdown/ActionCardDirective.tsx
@@ -9,6 +9,7 @@ import {
 import { getIcon } from "@app/components/resources/resources_icons";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { ActionCardBlock, Avatar } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { visit } from "unist-util-visit";
 
@@ -16,29 +17,30 @@ const DEFAULT_ICON: InternalAllowedIconType | CustomResourceIconType =
   "ActionRobotIcon";
 
 /**
- * Remark plugin: transforms `::action_card[title]{...attrs}` into a custom
- * HTML element for React rendering.
+ * Remark plugin: transforms the `:::action_card{...attrs}` container directive
+ * into a custom HTML element for React rendering.
  *
- * - `[title]`: short headline
+ * - `title`: short headline (required)
  * - `subtitle`: optional context line shown below the title
  * - `description`: one supporting sentence
  * - `icon`: name of icon shown
- * - `cta`: primary action button label.
- * - `dismiss`: secondary action button label.
+ * - `cta`: primary action button label
+ * - `dismiss`: secondary action button label
  * - `actionMessage`: message sent to the agent when the primary action is taken (defaults to "Accept").
  * - `dismissMessage`: message sent to the agent when the secondary action is taken (defaults to "Dismiss").
+ * - `collapsibleLabel`: label for the collapsible trigger.
+ * - `collapsibleContent`: markdown rendered inside the collapsible section.
  */
 export function actionCardDirective() {
   return (tree: any) => {
-    visit(tree, ["textDirective", "leafDirective"], (node) => {
+    visit(tree, ["containerDirective"], (node) => {
       if (node.name !== "action_card") {
         return;
       }
       node.data ??= {};
       const data = node.data;
-      const title = node.children?.[0]?.value ?? "";
       data.hName = "action_card";
-      data.hProperties = { title, ...node.attributes };
+      data.hProperties = { ...node.attributes };
     });
   };
 }
@@ -54,6 +56,8 @@ interface ActionCardProps {
   dismiss?: string;
   actionMessage?: string;
   dismissMessage?: string;
+  collapsibleContent?: ReactNode;
+  collapsibleLabel?: string;
   isLastMessage?: boolean;
   onSend?: (message: string) => Promise<void>;
 }
@@ -67,6 +71,8 @@ function ActionCard({
   dismiss,
   actionMessage,
   dismissMessage,
+  collapsibleContent,
+  collapsibleLabel,
   isLastMessage = true,
   onSend,
 }: ActionCardProps) {
@@ -111,6 +117,12 @@ function ActionCard({
           title={title}
           subtitle={subtitle}
           description={description}
+          collapsibleContent={
+            collapsibleContent ? (
+              <div className="prose prose-sm">{collapsibleContent}</div>
+            ) : undefined
+          }
+          collapsibleLabel={collapsibleContent ? collapsibleLabel : undefined}
           applyLabel={applyLabel}
           rejectLabel={dismiss ?? "Dismiss"}
           acceptedTitle={title}
@@ -141,8 +153,10 @@ interface ActionCardPluginProps {
   icon?: string;
   cta?: string;
   dismiss?: string;
-  actionmessage?: string;
-  dismissmessage?: string;
+  actionMessage?: string;
+  dismissMessage?: string;
+  collapsibleLabel?: string;
+  children?: ReactNode;
 }
 
 export function getActionCardPlugin(
@@ -156,8 +170,10 @@ export function getActionCardPlugin(
     icon,
     cta,
     dismiss,
-    actionmessage,
-    dismissmessage,
+    actionMessage,
+    dismissMessage,
+    collapsibleLabel,
+    children,
   }: ActionCardPluginProps) => {
     if (!title) {
       return null;
@@ -170,8 +186,10 @@ export function getActionCardPlugin(
         icon={icon}
         cta={cta}
         dismiss={dismiss}
-        actionMessage={actionmessage}
-        dismissMessage={dismissmessage}
+        actionMessage={actionMessage}
+        dismissMessage={dismissMessage}
+        collapsibleContent={children}
+        collapsibleLabel={collapsibleLabel}
         isLastMessage={isLastMessage}
         onSend={onSend}
       />

--- a/front/components/markdown/ActionCardDirective.tsx
+++ b/front/components/markdown/ActionCardDirective.tsx
@@ -1,0 +1,183 @@
+import { getIcon } from "@app/components/resources/resources_icons";
+import {
+  isCustomResourceIconType,
+  isInternalAllowedIcon,
+} from "@app/components/resources/resources_icon_names";
+import type {
+  CustomResourceIconType,
+  InternalAllowedIconType,
+} from "@app/components/resources/resources_icon_names";
+import { ActionCardBlock, Avatar } from "@dust-tt/sparkle";
+import { useState } from "react";
+import { visit } from "unist-util-visit";
+
+const DEFAULT_ICON: InternalAllowedIconType | CustomResourceIconType =
+  "ActionRobotIcon";
+
+/**
+ * Remark plugin: transforms `::action_card[title]{...attrs}` into a custom
+ * HTML element for React rendering.
+ *
+ * - `[title]`: short headline
+ * - `subtitle`: optional context line shown below the title
+ * - `description`: one supporting sentence
+ * - `icon`: name of icon shown
+ * - `cta`: primary action button label.
+ * - `dismiss`: secondary action button label.
+ * - `actionMessage`: message sent to the agent when the primary action is taken (defaults to "Accept").
+ * - `dismissMessage`: message sent to the agent when the secondary action is taken (defaults to "Dismiss").
+ */
+export function actionCardDirective() {
+  return (tree: any) => {
+    visit(tree, ["textDirective", "leafDirective"], (node) => {
+      if (node.name !== "action_card") {
+        return;
+      }
+      node.data ??= {};
+      const data = node.data;
+      const title = node.children?.[0]?.value ?? "";
+      data.hName = "action_card";
+      data.hProperties = { title, ...node.attributes };
+    });
+  };
+}
+
+type ActionCardStatus = "active" | "actioned" | "dismissed";
+
+export interface ActionCardCallbacks {
+  onAction?: (message: string) => Promise<void>;
+  onDismiss?: (message: string) => Promise<void>;
+}
+
+interface ActionCardProps {
+  title: string;
+  subtitle?: string;
+  description?: string;
+  icon?: string;
+  cta?: string;
+  dismiss?: string;
+  actionMessage?: string;
+  dismissMessage?: string;
+  isLastMessage?: boolean;
+  onAction?: (message: string) => Promise<void>;
+  onDismiss?: (message: string) => Promise<void>;
+}
+
+function ActionCard({
+  title,
+  subtitle,
+  description,
+  icon: iconName,
+  cta,
+  dismiss,
+  actionMessage,
+  dismissMessage,
+  isLastMessage = true,
+  onAction,
+  onDismiss,
+}: ActionCardProps) {
+  const applyLabel = cta ?? "Accept";
+  const [status, setStatus] = useState<ActionCardStatus>("active");
+
+  const resolvedIconName: InternalAllowedIconType | CustomResourceIconType =
+    iconName !== undefined &&
+    (isInternalAllowedIcon(iconName) || isCustomResourceIconType(iconName))
+      ? iconName
+      : DEFAULT_ICON;
+  const icon = getIcon(resolvedIconName);
+
+  if (status === "actioned") {
+    return (
+      <ActionCardBlock
+        title={title}
+        applyLabel={applyLabel}
+        acceptedTitle={title}
+        visual={<Avatar icon={icon} backgroundColor="bg-highlight-100" />}
+        state="accepted"
+      />
+    );
+  }
+
+  if (status === "dismissed") {
+    return (
+      <ActionCardBlock
+        title={title}
+        applyLabel={applyLabel}
+        rejectedTitle={title}
+        visual={<Avatar icon={icon} backgroundColor="bg-highlight-100" />}
+        state="rejected"
+      />
+    );
+  }
+
+  return (
+    <ActionCardBlock
+      title={title}
+      subtitle={subtitle}
+      description={description}
+      applyLabel={applyLabel}
+      rejectLabel={dismiss ?? "Dismiss"}
+      acceptedTitle={title}
+      rejectedTitle={title}
+      visual={<Avatar icon={icon} backgroundColor="bg-highlight-100" />}
+      state={isLastMessage ? "active" : "disabled"}
+      actionsPosition="header"
+      onClickAccept={() => {
+        setStatus("actioned");
+        void onAction?.(actionMessage ?? "Accept");
+      }}
+      onClickReject={() => {
+        setStatus("dismissed");
+        void onDismiss?.(dismissMessage ?? "Dismiss");
+      }}
+    />
+  );
+}
+
+interface ActionCardPluginProps {
+  title?: string;
+  subtitle?: string;
+  description?: string;
+  icon?: string;
+  cta?: string;
+  dismiss?: string;
+  actionmessage?: string;
+  dismissmessage?: string;
+}
+
+export function getActionCardPlugin(
+  callbacks: ActionCardCallbacks = {},
+  isLastMessage = true
+) {
+  const ActionCardPlugin = ({
+    title,
+    subtitle,
+    description,
+    icon,
+    cta,
+    dismiss,
+    actionmessage,
+    dismissmessage,
+  }: ActionCardPluginProps) => {
+    if (!title) {
+      return null;
+    }
+    return (
+      <ActionCard
+        title={title}
+        subtitle={subtitle}
+        description={description}
+        icon={icon}
+        cta={cta}
+        dismiss={dismiss}
+        actionMessage={actionmessage}
+        dismissMessage={dismissmessage}
+        isLastMessage={isLastMessage}
+        onAction={callbacks.onAction}
+        onDismiss={callbacks.onDismiss}
+      />
+    );
+  };
+
+  return ActionCardPlugin;
+}

--- a/front/components/markdown/ActionCardDirective.tsx
+++ b/front/components/markdown/ActionCardDirective.tsx
@@ -7,8 +7,9 @@ import {
   isInternalAllowedIcon,
 } from "@app/components/resources/resources_icon_names";
 import { getIcon } from "@app/components/resources/resources_icons";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { ActionCardBlock, Avatar } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { visit } from "unist-util-visit";
 
 const DEFAULT_ICON: InternalAllowedIconType | CustomResourceIconType =
@@ -44,11 +45,6 @@ export function actionCardDirective() {
 
 type ActionCardStatus = "active" | "actioned" | "dismissed";
 
-export interface ActionCardCallbacks {
-  onAction?: (message: string) => Promise<void>;
-  onDismiss?: (message: string) => Promise<void>;
-}
-
 interface ActionCardProps {
   title: string;
   subtitle?: string;
@@ -59,8 +55,7 @@ interface ActionCardProps {
   actionMessage?: string;
   dismissMessage?: string;
   isLastMessage?: boolean;
-  onAction?: (message: string) => Promise<void>;
-  onDismiss?: (message: string) => Promise<void>;
+  onSend?: (message: string) => Promise<void>;
 }
 
 function ActionCard({
@@ -73,8 +68,7 @@ function ActionCard({
   actionMessage,
   dismissMessage,
   isLastMessage = true,
-  onAction,
-  onDismiss,
+  onSend,
 }: ActionCardProps) {
   const applyLabel = cta ?? "Accept";
   const [status, setStatus] = useState<ActionCardStatus>("active");
@@ -85,53 +79,59 @@ function ActionCard({
       ? iconName
       : DEFAULT_ICON;
   const icon = getIcon(resolvedIconName);
-
-  if (status === "actioned") {
-    return (
-      <ActionCardBlock
-        title={title}
-        applyLabel={applyLabel}
-        acceptedTitle={title}
-        visual={<Avatar icon={icon} backgroundColor="bg-highlight-100" />}
-        state="accepted"
-      />
-    );
-  }
-
-  if (status === "dismissed") {
-    return (
-      <ActionCardBlock
-        title={title}
-        applyLabel={applyLabel}
-        rejectedTitle={title}
-        visual={<Avatar icon={icon} backgroundColor="bg-highlight-100" />}
-        state="rejected"
-      />
-    );
-  }
-
-  return (
-    <ActionCardBlock
-      title={title}
-      subtitle={subtitle}
-      description={description}
-      applyLabel={applyLabel}
-      rejectLabel={dismiss ?? "Dismiss"}
-      acceptedTitle={title}
-      rejectedTitle={title}
-      visual={<Avatar icon={icon} backgroundColor="bg-highlight-100" />}
-      state={isLastMessage ? "active" : "disabled"}
-      actionsPosition="header"
-      onClickAccept={() => {
-        setStatus("actioned");
-        void onAction?.(actionMessage ?? "Accept");
-      }}
-      onClickReject={() => {
-        setStatus("dismissed");
-        void onDismiss?.(dismissMessage ?? "Dismiss");
-      }}
-    />
+  const visual = useMemo(
+    () => <Avatar icon={icon} backgroundColor="bg-highlight-100" />,
+    [icon]
   );
+
+  switch (status) {
+    case "actioned":
+      return (
+        <ActionCardBlock
+          title={title}
+          applyLabel={applyLabel}
+          acceptedTitle={title}
+          visual={visual}
+          state="accepted"
+        />
+      );
+    case "dismissed":
+      return (
+        <ActionCardBlock
+          title={title}
+          applyLabel={applyLabel}
+          rejectedTitle={title}
+          visual={visual}
+          state="rejected"
+        />
+      );
+    case "active":
+      return (
+        <ActionCardBlock
+          title={title}
+          subtitle={subtitle}
+          description={description}
+          applyLabel={applyLabel}
+          rejectLabel={dismiss ?? "Dismiss"}
+          acceptedTitle={title}
+          rejectedTitle={title}
+          visual={visual}
+          state={isLastMessage ? "active" : "disabled"}
+          actionsPosition="header"
+          onClickAccept={() => {
+            setStatus("actioned");
+            void onSend?.(actionMessage ?? "Accept");
+          }}
+          onClickReject={() => {
+            setStatus("dismissed");
+            void onSend?.(dismissMessage ?? "Dismiss");
+          }}
+        />
+      );
+    default:
+      assertNeverAndIgnore(status);
+      return null;
+  }
 }
 
 interface ActionCardPluginProps {
@@ -146,7 +146,7 @@ interface ActionCardPluginProps {
 }
 
 export function getActionCardPlugin(
-  callbacks: ActionCardCallbacks = {},
+  onSend: (message: string) => Promise<void>,
   isLastMessage = true
 ) {
   const ActionCardPlugin = ({
@@ -173,8 +173,7 @@ export function getActionCardPlugin(
         actionMessage={actionmessage}
         dismissMessage={dismissmessage}
         isLastMessage={isLastMessage}
-        onAction={callbacks.onAction}
-        onDismiss={callbacks.onDismiss}
+        onSend={onSend}
       />
     );
   };

--- a/front/components/markdown/ActionCardDirective.tsx
+++ b/front/components/markdown/ActionCardDirective.tsx
@@ -1,12 +1,12 @@
-import { getIcon } from "@app/components/resources/resources_icons";
-import {
-  isCustomResourceIconType,
-  isInternalAllowedIcon,
-} from "@app/components/resources/resources_icon_names";
 import type {
   CustomResourceIconType,
   InternalAllowedIconType,
 } from "@app/components/resources/resources_icon_names";
+import {
+  isCustomResourceIconType,
+  isInternalAllowedIcon,
+} from "@app/components/resources/resources_icon_names";
+import { getIcon } from "@app/components/resources/resources_icons";
 import { ActionCardBlock, Avatar } from "@dust-tt/sparkle";
 import { useState } from "react";
 import { visit } from "unist-util-visit";

--- a/front/lib/api/actions/servers/user_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/user_analytics/metadata.ts
@@ -9,8 +9,7 @@ export const USER_ANALYTICS_SERVER_NAME = "user_analytics" as const;
 export const USER_ANALYTICS_TOOLS_METADATA = createToolsRecord({
   get_personal_usage: {
     description:
-      "Get this user's top skills and tools over the last 30 days, ranked by execution count. " +
-      "Always scoped to the authenticated user.",
+      "Get the authenticated user's personal usage over the last 30 days: their top skills and top tools ranked by execution count.",
     schema: {},
     stake: "never_ask",
     toolCostCategory: "basic",

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -12,7 +12,8 @@ import { isStringArray } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 
 const ACTIVATION_BEHAVIOR = `
-Recommend the next best action for the user to get more value from Dust. Help them execute it in this conversation, then offer to convert it into a saved skill and a recurring schedule.
+Recommend the next best action for the user to get more value from Dust. Help them execute it in this conversation, then convert it into a saved skill and a recurring schedule.
+Your job is to find work the user already does and use Dust to help them do it faster.
 
 ## User Context
 
@@ -22,22 +23,95 @@ Before providing a new use case for the user, you MUST acquire context to inform
 - Call \`list_skills\` to see what skills are pinned or available.
 - Call \`list_recommendations\` to see what recommendations have already been shown to the user. Do not repeat recommendations the user has already executed or dismissed.
 
-Do not recommend skills, tools, or agents that already appear in the user's personal usage results — they are already using those.
-- Account for the data already provided to you, including user job type, user preferred tools, and the existing tools
+## Guidelines
 
-## Recommend
+- Never recommend actions that are ONLY acting on Dust resources. Skills and tools related to Dust itself (i.e. Activation Skill) do not count as substantive personal usage. Ignore them when deciding what the user "already uses".
+- Do not recommend skills, tools, or agents that already appear in the user's personal usage results (they are already using those)
+- Mine usage data for evidence of tasks, not just exclusion:
+  - From \`get_personal_usage\`: look for repeated manual patterns — the same kind of request made multiple times. A repeated pattern is proof of the type of tasks relevant for users and the strongest possible recommendation basis.
+  - From \`get_workspace_activity\`: look for social proof — skills or agents that colleagues use regularly. "Teammates run this weekly" is proof the task exists in this workspace and is more persuasive than any generic pitch.
+- NEVER recommend the usage of agents other than customer agents OR the "Dust" default agent.
+- Never repeat recommendations the user has already executed or dismissed.
 
-Surface exactly one recommendation per turn. Follow this priority order. Move to the next tier only if the current tier yields no viable recommendation. Never explain the tier system to the user.
+## What makes a recommendation high-value
 
+Prioritize recommendations that exploit Dust's core differentiators over generic AI chat:
+1. Write and action tools — tools that take real-world actions, not just read or search. These eliminate context-switching and are a clear ROI.
+2. Frames — interactive dashboards, visualizations, and living reports built as React components. A Frame turns a one-off data pull into a reusable artifact teammates can explore. Target users who work with recurring data, metrics, or reports.
+3. Recurring triggers and skills — converting a manual task into a scheduled automation. A daily briefing, a weekly digest, a recurring report. This is the strongest habit-forming lever: Dust delivers value without the user initiating it. Default to daily or weekly cadence.
+4. Custom workspace agents or skills — encode this workspace's specific context, tools, and knowledge base. Higher-value than generic chat because they can't be replicated with a public AI tool.
+
+## Recommendation Requirements
+
+Every recommendation must meet the following requirements:
+- It replaces, shortens, or improves a task relevant to the user. It must be a tangible example of an activity that will improve the user's productivity.
+- It names actual tools, agents, skills, or usage patterns. Not a category ("automate your reporting") but an instance ("the pipeline summary you rebuild from HubSpot every week").
+- It is executable right now, in this conversation, with tools that are already connected. Never recommend connecting a new tool or data source — tool setup is an admin action outside the user's control. Only build on what is already available in the workspace context provided to you.
+- Executing it ends in a tangible artifact: a Frame, a drafted message, a created issue, a briefing. Never advice, tips, or a description of what's possible.
+- It can plausibly become a saved skill or a recurring schedule.
+
+## Recommendation Flow
+
+Surface exactly one new recommendation per turn. Follow this priority order:
 1. Pre-selected skills — Call \`list_skills\` to see what skills are pinned or available. Prioritize any that align with the user's stated goals or role.
-2. Existing agents in this workspace — Call \`list_all_published_agents\` to see what agents exist. Recommend the one whose description best fits the user's work.
-3. Curated use cases by job type — If no skills or agents are a clear fit, suggest a curated use case matched to the user's role. Keep setup steps minimal; note any required tool connections.
-4. Personalized daily task manager - Connect primary daily sources (Slack, email, calendar) and set up a daily briefing.
+2. Existing agents in this workspace — Call \`list_all_published_agents\`. Prefer agents with observed colleague usage, and say so.
+3. Curated use cases by job type — If no agents are a clear fit, suggest a curated use case matched to the user's role. Lean toward Frames, write/action tools, or recurring workflows over read/search-only use cases.
+4. Personalized daily task manager — Connect primary daily sources (Slack, email, calendar) and set up a daily briefing. It requires no usage history, so it is always available as the thin-signal fallback.
 
-Each recommendation includes:
-- A 1-2 sentence rationale explaining why this is worth their time.
-- An offer to execute it directly in this conversation — not just describe it.
-- If applicable, a brief, skippable inline explanation of the relevant Dust concept (skill, trigger, schedule, Frame, etc.). One sentence, easy to ignore.
+## How to present a recommendation
+
+Always start by surfacing a recommendation card — never open with a question. If you need more context from the user (e.g. after several dismissals), use the \`ask_question\` tool as a follow-up, never up front.
+
+Every recommendation follows this chain — if any link is missing, fall to a lower tier rather than surfacing it incomplete:
+1. Name the task they already do, and its current cost, stated naturally as an observation about their work. Vary the phrasing — never use a fixed template.
+2. Offer to execute it directly in this conversation — not just describe it.
+
+Every offer — new recommendations and post-execution conversion offers alike — is rendered as a card:
+
+1. Call \`create_recommendation\` with the recommendation text and your internal rationale.
+2. Using the \`recommendationId\` returned, render the card on its own line:
+
+::action_card[<short title, 3–6 words>]{sId=<recommendationId> subtitle="<context line>" description="<one sentence>" cta="<accept label>" dismiss="<reject label>" actionMessage="<message sent on accept>" dismissMessage="<message sent on dismiss>"}
+
+- \`[title]\`: short generic headline shown prominently (3–5 words), e.g. "Recommendation for you".
+- \`subtitle\`: optional context line shown below the title. 3-5 word specific title for the recommendation: "Generate daily brief".
+- \`description\`: one sentence a stranger could visualize. Name what appears in the output, not what it "turns into".
+- \`cta\`: short accept button label, e.g. "Try it", "Save it", "Set it up". This is display-only.
+- \`dismiss\`: short reject button label, e.g. "Not now", "Not for me", "Already doing this". This is display-only.
+- \`actionMessage\`: message sent to you when the user clicks the accept button, e.g. "Yes, let's do it", "Go ahead". Defaults to "Accept" if omitted.
+- \`dismissMessage\`: message sent to you when the user clicks the dismiss button, e.g. "Not for me", "Skip this one". Defaults to "Dismiss" if omitted.
+
+Do NOT emit \`ask_question\` buttons when the message ends with an \`::action_card\` directive.
+
+When the user responds to any card:
+- If they accept (the \`actionMessage\` arrives), call \`update_recommendation\` with \`status: "executed"\`, then proceed with execution.
+- If they decline (the \`dismissMessage\` arrives), call \`update_recommendation\` with \`status: "dismissed"\`. For a new recommendation, surface the next one. For a conversion card, follow the post-execution flow below.
+
+## Executing
+
+Once the user accepts, execute for real — this is where the value must become visible, not claimed:
+- End with the artifact itself: the rendered Frame, the drafted message, the created item, the actual briefing text.
+- Name what was touched as you go ("pulled from your Notion and HubSpot together") so the user sees the cross-tool reach rather than being told about it.
+
+When a required source is not connected, drive the connection — never dead-end.
+If execution needs a data source that isn't connected, do not ask the user to
+paste data as the primary path, and never simply report that nothing is
+available. Instead:
+
+1. Pick the single most valuable missing source for this workflow — one, not
+   a list. If several are missing, choose the one that unlocks the most of
+   the promised artifact.
+2. Render a \`connect_tool\` conversion card for it, with the payoff in the
+   card: \`label\` names the source ("Connect Google Calendar"),
+   \`description\` states what happens the moment it's linked ("I'll build
+   today's briefing from your actual meetings as soon as it connects").
+   Follow the standard card lifecycle (\`create_recommendation\`,
+   \`update_recommendation\`).
+3. If partial execution is possible with what IS connected, do that first and
+   show the partial artifact — then present the connect card as what
+   completes it ("here's the briefing from Slack alone; connect your calendar
+   and it includes your day").
+
 
 Immediately after surfacing a recommendation, call \`create_recommendation\` with the recommendation text and your internal rationale.
 
@@ -48,24 +122,21 @@ When the user responds to a recommendation:
 
 ## After Successful Use Case Execution
 
-Follow this sequence — do not offer it as a choice, just move through each step:
+This flow is mandatory and opinionated — move through it step by step, one card per turn. Do not present it as a menu of options, and do not skip steps unless the user declines.
 
-1. **Save as a skill** — Use the \`skill_authoring\` tools to save the workflow as a reusable skill. Confirm with the user before saving.
-2. **Make it recurring** — Use the \`schedules_management\` tools to set up a recurring trigger. End this step with:
+1. Echo the value — one sentence stating concretely what was produced, from which sources, and what manual task it replaces ("that combined 3 sources into the briefing you'd otherwise assemble by hand every morning"). One sentence, not a celebration.
+2. Offer the skill as a card — in the same message as the value echo, render a conversion card proposing to save exactly what just ran as a reusable skill. The card must be specific to the work just done: title names the workflow ("Weekly pipeline recap"), \`label\` names what it captures ("From the report we just built"), \`description\` states what saving it means ("Rerun this exact HubSpot + Slack recap anytime in one click"). On accept: call \`update_recommendation\` with \`status: "executed"\`, create the skill with the \`skill_authoring\` tools, then call \`update_recommendation\` again with \`createdSkillId\`.
+3. Offer the trigger as a card — once the skill is saved, in the same message that confirms it, render a second conversion card proposing the schedule. Default the cadence to the cadence of the manual task it replaces, and put the concrete schedule in the card itself: \`label\` like "Runs every Monday, 8am", \`description\` stating what arrives and when ("The recap lands in this conversation before your Monday pipeline review"). On accept: call \`update_recommendation\` with \`status: "executed"\`, create the trigger with the \`schedules_management\` tools, then call \`update_recommendation\` again with \`createdTriggerId\`.
+4. Handle declines gracefully — if the user declines the skill card, do not offer the trigger (a schedule needs the saved workflow); mark it dismissed and close the loop warmly. If they decline the trigger card, confirm the skill is saved and where to find it. In both cases, stop — do not immediately surface a new recommendation unless the user asks.
 
-:quickReply[Set it up]{message="Yes, set this up to run on a schedule"} :quickReply[Skip]{message="No thanks, skip the schedule"}
-
-## Accept / Reject
-
-After surfacing a recommendation, always end with one-click options:
-
-:quickReply[Let's try it]{message="Yes, let's try this now"} :quickReply[Not for me]{message="This isn't relevant to my work"} :quickReply[Tell me more]{message="Tell me more before we start"}
+Never bundle these into one combined ask ("want me to save this as a skill and schedule it?"). One card, one decision, one turn.
 
 ## Quality
 
 - Be concise. Every message should be actionable in under 30 seconds of reading.
 - Never block the user. If they want to skip, change direction, ask an unrelated question, or leave, let them.
-- Always end messages with at least one \`quickReply\` button.
+- Never end a message with an open question — use \`ask_question\` if you need input.
+- Never emit \`quickReply\` buttons.
 - If the user asks a question unrelated to recommendations, answer it helpfully, then gently steer back.
 - Present recommendations naturally. Do not explain the priority tiers, the skill-pinning mechanism, or how this works. The user should feel like they're getting personalized suggestions, not being processed through a funnel.
 `.trim();

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -6,6 +6,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import { isPodConversation } from "@app/types/assistant/conversation";
 import { isFavoritePlatform } from "@app/types/favorite_platforms";
 import { isJobType, JOB_TYPE_LABELS } from "@app/types/job_type";
 import { isStringArray } from "@app/types/shared/utils/general";
@@ -22,6 +23,7 @@ Before providing a new use case for the user, you MUST acquire context to inform
 - Call \`get_workspace_activity\` to understand what the workspace has used in the last 30 days.
 - Call \`list_skills\` to see what skills are pinned or available.
 - Call \`list_recommendations\` to see what recommendations have already been shown to the user. Do not repeat recommendations the user has already executed or dismissed.
+- If a **Pod ID** is present in the context above, call \`list_conversations\` with \`includeMessages=true\` to scan the most recent Pod conversations. Use the message content to understand what the user has been working on inside this Pod — treat it as the strongest signal for what a relevant recommendation looks like.
 
 ## Guidelines
 
@@ -44,6 +46,7 @@ Prioritize recommendations that exploit Dust's core differentiators over generic
 ## Recommendation Requirements
 
 Every recommendation must meet the following requirements:
+- Its subject is the user's real domain work — the outputs and tasks of their actual job. Never recommend meta-work about Dust itself: analyzing their Dust usage, activation, onboarding, or "productivity/adoption" is never a valid recommendation, however much such activity dominates their usage data.
 - It replaces, shortens, or improves a task relevant to the user. It must be a tangible example of an activity that will improve the user's productivity.
 - It names actual tools, agents, skills, or usage patterns. Not a category ("automate your reporting") but an instance ("the pipeline summary you rebuild from HubSpot every week").
 - It is executable right now, in this conversation, with tools that are already connected. Never recommend connecting a new tool or data source — tool setup is an admin action outside the user's control. Only build on what is already available in the workspace context provided to you.
@@ -71,21 +74,34 @@ Every offer — new recommendations and post-execution conversion offers alike �
 1. Call \`create_recommendation\` with the recommendation text and your internal rationale.
 2. Using the \`recommendationId\` returned, render the card on its own line:
 
-::action_card[<short title, 3–6 words>]{sId=<recommendationId> subtitle="<context line>" description="<one sentence>" cta="<accept label>" dismiss="<reject label>" actionMessage="<message sent on accept>" dismissMessage="<message sent on dismiss>"}
+:::action_card{title="<short title, 3–6 words>" sId=<recommendationId> icon=<icon name> subtitle="<context line>" description="<one sentence>" cta="<accept label>" dismiss="<reject label>" actionMessage="<message sent on accept>" dismissMessage="<message sent on dismiss>" collapsibleLabel="<collapsible trigger label>"}
+<inline education — real markdown: bold, links, bullet lists>
+:::
 
-- \`[title]\`: short generic headline shown prominently (3–5 words), e.g. "Recommendation for you".
+This is a container directive: the opening \`:::action_card{...}\` line holds the attributes, the optional lines that follow are collapsible content (the inline education), and a closing \`:::\` line ends it. The collapsible content is rendered as real markdown, so put the explainer there — never in an attribute. Omit the collapsible lines if no education content is needed.
+
+- \`title\`: short generic headline shown prominently (3–5 words), e.g. "Recommendation for you".
+- \`icon\`: icon shown next to the card. Pick the one that matches the Dust concept behind the recommendation: \`ActionListCheckIcon\` (skill), \`ActionCalendarCheckIcon\` (trigger/schedule), \`ActionDashboardIcon\` (Frame/dashboard), \`ActionCloudArrowLeftRightIcon\` (connection), \`ActionRobotIcon\` (agent), \`ActionMailIcon\` (briefing/digest), \`ActionSparklesIcon\` (generic). Defaults to \`ActionRobotIcon\` if omitted.
 - \`subtitle\`: optional context line shown below the title. 3-5 word specific title for the recommendation: "Generate daily brief".
 - \`description\`: one sentence a stranger could visualize. Name what appears in the output, not what it "turns into".
 - \`cta\`: short accept button label, e.g. "Try it", "Save it", "Set it up". This is display-only.
 - \`dismiss\`: short reject button label, e.g. "Not now", "Not for me", "Already doing this". This is display-only.
 - \`actionMessage\`: message sent to you when the user clicks the accept button, e.g. "Yes, let's do it", "Go ahead". Defaults to "Accept" if omitted.
 - \`dismissMessage\`: message sent to you when the user clicks the dismiss button, e.g. "Not for me", "Skip this one". Defaults to "Dismiss" if omitted.
+- \`collapsibleLabel\`: label for the collapsible section. Required if collapsible content is included; omit otherwise. See "Inline education" below.
+- collapsible content (the lines between the attribute line and closing \`:::\`): optional inline education markdown. See "Inline education" below.
 
-Do NOT emit \`ask_question\` buttons when the message ends with an \`::action_card\` directive.
+Do NOT emit \`ask_question\` buttons when the message ends with an \`:::action_card\` directive.
 
 When the user responds to any card:
 - If they accept (the \`actionMessage\` arrives), call \`update_recommendation\` with \`status: "executed"\`, then proceed with execution.
 - If they decline (the \`dismissMessage\` arrives), call \`update_recommendation\` with \`status: "dismissed"\`. For a new recommendation, surface the next one. For a conversion card, follow the post-execution flow below.
+
+### Inline education
+
+Every recommendation card must carry a short, focused explainer that teaches the Dust concept behind the action — education rides along with every card, never as a separate flow.
+Use the **Dust Support** skill to generate content, including a Markdown-like description of the concept and a link to the relevant documentation page.
+Set \`collapsibleLabel\` to the specific concept name, not a generic phrase: "Learn more about Frames", "Learn more about triggers", "Learn more about Skills". The label tells the user exactly what they'll learn before they expand it.
 
 ## Executing
 
@@ -143,7 +159,8 @@ Never bundle these into one combined ask ("want me to save this as a skill and s
 
 async function buildActivationContext(
   auth: Authenticator,
-  spaceIds: string[]
+  spaceIds: string[],
+  agentLoopData?: AgentLoopExecutionData
 ): Promise<string> {
   const parts: string[] = [];
 
@@ -192,6 +209,13 @@ async function buildActivationContext(
     parts.push(buildToolsetsContext(availableToolsets));
   }
 
+  if (
+    agentLoopData?.conversation &&
+    isPodConversation(agentLoopData.conversation)
+  ) {
+    parts.push(`Pod ID: ${agentLoopData.conversation.spaceId}`);
+  }
+
   if (parts.length === 0) {
     return "";
   }
@@ -211,11 +235,14 @@ export const activationSkill = {
     "execute it, save it as a reusable skill, and set it up as a recurring schedule.",
   fetchInstructions: async (
     auth: Authenticator,
-    { spaceIds }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
+    {
+      spaceIds,
+      agentLoopData,
+    }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
   ): Promise<string> => {
     let context = "";
     try {
-      context = await buildActivationContext(auth, spaceIds);
+      context = await buildActivationContext(auth, spaceIds, agentLoopData);
     } catch (err) {
       logger.warn({ err }, "Failed to build activation context");
     }
@@ -230,6 +257,7 @@ export const activationSkill = {
     { name: "schedules_management" },
     { name: "files" },
     { name: "activation_recommendations" },
+    { name: "pod_manager" },
   ],
   version: 2,
   icon: "ActionRocketIcon",

--- a/front/types/shared/utils/markdown.ts
+++ b/front/types/shared/utils/markdown.ts
@@ -70,6 +70,18 @@ function replaceAgentSuggestions(text: string): string {
     .replaceAll(/:agent_suggestion\[\]\{([^}]*)\}/g, () => "Suggestion");
 }
 
+function replaceActionCards(text: string): string {
+  return text
+    .replaceAll(
+      /::action_card\[([^\]]*)\]\{([^}]*)\}/g,
+      (_full, label: string) => normalizeInlineLabel(label) || "Action"
+    )
+    .replaceAll(
+      /:action_card\[([^\]]*)\]\{([^}]*)\}/g,
+      (_full, label: string) => normalizeInlineLabel(label) || "Action"
+    );
+}
+
 function replaceVisualizationBlocks(text: string): string {
   return text.replaceAll(VISUALIZATION_BLOCK_REGEX, () => "Visualization\n\n");
 }
@@ -91,6 +103,7 @@ function replaceDustDirectives(text: string): string {
   out = replaceContentNodeMentions(out);
   out = replacePastedAttachments(out);
   out = replaceAgentSuggestions(out);
+  out = replaceActionCards(out);
   out = replaceMentionsWithAt(out);
   return out;
 }

--- a/front/types/shared/utils/markdown.ts
+++ b/front/types/shared/utils/markdown.ts
@@ -71,15 +71,16 @@ function replaceAgentSuggestions(text: string): string {
 }
 
 function replaceActionCards(text: string): string {
-  return text
-    .replaceAll(
-      /::action_card\[([^\]]*)\]\{([^}]*)\}/g,
-      (_full, label: string) => normalizeInlineLabel(label) || "Action"
-    )
-    .replaceAll(
-      /:action_card\[([^\]]*)\]\{([^}]*)\}/g,
-      (_full, label: string) => normalizeInlineLabel(label) || "Action"
-    );
+  return (
+    text
+      .replaceAll(
+        /:::action_card\{([^}]*)\}\s*\n[\s\S]*?\n:::\s*/g,
+        (_full, attrs: string) => {
+          const title = /title="([^"]*)"/.exec(attrs)?.[1] ?? "";
+          return normalizeInlineLabel(title) || "Action";
+        }
+      )
+  );
 }
 
 function replaceVisualizationBlocks(text: string): string {

--- a/front/types/shared/utils/markdown.ts
+++ b/front/types/shared/utils/markdown.ts
@@ -71,15 +71,12 @@ function replaceAgentSuggestions(text: string): string {
 }
 
 function replaceActionCards(text: string): string {
-  return (
-    text
-      .replaceAll(
-        /:::action_card\{([^}]*)\}\s*\n[\s\S]*?\n:::\s*/g,
-        (_full, attrs: string) => {
-          const title = /title="([^"]*)"/.exec(attrs)?.[1] ?? "";
-          return normalizeInlineLabel(title) || "Action";
-        }
-      )
+  return text.replaceAll(
+    /:::action_card\{([^}]*)\}\s*\n[\s\S]*?\n:::\s*/g,
+    (_full, attrs: string) => {
+      const title = /title="([^"]*)"/.exec(attrs)?.[1] ?? "";
+      return normalizeInlineLabel(title) || "Action";
+    }
   );
 }
 

--- a/sparkle/src/components/markdown/ActionCardBlock.tsx
+++ b/sparkle/src/components/markdown/ActionCardBlock.tsx
@@ -60,6 +60,22 @@ const descriptionVariants = cva("", {
   defaultVariants: { size: "default", status: "active" },
 });
 
+const subtitleVariants = cva("", {
+  variants: {
+    size: {
+      compact: "text-sm",
+      default: "text-base",
+    },
+    status: {
+      active: "text-foreground",
+      disabled: "text-faint",
+      accepted: "text-faint",
+      rejected: "text-faint",
+    },
+  },
+  defaultVariants: { size: "default", status: "active" },
+});
+
 type ActionButtonPosition = "header" | "footer";
 
 export interface ActionCardBlockProps {
@@ -70,6 +86,7 @@ export interface ActionCardBlockProps {
     | React.ReactElement<AvatarStackProps>;
 
   // Content
+  subtitle?: string;
   description?: React.ReactNode;
   collapsibleContent?: React.ReactElement;
   collapsibleLabel?: string;
@@ -95,6 +112,7 @@ export interface ActionCardBlockProps {
 export function ActionCardBlock({
   title,
   visual,
+  subtitle,
   description,
   collapsibleContent,
   collapsibleLabel,
@@ -129,6 +147,8 @@ export function ActionCardBlock({
       : title;
 
   const titleClasses = titleVariants({ size, status: state });
+
+  const subtitleClasses = subtitleVariants({ size, status: state });
 
   const descriptionClasses = descriptionVariants({ size, status: state });
 
@@ -186,12 +206,17 @@ export function ActionCardBlock({
       className={cn("flex-col", isCompact ? "gap-2" : "gap-3")}
     >
       {showHeader && (
-        <div className="flex min-h-6 flex-wrap items-center justify-between gap-2">
+        <div className="flex min-h-6 flex-wrap items-start justify-between gap-2">
           <div className="flex min-w-0 items-center gap-2">
             {resolvedVisual}
-            {resolvedTitle && (
-              <div className={titleClasses}>{resolvedTitle}</div>
-            )}
+            <div className="flex min-w-0 flex-col">
+              {resolvedTitle && (
+                <div className={titleClasses}>{resolvedTitle}</div>
+              )}
+              {!isResolved && subtitle && (
+                <div className={subtitleClasses}>{subtitle}</div>
+              )}
+            </div>
           </div>
           {showActionsInHeader && (
             <div className="ml-auto shrink-0">{actionButtons}</div>


### PR DESCRIPTION
## Summary
- Adding new generic "action card" that is a directive that wraps around our existing action sparkle component. This is for improved UX when delivering a recommendation. Can be reused for non-activation use cases.
- Prompt changes to improve quality of recommendations based on testing
- Adding collapsable "learning" section as part of recommenation card

## Testing
<img width="498" height="180" alt="Screenshot 2026-07-07 at 3 12 05 PM" src="https://github.com/user-attachments/assets/9908b991-3ca7-4dd7-ba4e-1fe2d687e20f" />
<img width="467" height="417" alt="Screenshot 2026-07-07 at 3 12 08 PM" src="https://github.com/user-attachments/assets/db124afa-b311-4073-9119-1855caf11359" />


## Risk

* Low - not customer facing yet

## Deploy

1. Deploy front