### PR TITLE
Remove redundant delta dedup pass in Microsoft connector

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -1291,7 +1291,9 @@ export async function syncDeltaForRootNodesInDrive({
     }
     throw error;
   }
-  const uniqueChangedItems = removeAllButLastOccurences(results);
+  // getFullDeltaResults already dedups by id (last write wins), so no extra
+  // pass is needed here; avoid an extra full copy of the delta set.
+  const uniqueChangedItems = results;
 
   const sortedChangedItems: DriveItem[] = [];
   const containsWholeDrive = rootNodeIds.some(
@@ -1661,8 +1663,10 @@ export async function fetchDeltaForRootNodesInDrive({
   // Upload the delta data to GCS
   const file = getDeltaSyncBucket().file(gcsFilePath);
 
-  // Process changes in batches of 1000
-  const uniqueChangedItems = removeAllButLastOccurences(results);
+  // Process changes in batches of 1000.
+  // getFullDeltaResults already dedups by id (last write wins), so no extra
+  // pass is needed here; avoid an extra full copy of the delta set.
+  const uniqueChangedItems = results;
   const sortedChangedItems: DriveItem[] = [];
   const containsWholeDrive = rootNodeIds.some(
     (nodeId) => typeAndPathFromInternalId(nodeId).nodeType === "drive"
@@ -1813,28 +1817,6 @@ export async function cleanupDeltaGCSFile({
     );
     // Don't throw error as this is cleanup and shouldn't fail the workflow
   }
-}
-
-/**
- *  As per recommendation, remove all but the last occurences of the same
- *  driveItem in the list
- */
-function removeAllButLastOccurences(deltaList: DriveItem[]) {
-  const uniqueDeltas = new Set<string>();
-  const resultList = [];
-  for (const driveItem of deltaList.reverse()) {
-    if (!driveItem.id) {
-      throw new Error(`DriveItem id is missing: ${driveItem}`);
-    }
-
-    if (uniqueDeltas.has(driveItem.id)) {
-      continue;
-    }
-    uniqueDeltas.add(driveItem.id);
-    resultList.push(driveItem);
-  }
-
-  return resultList;
 }
 
 /**


### PR DESCRIPTION
## What

`fetchDeltaForRootNodesInDrive` and the legacy `syncDeltaForRootNodesInDrive` both ran `removeAllButLastOccurences(results)` on the delta results before sorting/uploading. That helper is now removed, and `uniqueChangedItems` aliases `results` directly.

## Why

`results` always comes from `getFullDeltaResults`, which already dedups by id (last write wins) via its item `Map`. So `removeAllButLastOccurences` only rebuilt the array (plus a `Set`) and reversed the order — a redundant **full in-memory copy** of the delta set.

This matters because the Microsoft connector worker runs many tenants' delta activities concurrently and sits close to its pod memory limit; a recent production **OOM kill** (containerd `event_type:oom`) traced back to large deltas being materialized several times over. This removes one of those copies. (Follow-ups still open: lowering worker concurrency, lowering `DELTA_MAX_ITEMS`, and an O(N) rewrite of `sortForIncrementalUpdate`.)

## Safety

- Verified `results` originates from `getFullDeltaResults` in both call paths (via `getDeltaData`), so it is always already deduped.
- The only behavioral difference is that the list is no longer reversed. Downstream, `sortForIncrementalUpdate` re-orders items topologically (parent-before-child), and `scrubRemovedFolders` only reads the list via `.filter()`/`.map()` — neither depends on input order or mutates it. So correctness is unchanged.

## Testing

- `tsgo --noEmit` clean; pre-commit `connectors-typecheck` + `biome` pass.
- No unit tests cover these delta helpers; the removed function was private and untested.