### PR TITLE
[front] redirect from checkout pages is current plan is not free

### DIFF
--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -8,6 +8,7 @@ import {
   CP_PRO_SEAT_COST_YEARLY,
   getPriceAsString,
   useIsMetronomeCheckout,
+  useRedirectAwayFromCheckoutIfAlreadyPaid,
   useUserBillingCurrency,
 } from "@app/lib/client/subscription";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
@@ -100,6 +101,8 @@ export function CheckoutPage() {
   const seatType = useSeatTypeParam();
   const targetUserId = useSearchParam("targetUserId");
   const { mutateAuthContext } = useAuthContext({ workspaceId: owner.sId });
+  const shouldRedirectAwayFromCheckout =
+    useRedirectAwayFromCheckoutIfAlreadyPaid();
 
   // Determine if CP checkout is enabled.
   const isMetronomeCheckout = useIsMetronomeCheckout();
@@ -396,6 +399,10 @@ export function CheckoutPage() {
   const planDisplayName = seatType === "pro" ? "Pro seat" : "Max seat";
 
   if (!isInitialized) {
+    return null;
+  }
+
+  if (shouldRedirectAwayFromCheckout) {
     return null;
   }
 

--- a/front/components/pages/onboarding/SelectSubscriptionPage.tsx
+++ b/front/components/pages/onboarding/SelectSubscriptionPage.tsx
@@ -6,6 +6,7 @@ import {
 } from "@app/components/pages/onboarding/SubscriptionPlans";
 import { UserMenu } from "@app/components/UserMenu";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { useRedirectAwayFromCheckoutIfAlreadyPaid } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { useAppRouter } from "@app/lib/platform";
 import { useUser } from "@app/lib/swr/user";
@@ -17,6 +18,9 @@ export function SelectSubscriptionPage() {
   const { workspace, user: authUser } = useAuth();
   const router = useAppRouter();
   const { user } = useUser();
+
+  const shouldRedirectAwayFromCheckout =
+    useRedirectAwayFromCheckoutIfAlreadyPaid();
 
   const [billingPeriod, setBillingPeriod] =
     React.useState<BillingPeriod>("monthly");
@@ -37,6 +41,10 @@ export function SelectSubscriptionPage() {
       );
     }
   );
+
+  if (shouldRedirectAwayFromCheckout) {
+    return null;
+  }
 
   return (
     <>

--- a/front/components/pages/onboarding/SubscribePage.tsx
+++ b/front/components/pages/onboarding/SubscribePage.tsx
@@ -7,7 +7,10 @@ import { ProPlansTable } from "@app/components/plans/ProPlansTable";
 import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { useIsMetronomeCheckout } from "@app/lib/client/subscription";
+import {
+  useIsMetronomeCheckout,
+  useRedirectAwayFromCheckoutIfAlreadyPaid,
+} from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { isFreeTrialPhonePlan, isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
@@ -29,6 +32,8 @@ function CPSubscribePage() {
   const { user } = useUser();
   const { shouldRedirect, redirectUrl, isSubscriptionStatusLoading } =
     useSubscriptionStatus({ workspaceId: workspace.sId });
+  const shouldRedirectAwayFromCheckout =
+    useRedirectAwayFromCheckoutIfAlreadyPaid();
 
   const [billingPeriod, setBillingPeriod] =
     React.useState<BillingPeriod>("monthly");
@@ -58,6 +63,10 @@ function CPSubscribePage() {
         <Spinner />
       </div>
     );
+  }
+
+  if (shouldRedirectAwayFromCheckout) {
+    return null;
   }
 
   if (!isAdmin) {
@@ -154,6 +163,8 @@ function LegacySubscribePage() {
   // Check if we need to redirect to trial-ended page.
   const { shouldRedirect, redirectUrl, isSubscriptionStatusLoading } =
     useSubscriptionStatus({ workspaceId: workspace.sId });
+  const shouldRedirectAwayFromCheckout =
+    useRedirectAwayFromCheckoutIfAlreadyPaid();
 
   useEffect(() => {
     if (shouldRedirect && redirectUrl) {
@@ -168,6 +179,10 @@ function LegacySubscribePage() {
         <Spinner />
       </div>
     );
+  }
+
+  if (shouldRedirectAwayFromCheckout) {
+    return null;
   }
 
   // We treat user as being in free trial if they don't have any non free subs,

--- a/front/components/pages/onboarding/TrialEndedPage.tsx
+++ b/front/components/pages/onboarding/TrialEndedPage.tsx
@@ -5,6 +5,7 @@ import {
 } from "@app/components/pages/onboarding/SubscriptionPlans";
 import { DontLoseSection } from "@app/components/paywall/DontLoseSection";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { useRedirectAwayFromCheckoutIfAlreadyPaid } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { useAppRouter } from "@app/lib/platform";
 import type { BillingPeriod } from "@app/types/plan";
@@ -15,6 +16,9 @@ export function TrialEndedPage() {
   const { workspace, user: authUser } = useAuth();
   const router = useAppRouter();
   const [billingPeriod, setBillingPeriod] = useState<BillingPeriod>("monthly");
+
+  const shouldRedirectAwayFromCheckout =
+    useRedirectAwayFromCheckoutIfAlreadyPaid();
 
   const { submit: handleSubscribe } = useSubmitFunction(
     async (seatType: PaidPlanTier) => {
@@ -28,6 +32,10 @@ export function TrialEndedPage() {
       );
     }
   );
+
+  if (shouldRedirectAwayFromCheckout) {
+    return null;
+  }
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center px-4 py-8">

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -1,9 +1,13 @@
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
+import { isFreePlan } from "@app/lib/plans/plan_codes";
+import { useAppRouter } from "@app/lib/platform";
 import type { KillSwitchType } from "@app/lib/poke/types";
 import { useGeolocation } from "@app/lib/swr/geo";
 import type { SupportedCurrency } from "@app/types/currency";
+import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import { useEffect, useState } from "react";
 import { useKillSwitches } from "../swr/kill";
 
 // If mention the price of the PRO plan in a few different places in the code base,
@@ -182,3 +186,39 @@ export const getPriceAsString = ({
       return `${price}${currency}`;
   }
 };
+
+/**
+ * Guards onboarding/checkout pages (select-subscription, subscribe,
+ * trial-ended, checkout) against workspaces that already have a paid plan —
+ * reachable via stale links or back navigation after the workspace already
+ * upgraded. Admins are sent to the subscription management page, other
+ * members to the workspace home since they cannot access billing.
+ *
+ * The check is captured once at mount rather than kept reactive: on
+ * `CheckoutPage`, a successful payment flips the workspace's subscription
+ * to paid (via `mutateAuthContext`) right before showing its own success
+ * screen, and that update must not be mistaken for "already paid" and
+ * redirect the user away from the success screen the payment just unlocked.
+ *
+ * Returns true while the redirect is in flight, so callers can render `null`
+ * instead of the checkout UI for that render.
+ */
+export function useRedirectAwayFromCheckoutIfAlreadyPaid(): boolean {
+  const { workspace, isAdmin, subscription } = useAuth();
+  const router = useAppRouter();
+
+  const [wasAlreadyOnPaidPlan] = useState(
+    () => !isFreePlan(subscription.plan.code)
+  );
+
+  useEffect(() => {
+    if (wasAlreadyOnPaidPlan) {
+      const adminTarget = isSubscriptionMetronomeBilled(subscription)
+        ? `/w/${workspace.sId}/billing`
+        : `/w/${workspace.sId}/subscription`;
+      void router.replace(isAdmin ? adminTarget : `/w/${workspace.sId}`);
+    }
+  }, [wasAlreadyOnPaidPlan, isAdmin, subscription, workspace.sId, router]);
+
+  return wasAlreadyOnPaidPlan;
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9417

Prevent re-checkout on paid workspaces from onboarding pages

* select-subscription, subscribe, trial-ended, and subscription/checkout let users start or complete a new checkout even when the workspace already has a paid plan — reachable via stale links, back navigation, or a member mid-flow while the workspace upgrades elsewhere.
* Added useRedirectAwayFromCheckoutIfAlreadyPaid() in lib/client/subscription.ts: if the workspace isn't on a free plan, redirect away — admins to /subscription (or straight to /billing for credit-priced/Metronome-billed workspaces, skipping the extra client-side hop), other members to the workspace home, since /subscription and /billing are admin-only routes.
* The check is captured once at mount, not kept reactive. This matters specifically for CheckoutPage: on a successful payment it flips the workspace's subscription to paid via mutateAuthContext() right before showing its own success screen — a reactive check would immediately redirect the user away from that screen. Freezing at mount also correctly reflects the actual bug (arriving at these pages via a stale link when already paid), rather than reacting to the payment this very page just completed.
* Wired the same hook into all four pages: SelectSubscriptionPage, TrialEndedPage, both CPSubscribePage/LegacySubscribePage variants of SubscribePage, and CheckoutPage. Each renders null while the redirect is in flight.

## Tests

Tested locally on paid plans and free plans

## Risk

Medium, could impact checkout flow if logic error

## Deploy Plan

Deploy front