### PR TITLE
[SPACES] Handle group name unique constraint race in createSpaceAndGroup

### DIFF
--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -39,7 +39,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
 import uniq from "lodash/uniq";
-import { Op } from "sequelize";
+import { Op, UniqueConstraintError } from "sequelize";
 
 export async function softDeleteSpaceAndLaunchScrubWorkflow(
   auth: Authenticator,
@@ -522,14 +522,27 @@ export async function createSpaceAndGroup(
       );
     }
 
-    const membersGroup = await GroupResource.makeNew(
-      {
-        name: `${spaceKind === "project" ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${name}`,
-        workspaceId: owner.id,
-        kind: "regular",
-      },
-      { transaction: t }
-    );
+    let membersGroup: GroupResource;
+    try {
+      membersGroup = await GroupResource.makeNew(
+        {
+          name: `${spaceKind === "project" ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${name}`,
+          workspaceId: owner.id,
+          kind: "regular",
+        },
+        { transaction: t }
+      );
+    } catch (err) {
+      if (err instanceof UniqueConstraintError) {
+        return new Err(
+          new DustError(
+            "space_already_exists",
+            "This pod name is already used."
+          )
+        );
+      }
+      throw err;
+    }
 
     let globalGroup: GroupResource | null = null;
     if (!isRestricted) {


### PR DESCRIPTION
## Description

Catch `UniqueConstraintError` when creating the members group in `createSpaceAndGroup` and return a `space_already_exists` `DustError` instead of a 500, fixing a race when two space creations collide on the same group name.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`