### PR TITLE
refactor(agents): add AgentUserRelationResource

### DIFF
--- a/front/lib/resources/agent_user_relation_resource.ts
+++ b/front/lib/resources/agent_user_relation_resource.ts
@@ -1,0 +1,58 @@
+import type { Authenticator } from "@app/lib/auth";
+import { AgentUserRelationModel } from "@app/lib/models/agent/agent";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { Attributes, Transaction } from "sequelize";
+
+export class AgentUserRelationResource extends BaseResource<AgentUserRelationModel> {
+  static model: ModelStaticWorkspaceAware<AgentUserRelationModel> =
+    AgentUserRelationModel;
+
+  constructor(
+    model: ModelStaticWorkspaceAware<AgentUserRelationModel>,
+    blob: Attributes<AgentUserRelationModel>
+  ) {
+    super(model, blob);
+  }
+
+  static async deleteForAgent(
+    auth: Authenticator,
+    agentId: string
+  ): Promise<void> {
+    await this.model.destroy({
+      where: {
+        agentConfiguration: agentId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+  }
+
+  static async countForAgent(
+    auth: Authenticator,
+    agentId: string
+  ): Promise<number> {
+    return this.model.count({
+      where: {
+        agentConfiguration: agentId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+}


### PR DESCRIPTION
## Description

Introduces a Resource wrapper over the agent_user_relations table (deleteForAgent / countForAgent) so callers stop touching the AgentUserRelationModel Sequelize model directly ([BACK3]). Consumed by the agent hard-delete cascade PR that will be submitted as a follow-up.

Broader migration of the other existing direct AgentUserRelationModel usages (favorites views, favorite states, user scrub) is intentionally out of scope.

## Tests

None

## Risk

None
## Deploy Plan

Front