### PR TITLE
feat: add products read scope to hubspot

### DIFF
--- a/front/lib/api/oauth/providers/hubspot.ts
+++ b/front/lib/api/oauth/providers/hubspot.ts
@@ -54,6 +54,7 @@ export class HubspotOAuthProvider implements BaseOAuthStrategyProvider {
       "marketing-email",
       "content",
       "tickets",
+      "crm.objects.products.read",
     ];
 
     const workspaceGrantedScopes = extraConfig?.workspace_granted_scopes;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9501

This PR adds the `crm.objects.products.read` scope to the HubSpot scopes list, allowing to read product data which was already possible with the existing tools.

## Tests

Manually.

## Risks

Low. 

## Deploy Plan
Add scope to hubspot app and then deploy.

