### PR TITLE
[front] Do not error when workspace Jira connection is missing on reconnect

### DIFF
--- a/front/lib/api/oauth/providers/jira.ts
+++ b/front/lib/api/oauth/providers/jira.ts
@@ -99,9 +99,20 @@ export class JiraOAuthProvider implements BaseOAuthStrategyProvider {
           connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
-          throw new Error(
-            "Failed to get connection metadata: " + connectionRes.error.message
+          // The workspace-level connection referenced by the MCP server may no
+          // longer exist (e.g. after a workspace relocation where Jira was not
+          // reconnected). `jira_cloud_url` is optional, so instead of failing
+          // the setup we fall back to dynamic resolution by omitting it.
+          logger.warn(
+            {
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              mcpServerId: mcp_server_id,
+              error: connectionRes.error,
+            },
+            "Jira OAuth: could not read workspace connection metadata, " +
+              "falling back to dynamic cloud URL resolution"
           );
+          return restConfig;
         }
         const connection = connectionRes.value.connection;
 


### PR DESCRIPTION
## Problem

Prod alerts fire on `Unhandled API Error` (error level) from a workspace that was relocated but did not reconnect Jira. The failing route is `GET /api/w/:wId/oauth/jira/setup` (personal Jira reconnect).

Flow: when setting up a personal Jira connection, `JiraOAuthProvider.getUpdatedExtraConfig` reads the **workspace-level** MCP server's OAuth connection metadata to copy `jira_cloud_url`. After relocation that connection no longer exists in the OAuth service, so `getConnectionMetadata` returns `Err` and the code did a bare `throw new Error(...)`. That throw escaped the `Result` and bubbled uncaught to the global Hono handler (`front-api/middlewares/utils.ts:143`), which logs `"Unhandled API Error"` unconditionally at error level → alert. It also broke the personal reconnect flow for those users.

## Fix

`jira_cloud_url` is optional (absent → dynamic resolution, see `isExtraConfigValid`). So when the workspace connection metadata can't be read, we now log a `warn` and continue without `jira_cloud_url` instead of throwing.

Result:
- No more `Unhandled API Error` (the throw was the only source of that log on this path).
- Personal Jira reconnect works via dynamic cloud-URL resolution without an admin first restoring the workspace connection.
- Aligns with ERR1 (handle gracefully rather than throw our own error).

## Note (out of scope)

The Jira MCP *tool* path (`withAuth` "No access token found") still logs at error level via `MCPError`'s default `tracked: true`, so a relocated-but-unreconnected workspace could also generate `"Tool execution error"` noise there. Left for a separate change.