### PR TITLE
Improve messages when changing seat billing period

### DIFF
--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -22,6 +22,7 @@ import { useAppRouter } from "@app/lib/platform";
 import { useUpdateMemberSeatType } from "@app/lib/swr/memberships";
 import {
   isMembershipSeatType,
+  isPaidSeatType,
   type MembershipSeatType,
 } from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -243,21 +244,29 @@ export function ChangeSeatModal({
     }
   }
 
-  // Mirrors the backend `classifySeatTransition` rule
-  // (lib/metronome/seat_types.ts): a transition is deferred when the target
-  // seat has strictly lower AWU allocation than the current one — the user
-  // keeps the richer access through the period they already paid for.
-  // Identical seats are never deferred (they're a no-op).
+  // Mirrors the backend `classifySeatChange` rule (lib/metronome/seats.ts):
+  // a transition is deferred either when the target seat has strictly lower
+  // AWU allocation than the current one — the user keeps the richer access
+  // through the period they already paid for — or when it commits a monthly
+  // paid seat to yearly billing, which never takes effect mid-period even
+  // when the target tier is higher. Identical seats are never deferred
+  // (they're a no-op).
   const currentAwuCredits = currentSeatType
     ? (seatPlans[currentSeatType]?.awuCredits ?? 0)
     : 0;
   const selectedAwuCredits = selectedSeat
     ? (seatPlans[selectedSeat]?.awuCredits ?? 0)
     : 0;
+  const isMonthlyToYearlySwitch =
+    !!currentSeatType &&
+    !!selectedSeat &&
+    isPaidSeatType(currentSeatType) &&
+    !currentSeatType.endsWith("_yearly") &&
+    selectedSeat.endsWith("_yearly");
   const isDeferredChange =
     !!selectedSeat &&
     selectedSeat !== currentSeatType &&
-    selectedAwuCredits < currentAwuCredits;
+    (selectedAwuCredits < currentAwuCredits || isMonthlyToYearlySwitch);
 
   const displayedFirstName =
     displayedMember?.name?.trim().split(/\s+/)[0] ?? null;

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -18,6 +18,7 @@ import { formatCredits } from "@app/lib/client/credits";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
 import type { AllowedAdvancedModelType } from "@app/types/api/advanced_models";
 import {
+  isPaidSeatType,
   type MembershipSeatType,
   SEAT_TYPE_ORDER,
   toBaseSeatType,
@@ -86,6 +87,28 @@ function getScheduledSeatChangeLabel(
   scheduledSeatType: MembershipSeatType,
   scheduledSeatChangeAt: string | null
 ): string {
+  const dateSuffix = scheduledSeatChangeAt
+    ? ` (${new Date(scheduledSeatChangeAt).toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        timeZone: "UTC",
+      })})`
+    : "";
+
+  // A same-tier monthly→yearly commitment (e.g. pro -> pro_yearly) isn't a
+  // tier upgrade/downgrade/change — the user stays on the same tier, only the
+  // billing cadence switches. Call that out explicitly instead of the
+  // confusing "changed to Pro" wording, since the user is already on Pro.
+  const isMonthlyToYearlySwitch =
+    !!currentSeatType &&
+    isPaidSeatType(currentSeatType) &&
+    !currentSeatType.endsWith("_yearly") &&
+    scheduledSeatType.endsWith("_yearly") &&
+    toBaseSeatType(currentSeatType) === toBaseSeatType(scheduledSeatType);
+  if (isMonthlyToYearlySwitch) {
+    return `This user will switch to annual billing at the end of the billing period${dateSuffix}`;
+  }
+
   const currentRank = currentSeatType ? SEAT_TYPE_ORDER[currentSeatType] : 0;
   const scheduledRank = SEAT_TYPE_ORDER[scheduledSeatType];
   const verb =
@@ -95,13 +118,6 @@ function getScheduledSeatChangeLabel(
         ? "downgraded"
         : "changed";
   const targetLabel = seatTypeDisplayName(scheduledSeatType);
-  const dateSuffix = scheduledSeatChangeAt
-    ? ` (${new Date(scheduledSeatChangeAt).toLocaleDateString("en-US", {
-        month: "long",
-        day: "numeric",
-        timeZone: "UTC",
-      })})`
-    : "";
   return `This user will be ${verb} to ${targetLabel} at the end of the billing period${dateSuffix}`;
 }
 


### PR DESCRIPTION
## Description

1. ChangeSeatModal.tsx — isDeferredChange now also accounts for the monthly→yearly commitment case (mirroring the backend's isMonthlyToYearlySwitch in classifySeatChange), so the "The change will take effect at the next credit refresh." message now shows up for monthly→yearly switches too.
2. MembersUsageTable.tsx — the scheduled-change tooltip now detects the same-tier monthly→yearly case and shows "This user will switch to annual billing at the end of the billing period (date)" instead of the confusing "This user will be changed to Pro..." (since pro and pro_yearly share the same tier rank, it previously fell into the generic "changed" verb).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
