### PR TITLE
[poke] improve plan type filtering

### DIFF
--- a/front-api/routes/poke/workspaces/index.test.ts
+++ b/front-api/routes/poke/workspaces/index.test.ts
@@ -1,3 +1,4 @@
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -143,6 +144,47 @@ describe("GET /api/poke/workspaces — plan type filter", () => {
       search: encodeURIComponent("Quibble Enterprise Corp Two"),
       limit: "20",
       planType: "enterprise",
+    });
+
+    expect(response.status).toBe(200);
+    const { workspaces } = await response.json();
+    expect(
+      workspaces.some((w: { sId: string }) => w.sId === workspace.sId)
+    ).toBe(false);
+  });
+
+  it("returns a workspace with no active subscription when filtering by planType=free", async () => {
+    const workspace = await createNamedWorkspace("Quibble No Sub Corp", () =>
+      WorkspaceFactory.basic()
+    );
+    await SubscriptionResource.endActiveSubscription(workspace);
+    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+
+    const response = await fetchWorkspaces({
+      search: encodeURIComponent("Quibble No Sub Corp"),
+      limit: "20",
+      planType: "free",
+    });
+
+    expect(response.status).toBe(200);
+    const { workspaces } = await response.json();
+    expect(
+      workspaces.some((w: { sId: string }) => w.sId === workspace.sId)
+    ).toBe(true);
+  });
+
+  it("excludes a workspace with no active subscription when filtering by planType=legacy_pro", async () => {
+    const workspace = await createNamedWorkspace(
+      "Quibble No Sub Corp Two",
+      () => WorkspaceFactory.basic()
+    );
+    await SubscriptionResource.endActiveSubscription(workspace);
+    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+
+    const response = await fetchWorkspaces({
+      search: encodeURIComponent("Quibble No Sub Corp Two"),
+      limit: "20",
+      planType: "legacy_pro",
     });
 
     expect(response.status).toBe(200);

--- a/front-api/routes/poke/workspaces/index.ts
+++ b/front-api/routes/poke/workspaces/index.ts
@@ -2,7 +2,6 @@ import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import type { PokePlanTypeFilter } from "@app/lib/plans/plan_codes";
 import {
-  getPokePlanTypeFilter,
   isPokePlanTypeFilter,
   POKE_PLAN_TYPE_FILTERS,
 } from "@app/lib/plans/plan_codes";
@@ -10,7 +9,10 @@ import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
 import { tryParsePhoneNumber } from "@app/lib/plans/trial/phone";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
-import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import {
+  buildPokePlanCodeWhere,
+  SubscriptionResource,
+} from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
@@ -22,7 +24,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
-import type { FindOptions, Order, WhereOptions } from "sequelize";
+import type { FindOptions, Includeable, Order, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
 import wId from "./[wId]";
@@ -122,6 +124,17 @@ app.get("/", async (ctx): HandlerResult<GetPokeWorkspacesResponseBody> => {
     }
   }
 
+  // "free" has no plan-code pattern of its own (it's "no active subscription,
+  // or one that isn't any of the other buckets"), so it's implemented as an
+  // exclude-list of the (small, non-free) workspace ids. Every other bucket
+  // is instead filtered directly in the main query below via an inner join
+  // on the matching plan code, so we only ever fetch the requested page.
+  if (planTypeFilter === "free") {
+    const nonFreeWorkspaceIds =
+      await SubscriptionResource.listActiveWorkspaceIdsWithNonFreePlanType();
+    conditions.push({ id: { [Op.notIn]: nonFreeWorkspaceIds } });
+  }
+
   if (searchTerm) {
     // Search by Stripe subscription ID (exact match).
     let isSearchByStripeSubscription = false;
@@ -200,54 +213,61 @@ app.get("/", async (ctx): HandlerResult<GetPokeWorkspacesResponseBody> => {
     }
   }
 
-  // Plan-type filtering happens in JS below (a workspace's plan type can
-  // depend on there being no active subscription at all, which SQL can't
-  // express against this over-fetched set), so we can't rely on SQL
-  // LIMIT/OFFSET to select the right page in that case: we over-fetch a
-  // wide candidate set from offset 0, filter it in JS, then slice out the
-  // requested page ourselves. Otherwise (plain pagination, no plan-type
-  // filter) we paginate directly in SQL. Either way we fetch one extra row
-  // past the requested page so we can tell whether a next page exists
-  // without a second query.
-  const needsOverFetch = planTypeFilter !== undefined;
-  const fetchLimit = needsOverFetch
-    ? Math.max(100, offset + limit + 1)
-    : limit + 1;
-  const fetchOffset = needsOverFetch ? 0 : offset;
-
   const where: FindOptions<WorkspaceModel>["where"] = conditions.length
     ? { [Op.and]: conditions }
     : {};
 
+  // For non-free buckets, filter directly via an inner join on the matching
+  // plan code so the DB does the filtering *and* the pagination in one
+  // query — we never materialize the (possibly large) matching id set in
+  // Node. "free" is instead expressed as an exclude condition above (see
+  // `conditions`), so the subscriptions include here stays a plain left
+  // join in that case, same as when there's no plan-type filter at all.
+  const subscriptionsInclude: Includeable =
+    planTypeFilter !== undefined && planTypeFilter !== "free"
+      ? {
+          model: SubscriptionModel,
+          as: "subscriptions",
+          where: { status: "active" },
+          required: true,
+          include: [
+            {
+              model: PlanModel,
+              as: "plan",
+              where: buildPokePlanCodeWhere(planTypeFilter),
+              required: true,
+            },
+          ],
+        }
+      : {
+          model: SubscriptionModel,
+          as: "subscriptions",
+          where: { status: "active" },
+          required: false,
+          include: [{ model: PlanModel, as: "plan" }],
+        };
+
+  // Fetch one extra row past the requested page so we can tell whether a
+  // next page exists without a second query.
+  //
+  // subQuery: false — Sequelize's default subquery-splitting for
+  // limit+hasMany-include generates invalid SQL once a nested `required`
+  // include is involved (a join clause ends up referencing the
+  // "subscriptions" alias without bringing it into that subquery's scope).
+  // Disabling it makes Sequelize LIMIT/OFFSET the joined row set directly,
+  // which is safe here since a workspace has at most one active
+  // subscription, so the join can't duplicate rows.
   const workspaces = await WorkspaceModel.findAll({
     where,
-    limit: fetchLimit,
-    offset: fetchOffset,
-    include: [
-      {
-        model: SubscriptionModel,
-        as: "subscriptions",
-        where: { status: "active" },
-        required: false,
-        include: [{ model: PlanModel, as: "plan" }],
-      },
-    ],
+    limit: limit + 1,
+    offset,
+    include: [subscriptionsInclude],
     order,
+    subQuery: false,
   });
 
-  let displayed = workspaces;
-  if (planTypeFilter) {
-    displayed = displayed.filter((workspace) => {
-      const planCode = workspace.subscriptions[0]
-        ? workspace.subscriptions[0].plan.code
-        : FREE_NO_PLAN_DATA.code;
-      return getPokePlanTypeFilter(planCode) === planTypeFilter;
-    });
-  }
-
-  const pageStart = needsOverFetch ? offset : 0;
-  const hasMore = displayed.length > pageStart + limit;
-  displayed = displayed.slice(pageStart, pageStart + limit);
+  const hasMore = workspaces.length > limit;
+  const displayed = workspaces.slice(0, limit);
 
   const lightWorkspaces = displayed.map((workspace) =>
     renderLightWorkspaceType({ workspace, role: "admin" })

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -116,33 +116,22 @@ export function isPokePlanTypeFilter(
   return POKE_PLAN_TYPE_FILTERS.some((filter) => filter === value);
 }
 
-// Classifies a plan code into a poke plan-type filter bucket, or null if it
-// doesn't match any of them.
-export const getPokePlanTypeFilter = (
-  planCode: string
-): PokePlanTypeFilter | null => {
-  if (planCode.startsWith("CP_ENT_")) {
-    return "enterprise";
-  }
-  if (planCode.startsWith("ENT_")) {
-    return "legacy_enterprise";
-  }
-  if (planCode.startsWith("PRO_")) {
-    return "legacy_pro";
-  }
-  if (planCode.startsWith("CP_BUSINESS_")) {
-    return "business";
-  }
-  if (isFriendsAndFamilyPlan(planCode)) {
-    return "friends_and_family";
-  }
-  if (planCode.startsWith("FREE_")) {
-    return "free";
-  }
-  if (planCode.startsWith("DUST_") || planCode.startsWith("CP_DUST_")) {
-    return "dust";
-  }
-  return null;
+export type PokeNonFreePlanTypeFilter = Exclude<PokePlanTypeFilter, "free">;
+
+// Single source of truth for how each non-free bucket maps to plan codes.
+// Consumed to build the SQL filter for the poke workspaces list endpoint:
+// `free` has no code pattern of its own there — it's derived as "doesn't
+// match any of these".
+export const POKE_PLAN_CODE_MATCHERS: Record<
+  PokeNonFreePlanTypeFilter,
+  { type: "prefix"; values: string[] } | { type: "exact"; values: string[] }
+> = {
+  enterprise: { type: "prefix", values: ["CP_ENT_"] },
+  legacy_enterprise: { type: "prefix", values: ["ENT_"] },
+  legacy_pro: { type: "prefix", values: ["PRO_"] },
+  business: { type: "prefix", values: ["CP_BUSINESS_"] },
+  friends_and_family: { type: "exact", values: ["FREE_FRIENDSAMILY"] },
+  dust: { type: "prefix", values: ["DUST_", "CP_DUST_"] },
 };
 
 export function isProPlan(plan?: PlanType) {

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -18,6 +18,7 @@ import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
+import type { PokeNonFreePlanTypeFilter } from "@app/lib/plans/plan_codes";
 import {
   FREE_TEST_PLAN_CODE,
   isEnterprisePlanPrefix,
@@ -26,6 +27,8 @@ import {
   isProPlanPrefix,
   isUpgraded,
   isWhitelistedBusinessPlan,
+  POKE_PLAN_CODE_MATCHERS,
+  POKE_PLAN_TYPE_FILTERS,
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
@@ -74,7 +77,12 @@ import { Err, Ok } from "@app/types/shared/result";
 import { sendUserOperationMessage } from "@app/types/shared/user_operation";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
 import keyBy from "lodash/keyBy";
-import type { Attributes, CreationAttributes, Transaction } from "sequelize";
+import type {
+  Attributes,
+  CreationAttributes,
+  Transaction,
+  WhereOptions,
+} from "sequelize";
 import { Op } from "sequelize";
 import type Stripe from "stripe";
 
@@ -89,6 +97,22 @@ export type GetSubscriptionStatusResponseBody = {
 
 const DEFAULT_PLAN_WHEN_NO_SUBSCRIPTION: PlanAttributes = FREE_NO_PLAN_DATA;
 const FREE_NO_PLAN_SUBSCRIPTION_ID = -1;
+
+// Builds the Sequelize where-clause matching a poke plan-type bucket's plan
+// codes (see POKE_PLAN_CODE_MATCHERS).
+export function buildPokePlanCodeWhere(
+  bucket: PokeNonFreePlanTypeFilter
+): WhereOptions<PlanModel> {
+  const matcher = POKE_PLAN_CODE_MATCHERS[bucket];
+  if (matcher.type === "exact") {
+    return { code: { [Op.in]: matcher.values } };
+  }
+  return {
+    [Op.or]: matcher.values.map((prefix) => ({
+      code: { [Op.like]: `${prefix}%` },
+    })),
+  };
+}
 
 type CachedSubscription = {
   id: number;
@@ -729,6 +753,50 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
           renderPlanFromModel({ plan: sub.plan })
         )
     );
+  }
+
+  /**
+   * Get workspace ids with an active subscription matching ANY non-free poke
+   * plan-type bucket (enterprise, legacy_enterprise, legacy_pro, business,
+   * friends_and_family, dust).
+   *
+   * Used to implement the "free" plan-type filter on the poke workspaces
+   * list as an exclude-list: a workspace counts as "free" if it has no
+   * active subscription at all, or one that isn't in one of the other
+   * buckets — there's no plan-code pattern to match "free" directly. This
+   * set is expected to stay in the low thousands (paying + legacy + F&F/dust
+   * tenants) even as the free-tier population grows into the hundreds of
+   * thousands, since it excludes free plans entirely.
+   */
+  static async listActiveWorkspaceIdsWithNonFreePlanType(): Promise<ModelId[]> {
+    const nonFreeBuckets = POKE_PLAN_TYPE_FILTERS.filter(
+      (filter): filter is PokeNonFreePlanTypeFilter => filter !== "free"
+    );
+
+    const subscriptions = await this.model.findAll({
+      where: { status: "active" },
+      attributes: ["workspaceId"],
+      // WORKSPACE_ISOLATION_BYPASS: Internal use to compute the (small,
+      // non-free) workspace id set to exclude for poke's "free" plan-type
+      // filter, across all workspaces.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+      include: [
+        {
+          model: PlanModel,
+          as: "plan",
+          attributes: [],
+          where: {
+            [Op.or]: nonFreeBuckets.map((bucket) =>
+              buildPokePlanCodeWhere(bucket)
+            ),
+          },
+          required: true,
+        },
+      ],
+    });
+
+    return subscriptions.map((s) => s.workspaceId);
   }
 
   /**


### PR DESCRIPTION
## Description

Follow-up to the poke workspaces plan-type filter. The filter previously over-fetched up to 100 workspaces per query and did the filtering/pagination in JS — which silently broke once a bucket had more candidates than that ahead of it in `createdAt DESC` order (e.g. filtering to "Enterprise" among ~500k free workspaces could come back empty or with a wrong `hasMore`).

This moves the filtering into SQL:

- Every bucket except `free` (enterprise, legacy_enterprise, legacy_pro, business, friends_and_family, dust) is now filtered via an inner join on `subscriptions.plan.code` directly in the main query, so the DB does the filtering *and* the pagination in one go — we only ever fetch the requested page, never the full matching set.
- `free` has no plan-code pattern of its own (it's "no active subscription, or one that isn't any other bucket"), so it stays an exclude-list: fetch the ids of the non-free buckets (expected to stay in the low thousands — ~500 enterprise + ~5000 pro/business + F&F/dust — even as the free tier grows into the hundreds of thousands) and `NOT IN` them.
- The bucket → plan-code mapping now lives in one place (`POKE_PLAN_CODE_MATCHERS` in `plan_codes.ts`), consumed by `SubscriptionResource.buildPokePlanCodeWhere` / `listActiveWorkspaceIdsWithNonFreePlanType` — no more duplicated prefix logic between a JS classifier and the SQL.
- Worked around a Sequelize limitation along the way: `limit` combined with a nested `required: true` include triggers Sequelize's automatic subquery-splitting for hasMany pagination, which generated invalid SQL (a join clause referencing an alias never brought into that subquery's scope). Disabled with `subQuery: false`, which is safe here since a workspace has at most one active subscription (enforced everywhere a subscription is switched), so the join can't duplicate rows.

## Tests

Extended `front-api/routes/poke/workspaces/index.test.ts`:
- Added coverage for the `free` bucket correctly including a workspace with no active subscription, and excluding that same workspace from other buckets.
- Existing plan-type filter and pagination tests (offset/hasMore, search combined with a filter) continue to pass end-to-end against the new SQL-based implementation.

Ran `npx tsgo --noEmit` on `front` and `front-api`, and the full `subscription_resource.test.ts` suite.

## Risk

Low — poke is an internal, super-user-only admin tool, and this is entirely behind the existing opt-in `planType` query param. No change to the response contract. The `subQuery: false` addition only applies when a plan-type filter is set, and relies on an invariant (≤1 active subscription per workspace) already enforced by every subscription-switching code path.

## Deploy Plan

Standard rollout — no migration, backfill, or feature flag needed.