### PR TITLE
fix(agents): cancel wake-ups when an agent is archived

### DIFF
--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -21,6 +21,7 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WakeUpFactory } from "@app/tests/utils/WakeUpFactory";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
@@ -352,32 +353,20 @@ describe("archiveAgentConfiguration and restoreAgentConfiguration", () => {
       messagesCreatedAt: [new Date()],
     });
 
-    const wakeUpResult = await WakeUpResource.makeNew(
+    const wakeUp = await WakeUpFactory.cron(
       authenticator,
-      {
-        scheduleType: "cron",
-        fireAt: null,
-        cronExpression: "0 7 * * *",
-        cronTimezone: "Europe/Paris",
-        reason: "Daily wake-up",
-      },
       conversation,
-      agent
+      agent,
+      {
+        reason: "Daily wake-up",
+      }
     );
-    if (wakeUpResult.isErr()) {
-      throw new Error(
-        `Failed to create test wake-up: ${wakeUpResult.error.message}`
-      );
-    }
 
     const archived = await archiveAgentConfiguration(authenticator, agent.sId);
     expect(archived).toBe(true);
 
     expect(cancelSpy).toHaveBeenCalled();
-    const refetched = await WakeUpResource.fetchById(
-      authenticator,
-      wakeUpResult.value.sId
-    );
+    const refetched = await WakeUpResource.fetchById(authenticator, wakeUp.sId);
     expect(refetched?.status).toBe("cancelled");
 
     launchSpy.mockRestore();
@@ -400,28 +389,19 @@ describe("archiveAgentConfiguration and restoreAgentConfiguration", () => {
       messagesCreatedAt: [new Date()],
     });
 
-    const wakeUpResult = await WakeUpResource.makeNew(
+    const wakeUp = await WakeUpFactory.cron(
       authenticator,
-      {
-        scheduleType: "cron",
-        fireAt: null,
-        cronExpression: "0 7 * * *",
-        cronTimezone: "Europe/Paris",
-        reason: "Daily wake-up",
-      },
       conversation,
-      agent
+      agent,
+      {
+        reason: "Daily wake-up",
+      }
     );
-    if (wakeUpResult.isErr()) {
-      throw new Error(
-        `Failed to create test wake-up: ${wakeUpResult.error.message}`
-      );
-    }
 
     // Drive the wake-up to a terminal state via a DB-only cancel (markCancelled
     // does not touch Temporal), simulating a cron schedule that leaked when the
     // wake-up became terminal.
-    await wakeUpResult.value.markCancelled(authenticator);
+    await wakeUp.markCancelled(authenticator);
 
     // Only count the Temporal calls made by archiving.
     cancelSpy.mockClear();

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -13,12 +13,16 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { describe, expect, it } from "vitest";
+import { Ok } from "@app/types/shared/result";
+import { describe, expect, it, vi } from "vitest";
 
 describe("createAgentConfiguration with pending agent", () => {
   it("converts pending agent to active when agentConfigurationId points to a pending agent", async () => {
@@ -330,6 +334,107 @@ describe("archiveAgentConfiguration and restoreAgentConfiguration", () => {
         "Agent configuration is not archived"
       );
     }
+  });
+
+  it("cancels scheduled wake-ups when archiving", async () => {
+    const launchSpy = vi
+      .spyOn(wakeUpClient, "launchOrScheduleWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+    const cancelSpy = vi
+      .spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const wakeUpResult = await WakeUpResource.makeNew(
+      authenticator,
+      {
+        scheduleType: "cron",
+        fireAt: null,
+        cronExpression: "0 7 * * *",
+        cronTimezone: "Europe/Paris",
+        reason: "Daily wake-up",
+      },
+      conversation,
+      agent
+    );
+    if (wakeUpResult.isErr()) {
+      throw new Error(
+        `Failed to create test wake-up: ${wakeUpResult.error.message}`
+      );
+    }
+
+    const archived = await archiveAgentConfiguration(authenticator, agent.sId);
+    expect(archived).toBe(true);
+
+    expect(cancelSpy).toHaveBeenCalled();
+    const refetched = await WakeUpResource.fetchById(
+      authenticator,
+      wakeUpResult.value.sId
+    );
+    expect(refetched?.status).toBe("cancelled");
+
+    launchSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
+
+  it("reconciles the leaked schedule of a terminal cron wake-up when archiving", async () => {
+    const launchSpy = vi
+      .spyOn(wakeUpClient, "launchOrScheduleWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+    const cancelSpy = vi
+      .spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const wakeUpResult = await WakeUpResource.makeNew(
+      authenticator,
+      {
+        scheduleType: "cron",
+        fireAt: null,
+        cronExpression: "0 7 * * *",
+        cronTimezone: "Europe/Paris",
+        reason: "Daily wake-up",
+      },
+      conversation,
+      agent
+    );
+    if (wakeUpResult.isErr()) {
+      throw new Error(
+        `Failed to create test wake-up: ${wakeUpResult.error.message}`
+      );
+    }
+
+    // Drive the wake-up to a terminal state via a DB-only cancel (markCancelled
+    // does not touch Temporal), simulating a cron schedule that leaked when the
+    // wake-up became terminal.
+    await wakeUpResult.value.markCancelled(authenticator);
+
+    // Only count the Temporal calls made by archiving.
+    cancelSpy.mockClear();
+
+    const archived = await archiveAgentConfiguration(authenticator, agent.sId);
+    expect(archived).toBe(true);
+
+    // Archive must reconcile the leaked schedule even though the row is already
+    // terminal (it used to skip non-scheduled wake-ups entirely).
+    expect(cancelSpy).toHaveBeenCalled();
+
+    launchSpy.mockRestore();
+    cancelSpy.mockRestore();
   });
 });
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1329,7 +1329,7 @@ async function cancelWakeUpsForAgent(
   await concurrentExecutor(
     wakeUps,
     async (wakeUp) => {
-      const cancelResult = await wakeUp.cancelForCascade(auth);
+      const cancelResult = await wakeUp.forceCancel(auth);
       if (cancelResult.isErr()) {
         logger.error(
           {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -55,6 +55,8 @@ import { TagResource } from "@app/lib/resources/tags_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import { tracer } from "@app/logger/tracer";
@@ -1311,6 +1313,39 @@ export async function createGenericAgentConfiguration(
   return new Ok({ agentConfiguration, subAgentConfiguration });
 }
 
+// Cancels every still-scheduled wake-up targeting the given agent, deleting the
+// backing Temporal schedule (cron) or pending workflow (one-shot). Errors are
+// logged but do not abort the caller.
+async function cancelWakeUpsForAgent(
+  auth: Authenticator,
+  agentConfigurationId: string
+): Promise<void> {
+  const workspace = auth.getNonNullableWorkspace();
+  const wakeUps = await WakeUpResource.listByAgentConfigurationId(
+    auth,
+    agentConfigurationId
+  );
+
+  await concurrentExecutor(
+    wakeUps,
+    async (wakeUp) => {
+      const cancelResult = await wakeUp.cancelForCascade(auth);
+      if (cancelResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            agentConfigurationId,
+            wakeUpId: wakeUp.sId,
+            error: cancelResult.error,
+          },
+          `Failed to cancel wake-up ${wakeUp.sId} for agent ${agentConfigurationId}`
+        );
+      }
+    },
+    { concurrency: 5 }
+  );
+}
+
 export async function archiveAgentConfiguration(
   auth: Authenticator,
   agentConfigurationId: string
@@ -1348,6 +1383,8 @@ export async function archiveAgentConfiguration(
       );
     }
   }
+
+  await cancelWakeUpsForAgent(auth, agentConfigurationId);
 
   const updated = await AgentConfigurationModel.update(
     { status: "archived" },

--- a/front/lib/resources/storage/models/wakeup.ts
+++ b/front/lib/resources/storage/models/wakeup.ts
@@ -114,6 +114,11 @@ WakeUpModel.init(
         name: "wake_ups_workspace_id_status_idx",
         concurrently: true,
       },
+      {
+        fields: ["workspaceId", "agentConfigurationId"],
+        name: "wake_ups_workspace_id_agent_configuration_id_idx",
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -503,20 +503,21 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       );
     }
 
-    return this.cancelForCascade(auth, { transaction });
+    return this.forceCancel(auth, { transaction });
   }
 
   /**
-   * Ensures a wake-up leaves no live Temporal footprint as part of a
-   * system-initiated cascade (agent archive / hard-delete), without the
-   * owner/admin permission check, since the agent it targets is going away.
+   * System-initiated counterpart of cancel(): guarantees the wake-up leaves no
+   * live Temporal footprint, WITHOUT the owner/admin permission check that
+   * cancel() runs. Used when the agent a wake-up targets is going away (archive
+   * / hard-delete), so ownership no longer matters.
    *
    * - If still scheduled: cancels it (deletes the cron schedule / cancels the
    *   pending one-shot workflow) and marks the row cancelled.
    * - If already terminal: reconciles a cron schedule that may have been left
    *   orphaned by a prior failed cleanup (no-op for one-shots / non-cron).
    */
-  async cancelForCascade(
+  async forceCancel(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<void, Error>> {

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -338,6 +338,23 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     });
   }
 
+  static async listByAgentConfigurationId(
+    auth: Authenticator,
+    agentConfigurationId: string,
+    { status }: { status?: WakeUpStatus | WakeUpStatus[] } = {}
+  ): Promise<WakeUpResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        agentConfigurationId,
+        ...(status !== undefined ? { status } : {}),
+      },
+      order: [
+        ["createdAt", "ASC"],
+        ["id", "ASC"],
+      ],
+    });
+  }
+
   /**
    * Checks whether the caller can post or edit user messages in a conversation that has active
    * wake-ups. Rejects when any active (scheduled) wake-up is owned by a user other than the current
@@ -486,8 +503,28 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       );
     }
 
+    return this.cancelForCascade(auth, { transaction });
+  }
+
+  /**
+   * Ensures a wake-up leaves no live Temporal footprint as part of a
+   * system-initiated cascade (agent archive / hard-delete), without the
+   * owner/admin permission check, since the agent it targets is going away.
+   *
+   * - If still scheduled: cancels it (deletes the cron schedule / cancels the
+   *   pending one-shot workflow) and marks the row cancelled.
+   * - If already terminal: reconciles a cron schedule that may have been left
+   *   orphaned by a prior failed cleanup (no-op for one-shots / non-cron).
+   */
+  async cancelForCascade(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<void, Error>> {
     if (this.status !== "scheduled") {
-      return new Ok(undefined);
+      // Already terminal: no row change is needed, but a cron schedule may still
+      // be orphaned from a prior failed cleanup: we reconcile it. No-op for
+      // one-shots and non-cron wake-ups.
+      return this.cleanupTemporalScheduleIfCronTerminal(auth);
     }
 
     const temporalResult = await this.cancelTemporalWorkflow(auth);

--- a/front/migrations/pre-deploy/20260708120858_index_wake_ups_on_agent_configuration_id.sql
+++ b/front/migrations/pre-deploy/20260708120858_index_wake_ups_on_agent_configuration_id.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "wake_ups_workspace_id_agent_configuration_id_idx" ON public.wake_ups USING btree ("workspaceId", "agentConfigurationId");

--- a/front/tests/utils/WakeUpFactory.ts
+++ b/front/tests/utils/WakeUpFactory.ts
@@ -1,0 +1,40 @@
+import type { Authenticator } from "@app/lib/auth";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import { faker } from "@faker-js/faker";
+
+type WakeUpConversation = Parameters<typeof WakeUpResource.makeNew>[2];
+type WakeUpAgentConfiguration = Parameters<typeof WakeUpResource.makeNew>[3];
+
+interface CronWakeUpOptions {
+  cronExpression?: string;
+  cronTimezone?: string;
+  reason?: string;
+}
+
+export class WakeUpFactory {
+  static async cron(
+    auth: Authenticator,
+    conversation: WakeUpConversation,
+    agentConfiguration: WakeUpAgentConfiguration,
+    options: CronWakeUpOptions = {}
+  ): Promise<WakeUpResource> {
+    const result = await WakeUpResource.makeNew(
+      auth,
+      {
+        scheduleType: "cron",
+        fireAt: null,
+        cronExpression: options.cronExpression ?? "0 7 * * *",
+        cronTimezone: options.cronTimezone ?? "Europe/Paris",
+        reason: options.reason ?? `wakeup-${faker.string.alphanumeric(8)}`,
+      },
+      conversation,
+      agentConfiguration
+    );
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    return result.value;
+  }
+}


### PR DESCRIPTION
## Description

archiveAgentConfiguration disabled the agent's triggers but never cancelled its wake-ups, so a cron wake-up kept firing after the agent was archived. It now cancels every wake-up for the agent (deleting the cron schedule / pending one-shot workflow, and reconciling a leaked schedule for already-terminal cron wake-ups), with bounded concurrency.

Adds:
- WakeUpResource.cancelForCascade (permission-checkless system cancel that also reconciles terminal-cron leaked schedules) and listByAgentConfigurationId.
- A (workspaceId, agentConfigurationId) index on wake_ups
## Tests

Unit

## Risk

Low
## Deploy Plan

pre-deploy mig + Front