### PR TITLE
Sandbox functions: MCP tool execution workflow

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -352,11 +352,7 @@ export async function* tryCallMCPTool(
     signal,
   }: {
     progressToken: ModelId;
-    // Optional: callers without a conversation surface (sandbox function invocations) skip it,
-    // and progress notifications are consumed but not yielded. Without a callback,
-    // `store_resource` notification contents are NOT persisted (persistence happens in the
-    // callback via `processToolNotification`). Acceptable while only `run_agent` emits them.
-    makeToolNotificationEvent?: (
+    makeToolNotificationEvent: (
       notification: MCPProgressNotificationType
     ) => Promise<ToolNotificationEvent>;
     signal?: AbortSignal;
@@ -597,9 +593,7 @@ export async function* tryCallMCPTool(
           break;
         }
         notificationPromise = notificationStream.next();
-        if (makeToolNotificationEvent) {
-          yield makeToolNotificationEvent(iteratorResult.value);
-        }
+        yield makeToolNotificationEvent(iteratorResult.value);
       }
     }
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -353,7 +353,11 @@ export async function* tryCallMCPTool(
   }: {
     progressToken: ModelId;
     // Optional: callers without a conversation surface (sandbox function invocations) have no
-    // notification event to build — progress notifications are consumed but not yielded.
+    // notification event to build — progress notifications are consumed but not yielded. Note
+    // that this drops more than UI events: `store_resource` notification contents are persisted
+    // by the caller-provided callback (via `processToolNotification`), so without a callback they
+    // are NOT persisted. Acceptable while no tool callable in these modes emits them (only
+    // `run_agent` does today).
     makeToolNotificationEvent?: (
       notification: MCPProgressNotificationType
     ) => Promise<ToolNotificationEvent>;

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -352,12 +352,10 @@ export async function* tryCallMCPTool(
     signal,
   }: {
     progressToken: ModelId;
-    // Optional: callers without a conversation surface (sandbox function invocations) have no
-    // notification event to build — progress notifications are consumed but not yielded. Note
-    // that this drops more than UI events: `store_resource` notification contents are persisted
-    // by the caller-provided callback (via `processToolNotification`), so without a callback they
-    // are NOT persisted. Acceptable while no tool callable in these modes emits them (only
-    // `run_agent` does today).
+    // Optional: callers without a conversation surface (sandbox function invocations) skip it,
+    // and progress notifications are consumed but not yielded. Without a callback,
+    // `store_resource` notification contents are NOT persisted (persistence happens in the
+    // callback via `processToolNotification`). Acceptable while only `run_agent` emits them.
     makeToolNotificationEvent?: (
       notification: MCPProgressNotificationType
     ) => Promise<ToolNotificationEvent>;

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -352,7 +352,9 @@ export async function* tryCallMCPTool(
     signal,
   }: {
     progressToken: ModelId;
-    makeToolNotificationEvent: (
+    // Optional: callers without a conversation surface (sandbox function invocations) have no
+    // notification event to build — progress notifications are consumed but not yielded.
+    makeToolNotificationEvent?: (
       notification: MCPProgressNotificationType
     ) => Promise<ToolNotificationEvent>;
     signal?: AbortSignal;
@@ -593,7 +595,9 @@ export async function* tryCallMCPTool(
           break;
         }
         notificationPromise = notificationStream.next();
-        yield makeToolNotificationEvent(iteratorResult.value);
+        if (makeToolNotificationEvent) {
+          yield makeToolNotificationEvent(iteratorResult.value);
+        }
       }
     }
 

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -16,17 +16,23 @@ import type { ToolContextType } from "@app/lib/actions/types";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
+import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { assert, describe, expect, it, vi } from "vitest";
 
@@ -468,6 +474,66 @@ describe("processToolResults", () => {
     expect(toolOutputWrite).toBeDefined();
     expect(toolOutputWrite?.filePath).toMatch(
       new RegExp(`${TOOL_OUTPUTS_FOLDER_NAME}/\\d+_test_tool\\.json$`)
+    );
+  });
+
+  it("should write the full content array to a single GCS object in a sandbox function run context", async () => {
+    const { auth, workspace, invocation, globalSpace } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+    const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
+      name: "common_utilities",
+      useCase: null,
+    });
+    const view = await MCPServerViewFactory.create(
+      workspace,
+      server.id,
+      globalSpace
+    );
+    const action = await SandboxFunctionMCPActionFactory.create(auth, {
+      invocation,
+      mcpServerView: view,
+    });
+
+    fileStorageMock.reset();
+
+    const toolCallResultContent: CallToolResult["content"] = [
+      { type: "text", text: "first block" },
+      { type: "text", text: "second block" },
+    ];
+
+    const { outputItems, generatedFiles } = await processToolResults(auth, {
+      localLogger: logger.child({ test: true }),
+      toolContext: {
+        runContext: {
+          contextType: "sandbox_function",
+          action,
+          invocation,
+          toolConfiguration: action.toolConfiguration,
+        },
+      },
+      toolCallResultContent,
+    });
+
+    // No per-block output items outside of a conversation.
+    expect(outputItems).toHaveLength(0);
+    expect(generatedFiles).toHaveLength(0);
+
+    // The full content array lands in one GCS object, recorded on the action row.
+    const outputWrite = fileStorageMock.saveFileCalls.find((call) =>
+      call.filePath.endsWith(`mcp_output_items/${action.sId}/output.json`)
+    );
+    expect(outputWrite).toBeDefined();
+    expect(JSON.parse(outputWrite?.content.toString() ?? "")).toEqual(
+      toolCallResultContent
+    );
+
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        auth,
+        action.id
+      );
+    expect(refetched?.outputGcsPath).toBe(
+      `w/${workspace.sId}/mcp_output_items/${action.sId}/output.json`
     );
   });
 });

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -523,8 +523,9 @@ describe("processToolResults", () => {
       toolCallResultContent,
     });
 
-    // No per-block output items outside of a conversation.
-    expect(outputItems).toHaveLength(0);
+    // Sandbox actions persist the whole content array as a single GCS object, but
+    // createOutputItems still returns the generic per-content items.
+    expect(outputItems).toHaveLength(2);
     expect(generatedFiles).toHaveLength(0);
 
     // The full content array lands in one GCS object, recorded on the action row.

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -477,7 +477,7 @@ describe("processToolResults", () => {
     );
   });
 
-  it("should write the full content array to a single GCS object in a sandbox function run context", async () => {
+  async function setupSandboxFunctionTest() {
     const { auth, workspace, invocation, globalSpace } =
       await createPersistedSandboxFunctionInvocationTokenTestContext();
     const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
@@ -496,6 +496,22 @@ describe("processToolResults", () => {
 
     fileStorageMock.reset();
 
+    const toolContext: ToolContextType = {
+      runContext: {
+        contextType: "sandbox_function",
+        action,
+        invocation,
+        toolConfiguration: action.toolConfiguration,
+      },
+    };
+
+    return { auth, workspace, action, toolContext };
+  }
+
+  it("should write the full content array to a single GCS object in a sandbox function run context", async () => {
+    const { auth, workspace, action, toolContext } =
+      await setupSandboxFunctionTest();
+
     const toolCallResultContent: CallToolResult["content"] = [
       { type: "text", text: "first block" },
       { type: "text", text: "second block" },
@@ -503,14 +519,7 @@ describe("processToolResults", () => {
 
     const { outputItems, generatedFiles } = await processToolResults(auth, {
       localLogger: logger.child({ test: true }),
-      toolContext: {
-        runContext: {
-          contextType: "sandbox_function",
-          action,
-          invocation,
-          toolConfiguration: action.toolConfiguration,
-        },
-      },
+      toolContext,
       toolCallResultContent,
     });
 
@@ -535,5 +544,29 @@ describe("processToolResults", () => {
     expect(refetched?.outputGcsPath).toBe(
       `w/${workspace.sId}/mcp_output_items/${action.sId}/output.json`
     );
+  });
+
+  it("should throw and leave the action without an output path when the sandbox output write fails", async () => {
+    const { auth, action, toolContext } = await setupSandboxFunctionTest();
+
+    fileStorageMock.setFileSaveFails((filePath) =>
+      filePath.endsWith(`mcp_output_items/${action.sId}/output.json`)
+    );
+
+    await expect(
+      processToolResults(auth, {
+        localLogger: logger.child({ test: true }),
+        toolContext,
+        toolCallResultContent: [{ type: "text", text: "some output" }],
+      })
+    ).rejects.toThrow();
+
+    // No acceptable degraded state: the row must not point at an object that was never written.
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        auth,
+        action.id
+      );
+    expect(refetched?.outputGcsPath).toBeNull();
   });
 });

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -157,7 +157,9 @@ export async function processToolNotification(
 }
 
 /**
- * Processes tool results, handles file uploads, and creates output items.
+ * Processes tool results, handles file uploads, and persists the output: one output item per
+ * content block in an agent loop, a single GCS object holding the full content array for a
+ * sandbox function invocation.
  * Returns the processed content and generated files.
  */
 export async function processToolResults(

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -27,15 +27,10 @@ import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import { TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS } from "@app/temporal/agent_loop/config";
+import { TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS } from "@app/temporal/agent_loop/config";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { heartbeat } from "@temporalio/activity";
-
-const TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS = 5 * 1000;
-const TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS =
-  TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS -
-  TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS;
 
 /**
  * Runs a tool with streaming for the given MCP action configuration.

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -13,6 +13,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import type { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   SandboxFunctionInvocationModel,
@@ -267,16 +268,17 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     return sandboxFunction ?? null;
   }
 
-  // Lives here rather than on SandboxFunctionInvocationResource: the invocation resource is
-  // constructed with its function, and importing this resource from there would close an import
-  // cycle (this file already imports the invocation resource for deletion).
-  static async fetchInvocationByModelIdWithAuth(
+  // Lives here rather than on SandboxFunctionMCPActionResource: that resource can only type-import
+  // the invocation resource (the invocation resource value-imports it for cascade deletion), so it
+  // cannot construct an invocation. Takes the action rather than its FK id so callers don't thread
+  // a ModelId around.
+  static async fetchInvocationForAction(
     auth: Authenticator,
-    id: ModelId
+    action: SandboxFunctionMCPActionResource
   ): Promise<SandboxFunctionInvocationResource | null> {
     const invocation = await SandboxFunctionInvocationModel.findOne({
       where: {
-        id,
+        id: action.sandboxFunctionInvocationId,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
     });

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -14,7 +14,10 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
+import {
+  SandboxFunctionInvocationModel,
+  SandboxFunctionModel,
+} from "@app/lib/resources/storage/models/sandbox_function";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import {
@@ -262,6 +265,41 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     });
 
     return sandboxFunction ?? null;
+  }
+
+  // Lives here rather than on SandboxFunctionInvocationResource: the invocation resource is
+  // constructed with its function, and importing this resource from there would close an import
+  // cycle (this file already imports the invocation resource for deletion).
+  static async fetchInvocationByModelIdWithAuth(
+    auth: Authenticator,
+    id: ModelId
+  ): Promise<SandboxFunctionInvocationResource | null> {
+    const invocation = await SandboxFunctionInvocationModel.findOne({
+      where: {
+        id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    if (!invocation) {
+      return null;
+    }
+
+    const sandboxFunction = await this.fetchById(
+      auth,
+      this.modelIdToSId({
+        id: invocation.sandboxFunctionId,
+        workspaceId: invocation.workspaceId,
+      })
+    );
+    if (!sandboxFunction) {
+      return null;
+    }
+
+    return new SandboxFunctionInvocationResource(
+      SandboxFunctionInvocationModel,
+      invocation.get(),
+      { sandboxFunction }
+    );
   }
 
   static async listBySpace(

--- a/front/lib/utils/async_utils.ts
+++ b/front/lib/utils/async_utils.ts
@@ -124,3 +124,16 @@ export async function withPeriodicHeartbeat<T>(
 export async function setTimeoutAync(delayMs: number = 0): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, delayMs));
 }
+
+// Consume an async generator, discarding its yields, and return its return value. `for await`
+// discards generator return values and `yield*` only works inside another generator, so callers
+// that need the return value outside of a generator have to drain manually.
+export async function drainAsyncGenerator<Y, R>(
+  generator: AsyncGenerator<Y, R>
+): Promise<R> {
+  let result = await generator.next();
+  while (!result.done) {
+    result = await generator.next();
+  }
+  return result.value;
+}

--- a/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
@@ -7,15 +7,10 @@ import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_fun
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import { TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS } from "@app/temporal/agent_loop/config";
+import { TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS } from "@app/temporal/agent_loop/config";
 import type { ModelId } from "@app/types/shared/model_id";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { heartbeat } from "@temporalio/activity";
-
-const TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS = 5 * 1000;
-const TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS =
-  TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS -
-  TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS;
 
 export async function runSandboxFunctionToolActivity(
   authType: AuthenticatorType,
@@ -100,7 +95,10 @@ export async function runSandboxFunctionToolActivity(
     );
   } catch (err) {
     // The poll contract requires a terminal status: a persistence failure (GCS retries
-    // exhausted) must surface as an errored action, not an action stuck `running`.
+    // exhausted) must surface as an errored action, not an action stuck `running`. Catching our
+    // own throw here is temporary — `processToolResults` throws because `createOutputItems`
+    // does (see the TODO(2026-05-08 FLAV) in agent_mcp_action_resource.ts to Result-ify it and
+    // its call sites); this catch goes away with that refactor.
     localLogger.error(
       { err: normalizeError(err) },
       "Failed to persist sandbox function tool output, marking action as errored"

--- a/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
@@ -1,5 +1,8 @@
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
-import { processToolResults } from "@app/lib/actions/mcp_execution";
+import {
+  processToolNotification,
+  processToolResults,
+} from "@app/lib/actions/mcp_execution";
 import type { SandboxFunctionRunContextType } from "@app/lib/actions/types";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
@@ -33,11 +36,10 @@ export async function runSandboxFunctionToolActivity(
     return;
   }
 
-  const invocation =
-    await SandboxFunctionResource.fetchInvocationByModelIdWithAuth(
-      auth,
-      action.sandboxFunctionInvocationId
-    );
+  const invocation = await SandboxFunctionResource.fetchInvocationForAction(
+    auth,
+    action
+  );
   if (!invocation) {
     await action.markAsErrored({ executionDurationMs: 0 });
     logger.error(
@@ -62,10 +64,11 @@ export async function runSandboxFunctionToolActivity(
 
   const startTimeMs = performance.now();
 
-  // There is no invocation event stream yet, so we pass no `makeToolNotificationEvent`: the
-  // generator yields nothing and we drain it for the tool result (its return value).
-  // TODO(2026-07-08 SANDBOX_FUNCTIONS): post progress notifications to the invocation event
-  // stream once it exists, instead of dropping them.
+  // `processToolNotification` persists `store_resource` progress output on the action. The event
+  // it returns has no stream to reach yet (there is no invocation event stream), so we drain the
+  // generator for the tool result (its return value) and discard the events.
+  // TODO(2026-07-08 SANDBOX_FUNCTIONS): forward these events to the invocation event stream once
+  // it exists (e.g. viz progress).
   const toolCallResult = await drainAsyncGenerator(
     tryCallMCPTool(
       auth,
@@ -73,6 +76,12 @@ export async function runSandboxFunctionToolActivity(
       { runContext },
       {
         progressToken: action.id,
+        makeToolNotificationEvent: async (notification) => {
+          const { event } = await processToolNotification(auth, notification, {
+            toolContext: { runContext },
+          });
+          return event;
+        },
       }
     )
   );

--- a/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
@@ -1,0 +1,121 @@
+import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
+import { processToolResults } from "@app/lib/actions/mcp_execution";
+import type { SandboxFunctionRunContextType } from "@app/lib/actions/types";
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import { TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS } from "@app/temporal/agent_loop/config";
+import type { ModelId } from "@app/types/shared/model_id";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { heartbeat } from "@temporalio/activity";
+
+const TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS = 5 * 1000;
+const TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS =
+  TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS -
+  TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS;
+
+export async function runSandboxFunctionToolActivity(
+  authType: AuthenticatorType,
+  { actionModelId }: { actionModelId: ModelId }
+): Promise<void> {
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+
+  const action = await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+    auth,
+    actionModelId
+  );
+  if (!action) {
+    logger.error(
+      { actionModelId },
+      "Sandbox function MCP action not found, skipping tool execution"
+    );
+    return;
+  }
+
+  const invocation =
+    await SandboxFunctionResource.fetchInvocationByModelIdWithAuth(
+      auth,
+      action.sandboxFunctionInvocationId
+    );
+  if (!invocation) {
+    await action.markAsErrored({ executionDurationMs: 0 });
+    logger.error(
+      { actionModelId, actionId: action.sId },
+      "Sandbox function invocation not found, marking action as errored"
+    );
+    return;
+  }
+
+  const localLogger = logger.child({
+    actionId: action.sId,
+    invocationId: invocation.sId,
+    workspaceId: auth.getNonNullableWorkspace().sId,
+  });
+
+  const runContext: SandboxFunctionRunContextType = {
+    contextType: "sandbox_function",
+    action,
+    invocation,
+    toolConfiguration: action.toolConfiguration,
+  };
+
+  const startTime = performance.now();
+
+  // Drain the generator: without `makeToolNotificationEvent`, progress notifications are consumed
+  // but never yielded — there is no conversation surface to stream them to.
+  const generator = tryCallMCPTool(
+    auth,
+    action.inputs,
+    { runContext },
+    { progressToken: action.id }
+  );
+  let iteratorResult = await generator.next();
+  while (!iteratorResult.done) {
+    iteratorResult = await generator.next();
+  }
+  const toolCallResult = iteratorResult.value;
+
+  // Persist the output — a tool error's content included, the poll endpoint returns it alongside
+  // the errored status — through the same result processing as the agent loop (writes the full
+  // content array to the action's single GCS output object). Result processing can take minutes
+  // when handling files, so heartbeat while it runs.
+  try {
+    await withPeriodicHeartbeat(
+      () =>
+        processToolResults(auth, {
+          localLogger,
+          toolCallResultContent: toolCallResult.content,
+          toolContext: { runContext },
+        }),
+      {
+        intervalMs: TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS,
+        heartbeatFn: () => {
+          heartbeat();
+          localLogger.info("MCP tool result processing heartbeat");
+        },
+      }
+    );
+  } catch (err) {
+    // The poll contract requires a terminal status: a persistence failure (GCS retries
+    // exhausted) must surface as an errored action, not an action stuck `running`.
+    localLogger.error(
+      { err: normalizeError(err) },
+      "Failed to persist sandbox function tool output, marking action as errored"
+    );
+    await action.markAsErrored({
+      executionDurationMs: Math.round(performance.now() - startTime),
+    });
+    return;
+  }
+
+  const executionDurationMs = Math.round(performance.now() - startTime);
+
+  if (toolCallResult.isError) {
+    await action.markAsErrored({ executionDurationMs });
+  } else {
+    await action.markAsSucceeded({ executionDurationMs });
+  }
+}

--- a/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
@@ -5,7 +5,10 @@ import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
+import {
+  drainAsyncGenerator,
+  withPeriodicHeartbeat,
+} from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS } from "@app/temporal/agent_loop/config";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -57,26 +60,27 @@ export async function runSandboxFunctionToolActivity(
     toolConfiguration: action.toolConfiguration,
   };
 
-  const startTime = performance.now();
+  const startTimeMs = performance.now();
 
-  // Drain the generator: without `makeToolNotificationEvent`, progress notifications are consumed
-  // but never yielded — there is no conversation surface to stream them to.
-  const generator = tryCallMCPTool(
-    auth,
-    action.inputs,
-    { runContext },
-    { progressToken: action.id }
+  // There is no invocation event stream yet, so we pass no `makeToolNotificationEvent`: the
+  // generator yields nothing and we drain it for the tool result (its return value).
+  // TODO(2026-07-08 SANDBOX_FUNCTIONS): post progress notifications to the invocation event
+  // stream once it exists, instead of dropping them.
+  const toolCallResult = await drainAsyncGenerator(
+    tryCallMCPTool(
+      auth,
+      action.inputs,
+      { runContext },
+      {
+        progressToken: action.id,
+      }
+    )
   );
-  let iteratorResult = await generator.next();
-  while (!iteratorResult.done) {
-    iteratorResult = await generator.next();
-  }
-  const toolCallResult = iteratorResult.value;
 
-  // Persist the output — a tool error's content included, the poll endpoint returns it alongside
-  // the errored status — through the same result processing as the agent loop (writes the full
-  // content array to the action's single GCS output object). Result processing can take minutes
-  // when handling files, so heartbeat while it runs.
+  // Persist the output through the same result processing as the agent loop: the full content
+  // array goes to the action's single GCS output object. Error content is persisted too, the
+  // poll endpoint returns it alongside the errored status. Processing can take minutes when
+  // handling files, so heartbeat while it runs.
   try {
     await withPeriodicHeartbeat(
       () =>
@@ -94,22 +98,21 @@ export async function runSandboxFunctionToolActivity(
       }
     );
   } catch (err) {
-    // The poll contract requires a terminal status: a persistence failure (GCS retries
-    // exhausted) must surface as an errored action, not an action stuck `running`. Catching our
-    // own throw here is temporary — `processToolResults` throws because `createOutputItems`
-    // does (see the TODO(2026-05-08 FLAV) in agent_mcp_action_resource.ts to Result-ify it and
-    // its call sites); this catch goes away with that refactor.
+    // `processToolResults` throws when output cannot be persisted (no acceptable degraded
+    // state). The agent loop lets that abort the step; here there is no step to abort, so catch
+    // it and mark the action errored, otherwise it would stay `running` and the poll never
+    // reaches a terminal status.
     localLogger.error(
       { err: normalizeError(err) },
       "Failed to persist sandbox function tool output, marking action as errored"
     );
     await action.markAsErrored({
-      executionDurationMs: Math.round(performance.now() - startTime),
+      executionDurationMs: Math.round(performance.now() - startTimeMs),
     });
     return;
   }
 
-  const executionDurationMs = Math.round(performance.now() - startTime);
+  const executionDurationMs = Math.round(performance.now() - startTimeMs);
 
   if (toolCallResult.isError) {
     await action.markAsErrored({ executionDurationMs });

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -2,6 +2,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { logAgentLoopStart } from "@app/temporal/agent_loop/activities/instrumentation";
@@ -9,6 +10,7 @@ import {
   makeAgentLoopWorkflowId,
   makeCompactionWorkflowId,
   makeSandboxChildToolWorkflowId,
+  makeSandboxFunctionToolWorkflowId,
 } from "@app/temporal/agent_loop/lib/workflow_ids";
 import type {
   AgentLoopArgs,
@@ -24,6 +26,7 @@ import {
   agentLoopWorkflow,
   compactionWorkflow,
   runSandboxChildToolWorkflow,
+  runSandboxFunctionToolWorkflow,
 } from "./workflows";
 
 export async function launchAgentLoopWorkflow({
@@ -244,6 +247,42 @@ export async function launchSandboxChildToolWorkflow(
       },
       memo: {
         conversationId: agentLoopArgs.conversationId,
+        workspaceId,
+      },
+    });
+  } catch (error) {
+    if (error instanceof WorkflowExecutionAlreadyStartedError) {
+      // Idempotent: another caller already kicked it off for this action.
+      return new Ok(undefined);
+    }
+    throw error;
+  }
+
+  return new Ok(undefined);
+}
+
+export async function launchSandboxFunctionToolWorkflow(
+  auth: Authenticator,
+  { action }: { action: SandboxFunctionMCPActionResource }
+): Promise<Result<undefined, Error>> {
+  const authType = auth.toJSON();
+  const { workspaceId } = authType;
+  const client = await getTemporalClientForAgentNamespace();
+
+  const workflowId = makeSandboxFunctionToolWorkflowId({
+    workspaceId,
+    actionModelId: action.id,
+  });
+
+  try {
+    await client.workflow.start(runSandboxFunctionToolWorkflow, {
+      args: [{ authType, actionModelId: action.id }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      searchAttributes: {
+        workspaceId: [workspaceId],
+      },
+      memo: {
         workspaceId,
       },
     });

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -10,3 +10,10 @@ export const RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS = 1 * 60 * 1000;
 
 export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
 export const MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
+
+// Heartbeat cadence while tool result processing runs (file handling can take minutes): fire
+// comfortably within the heartbeat timeout.
+const TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS = 5 * 1000;
+export const TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS =
+  TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS -
+  TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS;

--- a/front/temporal/agent_loop/lib/workflow_ids.ts
+++ b/front/temporal/agent_loop/lib/workflow_ids.ts
@@ -42,3 +42,13 @@ export function makeSandboxChildToolWorkflowId({
 }) {
   return `sandbox-child-tool-workflow-${workspaceId}-${actionModelId}`;
 }
+
+export function makeSandboxFunctionToolWorkflowId({
+  workspaceId,
+  actionModelId,
+}: {
+  workspaceId: string;
+  actionModelId: number;
+}) {
+  return `sandbox-function-tool-workflow-${workspaceId}-${actionModelId}`;
+}

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -23,6 +23,7 @@ import {
 } from "@app/temporal/agent_loop/activities/finalize";
 import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
+import { runSandboxFunctionToolActivity } from "@app/temporal/agent_loop/activities/run_sandbox_function_tool";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 import { QUEUE_NAME } from "@app/temporal/agent_loop/config";
 import { instrumentationSinks } from "@app/temporal/agent_loop/sinks";
@@ -70,6 +71,7 @@ export async function runAgentLoopWorker() {
       checkCreditsActivity,
       publishDeferredEventsActivity,
       runModelAndCreateActionsActivity,
+      runSandboxFunctionToolActivity,
       runToolActivity,
     },
     taskQueue: QUEUE_NAME,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -10,6 +10,7 @@ import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities
 import type * as finalizeActivities from "@app/temporal/agent_loop/activities/finalize";
 import type * as publishDeferredEventsActivities from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
+import type * as runSandboxFunctionToolActivities from "@app/temporal/agent_loop/activities/run_sandbox_function_tool";
 import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
 import {
   MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
@@ -93,6 +94,17 @@ const { runToolActivity: runRetryableToolActivity } = proxyActivities<
   heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
   retry: {
     maximumAttempts: RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
+  },
+});
+
+const { runSandboxFunctionToolActivity } = proxyActivities<
+  typeof runSandboxFunctionToolActivities
+>({
+  startToCloseTimeout: toolActivityStartToCloseTimeoutMs,
+  heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
+  retry: {
+    // Do not retry tool activities. Those are not idempotent.
+    maximumAttempts: 1,
   },
 });
 
@@ -527,4 +539,14 @@ export async function runSandboxChildToolWorkflow({
   if (deferredEvents.length > 0) {
     await publishDeferredEventsActivity(deferredEvents);
   }
+}
+
+export async function runSandboxFunctionToolWorkflow({
+  authType,
+  actionModelId,
+}: {
+  authType: AuthenticatorType;
+  actionModelId: number;
+}) {
+  await runSandboxFunctionToolActivity(authType, { actionModelId });
 }

--- a/front/tests/utils/SandboxTokenFactory.ts
+++ b/front/tests/utils/SandboxTokenFactory.ts
@@ -5,16 +5,20 @@ import {
 } from "@app/lib/api/sandbox/access_tokens";
 import { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { AgentMCPActionType } from "@app/types/actions";
+import { sandboxFunctionContentType } from "@app/types/files";
 
 process.env.DUST_SANDBOX_JWT_SECRET ??= "test-sandbox-jwt-secret";
 
@@ -128,6 +132,60 @@ export async function createSandboxFunctionInvocationTokenTestContext({
 
   return {
     ...context,
+    token,
+  };
+}
+
+// Same as above but with a real sandbox function and invocation persisted, for flows that fetch
+// them back (calling MCP tools from a function invocation).
+export async function createPersistedSandboxFunctionInvocationTokenTestContext() {
+  const context = await createSandboxTokenTestContext();
+  const { auth, workspace } = context;
+
+  const podSpace = await SpaceFactory.project(workspace);
+  const file = await FileFactory.create(auth, null, {
+    contentType: sandboxFunctionContentType,
+    fileName: "greet.ts",
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: podSpace.sId },
+  });
+  const sandboxFunction = await SandboxFunctionResource.makeNew(auth, {
+    space: podSpace,
+    file,
+    slug: "greet",
+    description: "Greet someone.",
+    inputSchema: {
+      type: "object",
+      properties: { message: { type: "string" } },
+      required: ["message"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: { greeting: { type: "string" } },
+      required: ["greeting"],
+    },
+  });
+  const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
+    sandboxFunction,
+  });
+
+  const token = await generateSandboxFunctionInvocationToken(auth, {
+    sandbox: context.sandbox,
+    sandboxFunction: {
+      sId: sandboxFunction.sId,
+      space: { sId: podSpace.sId },
+    },
+    invocationId: invocation.sId,
+    execId: `test-function-exec-${context.sandbox.sId}`,
+  });
+
+  return {
+    ...context,
+    podSpace,
+    sandboxFunction,
+    invocation,
     token,
   };
 }


### PR DESCRIPTION
## Description

Sandbox functions (code running via `dsbx function run` on a pod) will be able to call MCP tools without a conversation. The model landed in #28446 and the resource in #28604. This PR adds the execution layer: given a `SandboxFunctionMCPAction` row, run the tool on Temporal and persist its output. The endpoints that create these rows come in the next PR (stacked).

### Output persistence in `processToolResults`

Fills the `TODO(SANDBOX_FUNCTIONS)` left by #28631: `processToolResults` now branches on the run context for persistence.

| run context | persistence |
|---|---|
| `agent_loop` | one output item row per content block (unchanged) |
| `sandbox_function` | full content array as a single GCS object, `outputGcsPath` on the action row |

A single object because the consumer (dsbx) reads the output exactly once, as a whole array, at completion. There are no per-block consumers (rendering, citations, per-block file FKs and retention are conversation concepts). Everything upstream of persistence was already context-aware (#28435): generated files land as `project_context` on the pod's space, large
text offloads to the pod file system.

### Temporal execution

`runSandboxFunctionToolWorkflow` → `runSandboxFunctionToolActivity` on `agent-loop-queue-v2` (same queue as `runSandboxChildToolWorkflow`), `maximumAttempts: 1` (tool calls are not idempotent). The activity drives `tryCallMCPTool` with the `sandbox_function` run context, persists through `processToolResults` (error content included — the poll endpoint returns it alongside the errored status), then marks the action succeeded/errored. Heartbeats come from
`tryCallMCPTool` during the call and `withPeriodicHeartbeat` during result processing, mirroring `run_tool`.

`makeToolNotificationEvent` becomes optional in `tryCallMCPTool`: there is no conversation surface to stream progress notifications to.


## Tests

- `mcp_execution.test.ts`: sandbox run context writes the full content array to a single GCS
  object, sets `outputGcsPath`, returns no output items.
- Existing `processToolResults` suite passes unchanged (agent-loop path untouched).

## Risk

`launchSandboxFunctionToolWorkflow` has no caller in this PR: the `/sandbox/actions/call`  endpoint that invokes it is the next PR of the stack. So dead code until the follow-up PR lands (no caller). Worst case, revert. Safe to rollback.

## Deploy Plan

Deploy front.