### PR TITLE
[SANDBOX] drop workspaceId tag from tool duration metric

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -370,7 +370,6 @@ export async function runSandboxBashTool(
     sandboxAction: sandboxAction.toJSON(),
   });
 
-  const metricsCtx = { workspaceId: auth.getNonNullableWorkspace().sId };
   const startMs = performance.now();
 
   const providerId = model.providerId;
@@ -419,7 +418,6 @@ export async function runSandboxBashTool(
     recordToolDuration(
       "bash",
       durationMs,
-      metricsCtx,
       execResult.isOk() ? "success" : "error"
     );
   }

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -121,11 +121,9 @@ export function recordStateDuration(
 export function recordToolDuration(
   tool: string,
   durationMs: number,
-  ctx: MetricContext,
   status: "success" | "error" = "success"
 ): void {
   getStatsDClient().distribution("sandbox.tools.duration", durationMs, [
-    ...buildTags(ctx),
     `tool:${tool}`,
     `status:${status}`,
   ]);


### PR DESCRIPTION
## Description

Drop the high-cardinality `workspaceId` tag from the `sandbox.tools.duration` StatsD metric to reduce Datadog custom metric cardinality.

## Tests

Not needed.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`