### PR TITLE
fix(front): resolve Jira issue type by project-scoped id when creating issues

### DIFF
--- a/front/lib/api/actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/api/actions/servers/jira/jira_api_helper.ts
@@ -822,6 +822,32 @@ async function processFieldsWithMetadata(
   return processFieldsForJira(fields, fieldsMetadata);
 }
 
+// Jira resolves `issuetype.name` instance-wide, which is ambiguous when projects share a
+// localized name (e.g. sub-tasks named "Sous-tâche") and gets rejected. Resolve to the
+// project-scoped id instead.
+async function resolveIssueType(
+  baseUrl: string,
+  accessToken: string,
+  projectKey: string,
+  issuetype: { id?: string; name?: string }
+): Promise<{ id: string } | { name: string } | undefined> {
+  if (issuetype.id) {
+    return { id: issuetype.id };
+  }
+  if (!issuetype.name) {
+    return undefined;
+  }
+  const typesResult = await getIssueTypes(baseUrl, accessToken, projectKey);
+  if (typesResult.isOk()) {
+    const match = typesResult.value.find((t) => t.name === issuetype.name);
+    if (match) {
+      return { id: match.id };
+    }
+  }
+  // Fall back to the name so behavior is no worse than before if resolution fails.
+  return { name: issuetype.name };
+}
+
 export async function createIssue(
   baseUrl: string,
   resourceInfo: ResourceInfo,
@@ -834,6 +860,13 @@ export async function createIssue(
     issueData
   );
 
+  const issuetype = await resolveIssueType(
+    baseUrl,
+    accessToken,
+    issueData.project.key,
+    issueData.issuetype
+  );
+
   const result = await jiraApiCall(
     {
       endpoint: "/rest/api/3/issue",
@@ -842,7 +875,7 @@ export async function createIssue(
     JiraIssueSchema,
     {
       method: "POST",
-      body: { fields: processedFields },
+      body: { fields: { ...processedFields, issuetype } },
       baseUrl,
     }
   );

--- a/front/lib/api/actions/servers/jira/types.ts
+++ b/front/lib/api/actions/servers/jira/types.ts
@@ -558,9 +558,17 @@ export const JiraIssueFieldsSchema = z
     }),
     summary: z.string(),
     description: ADFDocumentSchema.nullable(),
-    issuetype: z.object({
-      name: z.string(),
-    }),
+    issuetype: z
+      .object({
+        id: z.string().optional(),
+        name: z.string().optional(),
+      })
+      .describe(
+        "The issue type, identified by `id` (preferred) or `name`. Use `get_issue_types` " +
+          "to list the valid types and their ids for the project. Prefer `id`: resolving a " +
+          "type by `name` is ambiguous when several projects share a localized type name " +
+          "(e.g. sub-task types), which can make Jira reject an otherwise valid type."
+      ),
     status: z.object({
       name: z.string(),
     }),


### PR DESCRIPTION
## Description

The built-in Jira `create_issue` tool rejected sub-task creation by type name (e.g. `"Sous-tâche"`) with a 400 `Le type de ticket sélectionné n'est pas valide`, even though `get_issue_types` returned that same type as valid for the project.

Root cause: Jira's `POST /rest/api/3/issue` resolves `issuetype.name` **instance-wide**, not within the target project. When several projects/schemes share a localized type name — as sub-task types do — that lookup is ambiguous and Jira rejects an otherwise valid type. The tool only accepted `issuetype: { name }` and sent it verbatim, so there was no way to disambiguate.

Changes:
- `create_issue` now resolves the type name against the **project-scoped** `get_issue_types` list (`createmeta/{projectKey}/issuetypes`) and sends the resolved `id`. If resolution fails, it falls back to the name so behavior is no worse than before.
- The `issuetype` schema now also accepts an explicit `id` (preferred), so callers can bypass name resolution entirely. Passing `id` avoids the extra lookup.

## Tests

Type-check and biome pass. Verified the resolution logic against the reported repro (projects IN / SAL, type `Sous-tâche` id `10006`): callers passing the name get the project-scoped id substituted; callers passing an id use it directly. No existing test harness for this internal MCP server, so no functional test added.

## Risk

Low. Change is scoped to `create_issue`; `update_issue` is untouched. Name-based creation adds one `get_issue_types` call per create (skipped when an id is passed). Fully backward compatible — existing callers keep passing `name`. Safe to roll back.

## Deploy Plan

Standard `front` deploy, no migration.