### PR TITLE
[dsbx] fix: address @dust/pod review feedback

### DIFF
--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -184,40 +184,43 @@ function wrapStatement<T extends object>(
  * through `prepare` (which `query()` and `transaction()` also go through).
  */
 class PodSqliteDatabase extends Database {
-  readonly #dbName: string;
-  readonly #maxSizeBytes: number;
+  private readonly dbName: string;
+  private readonly maxSizeBytes: number;
 
   constructor(path: string, dbName: string, maxSizeBytes: number) {
     // readwrite without create: opening a missing file throws SQLITE_CANTOPEN
     // instead of minting an empty database (verified against bun 1.3.14).
     super(path, { readwrite: true });
-    this.#dbName = dbName;
-    this.#maxSizeBytes = maxSizeBytes;
+    this.dbName = dbName;
+    this.maxSizeBytes = maxSizeBytes;
   }
 
-  run<ParamsType extends SQLQueryBindings[]>(
+  override run<ParamsType extends SQLQueryBindings[]>(
     sql: string,
     ...bindings: ParamsType[]
   ): Changes {
     try {
       return super.run(sql, ...bindings);
     } catch (err) {
-      throw translateSqliteError(err, this.#dbName, this.#maxSizeBytes);
+      throw translateSqliteError(err, this.dbName, this.maxSizeBytes);
     }
   }
 
-  exec<ParamsType extends SQLQueryBindings[]>(
+  override exec<ParamsType extends SQLQueryBindings[]>(
     sql: string,
     ...bindings: ParamsType[]
   ): Changes {
     try {
       return super.exec(sql, ...bindings);
     } catch (err) {
-      throw translateSqliteError(err, this.#dbName, this.#maxSizeBytes);
+      throw translateSqliteError(err, this.dbName, this.maxSizeBytes);
     }
   }
 
-  prepare<ReturnType, ParamsType extends SQLQueryBindings | SQLQueryBindings[]>(
+  override prepare<
+    ReturnType,
+    ParamsType extends SQLQueryBindings | SQLQueryBindings[],
+  >(
     sql: string,
     params?: ParamsType
     // The `any[]` conditional mirrors bun:sqlite's own Database.prepare signature.
@@ -226,7 +229,7 @@ class PodSqliteDatabase extends Database {
     ParamsType extends any[] ? ParamsType : [ParamsType]
   > {
     const stmt = super.prepare<ReturnType, ParamsType>(sql, params);
-    return wrapStatement(stmt, this.#dbName, this.#maxSizeBytes);
+    return wrapStatement(stmt, this.dbName, this.maxSizeBytes);
   }
 }
 

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -3,9 +3,6 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
-import { blob, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
-
 import {
   db,
   POD_DATABASE_BUSY_TIMEOUT_MS,
@@ -17,7 +14,8 @@ import {
   PodDatabaseInvalidNameError,
   PodDatabaseNotDeclaredError,
   PodDatabasesUnavailableError,
-} from "./index.ts";
+} from "@dust/pod";
+import { blob, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 // The production quota front passes per exec.
 const ONE_GIB_BYTES = 1024 * 1024 * 1024;

--- a/cli/dust-sandbox/pod/package.json
+++ b/cli/dust-sandbox/pod/package.json
@@ -5,6 +5,7 @@
   "description": "Runtime library for code running in a Dust pod sandbox.",
   "type": "module",
   "main": "index.ts",
+  "exports": { ".": "./index.ts" },
   "scripts": {
     "test": "bun test",
     "build": "bun build index.ts --bundle --target=bun --packages=external --outfile dist/index.js"

--- a/cli/dust-sandbox/pod/tsconfig.json
+++ b/cli/dust-sandbox/pod/tsconfig.json
@@ -8,6 +8,7 @@
     "verbatimModuleSyntax": true,
     "noEmit": true,
     "strict": true,
+    "noImplicitOverride": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true


### PR DESCRIPTION
Addresses @flvndvd's post-merge review comments on #28605:

- `#dbName`/`#maxSizeBytes` → `private readonly` fields, matching the codebase convention (native `#` private fields were used nowhere else in the repo).
- `override` keyword on the `Database` method overrides, with `noImplicitOverride` added to the package tsconfig so the compiler enforces it.
- The test now imports the package by name (`@dust/pod`) instead of `./index.ts`, backed by an `exports` entry in package.json (required for self-referencing imports, and pins the public entry point).

## Tests
- `bun test`: 22 pass, 0 fail.
- `bunx tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)