### PR TITLE
[Admin Gov] Phase 0.4a — governance capability read state (getCapabilitiesState)

### DIFF
--- a/front/lib/resources/group_permission_governance.test.ts
+++ b/front/lib/resources/group_permission_governance.test.ts
@@ -1,0 +1,84 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import assert from "assert";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// A concrete capability used across the governance-state tests.
+const CAPABILITY = { permissionType: "create", resourceType: "agent" } as const;
+
+describe("GroupPermissionResource — governance state (reads)", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let auth: Authenticator;
+  let globalGroup: GroupResource;
+  let groupA: GroupResource;
+  let groupB: GroupResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+    groupA = await GroupFactory.regular(workspace, "A");
+    groupB = await GroupFactory.regular(workspace, "B");
+    auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const fetched = await GroupResource.internalFetchWorkspaceGlobalGroup(
+      workspace.id
+    );
+    assert(fetched, "global group should exist");
+    globalGroup = fetched;
+  });
+
+  it("reports disabled when there is no -1 row", async () => {
+    expect(
+      await GroupPermissionResource.isCapabilityDisabled(auth, CAPABILITY)
+    ).toBe(true);
+    expect(
+      await GroupPermissionResource.isCapabilityForEverybody(auth, CAPABILITY)
+    ).toBe(false);
+    expect(
+      await GroupPermissionResource.getCapabilityGroups(auth, CAPABILITY)
+    ).toEqual([]);
+  });
+
+  it("reports everybody when the global group holds the -1 row", async () => {
+    await GroupPermissionResource.grantOnAllResourcesOfType(auth, {
+      group: globalGroup,
+      ...CAPABILITY,
+    });
+
+    expect(
+      await GroupPermissionResource.isCapabilityForEverybody(auth, CAPABILITY)
+    ).toBe(true);
+    expect(
+      await GroupPermissionResource.isCapabilityDisabled(auth, CAPABILITY)
+    ).toBe(false);
+    // The global group is not surfaced as a "specific" group.
+    expect(
+      await GroupPermissionResource.getCapabilityGroups(auth, CAPABILITY)
+    ).toEqual([]);
+  });
+
+  it("reports the specific groups when non-global groups hold -1 rows", async () => {
+    await GroupPermissionResource.grantOnAllResourcesOfTypeForGroups(auth, {
+      groups: [groupA, groupB],
+      ...CAPABILITY,
+    });
+
+    expect(
+      await GroupPermissionResource.isCapabilityForEverybody(auth, CAPABILITY)
+    ).toBe(false);
+    expect(
+      await GroupPermissionResource.isCapabilityDisabled(auth, CAPABILITY)
+    ).toBe(false);
+
+    const groups = await GroupPermissionResource.getCapabilityGroups(
+      auth,
+      CAPABILITY
+    );
+    expect(new Set(groups.map((g) => g.id))).toEqual(
+      new Set([groupA.id, groupB.id])
+    );
+  });
+});

--- a/front/lib/resources/group_permission_governance.test.ts
+++ b/front/lib/resources/group_permission_governance.test.ts
@@ -30,34 +30,22 @@ describe("GroupPermissionResource — governance state (reads)", () => {
     globalGroup = fetched;
   });
 
+  const stateOf = async (capability: typeof CAPABILITY) =>
+    (
+      await GroupPermissionResource.getCapabilitiesState(auth, [capability])
+    ).get(`${capability.permissionType}:${capability.resourceType}`);
+
   it("reports disabled when there is no -1 row", async () => {
-    expect(
-      await GroupPermissionResource.isCapabilityDisabled(auth, CAPABILITY)
-    ).toBe(true);
-    expect(
-      await GroupPermissionResource.isCapabilityForEverybody(auth, CAPABILITY)
-    ).toBe(false);
-    expect(
-      await GroupPermissionResource.getCapabilityGroups(auth, CAPABILITY)
-    ).toEqual([]);
+    expect(await stateOf(CAPABILITY)).toEqual({ scope: "disabled" });
   });
 
-  it("reports everybody when the global group holds the -1 row", async () => {
+  it("reports everyone when the global group holds the -1 row", async () => {
     await GroupPermissionResource.grantTypeWide(auth, {
       group: globalGroup,
       ...CAPABILITY,
     });
 
-    expect(
-      await GroupPermissionResource.isCapabilityForEverybody(auth, CAPABILITY)
-    ).toBe(true);
-    expect(
-      await GroupPermissionResource.isCapabilityDisabled(auth, CAPABILITY)
-    ).toBe(false);
-    // The global group is not surfaced as a "specific" group.
-    expect(
-      await GroupPermissionResource.getCapabilityGroups(auth, CAPABILITY)
-    ).toEqual([]);
+    expect(await stateOf(CAPABILITY)).toEqual({ scope: "everyone" });
   });
 
   it("reports the specific groups when non-global groups hold -1 rows", async () => {
@@ -66,19 +54,44 @@ describe("GroupPermissionResource — governance state (reads)", () => {
       ...CAPABILITY,
     });
 
-    expect(
-      await GroupPermissionResource.isCapabilityForEverybody(auth, CAPABILITY)
-    ).toBe(false);
-    expect(
-      await GroupPermissionResource.isCapabilityDisabled(auth, CAPABILITY)
-    ).toBe(false);
-
-    const groups = await GroupPermissionResource.getCapabilityGroups(
-      auth,
-      CAPABILITY
-    );
-    expect(new Set(groups.map((g) => g.id))).toEqual(
+    const state = await stateOf(CAPABILITY);
+    assert(state?.scope === "groups", "expected groups scope");
+    expect(new Set(state.groups.map((g) => g.id))).toEqual(
       new Set([groupA.id, groupB.id])
     );
+  });
+
+  it("resolves multiple capabilities in one call", async () => {
+    const everyoneCap = {
+      permissionType: "publish",
+      resourceType: "agent",
+    } as const;
+    const groupsCap = {
+      permissionType: "create",
+      resourceType: "skill",
+    } as const;
+    const disabledCap = {
+      permissionType: "admin",
+      resourceType: "billing",
+    } as const;
+    await GroupPermissionResource.grantTypeWide(auth, {
+      group: globalGroup,
+      ...everyoneCap,
+    });
+    await GroupPermissionResource.grantTypeWideForGroups(auth, {
+      groups: [groupA],
+      ...groupsCap,
+    });
+
+    const states = await GroupPermissionResource.getCapabilitiesState(auth, [
+      everyoneCap,
+      groupsCap,
+      disabledCap,
+    ]);
+    expect(states.get("publish:agent")).toEqual({ scope: "everyone" });
+    expect(states.get("admin:billing")).toEqual({ scope: "disabled" });
+    const groupsState = states.get("create:skill");
+    assert(groupsState?.scope === "groups", "expected groups scope");
+    expect(groupsState.groups.map((g) => g.id)).toEqual([groupA.id]);
   });
 });

--- a/front/lib/resources/group_permission_governance.test.ts
+++ b/front/lib/resources/group_permission_governance.test.ts
@@ -43,7 +43,7 @@ describe("GroupPermissionResource — governance state (reads)", () => {
   });
 
   it("reports everybody when the global group holds the -1 row", async () => {
-    await GroupPermissionResource.grantOnAllResourcesOfType(auth, {
+    await GroupPermissionResource.grantTypeWide(auth, {
       group: globalGroup,
       ...CAPABILITY,
     });
@@ -61,7 +61,7 @@ describe("GroupPermissionResource — governance state (reads)", () => {
   });
 
   it("reports the specific groups when non-global groups hold -1 rows", async () => {
-    await GroupPermissionResource.grantOnAllResourcesOfTypeForGroups(auth, {
+    await GroupPermissionResource.grantTypeWideForGroups(auth, {
       groups: [groupA, groupB],
       ...CAPABILITY,
     });

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -12,8 +12,10 @@ import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
 import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
+import { Op } from "sequelize";
 
 /**
  * All writes to `group_permissions` go through this resource — never a raw model write elsewhere.
@@ -40,6 +42,21 @@ interface TypeWideGrantSpec {
 interface CapabilitySpec {
   permissionType: PermissionType;
   resourceType: GroupPermissionResourceType;
+}
+
+// The state of a governance capability. "everyone" and "disabled" carry no groups; "groups" lists
+// the specific (non-global) groups it is granted to. Scope values match the governance page's
+// PermissionConfigurationScope.
+export type CapabilityState =
+  | { scope: "disabled" }
+  | { scope: "everyone" }
+  | { scope: "groups"; groups: GroupResource[] };
+
+function capabilityKey({
+  permissionType,
+  resourceType,
+}: CapabilitySpec): string {
+  return `${permissionType}:${resourceType}`;
 }
 
 interface ListForGroupsSpec {
@@ -321,75 +338,84 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
   // Governance-toggle state (read side).
   //
   // A capability is a (permissionType, resourceType) pair whose grants live on the type-wide (-1)
-  // rows. Three mutually-exclusive states, by convention:
-  //   - no -1 row for the capability          => disabled
-  //   - a -1 row for the workspace global group => everybody
+  // rows. Each is in one of three mutually-exclusive states, by convention:
+  //   - no -1 row                              => disabled
+  //   - a -1 row for the workspace global group => everyone
   //   - -1 rows for specific groups            => those groups only (additive)
   // The write side (which keeps the states exclusive) lands in a follow-up.
   // ---------------------------------------------------------------------------
 
-  // All type-wide (-1) grants for a capability, across every group in the workspace.
-  private static async listCapabilityGrants(
+  // Resolve the state of each requested capability in a single query (plus one batched group
+  // fetch), keyed by `${permissionType}:${resourceType}`. Backs the governance page, which needs
+  // every capability at once; per-capability helpers (disabled / everyone / groups) can derive
+  // from the returned state.
+  static async getCapabilitiesState(
     auth: Authenticator,
-    { permissionType, resourceType }: CapabilitySpec
-  ): Promise<GroupPermissionResource[]> {
-    // Reject invalid capability pairs (e.g. write/billing) on the read side too, so a bad caller
-    // fails fast rather than silently getting "disabled".
-    assertValidGrant({
-      permissionType,
-      resourceType,
-      resourceId: WHOLE_TYPE_RESOURCE_ID,
-    });
+    capabilities: CapabilitySpec[]
+  ): Promise<Map<string, CapabilityState>> {
+    const result = new Map<string, CapabilityState>();
+    if (capabilities.length === 0) {
+      return result;
+    }
+
+    // Reject invalid capability pairs (e.g. write/billing) — programmer errors, fail fast.
+    for (const capability of capabilities) {
+      assertValidGrant({ ...capability, resourceId: WHOLE_TYPE_RESOURCE_ID });
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const globalGroup =
+      await GroupResource.internalFetchWorkspaceGlobalGroup(workspaceId);
+    assert(globalGroup, "Workspace is missing its global group.");
+
+    // One query: every type-wide (-1) row for the requested capabilities.
     const rows = await GroupPermissionModel.findAll({
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        permissionType,
-        resourceType,
+        workspaceId,
         resourceId: WHOLE_TYPE_RESOURCE_ID,
+        [Op.or]: capabilities.map(({ permissionType, resourceType }) => ({
+          permissionType,
+          resourceType,
+        })),
       },
     });
-    return rows.map((row) => new this(GroupPermissionModel, row.get()));
-  }
 
-  static async isCapabilityDisabled(
-    auth: Authenticator,
-    capability: CapabilitySpec
-  ): Promise<boolean> {
-    const grants = await this.listCapabilityGrants(auth, capability);
-    return grants.length === 0;
-  }
+    // One batched fetch for every non-global group referenced across all capabilities.
+    const groupModelIds = [
+      ...new Set(
+        rows
+          .map((row) => row.groupId)
+          .filter((groupModelId) => groupModelId !== globalGroup.id)
+      ),
+    ];
+    const groups = groupModelIds.length
+      ? await GroupResource.fetchByModelIds(auth, groupModelIds)
+      : [];
+    const groupByModelId = new Map(groups.map((group) => [group.id, group]));
 
-  static async isCapabilityForEverybody(
-    auth: Authenticator,
-    capability: CapabilitySpec
-  ): Promise<boolean> {
-    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
-      auth.getNonNullableWorkspace().id
-    );
-    assert(globalGroup, "Workspace is missing its global group.");
+    for (const capability of capabilities) {
+      const capabilityRows = rows.filter(
+        (row) =>
+          row.permissionType === capability.permissionType &&
+          row.resourceType === capability.resourceType
+      );
+      const key = capabilityKey(capability);
 
-    const grants = await this.listCapabilityGrants(auth, capability);
-    return grants.some((grant) => grant.groupId === globalGroup.id);
-  }
-
-  // The specific (non-global) groups a capability is granted to.
-  static async getCapabilityGroups(
-    auth: Authenticator,
-    capability: CapabilitySpec
-  ): Promise<GroupResource[]> {
-    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
-      auth.getNonNullableWorkspace().id
-    );
-    assert(globalGroup, "Workspace is missing its global group.");
-
-    const grants = await this.listCapabilityGrants(auth, capability);
-    const groupModelIds = grants
-      .map((grant) => grant.groupId)
-      .filter((groupModelId) => groupModelId !== globalGroup.id);
-    if (groupModelIds.length === 0) {
-      return [];
+      if (capabilityRows.length === 0) {
+        result.set(key, { scope: "disabled" });
+      } else if (capabilityRows.some((row) => row.groupId === globalGroup.id)) {
+        result.set(key, { scope: "everyone" });
+      } else {
+        result.set(key, {
+          scope: "groups",
+          groups: removeNulls(
+            capabilityRows.map((row) => groupByModelId.get(row.groupId))
+          ),
+        });
+      }
     }
-    return GroupResource.fetchByModelIds(auth, groupModelIds);
+
+    return result;
   }
 
   async delete(

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -1,7 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { assertValidGrant } from "@app/lib/resources/group_permission_registry";
-import type { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type {
@@ -35,6 +35,11 @@ interface TypeWideGrantSpec {
   permissionType: PermissionType;
   resourceType: GroupPermissionResourceType;
   transaction?: Transaction;
+}
+
+interface CapabilitySpec {
+  permissionType: PermissionType;
+  resourceType: GroupPermissionResourceType;
 }
 
 interface ListForGroupsSpec {
@@ -310,6 +315,81 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       })),
       { ignoreDuplicates: true, transaction }
     );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Governance-toggle state (read side).
+  //
+  // A capability is a (permissionType, resourceType) pair whose grants live on the type-wide (-1)
+  // rows. Three mutually-exclusive states, by convention:
+  //   - no -1 row for the capability          => disabled
+  //   - a -1 row for the workspace global group => everybody
+  //   - -1 rows for specific groups            => those groups only (additive)
+  // The write side (which keeps the states exclusive) lands in a follow-up.
+  // ---------------------------------------------------------------------------
+
+  // All type-wide (-1) grants for a capability, across every group in the workspace.
+  private static async listCapabilityGrants(
+    auth: Authenticator,
+    { permissionType, resourceType }: CapabilitySpec
+  ): Promise<GroupPermissionResource[]> {
+    // Reject invalid capability pairs (e.g. write/billing) on the read side too, so a bad caller
+    // fails fast rather than silently getting "disabled".
+    assertValidGrant({
+      permissionType,
+      resourceType,
+      resourceId: WHOLE_TYPE_RESOURCE_ID,
+    });
+    const rows = await GroupPermissionModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        permissionType,
+        resourceType,
+        resourceId: WHOLE_TYPE_RESOURCE_ID,
+      },
+    });
+    return rows.map((row) => new this(GroupPermissionModel, row.get()));
+  }
+
+  static async isCapabilityDisabled(
+    auth: Authenticator,
+    capability: CapabilitySpec
+  ): Promise<boolean> {
+    const grants = await this.listCapabilityGrants(auth, capability);
+    return grants.length === 0;
+  }
+
+  static async isCapabilityForEverybody(
+    auth: Authenticator,
+    capability: CapabilitySpec
+  ): Promise<boolean> {
+    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
+      auth.getNonNullableWorkspace().id
+    );
+    assert(globalGroup, "Workspace is missing its global group.");
+
+    const grants = await this.listCapabilityGrants(auth, capability);
+    return grants.some((grant) => grant.groupId === globalGroup.id);
+  }
+
+  // The specific (non-global) groups a capability is granted to.
+  static async getCapabilityGroups(
+    auth: Authenticator,
+    capability: CapabilitySpec
+  ): Promise<GroupResource[]> {
+    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
+      auth.getNonNullableWorkspace().id
+    );
+    assert(globalGroup, "Workspace is missing its global group.");
+
+    const grants = await this.listCapabilityGrants(auth, capability);
+    const groupIds = grants
+      .map((grant) => grant.groupId)
+      .filter((groupId) => groupId !== globalGroup.id);
+    if (groupIds.length === 0) {
+      return [];
+    }
+    return GroupResource.fetchByModelIds(auth, groupIds);
   }
 
   async delete(

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -383,13 +383,13 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     assert(globalGroup, "Workspace is missing its global group.");
 
     const grants = await this.listCapabilityGrants(auth, capability);
-    const groupIds = grants
+    const groupModelIds = grants
       .map((grant) => grant.groupId)
-      .filter((groupId) => groupId !== globalGroup.id);
-    if (groupIds.length === 0) {
+      .filter((groupModelId) => groupModelId !== globalGroup.id);
+    if (groupModelIds.length === 0) {
       return [];
     }
-    return GroupResource.fetchByModelIds(auth, groupIds);
+    return GroupResource.fetchByModelIds(auth, groupModelIds);
   }
 
   async delete(


### PR DESCRIPTION
## Description

Admin Governance — Phase 0, PR 4a/9. Follows #28486.

The read side of the governance toggle. A capability is a `(permissionType, resourceType)` pair whose grants live on the type-wide (`-1`) rows. Three mutually-exclusive states by convention: no `-1` row = disabled; a `-1` row for the workspace global group = everybody; `-1` rows for specific groups = those groups.

Adds `GroupPermissionResource.getCapabilitiesState(capabilities[])` — resolves each capability's state (`disabled` / `everyone` / `groups`, matching the governance page's scope vocabulary) in a **single query** plus one batched group fetch, returned as a map. Built batch-first because the governance page needs every capability at once; per-capability checks derive trivially from the result. The write side that keeps states exclusive is PR 4b. No behavior change.

Context: [Design Doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48) · [Implementation Plan](https://app.notion.com/p/dust-tt/Implementation-Plan-Admin-Governance-39528599d9418153aa9bf3dd69d5448d)

## Risks

Blast radius: new read-only resource methods, not yet called.
Risk: none

## Deploy Plan

- deploy front