### PR TITLE
feat(assistant): pass requested model to placeholder user message on model picker override

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -291,7 +291,7 @@ function buildFirstMessagePlaceholders(
   pending: PendingConversationMessage,
   user: UserType
 ): FirstMessagePlaceholders {
-  const { input, mentions, contentFragments } = pending;
+  const { input, mentions, contentFragments, modelSelection } = pending;
 
   // Empty conversation: ranks start at 0 (no existing messages).
   let rank =
@@ -304,6 +304,7 @@ function buildFirstMessagePlaceholders(
     branchId: null,
     rank,
     contentFragments,
+    requestedModel: modelSelection ?? null,
   });
 
   const agentMessages: VirtuosoMessage[] = [];
@@ -1178,6 +1179,7 @@ export const ConversationViewer = ({
             branchId: null, // We can't know the branch id yet, it will be set when the message is created.
             rank,
             contentFragments,
+            requestedModel: modelSelection ?? null,
           });
 
         // Skip placeholder agent messages if there's already a running agent in the conversation

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -8,6 +8,7 @@ import type {
   RichAgentMention,
   RichMention,
 } from "@app/types/assistant/mentions";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import {
@@ -23,6 +24,7 @@ export type PendingConversationMessage = {
   input: string;
   mentions: RichMention[];
   contentFragments: ContentFragmentsType;
+  modelSelection?: ModelSelectionType;
 };
 
 export type PendingInputText = {

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -2,6 +2,7 @@ import type { AgentMessageWithStreaming } from "@app/components/assistant/conver
 import type { UserMessageType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import { toMentionType } from "@app/types/assistant/mentions";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type {
   ContentFragmentsType,
   ContentFragmentType,
@@ -17,6 +18,7 @@ export function createPlaceholderUserMessage({
   rank,
   branchId,
   contentFragments,
+  requestedModel,
 }: {
   input: string;
   mentions: RichMention[];
@@ -24,6 +26,7 @@ export function createPlaceholderUserMessage({
   rank: number;
   branchId: string | null;
   contentFragments?: ContentFragmentsType;
+  requestedModel?: ModelSelectionType | null;
 }): UserMessageType & { contentFragments: ContentFragmentType[] } {
   const createdAt = new Date().getTime();
   const { email, fullName, image, username } = user;
@@ -54,7 +57,7 @@ export function createPlaceholderUserMessage({
       origin: "web",
     },
     reactions: [],
-    requestedModel: null, // TODO(models_picker): add the requested model
+    requestedModel: requestedModel ?? null,
     contentFragments: [
       ...(contentFragments?.uploaded ?? []).map(
         (cf) =>

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -135,6 +135,7 @@ export function useCreateConversationWithMessage({
             input,
             mentions: richMentions ?? [],
             contentFragments,
+            modelSelection,
           });
 
           // Post the message in the background so navigation isn't blocked on it.


### PR DESCRIPTION
## Description

Threads the model picker's selection into the optimistic placeholder user message so that,
when a user overrides the model from the input bar, the placeholder rendered before the server
round-trip already carries the requested model (instead of always `null`).

This resolves the `TODO(models_picker)` left in `createPlaceholderUserMessage`, building on top
of the `requestedXXX` columns added in #28670.

Changes:
- `createPlaceholderUserMessage` now accepts an optional `requestedModel` and sets it on the
  placeholder `UserMessageType`.
- The immediate-send path (`ConversationViewer.handleSubmit`) passes the picker's
  `modelSelection` through.
- The deferred first-message path carries `modelSelection` on `PendingConversationMessage`
  (stashed in `useCreateConversationWithMessage`, consumed in `buildFirstMessagePlaceholders`).

Frontend / display-only: the actual message send already forwards `modelSelection` to the
backend; this only aligns the optimistic UI with the picked model.

## Tests

Manual: open the input bar model picker, override the model, and send a message — both from a
new conversation (deferred send) and an existing one. The optimistic user message reflects the
selected model with no flicker back to a default.

## Risk

Low. Change is confined to the optimistic placeholder rendering on the client; no schema, API,
or backend behavior changes. Safe to roll back.

## Deploy Plan

Depends on #28670 (adds `requestedModel` to `UserMessageType` / `ModelSelectionType`). Merge
after that PR lands.
