### PR TITLE
[front] chore: drop MCP listing errors from prompts

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -171,7 +171,7 @@ app.post(
       costCredits: null,
     };
 
-    const { serverToolsAndInstructions } = await tryListMCPTools(
+    const serverToolsAndInstructions = await tryListMCPTools(
       auth,
       {
         agentConfiguration,

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -171,17 +171,16 @@ app.post(
       costCredits: null,
     };
 
-    const { serverToolsAndInstructions, error: mcpToolsListingError } =
-      await tryListMCPTools(
-        auth,
-        {
-          agentConfiguration,
-          conversation,
-          agentMessage: placeholderAgentMessage,
-          clientSideActionConfigurations: clientSideMCPActionConfigurations,
-        },
-        { jitServers, skillServers }
-      );
+    const { serverToolsAndInstructions } = await tryListMCPTools(
+      auth,
+      {
+        agentConfiguration,
+        conversation,
+        agentMessage: placeholderAgentMessage,
+        clientSideActionConfigurations: clientSideMCPActionConfigurations,
+      },
+      { jitServers, skillServers }
+    );
 
     const availableActions = serverToolsAndInstructions.flatMap((s) => s.tools);
 
@@ -207,7 +206,6 @@ app.post(
         ...model,
       },
       hasAvailableActions: availableActions.length > 0,
-      errorContext: mcpToolsListingError,
       conversation,
       serverToolsAndInstructions,
       systemSkills,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -993,7 +993,8 @@ export function deduplicateMCPServerConfigurations({
 
 /**
  * List the MCP tools for the given agent actions.
- * Returns MCP tools by connecting to the specified MCP servers.
+ * Returns tools from MCP servers that listed successfully. Listing failures are
+ * logged and omitted from the returned tools.
  */
 export async function tryListMCPTools(
   auth: Authenticator,
@@ -1005,10 +1006,7 @@ export async function tryListMCPTools(
     jitServers: MCPServerConfigurationType[];
     skillServers: MCPServerConfigurationType[];
   }
-): Promise<{
-  serverToolsAndInstructions: ServerToolsAndInstructions[];
-  error?: string;
-}> {
+): Promise<ServerToolsAndInstructions[]> {
   const owner = auth.getNonNullableWorkspace();
 
   const deduplicatedConfigs = deduplicateMCPServerConfigurations({
@@ -1046,9 +1044,21 @@ export async function tryListMCPTools(
           action.mcpServerViewId
         );
         if (!mcpServerView) {
-          return new Err(
-            new Error(`MCP server view not found for ${action.name}`)
+          const error = new Error(
+            `MCP server view not found for ${action.name}`
           );
+          logger.error(
+            {
+              workspaceId: owner.sId,
+              conversationId: agentLoopListToolsContext.conversation.sId,
+              messageId: agentLoopListToolsContext.agentMessage.sId,
+              actionId: action.sId,
+              mcpServerName: action.name,
+              error,
+            },
+            `Error listing tools from MCP server: ${normalizeError(error)}`
+          );
+          return new Err(error);
         }
         connectionParams = makeServerSideMCPConnectionParams(mcpServerView);
       } else {
@@ -1083,14 +1093,7 @@ export async function tryListMCPTools(
             toolsAndInstructionsRes.error
           )}`
         );
-        return new Err(
-          new Error(
-            `An error occurred while listing the available tools for ${action.name}. ` +
-              "Tools from this server are not available for this message. " +
-              `Reason: ${normalizeError(toolsAndInstructionsRes.error).message}. ` +
-              "Inform the user of this issue."
-          )
-        );
+        return new Err(toolsAndInstructionsRes.error);
       }
 
       const { instructions, tools: rawToolsFromServer } =
@@ -1198,26 +1201,7 @@ export async function tryListMCPTools(
     { concurrency: 10 }
   );
 
-  // Aggregate results
-  const { serverToolsAndInstructions, errors } = results.reduce<{
-    serverToolsAndInstructions: ServerToolsAndInstructions[];
-    errors: string[];
-  }>(
-    (acc, result) => {
-      if (result.isOk()) {
-        acc.serverToolsAndInstructions.push(result.value);
-      } else {
-        acc.errors.push(result.error.message);
-      }
-      return acc;
-    },
-    { serverToolsAndInstructions: [], errors: [] }
-  );
-
-  return {
-    serverToolsAndInstructions,
-    error: errors.length > 0 ? errors.join("\n") : undefined,
-  };
+  return results.flatMap((result) => (result.isOk() ? [result.value] : []));
 }
 
 async function listToolsForClientSideMCPServer(

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -54,14 +54,12 @@ function constructContextSection({
   agentConfiguration,
   model,
   owner,
-  errorContext,
   disableFormattingPrompt,
 }: {
   userMessage: UserMessageType;
   agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
   model: AgentLoopExecutionData["model"];
   owner: WorkspaceType | null;
-  errorContext?: string;
   disableFormattingPrompt: boolean;
 }): string {
   const d = moment(new Date()).tz(userMessage.context.timezone);
@@ -76,13 +74,6 @@ function constructContextSection({
 
   if (model.formattingMetaPrompt && !disableFormattingPrompt) {
     context += `# RESPONSE FORMAT\n${model.formattingMetaPrompt}\n`;
-  }
-
-  if (errorContext) {
-    context +=
-      "\n\n # INSTRUCTIONS ERROR\n\nNote: There was an error while building instructions:\n" +
-      errorContext +
-      "\n";
   }
 
   return context;
@@ -390,7 +381,6 @@ export function constructPromptMultiActions(
     fallbackPrompt,
     model,
     hasAvailableActions,
-    errorContext,
     conversation,
     serverToolsAndInstructions,
     systemSkills,
@@ -407,7 +397,6 @@ export function constructPromptMultiActions(
     fallbackPrompt?: string;
     model: AgentLoopExecutionData["model"];
     hasAvailableActions: boolean;
-    errorContext?: string;
     conversation?: ConversationWithoutContentType;
     serverToolsAndInstructions?: ServerToolsAndInstructions[];
     systemSkills: SkillResource[];
@@ -439,7 +428,6 @@ export function constructPromptMultiActions(
 
   const contextSection = constructContextSection({
     agentConfiguration,
-    errorContext,
     model,
     owner,
     userMessage,

--- a/front/lib/api/assistant/skill_actions.test.ts
+++ b/front/lib/api/assistant/skill_actions.test.ts
@@ -58,7 +58,7 @@ describe("resolveSkillMCPServers", () => {
       conversation,
     });
 
-    const { error, serverToolsAndInstructions } = await tryListMCPTools(
+    const serverToolsAndInstructions = await tryListMCPTools(
       authenticator,
       {
         agentConfiguration,
@@ -71,7 +71,6 @@ describe("resolveSkillMCPServers", () => {
         skillServers,
       }
     );
-    expect(error).toBeUndefined();
 
     const serverNames = serverToolsAndInstructions.map(
       ({ serverName }) => serverName

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -146,7 +146,7 @@ makeScript(
       costCredits: null,
     };
 
-    const { serverToolsAndInstructions } = await tryListMCPTools(
+    const serverToolsAndInstructions = await tryListMCPTools(
       auth,
       {
         agentConfiguration,

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -146,17 +146,16 @@ makeScript(
       costCredits: null,
     };
 
-    const { serverToolsAndInstructions, error: mcpToolsListingError } =
-      await tryListMCPTools(
-        auth,
-        {
-          agentConfiguration,
-          conversation,
-          agentMessage: placeholderAgentMessage,
-          clientSideActionConfigurations: clientSideMCPActionConfigurations,
-        },
-        { jitServers, skillServers }
-      );
+    const { serverToolsAndInstructions } = await tryListMCPTools(
+      auth,
+      {
+        agentConfiguration,
+        conversation,
+        agentMessage: placeholderAgentMessage,
+        clientSideActionConfigurations: clientSideMCPActionConfigurations,
+      },
+      { jitServers, skillServers }
+    );
 
     const availableActions = serverToolsAndInstructions.flatMap((s) => s.tools);
 
@@ -182,7 +181,6 @@ makeScript(
         ...agentConfiguration.model,
       },
       hasAvailableActions: availableActions.length > 0,
-      errorContext: mcpToolsListingError,
       conversation,
       serverToolsAndInstructions,
       systemSkills,

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -178,7 +178,7 @@ async function listAvailableTools(
     skills: [...systemSkills, ...enabledSkills],
   });
 
-  const { serverToolsAndInstructions: mcpActions } = await tryListMCPTools(
+  const mcpActions = await tryListMCPTools(
     auth,
     {
       agentConfiguration,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -402,8 +402,7 @@ export async function runModel(
     enabledSkills,
     systemSkills,
     equippedSkills,
-    mcpActions,
-    mcpToolsListingError,
+    serverToolsAndInstructions: mcpActions,
   } = await startActiveObservation("resolve-tools", async () => {
     const attachments = await listAttachments(auth, { conversation });
     const jitServers = await getJITServers(auth, {
@@ -430,39 +429,28 @@ export async function runModel(
       skills: [...systemSkills, ...enabledSkills],
     });
 
-    const {
-      serverToolsAndInstructions: mcpActions,
-      error: mcpToolsListingError,
-    } = await startActiveObservation("list-mcp-tools", () =>
-      tryListMCPTools(
-        auth,
-        {
-          agentConfiguration,
-          conversation,
-          agentMessage,
-          clientSideActionConfigurations: clientSideMCPActionConfigurations,
-        },
-        { jitServers, skillServers }
-      )
+    const serverToolsAndInstructions = await startActiveObservation(
+      "list-mcp-tools",
+      () =>
+        tryListMCPTools(
+          auth,
+          {
+            agentConfiguration,
+            conversation,
+            agentMessage,
+            clientSideActionConfigurations: clientSideMCPActionConfigurations,
+          },
+          { jitServers, skillServers }
+        )
     );
 
     return {
       enabledSkills,
       equippedSkills,
       systemSkills,
-      mcpActions,
-      mcpToolsListingError,
+      serverToolsAndInstructions,
     };
   });
-
-  if (mcpToolsListingError) {
-    localLogger.error(
-      {
-        error: mcpToolsListingError,
-      },
-      "Error listing MCP tools."
-    );
-  }
 
   // Filter out ask_user_question when no human is available to answer: origins with no
   // interactive reply surface, or sub-agent runs (conversation depth > 0) where the

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -539,7 +539,6 @@ export async function runModel(
     fallbackPrompt,
     model,
     hasAvailableActions: availableActions.length > 0,
-    errorContext: mcpToolsListingError,
     conversation,
     serverToolsAndInstructions: filteredMcpActions,
     systemSkills,


### PR DESCRIPTION
## Description

This PR removes the model-facing `# INSTRUCTIONS ERROR` block that was injected when MCP tool listing failed.

The listing error is already logged server-side in the agent loop. Sending it to the model adds high-entropy (can change sporadically depending on network errors on the side of the MCP provider, which can be remote) backend text that hurts prompt caching, while the model cannot recover the missing tools from that error.
Prompt render and investigation paths now ignore listing errors and render only the tools that were successfully listed.
This is more of a pragmatic compromise, generally speaking it's desirable to have the error shown some way, will revisit if this proves to be an issue.

## Tests

- Covered by existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
