### PR TITLE
business_activation: use fresh workspace for zero amount activation

### DIFF
--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -275,8 +275,17 @@ export async function createPaymentGatedBusinessActivation({
 
   // Step 6: zero-amount fast path — no invoice to create, activate immediately.
   if (effectiveAmountCents === 0) {
+    // We need to retrieve an up-to-date workspace object here
+    // before calling handleSubscriptionActivationSuccess
+    const freshWorkspace = await WorkspaceResource.fetchById(workspace.sId);
+    if (!freshWorkspace) {
+      return new Err({
+        type: "metronome_error",
+        message: "Workspace not found during zero-amount activation",
+      });
+    }
     await handleSubscriptionActivationSuccess({
-      workspace,
+      workspace: freshWorkspace,
       contractId: metronomeContractId,
       invoiceId: "free-activation",
     });


### PR DESCRIPTION
## Description

During checkout, when the amount is 0 (thanks to a coupon) we bypass the webhook process and directly call handleSubscriptionActivationSuccess to finalize the activation.
BUT we were calling it with a stale version of the workspace, that did not have an up to date metronomeCustomerId

=> solution: retrieve a fresh workspace and use it when calling handleSubscriptionActivationSuccess

## Tests

Tested locally

## Risk

Low, checkout flow with zero amount only

## Deploy Plan

Deploy front