### PR TITLE
Load the files edit tool eagerly instead of behind tool search

### DIFF
--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -374,6 +374,9 @@ const EDIT_TOOL = {
       ),
   },
   stake: "never_ask" as const,
+  // Eager: kept in the cached prefix instead of behind tool search, so it never competes with
+  // other tools' descriptions for retrieval rank on an edit-intent query.
+  eager: true,
   displayLabels: {
     running: "Editing file",
     done: "Edited file",

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -374,8 +374,8 @@ const EDIT_TOOL = {
       ),
   },
   stake: "never_ask" as const,
-  // Eager: kept in the cached prefix instead of behind tool search, so it never competes with
-  // other tools' descriptions for retrieval rank on an edit-intent query.
+  // Editing a file is a common case, so it's worth keeping this in the cached prefix instead
+  // of behind tool search.
   eager: true,
   displayLabels: {
     running: "Editing file",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Editing a file is a common case, so it is worth keeping the files edit tool in the model's cached prefix instead of hiding it behind tool search, the same treatment already given to listing and reading files. This also gives it a stable spot in the model's toolset instead of leaving it to tool search ranking, which can be sensitive to wording changes elsewhere in the tool corpus.

This is required to align frames on the regular file handling operations.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
