### PR TITLE
feat(front): show radio btn or checkbox when asking question

### DIFF
--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -296,6 +296,7 @@ export function UserAnswerRequired({
               counterValue={index + 1}
               selected={answerDraft.selectedOptions.includes(index)}
               disableHover={isKeyboardNavigating}
+              selectionIndicator={question.multiSelect ? "checkbox" : "radio"}
               onFocusCapture={() => activateOption(index)}
               onMouseEnter={() => activateOption(index)}
               className={cn(

--- a/sparkle/src/components/Checkbox.tsx
+++ b/sparkle/src/components/Checkbox.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { Label } from "./Label";
 import { Tooltip } from "./Tooltip";
 
-const checkboxStyles = cva(
+export const checkboxStyles = cva(
   cn(
     "h-4 w-4 rounded-md relative shrink-0 peer border transition duration-200 ease-in-out motion-reduce:transition-none",
     "active:scale-95",
@@ -19,7 +19,7 @@ const checkboxStyles = cva(
 
 // The checked state renders a dark rounded square that fills the box's inner
 // content area; the light "ring" is the box's own border showing through.
-const checkboxIndicatorStyles = cva(
+export const checkboxIndicatorStyles = cva(
   "absolute inset-0 flex items-center justify-center rounded-[3px]",
   {
     variants: {

--- a/sparkle/src/components/OptionCard.tsx
+++ b/sparkle/src/components/OptionCard.tsx
@@ -1,10 +1,14 @@
 import { Card, type CardVariantType } from "@sparkle/components/Card";
-import { Checkbox } from "@sparkle/components/Checkbox";
+import {
+  checkboxIndicatorStyles,
+  checkboxStyles,
+} from "@sparkle/components/Checkbox";
 import { Counter } from "@sparkle/components/Counter";
 import {
   radioIndicatorStyles,
   radioStyles,
 } from "@sparkle/components/RadioGroup";
+import { Check } from "@sparkle/icons/v2-stroke";
 import { cn } from "@sparkle/lib/utils";
 import React from "react";
 
@@ -87,14 +91,16 @@ export function OptionCard({
         </div>
       )}
       {selectionIndicator === "checkbox" && (
-        <Checkbox
+        <div
           aria-hidden="true"
-          checked={selected}
-          disabled={disabled}
-          tabIndex={-1}
-          className="pointer-events-none shrink-0"
-          onCheckedChange={() => {}}
-        />
+          className={cn(checkboxStyles(), "pointer-events-none shrink-0")}
+        >
+          {selected && (
+            <div className={checkboxIndicatorStyles()}>
+              <Check className="h-3 w-3 text-background" />
+            </div>
+          )}
+        </div>
       )}
     </Card>
   );

--- a/sparkle/src/components/OptionCard.tsx
+++ b/sparkle/src/components/OptionCard.tsx
@@ -1,7 +1,14 @@
 import { Card, type CardVariantType } from "@sparkle/components/Card";
+import { Checkbox } from "@sparkle/components/Checkbox";
 import { Counter } from "@sparkle/components/Counter";
+import {
+  radioIndicatorStyles,
+  radioStyles,
+} from "@sparkle/components/RadioGroup";
 import { cn } from "@sparkle/lib/utils";
 import React from "react";
+
+export type OptionCardSelectionIndicator = "radio" | "checkbox";
 
 export interface OptionCardProps {
   label: string;
@@ -11,6 +18,7 @@ export interface OptionCardProps {
   disabled?: boolean;
   disableHover?: boolean;
   className?: string;
+  selectionIndicator?: OptionCardSelectionIndicator;
   onClick?: () => void;
   onFocusCapture?: React.FocusEventHandler<HTMLDivElement>;
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
@@ -27,6 +35,7 @@ export function OptionCard({
   onClick,
   onFocusCapture,
   onMouseEnter,
+  selectionIndicator,
 }: OptionCardProps) {
   const variant: CardVariantType = selected ? "active" : "tertiary";
   const isInteractive = onClick !== undefined && !disabled;
@@ -69,6 +78,24 @@ export function OptionCard({
           <span className="text-xs text-muted-foreground">{description}</span>
         )}
       </div>
+      {selectionIndicator === "radio" && (
+        <div
+          aria-hidden="true"
+          className={cn(radioStyles(), "pointer-events-none shrink-0")}
+        >
+          {selected && <div className={radioIndicatorStyles()} />}
+        </div>
+      )}
+      {selectionIndicator === "checkbox" && (
+        <Checkbox
+          aria-hidden="true"
+          checked={selected}
+          disabled={disabled}
+          tabIndex={-1}
+          className="pointer-events-none shrink-0"
+          onCheckedChange={() => {}}
+        />
+      )}
     </Card>
   );
 }

--- a/sparkle/src/stories/OptionCard.stories.tsx
+++ b/sparkle/src/stories/OptionCard.stories.tsx
@@ -17,6 +17,7 @@ const meta = {
 **Guidelines**
 - Provide \`onClick\` to make the card interactive; without it the card is display-only.
 - Use \`counterValue\` to convey ordering or quantity, and \`selected\` to reflect the current choice (it sets \`aria-pressed\`).
+- Use \`selectionIndicator="radio"\` for single-select lists and \`selectionIndicator="checkbox"\` for multi-select lists, so the selection mode is visually unambiguous.
 - Stack multiple cards in a column; for one-tap suggested prompts that send immediately, use **QuickReplyBlock** instead.`,
       },
     },
@@ -74,6 +75,59 @@ export const DisabledOption: Story = {
         label="Calendar conflicts"
         description="Events that overlap with your focus blocks."
         counterValue={3}
+      />
+    </div>
+  ),
+};
+
+export const SingleSelect: Story = {
+  render: () => (
+    <div className="flex w-full max-w-sm flex-col gap-2">
+      <OptionCard
+        label="Unread emails"
+        description="Only conversations you have not opened yet."
+        counterValue={1}
+        selectionIndicator="radio"
+        selected
+      />
+      <OptionCard
+        label="Slack mentions"
+        description="Messages where you were directly tagged."
+        counterValue={2}
+        selectionIndicator="radio"
+      />
+      <OptionCard
+        label="Calendar conflicts"
+        description="Events that overlap with your focus blocks."
+        counterValue={3}
+        selectionIndicator="radio"
+      />
+    </div>
+  ),
+};
+
+export const MultiSelect: Story = {
+  render: () => (
+    <div className="flex w-full max-w-sm flex-col gap-2">
+      <OptionCard
+        label="Unread emails"
+        description="Only conversations you have not opened yet."
+        counterValue={1}
+        selectionIndicator="checkbox"
+        selected
+      />
+      <OptionCard
+        label="Slack mentions"
+        description="Messages where you were directly tagged."
+        counterValue={2}
+        selectionIndicator="checkbox"
+        selected
+      />
+      <OptionCard
+        label="Calendar conflicts"
+        description="Events that overlap with your focus blocks."
+        counterValue={3}
+        selectionIndicator="checkbox"
       />
     </div>
   ),


### PR DESCRIPTION
## Description

Fixes [dust-tt/tasks#8739](https://github.com/dust-tt/tasks/issues/8739). 

This adds an explicit trailing selection indicator to each option row, radio button for single select, checkbox for multi select.

## Tests

<img width="441" height="255" alt="Screenshot 2026-07-08 at 16 14 49" src="https://github.com/user-attachments/assets/6afea1a0-aaa4-4350-a4f4-7cbdd7086c6d" />
<img width="415" height="255" alt="Screenshot 2026-07-08 at 16 14 54" src="https://github.com/user-attachments/assets/d503d9b6-f075-4cb5-9d31-3ed5a1fc6514" />
<img width="848" height="751" alt="Screenshot 2026-07-08 at 16 16 49" src="https://github.com/user-attachments/assets/b10bc7a8-f951-41a3-a586-bd40fd79665d" />
<img width="833" height="618" alt="Screenshot 2026-07-08 at 16 17 30" src="https://github.com/user-attachments/assets/bc3aa7f3-4fa7-4a20-8dac-fcf529e6dd77" />
