### PR TITLE
Add: requestXXX columns to user message, handle model resolution correctly.

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -169,6 +169,7 @@ app.post(
       richMentions: [],
       reactions: [],
       costCredits: null,
+      resolvedModel: null,
     };
 
     const { serverToolsAndInstructions, error: mcpToolsListingError } =

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -54,6 +54,7 @@ export function createPlaceholderUserMessage({
       origin: "web",
     },
     reactions: [],
+    requestedModel: null, // TODO(models_picker): add the requested model
     contentFragments: [
       ...(contentFragments?.uploaded ?? []).map(
         (cf) =>

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -632,6 +632,7 @@ describe("tryCallMCPTool", () => {
       branchId: messageRow.getBranchId(),
       richMentions: [],
       costCredits: null,
+      resolvedModel: null,
     };
     const userMessage: UserMessageType = {
       id: -1,
@@ -655,6 +656,7 @@ describe("tryCallMCPTool", () => {
         origin: "web",
       },
       reactions: [],
+      requestedModel: null,
     };
 
     // Create tool configuration

--- a/front/lib/api/actions/servers/run_agent/conversation.test.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.test.ts
@@ -41,6 +41,7 @@ function buildRunAgentFixtures({ spaceId }: { spaceId: string | null }): {
       origin: "web",
     },
     reactions: [],
+    requestedModel: null,
   };
 
   const originMessage = {
@@ -75,6 +76,7 @@ function buildRunAgentFixtures({ spaceId }: { spaceId: string | null }): {
     branchId: null,
     richMentions: [],
     costCredits: null,
+    requestedModel: null,
   } as unknown as AgentMessageType;
 
   const mainAgent = {

--- a/front/lib/api/assistant/content_fragments.test.ts
+++ b/front/lib/api/assistant/content_fragments.test.ts
@@ -72,6 +72,7 @@ function createMockUserMessage(rank: number): UserMessageType {
       origin: "api",
     },
     reactions: [],
+    requestedModel: null,
   };
 }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -27,10 +27,7 @@ import {
   batchRenderMessages,
   batchRenderUserMessagesWithoutMentions,
 } from "@app/lib/api/assistant/messages";
-import {
-  isProviderWhitelisted,
-  resolveModelSelection,
-} from "@app/lib/api/assistant/models";
+import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
 import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import {
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR,
@@ -159,10 +156,7 @@ import {
   isUserMention,
   toMentionType,
 } from "@app/types/assistant/mentions";
-import type {
-  ModelSelectionType,
-  ResolvedRequestedModel,
-} from "@app/types/assistant/models/types";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type {
   ContentFragmentContextType,
   ContentFragmentType,
@@ -596,14 +590,6 @@ export async function postUserMessage(
   }
 
   const featureFlags = await getFeatureFlags(auth);
-
-  // Resolve the picker selection to a concrete model for this workspace. If it
-  // cannot be honored (unknown/disabled model), we leave `resolvedModel` null
-  // and the agent's configured model is used.
-  const resolvedModel: ResolvedRequestedModel | null = modelSelection
-    ? resolveModelSelection(auth, modelSelection, { featureFlags })
-    : null;
-
   const isPartOfPod = isPodConversation(conversation);
 
   if (isPartOfPod) {
@@ -891,6 +877,7 @@ export async function postUserMessage(
                 ...context,
                 origin: "branch_anchor",
               },
+              requestedModel: modelSelection ?? null,
             },
             transaction: t,
           });
@@ -1001,6 +988,7 @@ export async function postUserMessage(
         context: enrichedContext,
         agenticMessageData,
         visibility,
+        requestedModel: modelSelection ?? null,
       },
       transaction: t,
     });
@@ -1045,7 +1033,6 @@ export async function postUserMessage(
             skipToolsValidation,
             nextMessageRank,
             userMessage: userMessageWithoutMentions,
-            resolvedModel,
           },
           transaction: t,
         });
@@ -1898,6 +1885,7 @@ export async function retryAgentMessage(
           type: "retry",
           parentId: messageRow.parentId,
           agentMessage: message,
+          agentMessageRow: messageRow.agentMessage,
         },
         transaction: t,
       });

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -1702,6 +1702,7 @@ describe("createUserMessage", () => {
             profilePictureUrl: userJson.image,
             origin: "web",
           },
+          requestedModel: null,
         },
         transaction,
       });
@@ -1779,6 +1780,7 @@ describe("createUserMessage", () => {
             profilePictureUrl: userJson.image,
             origin: "web",
           },
+          requestedModel: null,
         },
         transaction,
       });
@@ -1870,6 +1872,7 @@ describe("createUserMessage", () => {
               profilePictureUrl: userJson.image,
               origin: "web",
             },
+            requestedModel: null,
           },
           transaction,
         });

--- a/front/lib/api/assistant/conversation/messages.test.ts
+++ b/front/lib/api/assistant/conversation/messages.test.ts
@@ -1672,6 +1672,7 @@ describe("createUserMessage", () => {
           user: userJson,
           rank,
           context,
+          requestedModel: null,
         },
         transaction,
       });
@@ -1727,6 +1728,7 @@ describe("createUserMessage", () => {
           user: null, // User should be attributed from email
           rank,
           context,
+          requestedModel: null,
         },
         transaction,
       });
@@ -1792,6 +1794,7 @@ describe("createUserMessage", () => {
           rank,
           context,
           agenticMessageData,
+          requestedModel: null,
         },
         transaction,
       });
@@ -1837,6 +1840,7 @@ describe("createUserMessage", () => {
           rank,
           context,
           agenticMessageData,
+          requestedModel: null,
         },
         transaction,
       });
@@ -1877,6 +1881,7 @@ describe("createUserMessage", () => {
             profilePictureUrl: userJson.image,
             origin: "web",
           },
+          requestedModel: null,
         },
         transaction,
       });
@@ -1963,6 +1968,7 @@ describe("createUserMessage", () => {
             origin: "web",
           },
           agenticMessageData,
+          requestedModel: null,
         },
         transaction,
       });
@@ -2022,6 +2028,7 @@ describe("createUserMessage", () => {
           user: userJson,
           rank: 0,
           context: originalContext,
+          requestedModel: null,
         },
         transaction,
       });
@@ -2093,6 +2100,7 @@ describe("createUserMessage", () => {
             profilePictureUrl: userJson.image,
             origin: "web",
           },
+          requestedModel: null,
         },
         transaction,
       });
@@ -2185,6 +2193,7 @@ describe("createUserMessage", () => {
             profilePictureUrl: null,
             origin: "web",
           },
+          requestedModel: null,
         },
         transaction,
       });
@@ -2240,6 +2249,7 @@ describe("createUserMessage", () => {
             profilePictureUrl: userJson.image,
             origin: "web",
           },
+          requestedModel: null,
         },
         transaction,
       });
@@ -2297,6 +2307,7 @@ describe("createUserMessage", () => {
           user: userJson,
           rank,
           context,
+          requestedModel: null,
         },
         transaction,
       });
@@ -2344,6 +2355,7 @@ describe("createUserMessage", () => {
           user: userJson,
           rank,
           context,
+          requestedModel: null,
         },
         transaction,
       });
@@ -2384,6 +2396,7 @@ describe("createUserMessage", () => {
           user: userJson,
           rank: 0,
           context,
+          requestedModel: null,
         },
         transaction,
       });
@@ -2398,6 +2411,7 @@ describe("createUserMessage", () => {
           user: userJson,
           rank: 1,
           context,
+          requestedModel: null,
         },
         transaction,
       });
@@ -2431,6 +2445,7 @@ describe("createUserMessage", () => {
           user: null,
           rank,
           context,
+          requestedModel: null,
         },
         transaction,
       });

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -6,7 +6,7 @@ import {
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import {
   resolvedModelFromAgentMessageRow,
-  resolveModelSelection,
+  resolveModel,
 } from "@app/lib/api/assistant/models";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import {
@@ -39,7 +39,7 @@ import type {
 import { isPodConversation } from "@app/types/assistant/conversation";
 import type { MentionType } from "@app/types/assistant/mentions";
 import { isAgentMention } from "@app/types/assistant/mentions";
-import type { ResolvedRequestedModel } from "@app/types/assistant/models/types";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -97,6 +97,7 @@ export async function createUserMessage(
           context: UserMessageContext;
           agenticMessageData?: AgenticMessageData;
           visibility?: MessageVisibility;
+          requestedModel: ModelSelectionType | null;
         };
     transaction: Transaction;
   }
@@ -110,6 +111,7 @@ export async function createUserMessage(
   let context: UserMessageContext | null = null;
   let agenticMessageData: AgenticMessageData | undefined = undefined;
   let visibility: MessageVisibility = "visible";
+  let requestedModel: ModelSelectionType | null = null;
 
   switch (metadata.type) {
     case "edit":
@@ -121,6 +123,7 @@ export async function createUserMessage(
 
       context = metadata.message.context;
       agenticMessageData = metadata.message.agenticMessageData;
+      requestedModel = metadata.message.requestedModel;
       break;
     case "delete":
       // See softDeleteUserMessageAndReplies for why a v+1 placeholder is used instead of an UPDATE.
@@ -147,6 +150,7 @@ export async function createUserMessage(
 
       context = metadata.context;
       agenticMessageData = metadata.agenticMessageData;
+      requestedModel = metadata.requestedModel;
       if (metadata.visibility) {
         visibility = metadata.visibility;
       }
@@ -199,6 +203,9 @@ export async function createUserMessage(
       userContextAuthMethod: context.authMethod ?? null,
       agenticMessageType,
       agenticOriginMessageId,
+      requestedModelId: requestedModel?.modelId ?? null,
+      requestedProviderId: requestedModel?.providerId ?? null,
+      requestedReasoningEffort: requestedModel?.reasoningEffort ?? null,
       userId: user?.id,
       workspaceId: workspace.id,
     },
@@ -238,6 +245,7 @@ export async function createUserMessage(
     rank: m.rank,
     branchId: conversation.branchId,
     reactions: [],
+    requestedModel,
   };
   return createdUserMessage;
 }
@@ -254,6 +262,7 @@ export const createAgentMessages = async (
       | {
           type: "retry";
           agentMessage: AgentMessageType;
+          agentMessageRow: AgentMessageModel;
           parentId: number;
         }
       | {
@@ -268,7 +277,6 @@ export const createAgentMessages = async (
           skipToolsValidation: boolean;
           nextMessageRank: number;
           userMessage: UserMessageTypeWithoutMentions;
-          resolvedModel?: ResolvedRequestedModel | null;
         };
     transaction?: Transaction;
   }
@@ -292,26 +300,20 @@ export const createAgentMessages = async (
     case "retry":
       {
         const agentConfiguration = metadata.agentMessage.configuration;
-        // Preserve the per-message model override, but re-validate it: a model
-        // enabled at first send may have since been disabled for the workspace,
-        // in which case the retry falls back to the agent's configured model.
-        const retriedModel = metadata.agentMessage.requestedModel;
-        const revalidatedModel = retriedModel
-          ? resolveModelSelection(auth, retriedModel, {
-              featureFlags: await getFeatureFlags(auth),
-            })
-          : null;
         const agentMessageRow = await AgentMessageModel.create(
           {
             status: "created",
             agentConfigurationId: agentConfiguration.sId,
             agentConfigurationVersion: agentConfiguration.version,
             workspaceId: owner.id,
-            skipToolsValidation: metadata.agentMessage.skipToolsValidation,
-            resolvedProviderId: revalidatedModel?.providerId ?? null,
-            resolvedModelId: revalidatedModel?.modelId ?? null,
-            resolvedReasoningEffort: revalidatedModel?.reasoningEffort ?? null,
-            modelResolutionMethod: "auto", // TODO(models_picker): carry over the method from the original message
+            // Copy over the values from the original agent message row.
+            skipToolsValidation: metadata.agentMessageRow.skipToolsValidation,
+            resolvedProviderId: metadata.agentMessageRow.resolvedProviderId,
+            resolvedModelId: metadata.agentMessageRow.resolvedModelId,
+            resolvedReasoningEffort:
+              metadata.agentMessageRow.resolvedReasoningEffort,
+            modelResolutionMethod:
+              metadata.agentMessageRow.modelResolutionMethod,
           },
           { transaction }
         );
@@ -404,6 +406,7 @@ export const createAgentMessages = async (
           metadata.mentions.filter(isAgentMention),
           (mention) => mention.configurationId
         );
+        const featureFlags = await getFeatureFlags(auth);
 
         await concurrentExecutor(
           uniqueAgentMentions,
@@ -465,6 +468,15 @@ export const createAgentMessages = async (
               { transaction }
             );
 
+            const { resolvedModel, modelResolutionMethod } = resolveModel(
+              auth,
+              {
+                selection: metadata.userMessage.requestedModel ?? undefined,
+                configuration,
+                featureFlags,
+              }
+            );
+
             const agentMessageRow = await AgentMessageModel.create(
               {
                 status: "created",
@@ -472,11 +484,10 @@ export const createAgentMessages = async (
                 agentConfigurationVersion: configuration.version,
                 workspaceId: owner.id,
                 skipToolsValidation: metadata.skipToolsValidation,
-                resolvedProviderId: metadata.resolvedModel?.providerId ?? null,
-                resolvedModelId: metadata.resolvedModel?.modelId ?? null,
-                resolvedReasoningEffort:
-                  metadata.resolvedModel?.reasoningEffort ?? null,
-                modelResolutionMethod: "auto", // TODO(models_picker): carry over the method from the original message
+                resolvedProviderId: resolvedModel?.providerId ?? null,
+                resolvedModelId: resolvedModel?.modelId ?? null,
+                resolvedReasoningEffort: resolvedModel?.reasoningEffort ?? null,
+                modelResolutionMethod,
               },
               { transaction }
             );
@@ -577,7 +588,7 @@ export const createAgentMessages = async (
             richMentions: [],
             reactions: [],
             costCredits: null,
-            requestedModel: resolvedModelFromAgentMessageRow(agentMessageRow),
+            resolvedModel: resolvedModelFromAgentMessageRow(agentMessageRow),
           };
         }
       }

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -308,6 +308,7 @@ The following skills are available for use with the skill_management__enable_ski
       completionDurationMs: null,
       reactions: [],
       costCredits: null,
+      resolvedModel: null,
     } satisfies AgentMessageType;
 
     const steps = await getSteps(authenticator, {
@@ -438,6 +439,7 @@ describe("vision image rendering in getSteps", () => {
       completionDurationMs: null,
       reactions: [],
       costCredits: null,
+      resolvedModel: null,
     };
 
     return { auth: authenticator, message, model, workspaceId, conversationId };

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -100,6 +100,7 @@ describe("renderAllMessages", () => {
               origin: "web",
             },
             reactions: [],
+            requestedModel: null,
           } satisfies UserMessageType,
         ];
       }
@@ -138,6 +139,7 @@ describe("renderAllMessages", () => {
             completionDurationMs: null,
             reactions: [],
             costCredits: null,
+            resolvedModel: null,
           } satisfies AgentMessageType,
         ];
       }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -1,7 +1,10 @@
 import { renderAgentMessageContentView } from "@app/lib/api/assistant/activity_steps";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
+import {
+  resolvedModelFromAgentMessageRow,
+  resolvedModelFromUserMessageRow,
+} from "@app/lib/api/assistant/models";
 import { getMessagesReactions } from "@app/lib/api/assistant/reaction";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -221,6 +224,7 @@ function renderUserMessage(
           }
         : undefined,
     reactions: [],
+    requestedModel: resolvedModelFromUserMessageRow(userMessage),
   };
 }
 
@@ -824,7 +828,7 @@ async function renderSingleAgentMessage(
     // Aggregated only when rendering a single agent message (see
     // batchRenderAgentMessages), so it is `null` for bulk conversation rendering.
     subAgentCostCredits,
-    requestedModel: resolvedModelFromAgentMessageRow(agentMessage),
+    resolvedModel: resolvedModelFromAgentMessageRow(agentMessage),
   } satisfies AgentMessageType;
 
   if (viewType === "full") {

--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -1,17 +1,23 @@
 import {
   getWhitelistedProviders,
+  resolveModel,
   selectEnabledModel,
 } from "@app/lib/api/assistant/models";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import {
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
-import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type {
+  ModelIdType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/resources/provider_credential_resource");
@@ -145,6 +151,188 @@ describe("selectEnabledModel", () => {
 
     expect(selected?.modelId).toBe(
       CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG.modelId
+    );
+  });
+});
+
+function makeAgentConfiguration({
+  providerId,
+  modelId,
+}: {
+  providerId: ModelProviderIdType;
+  modelId: ModelIdType;
+}): LightAgentConfigurationType {
+  return {
+    id: 1,
+    versionCreatedAt: null,
+    sId: "agent_test",
+    version: 0,
+    versionAuthorId: null,
+    instructions: null,
+    model: {
+      providerId,
+      modelId,
+      temperature: 0,
+    },
+    status: "active",
+    scope: "visible",
+    userFavorite: false,
+    name: "Test Agent",
+    description: "Test Agent",
+    pictureUrl: "",
+    maxStepsPerRun: 8,
+    tags: [],
+    templateId: null,
+    requestedGroupIds: [],
+    requestedSpaceIds: [],
+    canRead: true,
+    canEdit: false,
+  };
+}
+
+describe("resolveModel", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function enterpriseRegionalOnlyAuth(): Promise<Authenticator> {
+    const workspace = await WorkspaceFactory.enterprise({
+      regionalModelsOnly: true,
+    });
+
+    return Authenticator.internalAdminForWorkspace(workspace.sId);
+  }
+
+  it("uses the user's enabled selection and marks resolution as user", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const { resolvedModel, modelResolutionMethod } = resolveModel(auth, {
+      selection: {
+        providerId: GPT_5_5_MODEL_CONFIG.providerId,
+        modelId: GPT_5_5_MODEL_CONFIG.modelId,
+      },
+      configuration: makeAgentConfiguration({
+        providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+        modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+      }),
+      featureFlags: [],
+    });
+
+    expect(modelResolutionMethod).toBe("user");
+    expect(resolvedModel).toEqual({
+      providerId: GPT_5_5_MODEL_CONFIG.providerId,
+      modelId: GPT_5_5_MODEL_CONFIG.modelId,
+      reasoningEffort: GPT_5_5_MODEL_CONFIG.defaultReasoningEffort,
+    });
+  });
+
+  it("uses the agent model when no selection is provided", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const { resolvedModel, modelResolutionMethod } = resolveModel(auth, {
+      configuration: makeAgentConfiguration({
+        providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+        modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+      }),
+      featureFlags: [],
+    });
+
+    expect(modelResolutionMethod).toBe("agent");
+    expect(resolvedModel).toEqual({
+      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+      reasoningEffort:
+        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+    });
+  });
+
+  it("falls back to a workspace large model when the agent model is unavailable", async () => {
+    vi.spyOn(regionConfig, "getCurrentRegion").mockReturnValue("europe-west1");
+    const auth = await enterpriseRegionalOnlyAuth();
+
+    const { resolvedModel, modelResolutionMethod } = resolveModel(auth, {
+      configuration: makeAgentConfiguration({
+        providerId: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG.providerId,
+        modelId: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG.modelId,
+      }),
+      featureFlags: [],
+    });
+
+    expect(modelResolutionMethod).toBe("agent");
+    expect(resolvedModel).toEqual({
+      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+      reasoningEffort:
+        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+    });
+  });
+
+  it("falls through a disabled user selection to the agent model", async () => {
+    vi.spyOn(regionConfig, "getCurrentRegion").mockReturnValue("europe-west1");
+    const auth = await enterpriseRegionalOnlyAuth();
+
+    const { resolvedModel, modelResolutionMethod } = resolveModel(auth, {
+      selection: {
+        providerId: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG.providerId,
+        modelId: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG.modelId,
+      },
+      configuration: makeAgentConfiguration({
+        providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+        modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+      }),
+      featureFlags: [],
+    });
+
+    expect(modelResolutionMethod).toBe("user");
+    expect(resolvedModel).toEqual({
+      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+      reasoningEffort:
+        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+    });
+  });
+
+  it("honors a supported reasoning effort from the selection", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const { resolvedModel } = resolveModel(auth, {
+      selection: {
+        providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+        modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+        reasoningEffort: "high",
+      },
+      configuration: makeAgentConfiguration({
+        providerId: GPT_5_5_MODEL_CONFIG.providerId,
+        modelId: GPT_5_5_MODEL_CONFIG.modelId,
+      }),
+      featureFlags: [],
+    });
+
+    expect(resolvedModel.reasoningEffort).toBe("high");
+  });
+
+  it("falls back to the model default when the selection pins an unsupported reasoning effort", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const { resolvedModel } = resolveModel(auth, {
+      selection: {
+        providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+        modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+        reasoningEffort: "none",
+      },
+      configuration: makeAgentConfiguration({
+        providerId: GPT_5_5_MODEL_CONFIG.providerId,
+        modelId: GPT_5_5_MODEL_CONFIG.modelId,
+      }),
+      featureFlags: [],
+    });
+
+    expect(resolvedModel.reasoningEffort).toBe(
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort
     );
   });
 });

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -1,8 +1,12 @@
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { isModelEnabled } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import type {
+  ModelResolutionMethodType,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
 import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
@@ -41,6 +45,8 @@ import {
   GROK_4_MODEL_CONFIG,
 } from "@app/types/assistant/models/xai";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import { removeNulls } from "@app/types/shared/utils/general";
+import assert from "assert";
 
 export function getWhitelistedProviders(
   auth: Authenticator
@@ -230,74 +236,115 @@ function toResolvedModel(
   };
 }
 
-// Resolves a raw picker selection to a concrete model, or null when it cannot be
-// honored for this workspace (unknown or disabled model), in which case the
-// caller falls back to the agent's configured model.
-export function resolveModelSelection(
+// Resolves the model for an agent message according to these rules:
+// 1. Pick the user's selection
+// 2. If the user did not select a model, pick the agent's configured model
+// 3. Finally fallback to the a supported model by the workspace.
+export function resolveModel(
   auth: Authenticator,
-  selection: ModelSelectionType,
-  { featureFlags }: { featureFlags: WhitelistableFeature[] }
-): ResolvedRequestedModel | null {
-  const config = SUPPORTED_MODEL_CONFIGS.find(
+  {
+    selection,
+    configuration,
+    featureFlags,
+  }: {
+    selection?: ModelSelectionType;
+    configuration: LightAgentConfigurationType;
+    featureFlags: WhitelistableFeature[];
+  }
+): {
+  resolvedModel: ResolvedRequestedModel;
+  modelResolutionMethod: ModelResolutionMethodType;
+} {
+  const userConfig = selection
+    ? SUPPORTED_MODEL_CONFIGS.find(
+        (m) =>
+          m.providerId === selection.providerId &&
+          m.modelId === selection.modelId
+      )
+    : null;
+
+  const agentConfig = SUPPORTED_MODEL_CONFIGS.find(
     (m) =>
-      m.providerId === selection.providerId && m.modelId === selection.modelId
+      m.providerId === configuration.model.providerId &&
+      m.modelId === configuration.model.modelId
   );
-  if (!config) {
-    return null;
-  }
-  const enabled = selectEnabledModel(auth, [config], { featureFlags });
-  if (!enabled) {
-    return null;
-  }
+
+  //TODO(models_picker): handle auto model selection.
+
+  const enabled = selectEnabledModel(
+    auth,
+    removeNulls([userConfig, agentConfig, ...ORDERED_LARGE_MODEL_CONFIGS]),
+    {
+      featureFlags,
+    }
+  );
+
+  // Should never happen as we should at least fallback to our selection of ORDERED_LARGE_MODEL_CONFIGS.
+  assert(enabled, "No enabled model found");
+
   // Honor an explicit effort only if the model supports it; otherwise fall back
   // to its default (raw API clients can send an unsupported effort).
   const effort =
-    selection.reasoningEffort &&
+    selection?.reasoningEffort &&
     enabled.supportedReasoningEfforts[selection.reasoningEffort]
       ? selection.reasoningEffort
-      : undefined;
-  return toResolvedModel(enabled, effort);
+      : enabled.defaultReasoningEffort;
+
+  return {
+    resolvedModel: toResolvedModel(enabled, effort),
+    modelResolutionMethod: selection ? "user" : "agent",
+  };
 }
 
-// Drops agent model settings the picked override can't honor: a structured-output
-// responseFormat inherited onto a model with `supportsResponseFormat: false` makes
-// the run error or silently ignore the schema.
-export function reconcileModelSettings<T extends { responseFormat?: string }>(
-  requested: ResolvedRequestedModel,
-  settings: T
-): T {
-  const config = SUPPORTED_MODEL_CONFIGS.find(
-    (m) =>
-      m.providerId === requested.providerId && m.modelId === requested.modelId
+function isResolvedModel(m: {
+  providerId: string | null;
+  modelId: string | null;
+  reasoningEffort: string | null;
+}): m is ResolvedRequestedModel {
+  return (
+    m.providerId !== null &&
+    m.modelId !== null &&
+    m.reasoningEffort !== null &&
+    isModelProviderId(m.providerId) &&
+    isModelId(m.modelId) &&
+    isReasoningEffort(m.reasoningEffort as ReasoningEffort)
   );
-  if (config?.supportsResponseFormat) {
-    return settings;
-  }
-  return { ...settings, responseFormat: undefined };
 }
 
-// Rebuilds a `ResolvedRequestedModel` from the raw agent-message columns, or null
-// when no override was stored (or the stored values fail validation). Values are
-// written by the resolver above, so validation is defensive.
-export function resolvedModelFromAgentMessageRow(
-  row: AgentMessageModel
+export function resolvedModelFromUserMessageRow(
+  row: UserMessageModel
 ): ResolvedRequestedModel | null {
-  const { resolvedProviderId, resolvedModelId, resolvedReasoningEffort } = row;
-
-  if (
-    !resolvedProviderId ||
-    !resolvedModelId ||
-    !resolvedReasoningEffort ||
-    !isModelProviderId(resolvedProviderId) ||
-    !isModelId(resolvedModelId) ||
-    !isReasoningEffort(resolvedReasoningEffort)
-  ) {
+  const { requestedProviderId, requestedModelId, requestedReasoningEffort } =
+    row;
+  const resolvedModel = {
+    providerId: requestedProviderId,
+    modelId: requestedModelId,
+    reasoningEffort: requestedReasoningEffort,
+  };
+  if (!isResolvedModel(resolvedModel)) {
     return null;
   }
 
-  return {
+  return resolvedModel;
+}
+
+// Rebuilds a `ResolvedRequestedModel` from the raw agent|user-message columns, or null
+// when no override was stored (or the stored values fail validation). Values are
+// written by the resolver above, so validation is defensive.
+export function resolvedModelFromAgentMessageRow(row: {
+  resolvedProviderId: string | null;
+  resolvedModelId: string | null;
+  resolvedReasoningEffort: string | null;
+}): ResolvedRequestedModel | null {
+  const { resolvedProviderId, resolvedModelId, resolvedReasoningEffort } = row;
+  const resolvedModel = {
     providerId: resolvedProviderId,
     modelId: resolvedModelId,
     reasoningEffort: resolvedReasoningEffort,
   };
+  if (!isResolvedModel(resolvedModel)) {
+    return null;
+  }
+
+  return resolvedModel;
 }

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -292,6 +292,12 @@ export class UserMessageModel extends WorkspaceAwareModel<UserMessageModel> {
   declare agenticMessageType: "run_agent" | "agent_handover" | null;
   declare agenticOriginMessageId: string | null;
 
+  // The concrete provider/model/effort triplet requested by the user when
+  // running the agent. null when the user did not request a specific model.
+  declare requestedProviderId: string | null;
+  declare requestedModelId: string | null;
+  declare requestedReasoningEffort: string | null;
+
   declare userContextLastTriggerRunAt: Date | null;
   declare userContextApiKeyId: ForeignKey<KeyModel["id"]> | null;
   declare userContextAuthMethod: string | null;
@@ -378,6 +384,21 @@ UserMessageModel.init(
       type: DataTypes.STRING(32),
       allowNull: true,
     },
+    requestedProviderId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
+    requestedModelId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
+    requestedReasoningEffort: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
   },
   {
     modelName: "user_message",
@@ -435,7 +456,8 @@ UserMessageModel.belongsTo(KeyModel, {
 
 const MODEL_RESOLUTION_METHODS = ["agent", "user", "auto"] as const;
 
-type ModelResolutionMethod = (typeof MODEL_RESOLUTION_METHODS)[number];
+export type ModelResolutionMethodType =
+  (typeof MODEL_RESOLUTION_METHODS)[number];
 
 export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
   declare createdAt: CreationOptional<Date>;
@@ -468,7 +490,7 @@ export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
   declare resolvedProviderId: string | null;
   declare resolvedModelId: string | null;
   declare resolvedReasoningEffort: string | null;
-  declare modelResolutionMethod: ModelResolutionMethod | null;
+  declare modelResolutionMethod: ModelResolutionMethodType | null;
 }
 
 AgentMessageModel.init(

--- a/front/migrations/pre-deploy/20260708083845_add_columns_for_requested_models_on_user_message.sql
+++ b/front/migrations/pre-deploy/20260708083845_add_columns_for_requested_models_on_user_message.sql
@@ -1,0 +1,14 @@
+SET
+  SESSION statement_timeout = 3000;
+
+SET
+  SESSION lock_timeout = 3000;
+
+ALTER TABLE "public"."user_messages"
+ADD COLUMN "requestedModelId" character varying(255) DEFAULT NULL;
+
+ALTER TABLE "public"."user_messages"
+ADD COLUMN "requestedProviderId" character varying(255) DEFAULT NULL;
+
+ALTER TABLE "public"."user_messages"
+ADD COLUMN "requestedReasoningEffort" character varying(255) DEFAULT NULL;

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -144,6 +144,7 @@ makeScript(
       richMentions: [],
       reactions: [],
       costCredits: null,
+      resolvedModel: null,
     };
 
     const { serverToolsAndInstructions, error: mcpToolsListingError } =

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -1,6 +1,7 @@
 import { renderAgentMessageContentView } from "@app/lib/api/assistant/activity_steps";
 import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
+import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import { TERMINAL_AGENT_MESSAGE_EVENT_TYPES } from "@app/lib/api/assistant/streaming/types";
@@ -618,6 +619,7 @@ export async function notifyWorkflowError(
     richMentions: [],
     reactions: [],
     costCredits: null,
+    resolvedModel: resolvedModelFromAgentMessageRow(messageRow.agentMessage),
 
     // HACKY: These last 3 fields are not used in the workflow error case but required in the type.
     configuration: null as unknown as LightAgentConfigurationType,

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -239,6 +239,7 @@ export class ConversationFactory {
         }),
       rank: messageRow.rank,
       reactions: [],
+      requestedModel: null,
     };
 
     return { messageRow, userMessage };
@@ -409,6 +410,7 @@ export class ConversationFactory {
       branchId: messageRow.getBranchId(),
       richMentions: [],
       costCredits: null,
+      resolvedModel: null,
     };
 
     if (!mcpAction) {

--- a/front/tests/utils/conversation_test_factories.ts
+++ b/front/tests/utils/conversation_test_factories.ts
@@ -52,6 +52,7 @@ export function mockUserMessage(
     },
     reactions: [],
     contentFragments: [],
+    requestedModel: null,
   };
 }
 

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -4,7 +4,6 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
-import { reconcileModelSettings } from "@app/lib/api/assistant/models";
 import { getStaticReplyForUserMessage } from "@app/lib/api/assistant/static_reply";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
@@ -325,29 +324,25 @@ export async function getAgentLoopDataWithAuth(
     return new Err(new Error(`Agent configuration not found ${agentId}`));
   }
 
-  const { model: agentConfigModel, ...agentConfigurationWithoutModel } =
+  const { model: agentModelConfig, ...agentConfigurationWithoutModel } =
     agentConfiguration;
 
-  // Apply the per-message model override from the input-bar picker, if any. This
-  // is the single choke point every downstream consumer reads for the run model
-  // (run_model, prompt commands, ...). Settings are inherited from the agent's
-  // configuration, then reconciled against the picked model's capabilities.
-  const { requestedModel } = agentMessage;
-  const agentModel = requestedModel
-    ? reconcileModelSettings(requestedModel, {
-        ...agentConfigModel,
-        providerId: requestedModel.providerId,
-        modelId: requestedModel.modelId,
-        reasoningEffort: requestedModel.reasoningEffort,
-      })
-    : agentConfigModel;
+  // The resolved model is stored in the agent message.
+  // Legacy message will not have a resolved model.
+  const { resolvedModel } = agentMessage;
+  const resolvedModelConfig: AgentModelConfigurationType = {
+    // Apply configuration that are not stored in the resolved model (temperature, responseFormat, etc.)
+    ...agentModelConfig,
+    // Apply the resolved model.
+    ...resolvedModel,
+  };
 
-  const model = getSupportedModelConfig(agentModel);
+  const modelConfig = getSupportedModelConfig(resolvedModelConfig);
 
-  if (!model) {
+  if (!modelConfig) {
     return new Err(
       new Error(
-        `The model you selected does not support multi-actions ${agentModel.modelId}.`
+        `The model you selected does not support multi-actions ${resolvedModelConfig.modelId}.`
       )
     );
   }
@@ -355,8 +350,14 @@ export async function getAgentLoopDataWithAuth(
   return new Ok({
     agentConfiguration: agentConfigurationWithoutModel,
     model: {
-      ...agentModel,
-      ...model,
+      // This contains general configuration for the model, like the provider and model ID.
+      ...modelConfig,
+      // This contains specific configuration for reasoning effort, temperature, etc.
+      ...resolvedModelConfig,
+      // Cleanup unsupported settings
+      ...(modelConfig?.supportsResponseFormat
+        ? { responseFormat: resolvedModelConfig.responseFormat }
+        : { responseFormat: undefined }),
     },
     agentMessage,
     auth,

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -17,7 +17,10 @@ import type {
   LightAgentConfigurationType,
 } from "./agent";
 import type { MentionType, RichMention } from "./mentions";
-import type { ResolvedRequestedModel } from "./models/types";
+import type {
+  ModelSelectionType,
+  ResolvedRequestedModel,
+} from "./models/types";
 
 export type MessageVisibility = "visible" | "deleted" | "pending";
 
@@ -194,6 +197,8 @@ export type UserMessageType = {
   context: UserMessageContext;
   agenticMessageData?: AgenticMessageData;
   reactions: MessageReactionType[];
+  // Model's triplet requested by the user manually when running the agent. Null when the user did not request a specific model.
+  requestedModel: ModelSelectionType | null;
 };
 
 export type UserMessageTypeWithoutMentions = Omit<
@@ -363,10 +368,8 @@ export type AgentMessageType = BaseAgentMessageType & {
   actions: AgentMCPActionWithOutputType[];
   contents: Array<{ step: number; content: AgentContentItemType }>;
   modelInteractionDurationMs: number | null;
-  // Per-message model override from the input-bar model picker: the resolved
-  // model. Null/undefined when the agent ran its own configured model. Optional
-  // during rollout. See [BACK12].
-  requestedModel?: ResolvedRequestedModel | null;
+  // Model's triplet used to generate the message. Legacy: null, the agent ran its own configured model.
+  resolvedModel: ResolvedRequestedModel | null;
 };
 
 export type AgentMessageTypeWithoutMentions = Omit<

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -7,7 +7,8 @@ import {
 import type { ExtractSpecificKeys } from "../../shared/typescipt_utils";
 import type { TokenizerConfig } from "../../tokenizer";
 import type { EMBEDDING_PROVIDER_IDS } from "./embedding";
-import type { MODEL_IDS, SUPPORTED_MODEL_CONFIGS } from "./models";
+import type { SUPPORTED_MODEL_CONFIGS } from "./models";
+import { MODEL_IDS } from "./models";
 import type { BYOK_MODEL_PROVIDER_IDS } from "./providers";
 import { MODEL_PROVIDER_IDS } from "./providers";
 import { ORDERED_REASONING_EFFORTS } from "./reasoning";
@@ -23,7 +24,7 @@ export type CustomThinkingType = (typeof CUSTOM_THINKING_TYPES)[number];
 // provider/model pick, with an optional reasoning-effort override.
 export const ModelSelectionSchema = z.object({
   providerId: z.enum(MODEL_PROVIDER_IDS),
-  modelId: z.string(),
+  modelId: z.enum(MODEL_IDS),
   reasoningEffort: z.enum(ORDERED_REASONING_EFFORTS).optional(),
 });
 export type ModelSelectionType = z.infer<typeof ModelSelectionSchema>;


### PR DESCRIPTION
## Description

Adds `requestedProviderId`, `requestedModelId`, `requestedReasoningEffort` columns to `user_messages` so the raw model selection from the picker is persisted on the user message (`UserMessageType.requestedModel: ModelSelectionType | null`).

Alongside this, model resolution is refactored:
- `resolveModelSelection` → `resolveModel`, which now takes both the user's `selection` and the agent's `configuration`, resolving in priority order: user selection → agent config → workspace-supported fallback. It always returns a resolved model and a `modelResolutionMethod` ('user' | 'agent').
- Resolution is moved from `postUserMessage` (single, pre-mention) to `createAgentMessages` (per agent-mention), so each mention is resolved against its own agent's configured model.
- `AgentMessageType.requestedModel` (optional) is replaced by `resolvedModel: ResolvedRequestedModel | null` (required), reflecting the actual model used.
- The retry path now copies the original `AgentMessageModel` row columns verbatim instead of re-validating at retry time.
- `ModelSelectionSchema.modelId` tightened from `z.string()` to `z.enum(MODEL_IDS)`.

## Tests

- Extended `models.test.ts` with a full `resolveModel` suite: user selection honored, fallback to agent model, fallback to workspace large model, disabled selection fallthrough, reasoning effort pass-through and fallback.
- Existing `createUserMessage`, `createAgentMessages`, and MCP action tests updated to include the new required fields.
- Tested locally.

## Risk

Medium. This is a DB schema addition (nullable columns, no data backfill) on `user_messages` — safe to run while the app is live. The resolution logic change moves `resolveModel` to per-mention scope; behavior is equivalent for single-agent messages and improves correctness for multi-mention threads. Retry path now copies original row values instead of re-resolving, which removes an edge case where a model disabled post-send would silently change retry behavior.

## Deploy Plan

1. Run pre-deploy SQL migration (`20260708083845_add_columns_for_requested_models_on_user_message.sql`) on the front DB.
2. Deploy front.
