### PR TITLE
fix(agents): cascade cleanup on agent hard-delete

### DIFF
--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -1,28 +1,33 @@
 import {
   archiveAgentConfiguration,
+  cleanupAgentScopedResourcesForHardDeletion,
   createAgentConfiguration,
   createPendingAgentConfiguration,
   getAgentConfiguration,
   restoreAgentConfiguration,
   updateAgentConfigurationsScope,
 } from "@app/lib/api/assistant/configuration/agent";
+import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import * as scheduleClient from "@app/temporal/triggers/schedule_client";
 import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WakeUpFactory } from "@app/tests/utils/WakeUpFactory";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
 describe("createAgentConfiguration with pending agent", () => {
@@ -412,6 +417,115 @@ describe("archiveAgentConfiguration and restoreAgentConfiguration", () => {
     // Archive must reconcile the leaked schedule even though the row is already
     // terminal (it used to skip non-scheduled wake-ups entirely).
     expect(cancelSpy).toHaveBeenCalled();
+
+    launchSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
+});
+
+describe("cleanupAgentScopedResourcesForHardDeletion", () => {
+  it("removes triggers, wake-ups and favorites for the agent", async () => {
+    const mockCreateSchedule = vi
+      .spyOn(scheduleClient, "createOrUpdateAgentSchedule")
+      .mockResolvedValue(new Ok("workflow-id"));
+    const mockDeleteSchedule = vi
+      .spyOn(scheduleClient, "deleteTriggerSchedule")
+      .mockResolvedValue(new Ok(undefined));
+    const launchSpy = vi
+      .spyOn(wakeUpClient, "launchOrScheduleWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+    const cancelSpy = vi
+      .spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+
+    const { authenticator } = await createResourceTest({
+      role: "admin",
+    });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    await TriggerFactory.schedule(authenticator, {
+      agentConfigurationId: agent.sId,
+      status: "enabled",
+      configuration: {
+        cron: "0 9 * * 1",
+        timezone: "UTC",
+      },
+    });
+
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    await WakeUpFactory.cron(authenticator, conversation, agent, {
+      reason: "Daily wake-up",
+    });
+
+    const favoriteResult = await setAgentUserFavorite({
+      auth: authenticator,
+      agentId: agent.sId,
+      userFavorite: true,
+    });
+    expect(favoriteResult.isOk()).toBe(true);
+
+    await cleanupAgentScopedResourcesForHardDeletion(authenticator, agent.sId);
+
+    const remainingTriggers = await TriggerResource.listByAgentConfigurationId(
+      authenticator,
+      agent.sId
+    );
+    expect(remainingTriggers).toHaveLength(0);
+
+    const remainingWakeUps = await WakeUpResource.listByAgentConfigurationId(
+      authenticator,
+      agent.sId
+    );
+    expect(remainingWakeUps).toHaveLength(0);
+
+    const remainingFavoriteCount =
+      await AgentUserRelationResource.countForAgent(authenticator, agent.sId);
+    expect(remainingFavoriteCount).toBe(0);
+
+    expect(mockDeleteSchedule).toHaveBeenCalled();
+    expect(cancelSpy).toHaveBeenCalled();
+
+    mockCreateSchedule.mockRestore();
+    mockDeleteSchedule.mockRestore();
+    launchSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
+
+  it("keeps the wake-up row when Temporal cancellation fails", async () => {
+    const launchSpy = vi
+      .spyOn(wakeUpClient, "launchOrScheduleWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Ok(undefined));
+    // Simulate a transient Temporal failure when cancelling the schedule.
+    const cancelSpy = vi
+      .spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow")
+      .mockResolvedValue(new Err(new Error("temporal unavailable")));
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    await WakeUpFactory.cron(authenticator, conversation, agent, {
+      reason: "Daily wake-up",
+    });
+
+    await cleanupAgentScopedResourcesForHardDeletion(authenticator, agent.sId);
+
+    // The Temporal schedule could not be deleted, so the row must survive to
+    // keep the wake-up id available for a retry / the reconciler.
+    const remainingWakeUps = await WakeUpResource.listByAgentConfigurationId(
+      authenticator,
+      agent.sId
+    );
+    expect(remainingWakeUps).toHaveLength(1);
+    expect(remainingWakeUps[0].status).toBe("scheduled");
 
     launchSpy.mockRestore();
     cancelSpy.mockRestore();

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -40,6 +40,7 @@ import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
+import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -1567,6 +1568,71 @@ export async function restoreAgentConfiguration(
   return new Ok({ restored: updated[0] > 0 });
 }
 
+// Deletes the agent-scoped resources that are keyed by the agent sId (stable
+// across versions) and therefore have no DB foreign key to cascade on: triggers
+// (with their Temporal schedule), wake-ups (with their Temporal schedule /
+// pending workflow) and favorite / agent-user-relation rows.
+export async function cleanupAgentScopedResourcesForHardDeletion(
+  auth: Authenticator,
+  agentConfigurationId: string
+): Promise<void> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const triggers = await TriggerResource.listByAgentConfigurationId(
+    auth,
+    agentConfigurationId
+  );
+  for (const trigger of triggers) {
+    const deleteResult = await trigger.delete(auth);
+    if (deleteResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          agentConfigurationId,
+          triggerId: trigger.sId,
+          error: deleteResult.error,
+        },
+        `Failed to delete trigger ${trigger.sId} while hard-deleting agent ${agentConfigurationId}`
+      );
+    }
+  }
+
+  const wakeUps = await WakeUpResource.listByAgentConfigurationId(
+    auth,
+    agentConfigurationId
+  );
+  for (const wakeUp of wakeUps) {
+    const cleanupResult = await wakeUp.forceCancel(auth);
+    if (cleanupResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          agentConfigurationId,
+          wakeUpId: wakeUp.sId,
+          error: cleanupResult.error,
+        },
+        `Failed cleaning up wake-up ${wakeUp.sId} Temporal state while hard-deleting agent ${agentConfigurationId}; leaving row for retry`
+      );
+      continue;
+    }
+
+    const deleteResult = await wakeUp.delete(auth);
+    if (deleteResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          agentConfigurationId,
+          wakeUpId: wakeUp.sId,
+          error: deleteResult.error,
+        },
+        `Failed to delete wake-up ${wakeUp.sId} while hard-deleting agent ${agentConfigurationId}`
+      );
+    }
+  }
+
+  await AgentUserRelationResource.deleteForAgent(auth, agentConfigurationId);
+}
+
 // Should only be called when we need to clean up the agent configuration
 // right after creating it due to an error.
 export async function unsafeHardDeleteAgentConfiguration(
@@ -1693,6 +1759,11 @@ export async function batchHardDeletePendingAgentConfigurations(
       where: { agentConfigurationId: agentIds, workspaceId },
       transaction: t,
     });
+
+    await AgentUserRelationResource.deleteForAgents(
+      agents.map((a) => a.sId),
+      { workspaceId, transaction: t }
+    );
 
     await AgentConfigurationModel.destroy({
       where: { id: agentIds, workspaceId },

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1582,25 +1582,30 @@ export async function cleanupAgentScopedResourcesForHardDeletion(
     auth,
     agentConfigurationId
   );
-  for (const trigger of triggers) {
-    const deleteResult = await trigger.delete(auth);
-    if (deleteResult.isErr()) {
-      logger.error(
-        {
-          workspaceId: workspace.sId,
-          agentConfigurationId,
-          triggerId: trigger.sId,
-          error: deleteResult.error,
-        },
-        `Failed to delete trigger ${trigger.sId} while hard-deleting agent ${agentConfigurationId}`
-      );
-    }
-  }
+  await concurrentExecutor(
+    triggers,
+    async (trigger) => {
+      const deleteResult = await trigger.delete(auth);
+      if (deleteResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            agentConfigurationId,
+            triggerId: trigger.sId,
+            error: deleteResult.error,
+          },
+          `Failed to delete trigger ${trigger.sId} while hard-deleting agent ${agentConfigurationId}`
+        );
+      }
+    },
+    { concurrency: 4 }
+  );
 
   const wakeUps = await WakeUpResource.listByAgentConfigurationId(
     auth,
     agentConfigurationId
   );
+  const deletableWakeUpIds: ModelId[] = [];
   for (const wakeUp of wakeUps) {
     const cleanupResult = await wakeUp.forceCancel(auth);
     if (cleanupResult.isErr()) {
@@ -1615,20 +1620,9 @@ export async function cleanupAgentScopedResourcesForHardDeletion(
       );
       continue;
     }
-
-    const deleteResult = await wakeUp.delete(auth);
-    if (deleteResult.isErr()) {
-      logger.error(
-        {
-          workspaceId: workspace.sId,
-          agentConfigurationId,
-          wakeUpId: wakeUp.sId,
-          error: deleteResult.error,
-        },
-        `Failed to delete wake-up ${wakeUp.sId} while hard-deleting agent ${agentConfigurationId}`
-      );
-    }
+    deletableWakeUpIds.push(wakeUp.id);
   }
+  await WakeUpResource.deleteByModelIds(auth, deletableWakeUpIds);
 
   await AgentUserRelationResource.deleteForAgent(auth, agentConfigurationId);
 }

--- a/front/lib/resources/agent_user_relation_resource.ts
+++ b/front/lib/resources/agent_user_relation_resource.ts
@@ -2,6 +2,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentUserRelationModel } from "@app/lib/models/agent/agent";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type { Attributes, Transaction } from "sequelize";
@@ -26,6 +27,22 @@ export class AgentUserRelationResource extends BaseResource<AgentUserRelationMod
         agentConfiguration: agentId,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
+    });
+  }
+
+  static async deleteForAgents(
+    agentIds: string[],
+    {
+      workspaceId,
+      transaction,
+    }: { workspaceId: ModelId; transaction?: Transaction }
+  ): Promise<void> {
+    await this.model.destroy({
+      where: {
+        agentConfiguration: agentIds,
+        workspaceId,
+      },
+      transaction,
     });
   }
 

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -744,7 +744,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       where: {
         id: ids,
         workspaceId: auth.getNonNullableWorkspace().id,
-      } as WhereOptions<WakeUpModel>,
+      },
       transaction,
     });
   }

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -728,6 +728,27 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     return new Ok(undefined);
   }
 
+  // Batch-deletes wake-up rows by their model ids in a single query. Callers are
+  // responsible for having torn down each wake-up's Temporal footprint first, as
+  // this only removes the DB rows.
+  static async deleteByModelIds(
+    auth: Authenticator,
+    ids: ModelId[],
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    if (ids.length === 0) {
+      return;
+    }
+
+    await this.model.destroy({
+      where: {
+        id: ids,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      } as WhereOptions<WakeUpModel>,
+      transaction,
+    });
+  }
+
   toJSON(): WakeUpType {
     const scheduleConfig: WakeUpScheduleConfig = (() => {
       switch (this.scheduleType) {

--- a/front/scripts/scrub_agent.ts
+++ b/front/scripts/scrub_agent.ts
@@ -1,8 +1,12 @@
 import {
+  cleanupAgentScopedResourcesForHardDeletion,
   listsAgentConfigurationVersions,
   unsafeHardDeleteAgentConfiguration,
 } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
+import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { makeScript } from "@app/scripts/helpers";
 
 makeScript(
@@ -63,6 +67,49 @@ makeScript(
         versionCount: versions.length,
       },
       "Hard-deleting all versions of the agent."
+    );
+
+    await cleanupAgentScopedResourcesForHardDeletion(auth, agentId);
+
+    const remainingTriggers = await TriggerResource.listByAgentConfigurationId(
+      auth,
+      agentId
+    );
+    const remainingWakeUps = await WakeUpResource.listByAgentConfigurationId(
+      auth,
+      agentId
+    );
+    const remainingFavoriteCount =
+      await AgentUserRelationResource.countForAgent(auth, agentId);
+
+    if (
+      remainingTriggers.length > 0 ||
+      remainingWakeUps.length > 0 ||
+      remainingFavoriteCount > 0
+    ) {
+      logger.error(
+        {
+          workspaceId,
+          agentId,
+          remainingTriggerIds: remainingTriggers.map((t) => t.sId),
+          remainingWakeUps: remainingWakeUps.map((w) => ({
+            sId: w.sId,
+            status: w.status,
+            scheduleType: w.scheduleType,
+          })),
+          remainingFavoriteCount,
+        },
+        "Agent scoped cleanup incomplete; aborting hard-delete of agent versions. " +
+          "Resolve the underlying Temporal failure and rerun."
+      );
+      throw new Error(
+        `Agent scoped cleanup incomplete for ${agentId}; aborted before deleting versions.`
+      );
+    }
+
+    logger.info(
+      { workspaceId, agentId },
+      "Agent triggers, wake-ups and favorites fully cleaned up."
     );
 
     for (const version of versions) {


### PR DESCRIPTION
## Description

Hard-deleting an agent (scrub_agent / GDPR purge) left behind trigger rows + their Temporal schedules, wake-up rows + their schedules, and favorite rows, because all three reference the agent by sId with no DB foreign key.

- New cleanupAgentScopedResourcesForHardDeletion deletes the agent's triggers (with their schedule), tears down its wake-ups via WakeUpResource.forceCancel (keeping a row whose Temporal cleanup failed, for retry), and deletes its favorite rows via AgentUserRelationResource. Only invoked from terminal whole-agent deletion, never the failed-upgrade rollback path.
- scrub_agent verifies cleanup completed (no scoped rows survive) and aborts before deleting the irreversible version rows otherwise, so a rerun can finish once the underlying Temporal issue clears.
- batchHardDeletePendingAgentConfigurations bulk-deletes favorite rows.
## Tests

Unit

## Risk

Low: only on scrubbed agents

## Deploy Plan

Front