### PR TITLE
[front] move logger for unsupported file type 

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -414,6 +414,19 @@ export async function processToolResults(
                 file: null,
               };
             }
+
+            localLogger.info(
+              {
+                mimeType: block.resource.mimeType ?? null,
+                toolName: toolConfiguration.name,
+                serverName: toolConfiguration.mcpServerName,
+                blobBytes: isBlobResource(block)
+                  ? Buffer.byteLength(block.resource.blob, "utf8")
+                  : 0,
+              },
+              "MCP tool returned an embedded resource with an unsupported or missing mimeType; storing it inline in the conversation."
+            );
+
             return {
               content: {
                 type: block.type,

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -377,16 +377,6 @@ export async function processToolResults(
               file: fileUpsertResult.value,
             };
           } else {
-            localLogger.info(
-              {
-                workspaceId: auth.getNonNullableWorkspace().sId,
-                mimeType: block.resource.mimeType ?? null,
-                toolName: toolConfiguration.name,
-                serverName: toolConfiguration.mcpServerName,
-              },
-              "MCP tool returned an unsupported file type; embedding resource as tool output."
-            );
-
             const text =
               "text" in block.resource &&
               typeof block.resource.text === "string"


### PR DESCRIPTION
## Description
This PR is to change the logger position I added in [this PR](https://github.com/dust-tt/dust/pull/28561). Inside the `processToolResults`, we first run `persistToolOutput` and this offload text block (except "conversation_files",  "files", "interactive_content", "sandbox" tools, iiuc they are capped somewhere) so we don't need to log them. I moved it to after `(res.value !== null) ` check, null equals persistToolOutput doesn't do anything (which I find it a bit weird but ok) 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
