### PR TITLE
[front] fix: split write and admin access on skills

### DIFF
--- a/front-api/middlewares/with_skill.ts
+++ b/front-api/middlewares/with_skill.ts
@@ -4,9 +4,9 @@ import { apiError } from "@front-api/middlewares/utils";
 import { createMiddleware } from "hono/factory";
 
 /**
- * Fetches `SkillResource` named by `:sId`, enforces `canWrite`, and stashes
- * it on `ctx.var.skill`. Apply after `workspaceAuth` so `ctx.get("auth")` is
- * available.
+ * Fetches `SkillResource` named by `:sId`, enforces `canAdministrate`, and
+ * stashes it on `ctx.var.skill`. Apply after `workspaceAuth` so
+ * `ctx.get("auth")` is available.
  */
 export const withSkill = createMiddleware<SkillCtx>(async (ctx, next) => {
   const auth = ctx.get("auth");
@@ -23,7 +23,7 @@ export const withSkill = createMiddleware<SkillCtx>(async (ctx, next) => {
     });
   }
 
-  if (!skill.canWrite(auth)) {
+  if (!skill.canAdministrate(auth)) {
     return apiError(ctx, {
       status_code: 403,
       api_error: {

--- a/front-api/routes/w/[wId]/assistant/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/skills/[sId]/index.ts
@@ -4,7 +4,7 @@ import { withSkill } from "@front-api/middlewares/with_skill";
 import suggestions from "./suggestions";
 
 // Mounted under /api/w/:wId/assistant/skills/:sId. Resolves :sId into a
-// SkillResource and enforces canWrite; everything below this directory
+// SkillResource and enforces canAdministrate; everything below this directory
 // inherits the `skill` context variable.
 const app = skillApp();
 

--- a/front-api/routes/w/[wId]/assistant/skills/[sId]/suggestions.test.ts
+++ b/front-api/routes/w/[wId]/assistant/skills/[sId]/suggestions.test.ts
@@ -35,6 +35,28 @@ async function setup(options: { role?: MembershipRoleType } = {}) {
   return { workspace, auth, skill };
 }
 
+async function setupAdminWithOtherBuilderSkill() {
+  const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+
+  const skillOwner = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, skillOwner, {
+    role: "builder",
+  });
+  const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    skillOwner.sId,
+    workspace.sId
+  );
+  const skill = await SkillFactory.create(ownerAuth, {
+    name: "Other Builder Skill",
+  });
+  await ownerAuth.refresh();
+  const suggestion = await SkillSuggestionFactory.create(ownerAuth, skill, {
+    state: "pending",
+  });
+
+  return { workspace, skill, suggestion };
+}
+
 function patch(workspace: { sId: string }, sId: string, body: unknown) {
   return honoApp.request(
     `/api/w/${workspace.sId}/assistant/skills/${sId}/suggestions`,
@@ -254,6 +276,19 @@ describe("PATCH /api/w/:wId/assistant/skills/:sId/suggestions", () => {
     expect((await response.json()).suggestions[0].state).toBe("approved");
   });
 
+  it("admin can update suggestions for a skill they do not edit", async () => {
+    const { workspace, skill, suggestion } =
+      await setupAdminWithOtherBuilderSkill();
+
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: [suggestion.sId],
+      state: "approved",
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).suggestions[0].state).toBe("approved");
+  });
+
   it("returns 403 for non-editor of the skill", async () => {
     const { workspace } = await setup();
 
@@ -399,6 +434,18 @@ describe("GET /api/w/:wId/assistant/skills/:sId/suggestions", () => {
     const suggestion = await SkillSuggestionFactory.create(auth, skill, {
       state: "pending",
     });
+
+    const response = await get(workspace, skill.sId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.suggestions).toHaveLength(1);
+    expect(body.suggestions[0].sId).toBe(suggestion.sId);
+  });
+
+  it("returns suggestions to an admin for a skill they do not edit", async () => {
+    const { workspace, skill, suggestion } =
+      await setupAdminWithOtherBuilderSkill();
 
     const response = await get(workspace, skill.sId);
 

--- a/front-api/routes/w/[wId]/assistant/skills/[sId]/suggestions.ts
+++ b/front-api/routes/w/[wId]/assistant/skills/[sId]/suggestions.ts
@@ -17,7 +17,7 @@ import { validate } from "@front-api/middlewares/validator";
 
 // Mounted at /api/w/:wId/assistant/skills/:sId/suggestions.
 // The `skill` context variable is set by the parent skills/[sId]/index.ts
-// middleware, which also enforces canWrite.
+// middleware, which also enforces canAdministrate.
 const app = skillApp();
 
 /** @ignoreswagger */

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.ts
@@ -95,7 +95,7 @@ app.patch(
     }
     const { skill: skillRes, editorGroup } = loaded;
 
-    if (!skillRes.canWrite(auth)) {
+    if (!skillRes.canAdministrate(auth)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
@@ -137,10 +137,10 @@ app.patch(
       }
     }
 
-    // Check authorization for modifying group members
-    if (!editorGroup.canWrite(auth)) {
+    // Check authorization for modifying group members.
+    if (!editorGroup.canAdministrate(auth)) {
       return apiError(ctx, {
-        status_code: 401,
+        status_code: 403,
         api_error: {
           type: "workspace_auth_error",
           message: "You are not authorized to modify the skill editors group.",

--- a/front-api/routes/w/[wId]/skills/[sId]/history/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/history/index.test.ts
@@ -1,0 +1,62 @@
+import { Authenticator } from "@app/lib/auth";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function setupOtherBuilderSkill({
+  requestUserRole,
+}: {
+  requestUserRole: "admin" | "builder";
+}) {
+  const { workspace } = await createPrivateApiMockRequest({
+    role: requestUserRole,
+  });
+
+  const skillOwner = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, skillOwner, {
+    role: "builder",
+  });
+  const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    skillOwner.sId,
+    workspace.sId
+  );
+  const skill = await SkillFactory.create(skillOwnerAuth);
+
+  return { workspace, skill };
+}
+
+function get(workspace: { sId: string }, sId: string) {
+  return honoApp.request(`/api/w/${workspace.sId}/skills/${sId}/history`);
+}
+
+describe("GET /api/w/:wId/skills/:sId/history", () => {
+  it("allows a workspace admin to view history for a skill they do not edit", async () => {
+    const { workspace, skill } = await setupOtherBuilderSkill({
+      requestUserRole: "admin",
+    });
+
+    const response = await get(workspace, skill.sId);
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).history).toBeDefined();
+  });
+
+  it("returns 404 for a non-admin user who cannot administrate the skill", async () => {
+    const { workspace, skill } = await setupOtherBuilderSkill({
+      requestUserRole: "builder",
+    });
+
+    const response = await get(workspace, skill.sId);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "skill_not_found",
+        message: "The skill you're trying to access was not found.",
+      },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/skills/[sId]/history/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/history/index.ts
@@ -27,7 +27,7 @@ app.get(
     // Check that user has access to this skill.
     const skill = await SkillResource.fetchById(auth, sId);
 
-    if (!skill || !skill.canWrite(auth)) {
+    if (!skill) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {

--- a/front-api/routes/w/[wId]/skills/[sId]/history/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/history/index.ts
@@ -24,10 +24,10 @@ app.get(
     const auth = ctx.get("auth");
     const { sId } = ctx.req.valid("param");
 
-    // Check that user has access to this skill.
+    // Check that user can administrate this skill.
     const skill = await SkillResource.fetchById(auth, sId);
 
-    if (!skill) {
+    if (!skill || !skill.canAdministrate(auth)) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -992,9 +992,27 @@ describe("DELETE /api/w/:wId/skills/:sId", () => {
     expect(await response.json()).toEqual({
       error: {
         type: "app_auth_error",
-        message: "Only editors can delete this skill.",
+        message: "Only admins and editors can archive this skill.",
       },
     });
+  });
+
+  it("allows a workspace admin to archive a skill they do not edit", async () => {
+    const { workspace, requestUserAuth, skill } = await setupTest({
+      skillOwnerRole: "builder",
+      requestUserRole: "admin",
+    });
+
+    const response = await deleteSkill(workspace, skill.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+
+    const archivedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(archivedSkill?.status).toBe("archived");
   });
 
   it("should return 404 for non-existent skill", async () => {

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -404,13 +404,13 @@ app.delete(
     }
     const { skill } = loaded;
 
-    // Check if user can write.
-    if (!skill.canWrite(auth)) {
+    // Check if user can administrate.
+    if (!skill.canAdministrate(auth)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
           type: "app_auth_error",
-          message: "Only editors can delete this skill.",
+          message: "Only admins and editors can archive this skill.",
         },
       });
     }

--- a/front-api/routes/w/[wId]/skills/[sId]/reinforcement.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/reinforcement.test.ts
@@ -110,6 +110,22 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
     expect(updated?.agentFacingDescription).toBe(skill.agentFacingDescription);
   });
 
+  it("allows a workspace admin to update reinforcement for a skill they do not edit", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      skillOwnerRole: "builder",
+      requestUserRole: "admin",
+    });
+
+    const response = await patch(workspace, skill.sId, {
+      reinforcement: "off",
+    });
+
+    expect(response.status).toBe(200);
+
+    const updated = await SkillResource.fetchById(requestUserAuth, skill.sId);
+    expect(updated?.reinforcement).toBe("off");
+  });
+
   it("accepts each valid reinforcement mode", async () => {
     for (const mode of ["auto", "on", "off"] as const) {
       const { workspace, skill, requestUserAuth } = await setupTest({
@@ -140,7 +156,7 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
     expect(await response.json()).toEqual({
       error: {
         type: "app_auth_error",
-        message: "Only editors can modify this skill.",
+        message: "Only admins and editors can modify this skill.",
       },
     });
   });

--- a/front-api/routes/w/[wId]/skills/[sId]/reinforcement.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/reinforcement.ts
@@ -92,15 +92,15 @@ app.patch(
       });
     }
 
-    // Toggling reinforcement requires editor access; if the skill is locked,
-    // only admins can flip it.
+    // Toggling reinforcement requires skill administration access; if the
+    // skill is locked, only admins can flip it.
     if (reinforcement !== undefined) {
-      if (!skill.canWrite(auth)) {
+      if (!skill.canAdministrate(auth)) {
         return apiError(ctx, {
           status_code: 403,
           api_error: {
             type: "app_auth_error",
-            message: "Only editors can modify this skill.",
+            message: "Only admins and editors can modify this skill.",
           },
         });
       }

--- a/front-api/routes/w/[wId]/skills/[sId]/restore.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/restore.test.ts
@@ -7,23 +7,30 @@ import { UserFactory } from "@app/tests/utils/UserFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
-async function setupTest(options: { canWrite?: boolean } = {}) {
-  const canWrite = options.canWrite ?? true;
-
+async function setupTest(
+  options: {
+    requestUserRole?: "admin" | "builder" | "user";
+    skillOwnerRole?: "admin" | "builder";
+  } = {}
+) {
+  const requestUserRole = options.requestUserRole ?? "builder";
+  const skillOwnerRole = options.skillOwnerRole ?? requestUserRole;
   const { workspace, user } = await createPrivateApiMockRequest({
-    role: "builder",
+    role: requestUserRole,
     method: "POST",
   });
 
   let skillOwnerAuth: Authenticator;
-  if (canWrite) {
+  if (skillOwnerRole === requestUserRole) {
     skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
       workspace.sId
     );
   } else {
     const skillOwner = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, skillOwner, { role: "admin" });
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: skillOwnerRole,
+    });
     skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       skillOwner.sId,
       workspace.sId
@@ -44,8 +51,10 @@ function post(workspace: { sId: string }, sId: string) {
 }
 
 describe("POST /api/w/:wId/skills/:sId/restore", () => {
-  it("should return 200 and restore skill when user can write", async () => {
-    const { workspace, skill, auth } = await setupTest({ canWrite: true });
+  it("should return 200 and restore skill when user can administrate", async () => {
+    const { workspace, skill, auth } = await setupTest({
+      requestUserRole: "builder",
+    });
 
     const response = await post(workspace, skill.sId);
 
@@ -56,8 +65,26 @@ describe("POST /api/w/:wId/skills/:sId/restore", () => {
     expect(updatedSkill?.status).toBe("active");
   });
 
-  it("should return 403 when user cannot write", async () => {
-    const { workspace, skill } = await setupTest({ canWrite: false });
+  it("allows a workspace admin to restore a skill they do not edit", async () => {
+    const { workspace, skill, auth } = await setupTest({
+      requestUserRole: "admin",
+      skillOwnerRole: "builder",
+    });
+
+    const response = await post(workspace, skill.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+
+    const updatedSkill = await SkillResource.fetchById(auth, skill.sId);
+    expect(updatedSkill?.status).toBe("active");
+  });
+
+  it("should return 403 when user cannot administrate", async () => {
+    const { workspace, skill } = await setupTest({
+      requestUserRole: "builder",
+      skillOwnerRole: "admin",
+    });
 
     const response = await post(workspace, skill.sId);
 
@@ -65,13 +92,13 @@ describe("POST /api/w/:wId/skills/:sId/restore", () => {
     expect(await response.json()).toEqual({
       error: {
         type: "app_auth_error",
-        message: "Only editors can restore this skill.",
+        message: "Only admins and editors can restore this skill.",
       },
     });
   });
 
   it("should return 404 when skill does not exist", async () => {
-    const { workspace } = await setupTest({ canWrite: true });
+    const { workspace } = await setupTest();
 
     const response = await post(workspace, "non_existent_skill_id");
 

--- a/front-api/routes/w/[wId]/skills/[sId]/restore.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/restore.ts
@@ -33,12 +33,12 @@ app.post(
       });
     }
 
-    if (!skillResource.canWrite(auth)) {
+    if (!skillResource.canAdministrate(auth)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
           type: "app_auth_error",
-          message: "Only editors can restore this skill.",
+          message: "Only admins and editors can restore this skill.",
         },
       });
     }

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage.tsx
@@ -33,7 +33,7 @@ export function SkillInfoPage({
   onClose,
 }: SkillInfoPageProps) {
   const [selectedTab, setSelectedTab] = useState<SkillTabType>("info");
-  const showEditorsTabs = skill.canWrite;
+  const showEditorsTabs = skill.canAdministrate;
 
   return (
     <div className="flex h-full flex-col gap-4">

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -198,8 +198,8 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
         void router.push(getPodRoute(owner.sId, item.pod.sId));
         return;
       }
-      // Skills without write access have only one action (view details).
-      if (item.kind === "skill" && !item.skill.canWrite) {
+      // Skills without administration access have only one action (view details).
+      if (item.kind === "skill" && !item.skill.canAdministrate) {
         executeAction(item, "view_details");
       } else {
         setSelectedItem(item);

--- a/front/components/command_palette/CommandPaletteActionPhase.tsx
+++ b/front/components/command_palette/CommandPaletteActionPhase.tsx
@@ -39,7 +39,7 @@ function canEdit(item: ActionPhaseItem): boolean {
     case "agent":
       return item.agent.canEdit;
     case "skill":
-      return item.skill.canWrite;
+      return item.skill.canAdministrate;
   }
 }
 

--- a/front/components/pages/builder/skills/EditSkillPage.tsx
+++ b/front/components/pages/builder/skills/EditSkillPage.tsx
@@ -23,7 +23,7 @@ export function EditSkillPage() {
   const isNotFound =
     isSkillError ||
     (!isSkillLoading && !skill) ||
-    (skill && (!skill.canWrite || skill.status === "archived"));
+    (skill && (!skill.canAdministrate || skill.status === "archived"));
 
   if (isNotFound) {
     return <Custom404 />;

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -43,15 +43,13 @@ export function SkillDetailsButtonBar({
         }}
       />
       <div className="flex flex-row items-center gap-2 px-1.5">
-        {skill.canWrite && (
-          <Button
-            size="sm"
-            tooltip="Edit skill"
-            href={getSkillBuilderRoute(owner.sId, skill.sId)}
-            variant="outline"
-            icon={Edit04}
-          />
-        )}
+        <Button
+          size="sm"
+          tooltip="Edit skill"
+          href={getSkillBuilderRoute(owner.sId, skill.sId)}
+          variant="outline"
+          icon={Edit04}
+        />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button icon={DotsHorizontal} size="sm" variant="ghost" />

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -27,7 +27,7 @@ export function SkillDetailsButtonBar({
 }: SkillDetailsButtonBarProps) {
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
 
-  if (!skill.canWrite) {
+  if (!skill.canAdministrate) {
     return null;
   }
 
@@ -57,17 +57,15 @@ export function SkillDetailsButtonBar({
             <Button icon={DotsHorizontal} size="sm" variant="ghost" />
           </DropdownMenuTrigger>
           <DropdownMenuContent>
-            {skill.canWrite && (
-              <DropdownMenuItem
-                label="Archive"
-                icon={Trash01}
-                variant="warning"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setShowArchiveDialog(true);
-                }}
-              />
-            )}
+            <DropdownMenuItem
+              label="Archive"
+              icon={Trash01}
+              variant="warning"
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowArchiveDialog(true);
+              }}
+            />
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -190,7 +190,7 @@ const DescriptionSection = ({
             size="sm"
           >
             It is no longer active and cannot be used.
-            {skill.canWrite && (
+            {skill.canAdministrate && (
               <div className="mt-2">
                 <Button
                   variant="outline"

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -99,7 +99,7 @@ export function SkillDetailsSheetContent({
 }: SkillDetailsSheetContentProps) {
   const [selectedTab, setSelectedTab] = useState<"info" | "editors">("info");
 
-  const showEditorsTabs = skill.status !== "suggested" && skill.canWrite;
+  const showEditorsTabs = skill.status !== "suggested" && skill.canAdministrate;
 
   if (showEditorsTabs) {
     return (

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -217,7 +217,7 @@ export function SkillsTable({
                 {
                   label: "Archive",
                   icon: Trash01,
-                  disabled: !skill.canWrite,
+                  disabled: !skill.canAdministrate,
                   variant: "warning" as const,
                   onClick: (e: React.MouseEvent) => {
                     e.stopPropagation();

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -196,7 +196,7 @@ export function SkillsTable({
                 {
                   label: "Edit",
                   icon: Edit04,
-                  disabled: !skill.canWrite,
+                  disabled: !skill.canAdministrate,
                   onClick: (e: React.MouseEvent) => {
                     e.stopPropagation();
                     void router.push(

--- a/front/lib/api/analytics/agents_export.test.ts
+++ b/front/lib/api/analytics/agents_export.test.ts
@@ -7,6 +7,7 @@ import {
 import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -71,6 +72,25 @@ describe("fetchAgentExportRows", () => {
     const agent = await AgentConfigurationFactory.createTestAgent(authorAAuth, {
       name: "Multi-author agent",
     });
+
+    const editorGroupResult = await GroupResource.findEditorGroupForAgent(
+      authorAAuth,
+      agent
+    );
+    expect(editorGroupResult.isOk()).toBe(true);
+    if (editorGroupResult.isErr()) {
+      throw editorGroupResult.error;
+    }
+    const addAuthorBResult =
+      await editorGroupResult.value.dangerouslyAddMembers(authorAAuth, {
+        users: [authorB.toJSON()],
+      });
+    expect(addAuthorBResult.isOk()).toBe(true);
+    if (addAuthorBResult.isErr()) {
+      throw addAuthorBResult.error;
+    }
+    await authorBAuth.refresh();
+
     await AgentConfigurationFactory.updateTestAgent(authorBAuth, agent.sId);
 
     const result = await fetchAgentExportRows(

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -26,6 +26,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     requestedSpaceIds: [],
     tools: [],
     fileAttachments: [],
+    canAdministrate: true,
     canWrite: true,
     isDefault: false,
     ...overrides,

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -25,6 +25,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     requestedSpaceIds: [],
     tools: [],
     fileAttachments: [],
+    canAdministrate: true,
     canWrite: true,
     isDefault: false,
     ...overrides,

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2357,8 +2357,8 @@ export class GroupResource extends BaseResource<GroupModel> {
     return auth.canWrite(this.requestedPermissions());
   }
 
-  canAdmin(auth: Authenticator): boolean {
-    return auth.canAdmin(this.requestedPermissions());
+  canAdministrate(auth: Authenticator): boolean {
+    return auth.canAdministrate(this.requestedPermissions());
   }
 
   isSystem(): boolean {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2283,9 +2283,11 @@ export class GroupResource extends BaseResource<GroupModel> {
    * 2. Role-based: Workspace admins get read and write access
    *
    * For agent_editors and skill_editors groups, the permissions are:
-   * 1. Group-based: The group's members get read and write access
-   * 2. Role-based: Workspace admins get read and write access. All users can
+   * 1. Group-based: The group's members get full access
+   * 2. Role-based: Workspace admins get read and admin access. All users can
    *    read "agent_editors" and "skill_editors" groups.
+   *    Admin do not have write access, they can however add themselves to
+   *    groups to gain it.
    *
    * CAUTION: if / when editing, note that for role permissions, permissions are
    * NOT inherited, i.e., if you set a permission for role "user", an "admin"
@@ -2301,11 +2303,11 @@ export class GroupResource extends BaseResource<GroupModel> {
           groups: [
             {
               id: this.id,
-              permissions: ["read", "write"],
+              permissions: ["read", "write", "admin"],
             },
           ],
           roles: [
-            { role: "admin", permissions: ["read", "write", "admin"] },
+            { role: "admin", permissions: ["read", "admin"] },
             {
               role: "user",
               permissions: ["read"],

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2357,6 +2357,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     return auth.canWrite(this.requestedPermissions());
   }
 
+  canAdmin(auth: Authenticator): boolean {
+    return auth.canAdmin(this.requestedPermissions());
+  }
+
   isSystem(): boolean {
     return this.kind === "system";
   }

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1,4 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { SkillDataSourceConfigurationModel } from "@app/lib/models/skill";
@@ -17,6 +18,7 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -39,6 +41,27 @@ describe("SkillResource", () => {
       await config.destroy();
     }
     createdConfigurations.length = 0;
+  });
+
+  describe("permissions", () => {
+    it("allows builder API keys to administrate skills", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator);
+      const builderKey = await KeyFactory.regular(testContext.globalGroup);
+      const readOnlyKey = await KeyFactory.readOnly(testContext.globalGroup);
+
+      const builderAuth = (
+        await Authenticator.fromKey(builderKey, testContext.workspace.sId)
+      ).workspaceAuth;
+      const readOnlyAuth = (
+        await Authenticator.fromKey(readOnlyKey, testContext.workspace.sId)
+      ).workspaceAuth;
+
+      expect(skill.canWrite(builderAuth)).toBe(true);
+      expect(skill.canAdministrate(builderAuth)).toBe(true);
+
+      expect(skill.canWrite(readOnlyAuth)).toBe(false);
+      expect(skill.canAdministrate(readOnlyAuth)).toBe(false);
+    });
   });
 
   // Helper function to create real SkillDataSourceConfigurationModel instances

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1801,6 +1801,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   canAdministrate(auth: Authenticator): boolean {
+    // API keys with at least builder role can administrate any skill.
+    if (auth.isKey() && auth.isBuilder()) {
+      return true;
+    }
+
     if (!this.editorGroup) {
       return false;
     }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2087,7 +2087,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return new Ok(undefined);
     }
 
-    if (!this.canWrite(auth)) {
+    if (!this.canAdministrate(auth)) {
       return new Err(
         new Error("User is not authorized to update skill editors.")
       );
@@ -2422,7 +2422,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   async archive(auth: Authenticator): Promise<{ affectedCount: number }> {
-    assert(this.canWrite(auth), "User is not authorized to archive this skill");
+    assert(this.canAdministrate(auth), "User is not authorized to archive this skill");
 
     const workspace = auth.getNonNullableWorkspace();
 
@@ -2490,7 +2490,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   async restore(auth: Authenticator): Promise<{ affectedCount: number }> {
-    assert(this.canWrite(auth), "User is not authorized to restore this skill");
+    assert(this.canAdministrate(auth), "User is not authorized to restore this skill");
 
     const affectedCount = await withTransaction(async (transaction) => {
       const [count] = await this.update({ status: "active" }, transaction);
@@ -3143,7 +3143,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   async delete(auth: Authenticator): Promise<Result<number, Error>> {
     try {
       assert(
-        this.canWrite(auth),
+        this.canAdministrate(auth),
         "User does not have permission to delete this skill."
       );
 
@@ -3748,6 +3748,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         fileName: file.fileName,
       })),
       canWrite: this.canWrite(auth),
+      canAdministrate: this.canAdministrate(auth),
       isDefault: this.isDefault,
     };
   }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2422,7 +2422,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   async archive(auth: Authenticator): Promise<{ affectedCount: number }> {
-    assert(this.canAdministrate(auth), "User is not authorized to archive this skill");
+    assert(
+      this.canAdministrate(auth),
+      "User is not authorized to archive this skill"
+    );
 
     const workspace = auth.getNonNullableWorkspace();
 
@@ -2490,7 +2493,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   async restore(auth: Authenticator): Promise<{ affectedCount: number }> {
-    assert(this.canAdministrate(auth), "User is not authorized to restore this skill");
+    assert(
+      this.canAdministrate(auth),
+      "User is not authorized to restore this skill"
+    );
 
     const affectedCount = await withTransaction(async (transaction) => {
       const [count] = await this.update({ status: "active" }, transaction);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1800,6 +1800,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return this.editorGroup.canWrite(auth);
   }
 
+  canAdministrate(auth: Authenticator): boolean {
+    if (!this.editorGroup) {
+      return false;
+    }
+
+    return this.editorGroup.canAdministrate(auth);
+  }
+
   private async listActiveAgents(
     auth: Authenticator
   ): Promise<AgentConfigurationModel[]> {

--- a/front/lib/resources/skill_suggestion_resource.ts
+++ b/front/lib/resources/skill_suggestion_resource.ts
@@ -166,13 +166,14 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
       skillResources.map((s) => [s.id, s])
     );
 
-    // Filter suggestions to only include those for skills the user can edit.
+    // Filter suggestions to only include those for skills the user can
+    // administrate.
     const resources = removeNulls(
       suggestions.map((suggestion) => {
         const skillResource = skillResourceByModelId.get(
           suggestion.skillConfigurationId
         );
-        if (!skillResource || !skillResource.canWrite(auth)) {
+        if (!skillResource || !skillResource.canAdministrate(auth)) {
           return null;
         }
         const user = suggestion.updatedByUser;

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -89,6 +89,7 @@ function makeSkillType(config: MockSkillConfig): SkillType {
     })),
     fileAttachments: [],
     canWrite: false,
+    canAdministrate: false,
     isDefault: false,
   };
 }

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -45,7 +45,7 @@ export class SkillFactory {
     const attachedKnowledge = overrides.attachedKnowledge ?? [];
     const mcpServerViews = overrides.mcpServerViews ?? [];
 
-    return SkillResource.makeNew(
+    const skill = await SkillResource.makeNew(
       auth,
       {
         editedBy,
@@ -65,6 +65,10 @@ export class SkillFactory {
         attachedKnowledge,
       }
     );
+
+    await auth.refresh();
+
+    return skill;
   }
 
   static serializeSkillReferenceTag(

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -58,6 +58,7 @@ export const SkillWithoutInstructionsAndToolsSchema = z.object({
     })
   ),
   canWrite: z.boolean(),
+  canAdministrate: z.boolean(),
   isDefault: z.boolean(),
 });
 


### PR DESCRIPTION
## Description

Following up on the [following thread](https://dust4ai.slack.com/archives/C0B2L7PT56C/p1783337776146159).

This PR separates the concerns of admin rights and edit writes, currently merged into a single `canWrite` check.
Admins have the right to add themselves as editors (gated behind `canAdministrate`), but lose direct write access.
This does not change the behavior in Skill Builder, which additionally implemented this behavior client-side and forced users to add themselves as editors before making any change.

> [!NOTE]
>  This does change the behavior for the skill authoring tools, which now prevents admins to make change to any skill on the workspace.
> These tools intentionally do not allow editing editors lists, which remains a manual, very intentional action.

## Tests

- Tested locally.

## Risk

- Medium as it touches permissions, but technically should not get any user to get stuck as admins can always add themselves as editors.

## Deploy Plan

- Deploy front.
