### PR TITLE
feat(front): attach remote MCP servers via agent toolset API

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -715,6 +715,7 @@
                   },
                   "toolset": {
                     "type": "array",
+                    "description": "Replaces the full set of tools on the agent. Any tool not present in this array is removed, so send the complete desired toolset. Each entry resolves an MCP server by name (see configuration.mcp_server_name). Entries that cannot be resolved are not applied and are returned in the skippedActions field of the response rather than causing the whole request to fail.",
                     "items": {
                       "type": "object",
                       "properties": {
@@ -731,7 +732,13 @@
                           ]
                         },
                         "configuration": {
-                          "type": "object"
+                          "type": "object",
+                          "properties": {
+                            "mcp_server_name": {
+                              "type": "string",
+                              "description": "Name of the MCP server to attach. Both built-in (internal) tools and remote MCP servers are supported. A remote MCP server must first be shared to a space (global or a regular space the caller can access); it is matched by its display name, which must be unambiguous within the workspace."
+                            }
+                          }
                         }
                       }
                     }
@@ -759,6 +766,7 @@
                     },
                     "skippedActions": {
                       "type": "array",
+                      "description": "Toolset entries that could not be applied (e.g. the referenced MCP server was not found, is not shared to an accessible space, or the name was ambiguous). The request still succeeds; inspect this list to confirm every intended tool was attached.",
                       "items": {
                         "type": "object",
                         "properties": {

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -167,6 +167,12 @@ const VariantQuerySchema = z.object({
  *                       type: string
  *               toolset:
  *                 type: array
+ *                 description: >-
+ *                   Replaces the full set of tools on the agent. Any tool not present in this
+ *                   array is removed, so send the complete desired toolset. Each entry resolves
+ *                   an MCP server by name (see configuration.mcp_server_name). Entries that cannot
+ *                   be resolved are not applied and are returned in the skippedActions field of
+ *                   the response rather than causing the whole request to fail.
  *                 items:
  *                   type: object
  *                   properties:
@@ -179,6 +185,15 @@ const VariantQuerySchema = z.object({
  *                       enum: [MCP]
  *                     configuration:
  *                       type: object
+ *                       properties:
+ *                         mcp_server_name:
+ *                           type: string
+ *                           description: >-
+ *                             Name of the MCP server to attach. Both built-in (internal) tools and
+ *                             remote MCP servers are supported. A remote MCP server must first be
+ *                             shared to a space (global or a regular space the caller can access);
+ *                             it is matched by its display name, which must be unambiguous within
+ *                             the workspace.
  *     security:
  *       - BearerAuth: []
  *     responses:
@@ -193,6 +208,11 @@ const VariantQuerySchema = z.object({
  *                   $ref: '#/components/schemas/AgentConfiguration'
  *                 skippedActions:
  *                   type: array
+ *                   description: >-
+ *                     Toolset entries that could not be applied (e.g. the referenced MCP server
+ *                     was not found, is not shared to an accessible space, or the name was
+ *                     ambiguous). The request still succeeds; inspect this list to confirm every
+ *                     intended tool was attached.
  *                   items:
  *                     type: object
  *                     properties:

--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -1,5 +1,6 @@
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { processAdditionalConfiguration } from "@app/components/agent_builder/submitAgentBuilderForm";
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   isAutoInternalMCPServerName,
   isInternalMCPServerName,
@@ -303,9 +304,25 @@ export class AgentYAMLConverter {
     }));
   }
 
+  private static async resolveAutoInternalMCPServerView(
+    auth: Authenticator,
+    name: AutoInternalMCPServerNameType
+  ): Promise<Result<MCPServerViewResource, Error>> {
+    const mcpServerView =
+      await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+        auth,
+        name
+      );
+    if (!mcpServerView) {
+      return new Err(new Error(`MCP server view not found for: ${name}`));
+    }
+    return new Ok(mcpServerView);
+  }
+
   static async convertYAMLActionToMCPConfiguration(
     auth: Authenticator,
-    action: AgentYAMLAction
+    action: AgentYAMLAction,
+    workspaceViews: MCPServerViewResource[]
   ): Promise<
     Result<
       | PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"][number]
@@ -318,32 +335,22 @@ export class AgentYAMLConverter {
       return new Err(new Error("MCP server name is required"));
     }
 
-    if (!isInternalMCPServerName(mcpServerName)) {
-      return new Err(
-        new Error(`Invalid internal MCP server name: ${mcpServerName}`)
-      );
-    }
-
-    if (!isAutoInternalMCPServerName(mcpServerName)) {
-      return new Err(
-        new Error(
-          `MCP server ${mcpServerName} is not available for auto configuration`
-        )
-      );
-    }
-
     try {
-      const mcpServerView =
-        await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          mcpServerName
-        );
-
-      if (!mcpServerView) {
-        return new Err(
-          new Error(`MCP server view not found for: ${mcpServerName}`)
-        );
+      // Auto internal servers get a just-in-time global-space view; everything else is matched
+      // by name against the pre-fetched workspace views.
+      const mcpServerViewResult =
+        isInternalMCPServerName(mcpServerName) &&
+        isAutoInternalMCPServerName(mcpServerName)
+          ? await this.resolveAutoInternalMCPServerView(auth, mcpServerName)
+          : MCPServerViewResource.resolveAttachableByName(
+              auth,
+              workspaceViews,
+              mcpServerName
+            );
+      if (mcpServerViewResult.isErr()) {
+        return new Err(mcpServerViewResult.error);
       }
+      const mcpServerView = mcpServerViewResult.value;
 
       const workspaceId = auth.getNonNullableWorkspace().sId;
 
@@ -402,9 +409,16 @@ export class AgentYAMLConverter {
     >
   > {
     try {
+      // Fetch once to avoid an N+1 across toolset entries.
+      const workspaceViews = await MCPServerViewResource.listByWorkspace(auth);
       const results = await concurrentExecutor(
         yamlActions,
-        (action) => this.convertYAMLActionToMCPConfiguration(auth, action),
+        (action) =>
+          this.convertYAMLActionToMCPConfiguration(
+            auth,
+            action,
+            workspaceViews
+          ),
         { concurrency: 5 }
       );
 

--- a/front/lib/api/assistant/configuration/yaml_import.test.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.test.ts
@@ -196,12 +196,158 @@ describe("patchAgentConfigurationFromJSON", () => {
     expect(result.value.skippedActions).toEqual([
       {
         name: "Missing MCP server",
-        reason: "Invalid internal MCP server name: missing_server",
+        reason: "MCP server not found: missing_server",
       },
     ]);
     expect(result.value.agentConfiguration.actions).toHaveLength(0);
     expect(result.value.agentConfiguration.requestedSpaceIds).not.toContain(
       space.sId
     );
+  });
+
+  it("should attach a remote MCP server referenced by name when patching toolset", async () => {
+    const { authenticator, globalGroup } = await createResourceTest({
+      role: "admin",
+    });
+    const { agent, space } = await createPatchableAgent({
+      auth: authenticator,
+      globalGroup,
+    });
+
+    const result = await patchAgentConfigurationFromJSON(
+      authenticator,
+      agent.sId,
+      {
+        toolset: [
+          {
+            name: "Remote tool",
+            description: "A remote MCP server attached by name",
+            type: "MCP",
+            configuration: {
+              mcp_server_name: "YAML Import Test Server",
+            },
+          },
+        ],
+        spaces: [
+          {
+            space_id: space.sId,
+            name: space.name,
+          },
+        ],
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw new Error(result.error.api_error.message);
+    }
+
+    expect(result.value.skippedActions).toEqual([]);
+    expect(result.value.agentConfiguration.actions).toHaveLength(1);
+    expect(result.value.agentConfiguration.requestedSpaceIds).toContain(
+      space.sId
+    );
+  });
+
+  it("should skip a remote MCP server that is only present in the system space", async () => {
+    const { authenticator, globalGroup } = await createResourceTest({
+      role: "admin",
+    });
+    const { agent } = await createPatchableAgent({
+      auth: authenticator,
+      globalGroup,
+    });
+
+    const workspace = authenticator.getNonNullableWorkspace();
+    // Never shared to a space, so only its system-space view exists — not attachable.
+    await RemoteMCPServerFactory.create(workspace, {
+      name: "System Only Server",
+    });
+
+    const result = await patchAgentConfigurationFromJSON(
+      authenticator,
+      agent.sId,
+      {
+        toolset: [
+          {
+            name: "Unshared remote tool",
+            description: "Should be skipped",
+            type: "MCP",
+            configuration: {
+              mcp_server_name: "System Only Server",
+            },
+          },
+        ],
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw new Error(result.error.api_error.message);
+    }
+
+    expect(result.value.skippedActions).toEqual([
+      {
+        name: "Unshared remote tool",
+        reason: "MCP server not found: System Only Server",
+      },
+    ]);
+    expect(result.value.agentConfiguration.actions).toHaveLength(0);
+  });
+
+  it("should skip a remote MCP server name that resolves to several servers", async () => {
+    const { authenticator, globalGroup } = await createResourceTest({
+      role: "admin",
+    });
+    const { agent, space } = await createPatchableAgent({
+      auth: authenticator,
+      globalGroup,
+    });
+
+    const workspace = authenticator.getNonNullableWorkspace();
+    // Two distinct remote servers sharing a display name, both shared to an accessible space.
+    for (let i = 0; i < 2; i++) {
+      const server = await RemoteMCPServerFactory.create(workspace, {
+        name: "Duplicate Server",
+      });
+      await MCPServerViewFactory.create(workspace, server.sId, space);
+    }
+
+    const result = await patchAgentConfigurationFromJSON(
+      authenticator,
+      agent.sId,
+      {
+        toolset: [
+          {
+            name: "Ambiguous remote tool",
+            description: "Should be skipped",
+            type: "MCP",
+            configuration: {
+              mcp_server_name: "Duplicate Server",
+            },
+          },
+        ],
+        spaces: [
+          {
+            space_id: space.sId,
+            name: space.name,
+          },
+        ],
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw new Error(result.error.api_error.message);
+    }
+
+    expect(result.value.skippedActions).toEqual([
+      {
+        name: "Ambiguous remote tool",
+        reason:
+          'Multiple MCP servers named "Duplicate Server" found; cannot resolve unambiguously.',
+      },
+    ]);
+    expect(result.value.agentConfiguration.actions).toHaveLength(0);
   });
 });

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -839,6 +839,43 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return map;
   }
 
+  // Matches a view by display name from a pre-fetched list (callers fetch once to avoid an N+1).
+  // System-space views are excluded since agents attach from global/regular spaces; when a server
+  // is shared to several spaces the global-space view wins, otherwise the name must be unambiguous.
+  static resolveAttachableByName(
+    auth: Authenticator,
+    views: MCPServerViewResource[],
+    name: string
+  ): Result<MCPServerViewResource, Error> {
+    const matches = views.filter((view) => {
+      if (
+        view.space.kind === "system" ||
+        !view.space.canReadOrAdministrate(auth)
+      ) {
+        return false;
+      }
+      const json = view.toJSON();
+      return (json.name ?? json.server.name) === name;
+    });
+
+    if (matches.length === 0) {
+      return new Err(new Error(`MCP server not found: ${name}`));
+    }
+
+    const globalMatches = matches.filter(
+      (view) => view.space.kind === "global"
+    );
+    const candidates = globalMatches.length > 0 ? globalMatches : matches;
+    if (candidates.length > 1) {
+      return new Err(
+        new Error(
+          `Multiple MCP servers named "${name}" found; cannot resolve unambiguously.`
+        )
+      );
+    }
+    return new Ok(candidates[0]);
+  }
+
   static async listMCPServerViewsAutoInternalForSpaces(
     auth: Authenticator,
     name: AutoInternalMCPServerNameType,


### PR DESCRIPTION
## Description

The `toolset` field of `PATCH`/`POST /api/v1/w/{wId}/assistant/agent_configurations` only resolved internal auto-available servers by name. Any other `mcp_server_name` was silently skipped, so remote tools could never be attached to an agent programmatically.

Non-auto names are now matched against the workspace's MCP server views by display name:
- system-space views are excluded (agents attach from global/regular spaces);
- when a server is shared to several spaces, the global-space view wins (same as the auto-internal path);
- an ambiguous name resolves to nothing and is reported in `skippedActions` rather than guessing.

Views are fetched once per request, so resolving many toolset entries doesn't fan out into an N+1. Name resolution lives on `MCPServerViewResource.resolveAttachableByName`. 

## Tests

`front/lib/api/assistant/configuration/yaml_import.test.ts` added cases for: remote server attached by name, remote server present only in the system space (skipped), and a name matching several servers (skipped as ambiguous). Existing skip-reason expectation updated.

## Risk

Safe to rollback.

## Deploy Plan

Standard front deploy.