### PR TITLE
fix(core): avoid token-string materialization in /tokenize/batch/count (Core OOM)

### DIFF
--- a/core/src/api/tokenize.rs
+++ b/core/src/api/tokenize.rs
@@ -113,25 +113,37 @@ pub async fn tokenize_batch(
 pub async fn tokenize_batch_count(
     Json(payload): Json<TokenizeBatchPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    match tokenize_batch_internal(payload).await {
+    // Count tokens through the encode path (token ids only) rather than the full tokenize path,
+    // which allocates an owned String per token for the whole batch at once and OOMs on large
+    // payloads. Token counting is purely local to the tokenizer, so we skip building the provider
+    // LLM (and its credentials) entirely.
+    let tokenizer = match TokenizerSingleton::from_config(&payload.tokenizer) {
+        Some(tokenizer) => tokenizer,
+        None => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_tokenizer",
+                "Failed to tokenize text - unsupported tokenizer",
+                None,
+            )
+        }
+    };
+
+    match tokenizer.batch_count(payload.texts).await {
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "internal_server_error",
             "Failed to tokenize text",
             Some(e),
         ),
-        Ok(res) => {
-            // Only return counts instead of full token arrays to avoid OOM.
-            let counts: Vec<usize> = res.iter().map(|tokens| tokens.len()).collect();
-            (
-                StatusCode::OK,
-                Json(APIResponse {
-                    error: None,
-                    response: Some(json!({
-                        "counts": counts,
-                    })),
-                }),
-            )
-        }
+        Ok(counts) => (
+            StatusCode::OK,
+            Json(APIResponse {
+                error: None,
+                response: Some(json!({
+                    "counts": counts,
+                })),
+            }),
+        ),
     }
 }

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -107,6 +107,21 @@ impl TokenizerSingleton {
             }
         }
     }
+
+    pub async fn batch_count(&self, texts: Vec<String>) -> Result<Vec<usize>> {
+        match self {
+            TokenizerSingleton::Tiktoken(bpe) => {
+                crate::providers::tiktoken::tiktoken::batch_count_async(bpe.clone(), texts).await
+            }
+            TokenizerSingleton::SentencePiece(spp) => {
+                crate::providers::sentencepiece::sentencepiece::batch_count_async(
+                    spp.clone(),
+                    texts,
+                )
+                .await
+            }
+        }
+    }
 }
 
 #[derive(Debug, Serialize, PartialEq, Clone, Deserialize)]

--- a/core/src/providers/sentencepiece/sentencepiece.rs
+++ b/core/src/providers/sentencepiece/sentencepiece.rs
@@ -136,3 +136,29 @@ pub async fn batch_count_async(
 
     Ok(r)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::providers::sentencepiece::sentencepiece::batch_count_async;
+    use crate::providers::sentencepiece::sentencepiece::batch_tokenize_async;
+    use crate::providers::sentencepiece::sentencepiece::mistral_instruct_tokenizer_240216_model_v2_base_singleton;
+
+    #[tokio::test]
+    async fn batch_count_matches_tokenize_test() {
+        let spp = mistral_instruct_tokenizer_240216_model_v2_base_singleton();
+        let texts = vec![
+            "Un petit Soupinou".to_string(),
+            "Soupinou 🤗".to_string(),
+            "This is a test         with a lot of spaces".to_string(),
+            "".to_string(),
+        ];
+
+        let tokenized = batch_tokenize_async(spp.clone(), texts.clone())
+            .await
+            .unwrap();
+        let counts = batch_count_async(spp, texts).await.unwrap();
+
+        let expected: Vec<usize> = tokenized.iter().map(|tokens| tokens.len()).collect();
+        assert_eq!(counts, expected);
+    }
+}

--- a/core/src/providers/sentencepiece/sentencepiece.rs
+++ b/core/src/providers/sentencepiece/sentencepiece.rs
@@ -114,3 +114,25 @@ pub async fn batch_tokenize_async(
 
     Ok(r)
 }
+
+// Counts tokens per text without materializing the token strings. `batch_tokenize_async` clones an
+// owned String per token for the whole batch at once, which blows up memory (and OOMs) when only
+// counts are needed; encoding to token ids and taking the length keeps peak memory tiny.
+pub async fn batch_count_async(
+    ssp: Arc<RwLock<SentencePieceProcessor>>,
+    texts: Vec<String>,
+) -> Result<Vec<usize>> {
+    let r = tokio::task::spawn_blocking(move || {
+        texts
+            .par_iter()
+            .map(|text| {
+                let guard = ssp.read();
+                guard.encode(text).map(|p| p.len())
+            })
+            .collect::<Result<Vec<usize>, SentencePieceError>>()
+            .map_err(|e| anyhow::anyhow!(e))
+    })
+    .await??;
+
+    Ok(r)
+}

--- a/core/src/providers/tiktoken/tiktoken.rs
+++ b/core/src/providers/tiktoken/tiktoken.rs
@@ -209,6 +209,27 @@ pub async fn batch_tokenize_async(
     Ok(r)
 }
 
+// Counts tokens per text without materializing the token strings. `batch_tokenize_async` allocates
+// an owned String per token for the whole batch at once, which blows up memory (and OOMs) when only
+// counts are needed; encoding to token ids and taking the length keeps peak memory tiny.
+pub async fn batch_count_async(
+    bpe: Arc<RwLock<CoreBPE>>,
+    texts: Vec<String>,
+) -> Result<Vec<usize>> {
+    let r = tokio::task::spawn_blocking(move || {
+        texts
+            .par_iter()
+            .map(|text| {
+                let guard = bpe.read();
+                guard.encode_with_special_tokens(text).len()
+            })
+            .collect::<Vec<usize>>()
+    })
+    .await?;
+
+    Ok(r)
+}
+
 fn _byte_pair_merge<T>(
     piece: &[u8],
     ranks: &HashMap<Vec<u8>, usize>,
@@ -982,5 +1003,26 @@ mod tests {
         ];
 
         run_tokenize_test(&japanese, expected_japanese).await;
+    }
+
+    #[tokio::test]
+    async fn batch_count_matches_tokenize_test() {
+        use crate::providers::tiktoken::tiktoken::batch_count_async;
+
+        let bpe = p50k_base_singleton();
+        let texts = vec![
+            "Un petit Soupinou".to_string(),
+            "Soupinou 🤗".to_string(),
+            "This is a test         with a lot of spaces".to_string(),
+            "".to_string(),
+        ];
+
+        let tokenized = batch_tokenize_async(bpe.clone(), texts.clone())
+            .await
+            .unwrap();
+        let counts = batch_count_async(bpe, texts).await.unwrap();
+
+        let expected: Vec<usize> = tokenized.iter().map(|tokens| tokens.len()).collect();
+        assert_eq!(counts, expected);
     }
 }


### PR DESCRIPTION
## Problem

Core pods have been seen OOMing. Investigating one (pod `core-deployment-5f6c67fc5c-q47zf`, 2026-07-06 21:04:09Z), the pod was under a heavy connector sync, and two endpoints dominated memory: `POST /documents` upserts and **`/tokenize/batch/count`** (chronic ~40s tail latency).

`/tokenize/batch/count` has a memory inefficiency:

- `tokenize_batch_count` → `tokenize_batch_internal` → `LLM::tokenize` → `batch_tokenize_async` allocates an **owned `String` per token** (`tiktoken.rs` `_tokenize_with_spe_regex`, sentencepiece `piece.clone()`), for **every text in the batch, in parallel** (rayon `par_iter`), materializing the whole `Vec<Vec<(usize, String)>>` at once — then throws all of it away except `.len()`.
- That's a sizeable memory amplification (each token: `usize` + heap `String` ≈ 40 B vs. the `encode` path's `Vec<usize>` at 8 B, no per-token allocation) for a count-only operation.

We already half-knew this: the old `tokenize.rs` comment *"Only return counts … to avoid OOM"* fixed only the **response** serialization, and `front/lib/tokenization.ts` bounds batches to 50 texts — but by **count, not byte size**, so large texts still blow up.

## Fix

Count via the `encode` path (token ids only) instead of the full tokenize path:

- New `batch_count_async` on both tokenizer backends (`tiktoken`, `sentencepiece`) — encodes each text and keeps only the length; each text's transient `Vec<usize>` is dropped immediately, so peak memory is ~one text per rayon thread instead of the whole batch's token strings. Mirrors the existing `batch_tokenize_async` pair.
- `TokenizerSingleton::batch_count` dispatcher, mirroring `tokenize`.
- `tokenize_batch_count` builds the tokenizer from config and calls `batch_count` directly, skipping the provider LLM (token counting is purely local to the tokenizer; `provider_id`/`model_id`/`credentials` don't affect it).

**Response shape unchanged** (`{"counts": [...]}`), so the sole caller (`front` `tokenCountForTexts`) is unaffected. The sentencepiece branch matters for **Mistral** agents specifically (only model family on `sentence_piece`); tiktoken covers OpenAI/Anthropic/etc.

## Testing

- TDD: added `batch_count_matches_tokenize_test` (tiktoken) asserting `batch_count` equals the old `tokenize().len()` across regular/unicode/whitespace/empty inputs. Counts are provably identical (both allow the same special tokens).
- `cargo fmt` clean, `cargo build` clean, tiktoken suite passes. (The `cargo clippy` error in `data_sources/splitter.rs` is pre-existing on `main`, unrelated.)
