### PR TITLE
Fix: deployment instruction danger rules detection

### DIFF
--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -148,10 +148,10 @@ function checkSDKLabel() {
 }
 
 function checkDeployPlanSection() {
-  const PRDescription = danger.github.pr.body;
+  const PRDescription = danger.github.pr.body ?? "";
 
   const deployPlanSectionRegex =
-    /## Deploy Plan.*?\r\n([\s\S]*?)(?=<!--|\n##|$)/;
+    /## Deploy Plan.*?\r?\n([\s\S]*?)(?=<!--|\n##|$)/;
 
   const match = PRDescription.match(deployPlanSectionRegex);
   if (!match || match[1].trim().length < 20) {


### PR DESCRIPTION
## Description

Two fixes in `checkDeployPlanSection` in `front/dangerfile.ts`:
- `danger.github.pr.body ?? ""` — prevents a crash when the PR body is `null`.
- `\r?\n` instead of `\r\n` in the Deploy Plan section regex — makes the match work on both CRLF and LF line endings (GitHub delivers either depending on the client).

These were silently causing the danger rule to fail to detect a filled-in Deploy Plan section, so valid PRs would get a false-positive danger warning.

## Tests

Tested locally by running the danger check against PRs with LF-only bodies and null bodies.

## Risk

Low. Change is limited to the dangerfile CI check; no production code affected. Fully safe to rollback.

## Deploy Plan

No deploy needed — dangerfile change only, takes effect on the next CI run.
