### PR TITLE
Sandbox functions: list, call and poll MCP tools from invocations

### DIFF
--- a/front-api/middlewares/sandbox_auth.ts
+++ b/front-api/middlewares/sandbox_auth.ts
@@ -1,3 +1,4 @@
+import type { SandboxTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import {
   isSandboxExecTokenPayload,
   isSandboxFunctionInvocationTokenPayload,
@@ -18,8 +19,20 @@ import { apiError } from "./utils";
 
 type SandboxTokenKind = "action" | "function_invocation";
 type SandboxAuthOptions = {
-  tokenKind: SandboxTokenKind;
+  allowedTokenKinds: SandboxTokenKind[];
 };
+
+function getSandboxTokenKind(
+  claims: SandboxTokenPayload
+): SandboxTokenKind | null {
+  if (isSandboxExecTokenPayload(claims)) {
+    return "action";
+  }
+  if (isSandboxFunctionInvocationTokenPayload(claims)) {
+    return "function_invocation";
+  }
+  return null;
+}
 
 function readHeaders(ctx: Context): Record<string, string> {
   const headers: Record<string, string> = {};
@@ -38,7 +51,7 @@ function readHeaders(ctx: Context): Record<string, string> {
  * Mirrors `withSandboxAuthentication` in `front/lib/api/auth_wrappers.ts`.
  */
 export function sandboxAuth({
-  tokenKind,
+  allowedTokenKinds,
 }: SandboxAuthOptions): MiddlewareHandler<SandboxCtx> {
   return createMiddleware<SandboxCtx>(async (ctx, next) => {
     const wId = ctx.req.param("wId");
@@ -83,25 +96,13 @@ export function sandboxAuth({
         },
       });
     }
-    if (tokenKind === "action" && !isSandboxExecTokenPayload(claims)) {
+    const claimsKind = getSandboxTokenKind(claims);
+    if (claimsKind === null || !allowedTokenKinds.includes(claimsKind)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
           type: "invalid_request_error",
-          message: "This sandbox token cannot access sandbox actions.",
-        },
-      });
-    }
-    if (
-      tokenKind === "function_invocation" &&
-      !isSandboxFunctionInvocationTokenPayload(claims)
-    ) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "invalid_request_error",
-          message:
-            "This sandbox token cannot access sandbox function invocations.",
+          message: "This sandbox token cannot access this endpoint.",
         },
       });
     }
@@ -112,7 +113,7 @@ export function sandboxAuth({
     }
     const auth = authRes.value;
 
-    if (tokenKind === "action") {
+    if (claimsKind === "action") {
       const featureFlags = await getFeatureFlags(auth);
       if (!isComputerFeatureEnabled(featureFlags)) {
         return apiError(ctx, {

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
@@ -1,0 +1,126 @@
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
+import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory GCS mock: writes persist content that reads can return.
+const gcsStore = new Map<string, Buffer>();
+
+vi.mock("@app/lib/file_storage", () => ({
+  getPrivateUploadBucket: vi.fn(() => ({
+    file: vi.fn((path: string) => ({
+      save: vi.fn(async (data: Buffer) => {
+        gcsStore.set(path, data);
+      }),
+      download: vi.fn(async () => {
+        const buf = gcsStore.get(path);
+        if (!buf) {
+          throw new Error(`GCS file not found: ${path}`);
+        }
+        return [buf];
+      }),
+    })),
+    delete: vi.fn(async (path: string) => {
+      gcsStore.delete(path);
+    }),
+  })),
+}));
+
+function getSandboxAction(
+  workspace: { sId: string },
+  token: string,
+  actionId: string
+) {
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/sandbox/actions/${actionId}`,
+    { headers: { authorization: `Bearer ${token}` } }
+  );
+}
+
+async function setupWithAction() {
+  const context =
+    await createPersistedSandboxFunctionInvocationTokenTestContext();
+  const commonUtilities = await InternalMCPServerInMemoryResource.makeNew(
+    context.auth,
+    { name: "common_utilities", useCase: null }
+  );
+  const view = await MCPServerViewFactory.create(
+    context.workspace,
+    commonUtilities.id,
+    context.globalSpace
+  );
+  const action = await SandboxFunctionMCPActionFactory.create(context.auth, {
+    invocation: context.invocation,
+    mcpServerView: view,
+    toolName: "generate_random_number",
+    inputs: { max: 10 },
+  });
+  return { ...context, view, action };
+}
+
+describe("GET /api/v1/w/[wId]/sandbox/actions/[aId] (function invocation)", () => {
+  beforeEach(() => {
+    gcsStore.clear();
+  });
+
+  it("returns pending while the action is running", async () => {
+    const { token, workspace, action } = await setupWithAction();
+
+    const response = await getSandboxAction(workspace, token, action.sId);
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      status: "pending",
+      actionId: action.sId,
+    });
+  });
+
+  it("returns the output once the action succeeded", async () => {
+    const { auth, token, workspace, action } = await setupWithAction();
+
+    const content = [{ type: "text" as const, text: "7" }];
+    const writeResult = await action.createOutputItems(
+      auth,
+      content.map((c) => ({ content: c }))
+    );
+    expect(writeResult.isOk()).toBe(true);
+    await action.markAsSucceeded({ executionDurationMs: 42 });
+
+    const response = await getSandboxAction(workspace, token, action.sId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("success");
+    expect(body.action.status).toBe("succeeded");
+    expect(body.action.output).toEqual(content);
+  });
+
+  it("scopes actions to the token's invocation", async () => {
+    const { auth, token, workspace, view, sandboxFunction, action } =
+      await setupWithAction();
+
+    // An action of another invocation of the same function is not visible.
+    const otherInvocation = await SandboxFunctionInvocationResource.makeNew(
+      auth,
+      { sandboxFunction }
+    );
+    const otherAction = await SandboxFunctionMCPActionFactory.create(auth, {
+      invocation: otherInvocation,
+      mcpServerView: view,
+    });
+
+    const otherResponse = await getSandboxAction(
+      workspace,
+      token,
+      otherAction.sId
+    );
+    expect(otherResponse.status).toBe(404);
+
+    // The token's own action stays visible.
+    const ownResponse = await getSandboxAction(workspace, token, action.sId);
+    expect(ownResponse.status).toBe(202);
+  });
+});

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.ts
@@ -1,13 +1,19 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
-import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import {
+  isSandboxExecTokenPayload,
+  isSandboxFunctionInvocationTokenPayload,
+} from "@app/lib/api/sandbox/access_tokens";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { SandboxFunctionMCPActionType } from "@app/types/api/sandbox_functions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -28,8 +34,18 @@ type CallToolSuccessResponse = {
   action: AgentMCPActionWithOutputType;
 };
 
-export type FetchConversationMessageActionResponse =
+type CallToolSandboxFunctionSuccessResponse = {
+  status: "success";
+  action: SandboxFunctionMCPActionType & {
+    output: CallToolResult["content"] | null;
+  };
+};
+
+// Flavor-neutral on purpose: exec tokens poll AgentMCPActions (conversation sandboxes) and
+// invocation tokens poll SandboxFunctionMCPActions, through the same handler and wire contract.
+export type GetSandboxActionResponseType =
   | CallToolSuccessResponse
+  | CallToolSandboxFunctionSuccessResponse
   | CallToolPendingResponse
   | CallToolRejectedResponse;
 
@@ -43,9 +59,60 @@ const app = sandboxApp();
 app.get(
   "/",
   validate("param", ParamsSchema),
-  async (ctx): HandlerResult<FetchConversationMessageActionResponse> => {
+  async (ctx): HandlerResult<GetSandboxActionResponseType> => {
     const auth = ctx.get("auth");
     const claims = ctx.get("sandboxClaims");
+
+    const { aId } = ctx.req.valid("param");
+
+    if (isSandboxFunctionInvocationTokenPayload(claims)) {
+      const action = await SandboxFunctionMCPActionResource.fetchById(
+        auth,
+        aId
+      );
+      // Scope the lookup to the token's invocation so a token cannot read actions of other
+      // invocations in the same workspace.
+      if (!action || action.invocationId !== claims.invocationId) {
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "action_not_found",
+            message: "Action not found.",
+          },
+        });
+      }
+
+      switch (action.status) {
+        case "running":
+        case "blocked_validation_required":
+          return ctx.json({ status: "pending", actionId: action.sId }, 202);
+        case "succeeded":
+        case "errored": {
+          const outputResult = await action.readOutput();
+          if (outputResult.isErr()) {
+            return apiError(ctx, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to read the action output.",
+              },
+            });
+          }
+          return ctx.json(
+            {
+              status: "success",
+              action: { ...action.toJSON(), output: outputResult.value },
+            },
+            200
+          );
+        }
+        case "denied":
+          return ctx.json({ status: "rejected" }, 403);
+        default:
+          assertNever(action.status);
+      }
+    }
+
     if (!isSandboxExecTokenPayload(claims)) {
       return apiError(ctx, {
         status_code: 403,
@@ -55,8 +122,6 @@ app.get(
         },
       });
     }
-
-    const { aId } = ctx.req.valid("param");
 
     const action = await AgentMCPActionResource.fetchById(auth, aId);
     if (!action) {

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
@@ -87,7 +87,7 @@ describe("POST /api/v1/w/[wId]/sandbox/actions/call (function invocation)", () =
     expect(response.status).toBe(404);
   });
 
-  it("rejects tools on non-internal servers", async () => {
+  it("creates actions for remote tools", async () => {
     const context =
       await createPersistedSandboxFunctionInvocationTokenTestContext();
     const remoteServer = await RemoteMCPServerFactory.create(context.workspace);
@@ -99,11 +99,20 @@ describe("POST /api/v1/w/[wId]/sandbox/actions/call (function invocation)", () =
 
     const response = await callSandboxTool(context.workspace, context.token, {
       serverViewId: view.sId,
-      toolName: "whatever",
+      toolName: "tool",
       arguments: {},
     });
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(202);
+    const body = await response.json();
+    expect(body.status).toBe("pending");
+
+    // The stake is snapshotted but not enforced: remote tools default to high and still run.
+    const action = await SandboxFunctionMCPActionResource.fetchById(
+      context.auth,
+      body.actionId
+    );
+    expect(action?.toolConfiguration.permission).toBe("high");
   });
 
   it("creates actions for conversation-coupled servers too", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
@@ -1,0 +1,171 @@
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/temporal/agent_loop/client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/temporal/agent_loop/client")>();
+  return {
+    ...actual,
+    launchSandboxFunctionToolWorkflow: vi.fn(async () => new Ok(undefined)),
+  };
+});
+
+function callSandboxTool(
+  workspace: { sId: string },
+  token: string,
+  body: Record<string, unknown>
+) {
+  return honoApp.request(`/api/v1/w/${workspace.sId}/sandbox/actions/call`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function setupWithView() {
+  const context =
+    await createPersistedSandboxFunctionInvocationTokenTestContext();
+  const commonUtilities = await InternalMCPServerInMemoryResource.makeNew(
+    context.auth,
+    { name: "common_utilities", useCase: null }
+  );
+  const view = await MCPServerViewFactory.create(
+    context.workspace,
+    commonUtilities.id,
+    context.globalSpace
+  );
+  return { ...context, view };
+}
+
+describe("POST /api/v1/w/[wId]/sandbox/actions/call (function invocation)", () => {
+  it("creates a running action and launches its workflow", async () => {
+    const { auth, token, workspace, invocation, view } = await setupWithView();
+
+    const response = await callSandboxTool(workspace, token, {
+      serverViewId: view.sId,
+      toolName: "generate_random_number",
+      arguments: { max: 10 },
+    });
+
+    expect(response.status).toBe(202);
+    const body = await response.json();
+    expect(body.status).toBe("pending");
+    expect(body.actionId).toMatch(/^sfa_/);
+
+    const action = await SandboxFunctionMCPActionResource.fetchById(
+      auth,
+      body.actionId
+    );
+    expect(action).not.toBeNull();
+    expect(action?.status).toBe("running");
+    expect(action?.toolName).toBe("generate_random_number");
+    expect(action?.inputs).toEqual({ max: 10 });
+    expect(action?.sandboxFunctionInvocationId).toBe(invocation.id);
+    expect(action?.toolConfiguration.permission).toBe("never_ask");
+  });
+
+  it("returns 404 for an unknown server view", async () => {
+    const { token, workspace } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+
+    const response = await callSandboxTool(workspace, token, {
+      serverViewId: "msv_unknown",
+      toolName: "generate_random_number",
+      arguments: {},
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects tools on non-internal servers", async () => {
+    const context =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+    const remoteServer = await RemoteMCPServerFactory.create(context.workspace);
+    const view = await MCPServerViewFactory.create(
+      context.workspace,
+      remoteServer.sId,
+      context.globalSpace
+    );
+
+    const response = await callSandboxTool(context.workspace, context.token, {
+      serverViewId: view.sId,
+      toolName: "whatever",
+      arguments: {},
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("creates actions for conversation-coupled servers too", async () => {
+    // No creation-time gating on the server: tools that require an agent-loop context error at
+    // execution based on the run context.
+    const context =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+    const search = await InternalMCPServerInMemoryResource.makeNew(
+      context.auth,
+      { name: "search", useCase: null }
+    );
+    const view = await MCPServerViewFactory.create(
+      context.workspace,
+      search.id,
+      context.globalSpace
+    );
+
+    const response = await callSandboxTool(context.workspace, context.token, {
+      serverViewId: view.sId,
+      toolName: "semantic_search",
+      arguments: {},
+    });
+
+    expect(response.status).toBe(202);
+    const body = await response.json();
+    expect(body.status).toBe("pending");
+  });
+
+  it("rejects unknown tools on an allowed server", async () => {
+    const { token, workspace, view } = await setupWithView();
+
+    const response = await callSandboxTool(workspace, token, {
+      serverViewId: view.sId,
+      toolName: "not_a_tool",
+      arguments: {},
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("reports a view outside the pod and global spaces as not found", async () => {
+    // `fetchById` is workspace-scoped, so a view in another space is fetchable: the endpoint
+    // must confine to the invocation's pod space + global space, matching the listing.
+    const context =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+    const otherSpace = await SpaceFactory.regular(context.workspace);
+    const commonUtilities = await InternalMCPServerInMemoryResource.makeNew(
+      context.auth,
+      { name: "common_utilities", useCase: null }
+    );
+    const view = await MCPServerViewFactory.create(
+      context.workspace,
+      commonUtilities.id,
+      otherSpace
+    );
+
+    const response = await callSandboxTool(context.workspace, context.token, {
+      serverViewId: view.sId,
+      toolName: "generate_random_number",
+      arguments: { max: 10 },
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -61,14 +61,6 @@ app.post(
                 message: result.error.message,
               },
             });
-          case "tool_requires_approval":
-            return apiError(ctx, {
-              status_code: 403,
-              api_error: {
-                type: "invalid_request_error",
-                message: result.error.message,
-              },
-            });
           case "tool_not_available":
           case "invalid_inputs":
             return apiError(ctx, {

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -1,6 +1,11 @@
-import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import {
+  isSandboxExecTokenPayload,
+  isSandboxFunctionInvocationTokenPayload,
+} from "@app/lib/api/sandbox/access_tokens";
 import { createSandboxChildAction } from "@app/lib/api/sandbox/create_child_action";
+import { createSandboxFunctionMCPAction } from "@app/lib/api/sandbox_functions/create_sandbox_function_mcp_action";
 import logger from "@app/logger/logger";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { CallMCPToolRequestBodySchema } from "@dust-tt/client";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -25,6 +30,65 @@ app.post(
   async (ctx): HandlerResult<CallSandboxToolResponse> => {
     const auth = ctx.get("auth");
     const claims = ctx.get("sandboxClaims");
+
+    const {
+      serverViewId,
+      toolName,
+      arguments: toolArgs,
+    } = ctx.req.valid("json");
+
+    // Sandbox function invocations have no conversation: the action is persisted on the
+    // invocation and executed by a dedicated workflow. The sandbox is never paused (function
+    // invocations are blocking execs) so the response can be returned directly.
+    if (isSandboxFunctionInvocationTokenPayload(claims)) {
+      const result = await createSandboxFunctionMCPAction(auth, {
+        sandboxFunctionId: claims.sandboxFunctionId,
+        invocationId: claims.invocationId,
+        podSpaceId: claims.spaceId,
+        serverViewId,
+        toolName,
+        rawInputs: toolArgs ?? {},
+      });
+
+      if (result.isErr()) {
+        switch (result.error.type) {
+          case "server_view_not_found":
+          case "invocation_not_found":
+            return apiError(ctx, {
+              status_code: 404,
+              api_error: {
+                type: "invalid_request_error",
+                message: result.error.message,
+              },
+            });
+          case "tool_requires_approval":
+            return apiError(ctx, {
+              status_code: 403,
+              api_error: {
+                type: "invalid_request_error",
+                message: result.error.message,
+              },
+            });
+          case "tool_not_available":
+          case "invalid_inputs":
+            return apiError(ctx, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: result.error.message,
+              },
+            });
+          default:
+            assertNever(result.error.type);
+        }
+      }
+
+      return ctx.json(
+        { status: "pending" as const, actionId: result.value.actionId },
+        202
+      );
+    }
+
     if (!isSandboxExecTokenPayload(claims)) {
       return apiError(ctx, {
         status_code: 403,
@@ -34,12 +98,6 @@ app.post(
         },
       });
     }
-
-    const {
-      serverViewId,
-      toolName,
-      arguments: toolArgs,
-    } = ctx.req.valid("json");
 
     const result = await createSandboxChildAction(auth, {
       parentActionId: claims.actionId,

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.test.ts
@@ -1,5 +1,6 @@
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import {
   createSandboxFunctionInvocationTokenTestContext,
   createSandboxTokenTestContext,
@@ -45,7 +46,7 @@ describe("GET /api/v1/w/[wId]/sandbox/actions", () => {
     });
   });
 
-  it("lists internal servers of the pod and global spaces for invocation tokens", async () => {
+  it("lists servers of the pod and global spaces for invocation tokens", async () => {
     const { auth, token, workspace, globalSpace } =
       await createSandboxFunctionInvocationTokenTestContext();
 
@@ -63,6 +64,10 @@ describe("GET /api/v1/w/[wId]/sandbox/actions", () => {
       useCase: null,
     });
     await MCPServerViewFactory.create(workspace, search.id, globalSpace);
+    const remoteServer = await RemoteMCPServerFactory.create(workspace, {
+      name: "remote_server",
+    });
+    await MCPServerViewFactory.create(workspace, remoteServer.sId, globalSpace);
 
     const response = await getSandboxActions(workspace, token);
 
@@ -72,6 +77,6 @@ describe("GET /api/v1/w/[wId]/sandbox/actions", () => {
       body.serverViews
         .map((sv: { server: { name: string } }) => sv.server.name)
         .sort()
-    ).toEqual(["common_utilities", "search"]);
+    ).toEqual(["common_utilities", "remote_server", "search"]);
   });
 });

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.test.ts
@@ -1,3 +1,5 @@
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import {
   createSandboxFunctionInvocationTokenTestContext,
   createSandboxTokenTestContext,
@@ -43,18 +45,33 @@ describe("GET /api/v1/w/[wId]/sandbox/actions", () => {
     });
   });
 
-  it("rejects sandbox function invocation tokens", async () => {
-    const { token, workspace } =
+  it("lists internal servers of the pod and global spaces for invocation tokens", async () => {
+    const { auth, token, workspace, globalSpace } =
       await createSandboxFunctionInvocationTokenTestContext();
+
+    const commonUtilities = await InternalMCPServerInMemoryResource.makeNew(
+      auth,
+      { name: "common_utilities", useCase: null }
+    );
+    await MCPServerViewFactory.create(
+      workspace,
+      commonUtilities.id,
+      globalSpace
+    );
+    const search = await InternalMCPServerInMemoryResource.makeNew(auth, {
+      name: "search",
+      useCase: null,
+    });
+    await MCPServerViewFactory.create(workspace, search.id, globalSpace);
 
     const response = await getSandboxActions(workspace, token);
 
-    expect(response.status).toBe(403);
-    expect(await response.json()).toEqual({
-      error: {
-        type: "invalid_request_error",
-        message: "This sandbox token cannot access sandbox actions.",
-      },
-    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(
+      body.serverViews
+        .map((sv: { server: { name: string } }) => sv.server.name)
+        .sort()
+    ).toEqual(["common_utilities", "search"]);
   });
 });

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
@@ -6,7 +6,10 @@ import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import {
+  isSandboxExecTokenPayload,
+  isSandboxFunctionInvocationTokenPayload,
+} from "@app/lib/api/sandbox/access_tokens";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import { sandboxAuth } from "@front-api/middlewares/sandbox_auth";
@@ -23,7 +26,38 @@ interface GetSandboxToolsResponseType {
 // Mounted at /api/v1/w/:wId/sandbox/actions.
 const app = sandboxApp();
 
-app.use("*", sandboxAuth({ tokenKind: "action" }));
+// The dsbx CLI hits these same URLs from both conversation sandboxes (exec tokens) and
+// sandbox function invocations; handlers branch on the claims kind.
+app.use(
+  "*",
+  sandboxAuth({ allowedTokenKinds: ["action", "function_invocation"] })
+);
+
+// Response shaping shared by both token kinds: `?server=` name filtering and `?light=true`
+// inputSchema stripping.
+function filterServerViews(
+  views: MCPServerViewType[],
+  { server, light }: { server?: string; light?: string }
+): MCPServerViewType[] {
+  let serverViews = views.filter((sv) => sv.server.name !== SANDBOX_TOOL_NAME);
+
+  if (server !== undefined) {
+    serverViews = serverViews.filter((sv) => sv.server.name === server);
+  }
+
+  // Strip tool inputSchemas in light mode.
+  if (light === "true") {
+    serverViews = serverViews.map((sv) => ({
+      ...sv,
+      server: {
+        ...sv.server,
+        tools: sv.server.tools.map(({ inputSchema, ...rest }) => rest),
+      },
+    }));
+  }
+
+  return serverViews;
+}
 
 /**
  * @ignoreswagger
@@ -32,6 +66,30 @@ app.use("*", sandboxAuth({ tokenKind: "action" }));
 app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
   const auth = ctx.get("auth");
   const claims = ctx.get("sandboxClaims");
+
+  // Sandbox function invocations have no agent configuration or conversation: they see the
+  // internal servers of their pod space (+ global space). Tools that require an agent-loop
+  // context error at execution based on the run context.
+  if (isSandboxFunctionInvocationTokenPayload(claims)) {
+    // Deliberately not the EnsuringAutoViews variant: token read paths must not write. Auto
+    // views not yet materialized in the global space stay invisible until another surface
+    // hydrates them.
+    const views = await MCPServerViewResource.listBySpaceIds(
+      auth,
+      [claims.spaceId],
+      { includeGlobalSpace: true }
+    );
+
+    const serverViews = views
+      .filter((view) => view.serverType === "internal")
+      .map((view) => view.toJSON());
+
+    return ctx.json(
+      { serverViews: filterServerViews(serverViews, ctx.req.query()) },
+      200
+    );
+  }
+
   if (!isSandboxExecTokenPayload(claims)) {
     return apiError(ctx, {
       status_code: 403,
@@ -103,30 +161,15 @@ app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
   // Fetch the server views with their tools metadata.
   const views = await MCPServerViewResource.fetchByIds(auth, [...viewIds]);
 
-  const server = ctx.req.query("server");
-  const light = ctx.req.query("light");
-
-  let serverViews = views
-    .map((view) => view.toJSON())
-    .filter((sv) => sv.server.name !== SANDBOX_TOOL_NAME);
-
-  // Filter by server name if requested.
-  if (server !== undefined) {
-    serverViews = serverViews.filter((sv) => sv.server.name === server);
-  }
-
-  // Strip tool inputSchemas in light mode.
-  if (light === "true") {
-    serverViews = serverViews.map((sv) => ({
-      ...sv,
-      server: {
-        ...sv.server,
-        tools: sv.server.tools.map(({ inputSchema, ...rest }) => rest),
-      },
-    }));
-  }
-
-  return ctx.json({ serverViews }, 200);
+  return ctx.json(
+    {
+      serverViews: filterServerViews(
+        views.map((view) => view.toJSON()),
+        ctx.req.query()
+      ),
+    },
+    200
+  );
 });
 
 // `/call` (literal) must be registered before `/:aId` (param) so the param

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
@@ -68,8 +68,8 @@ app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
   const claims = ctx.get("sandboxClaims");
 
   // Sandbox function invocations have no agent configuration or conversation: they see the
-  // internal servers of their pod space (+ global space). Tools that require an agent-loop
-  // context error at execution based on the run context.
+  // servers of their pod space (+ global space). Tools that require an agent-loop context error
+  // at execution based on the run context.
   if (isSandboxFunctionInvocationTokenPayload(claims)) {
     // Deliberately not the EnsuringAutoViews variant: token read paths must not write. Auto
     // views not yet materialized in the global space stay invisible until another surface
@@ -80,9 +80,7 @@ app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
       { includeGlobalSpace: true }
     );
 
-    const serverViews = views
-      .filter((view) => view.serverType === "internal")
-      .map((view) => view.toJSON());
+    const serverViews = views.map((view) => view.toJSON());
 
     return ctx.json(
       { serverViews: filterServerViews(serverViews, ctx.req.query()) },

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/index.ts
@@ -6,7 +6,7 @@ import result from "./result";
 // Mounted at /api/v1/w/:wId/sandbox/sandbox-functions.
 const app = sandboxApp();
 
-app.use("*", sandboxAuth({ tokenKind: "function_invocation" }));
+app.use("*", sandboxAuth({ allowedTokenKinds: ["function_invocation"] }));
 
 app.route("/result", result);
 

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
@@ -89,8 +89,7 @@ describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
     expect(await response.json()).toEqual({
       error: {
         type: "invalid_request_error",
-        message:
-          "This sandbox token cannot access sandbox function invocations.",
+        message: "This sandbox token cannot access this endpoint.",
       },
     });
     expect(publishSandboxFunctionInvocationEvent).not.toHaveBeenCalled();

--- a/front/lib/api/actions/servers/pod_manager/helpers.test.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.test.ts
@@ -1,10 +1,11 @@
+import { makePodConfigurationURI } from "@app/lib/actions/mcp_internal_actions/pod_configuration_uri";
 import { getProjectConversationFolderInternalId } from "@app/lib/api/projects/context";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildProjectRetrieveDataSources } from "./helpers";
+import { buildProjectRetrieveDataSources, getPod } from "./helpers";
 
 const { mockFetchProjectDataSourceView, mockListProjectContextAttachments } =
   vi.hoisted(() => ({
@@ -232,5 +233,46 @@ describe("buildProjectRetrieveDataSources", () => {
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       },
     ]);
+  });
+});
+
+describe("getPod with a caller-supplied dustPod", () => {
+  it("returns not-found for a pod the caller cannot read", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    // A private project the caller is not a member of (admin role does not grant read).
+    const otherPod = await SpaceFactory.project(workspace);
+
+    const result = await getPod(auth, {
+      dustPod: {
+        uri: makePodConfigurationURI(workspace.sId, otherPod.sId),
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Pod not found");
+    }
+  });
+
+  it("resolves a pod the caller can read", async () => {
+    const { auth, workspace, globalSpace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const result = await getPod(auth, {
+      dustPod: {
+        uri: makePodConfigurationURI(workspace.sId, globalSpace.sId),
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.pod.sId).toBe(globalSpace.sId);
+    }
   });
 });

--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -142,6 +142,16 @@ export async function getPod(
       );
     }
 
+    // `SpaceResource.fetchById` filters by workspace only, not by the caller's space
+    // membership, so a caller passing an arbitrary pod id could otherwise read its members,
+    // conversations, documents and tasks. Report unreadable pods as not-found so this cannot
+    // probe which pod sIds exist.
+    if (!pod.canRead(auth)) {
+      return new Err(
+        new MCPError(`Pod not found: ${podId}`, { tracked: false })
+      );
+    }
+
     return new Ok({ pod });
   }
 

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -18,7 +18,6 @@ export class SandboxFunctionMCPActionError extends Error {
     readonly type:
       | "server_view_not_found"
       | "tool_not_available"
-      | "tool_requires_approval"
       | "invalid_inputs"
       | "invocation_not_found",
     message: string
@@ -27,10 +26,10 @@ export class SandboxFunctionMCPActionError extends Error {
   }
 }
 
-// Resolves and gates a tool for execution from a sandbox function invocation: the server must be
-// internal (remote servers have their own auth story), the tool must exist and be enabled, and
-// its effective stake must be `never_ask` (no approval surface without a conversation; approval
-// bubbling is gated on invocation durability). Tools that need an agent-loop context error at
+// Resolves a tool for execution from a sandbox function invocation: the tool must exist and be
+// enabled. The tool's stake is snapshotted but not enforced yet: tools execute regardless of it.
+// TODO(2026-07-09 SANDBOX_FUNCTIONS): bubble approval events up from the frame instead, honoring
+// stakes (gated on invocation durability). Tools that need an agent-loop context error at
 // execution based on the run context.
 async function resolveSandboxFunctionTool(
   auth: Authenticator,
@@ -39,15 +38,6 @@ async function resolveSandboxFunctionTool(
 ): Promise<
   Result<ServerSideMCPToolConfigurationType, SandboxFunctionMCPActionError>
 > {
-  if (view.serverType !== "internal") {
-    return new Err(
-      new SandboxFunctionMCPActionError(
-        "tool_not_available",
-        "This server's tools cannot be called from a sandbox function."
-      )
-    );
-  }
-
   const viewJSON = view.toJSON();
   const tool = viewJSON.server.tools.find((t) => t.name === toolName);
   if (!tool) {
@@ -80,7 +70,8 @@ async function resolveSandboxFunctionTool(
       dustAppConfiguration: null,
       secretName: null,
       dustProject: null,
-      internalMCPServerId: view.mcpServerId,
+      // Null for remote servers, matching the agent path (see `configuration/actions.ts`).
+      internalMCPServerId: view.internalMCPServerId,
     },
     [{ name: tool.name, description: tool.description }]
   );
@@ -100,19 +91,6 @@ async function resolveSandboxFunctionTool(
       new SandboxFunctionMCPActionError(
         "tool_not_available",
         `Tool ${toolName} is not available.`
-      )
-    );
-  }
-
-  if (
-    toolConfiguration.permission !== "never_ask" ||
-    (toolConfiguration.argumentsRequiringApproval ?? []).length > 0
-  ) {
-    return new Err(
-      new SandboxFunctionMCPActionError(
-        "tool_requires_approval",
-        `Tool ${toolName} requires user approval and cannot be called from a ` +
-          "sandbox function."
       )
     );
   }

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -1,0 +1,220 @@
+import type { ServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import { MCP_TOOL_CONFIGURATION_FIELDS_TO_OMIT } from "@app/lib/actions/mcp";
+import { buildToolConfigurationsFromRawTools } from "@app/lib/actions/mcp_actions";
+import { validateToolInputs } from "@app/lib/actions/mcp_utils";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { launchSandboxFunctionToolWorkflow } from "@app/temporal/agent_loop/client";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import omit from "lodash/omit";
+
+export class SandboxFunctionMCPActionError extends Error {
+  constructor(
+    readonly type:
+      | "server_view_not_found"
+      | "tool_not_available"
+      | "tool_requires_approval"
+      | "invalid_inputs"
+      | "invocation_not_found",
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+// Resolves and gates a tool for execution from a sandbox function invocation: the server must be
+// internal (remote servers have their own auth story), the tool must exist and be enabled, and
+// its effective stake must be `never_ask` (no approval surface without a conversation; approval
+// bubbling is gated on invocation durability). Tools that need an agent-loop context error at
+// execution based on the run context.
+async function resolveSandboxFunctionTool(
+  auth: Authenticator,
+  view: MCPServerViewResource,
+  toolName: string
+): Promise<
+  Result<ServerSideMCPToolConfigurationType, SandboxFunctionMCPActionError>
+> {
+  if (view.serverType !== "internal") {
+    return new Err(
+      new SandboxFunctionMCPActionError(
+        "tool_not_available",
+        "This server's tools cannot be called from a sandbox function."
+      )
+    );
+  }
+
+  const viewJSON = view.toJSON();
+  const tool = viewJSON.server.tools.find((t) => t.name === toolName);
+  if (!tool) {
+    return new Err(
+      new SandboxFunctionMCPActionError(
+        "tool_not_available",
+        `Tool ${toolName} not found on server ${viewJSON.server.name}.`
+      )
+    );
+  }
+
+  // View-default server configuration: there is no agent configuration to inject settings from
+  // (same synthesized shape as JIT servers, see `jit/common_utilities.ts`).
+  const toolConfigurationsRes = await buildToolConfigurationsFromRawTools(
+    auth,
+    view.mcpServerId,
+    {
+      id: -1,
+      sId: generateRandomModelSId(),
+      type: "mcp_server_configuration",
+      name: viewJSON.name ?? viewJSON.server.name,
+      description: viewJSON.description ?? viewJSON.server.description,
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: viewJSON.sId,
+      dustAppConfiguration: null,
+      secretName: null,
+      dustProject: null,
+      internalMCPServerId: view.mcpServerId,
+    },
+    [{ name: tool.name, description: tool.description }]
+  );
+  if (toolConfigurationsRes.isErr()) {
+    return new Err(
+      new SandboxFunctionMCPActionError(
+        "tool_not_available",
+        toolConfigurationsRes.error.message
+      )
+    );
+  }
+
+  // Empty when the tool has been disabled by an admin.
+  const [toolConfiguration] = toolConfigurationsRes.value;
+  if (!toolConfiguration) {
+    return new Err(
+      new SandboxFunctionMCPActionError(
+        "tool_not_available",
+        `Tool ${toolName} is not available.`
+      )
+    );
+  }
+
+  if (
+    toolConfiguration.permission !== "never_ask" ||
+    (toolConfiguration.argumentsRequiringApproval ?? []).length > 0
+  ) {
+    return new Err(
+      new SandboxFunctionMCPActionError(
+        "tool_requires_approval",
+        `Tool ${toolName} requires user approval and cannot be called from a ` +
+          "sandbox function."
+      )
+    );
+  }
+
+  return new Ok(toolConfiguration);
+}
+
+/**
+ * Creates a sandbox function MCP action (code running inside a sandbox function invocation
+ * calling an MCP tool through the public sandbox API) and launches its execution workflow.
+ */
+export async function createSandboxFunctionMCPAction(
+  auth: Authenticator,
+  {
+    sandboxFunctionId,
+    invocationId,
+    podSpaceId,
+    serverViewId,
+    toolName,
+    rawInputs,
+  }: {
+    sandboxFunctionId: string;
+    invocationId: string;
+    podSpaceId: string;
+    serverViewId: string;
+    toolName: string;
+    rawInputs: Record<string, unknown>;
+  }
+): Promise<Result<{ actionId: string }, SandboxFunctionMCPActionError>> {
+  const validateInputsResult = validateToolInputs(rawInputs);
+  if (validateInputsResult.isErr()) {
+    return new Err(
+      new SandboxFunctionMCPActionError(
+        "invalid_inputs",
+        validateInputsResult.error.message
+      )
+    );
+  }
+
+  const view = await MCPServerViewResource.fetchById(auth, serverViewId);
+  // `fetchById` is workspace-scoped, so reproduce the listing endpoint's confinement: the view
+  // must be in the pod or global space (the spaces the listing queries) AND readable by the
+  // caller. The permission check keeps this correct if pod access is revoked within the token
+  // TTL; on its own it would not confine, since an admin can administrate any space. Out-of-scope
+  // ids report as not-found so the sandbox cannot probe other spaces.
+  const inScope = view?.space.sId === podSpaceId || view?.space.isGlobal();
+  if (!view || !inScope || !view.canReadOrAdministrate(auth)) {
+    return new Err(
+      new SandboxFunctionMCPActionError(
+        "server_view_not_found",
+        "MCP server view not found."
+      )
+    );
+  }
+
+  const toolConfigurationRes = await resolveSandboxFunctionTool(
+    auth,
+    view,
+    toolName
+  );
+  if (toolConfigurationRes.isErr()) {
+    return toolConfigurationRes;
+  }
+
+  const sandboxFunction = await SandboxFunctionResource.fetchById(
+    auth,
+    sandboxFunctionId
+  );
+  if (!sandboxFunction) {
+    return new Err(
+      new SandboxFunctionMCPActionError(
+        "invocation_not_found",
+        "Sandbox function not found."
+      )
+    );
+  }
+
+  const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
+    sandboxFunction,
+    invocationId,
+  });
+  if (!invocation) {
+    return new Err(
+      new SandboxFunctionMCPActionError(
+        "invocation_not_found",
+        "Sandbox function invocation not found."
+      )
+    );
+  }
+
+  const action = await SandboxFunctionMCPActionResource.makeNew(auth, {
+    invocation,
+    mcpServerView: view,
+    toolName,
+    inputs: rawInputs,
+    toolConfiguration: omit(
+      toolConfigurationRes.value,
+      MCP_TOOL_CONFIGURATION_FIELDS_TO_OMIT
+    ),
+  });
+
+  await launchSandboxFunctionToolWorkflow(auth, { action });
+
+  return new Ok({ actionId: action.sId });
+}

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -26,6 +26,7 @@ import {
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import {
   getResourceIdFromSId,
   isResourceSId,
@@ -714,6 +715,18 @@ export class Authenticator {
     }
 
     const allowedSpaceIds = new Set<ModelId>([podSpaceModelId]);
+
+    // Auto internal MCP server views live in the global space: without it, a function invocation
+    // cannot list or call any tool. Group membership still applies (the groups below are
+    // intersected with the token's base groups).
+    const globalSpace = await SpaceModel.findOne({
+      attributes: ["id"],
+      where: { workspaceId, kind: "global" },
+    });
+    if (globalSpace) {
+      allowedSpaceIds.add(globalSpace.id);
+    }
+
     if (claims.cId) {
       const requestedSpaceIds =
         await this.fetchRequestedSpaceIdsForSandboxTokenAuth({

--- a/front/lib/resources/sandbox_function_mcp_action_resource.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.ts
@@ -59,6 +59,14 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
     });
   }
 
+  // String identifier of the invocation this action belongs to.
+  get invocationId(): string {
+    return makeSId("sandbox_function_invocation", {
+      id: this.sandboxFunctionInvocationId,
+      workspaceId: this.workspaceId,
+    });
+  }
+
   static modelIdToSId({
     id,
     workspaceId,
@@ -244,10 +252,18 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
       return new Ok(null);
     }
 
-    try {
-      const file = getPrivateUploadBucket().file(this.outputGcsPath);
-      const [buffer] = await file.download();
+    // Retry the download: the poll client treats an error response as terminal, so a transient
+    // GCS failure here would permanently fail a tool call that actually succeeded.
+    const gcsPath = this.outputGcsPath;
+    const downloadResult = await withRetry(() =>
+      getPrivateUploadBucket().file(gcsPath).download()
+    );
+    if (downloadResult.isErr()) {
+      return new Err(downloadResult.error);
+    }
 
+    try {
+      const [buffer] = downloadResult.value;
       return new Ok(JSON.parse(buffer.toString("utf-8")));
     } catch (err) {
       return new Err(normalizeError(err));
@@ -389,10 +405,7 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
       sId: this.sId,
       createdAt: this.createdAt.getTime(),
       updatedAt: this.updatedAt.getTime(),
-      invocationId: makeSId("sandbox_function_invocation", {
-        id: this.sandboxFunctionInvocationId,
-        workspaceId: this.workspaceId,
-      }),
+      invocationId: this.invocationId,
       toolName: this.toolName,
       inputs: this.inputs,
       status: this.status,


### PR DESCRIPTION
Follow up of #28664.
Code running in a sandbox function invocation can now list, call and poll MCP tools through the sandbox API using its invocation token, no conversation involved.

The three `/v1/w/:wId/sandbox/actions` endpoints previously hard-required a conversation-bound exec token. `sandboxAuth` now takes `allowedTokenKinds` and the handlers branch on the claims type (exec-token behavior unchanged; the computer feature-flag check still applies to exec tokens only).

| endpoint | invocation-token behavior |
|---|---|
| `GET /` | internal server views of the pod space + global space |
| `POST /call` | resolves the view within the pod + global space, creates a `SandboxFunctionMCPAction` (status `running`), launches its workflow, `202 {status: "pending", actionId}` |
| `GET /:aId` | scoped to the token's invocation; running → `202 pending`, succeeded/errored → `200` with the output array read from GCS, denied → `403 rejected` |

Same wire contract as the exec-token flavor: dsbx cannot tell which storage produced its answer.

`createSandboxFunctionMCPAction` gates at creation: the server view must be in the pod or global space and readable by the caller (same confinement as the listing: pod + global space selection plus a `canReadOrAdministrate` check, so a revoked pod access within the token TTL is honored); internal servers only (remote servers have their own auth story); the tool exists and is enabled; effective stake `never_ask`, since there is no approval surface without a conversation, so approval-requiring tools are rejected with a clear error (approval bubbling is a follow-up, gated on invocation durability). An out-of-scope view id reports as not-found so the sandbox cannot probe other spaces. The resolved tool configuration is snapshotted on the row (same derive-then-snapshot pattern as `create_child_action`), keeping activity re-runs deterministic. There is deliberately no per-server gating beyond that: tools that require an agent-loop context error at execution based on the run context.

Security-relevant change to call out: `restrictGroupsToSandboxFunctionInvocationSpaces` now also grants invocation tokens the global space. The auto internal server views (`common_utilities`, `search`, …) live there, so without it nothing is listable or callable. Still intersected with the token user's base groups.

Known edges, deferred: invocation tokens expire after 2 minutes (durability follow-up), and a token minted without a `uId` (non-human actor) gets minimal groups, so `/call` resolves nothing and 404s. File outputs from tools land as `project_context` files on the pod's space; surfacing them on the pod filesystem is a follow-up.

## Tests

Endpoint tests: listing (invocation vs exec branch), call (happy path, unknown view, view outside the pod + global spaces → 404, remote server, unknown tool, conversation-coupled server), poll (pending, success with GCS output, cross-invocation scoping 404).

Manual e2e on a local pod: a published function shelling out to `dsbx tools` listed 33 servers and called `common_utilities.generate_random_number` (result returned through call → workflow → GCS → poll, 392ms). Also driven raw with a minted invocation token and `curl` only, no agent, no conversation: `202 pending` → `200 success` with the output array inline.

## Risk

New token kind on an existing surface: exec-token requests go through the same middleware. Regression risk is covered by the existing exec-token tests; behavior for them is unchanged. Worst case, invocation-token tool calls fail. Safe to rollback.

## Deploy Plan

Deploy front.