### PR TITLE
fix(agents): cascade trigger/wake-up/favorite cleanup on archive and hard delete

### DIFF
--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -9,11 +9,9 @@ import {
 } from "@app/lib/api/assistant/configuration/agent";
 import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
 import { Authenticator } from "@app/lib/auth";
-import {
-  AgentConfigurationModel,
-  AgentUserRelationModel,
-} from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -521,13 +519,9 @@ describe("cleanupAgentScopedResourcesForHardDeletion", () => {
     );
     expect(remainingWakeUps).toHaveLength(0);
 
-    const remainingFavorites = await AgentUserRelationModel.findAll({
-      where: {
-        agentConfiguration: agent.sId,
-        workspaceId: workspace.id,
-      },
-    });
-    expect(remainingFavorites).toHaveLength(0);
+    const remainingFavoriteCount =
+      await AgentUserRelationResource.countForAgent(authenticator, agent.sId);
+    expect(remainingFavoriteCount).toBe(0);
 
     expect(mockDeleteSchedule).toHaveBeenCalled();
     expect(cancelSpy).toHaveBeenCalled();

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -1,24 +1,34 @@
 import {
   archiveAgentConfiguration,
+  cleanupAgentScopedResourcesForHardDeletion,
   createAgentConfiguration,
   createPendingAgentConfiguration,
   getAgentConfiguration,
   restoreAgentConfiguration,
   updateAgentConfigurationsScope,
 } from "@app/lib/api/assistant/configuration/agent";
+import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import {
+  AgentConfigurationModel,
+  AgentUserRelationModel,
+} from "@app/lib/models/agent/agent";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import * as scheduleClient from "@app/temporal/triggers/schedule_client";
+import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { describe, expect, it } from "vitest";
+import { Err, Ok } from "@app/types/shared/result";
+import { describe, expect, it, vi } from "vitest";
 
 describe("createAgentConfiguration with pending agent", () => {
   it("converts pending agent to active when agentConfigurationId points to a pending agent", async () => {
@@ -330,6 +340,248 @@ describe("archiveAgentConfiguration and restoreAgentConfiguration", () => {
         "Agent configuration is not archived"
       );
     }
+  });
+
+  it("cancels scheduled wake-ups when archiving", async () => {
+    const launchSpy = vi
+      .spyOn(wakeUpClient, "launchOrScheduleWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+    const cancelSpy = vi
+      .spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const wakeUpResult = await WakeUpResource.makeNew(
+      authenticator,
+      {
+        scheduleType: "cron",
+        fireAt: null,
+        cronExpression: "0 7 * * *",
+        cronTimezone: "Europe/Paris",
+        reason: "Daily wake-up",
+      },
+      conversation,
+      agent
+    );
+    if (wakeUpResult.isErr()) {
+      throw new Error(
+        `Failed to create test wake-up: ${wakeUpResult.error.message}`
+      );
+    }
+
+    const archived = await archiveAgentConfiguration(authenticator, agent.sId);
+    expect(archived).toBe(true);
+
+    expect(cancelSpy).toHaveBeenCalled();
+    const refetched = await WakeUpResource.fetchById(
+      authenticator,
+      wakeUpResult.value.sId
+    );
+    expect(refetched?.status).toBe("cancelled");
+
+    launchSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
+
+  it("reconciles the leaked schedule of a terminal cron wake-up when archiving", async () => {
+    const launchSpy = vi
+      .spyOn(wakeUpClient, "launchOrScheduleWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+    const cancelSpy = vi
+      .spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const wakeUpResult = await WakeUpResource.makeNew(
+      authenticator,
+      {
+        scheduleType: "cron",
+        fireAt: null,
+        cronExpression: "0 7 * * *",
+        cronTimezone: "Europe/Paris",
+        reason: "Daily wake-up",
+      },
+      conversation,
+      agent
+    );
+    if (wakeUpResult.isErr()) {
+      throw new Error(
+        `Failed to create test wake-up: ${wakeUpResult.error.message}`
+      );
+    }
+
+    // Drive the wake-up to a terminal state via a DB-only cancel (markCancelled
+    // does not touch Temporal), simulating a cron schedule that leaked when the
+    // wake-up became terminal.
+    await wakeUpResult.value.markCancelled(authenticator);
+
+    // Only count the Temporal calls made by archiving.
+    cancelSpy.mockClear();
+
+    const archived = await archiveAgentConfiguration(authenticator, agent.sId);
+    expect(archived).toBe(true);
+
+    // Archive must reconcile the leaked schedule even though the row is already
+    // terminal (it used to skip non-scheduled wake-ups entirely).
+    expect(cancelSpy).toHaveBeenCalled();
+
+    launchSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
+});
+
+describe("cleanupAgentScopedResourcesForHardDeletion", () => {
+  it("removes triggers, wake-ups and favorites for the agent", async () => {
+    const mockCreateSchedule = vi
+      .spyOn(scheduleClient, "createOrUpdateAgentSchedule")
+      .mockResolvedValue(new Ok("workflow-id"));
+    const mockDeleteSchedule = vi
+      .spyOn(scheduleClient, "deleteTriggerSchedule")
+      .mockResolvedValue(new Ok(undefined));
+    const launchSpy = vi
+      .spyOn(wakeUpClient, "launchOrScheduleWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+    const cancelSpy = vi
+      .spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    const triggerResult = await TriggerResource.makeNew(authenticator, {
+      id: 300,
+      workspaceId: workspace.id,
+      name: "Schedule Trigger",
+      kind: "schedule",
+      agentConfigurationId: agent.sId,
+      editor: user.id,
+      customPrompt: null,
+      status: "enabled",
+      configuration: {
+        cron: "0 9 * * 1",
+        timezone: "UTC",
+      },
+      origin: "user",
+    });
+    expect(triggerResult.isOk()).toBe(true);
+
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    const wakeUpResult = await WakeUpResource.makeNew(
+      authenticator,
+      {
+        scheduleType: "cron",
+        fireAt: null,
+        cronExpression: "0 7 * * *",
+        cronTimezone: "Europe/Paris",
+        reason: "Daily wake-up",
+      },
+      conversation,
+      agent
+    );
+    expect(wakeUpResult.isOk()).toBe(true);
+
+    const favoriteResult = await setAgentUserFavorite({
+      auth: authenticator,
+      agentId: agent.sId,
+      userFavorite: true,
+    });
+    expect(favoriteResult.isOk()).toBe(true);
+
+    await cleanupAgentScopedResourcesForHardDeletion(authenticator, agent.sId);
+
+    const remainingTriggers = await TriggerResource.listByAgentConfigurationId(
+      authenticator,
+      agent.sId
+    );
+    expect(remainingTriggers).toHaveLength(0);
+
+    const remainingWakeUps = await WakeUpResource.listByAgentConfigurationId(
+      authenticator,
+      agent.sId
+    );
+    expect(remainingWakeUps).toHaveLength(0);
+
+    const remainingFavorites = await AgentUserRelationModel.findAll({
+      where: {
+        agentConfiguration: agent.sId,
+        workspaceId: workspace.id,
+      },
+    });
+    expect(remainingFavorites).toHaveLength(0);
+
+    expect(mockDeleteSchedule).toHaveBeenCalled();
+    expect(cancelSpy).toHaveBeenCalled();
+
+    mockCreateSchedule.mockRestore();
+    mockDeleteSchedule.mockRestore();
+    launchSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
+
+  it("keeps the wake-up row when Temporal cancellation fails", async () => {
+    const launchSpy = vi
+      .spyOn(wakeUpClient, "launchOrScheduleWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+    // Simulate a transient Temporal failure when cancelling the schedule.
+    const cancelSpy = vi
+      .spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Err(new Error("temporal unavailable")));
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    const wakeUpResult = await WakeUpResource.makeNew(
+      authenticator,
+      {
+        scheduleType: "cron",
+        fireAt: null,
+        cronExpression: "0 7 * * *",
+        cronTimezone: "Europe/Paris",
+        reason: "Daily wake-up",
+      },
+      conversation,
+      agent
+    );
+    expect(wakeUpResult.isOk()).toBe(true);
+
+    await cleanupAgentScopedResourcesForHardDeletion(authenticator, agent.sId);
+
+    // The Temporal schedule could not be deleted, so the row must survive to
+    // keep the wake-up id available for a retry / the reconciler.
+    const remainingWakeUps = await WakeUpResource.listByAgentConfigurationId(
+      authenticator,
+      agent.sId
+    );
+    expect(remainingWakeUps).toHaveLength(1);
+    expect(remainingWakeUps[0].status).toBe("scheduled");
+
+    launchSpy.mockRestore();
+    cancelSpy.mockRestore();
   });
 });
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -55,6 +55,7 @@ import { TagResource } from "@app/lib/resources/tags_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import { tracer } from "@app/logger/tracer";
@@ -1311,6 +1312,34 @@ export async function createGenericAgentConfiguration(
   return new Ok({ agentConfiguration, subAgentConfiguration });
 }
 
+// Cancels every still-scheduled wake-up targeting the given agent, deleting the
+// backing Temporal schedule (cron) or pending workflow (one-shot). Errors are
+// logged but do not abort the caller; the reconciler worker is the backstop.
+async function cancelWakeUpsForAgent(
+  auth: Authenticator,
+  agentConfigurationId: string
+): Promise<void> {
+  const workspace = auth.getNonNullableWorkspace();
+  const wakeUps = await WakeUpResource.listByAgentConfigurationId(
+    auth,
+    agentConfigurationId
+  );
+  for (const wakeUp of wakeUps) {
+    const cancelResult = await wakeUp.cancelForCascade(auth);
+    if (cancelResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          agentConfigurationId,
+          wakeUpId: wakeUp.sId,
+          error: cancelResult.error,
+        },
+        `Failed to cancel wake-up ${wakeUp.sId} for agent ${agentConfigurationId}`
+      );
+    }
+  }
+}
+
 export async function archiveAgentConfiguration(
   auth: Authenticator,
   agentConfigurationId: string
@@ -1348,6 +1377,8 @@ export async function archiveAgentConfiguration(
       );
     }
   }
+
+  await cancelWakeUpsForAgent(auth, agentConfigurationId);
 
   const updated = await AgentConfigurationModel.update(
     { status: "archived" },
@@ -1530,6 +1561,85 @@ export async function restoreAgentConfiguration(
   return new Ok({ restored: updated[0] > 0 });
 }
 
+// Deletes the agent-scoped resources that are keyed by the agent sId (stable
+// across versions) and therefore have no DB foreign key to cascade on: triggers
+// (with their Temporal schedule), wake-ups (with their Temporal schedule /
+// pending workflow) and favorite / agent-user-relation rows.
+//
+// Must only be called when the whole agent (every version) is being terminally
+// hard-deleted, never from a single-version cleanup such as a failed upgrade
+// rollback: those keep the agent alive under the same sId, so wiping these
+// rows would break a live agent.
+export async function cleanupAgentScopedResourcesForHardDeletion(
+  auth: Authenticator,
+  agentConfigurationId: string
+): Promise<void> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const triggers = await TriggerResource.listByAgentConfigurationId(
+    auth,
+    agentConfigurationId
+  );
+  for (const trigger of triggers) {
+    const deleteResult = await trigger.delete(auth);
+    if (deleteResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          agentConfigurationId,
+          triggerId: trigger.sId,
+          error: deleteResult.error,
+        },
+        `Failed to delete trigger ${trigger.sId} while hard-deleting agent ${agentConfigurationId}`
+      );
+    }
+  }
+
+  const wakeUps = await WakeUpResource.listByAgentConfigurationId(
+    auth,
+    agentConfigurationId
+  );
+  for (const wakeUp of wakeUps) {
+    // Ensure the wake-up's Temporal footprint is gone before deleting its row
+    // (cancelForCascade handles both scheduled and terminal-cron cases). The row
+    // is the only handle for retrying, so we keep it if the cleanup fails and
+    // let a scrub retry / the fire-time path.
+    const cleanupResult = await wakeUp.cancelForCascade(auth);
+    if (cleanupResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          agentConfigurationId,
+          wakeUpId: wakeUp.sId,
+          error: cleanupResult.error,
+        },
+        `Failed cleaning up wake-up ${wakeUp.sId} Temporal state while hard-deleting agent ${agentConfigurationId}; leaving row for retry`
+      );
+      continue;
+    }
+
+    const deleteResult = await wakeUp.delete(auth);
+    if (deleteResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          agentConfigurationId,
+          wakeUpId: wakeUp.sId,
+          error: deleteResult.error,
+        },
+        `Failed to delete wake-up ${wakeUp.sId} while hard-deleting agent ${agentConfigurationId}`
+      );
+    }
+  }
+
+  await AgentUserRelationModel.destroy({
+    where: {
+      agentConfiguration: agentConfigurationId,
+      workspaceId: workspace.id,
+    },
+  });
+}
+
 // Should only be called when we need to clean up the agent configuration
 // right after creating it due to an error.
 export async function unsafeHardDeleteAgentConfiguration(
@@ -1654,6 +1764,18 @@ export async function batchHardDeletePendingAgentConfigurations(
     // Delete agent suggestions before agents (FK constraint)
     await AgentSuggestionModel.destroy({
       where: { agentConfigurationId: agentIds, workspaceId },
+      transaction: t,
+    });
+
+    // Favorite / agent-user-relation rows are keyed by the agent sId with no
+    // foreign key, so they do not cascade on delete. Pending agents cannot own
+    // triggers or wake-ups (those require an active agent), so a bulk delete of
+    // the relation rows is enough here.
+    await AgentUserRelationModel.destroy({
+      where: {
+        agentConfiguration: agents.map((a) => a.sId),
+        workspaceId,
+      },
       transaction: t,
     });
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -40,6 +40,7 @@ import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
+import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -1632,12 +1633,7 @@ export async function cleanupAgentScopedResourcesForHardDeletion(
     }
   }
 
-  await AgentUserRelationModel.destroy({
-    where: {
-      agentConfiguration: agentConfigurationId,
-      workspaceId: workspace.id,
-    },
-  });
+  await AgentUserRelationResource.deleteForAgent(auth, agentConfigurationId);
 }
 
 // Should only be called when we need to clean up the agent configuration

--- a/front/lib/resources/agent_user_relation_resource.ts
+++ b/front/lib/resources/agent_user_relation_resource.ts
@@ -1,0 +1,61 @@
+import type { Authenticator } from "@app/lib/auth";
+import { AgentUserRelationModel } from "@app/lib/models/agent/agent";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { Attributes, Transaction } from "sequelize";
+
+// Wraps the agent_user_relations table (per-user favorite flag for an agent).
+// The rows reference the agent by sId with no foreign key, so they do not
+// cascade on agent deletion and must be cleaned up explicitly.
+export class AgentUserRelationResource extends BaseResource<AgentUserRelationModel> {
+  static model: ModelStaticWorkspaceAware<AgentUserRelationModel> =
+    AgentUserRelationModel;
+
+  constructor(
+    model: ModelStaticWorkspaceAware<AgentUserRelationModel>,
+    blob: Attributes<AgentUserRelationModel>
+  ) {
+    super(AgentUserRelationModel, blob);
+  }
+
+  static async deleteForAgent(
+    auth: Authenticator,
+    agentId: string
+  ): Promise<void> {
+    await this.model.destroy({
+      where: {
+        agentConfiguration: agentId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+  }
+
+  static async countForAgent(
+    auth: Authenticator,
+    agentId: string
+  ): Promise<number> {
+    return this.model.count({
+      where: {
+        agentConfiguration: agentId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+}

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -338,6 +338,23 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     });
   }
 
+  static async listByAgentConfigurationId(
+    auth: Authenticator,
+    agentConfigurationId: string,
+    { status }: { status?: WakeUpStatus | WakeUpStatus[] } = {}
+  ): Promise<WakeUpResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        agentConfigurationId,
+        ...(status !== undefined ? { status } : {}),
+      },
+      order: [
+        ["createdAt", "ASC"],
+        ["id", "ASC"],
+      ],
+    });
+  }
+
   /**
    * Checks whether the caller can post or edit user messages in a conversation that has active
    * wake-ups. Rejects when any active (scheduled) wake-up is owned by a user other than the current
@@ -486,8 +503,32 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       );
     }
 
+    return this.cancelForCascade(auth, { transaction });
+  }
+
+  /**
+   * Ensures a wake-up leaves no live Temporal footprint as part of a
+   * system-initiated cascade (agent archive / hard-delete), without the
+   * owner/admin permission check, since the agent it targets is going away.
+   *
+   * - If still scheduled: cancels it (deletes the cron schedule / cancels the
+   *   pending one-shot workflow) and marks the row cancelled.
+   * - If already terminal: reconciles a cron schedule that may have been left
+   *   orphaned by a prior failed cleanup (no-op for one-shots / non-cron).
+   *
+   * Must not be called from within the wake-up's own running workflow (for
+   * one-shot wake-ups this would cancel the current execution): the fire-time
+   * path uses markCancelled + cleanupTemporalScheduleIfCronTerminal instead.
+   */
+  async cancelForCascade(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<void, Error>> {
     if (this.status !== "scheduled") {
-      return new Ok(undefined);
+      // Already terminal: no row change is needed, but a cron schedule may still
+      // be orphaned from a prior failed cleanup: we reconcile it. No-op for
+      // one-shots and non-cron wake-ups.
+      return this.cleanupTemporalScheduleIfCronTerminal(auth);
     }
 
     const temporalResult = await this.cancelTemporalWorkflow(auth);

--- a/front/scripts/scrub_agent.ts
+++ b/front/scripts/scrub_agent.ts
@@ -1,8 +1,12 @@
 import {
+  cleanupAgentScopedResourcesForHardDeletion,
   listsAgentConfigurationVersions,
   unsafeHardDeleteAgentConfiguration,
 } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
+import { AgentUserRelationModel } from "@app/lib/models/agent/agent";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { makeScript } from "@app/scripts/helpers";
 
 makeScript(
@@ -63,6 +67,60 @@ makeScript(
         versionCount: versions.length,
       },
       "Hard-deleting all versions of the agent."
+    );
+
+    // Clean up the agent-scoped resources keyed by the sId (triggers, wake-ups
+    // and their Temporal schedules, favorites) once before deleting the version
+    // rows: they are shared across all versions, not per-version. This is
+    // best-effort: it intentionally keeps rows whose Temporal cleanup failed so
+    // they can be retried.
+    await cleanupAgentScopedResourcesForHardDeletion(auth, agentId);
+
+    // Verify the cleanup actually removed everything before deleting the version
+    // rows. Deleting the versions is irreversible and removes the only handle to
+    // re-run this script, so if any scoped row survived (its Temporal cleanup
+    // failed and it was kept for retry) we abort and leave the agent intact so a
+    // rerun can finish the job once the underlying issue is resolved.
+    const [remainingTriggers, remainingWakeUps, remainingFavorites] =
+      await Promise.all([
+        TriggerResource.listByAgentConfigurationId(auth, agentId),
+        WakeUpResource.listByAgentConfigurationId(auth, agentId),
+        AgentUserRelationModel.findAll({
+          where: {
+            agentConfiguration: agentId,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+        }),
+      ]);
+
+    if (
+      remainingTriggers.length > 0 ||
+      remainingWakeUps.length > 0 ||
+      remainingFavorites.length > 0
+    ) {
+      logger.error(
+        {
+          workspaceId,
+          agentId,
+          remainingTriggerIds: remainingTriggers.map((t) => t.sId),
+          remainingWakeUps: remainingWakeUps.map((w) => ({
+            sId: w.sId,
+            status: w.status,
+            scheduleType: w.scheduleType,
+          })),
+          remainingFavoriteCount: remainingFavorites.length,
+        },
+        "Agent scoped cleanup incomplete; aborting hard-delete of agent versions. " +
+          "Resolve the underlying Temporal failure and rerun."
+      );
+      throw new Error(
+        `Agent scoped cleanup incomplete for ${agentId}; aborted before deleting versions.`
+      );
+    }
+
+    logger.info(
+      { workspaceId, agentId },
+      "Agent triggers, wake-ups and favorites fully cleaned up."
     );
 
     for (const version of versions) {

--- a/front/scripts/scrub_agent.ts
+++ b/front/scripts/scrub_agent.ts
@@ -4,7 +4,7 @@ import {
   unsafeHardDeleteAgentConfiguration,
 } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
-import { AgentUserRelationModel } from "@app/lib/models/agent/agent";
+import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { makeScript } from "@app/scripts/helpers";
@@ -81,22 +81,21 @@ makeScript(
     // re-run this script, so if any scoped row survived (its Temporal cleanup
     // failed and it was kept for retry) we abort and leave the agent intact so a
     // rerun can finish the job once the underlying issue is resolved.
-    const [remainingTriggers, remainingWakeUps, remainingFavorites] =
-      await Promise.all([
-        TriggerResource.listByAgentConfigurationId(auth, agentId),
-        WakeUpResource.listByAgentConfigurationId(auth, agentId),
-        AgentUserRelationModel.findAll({
-          where: {
-            agentConfiguration: agentId,
-            workspaceId: auth.getNonNullableWorkspace().id,
-          },
-        }),
-      ]);
+    const remainingTriggers = await TriggerResource.listByAgentConfigurationId(
+      auth,
+      agentId
+    );
+    const remainingWakeUps = await WakeUpResource.listByAgentConfigurationId(
+      auth,
+      agentId
+    );
+    const remainingFavoriteCount =
+      await AgentUserRelationResource.countForAgent(auth, agentId);
 
     if (
       remainingTriggers.length > 0 ||
       remainingWakeUps.length > 0 ||
-      remainingFavorites.length > 0
+      remainingFavoriteCount > 0
     ) {
       logger.error(
         {
@@ -108,7 +107,7 @@ makeScript(
             status: w.status,
             scheduleType: w.scheduleType,
           })),
-          remainingFavoriteCount: remainingFavorites.length,
+          remainingFavoriteCount,
         },
         "Agent scoped cleanup incomplete; aborting hard-delete of agent versions. " +
           "Resolve the underlying Temporal failure and rerun."


### PR DESCRIPTION
## Description

Triggers, wake-ups and favorite (agent_user_relation) rows all reference their agent by sId as a plain string with no DB foreign key, so agent archive and hard-delete never cascade to them. This left orphaned Temporal schedules firing after an agent was gone, and stale favorite rows for deleted agents.

- archiveAgentConfiguration now cancels the agent's scheduled wake-ups (mirroring the existing trigger-disable loop).
- New cleanupAgentScopedResourcesForHardDeletion deletes the agent's triggers (with their Temporal schedule), cancels and deletes its wake-ups (with their schedule / pending workflow) and deletes its favorite rows. Wired into scrub_agent.ts. It must only run on terminal whole-agent deletion, never from the failed-upgrade rollback path (which keeps the agent alive under the same sId), so it is intentionally not called from unsafeHardDeleteAgentConfiguration.
- batchHardDeletePendingAgentConfigurations bulk-deletes favorite rows for the purged pending agents.

Adds WakeUpResource.cancelForCascade (permission-checkless system cancel) and WakeUpResource.listByAgentConfigurationId.

Refs dust-tt/tasks#8477

## Tests

Unit + local

## Risk

Low: it could introduce bugs on the agent archive/delete flow. Tested locally but probably not on the whole surface.

## Deploy Plan

Front
