### PR TITLE
Fix: do not show depth > 0 conversations in pods.

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3182,6 +3182,43 @@ describe("listSpaceUnreadConversationsForUser", () => {
     expect(spaceConversationIds).toContain(conversationIds[0]); // space conversation should be included
     expect(spaceConversationIds).not.toContain(privateConvo.sId); // private conversation should be filtered out
   });
+
+  it("should exclude sub-conversations (depth > 0) from unread lists", async () => {
+    const subConversation = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agents[0].sId,
+      messagesCreatedAt: [dateFromDaysAgo(1)],
+      spaceId: spaceModelIds[0],
+    });
+    await ConversationModel.update(
+      { depth: 1 },
+      {
+        where: {
+          workspaceId: workspace.id,
+          sId: subConversation.sId,
+        },
+      }
+    );
+
+    await ConversationResource.upsertParticipation(userAuth, {
+      conversation: subConversation,
+      action: "posted",
+      user: userAuth.getNonNullableUser().toJSON(),
+      lastReadAt: null,
+    });
+
+    const userConversations =
+      await ConversationResource.listSpaceUnreadConversationsAndActivityForUser(
+        userAuth,
+        spaceModelIds
+      );
+
+    const allConversationIds = [
+      ...userConversations.unreadConversations,
+      ...userConversations.nonParticipantUnreadConversations,
+    ].map((c) => c.sId);
+    expect(allConversationIds).toContain(conversationIds[0]);
+    expect(allConversationIds).not.toContain(subConversation.sId);
+  });
 });
 
 describe("Space Handling", () => {
@@ -6436,6 +6473,32 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
     expect(result.conversations).toHaveLength(2);
     expect(result.hasMore).toBe(true);
     expect(result.lastValue).not.toBeNull();
+  });
+
+  it("should exclude sub-conversations (depth > 0) from the list", async () => {
+    const rootConversation = await createConvoWithUpdatedAt(1);
+    const subConversation = await createConvoWithUpdatedAt(0);
+    await ConversationModel.update(
+      { depth: 1 },
+      {
+        where: {
+          workspaceId: workspace.id,
+          sId: subConversation.sId,
+        },
+      }
+    );
+
+    const result = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: space.sId,
+        pagination: { limit: 10 },
+      }
+    );
+
+    const conversationIds = result.conversations.map((c) => c.sId);
+    expect(conversationIds).toContain(rootConversation.sId);
+    expect(conversationIds).not.toContain(subConversation.sId);
   });
 
   it("should return hasMore: false when no more results", async () => {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1944,6 +1944,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         where: {
           spaceId: { [Op.in]: spaceIds },
           visibility: { [Op.eq]: "unlisted" },
+          depth: { [Op.eq]: 0 }, // Only fetch root conversations
         },
       }
     );
@@ -2120,6 +2121,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const whereClause: WhereOptions<InferAttributes<ConversationModel>> = {
       ...filterWhere,
       spaceId: spaceModelId,
+      depth: { [Op.eq]: 0 }, // Only fetch root conversations
       ...(restrictToConversationModelIds && {
         id: { [Op.in]: restrictToConversationModelIds },
       }),


### PR DESCRIPTION
## Description

Sub-conversations (agent-spawned child conversations with `depth > 0`) were leaking into Pod conversation lists. Added `depth: { [Op.eq]: 0 }` filters to both `listSpaceUnreadConversationsAndActivityForUser` and `listConversationsInSpacePaginated` in `ConversationResource` so only root conversations are returned.

## Tests

Added unit tests for both query paths in `conversation_resource.test.ts`: create a conversation, force-set `depth: 1` via `ConversationModel.update`, assert it's excluded from the result while root conversations are still returned.

## Risk

Low. Two additive `WHERE` clause filters on an existing indexed column (`depth`). No schema change. Existing conversations at `depth: 0` are unaffected.

## Deploy Plan

Deploy front.
