### PR TITLE
Publish Frames by their actual current path, not by name

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -302,9 +302,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
             "`conversation-<conversationId>/<filename>`, or `pod-<id>/<filename>` for a Frame " +
             "stored in a project's shared space. If the file was renamed, use its current " +
             "name, listing the directory first if unsure. This path's directory becomes the " +
-            "bundling root: keep every source file under it. Anything reaching outside it, " +
-            "whether `../` above the root or into a different scoped path, is not bundled and " +
-            "will not resolve at render."
+            "bundling root for relative imports."
         ),
     },
     enableAlerting: true,

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -302,7 +302,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
             "`conversation-<conversationId>/<filename>`, or `pod-<id>/<filename>` for a Frame " +
             "stored in a project's shared space. If the file was renamed, use its current " +
             "name, listing the directory first if unsure. This path's directory becomes the " +
-            "bundling root for relative imports."
+            "bundling root."
         ),
     },
     enableAlerting: true,

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -282,11 +282,12 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
       "`conversation-<conversationId>/<filename>` (mounted in the Computer at " +
       "`/files/conversation-<conversationId>/<filename>` when the Computer is available), so " +
       "edit it in place rather than copying it elsewhere, then call this to build it into the " +
-      "live Frame. It resolves the Frame's dependency tree from the given directory (inlining relative " +
-      "imports), validates TypeScript and JSX, then updates the canonical Frame so viewers and " +
-      "shares see the new version. A syntax error blocks publishing and is reported back so you " +
-      "can fix it. Tailwind warnings are returned but do not block. Pass the `file_id` of the " +
-      "Frame and `path` set to `conversation-<conversationId>`, the directory that holds the file.",
+      "live Frame. It resolves the Frame's dependency tree from the entry file's directory " +
+      "(inlining relative imports), validates TypeScript and JSX, then updates the canonical " +
+      "Frame so viewers and shares see the new version. A syntax error blocks publishing and is " +
+      "reported back so you can fix it. Tailwind warnings are returned but do not block. Pass " +
+      "the `file_id` of the Frame and `path` set to the entry file's current scoped path, e.g. " +
+      "`conversation-<conversationId>/<filename>`.",
     schema: {
       file_id: z
         .string()
@@ -297,13 +298,13 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
       path: z
         .string()
         .describe(
-          "Scoped path of the directory holding the Frame's source files, normally the " +
-            "conversation root `conversation-<conversationId>` (the directory that holds the " +
-            "file, not a subdirectory). This directory is the bundling root: the entry is the " +
-            "Frame's file name within it, and only relative imports resolving to files under " +
-            "this root are bundled. Keep every source file under this root. Anything that " +
-            "reaches outside it, whether `../` above the root or another scoped path such as " +
-            "`pod-<id>/...`, is not bundled and will not resolve at render."
+          "Scoped path of the Frame's entry source file, not just its directory, e.g. " +
+            "`conversation-<conversationId>/<filename>`, or `pod-<id>/<filename>` for a Frame " +
+            "stored in a project's shared space. If the file was renamed, use its current " +
+            "name, listing the directory first if unsure. This path's directory becomes the " +
+            "bundling root: keep every source file under it. Anything reaching outside it, " +
+            "whether `../` above the root or into a different scoped path, is not bundled and " +
+            "will not resolve at render."
         ),
     },
     enableAlerting: true,

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -25,6 +25,7 @@ import {
   revertClientExecutableFileChanges,
 } from "@app/lib/api/files/client_executable";
 import { formatValidationWarningsForLLM } from "@app/lib/api/files/content_validation";
+import { splitFrameEntryScopedPath } from "@app/lib/api/files/mount_path";
 import { exportInteractiveContentFileAsPdf } from "@app/lib/api/files/pdf_export";
 import { screenshotInteractiveContentFile } from "@app/lib/api/files/screenshot";
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
@@ -397,8 +398,15 @@ export async function createInteractiveContentTools(
         );
       }
 
-      // Resolve the Computer mount that holds the Frame's source files.
-      const fsResult = await DustFileSystem.fromScopedPath(auth, path);
+      const splitResult = splitFrameEntryScopedPath(path);
+      if (splitResult.isErr()) {
+        return new Err(
+          new MCPError(splitResult.error.message, { tracked: false })
+        );
+      }
+      const { root, entryRelPath } = splitResult.value;
+
+      const fsResult = await DustFileSystem.fromScopedPath(auth, root);
       if (fsResult.isErr()) {
         return new Err(
           new MCPError(fsResult.error.message, { tracked: false })
@@ -407,8 +415,9 @@ export async function createInteractiveContentTools(
 
       const result = await publishFrame(auth, {
         file,
-        reader: createMountFrameSourceReader(fsResult.value, path),
-        rootScopedPath: path,
+        reader: createMountFrameSourceReader(fsResult.value, root),
+        entryRelPath,
+        rootScopedPath: root,
         publishedByAgentConfigurationId: agentConfiguration?.sId,
       });
       if (result.isErr()) {

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -21,6 +21,7 @@ import {
   resolveMountFileSourcePath,
   resolveMoveSourcePath,
   resolveScopedMountFilePath,
+  splitFrameEntryScopedPath,
   validateMountFolderName,
 } from "@app/lib/api/files/mount_path";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -566,6 +567,65 @@ describe("mount_path helpers", () => {
       });
 
       expect(disambiguateFileName(file)).toBe(`.gitignore_${file.sId}`);
+    });
+  });
+
+  describe("splitFrameEntryScopedPath", () => {
+    it("splits a conversation-scoped entry path into its root and relative entry", () => {
+      const result = splitFrameEntryScopedPath(
+        "conversation-abc/Dashboard.tsx"
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toEqual({
+          root: "conversation-abc",
+          entryRelPath: "Dashboard.tsx",
+        });
+      }
+    });
+
+    it("splits an entry nested under a subdirectory", () => {
+      const result = splitFrameEntryScopedPath(
+        "conversation-abc/dashboards/Sales.tsx"
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toEqual({
+          root: "conversation-abc/dashboards",
+          entryRelPath: "Sales.tsx",
+        });
+      }
+    });
+
+    it("splits a pod-scoped entry path", () => {
+      const result = splitFrameEntryScopedPath("pod-xyz/Dashboard.tsx");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toEqual({
+          root: "pod-xyz",
+          entryRelPath: "Dashboard.tsx",
+        });
+      }
+    });
+
+    it("ignores a trailing slash", () => {
+      const result = splitFrameEntryScopedPath(
+        "conversation-abc/Dashboard.tsx/"
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.entryRelPath).toBe("Dashboard.tsx");
+      }
+    });
+
+    it("fails when the path has no directory component", () => {
+      const result = splitFrameEntryScopedPath("Dashboard.tsx");
+
+      expect(result.isErr()).toBe(true);
     });
   });
 });

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -618,6 +618,28 @@ export function disambiguateFileName(file: FileResource): string {
 }
 
 /**
+ * Split a scoped path to a Frame's entry source file into its bundling root and the entry's path
+ * relative to that root, e.g. "conversation-abc/dashboards/Sales.tsx" splits into
+ * "conversation-abc/dashboards" and "Sales.tsx". Callers pass the entry's full current path
+ * rather than a directory (see `frameEntryRelPath` on `FileUseCaseMetadata` for why).
+ */
+export function splitFrameEntryScopedPath(
+  scopedPath: string
+): Result<{ root: string; entryRelPath: string }, Error> {
+  const trimmed = scopedPath.replace(/\/+$/, "");
+  const root = path.posix.dirname(trimmed);
+  if (root === "." || root === "/") {
+    return new Err(
+      new Error(
+        `Path must include the entry file's directory, e.g. 'conversation-<id>/<filename>': got '${scopedPath}'.`
+      )
+    );
+  }
+
+  return new Ok({ root, entryRelPath: path.posix.basename(trimmed) });
+}
+
+/**
  * Validate a single folder segment name (no path separators).
  */
 export function validateMountFolderName(

--- a/front/lib/api/viz/edit_frame_text.ts
+++ b/front/lib/api/viz/edit_frame_text.ts
@@ -144,9 +144,14 @@ export async function editFrameTextAtSource(
       );
     }
 
+    // Falls back to fileName for Frames published before frameEntryRelPath existed.
+    const entryRelPath =
+      file.useCaseMetadata?.frameEntryRelPath ?? file.fileName;
+
     const publishResult = await publishFrame(auth, {
       file,
       reader: createMountFrameSourceReader(dustFs, rootScopedPath),
+      entryRelPath,
       rootScopedPath,
       publishedByAgentConfigurationId: editedByAgentConfigurationId,
     });

--- a/front/lib/api/viz/publish_frame.test.ts
+++ b/front/lib/api/viz/publish_frame.test.ts
@@ -1,6 +1,7 @@
 // esbuild (pulled in by buildFrameBundle) requires a real node environment; jsdom breaks its
 // TextEncoder invariant.
 // @vitest-environment node
+import { splitFrameEntryScopedPath } from "@app/lib/api/files/mount_path";
 import type { FrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
 import { publishFrame } from "@app/lib/api/viz/publish_frame";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -10,6 +11,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { frameContentType } from "@app/types/files";
+import assert from "assert";
 import { Readable } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -115,6 +117,7 @@ describe("publishFrame", () => {
     const result = await publishFrame(auth, {
       file,
       reader: inMemoryReader(VALID_SOURCES),
+      entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
     });
 
@@ -123,9 +126,10 @@ describe("publishFrame", () => {
       expect(result.value.warnings).toEqual([]);
     }
 
-    // The frame now renders the bundle, and the build root is recorded for republish.
+    // The frame now renders the bundle, and the build root and entry are recorded for republish.
     expect(file.getRenderableVersion()).toBe("processed");
     expect(file.useCaseMetadata?.frameBundleRootPath).toBe(ROOT);
+    expect(file.useCaseMetadata?.frameEntryRelPath).toBe("Dashboard.tsx");
 
     expect(uploadBundleSpy).toHaveBeenCalledTimes(1);
     const bundle = uploadBundleSpy.mock.calls[0][1];
@@ -158,6 +162,7 @@ describe("publishFrame", () => {
 }
 `,
       }),
+      entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
     });
 
@@ -197,6 +202,7 @@ describe("publishFrame", () => {
     const result = await publishFrame(auth, {
       file,
       reader,
+      entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
     });
 
@@ -220,6 +226,7 @@ describe("publishFrame", () => {
       file,
       // Entry is "Dashboard.tsx" but the tree only has a component.
       reader: inMemoryReader({ "Chart.tsx": VALID_SOURCES["Chart.tsx"] }),
+      entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
     });
 
@@ -248,6 +255,7 @@ describe("publishFrame", () => {
     const result = await publishFrame(auth, {
       file,
       reader: inMemoryReader({ "notes.txt": "hello" }),
+      entryRelPath: "notes.txt",
       rootScopedPath: ROOT,
     });
 
@@ -255,5 +263,82 @@ describe("publishFrame", () => {
     if (result.isErr()) {
       expect(result.error.code).toBe("not_interactive_content");
     }
+  });
+
+  it("publishes two frames sharing a fileName independently, each from its own content", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const first = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "Dashboard.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+    const second = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "Dashboard.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    // The second frame keeps the same fileName but is stored under an sId-disambiguated path,
+    // exactly what the model would see if it listed the directory before publishing.
+    const firstScopedPath = first.toScopedPath(auth);
+    const secondScopedPath = second.toScopedPath(auth);
+    expect(firstScopedPath).not.toBe(secondScopedPath);
+    assert(firstScopedPath && secondScopedPath);
+
+    const firstSplit = splitFrameEntryScopedPath(firstScopedPath);
+    const secondSplit = splitFrameEntryScopedPath(secondScopedPath);
+    assert(firstSplit.isOk() && secondSplit.isOk());
+
+    // mockImplementation, not mockReturnValue: a Readable is single-use, and this mock is read
+    // once per publish call (twice here).
+    vi.spyOn(FileResource.prototype, "getSharedReadStream").mockImplementation(
+      () => Readable.from([Buffer.from("self contained", "utf-8")])
+    );
+
+    const firstSource = `export default function Dashboard() {
+  return <div>first frame</div>;
+}
+`;
+    const secondSource = `export default function Dashboard() {
+  return <div>second frame</div>;
+}
+`;
+
+    const firstResult = await publishFrame(auth, {
+      file: first,
+      reader: inMemoryReader({ [firstSplit.value.entryRelPath]: firstSource }),
+      entryRelPath: firstSplit.value.entryRelPath,
+      rootScopedPath: firstSplit.value.root,
+    });
+    const secondResult = await publishFrame(auth, {
+      file: second,
+      reader: inMemoryReader({
+        [secondSplit.value.entryRelPath]: secondSource,
+      }),
+      entryRelPath: secondSplit.value.entryRelPath,
+      rootScopedPath: secondSplit.value.root,
+    });
+
+    expect(firstResult.isOk()).toBe(true);
+    expect(secondResult.isOk()).toBe(true);
+    expect(first.getRenderableVersion()).toBe("processed");
+    expect(second.getRenderableVersion()).toBe("processed");
+    expect(first.useCaseMetadata?.frameEntryRelPath).toBe(
+      firstSplit.value.entryRelPath
+    );
+    expect(second.useCaseMetadata?.frameEntryRelPath).toBe(
+      secondSplit.value.entryRelPath
+    );
   });
 });

--- a/front/lib/api/viz/publish_frame.ts
+++ b/front/lib/api/viz/publish_frame.ts
@@ -48,24 +48,28 @@ function shouldValidate(relPath: string): boolean {
  *    only files reachable from the entry are pulled from the mount. A validating wrapper checks
  *    each file as it loads: TS/JSX syntax errors are blocking, Tailwind warnings are not and are
  *    returned to the caller. Files in the mount that the frame does not import are never touched.
- * 2. Store the bundle as the processed (rendered) version and record the root in metadata, which
- *    flips {@link FileResource.getRenderableVersion} to "processed".
+ * 2. Store the bundle as the processed (rendered) version and record the root and entry in
+ *    metadata, which flips {@link FileResource.getRenderableVersion} to "processed".
  * 3. Refresh the canonical source from the entry so MCP retrieve and the render fallback match.
  * 4. Recompute the authorized-file allowlist against the rendered bundle.
  *
  * `reader` is injected (rather than a `DustFileSystem`) so this stays unit-testable with an
- * in-memory tree. The handler wires `createMountFrameSourceReader`.
+ * in-memory tree. The handler wires `createMountFrameSourceReader`. `entryRelPath` is resolved by
+ * the caller, not derived here from `file.fileName` (see `frameEntryRelPath` on
+ * `FileUseCaseMetadata` for why).
  */
 export async function publishFrame(
   auth: Authenticator,
   {
     file,
     reader,
+    entryRelPath,
     rootScopedPath,
     publishedByAgentConfigurationId,
   }: {
     file: FileResource;
     reader: FrameSourceReader;
+    entryRelPath: string;
     rootScopedPath: string;
     publishedByAgentConfigurationId?: string;
   }
@@ -114,7 +118,7 @@ export async function publishFrame(
       };
 
       const buildResult = await buildFrameBundle({
-        entryRelPath: file.fileName,
+        entryRelPath,
         reader: validatingReader,
       });
 
@@ -152,18 +156,19 @@ export async function publishFrame(
 
       // 2. Refresh the canonical source from the entry so MCP retrieve and the render fallback
       //    stay in sync with what was published (the entry is always read during the build).
-      const entrySource = cache.get(file.fileName);
+      const entrySource = cache.get(entryRelPath);
       if (entrySource !== undefined) {
         await file.uploadContent(auth, entrySource);
       }
 
       // 3. Store the bundle as the rendered version and mark the frame published.
       await file.uploadProcessed(auth, buildResult.value.code);
-      // frameBundleRootPath flips rendering to the bundle, and live edits later reuse it to
-      // relocate the source tree in the mount and rebuild without a model in the loop.
+      // frameBundleRootPath and frameEntryRelPath flip rendering to the bundle and let live
+      // edits rebuild later without a model in the loop.
       await file.setUseCaseMetadata(auth, {
         ...(file.useCaseMetadata ?? {}),
         frameBundleRootPath: rootScopedPath,
+        frameEntryRelPath: entryRelPath,
         ...(publishedByAgentConfigurationId
           ? {
               lastEditedByAgentConfigurationId: publishedByAgentConfigurationId,

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -57,6 +57,12 @@ export type FileUseCaseMetadata = {
   // only). Set when the frame has been published: its presence means a built bundle exists
   // (stored as the processed version) and records where to re-read sources on republish.
   frameBundleRootPath?: string;
+  // Scoped path of the Frame's entry file, relative to frameBundleRootPath, as of the last
+  // successful publish. The model names the entry's full path directly when publishing (see the
+  // publish tool), so fileName has no guaranteed relationship to it: this is the only durable
+  // record of what the entry actually is. Live edits (no model in the loop, triggered by a UI
+  // click) reuse it to know what to rebuild from, rather than guessing from fileName.
+  frameEntryRelPath?: string;
 };
 
 export function isConversationFileUseCase(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Two Frames in the same conversation could end up sharing the same file name. Publishing resolved which file to build from that name alone, so the second Frame to collide on a name could silently build from the first Frame's content instead of its own, or fail to find anything at all, with no way for the caller to tell it apart.

Rather than trusting a name that can collide or go stale after a rename, publishing now takes the entry's actual current location directly, the same thing already visible when listing the conversation's files. This removes the dependency on the file's own name entirely.

The one place that still needs to know the entry without asking again is a live edit made directly on the rendered Frame, since no model is involved there to supply it fresh. For that case, the entry is now remembered from the last successful publish and reused, rather than guessed from the file's name.

Added a test that publishes two Frames sharing a name and confirms each one builds from its own content, independently of the other.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
