### PR TITLE
feat(sandbox): pod egress policy backend [dedicated-file variant]

### DIFF
--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -106,13 +106,22 @@ async function runSuccessfulRootCommand(
   return new Ok(undefined);
 }
 
-export function mintEgressJwt(providerId: string, workspaceId: string): string {
+// spaceId is set for pod (Shared Computer) sandboxes so the proxy evaluates
+// the pod's space policy file (`pods/{spaceId}.json`) in addition to the
+// workspace and sandbox policies. Optional and back-compatible: proxy builds
+// that predate the claim ignore it.
+export function mintEgressJwt(
+  providerId: string,
+  workspaceId: string,
+  { spaceId }: { spaceId?: string } = {}
+): string {
   return jwt.sign(
     {
       iss: "dust-front",
       aud: "dust-egress-proxy",
       sbId: providerId,
       wId: workspaceId,
+      ...(spaceId ? { spaceId } : {}),
     },
     config.getEgressProxyJwtSecret(),
     {
@@ -124,11 +133,15 @@ export function mintEgressJwt(providerId: string, workspaceId: string): string {
 
 const INVALIDATION_JWT_TTL_SECONDS = 60;
 
+// The proxy derives the cache key to evict from the claims: exactly one of
+// workspaceId, spaceId, or sandboxId must be set.
 export function mintEgressInvalidationJwt({
   workspaceId,
+  spaceId,
   sandboxId,
 }: {
   workspaceId?: string;
+  spaceId?: string;
   sandboxId?: string;
 }): string {
   return jwt.sign(
@@ -137,6 +150,7 @@ export function mintEgressInvalidationJwt({
       aud: "dust-egress-proxy",
       action: "invalidate-policy",
       ...(workspaceId ? { wId: workspaceId } : {}),
+      ...(spaceId ? { spaceId } : {}),
       ...(sandboxId ? { sbId: sandboxId } : {}),
     },
     config.getEgressProxyJwtSecret(),
@@ -507,7 +521,10 @@ export async function setupEgressForwarder(
 
   const token = mintEgressJwt(
     sandbox.providerId,
-    auth.getNonNullableWorkspace().sId
+    auth.getNonNullableWorkspace().sId,
+    // Pod sandboxes carry the pod's space sId so the proxy evaluates the
+    // pod-level policy file on top of the workspace/sandbox ones.
+    { spaceId: runtimeOwner.kind === "pod" ? runtimeOwner.spaceId : undefined }
   );
 
   // Token, secrets, and manifest are written in order, each gated on the

--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -39,11 +39,14 @@ vi.mock("@app/lib/file_storage", () => ({
 
 import {
   addSandboxPolicyDomain,
+  deletePodSpacePolicy,
   deleteSandboxPolicy,
   deleteWorkspacePolicy,
   parseExactEgressDomain,
+  readPodSpacePolicy,
   readSandboxPolicy,
   readWorkspacePolicy,
+  writePodSpacePolicy,
   writeWorkspacePolicy,
 } from "./egress_policy";
 
@@ -316,5 +319,117 @@ describe("sandbox egress policy storage", () => {
     );
     expect(parseExactEgressDomain("127.0.0.1").isErr()).toBe(true);
     expect(parseExactEgressDomain("*.github.com").isErr()).toBe(true);
+  });
+});
+
+describe("pod space egress policy storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGetEgressPolicyBucket.mockReturnValue("egress-policy-bucket");
+    mockGetEgressProxyInternalUrl.mockReturnValue("https://egress-proxy");
+    mockMintEgressInvalidationJwt.mockReturnValue("invalidation-token");
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetchFileContent.mockResolvedValue(
+      JSON.stringify({ allowedDomains: ["API.GitHub.COM"] })
+    );
+    mockUploadRawContentToBucket.mockResolvedValue(undefined);
+    mockDelete.mockResolvedValue(undefined);
+    mockGetBucketInstance.mockReturnValue({
+      delete: mockDelete,
+      fetchFileContent: mockFetchFileContent,
+      uploadRawContentToBucket: mockUploadRawContentToBucket,
+    });
+  });
+
+  it("reads pod policy files from the pods prefix", async () => {
+    const result = await readPodSpacePolicy("space-sid");
+
+    expect(result).toEqual(
+      new Ok({
+        allowedDomains: ["api.github.com"],
+      })
+    );
+    expect(mockFetchFileContent).toHaveBeenCalledWith("pods/space-sid.json");
+  });
+
+  it("returns an empty policy when the pod policy file is missing", async () => {
+    mockFetchFileContent.mockRejectedValue({ code: 404 });
+
+    const result = await readPodSpacePolicy("space-sid");
+
+    expect(result).toEqual(new Ok({ allowedDomains: [] }));
+  });
+
+  it("writes normalized pod policy files and supports wildcards", async () => {
+    const result = await writePodSpacePolicy("space-sid", {
+      policy: {
+        allowedDomains: ["API.GitHub.COM", "*.GitHub.COM"],
+      },
+    });
+
+    expect(result).toEqual(
+      new Ok({
+        allowedDomains: ["api.github.com", "*.github.com"],
+      })
+    );
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
+      content: JSON.stringify({
+        allowedDomains: ["api.github.com", "*.github.com"],
+      }),
+      contentType: "application/json",
+      filePath: "pods/space-sid.json",
+    });
+  });
+
+  it("does not write invalid pod domain entries", async () => {
+    const result = await writePodSpacePolicy("space-sid", {
+      policy: {
+        allowedDomains: ["127.0.0.1"],
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the pod policy cache by spaceId after writes", async () => {
+    await writePodSpacePolicy("space-sid", {
+      policy: { allowedDomains: ["example.org"] },
+    });
+
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://egress-proxy/invalidate-policy",
+        expect.objectContaining({
+          headers: {
+            Authorization: "Bearer invalidation-token",
+          },
+          method: "POST",
+        })
+      );
+    });
+    expect(mockMintEgressInvalidationJwt).toHaveBeenCalledWith({
+      spaceId: "space-sid",
+    });
+  });
+
+  it("deletes pod policy files and ignores missing objects", async () => {
+    const result = await deletePodSpacePolicy("space-sid");
+
+    expect(result).toEqual(new Ok(undefined));
+    expect(mockDelete).toHaveBeenCalledWith("pods/space-sid.json", {
+      ignoreNotFound: true,
+    });
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://egress-proxy/invalidate-policy",
+        expect.anything()
+      );
+    });
+    expect(mockMintEgressInvalidationJwt).toHaveBeenCalledWith({
+      spaceId: "space-sid",
+    });
   });
 });

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -199,6 +199,118 @@ export async function deleteSandboxPolicy(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Pod space egress policy
+//
+// A Pod's egress allowlist is a space-keyed policy file
+// (`pods/{spaceSId}.json`) that the egress proxy reads directly and unions
+// with the workspace and sandbox policies. GCS-only, exactly like the
+// workspace policy above: the file is the store, there is no DB record.
+// Because it is keyed by the pod's stable space sId (not the ephemeral
+// sandbox providerId), it survives sandbox destroy/recreate cycles and
+// nothing is written at sandbox activation.
+// ---------------------------------------------------------------------------
+
+function getPodSpacePolicyPath(spaceId: string): string {
+  return `pods/${spaceId}.json`;
+}
+
+export async function readPodSpacePolicy(
+  spaceId: string
+): Promise<Result<EgressPolicy, Error>> {
+  try {
+    const content = await getPolicyBucket().fetchFileContent(
+      getPodSpacePolicyPath(spaceId)
+    );
+    const parsed = parseEgressPolicy(JSON.parse(content));
+
+    if (parsed.isErr()) {
+      return parsed;
+    }
+
+    return new Ok(parsed.value);
+  } catch (error) {
+    if (isGCSNotFoundError(error)) {
+      return new Ok(EMPTY_EGRESS_POLICY);
+    }
+
+    return new Err(normalizeError(error));
+  }
+}
+
+export async function writePodSpacePolicy(
+  spaceId: string,
+  { policy }: { policy: EgressPolicy }
+): Promise<Result<EgressPolicy, Error>> {
+  const normalizedPolicy = normalizeEgressPolicy(policy);
+
+  if (normalizedPolicy.isErr()) {
+    return normalizedPolicy;
+  }
+
+  try {
+    await getPolicyBucket().uploadRawContentToBucket({
+      content: JSON.stringify(normalizedPolicy.value),
+      contentType: "application/json",
+      filePath: getPodSpacePolicyPath(spaceId),
+    });
+
+    void invalidatePodPolicyCache(spaceId);
+
+    return new Ok(normalizedPolicy.value);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+export async function deletePodSpacePolicy(
+  spaceId: string
+): Promise<Result<void, Error>> {
+  try {
+    await getPolicyBucket().delete(getPodSpacePolicyPath(spaceId), {
+      ignoreNotFound: true,
+    });
+
+    void invalidatePodPolicyCache(spaceId);
+
+    return new Ok(undefined);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+async function invalidatePodPolicyCache(spaceId: string): Promise<void> {
+  try {
+    const baseUrl = config.getEgressProxyInternalUrl();
+    if (!baseUrl) {
+      return;
+    }
+
+    const token = mintEgressInvalidationJwt({ spaceId });
+    const url = `${baseUrl.replace(/\/+$/, "")}/invalidate-policy`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      signal: AbortSignal.timeout(INVALIDATION_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      logger.warn(
+        { statusCode: response.status, spaceId },
+        "Egress proxy cache invalidation failed"
+      );
+    }
+  } catch (error) {
+    logger.warn(
+      { error: normalizeError(error), spaceId },
+      "Egress proxy cache invalidation error"
+    );
+  }
+}
+
 async function invalidateWorkspacePolicyCache(
   auth: Authenticator
 ): Promise<void> {


### PR DESCRIPTION
> **Superseded** by the owner-keyed egress policy re-layout stack (`egress-relayout-*` branches, PRs `28652`–`28655`). Branch kept for reference.

## Pod egress allowlist — backend (GCS-only, workspace mirror)

**DEDICATED-FILE variant.** The pod section in `egress_policy.ts` is a verbatim mirror of the workspace trio, keyed by the pod's space sId:

- `readPodSpacePolicy` / `writePodSpacePolicy` / `deletePodSpacePolicy` on `pods/{spaceSId}.json` — same normalization (wildcards supported), same missing-file-is-empty semantics, same shapes (`write(key, { policy })`), cache invalidation keyed by spaceId. Like `writeWorkspacePolicy`, there is **no domain-count cap** (the projection variant's 100-cap protected the shared per-sandbox file; that constraint doesn't exist here).
- `mintEgressJwt` gains an optional `spaceId` claim (set for pod sandboxes via the runtime owner in `setupEgressForwarder`); `mintEgressInvalidationJwt` gains the matching invalidation key. Back-compatible with older proxy builds.

The space-keyed file survives sandbox destroy/recreate and sleep/wake: **no per-activation projection, no wake rewrite, zero sandbox-adapter changes** — total front diff is 3 files.

> [!NOTE]
> Mirroring the workspace policy exactly means inheriting its gaps knowingly: no file scrub on space deletion (the workspace file has none on workspace deletion either) and no relocation handling. Stale files are inert — space sIds are never reused and no sandbox carries the claim after deletion.

### Stack (DEDICATED-FILE variant, GCS-only)

Alternative implementation of pod-level egress allowlists that mirrors the workspace egress policy mechanism **exactly** — GCS-only, the policy file is the store, no DB record. Built for side-by-side comparison with the PROJECTION stack (#28352 → #28512 → #28513 → #28514 → #28515). **Do not merge both.**

1. #28544 — egress-proxy: pod space policy file (deploys first)
2. #28650 — backend: GCS trio + spaceId JWT claim
3. #28547 — admin API (route mirrors the workspace route; contract identical to projection variant)
4. #28548 — audit (emit in route, like the workspace route)
5. #28549 — settings UI (byte-identical to projection variant)

_(#28545, a dedicated DB table, was dropped in favor of exact workspace mimicry; #28546 was auto-closed with it and replaced by #28650.)_

### Risk

Worst case, the pod file is missing → fail-closed to the workspace allowlist. Requires #28544 deployed first.