### PR TITLE
feat(skills): handle private repo import with GitHub connection

### DIFF
--- a/front-api/routes/w/[wId]/skills/detect/index.ts
+++ b/front-api/routes/w/[wId]/skills/detect/index.ts
@@ -75,7 +75,7 @@ app.post(
           return apiError(ctx, {
             status_code: 404,
             api_error: {
-              type: "invalid_request_error",
+              type: "skill_github_repository_not_found",
               message: error.message,
             },
           });

--- a/front-api/routes/w/[wId]/skills/github-connection/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/github-connection/index.test.ts
@@ -1,0 +1,86 @@
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { honoApp } from "@front-api/app";
+import { ENSURE_IS_ADMIN_ERROR_MESSAGE } from "@front-api/middlewares/ensure_role";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/types/oauth/oauth_api", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/types/oauth/oauth_api")>();
+  const { Ok } = await import("@app/types/shared/result");
+  return {
+    ...actual,
+    OAuthAPI: class {
+      async getConnectionMetadata() {
+        return new Ok({
+          connection: {
+            connection_id: "con_test",
+            created: 0,
+            metadata: {},
+            provider: "github",
+            status: "finalized",
+          },
+        });
+      }
+    },
+  };
+});
+
+async function setup(role: MembershipRoleType = "admin") {
+  return createPrivateApiMockRequest({ method: "POST", role });
+}
+
+function post(workspace: { sId: string }, body: unknown) {
+  return honoApp.request(`/api/w/${workspace.sId}/skills/github-connection`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/w/:wId/skills/github-connection", () => {
+  it("stores the connection in workspace metadata for an admin", async () => {
+    const { workspace, user } = await setup("admin");
+
+    const response = await post(workspace, {
+      connectionId: "test-connection-id",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+
+    await WorkspaceResource.invalidateCache(workspace.sId);
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    expect(refreshed?.metadata?.skillImportGithubConnection).toEqual({
+      connectionId: "test-connection-id",
+      connectedBy: user.sId,
+    });
+  });
+
+  it("returns 400 when connectionId is missing", async () => {
+    const { workspace } = await setup("admin");
+
+    const response = await post(workspace, {});
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    for (const role of ["builder", "user"] as const) {
+      const { workspace } = await setup(role);
+
+      const response = await post(workspace, {
+        connectionId: "test-connection-id",
+      });
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        error: {
+          type: "workspace_auth_error",
+          message: ENSURE_IS_ADMIN_ERROR_MESSAGE,
+        },
+      });
+    }
+  });
+});

--- a/front-api/routes/w/[wId]/skills/github-connection/index.ts
+++ b/front-api/routes/w/[wId]/skills/github-connection/index.ts
@@ -1,0 +1,47 @@
+import { setWorkspaceGitHubConnection } from "@app/lib/api/skills/github_connection";
+import { isString } from "@app/types/shared/utils/general";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import type { SuccessResponseBody } from "@front-api/routes/types";
+
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<SuccessResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const body = await ctx.req.json().catch(() => null);
+    const connectionId = body?.connectionId;
+
+    if (!isString(connectionId)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "connectionId is required and must be a string.",
+        },
+      });
+    }
+
+    const result = await setWorkspaceGitHubConnection(auth, { connectionId });
+
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    return ctx.json({ success: true });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -27,6 +27,7 @@ import uniq from "lodash/uniq";
 import { z } from "zod";
 import skill from "./[sId]";
 import detect from "./detect";
+import githubConnection from "./github-connection";
 import importRoute from "./import";
 import reinforcementDailySpend from "./reinforcement_daily_spend";
 import reinforcementSpend from "./reinforcement_spend";
@@ -80,6 +81,7 @@ const app = workspaceApp();
 
 // Static sub-paths must be registered before the param sub-app.
 app.route("/detect", detect);
+app.route("/github-connection", githubConnection);
 app.route("/import", importRoute);
 app.route("/reinforcement_daily_spend", reinforcementDailySpend);
 app.route("/reinforcement_spend", reinforcementSpend);

--- a/front/components/skills/import/ConnectWorkspaceGitHubMessage.tsx
+++ b/front/components/skills/import/ConnectWorkspaceGitHubMessage.tsx
@@ -1,0 +1,54 @@
+import { useConnectWorkspaceGitHub } from "@app/lib/swr/github_connection";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  CloudArrowLeftRight,
+  ContentMessage,
+  GithubLogo,
+} from "@dust-tt/sparkle";
+
+interface ConnectWorkspaceGitHubMessageProps {
+  owner: LightWorkspaceType;
+  onConnected: () => void;
+}
+
+export function ConnectWorkspaceGitHubMessage({
+  owner,
+  onConnected,
+}: ConnectWorkspaceGitHubMessageProps) {
+  const { connectGitHub, isConnectingGitHub } = useConnectWorkspaceGitHub({
+    owner,
+  });
+
+  const handleConnect = async () => {
+    const connected = await connectGitHub();
+    if (connected) {
+      onConnected();
+    }
+  };
+
+  return (
+    <ContentMessage
+      variant="primary"
+      size="lg"
+      icon={GithubLogo}
+      title="Connect GitHub to import from private repositories"
+      action={
+        <Button
+          variant="highlight"
+          size="sm"
+          icon={CloudArrowLeftRight}
+          label="Connect GitHub"
+          isLoading={isConnectingGitHub}
+          disabled={isConnectingGitHub}
+          onClick={() => {
+            void handleConnect();
+          }}
+        />
+      }
+    >
+      For private repos, connect a GitHub account that has access. All workspace
+      members will share this connection.
+    </ContentMessage>
+  );
+}

--- a/front/components/skills/import/ImportFromRepositoryTab.tsx
+++ b/front/components/skills/import/ImportFromRepositoryTab.tsx
@@ -1,3 +1,4 @@
+import { ConnectWorkspaceGitHubMessage } from "@app/components/skills/import/ConnectWorkspaceGitHubMessage";
 import { DetectedSkillsList } from "@app/components/skills/import/DetectedSkillsList";
 import type { RepositoryImportFormValues } from "@app/components/skills/import/formSchema";
 import {
@@ -6,7 +7,8 @@ import {
 } from "@app/lib/skill_detection";
 import { useDetectSkillsFromRepo } from "@app/lib/swr/skill_configurations";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Input } from "@dust-tt/sparkle";
+import { isAdmin } from "@app/types/user";
+import { ContentMessage, InfoCircle, Input } from "@dust-tt/sparkle";
 import { useEffect } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
@@ -28,8 +30,13 @@ export function ImportFromRepositoryTab({
   const { control, setValue } = useFormContext<RepositoryImportFormValues>();
   const { field: repoUrlField } = useController({ name: "repoUrl", control });
 
-  const { detectedSkills, isDetecting, detectError, triggerDetect } =
-    useDetectSkillsFromRepo({ owner });
+  const {
+    detectedSkills,
+    isDetecting,
+    detectError,
+    repositoryNotFound,
+    triggerDetect,
+  } = useDetectSkillsFromRepo({ owner });
 
   // Re-sync selected skills when detection completes or when this tab becomes active.
   // detectedSkills come from an async hook, so values don't exist at form init time.
@@ -70,12 +77,32 @@ export function ImportFromRepositoryTab({
         onBlur={repoUrlField.onBlur}
         placeholder="https://github.com/owner/repo"
         disabled={isImporting}
+        className="bg-muted-background"
       />
-      <DetectedSkillsList
-        detectedSkills={detectedSkills}
-        isDetecting={isDetecting}
-        detectError={detectError}
-      />
+      {repositoryNotFound ? (
+        isAdmin(owner) ? (
+          <ConnectWorkspaceGitHubMessage
+            owner={owner}
+            onConnected={() => triggerDetect(repoUrlField.value)}
+          />
+        ) : (
+          <ContentMessage
+            variant="warning"
+            size="lg"
+            icon={InfoCircle}
+            title="Repository not found"
+          >
+            Check the URL. For private repos, ask an admin to connect a GitHub
+            account with access.
+          </ContentMessage>
+        )
+      ) : (
+        <DetectedSkillsList
+          detectedSkills={detectedSkills}
+          isDetecting={isDetecting}
+          detectError={detectError}
+        />
+      )}
     </div>
   );
 }

--- a/front/components/skills/import/ImportSkillsDialog.tsx
+++ b/front/components/skills/import/ImportSkillsDialog.tsx
@@ -117,6 +117,7 @@ export function ImportSkillsDialog({
                   importTypeField.onChange(value);
                   selectedSkillNamesField.onChange([]);
                   setDetectedCount(0);
+                  form.setValue("repoUrl", "");
                 }
               }}
             >

--- a/front/lib/api/skills/detection/github/github_auth.ts
+++ b/front/lib/api/skills/detection/github/github_auth.ts
@@ -4,39 +4,58 @@ import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import logger from "@app/logger/logger";
+import { isString } from "@app/types/shared/utils/general";
 
-/**
- * Attempts to retrieve a GitHub access token from an existing MCP connection
- * (workspace only). Returns null if no connection is available or if the
- * GitHub server is not on the global space.
- */
+function getSkillImportGitHubConnectionId(
+  workspaceMetadata: Record<string, unknown> | null
+): string | null {
+  const connection = workspaceMetadata?.skillImportGithubConnection;
+  if (
+    typeof connection === "object" &&
+    connection !== null &&
+    "connectionId" in connection &&
+    isString(connection.connectionId)
+  ) {
+    return connection.connectionId;
+  }
+  return null;
+}
+
 export async function getWorkspaceLevelGitHubAccessToken(
   auth: Authenticator
 ): Promise<string | null> {
-  const connection = await MCPServerConnectionResource.findByInternalServerName(
-    auth,
-    {
-      serverName: "github",
-      connectionType: "workspace",
+  const owner = auth.getNonNullableWorkspace();
+
+  let connectionId = getSkillImportGitHubConnectionId(owner.metadata ?? null);
+
+  if (!connectionId) {
+    // TODO(2026-08-15): remove this MCP fallback once the workspace GitHub
+    // connection UI ships.
+    const connection =
+      await MCPServerConnectionResource.findByInternalServerName(auth, {
+        serverName: "github",
+        connectionType: "workspace",
+      });
+    if (!connection?.connectionId || !connection.internalMCPServerId) {
+      return null;
     }
-  );
 
-  if (!connection?.connectionId || !connection.internalMCPServerId) {
-    return null;
-  }
+    const globalView =
+      await MCPServerViewResource.getMCPServerViewForGlobalSpace(
+        auth,
+        connection.internalMCPServerId
+      );
+    if (!globalView) {
+      return null;
+    }
 
-  const globalView = await MCPServerViewResource.getMCPServerViewForGlobalSpace(
-    auth,
-    connection.internalMCPServerId
-  );
-  if (!globalView) {
-    return null;
+    connectionId = connection.connectionId;
   }
 
   const tokenResult = await getOAuthConnectionAccessToken({
     config: apiConfig.getOAuthAPIConfig(),
     logger,
-    connectionId: connection.connectionId,
+    connectionId,
   });
   if (tokenResult.isOk()) {
     return tokenResult.value.access_token;
@@ -44,7 +63,7 @@ export async function getWorkspaceLevelGitHubAccessToken(
 
   logger.warn(
     {
-      workspaceId: auth.getNonNullableWorkspace().sId,
+      workspaceId: owner.sId,
       error: tokenResult.error,
     },
     "Failed to get GitHub access token from existing connection."

--- a/front/lib/api/skills/github_connection.ts
+++ b/front/lib/api/skills/github_connection.ts
@@ -1,0 +1,43 @@
+import apiConfig from "@app/lib/api/config";
+import { checkConnectionOwnership } from "@app/lib/api/oauth";
+import { updateWorkspaceMetadata } from "@app/lib/api/workspace";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export async function setWorkspaceGitHubConnection(
+  auth: Authenticator,
+  { connectionId }: { connectionId: string }
+): Promise<Result<void, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const connectedBy = auth.user()?.sId;
+  if (!connectedBy) {
+    return new Err(new Error("A user is required to connect GitHub."));
+  }
+
+  const ownershipRes = await checkConnectionOwnership(auth, connectionId);
+  if (ownershipRes.isErr()) {
+    return new Err(new Error("The GitHub connection is invalid."));
+  }
+
+  const oauthAPI = new OAuthAPI(apiConfig.getOAuthAPIConfig(), logger);
+  const metadataRes = await oauthAPI.getConnectionMetadata({ connectionId });
+  if (
+    metadataRes.isErr() ||
+    metadataRes.value.connection.provider !== "github"
+  ) {
+    return new Err(new Error("The GitHub connection is invalid."));
+  }
+
+  const updateRes = await updateWorkspaceMetadata(owner, {
+    skillImportGithubConnection: { connectionId, connectedBy },
+  });
+  if (updateRes.isErr()) {
+    return new Err(new Error("Failed to save the GitHub connection."));
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -545,6 +545,10 @@ export function isWebBrowseProvider(
 
 export interface WorkspaceMetadata {
   maintenance?: "relocation" | "relocation-done";
+  skillImportGithubConnection?: {
+    connectionId: string;
+    connectedBy: string;
+  };
   killSwitched?: WorkspaceKillSwitchValue;
   allowContentCreationFileSharing?: boolean;
   allowEmailAgents?: boolean;

--- a/front/lib/swr/github_connection.ts
+++ b/front/lib/swr/github_connection.ts
@@ -1,0 +1,69 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useRegionContext } from "@app/lib/auth/RegionContext";
+import { useFetcher } from "@app/lib/swr/swr";
+import { isAPIErrorResponse } from "@app/types/error";
+import { setupOAuthConnection } from "@app/types/oauth/client/setup";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useState } from "react";
+
+export function useConnectWorkspaceGitHub({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const { fetcher } = useFetcher();
+  const { regionInfo } = useRegionContext();
+  const sendNotification = useSendNotification();
+  const [isConnectingGitHub, setIsConnectingGitHub] = useState(false);
+
+  const connectGitHub = useCallback(async (): Promise<boolean> => {
+    setIsConnectingGitHub(true);
+    try {
+      const connectionResult = await setupOAuthConnection({
+        owner,
+        provider: "github",
+        useCase: "platform_actions",
+        extraConfig: {},
+        regionInfo,
+      });
+      if (connectionResult.isErr()) {
+        sendNotification({
+          type: "error",
+          title: "Failed to connect GitHub",
+          description: connectionResult.error.message,
+        });
+        return false;
+      }
+
+      try {
+        await fetcher(`/api/w/${owner.sId}/skills/github-connection`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            connectionId: connectionResult.value.connection_id,
+          }),
+        });
+      } catch (err) {
+        sendNotification({
+          type: "error",
+          title: "Failed to connect GitHub",
+          description: isAPIErrorResponse(err)
+            ? err.error.message
+            : "Could not save the GitHub connection.",
+        });
+        return false;
+      }
+
+      sendNotification({
+        type: "success",
+        title: "GitHub connected",
+        description: "All workspace members will share this connection.",
+      });
+      return true;
+    } finally {
+      setIsConnectingGitHub(false);
+    }
+  }, [fetcher, owner, regionInfo, sendNotification]);
+
+  return { connectGitHub, isConnectingGitHub };
+}

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -440,6 +440,7 @@ export function useDetectSkillsFromRepo({
   );
   const [isDetecting, setIsDetecting] = useState(false);
   const [detectError, setDetectError] = useState<string | null>(null);
+  const [repositoryNotFound, setRepositoryNotFound] = useState(false);
   const lastDetectedUrl = useRef<string | null>(null);
 
   const triggerDetect = useDebounceWithAbort(
@@ -447,10 +448,12 @@ export function useDetectSkillsFromRepo({
       async (repoUrl: string, signal: AbortSignal) => {
         if (repoUrl === lastDetectedUrl.current) {
           setDetectError(null);
+          setRepositoryNotFound(false);
           return;
         }
         setIsDetecting(true);
         setDetectError(null);
+        setRepositoryNotFound(false);
 
         try {
           const response: DetectSkillsResponseBody = await fetcher(
@@ -469,11 +472,14 @@ export function useDetectSkillsFromRepo({
           if (signal.aborted) {
             return;
           }
-          setDetectError(
-            isAPIErrorResponse(err)
-              ? err.error.message
-              : "Failed to detect skills from this repository."
-          );
+          if (isAPIErrorResponse(err)) {
+            setDetectError(err.error.message);
+            setRepositoryNotFound(
+              err.error.type === "skill_github_repository_not_found"
+            );
+          } else {
+            setDetectError("Failed to detect skills from this repository.");
+          }
         } finally {
           if (!signal.aborted) {
             setIsDetecting(false);
@@ -485,7 +491,13 @@ export function useDetectSkillsFromRepo({
     { delayMs: DETECT_SKILLS_DEBOUNCE_MS }
   );
 
-  return { detectedSkills, isDetecting, detectError, triggerDetect };
+  return {
+    detectedSkills,
+    isDetecting,
+    detectError,
+    repositoryNotFound,
+    triggerDetect,
+  };
 }
 
 function notifyImportResult(

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -164,6 +164,7 @@ const API_ERROR_TYPES = [
   "elasticsearch_error",
   // Skills
   "skill_not_found",
+  "skill_github_repository_not_found",
   "sandbox_function_not_found",
   // Projects
   "project_metadata_not_found",


### PR DESCRIPTION
## Description

Handles importing skills from private GitHub repos. Just the NO connection part for now. When a repo can't be reached and the workspace has no GitHub connection, `skills/detect` now returns `{ skills: [], githubConnectionRequired: true }` instead of an error, and the UI branches on role:

- **Admins** get a  "Connect GitHub" card that runs the workspace OAuth flow (shared, all-members connection) and reruns detection.
- **Builders** get a "Repository not found, check the URL or ask an admin to connect GitHub" message.

Switching tabs also clears the repo URL for a clean slate.

Admin: 
<img width="564" height="394" alt="Screenshot 2026-07-08 at 17 13 53" src="https://github.com/user-attachments/assets/cd3a975e-1284-4863-9485-2fd4583ca7a8" />

Builder : 
<img width="783" height="487" alt="Screenshot 2026-07-08 at 16 19 02" src="https://github.com/user-attachments/assets/778d83e3-0a38-4bf3-876b-054cb61825f1" />


## Tests

Tested locally as both builder and admin for the UI but couldn't test the full flow due to OAuth issues 

## Risk

Low

## Deploy Plan

Deploy front and fronnt-api