### PR TITLE
feat(sandbox): cut front over to owner-keyed egress policy layout

### DIFF
--- a/front/admin/audit_log_schemas/sandbox_egress_policy.sandbox_updated.json
+++ b/front/admin/audit_log_schemas/sandbox_egress_policy.sandbox_updated.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "sandbox_provider_id": "string",
+    "conversation_id": "string",
     "domain": "string",
     "added": "string",
     "reason": "string",

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -6,7 +6,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  mockAddSandboxPolicyDomain,
+  mockAddOwnerPolicyDomain,
   mockReadNewDenyLogEntries,
   mockEmitAuditLogEvent,
   mockGenerateExecId,
@@ -21,7 +21,7 @@ const {
   mockLoggerWarn,
   mockFetchActionById,
 } = vi.hoisted(() => ({
-  mockAddSandboxPolicyDomain: vi.fn(),
+  mockAddOwnerPolicyDomain: vi.fn(),
   mockReadNewDenyLogEntries: vi.fn(),
   mockEmitAuditLogEvent: vi.fn(),
   mockGenerateExecId: vi.fn(),
@@ -54,7 +54,7 @@ vi.mock("@app/lib/api/sandbox/egress_policy", async (importOriginal) => {
 
   return {
     ...actual,
-    addSandboxPolicyDomain: mockAddSandboxPolicyDomain,
+    addOwnerPolicyDomain: mockAddOwnerPolicyDomain,
   };
 });
 
@@ -762,7 +762,7 @@ describe("addEgressDomainTool", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAddSandboxPolicyDomain.mockResolvedValue(
+    mockAddOwnerPolicyDomain.mockResolvedValue(
       new Ok({
         addedDomain: "example.org",
         policy: { allowedDomains: ["example.org"] },
@@ -809,7 +809,7 @@ describe("addEgressDomainTool", () => {
       );
     }
     expect(mockEnsureSandboxReady).not.toHaveBeenCalled();
-    expect(mockAddSandboxPolicyDomain).not.toHaveBeenCalled();
+    expect(mockAddOwnerPolicyDomain).not.toHaveBeenCalled();
   });
 
   it("adds the domain to the active sandbox policy and emits an audit event", async () => {
@@ -834,9 +834,9 @@ describe("addEgressDomainTool", () => {
       expect.anything(),
       expect.objectContaining({ sId: "conversation-id" })
     );
-    expect(mockAddSandboxPolicyDomain).toHaveBeenCalledWith(expect.anything(), {
+    expect(mockAddOwnerPolicyDomain).toHaveBeenCalledWith(expect.anything(), {
       domain: "example.org",
-      sandboxProviderId: "provider-id",
+      ownerId: "conversation-id",
     });
     expect(mockEmitAuditLogEvent).toHaveBeenCalledWith({
       auth: expect.anything(),
@@ -852,6 +852,7 @@ describe("addEgressDomainTool", () => {
       metadata: {
         added: "true",
         domain: "example.org",
+        conversation_id: "conversation-id",
         reason: "Install package dependencies.",
         sandbox_provider_id: "provider-id",
       },
@@ -871,7 +872,7 @@ describe("addEgressDomainTool", () => {
         freshlyCreated: false,
       })
     );
-    mockAddSandboxPolicyDomain.mockResolvedValue(
+    mockAddOwnerPolicyDomain.mockResolvedValue(
       new Ok({
         addedDomain: null,
         policy: { allowedDomains: ["example.org"] },
@@ -920,7 +921,7 @@ describe("addEgressDomainTool", () => {
     );
 
     expect(result.isErr()).toBe(true);
-    expect(mockAddSandboxPolicyDomain).not.toHaveBeenCalled();
+    expect(mockAddOwnerPolicyDomain).not.toHaveBeenCalled();
     expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
   });
 
@@ -938,7 +939,7 @@ describe("addEgressDomainTool", () => {
     );
 
     expect(result.isErr()).toBe(true);
-    expect(mockAddSandboxPolicyDomain).not.toHaveBeenCalled();
+    expect(mockAddOwnerPolicyDomain).not.toHaveBeenCalled();
   });
 
   it("surfaces sandbox policy helper errors", async () => {
@@ -951,7 +952,7 @@ describe("addEgressDomainTool", () => {
         freshlyCreated: false,
       })
     );
-    mockAddSandboxPolicyDomain.mockResolvedValue(
+    mockAddOwnerPolicyDomain.mockResolvedValue(
       new Err(new Error("Sandbox egress policy cannot exceed 100 domains."))
     );
 

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -29,7 +29,7 @@ import {
 } from "@app/lib/api/sandbox/access_tokens";
 import { readNewDenyLogEntries } from "@app/lib/api/sandbox/egress";
 import {
-  addSandboxPolicyDomain,
+  addOwnerPolicyDomain,
   parseExactEgressDomain,
 } from "@app/lib/api/sandbox/egress_policy";
 import {
@@ -498,10 +498,9 @@ export async function addEgressDomainTool(
     );
   }
 
-  const ensureResult = await ensureConversationSandboxReady(
-    auth,
-    runContext.conversation
-  );
+  const { conversation } = runContext;
+
+  const ensureResult = await ensureConversationSandboxReady(auth, conversation);
   if (ensureResult.isErr()) {
     return new Err(new MCPError(ensureResult.error.message));
   }
@@ -512,8 +511,10 @@ export async function addEgressDomainTool(
     return new Err(new MCPError(parsed.error.message));
   }
 
-  const result = await addSandboxPolicyDomain(auth, {
-    sandboxProviderId: sandbox.providerId,
+  // Keyed by the conversation: approvals persist for the conversation's
+  // lifetime, across sandbox destroy/recreate cycles.
+  const result = await addOwnerPolicyDomain(auth, {
+    ownerId: conversation.sId,
     domain: parsed.value,
   });
   if (result.isErr()) {
@@ -533,6 +534,9 @@ export async function addEgressDomainTool(
     ],
     metadata: {
       sandbox_provider_id: sandbox.providerId,
+      // The approval's durable scope: policies are owner-keyed, so the
+      // conversation outlives any individual sandbox.
+      conversation_id: conversation.sId,
       domain: parsed.value,
       added: String(result.value.addedDomain !== null),
       reason,
@@ -542,10 +546,10 @@ export async function addEgressDomainTool(
   const text =
     result.value.addedDomain !== null
       ? `Allowed: ${result.value.addedDomain}\n` +
-        "The change is in effect for the current sandbox only and applies to " +
-        "subsequent commands in this conversation."
+        "The change applies to this conversation and persists across " +
+        "sandbox restarts."
       : `Already allowed: ${parsed.value}\n` +
-        "No change made; this domain was already in the sandbox's allowlist.";
+        "No change made; this domain was already in the conversation's allowlist.";
 
   return new Ok([{ type: "text" as const, text }]);
 }

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,4 +1,5 @@
 import { hardDeleteDataSource } from "@app/lib/api/data_sources";
+import { deleteOwnerPolicy } from "@app/lib/api/sandbox/egress_policy";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import {
@@ -28,6 +29,7 @@ import {
   ProjectTaskSourceModel,
 } from "@app/lib/resources/storage/models/project_task";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -184,6 +186,20 @@ export async function destroyConversation(
   }
 ): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
+
+  // Best-effort scrub of the conversation's sandbox egress allowlist file
+  // (owner-keyed, so it is not deleted with individual sandboxes). A failure
+  // logs but does not block the destroy.
+  const deleteOwnerPolicyRes = await deleteOwnerPolicy(auth, conversation.sId);
+  if (deleteOwnerPolicyRes.isErr()) {
+    logger.warn(
+      {
+        err: deleteOwnerPolicyRes.error,
+        conversationId: conversation.sId,
+      },
+      "Failed to delete conversation egress policy file on destroy."
+    );
+  }
 
   await ConversationForkResource.deleteForConversationModelId(auth, {
     conversationModelId: conversation.id,

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -53,7 +53,7 @@
   "project.joined": 3,
   "project.left": 3,
   "sandbox_egress_policy.agent_requests_setting_updated": 1,
-  "sandbox_egress_policy.sandbox_updated": 1,
+  "sandbox_egress_policy.sandbox_updated": 2,
   "sandbox_egress_policy.updated": 1,
   "sandbox_env_var.allowed_domains_updated": 1,
   "sandbox_env_var.created": 1,

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -159,8 +159,12 @@ describe("sandbox egress helpers", () => {
     });
   }
 
-  it("mints a proxy JWT bound to the provider sandbox id", () => {
-    const token = mintEgressJwt("provider-sandbox-id", "workspace-id");
+  it("mints a proxy JWT bound to the provider sandbox id and owner", () => {
+    const token = mintEgressJwt({
+      providerId: "provider-sandbox-id",
+      workspaceId: "workspace-id",
+      ownerId: "owner-id",
+    });
     const payload = jwt.verify(token, "egress-secret", {
       algorithms: ["HS256"],
       audience: "dust-egress-proxy",
@@ -169,6 +173,7 @@ describe("sandbox egress helpers", () => {
 
     expect(payload.sbId).toBe("provider-sandbox-id");
     expect(payload.wId).toBe("workspace-id");
+    expect(payload.ownerId).toBe("owner-id");
     expect(payload.exp).toBeGreaterThan(payload.iat ?? 0);
   });
 

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -22,6 +22,7 @@ import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import { isDevelopment } from "@app/types/shared/env";
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import jwt from "jsonwebtoken";
 import { z } from "zod";
@@ -106,13 +107,28 @@ async function runSuccessfulRootCommand(
   return new Ok(undefined);
 }
 
-export function mintEgressJwt(providerId: string, workspaceId: string): string {
+// ownerId is the sandbox owner's stable sId (conversation sId for
+// conversation sandboxes, space sId for pod sandboxes); it selects the owner
+// policy file `w/{wId}/sandboxes/{ownerId}.json`. sbId stays for identity and
+// log tracing. Older proxy builds ignore the ownerId claim. Object params on
+// purpose: the values are look-alike sIds and transposed positional args
+// would compile fine and fail silently.
+export function mintEgressJwt({
+  providerId,
+  workspaceId,
+  ownerId,
+}: {
+  providerId: string;
+  workspaceId: string;
+  ownerId: string;
+}): string {
   return jwt.sign(
     {
       iss: "dust-front",
       aud: "dust-egress-proxy",
       sbId: providerId,
       wId: workspaceId,
+      ownerId,
     },
     config.getEgressProxyJwtSecret(),
     {
@@ -124,20 +140,24 @@ export function mintEgressJwt(providerId: string, workspaceId: string): string {
 
 const INVALIDATION_JWT_TTL_SECONDS = 60;
 
+// The proxy derives the cache keys to evict from the claims: workspaceId
+// alone evicts the workspace policy (both layouts during the migration
+// window); workspaceId + ownerId evicts the owner policy. workspaceId is
+// required so the proxy-rejected `ownerId`-only shape is unrepresentable.
 export function mintEgressInvalidationJwt({
   workspaceId,
-  sandboxId,
+  ownerId,
 }: {
-  workspaceId?: string;
-  sandboxId?: string;
+  workspaceId: string;
+  ownerId?: string;
 }): string {
   return jwt.sign(
     {
       iss: "dust-front",
       aud: "dust-egress-proxy",
       action: "invalidate-policy",
-      ...(workspaceId ? { wId: workspaceId } : {}),
-      ...(sandboxId ? { sbId: sandboxId } : {}),
+      wId: workspaceId,
+      ...(ownerId ? { ownerId } : {}),
     },
     config.getEgressProxyJwtSecret(),
     {
@@ -505,10 +525,23 @@ export async function setupEgressForwarder(
     return new Err(normalizeError(error));
   }
 
-  const token = mintEgressJwt(
-    sandbox.providerId,
-    auth.getNonNullableWorkspace().sId
-  );
+  let ownerId: string;
+  switch (runtimeOwner.kind) {
+    case "pod":
+      ownerId = runtimeOwner.spaceId;
+      break;
+    case "conversation":
+      ownerId = runtimeOwner.conversationId;
+      break;
+    default:
+      assertNever(runtimeOwner);
+  }
+
+  const token = mintEgressJwt({
+    providerId: sandbox.providerId,
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    ownerId,
+  });
 
   // Token, secrets, and manifest are written in order, each gated on the
   // previous succeeding, mirroring the original sequential flow exactly: any

--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -38,11 +38,12 @@ vi.mock("@app/lib/file_storage", () => ({
 }));
 
 import {
-  addSandboxPolicyDomain,
-  deleteSandboxPolicy,
+  addOwnerPolicyDomain,
+  deleteLegacySandboxPolicy,
+  deleteOwnerPolicy,
   deleteWorkspacePolicy,
   parseExactEgressDomain,
-  readSandboxPolicy,
+  readOwnerPolicy,
   readWorkspacePolicy,
   writeWorkspacePolicy,
 } from "./egress_policy";
@@ -51,50 +52,90 @@ const mockAuth = {
   getNonNullableWorkspace: () => ({ sId: "workspace-sid" }),
 } as unknown as Authenticator;
 
+const WORKSPACE_PATH = "w/workspace-sid/sandbox-egress-policy.json";
+const LEGACY_WORKSPACE_PATH = "workspaces/workspace-sid.json";
+const OWNER_PATH = "w/workspace-sid/sandboxes/owner-sid.json";
+
+const NOT_FOUND = { code: 404 };
+
+function setupBucketMocks() {
+  mockGetEgressPolicyBucket.mockReturnValue("egress-policy-bucket");
+  mockGetEgressProxyInternalUrl.mockReturnValue("https://egress-proxy");
+  mockMintEgressInvalidationJwt.mockReturnValue("invalidation-token");
+  mockFetch.mockResolvedValue({ ok: true, status: 200 });
+  vi.stubGlobal("fetch", mockFetch);
+  mockUploadRawContentToBucket.mockResolvedValue(undefined);
+  mockDelete.mockResolvedValue(undefined);
+  mockGetBucketInstance.mockReturnValue({
+    delete: mockDelete,
+    fetchFileContent: mockFetchFileContent,
+    uploadRawContentToBucket: mockUploadRawContentToBucket,
+  });
+}
+
+// Path-aware GCS stub: absent paths reject like GCS 404s.
+function setGcsObjects(objects: Record<string, { allowedDomains: string[] }>) {
+  mockFetchFileContent.mockImplementation(async (filePath: string) => {
+    const policy = objects[filePath];
+    if (!policy) {
+      throw NOT_FOUND;
+    }
+    return JSON.stringify(policy);
+  });
+}
+
 describe("workspace egress policy storage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-
-    mockGetEgressPolicyBucket.mockReturnValue("egress-policy-bucket");
-    mockGetEgressProxyInternalUrl.mockReturnValue("https://egress-proxy");
-    mockMintEgressInvalidationJwt.mockReturnValue("invalidation-token");
-    mockFetch.mockResolvedValue({ ok: true, status: 200 });
-    vi.stubGlobal("fetch", mockFetch);
-    mockFetchFileContent.mockResolvedValue(
-      JSON.stringify({ allowedDomains: ["API.GitHub.COM"] })
-    );
-    mockUploadRawContentToBucket.mockResolvedValue(undefined);
-    mockDelete.mockResolvedValue(undefined);
-    mockGetBucketInstance.mockReturnValue({
-      delete: mockDelete,
-      fetchFileContent: mockFetchFileContent,
-      uploadRawContentToBucket: mockUploadRawContentToBucket,
-    });
+    setupBucketMocks();
   });
 
-  it("reads workspace policy files from the workspace prefix", async () => {
+  it("reads the workspace policy from the new layout", async () => {
+    setGcsObjects({
+      [WORKSPACE_PATH]: { allowedDomains: ["API.GitHub.COM"] },
+    });
+
     const result = await readWorkspacePolicy(mockAuth);
 
-    expect(result).toEqual(
-      new Ok({
-        allowedDomains: ["api.github.com"],
-      })
-    );
-    expect(mockGetBucketInstance).toHaveBeenCalledWith("egress-policy-bucket");
-    expect(mockFetchFileContent).toHaveBeenCalledWith(
-      "workspaces/workspace-sid.json"
+    expect(result).toEqual(new Ok({ allowedDomains: ["api.github.com"] }));
+    expect(mockFetchFileContent).toHaveBeenCalledWith(WORKSPACE_PATH);
+  });
+
+  it("falls back to the legacy path when the new object is absent", async () => {
+    setGcsObjects({
+      [LEGACY_WORKSPACE_PATH]: { allowedDomains: ["legacy.example.com"] },
+    });
+
+    const result = await readWorkspacePolicy(mockAuth);
+
+    expect(result).toEqual(new Ok({ allowedDomains: ["legacy.example.com"] }));
+    expect(mockFetchFileContent).toHaveBeenCalledWith(WORKSPACE_PATH);
+    expect(mockFetchFileContent).toHaveBeenCalledWith(LEGACY_WORKSPACE_PATH);
+  });
+
+  it("prefers the new layout over the legacy path when both exist", async () => {
+    setGcsObjects({
+      [WORKSPACE_PATH]: { allowedDomains: ["new.example.com"] },
+      [LEGACY_WORKSPACE_PATH]: { allowedDomains: ["legacy.example.com"] },
+    });
+
+    const result = await readWorkspacePolicy(mockAuth);
+
+    expect(result).toEqual(new Ok({ allowedDomains: ["new.example.com"] }));
+    expect(mockFetchFileContent).not.toHaveBeenCalledWith(
+      LEGACY_WORKSPACE_PATH
     );
   });
 
-  it("returns an empty policy when the workspace policy file is missing", async () => {
-    mockFetchFileContent.mockRejectedValue({ code: 404 });
+  it("returns an empty policy when neither layout has a file", async () => {
+    setGcsObjects({});
 
     const result = await readWorkspacePolicy(mockAuth);
 
     expect(result).toEqual(new Ok({ allowedDomains: [] }));
   });
 
-  it("writes normalized workspace policy files", async () => {
+  it("writes normalized policy files to both layouts", async () => {
     const result = await writeWorkspacePolicy(mockAuth, {
       policy: {
         allowedDomains: ["API.GitHub.COM", "*.GitHub.COM"],
@@ -106,13 +147,36 @@ describe("workspace egress policy storage", () => {
         allowedDomains: ["api.github.com", "*.github.com"],
       })
     );
-    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
-      content: JSON.stringify({
-        allowedDomains: ["api.github.com", "*.github.com"],
-      }),
-      contentType: "application/json",
-      filePath: "workspaces/workspace-sid.json",
+    const content = JSON.stringify({
+      allowedDomains: ["api.github.com", "*.github.com"],
     });
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
+      content,
+      contentType: "application/json",
+      filePath: WORKSPACE_PATH,
+    });
+    // Dual-write to the legacy path for front rollback safety.
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
+      content,
+      contentType: "application/json",
+      filePath: LEGACY_WORKSPACE_PATH,
+    });
+  });
+
+  it("succeeds when only the legacy dual-write fails", async () => {
+    mockUploadRawContentToBucket.mockImplementation(
+      async ({ filePath }: { filePath: string }) => {
+        if (filePath === LEGACY_WORKSPACE_PATH) {
+          throw new Error("legacy write failed");
+        }
+      }
+    );
+
+    const result = await writeWorkspacePolicy(mockAuth, {
+      policy: { allowedDomains: ["api.github.com"] },
+    });
+
+    expect(result).toEqual(new Ok({ allowedDomains: ["api.github.com"] }));
   });
 
   it("does not write invalid domain entries", async () => {
@@ -126,65 +190,51 @@ describe("workspace egress policy storage", () => {
     expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
   });
 
-  it("deletes workspace policy files and ignores missing objects", async () => {
+  it("deletes both layouts and ignores missing objects", async () => {
     const result = await deleteWorkspacePolicy(mockAuth);
 
     expect(result).toEqual(new Ok(undefined));
-    expect(mockDelete).toHaveBeenCalledWith("workspaces/workspace-sid.json", {
+    expect(mockDelete).toHaveBeenCalledWith(WORKSPACE_PATH, {
+      ignoreNotFound: true,
+    });
+    expect(mockDelete).toHaveBeenCalledWith(LEGACY_WORKSPACE_PATH, {
       ignoreNotFound: true,
     });
   });
 });
 
-describe("sandbox egress policy storage", () => {
+describe("owner egress policy storage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setupBucketMocks();
+  });
 
-    mockGetEgressPolicyBucket.mockReturnValue("egress-policy-bucket");
-    mockGetEgressProxyInternalUrl.mockReturnValue("https://egress-proxy");
-    mockMintEgressInvalidationJwt.mockReturnValue("invalidation-token");
-    mockFetch.mockResolvedValue({ ok: true, status: 200 });
-    vi.stubGlobal("fetch", mockFetch);
-    mockFetchFileContent.mockResolvedValue(
-      JSON.stringify({ allowedDomains: ["API.GitHub.COM"] })
-    );
-    mockUploadRawContentToBucket.mockResolvedValue(undefined);
-    mockDelete.mockResolvedValue(undefined);
-    mockGetBucketInstance.mockReturnValue({
-      delete: mockDelete,
-      fetchFileContent: mockFetchFileContent,
-      uploadRawContentToBucket: mockUploadRawContentToBucket,
+  it("reads owner policy files from the workspace-prefixed path", async () => {
+    setGcsObjects({
+      [OWNER_PATH]: { allowedDomains: ["API.GitHub.COM"] },
     });
+
+    const result = await readOwnerPolicy(mockAuth, "owner-sid");
+
+    expect(result).toEqual(new Ok({ allowedDomains: ["api.github.com"] }));
+    expect(mockFetchFileContent).toHaveBeenCalledWith(OWNER_PATH);
   });
 
-  it("reads sandbox policy files from the sandbox prefix", async () => {
-    const result = await readSandboxPolicy("provider-id");
+  it("returns an empty policy when the owner file is missing", async () => {
+    setGcsObjects({});
 
-    expect(result).toEqual(
-      new Ok({
-        allowedDomains: ["api.github.com"],
-      })
-    );
-    expect(mockFetchFileContent).toHaveBeenCalledWith(
-      "sandboxes/provider-id.json"
-    );
-  });
-
-  it("returns an empty policy when the sandbox policy file is missing", async () => {
-    mockFetchFileContent.mockRejectedValue({ code: 404 });
-
-    const result = await readSandboxPolicy("provider-id");
+    const result = await readOwnerPolicy(mockAuth, "owner-sid");
 
     expect(result).toEqual(new Ok({ allowedDomains: [] }));
   });
 
-  it("normalizes a sandbox domain and appends it to the existing policy", async () => {
-    mockFetchFileContent.mockResolvedValue(
-      JSON.stringify({ allowedDomains: ["api.github.com"] })
-    );
+  it("normalizes a domain and appends it to the existing owner policy", async () => {
+    setGcsObjects({
+      [OWNER_PATH]: { allowedDomains: ["api.github.com"] },
+    });
 
-    const result = await addSandboxPolicyDomain(mockAuth, {
-      sandboxProviderId: "provider-id",
+    const result = await addOwnerPolicyDomain(mockAuth, {
+      ownerId: "owner-sid",
       domain: "Registry.NPMJS.org",
     });
 
@@ -201,17 +251,17 @@ describe("sandbox egress policy storage", () => {
         allowedDomains: ["api.github.com", "registry.npmjs.org"],
       }),
       contentType: "application/json",
-      filePath: "sandboxes/provider-id.json",
+      filePath: OWNER_PATH,
     });
   });
 
   it("reports addedDomain as null when the domain is already allowed", async () => {
-    mockFetchFileContent.mockResolvedValue(
-      JSON.stringify({ allowedDomains: ["api.github.com"] })
-    );
+    setGcsObjects({
+      [OWNER_PATH]: { allowedDomains: ["api.github.com"] },
+    });
 
-    const result = await addSandboxPolicyDomain(mockAuth, {
-      sandboxProviderId: "provider-id",
+    const result = await addOwnerPolicyDomain(mockAuth, {
+      ownerId: "owner-sid",
       domain: "API.GitHub.COM",
     });
 
@@ -223,11 +273,11 @@ describe("sandbox egress policy storage", () => {
     );
   });
 
-  it("creates sandbox policy files from an empty start", async () => {
-    mockFetchFileContent.mockRejectedValue({ code: 404 });
+  it("creates owner policy files from an empty start", async () => {
+    setGcsObjects({});
 
-    const result = await addSandboxPolicyDomain(mockAuth, {
-      sandboxProviderId: "provider-id",
+    const result = await addOwnerPolicyDomain(mockAuth, {
+      ownerId: "owner-sid",
       domain: "example.org",
     });
 
@@ -240,13 +290,13 @@ describe("sandbox egress policy storage", () => {
     expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
       content: JSON.stringify({ allowedDomains: ["example.org"] }),
       contentType: "application/json",
-      filePath: "sandboxes/provider-id.json",
+      filePath: OWNER_PATH,
     });
   });
 
-  it("rejects wildcard domains for sandbox policy additions", async () => {
-    const result = await addSandboxPolicyDomain(mockAuth, {
-      sandboxProviderId: "provider-id",
+  it("rejects wildcard domains for owner policy additions", async () => {
+    const result = await addOwnerPolicyDomain(mockAuth, {
+      ownerId: "owner-sid",
       domain: "*.example.org",
     });
 
@@ -255,17 +305,17 @@ describe("sandbox egress policy storage", () => {
     expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
   });
 
-  it("rejects sandbox policies over the domain cap", async () => {
+  it("rejects owner policies over the domain cap", async () => {
     const existingDomains = Array.from(
       { length: 100 },
       (_, i) => `domain-${i}.example.com`
     );
-    mockFetchFileContent.mockResolvedValue(
-      JSON.stringify({ allowedDomains: existingDomains })
-    );
+    setGcsObjects({
+      [OWNER_PATH]: { allowedDomains: existingDomains },
+    });
 
-    const result = await addSandboxPolicyDomain(mockAuth, {
-      sandboxProviderId: "provider-id",
+    const result = await addOwnerPolicyDomain(mockAuth, {
+      ownerId: "owner-sid",
       domain: "overflow.example.com",
     });
 
@@ -273,9 +323,11 @@ describe("sandbox egress policy storage", () => {
     expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
   });
 
-  it("invalidates the sandbox policy cache after writes", async () => {
-    await addSandboxPolicyDomain(mockAuth, {
-      sandboxProviderId: "provider-id",
+  it("invalidates the owner policy cache with workspace and owner", async () => {
+    setGcsObjects({});
+
+    await addOwnerPolicyDomain(mockAuth, {
+      ownerId: "owner-sid",
       domain: "example.org",
     });
 
@@ -291,15 +343,16 @@ describe("sandbox egress policy storage", () => {
       );
     });
     expect(mockMintEgressInvalidationJwt).toHaveBeenCalledWith({
-      sandboxId: "provider-id",
+      workspaceId: "workspace-sid",
+      ownerId: "owner-sid",
     });
   });
 
-  it("deletes sandbox policy files and invalidates cache", async () => {
-    const result = await deleteSandboxPolicy("provider-id");
+  it("deletes owner policy files and invalidates cache", async () => {
+    const result = await deleteOwnerPolicy(mockAuth, "owner-sid");
 
     expect(result).toEqual(new Ok(undefined));
-    expect(mockDelete).toHaveBeenCalledWith("sandboxes/provider-id.json", {
+    expect(mockDelete).toHaveBeenCalledWith(OWNER_PATH, {
       ignoreNotFound: true,
     });
     await vi.waitFor(() => {
@@ -308,6 +361,16 @@ describe("sandbox egress policy storage", () => {
         expect.anything()
       );
     });
+  });
+
+  it("deletes legacy per-provider policy files without invalidation", async () => {
+    const result = await deleteLegacySandboxPolicy("provider-id");
+
+    expect(result).toEqual(new Ok(undefined));
+    expect(mockDelete).toHaveBeenCalledWith("sandboxes/provider-id.json", {
+      ignoreNotFound: true,
+    });
+    expect(mockMintEgressInvalidationJwt).not.toHaveBeenCalled();
   });
 
   it("parses exact domains and rejects malformed entries", () => {

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -17,25 +17,42 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 const INVALIDATION_TIMEOUT_MS = 5_000;
 const SANDBOX_POLICY_MAX_DOMAINS = 100;
 
+// Policy layout: everything lives under a per-workspace prefix so relocation
+// and scrubbing are prefix operations.
+//
+//   w/{wId}/sandbox-egress-policy.json  workspace-wide policy
+//   w/{wId}/sandboxes/{ownerId}.json owner policy; ownerId is a conversation
+//                                    sId (conversation sandboxes) or a space
+//                                    sId (pod sandboxes)
+//
+// Owner files are keyed by the sandbox's stable owner, not the ephemeral
+// provider id, so they survive sandbox destroy/recreate cycles.
 function getWorkspacePolicyPath(auth: Authenticator): string {
+  return `w/${auth.getNonNullableWorkspace().sId}/sandbox-egress-policy.json`;
+}
+
+// TODO(2026-08-15 EGRESS_RELAYOUT): drop the legacy path (reads fall back to
+// it, writes dual-write it for front rollback safety) once the backfill has
+// run and legacy objects are deleted.
+function getLegacyWorkspacePolicyPath(auth: Authenticator): string {
   return `workspaces/${auth.getNonNullableWorkspace().sId}.json`;
 }
 
-function getSandboxPolicyPath(sandboxProviderId: string): string {
-  return `sandboxes/${sandboxProviderId}.json`;
+function getOwnerPolicyPath(auth: Authenticator, ownerId: string): string {
+  return `w/${auth.getNonNullableWorkspace().sId}/sandboxes/${ownerId}.json`;
 }
 
 function getPolicyBucket() {
   return getBucketInstance(config.getEgressPolicyBucket());
 }
 
-export async function readWorkspacePolicy(
-  auth: Authenticator
-): Promise<Result<EgressPolicy, Error>> {
+// Reads a policy file, distinguishing "absent" (Ok(null)) from real errors so
+// callers can fall back across layouts without masking failures.
+async function fetchPolicyAtPath(
+  filePath: string
+): Promise<Result<EgressPolicy | null, Error>> {
   try {
-    const content = await getPolicyBucket().fetchFileContent(
-      getWorkspacePolicyPath(auth)
-    );
+    const content = await getPolicyBucket().fetchFileContent(filePath);
     const parsed = parseEgressPolicy(JSON.parse(content));
 
     if (parsed.isErr()) {
@@ -45,11 +62,30 @@ export async function readWorkspacePolicy(
     return new Ok(parsed.value);
   } catch (error) {
     if (isGCSNotFoundError(error)) {
-      return new Ok(EMPTY_EGRESS_POLICY);
+      return new Ok(null);
     }
 
     return new Err(normalizeError(error));
   }
+}
+
+export async function readWorkspacePolicy(
+  auth: Authenticator
+): Promise<Result<EgressPolicy, Error>> {
+  const current = await fetchPolicyAtPath(getWorkspacePolicyPath(auth));
+  if (current.isErr()) {
+    return current;
+  }
+  if (current.value !== null) {
+    return new Ok(current.value);
+  }
+
+  const legacy = await fetchPolicyAtPath(getLegacyWorkspacePolicyPath(auth));
+  if (legacy.isErr()) {
+    return legacy;
+  }
+
+  return new Ok(legacy.value ?? EMPTY_EGRESS_POLICY);
 }
 
 export async function writeWorkspacePolicy(
@@ -68,19 +104,45 @@ export async function writeWorkspacePolicy(
       contentType: "application/json",
       filePath: getWorkspacePolicyPath(auth),
     });
-
-    void invalidateWorkspacePolicyCache(auth);
-
-    return new Ok(normalizedPolicy.value);
   } catch (error) {
     return new Err(normalizeError(error));
   }
+
+  // Dual-write the legacy path so a front rollback keeps seeing (and safely
+  // editing) the same policy. Best-effort: the new path is canonical and the
+  // proxy prefers it.
+  try {
+    await getPolicyBucket().uploadRawContentToBucket({
+      content: JSON.stringify(normalizedPolicy.value),
+      contentType: "application/json",
+      filePath: getLegacyWorkspacePolicyPath(auth),
+    });
+  } catch (error) {
+    logger.warn(
+      {
+        error: normalizeError(error),
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Failed to dual-write legacy workspace egress policy path"
+    );
+  }
+
+  void invalidateWorkspacePolicyCache(auth);
+
+  return new Ok(normalizedPolicy.value);
 }
 
 export async function deleteWorkspacePolicy(
   auth: Authenticator
 ): Promise<Result<void, Error>> {
   try {
+    // Legacy first: if the new-path delete succeeded but the legacy delete
+    // failed, reads would fall back to the still-present legacy file and the
+    // "deleted" policy would resurrect. Deleting legacy first leaves the
+    // (canonical) new path authoritative in every partial-failure state.
+    await getPolicyBucket().delete(getLegacyWorkspacePolicyPath(auth), {
+      ignoreNotFound: true,
+    });
     await getPolicyBucket().delete(getWorkspacePolicyPath(auth), {
       ignoreNotFound: true,
     });
@@ -110,32 +172,21 @@ export function parseExactEgressDomain(value: string): Result<string, Error> {
   return new Ok(normalized.value);
 }
 
-export async function readSandboxPolicy(
-  sandboxProviderId: string
+export async function readOwnerPolicy(
+  auth: Authenticator,
+  ownerId: string
 ): Promise<Result<EgressPolicy, Error>> {
-  try {
-    const content = await getPolicyBucket().fetchFileContent(
-      getSandboxPolicyPath(sandboxProviderId)
-    );
-    const parsed = parseEgressPolicy(JSON.parse(content));
-
-    if (parsed.isErr()) {
-      return parsed;
-    }
-
-    return new Ok(parsed.value);
-  } catch (error) {
-    if (isGCSNotFoundError(error)) {
-      return new Ok(EMPTY_EGRESS_POLICY);
-    }
-
-    return new Err(normalizeError(error));
+  const policy = await fetchPolicyAtPath(getOwnerPolicyPath(auth, ownerId));
+  if (policy.isErr()) {
+    return policy;
   }
+
+  return new Ok(policy.value ?? EMPTY_EGRESS_POLICY);
 }
 
-export async function addSandboxPolicyDomain(
-  _auth: Authenticator,
-  { sandboxProviderId, domain }: { sandboxProviderId: string; domain: string }
+export async function addOwnerPolicyDomain(
+  auth: Authenticator,
+  { ownerId, domain }: { ownerId: string; domain: string }
 ): Promise<
   Result<{ policy: EgressPolicy; addedDomain: string | null }, Error>
 > {
@@ -144,11 +195,18 @@ export async function addSandboxPolicyDomain(
     return new Err(parsedDomain.error);
   }
 
-  const currentPolicy = await readSandboxPolicy(sandboxProviderId);
+  const currentPolicy = await readOwnerPolicy(auth, ownerId);
   if (currentPolicy.isErr()) {
     return new Err(currentPolicy.error);
   }
 
+  // Exact-string membership is enough today: this function is the only
+  // writer of conversation owner files, and it only ever appends exact
+  // domains. If another writer starts putting wildcard entries in a file the
+  // tool also appends to (e.g. enabling the add_egress_domain tool on pod
+  // sandboxes, whose files are admin-managed), this check must become
+  // wildcard-aware or users will be prompted for domains a wildcard already
+  // covers.
   const alreadyAllowed = currentPolicy.value.allowedDomains.includes(
     parsedDomain.value
   );
@@ -172,10 +230,10 @@ export async function addSandboxPolicyDomain(
     await getPolicyBucket().uploadRawContentToBucket({
       content: JSON.stringify(policy),
       contentType: "application/json",
-      filePath: getSandboxPolicyPath(sandboxProviderId),
+      filePath: getOwnerPolicyPath(auth, ownerId),
     });
 
-    void invalidateSandboxPolicyCache(sandboxProviderId);
+    void invalidateOwnerPolicyCache(auth, ownerId);
 
     return new Ok({ policy, addedDomain });
   } catch (error) {
@@ -183,15 +241,39 @@ export async function addSandboxPolicyDomain(
   }
 }
 
-export async function deleteSandboxPolicy(
+// Deletes the legacy per-providerId policy file written before the
+// owner-keyed layout. Still called on sandbox destroy so pre-migration files
+// get cleaned up as their sandboxes die. No proxy cache invalidation: the
+// sandbox (and its token) is gone, so the cached entry just ages out with
+// the TTL.
+// TODO(2026-08-15 EGRESS_RELAYOUT): remove with the legacy layout.
+export async function deleteLegacySandboxPolicy(
   sandboxProviderId: string
 ): Promise<Result<void, Error>> {
   try {
-    await getPolicyBucket().delete(getSandboxPolicyPath(sandboxProviderId), {
+    await getPolicyBucket().delete(`sandboxes/${sandboxProviderId}.json`, {
       ignoreNotFound: true,
     });
 
-    void invalidateSandboxPolicyCache(sandboxProviderId);
+    return new Ok(undefined);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+// Owner files outlive individual sandboxes by design; they are deleted when
+// their owner is (conversation destruction, pod space deletion), not when a
+// sandbox is destroyed.
+export async function deleteOwnerPolicy(
+  auth: Authenticator,
+  ownerId: string
+): Promise<Result<void, Error>> {
+  try {
+    await getPolicyBucket().delete(getOwnerPolicyPath(auth, ownerId), {
+      ignoreNotFound: true,
+    });
+
+    void invalidateOwnerPolicyCache(auth, ownerId);
 
     return new Ok(undefined);
   } catch (error) {
@@ -234,8 +316,9 @@ async function invalidateWorkspacePolicyCache(
   }
 }
 
-async function invalidateSandboxPolicyCache(
-  sandboxProviderId: string
+async function invalidateOwnerPolicyCache(
+  auth: Authenticator,
+  ownerId: string
 ): Promise<void> {
   try {
     const baseUrl = config.getEgressProxyInternalUrl();
@@ -243,7 +326,11 @@ async function invalidateSandboxPolicyCache(
       return;
     }
 
-    const token = mintEgressInvalidationJwt({ sandboxId: sandboxProviderId });
+    // The proxy's owner cache key needs both the workspace and the owner.
+    const token = mintEgressInvalidationJwt({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      ownerId,
+    });
     const url = `${baseUrl.replace(/\/+$/, "")}/invalidate-policy`;
 
     const response = await fetch(url, {
@@ -256,13 +343,13 @@ async function invalidateSandboxPolicyCache(
 
     if (!response.ok) {
       logger.warn(
-        { statusCode: response.status, sandboxProviderId },
+        { statusCode: response.status, ownerId },
         "Egress proxy cache invalidation failed"
       );
     }
   } catch (error) {
     logger.warn(
-      { error: normalizeError(error), sandboxProviderId },
+      { error: normalizeError(error), ownerId },
       "Egress proxy cache invalidation error"
     );
   }

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -45,6 +45,21 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { destroyConversation } from "../api/assistant/conversation/destroy";
 
+const { mockDeleteOwnerPolicy } = vi.hoisted(() => ({
+  mockDeleteOwnerPolicy: vi.fn(),
+}));
+
+vi.mock(
+  import("../../lib/api/sandbox/egress_policy"),
+  async (importOriginal) => {
+    const mod = await importOriginal();
+    return {
+      ...mod,
+      deleteOwnerPolicy: mockDeleteOwnerPolicy,
+    };
+  }
+);
+
 vi.mock(import("../../lib/api/redis"), async (importOriginal) => {
   const mod = await importOriginal();
   return {
@@ -628,6 +643,26 @@ describe("destroyConversation", () => {
 
     const agents = await setupTestAgents(workspace, user);
     agentConfigurationId = agents[0].sId;
+  });
+
+  it("scrubs the conversation's egress policy file on destroy", async () => {
+    mockDeleteOwnerPolicy.mockResolvedValue(new Ok(undefined));
+    const conversationType = await ConversationFactory.create(auth, {
+      agentConfigurationId,
+      messagesCreatedAt: [new Date()],
+    });
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationType.sId
+    );
+    assert(conversation, "Conversation should exist");
+
+    await destroyConversation(auth, { conversation });
+
+    expect(mockDeleteOwnerPolicy).toHaveBeenCalledWith(
+      expect.anything(),
+      conversation.sId
+    );
   });
 
   it("should delete batched message resources chunk by chunk", async () => {

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  mockDeleteSandboxPolicy,
+  mockDeleteLegacySandboxPolicy,
   mockDistribution,
   mockExecuteWithLock,
   mockGetSandboxImage,
@@ -11,7 +11,7 @@ const {
   mockProviderExec,
   mockRevokeAllExecTokensForSandbox,
 } = vi.hoisted(() => ({
-  mockDeleteSandboxPolicy: vi.fn(),
+  mockDeleteLegacySandboxPolicy: vi.fn(),
   mockDistribution: vi.fn(),
   mockExecuteWithLock: vi.fn(),
   mockGetSandboxImage: vi.fn(),
@@ -38,7 +38,7 @@ vi.mock("@app/lib/api/sandbox/access_tokens", () => ({
 }));
 
 vi.mock("@app/lib/api/sandbox/egress_policy", () => ({
-  deleteSandboxPolicy: mockDeleteSandboxPolicy,
+  deleteLegacySandboxPolicy: mockDeleteLegacySandboxPolicy,
 }));
 
 vi.mock("@app/lib/api/sandbox/image", () => ({
@@ -80,7 +80,7 @@ describe("SandboxResource.updateStatus", () => {
       destroy: mockProviderDestroy,
     });
     mockProviderDestroy.mockResolvedValue(new Ok(undefined));
-    mockDeleteSandboxPolicy.mockResolvedValue(new Ok(undefined));
+    mockDeleteLegacySandboxPolicy.mockResolvedValue(new Ok(undefined));
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
 
     const testSetup = await createResourceTest({ role: "admin" });
@@ -189,7 +189,7 @@ describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping", () =>
       destroy: mockProviderDestroy,
     });
     mockProviderDestroy.mockResolvedValue(new Ok(undefined));
-    mockDeleteSandboxPolicy.mockResolvedValue(new Ok(undefined));
+    mockDeleteLegacySandboxPolicy.mockResolvedValue(new Ok(undefined));
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
 
     const testSetup = await createResourceTest({ role: "admin" });
@@ -230,7 +230,9 @@ describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping", () =>
     expect(mockProviderDestroy).toHaveBeenCalledWith(sandbox.providerId, {
       workspaceId: authenticator.getNonNullableWorkspace().sId,
     });
-    expect(mockDeleteSandboxPolicy).toHaveBeenCalledWith(sandbox.providerId);
+    expect(mockDeleteLegacySandboxPolicy).toHaveBeenCalledWith(
+      sandbox.providerId
+    );
 
     const reloaded = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
@@ -314,7 +316,7 @@ describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested", 
       destroy: mockProviderDestroy,
     });
     mockProviderDestroy.mockResolvedValue(new Ok(undefined));
-    mockDeleteSandboxPolicy.mockResolvedValue(new Ok(undefined));
+    mockDeleteLegacySandboxPolicy.mockResolvedValue(new Ok(undefined));
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
 
     const testSetup = await createResourceTest({ role: "admin" });

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,6 +1,6 @@
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { revokeAllExecTokensForSandbox } from "@app/lib/api/sandbox/access_tokens";
-import { deleteSandboxPolicy } from "@app/lib/api/sandbox/egress_policy";
+import { deleteLegacySandboxPolicy } from "@app/lib/api/sandbox/egress_policy";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import {
   recordLifecycleOperation,
@@ -94,10 +94,14 @@ export interface SandboxResource extends ReadonlyAttributesType<SandboxModel> {}
 export class SandboxResource extends BaseResource<SandboxModel> {
   static model: ModelStaticWorkspaceAware<SandboxModel> = SandboxModel;
 
+  // Owner policy files (w/{wId}/sandboxes/{ownerId}.json) intentionally
+  // survive sandbox destruction; only the legacy per-providerId file is
+  // scrubbed here. Owner files are deleted with their owner (conversation
+  // destruction, pod space deletion).
   private static deleteEgressPolicyAfterDestroy(
     sandbox: SandboxResource
   ): void {
-    void deleteSandboxPolicy(sandbox.providerId).catch((err) =>
+    void deleteLegacySandboxPolicy(sandbox.providerId).catch((err) =>
       logger.warn(
         {
           err,

--- a/front/migrations/20260707_backfill_egress_policy_layout.ts
+++ b/front/migrations/20260707_backfill_egress_policy_layout.ts
@@ -1,0 +1,68 @@
+import config from "@app/lib/api/config";
+import { getBucketInstance } from "@app/lib/file_storage";
+import { makeScript } from "@app/scripts/helpers";
+
+const LEGACY_WORKSPACE_PREFIX = "workspaces/";
+
+// Copies legacy workspace egress policy files (`workspaces/{wId}.json`) to
+// the workspace-prefixed layout (`w/{wId}/sandbox-egress-policy.json`).
+//
+// Idempotent and safe to re-run: a workspace whose new-path object already
+// exists is skipped, so the script can never clobber a policy written after
+// the front cutover. Run it AFTER the front deploy that writes the new
+// layout; until then, reads fall back to the legacy path anyway.
+//
+// Legacy objects are left in place (reads fall back to them and writes
+// dual-write them for rollback safety); they get deleted with the cleanup PR
+// that drops the legacy layout.
+makeScript({}, async ({ execute }, logger) => {
+  const bucket = getBucketInstance(config.getEgressPolicyBucket());
+
+  const { files } = await bucket.getAllFilesByPrefix({
+    prefix: LEGACY_WORKSPACE_PREFIX,
+  });
+
+  logger.info({ count: files.length }, "Found legacy workspace policy files");
+
+  let copied = 0;
+  let skippedExisting = 0;
+  let skippedMalformed = 0;
+
+  for (const file of files) {
+    const match = file.name.match(/^workspaces\/([^/]+)\.json$/);
+    if (!match) {
+      skippedMalformed++;
+      logger.warn({ file: file.name }, "Skipping unexpected object name");
+      continue;
+    }
+
+    const workspaceId = match[1];
+    const targetPath = `w/${workspaceId}/sandbox-egress-policy.json`;
+    const target = bucket.file(targetPath);
+
+    const [targetExists] = await target.exists();
+    if (targetExists) {
+      skippedExisting++;
+      logger.info(
+        { workspaceId, targetPath },
+        "Skipping: new-layout object already exists"
+      );
+      continue;
+    }
+
+    if (execute) {
+      await file.copy(target);
+      logger.info({ workspaceId, targetPath }, "Copied policy to new layout");
+    } else {
+      logger.info({ workspaceId, targetPath }, "Would copy policy (dry run)");
+    }
+    copied++;
+  }
+
+  logger.info(
+    { copied, skippedExisting, skippedMalformed, execute },
+    execute
+      ? "Egress policy layout backfill complete"
+      : "Egress policy layout backfill dry run complete (nothing written; `copied` counts objects that would be copied)"
+  );
+});


### PR DESCRIPTION
## Egress policy re-layout — front cutover

Second phase (proxy dual-read is #28652 — **must deploy first**). Front now writes the owner-keyed layout:

- **Workspace policy** → `w/{wId}/sandbox-egress-policy.json`. Reads fall back to the legacy path when the new object is absent (covers un-backfilled workspaces); writes go to the new path and **dual-write the legacy path** so a front rollback keeps seeing — and safely editing — the same policy. Dated TODOs on both.
- **Owner policy** replaces the per-providerId sandbox policy: `readOwnerPolicy` / `addOwnerPolicyDomain` / `deleteOwnerPolicy` on `w/{wId}/sandboxes/{ownerId}.json`.
- **Behavior change (intended):** agent-approved domains now persist for the **conversation's lifetime**, across sandbox destroy/recreate cycles — previously they silently died with the sandbox. The `add_egress_domain` tool copy is updated to say so.
- `mintEgressJwt` carries `ownerId` (conversation sId or pod space sId, from the runtime owner); `sbId` stays for identity/log tracing. Owner cache invalidation sends `workspaceId` + `ownerId`.
- **Lifecycle:** owner files are deleted with their owner — conversation destruction scrubs the file (pod space deletion follows in the pod PR). Sandbox destroy now only cleans up legacy per-providerId files, with no invalidation (the sandbox and its token are gone; cache entries age out).
- The existing `sandbox_egress_policy.sandbox_updated` audit event gains a `conversation_id` metadata field: the provider id it logged no longer identifies the approval's durable scope. Schema version bumped — **re-register with WorkOS before deploy** (`npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`). No new audit actions in this stack.
- The tool's "already allowed?" pre-check keeps exact-string membership, with a comment documenting the assumption (this function is the only writer of conversation owner files and only appends exact domains); it must become wildcard-aware before the tool is ever enabled on pod sandboxes, whose files are admin-managed.

### Stack / rollout

See #28652. After this deploys: run the backfill script (follow-up PR) to copy legacy workspace files; the read fallback covers the gap until then.

### Risk

Worst case, an owner file write fails → fail-closed to the workspace policy, same as today. Requires #28652 deployed and healthy first — on an old proxy, the ownerId claim is ignored and new-path files are unread, degrading to "conversation/pod grants not applied" (never an over-grant). Front rollback is covered by the legacy dual-write. **Proxy rollback stops being clean once this deploys** (owner-file approvals go invisible to an old proxy while the tool's pre-check still sees them) — if both must roll back, front first.

### Tests

Workspace: new-layout read, legacy fallback, new-preferred, dual-write (incl. legacy-write-failure tolerated), delete-both. Owner: read/append/dedupe/cap/wildcard-reject, workspace+owner invalidation, delete, legacy-file deletion without invalidation. Tool: owner-keyed call expectations. front-api workspace route suite unchanged and green.
