### PR TITLE
Rework default model selection for agent builder.

### DIFF
--- a/front-api/routes/w/[wId]/models.ts
+++ b/front-api/routes/w/[wId]/models.ts
@@ -1,5 +1,4 @@
-import { withModelSelectability } from "@app/lib/advanced_models/enabled_models";
-import { getAvailableModelsForWorkspace } from "@app/lib/api/assistant/workspace_capabilities";
+import { getModelsForAuth } from "@app/lib/advanced_models/enabled_models";
 import type { GetEnabledModelsResponseType } from "@app/types/api/assistant/models";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -11,13 +10,7 @@ const app = workspaceApp();
 app.get("/", async (ctx): HandlerResult<GetEnabledModelsResponseType> => {
   const auth = ctx.get("auth");
 
-  const availableModels = await getAvailableModelsForWorkspace(auth);
-
-  const models = await withModelSelectability(auth, {
-    models: availableModels,
-  });
-
-  return ctx.json({ models });
+  return ctx.json(await getModelsForAuth(auth));
 });
 
 export default app;

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -25,7 +25,6 @@ import { useSidekickMCPServer } from "@app/components/agent_builder/sidekick/use
 import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgentBuilderForm";
 import {
   getDefaultAgentFormData,
-  getDefaultModel,
   transformAgentConfigurationToFormData,
   transformDuplicateAgentToFormData,
   transformTemplateToFormData,
@@ -59,12 +58,20 @@ import { emptyArray, useFetcher } from "@app/lib/swr/swr";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import datadogLogger from "@app/logger/datadogLogger";
+import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { TemplateInfo } from "@app/types/assistant/templates";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import { isBuilder } from "@app/types/user";
+import {
+  ContentMessage,
+  ContentMessageAction,
+  InfoCircle,
+  RefreshCw02,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import set from "lodash/set";
 import {
@@ -110,12 +117,63 @@ interface AgentBuilderProps {
   onSaved?: () => void;
 }
 
-export default function AgentBuilder({
+export default function AgentBuilder(props: AgentBuilderProps) {
+  const { owner } = useAgentBuilderContext();
+  const { defaultModel, isModelsError } = useModels({ owner });
+
+  if (!props.agentConfiguration && !defaultModel) {
+    if (isModelsError) {
+      return (
+        <div className="flex h-full w-full items-center justify-center p-4">
+          <ContentMessage
+            title="Unable to load models"
+            variant="warning"
+            icon={InfoCircle}
+            size="lg"
+            action={
+              <ContentMessageAction
+                icon={RefreshCw02}
+                label="Retry"
+                variant="warning"
+                onClick={() => window.location.reload()}
+              />
+            }
+          >
+            We could not determine the default model for this agent. Please try
+            again.
+          </ContentMessage>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <AgentBuilderForm
+      {...props}
+      newAgentDefaultModel={
+        props.agentConfiguration ? undefined : defaultModel!
+      }
+    />
+  );
+}
+
+interface AgentBuilderFormProps extends AgentBuilderProps {
+  newAgentDefaultModel?: EnabledModelConfigurationType;
+}
+
+function AgentBuilderForm({
   agentConfiguration,
   duplicateAgentId,
   conversationId,
   onSaved,
-}: AgentBuilderProps) {
+  newAgentDefaultModel,
+}: AgentBuilderFormProps) {
   const { owner, user, isAdmin, assistantTemplate } = useAgentBuilderContext();
   const { supportedDataSourceViews } = useDataSourceViewsContext();
   const { mcpServerViews } = useMCPServerViewsContext();
@@ -180,8 +238,6 @@ export default function AgentBuilder({
     owner,
     agentConfigurationId: agentConfiguration?.sId ?? null,
   });
-
-  const { models: availableModels } = useModels({ owner });
 
   const { slackChannels: slackChannelsLinkedWithAgent } =
     useSlackChannelsLinkedWithAgent({
@@ -274,12 +330,25 @@ export default function AgentBuilder({
       return transformAgentConfigurationToFormData(agentConfiguration);
     }
 
-    if (assistantTemplate) {
-      return transformTemplateToFormData(assistantTemplate, user);
+    if (assistantTemplate && newAgentDefaultModel) {
+      return transformTemplateToFormData(
+        assistantTemplate,
+        user,
+        newAgentDefaultModel
+      );
     }
 
-    return getDefaultAgentFormData({ user });
-  }, [agentConfiguration, duplicateAgentId, assistantTemplate, user]);
+    return getDefaultAgentFormData({
+      user,
+      defaultModel: newAgentDefaultModel!,
+    });
+  }, [
+    agentConfiguration,
+    duplicateAgentId,
+    assistantTemplate,
+    user,
+    newAgentDefaultModel,
+  ]);
 
   const form = useForm<AgentBuilderFormData>({
     resolver: zodResolver(agentBuilderFormSchema),
@@ -294,7 +363,6 @@ export default function AgentBuilder({
   useEffect(() => {
     const currentValues = form.getValues();
 
-    const defaultModel = getDefaultModel(availableModels);
     const userOwnedTriggers = triggers.filter(
       (trigger) => trigger.editor === user.id
     );
@@ -317,17 +385,19 @@ export default function AgentBuilder({
             : [user],
         slackChannels: agentSlackChannels,
       },
-      // For new agents, update model settings once available models are loaded.
-      ...(!agentConfiguration && {
-        generationSettings: {
-          ...currentValues.generationSettings,
-          modelSettings: {
-            modelId: defaultModel.modelId,
-            providerId: defaultModel.providerId,
+      // Templates may preset a model; override it with the backend default.
+      ...(!agentConfiguration &&
+        assistantTemplate &&
+        newAgentDefaultModel && {
+          generationSettings: {
+            ...currentValues.generationSettings,
+            modelSettings: {
+              modelId: newAgentDefaultModel.modelId,
+              providerId: newAgentDefaultModel.providerId,
+            },
+            reasoningEffort: newAgentDefaultModel.defaultReasoningEffort,
           },
-          reasoningEffort: defaultModel.defaultReasoningEffort,
-        },
-      }),
+        }),
     });
   }, [
     triggers,
@@ -344,7 +414,8 @@ export default function AgentBuilder({
     editors,
     agentConfiguration,
     agentSlackChannels,
-    availableModels,
+    assistantTemplate,
+    newAgentDefaultModel,
   ]);
 
   const { showDialog, ...dialogProps } = useAwaitableDialog({

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -4,15 +4,6 @@ import type { FetchAgentTemplateResponse } from "@app/lib/resources/template_res
 import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/types/assistant/creativity";
-import {
-  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-  CLAUDE_SONNET_4_6_MODEL_ID,
-} from "@app/types/assistant/models/anthropic";
-import { GEMINI_3_1_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
-import { MISTRAL_MEDIUM_3_5_MODEL_ID } from "@app/types/assistant/models/mistral";
-import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
-import type { ModelIdType } from "@app/types/assistant/models/types";
-import { GROK_4_MODEL_ID } from "@app/types/assistant/models/xai";
 import type { UserType } from "@app/types/user";
 import uniqueId from "lodash/uniqueId";
 
@@ -59,52 +50,13 @@ export function transformAgentConfigurationToFormData(
   };
 }
 
-const PREFERRED_LARGE_MODEL_IDS: ModelIdType[] = [
-  CLAUDE_SONNET_4_6_MODEL_ID,
-  GPT_5_5_MODEL_ID,
-  GEMINI_3_1_PRO_MODEL_ID,
-  MISTRAL_MEDIUM_3_5_MODEL_ID,
-  GROK_4_MODEL_ID,
-];
-
-/**
- * Returns the best available model from the user's allowed models, matching
- * against a preferred order. Falls back to any large model, then any model,
- * then a hardcoded default.
- */
-export function getDefaultModel(
-  availableModels: EnabledModelConfigurationType[]
-): EnabledModelConfigurationType {
-  const selectableModels = availableModels.filter((m) => m.isSelectable);
-
-  for (const modelId of PREFERRED_LARGE_MODEL_IDS) {
-    const model = selectableModels.find((m) => m.modelId === modelId);
-    if (model) {
-      return model;
-    }
-  }
-
-  const fallbackModel =
-    selectableModels.find((m) => m.largeModel) ??
-    selectableModels.find((m) => !m.largeModel);
-
-  return (
-    fallbackModel ?? {
-      ...CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-      isSelectable: true,
-    }
-  );
-}
-
 export function getDefaultAgentFormData({
   user,
+  defaultModel,
 }: {
   user: UserType;
+  defaultModel: EnabledModelConfigurationType;
 }): AgentBuilderFormData {
-  // Static fallback — overridden by the useEffect in AgentBuilder once available
-  // models are loaded.
-  const defaultModel = CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
-
   return {
     agentSettings: {
       name: "",
@@ -142,10 +94,12 @@ export function getDefaultAgentFormData({
  */
 export function transformTemplateToFormData(
   template: FetchAgentTemplateResponse,
-  user: UserType
+  user: UserType,
+  defaultModel: EnabledModelConfigurationType
 ): AgentBuilderFormData {
   const defaultFormData = getDefaultAgentFormData({
     user,
+    defaultModel,
   });
 
   return {

--- a/front/lib/advanced_models/enabled_models.test.ts
+++ b/front/lib/advanced_models/enabled_models.test.ts
@@ -1,4 +1,7 @@
-import { withModelSelectability } from "@app/lib/advanced_models/enabled_models";
+import {
+  getDefaultModelFromEnabledModels,
+  withModelSelectability,
+} from "@app/lib/advanced_models/enabled_models";
 import { Authenticator } from "@app/lib/auth";
 import { AdvancedModelResource } from "@app/lib/resources/advanced_model_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -7,9 +10,12 @@ import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import {
   CLAUDE_OPUS_4_6_MODEL_ID,
+  CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
+import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import { describe, expect, it } from "vitest";
 
 const opusModel = SUPPORTED_MODEL_CONFIGS.find(
@@ -110,5 +116,39 @@ describe("withModelSelectability", () => {
 
     expect(getModelSelectability(result, opusModel.modelId)).toBe(true);
     expect(getModelSelectability(result, sonnetModel.modelId)).toBe(true);
+  });
+});
+
+describe("getDefaultModelFromEnabledModels", () => {
+  it("picks the first selectable model in the preferred order", () => {
+    const defaultModel = getDefaultModelFromEnabledModels([
+      { ...GPT_5_5_MODEL_CONFIG, isSelectable: true },
+      { ...CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG, isSelectable: true },
+    ]);
+
+    expect(defaultModel.modelId).toBe(
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
+    );
+    expect(defaultModel.isSelectable).toBe(true);
+  });
+
+  it("skips models that are not selectable", () => {
+    const defaultModel = getDefaultModelFromEnabledModels([
+      { ...CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG, isSelectable: false },
+      { ...GPT_5_5_MODEL_CONFIG, isSelectable: true },
+    ]);
+
+    expect(defaultModel.modelId).toBe(GPT_5_5_MODEL_CONFIG.modelId);
+  });
+
+  it("falls back to the hardcoded default when no selectable models exist", () => {
+    const defaultModel = getDefaultModelFromEnabledModels([
+      { ...CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG, isSelectable: false },
+    ]);
+
+    expect(defaultModel.modelId).toBe(
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
+    );
+    expect(defaultModel.isSelectable).toBe(true);
   });
 });

--- a/front/lib/advanced_models/enabled_models.ts
+++ b/front/lib/advanced_models/enabled_models.ts
@@ -1,4 +1,6 @@
 import { advancedModelKey } from "@app/lib/advanced_models/resolve_allowed";
+import { pickPreferredLargeModel } from "@app/lib/api/assistant/models";
+import { getAvailableModelsForWorkspace } from "@app/lib/api/assistant/workspace_capabilities";
 import { isAdvancedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -34,4 +36,32 @@ export async function withModelSelectability(
       !isAdvancedModel(model) ||
       allowedAdvancedModelKeys.has(advancedModelKey(model)),
   }));
+}
+
+export async function getEnabledModelsForAuth(
+  auth: Authenticator
+): Promise<EnabledModelConfigurationType[]> {
+  const availableModels = await getAvailableModelsForWorkspace(auth);
+  return withModelSelectability(auth, { models: availableModels });
+}
+
+export function getDefaultModelFromEnabledModels(
+  models: EnabledModelConfigurationType[]
+): EnabledModelConfigurationType {
+  const selectableModels = models.filter((m) => m.isSelectable);
+  return {
+    ...pickPreferredLargeModel(selectableModels),
+    isSelectable: true,
+  };
+}
+
+export async function getModelsForAuth(auth: Authenticator): Promise<{
+  models: EnabledModelConfigurationType[];
+  defaultModel: EnabledModelConfigurationType;
+}> {
+  const models = await getEnabledModelsForAuth(auth);
+  return {
+    models,
+    defaultModel: getDefaultModelFromEnabledModels(models),
+  };
 }

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1,4 +1,5 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import { getModelsForAuth } from "@app/lib/advanced_models/enabled_models";
 import {
   WEB_SEARCH_BROWSE_ACTION_DESCRIPTION,
   WEB_SEARCH_BROWSE_SERVER_NAME,
@@ -75,7 +76,6 @@ import {
   GLOBAL_AGENTS_SID,
   isGlobalAgentId,
 } from "@app/types/assistant/assistant";
-import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 import { validateResponseFormat } from "@app/types/assistant/models/utils";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -113,6 +113,7 @@ export async function createPendingAgentConfiguration(
   const user = auth.getNonNullableUser();
 
   const sId = generateRandomModelSId();
+  const { defaultModel } = await getModelsForAuth(auth);
 
   await withTransaction(async (t) => {
     const agent = await AgentConfigurationModel.create(
@@ -124,11 +125,10 @@ export async function createPendingAgentConfiguration(
         name: PENDING_AGENT_PLACEHOLDER_NAME,
         description: PENDING_AGENT_PLACEHOLDER_DESCRIPTION,
         instructions: null,
-        providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
-        modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+        providerId: defaultModel.providerId,
+        modelId: defaultModel.modelId,
         temperature: 0.7,
-        reasoningEffort:
-          CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+        reasoningEffort: defaultModel.defaultReasoningEffort,
         maxStepsPerRun: 8,
         reinforcement: "auto",
         pictureUrl: PENDING_AGENT_PLACEHOLDER_PICTURE_URL,

--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -1,5 +1,6 @@
 import {
   getWhitelistedProviders,
+  pickPreferredLargeModel,
   resolveModel,
   selectEnabledModel,
 } from "@app/lib/api/assistant/models";
@@ -15,6 +16,7 @@ import {
 import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type {
+  ModelConfigurationType,
   ModelIdType,
   ModelProviderIdType,
 } from "@app/types/assistant/models/types";
@@ -333,6 +335,34 @@ describe("resolveModel", () => {
 
     expect(resolvedModel.reasoningEffort).toBe(
       CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort
+    );
+  });
+});
+
+describe("pickPreferredLargeModel", () => {
+  it("picks the first model in the preferred order", () => {
+    const selected = pickPreferredLargeModel([
+      GPT_5_5_MODEL_CONFIG,
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    ]);
+
+    expect(selected.modelId).toBe(
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
+    );
+  });
+
+  it("falls back to any large model when no preferred model is available", () => {
+    const selected = pickPreferredLargeModel([GPT_5_5_MODEL_CONFIG]);
+
+    expect(selected.modelId).toBe(GPT_5_5_MODEL_CONFIG.modelId);
+  });
+
+  it("falls back to the hardcoded default when no models are available", () => {
+    const models: ModelConfigurationType[] = [];
+    const selected = pickPreferredLargeModel(models);
+
+    expect(selected.modelId).toBe(
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
     );
   });
 });

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -196,7 +196,7 @@ function _getSmallWhitelistedModel(
   );
 }
 
-const ORDERED_LARGE_MODEL_CONFIGS: ModelConfigurationType[] = [
+export const PREFERRED_LARGE_MODEL_CONFIGS: ModelConfigurationType[] = [
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   GPT_5_5_MODEL_CONFIG,
   GEMINI_3_1_PRO_MODEL_CONFIG,
@@ -204,12 +204,29 @@ const ORDERED_LARGE_MODEL_CONFIGS: ModelConfigurationType[] = [
   GROK_4_MODEL_CONFIG,
 ];
 
+export function pickPreferredLargeModel<
+  T extends Pick<ModelConfigurationType, "modelId" | "largeModel">,
+>(models: T[]): T {
+  for (const preferred of PREFERRED_LARGE_MODEL_CONFIGS) {
+    const match = models.find((m) => m.modelId === preferred.modelId);
+    if (match) {
+      return match;
+    }
+  }
+
+  return (
+    models.find((m) => m.largeModel) ??
+    models[0] ??
+    CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG
+  );
+}
+
 function _getLargeWhitelistedModel(
   context: ModelEnablementContext,
   { forBatch: hasBatch }: { forBatch?: boolean } = {}
 ): ModelConfigurationType | null {
   return (
-    ORDERED_LARGE_MODEL_CONFIGS.find(
+    PREFERRED_LARGE_MODEL_CONFIGS.find(
       (m) =>
         isModelEnabled(m, context) && (!hasBatch || m.supportsBatchProcessing)
     ) ?? null
@@ -273,13 +290,13 @@ export function resolveModel(
 
   const enabled = selectEnabledModel(
     auth,
-    removeNulls([userConfig, agentConfig, ...ORDERED_LARGE_MODEL_CONFIGS]),
+    removeNulls([userConfig, agentConfig, ...PREFERRED_LARGE_MODEL_CONFIGS]),
     {
       featureFlags,
     }
   );
 
-  // Should never happen as we should at least fallback to our selection of ORDERED_LARGE_MODEL_CONFIGS.
+  // Should never happen as we should at least fallback to our selection of PREFERRED_LARGE_MODEL_CONFIGS.
   assert(enabled, "No enabled model found");
 
   // Honor an explicit effort only if the model supports it; otherwise fall back

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -21,6 +21,7 @@ export function useModels({
 
   return {
     models: data?.models ?? emptyArray(),
+    defaultModel: data?.defaultModel ?? null,
     isModelsLoading: !error && !data && !disabled,
     isModelsError: !!error,
   };

--- a/front/types/api/assistant/models.ts
+++ b/front/types/api/assistant/models.ts
@@ -6,4 +6,5 @@ export type EnabledModelConfigurationType = ModelConfigurationType & {
 
 export type GetEnabledModelsResponseType = {
   models: EnabledModelConfigurationType[];
+  defaultModel: EnabledModelConfigurationType;
 };


### PR DESCRIPTION
## Description

Default model selection in the agent builder was split across client-side logic: `getDefaultModel()` computed the best model from a hardcoded `PREFERRED_LARGE_MODEL_IDS` list after models loaded asynchronously, causing a render race where the form could initialize with a stale `CLAUDE_SONNET_4_6` fallback before being corrected by a `useEffect`.

- `getModelsForAuth(auth)` in `enabled_models.ts` now returns both `models` and `defaultModel` together, replacing the two-step `getAvailableModelsForWorkspace` + `withModelSelectability` call in the `/models` route.
- `AgentBuilder` is split: a thin outer component waits for `defaultModel` (showing a spinner or error state), then passes it as a resolved prop to `AgentBuilderForm`.
- `getDefaultModel` and `PREFERRED_LARGE_MODEL_IDS` are removed from `transformAgentConfiguration.ts`; `getDefaultAgentFormData` and `transformTemplateToFormData` now require `defaultModel` explicitly.
- `pickPreferredLargeModel` is extracted as a reusable exported fn and used in both `getDefaultModelFromEnabledModels` and `resolveModel`.
- `createPendingAgentConfiguration` now uses `getModelsForAuth` instead of hardcoding `CLAUDE_SONNET_4_6`.

## Tests

- Added Vitest unit tests for `getDefaultModelFromEnabledModels` (preferred order, non-selectable skip, hardcoded fallback) in `enabled_models.test.ts`.
- Added Vitest unit tests for `pickPreferredLargeModel` (preferred order, large model fallback, empty list fallback) in `models.test.ts`.
- Tested locally: new agent creation picks the correct workspace-level default model without a flash of the hardcoded Sonnet fallback.

## Risk

Low. Pure front-end refactor — no DB changes, no API contract changes (the `/models` route response shape is unchanged, now just also includes `defaultModel`). The hardcoded `CLAUDE_SONNET_4_6` fallback is preserved for the edge case where no selectable models exist. Rollback is safe.

## Deploy Plan

Deploy front.
