### PR TITLE
feat(assistant): default @dust to the auto model and refresh auto branding

### DIFF
--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -408,10 +408,10 @@
  *           type: number
  *           nullable: true
  *           description: Aggregated credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise.
- *         requestedModel:
+ *         resolvedModel:
  *           type: object
  *           nullable: true
- *           description: Per-message model override from the input-bar model picker. Null when the agent ran its configured model.
+ *           description: Model triplet used to generate the message. Null when the agent ran its configured model (legacy).
  *           properties:
  *             providerId:
  *               type: string
@@ -419,6 +419,11 @@
  *               type: string
  *             reasoningEffort:
  *               type: string
+ *         modelResolutionMethod:
+ *           type: string
+ *           nullable: true
+ *           enum: [agent, user, auto]
+ *           description: How resolvedModel was chosen - agent (configured model), user (per-message picker), or auto (routed through the auto model). Null (legacy).
  *     PrivateLightAgentMessage:
  *       type: object
  *       description: A lighter agent message used in paginated message list responses.
@@ -524,6 +529,22 @@
  *           type: number
  *           nullable: true
  *           description: Aggregated credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise.
+ *         resolvedModel:
+ *           type: object
+ *           nullable: true
+ *           description: Model triplet used to generate the message. Null when the agent ran its configured model (legacy).
+ *           properties:
+ *             providerId:
+ *               type: string
+ *             modelId:
+ *               type: string
+ *             reasoningEffort:
+ *               type: string
+ *         modelResolutionMethod:
+ *           type: string
+ *           nullable: true
+ *           enum: [agent, user, auto]
+ *           description: How resolvedModel was chosen - agent (configured model), user (per-message picker), or auto (routed through the auto model). Null (legacy).
  *         activitySteps:
  *           type: array
  *           items:

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -104,6 +104,10 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
         m.visibility !== "deleted"
     );
 
+  // Model the current user's previous message ran on, used to derive the model
+  // picker's default so a follow-up keeps the last model.
+  const lastRequestedModel = lastUserMessage?.requestedModel ?? null;
+
   // Last agent mentioned by anyone in the conversation. Computed outside useMemo so the
   // result is a stable object reference (same mention object from the message list) that
   // won't cause unnecessary recomputation of autoMentions when allMessages array ref changes.
@@ -549,6 +553,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           user={context.user}
           onSubmit={context.handleSubmit}
           stickyMentions={autoMentions}
+          lastRequestedModel={lastRequestedModel}
           conversation={context.conversation}
           draftKey={context.draftKey}
           disableAutoFocus={isMobile || hasUserAnswerRequired}

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -104,8 +104,6 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
         m.visibility !== "deleted"
     );
 
-  // Model the current user's previous message ran on, used to derive the model
-  // picker's default so a follow-up keeps the last model.
   const lastRequestedModel = lastUserMessage?.requestedModel ?? null;
 
   // Last agent mentioned by anyone in the conversation. Computed outside useMemo so the

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -14,6 +14,7 @@ import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conver
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
 import { useAutoOpenFilesPanel } from "@app/components/assistant/conversation/files_panel/useAutoOpenFilesPanel";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { getModelWithReasoningEffortLabel } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { useAutoOpenInteractiveContent } from "@app/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent";
 import type {
   AgentMessageStateWithControlEvent,
@@ -65,7 +66,7 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
-import { getResolvedModelLabel } from "@app/lib/llms/model_configurations";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { getFilePreviewDirectivePaths } from "@app/lib/markdown/file_preview";
 import { extractFromString } from "@app/lib/mentions/format";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
@@ -1050,12 +1051,17 @@ export function AgentMessage({
     canShowAgentConversationActions(agentConfiguration.sId);
   const isArchived = agentConfiguration.status === "archived";
 
-  // When this message ran on a per-message model picked from the input-bar
-  // picker (rather than the agent's preset or an auto resolution), surface the
-  // model next to the agent name (e.g. "Dust with GPT-5.5 Light").
-  const perMessageModelLabel =
+  const perMessageModel =
     agentMessage.modelResolutionMethod === "user" && agentMessage.resolvedModel
-      ? getResolvedModelLabel(agentMessage.resolvedModel)
+      ? getSupportedModelConfig(agentMessage.resolvedModel)
+      : null;
+  const perMessageModelLabel =
+    perMessageModel && agentMessage.resolvedModel
+      ? getModelWithReasoningEffortLabel({
+          kind: "model",
+          model: perMessageModel,
+          effort: agentMessage.resolvedModel.reasoningEffort,
+        })
       : null;
 
   const renderName = useCallback(

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -65,6 +65,7 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
+import { getResolvedModelLabel } from "@app/lib/llms/model_configurations";
 import { getFilePreviewDirectivePaths } from "@app/lib/markdown/file_preview";
 import { extractFromString } from "@app/lib/mentions/format";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
@@ -1049,6 +1050,14 @@ export function AgentMessage({
     canShowAgentConversationActions(agentConfiguration.sId);
   const isArchived = agentConfiguration.status === "archived";
 
+  // When this message ran on a per-message model picked from the input-bar
+  // picker (rather than the agent's preset or an auto resolution), surface the
+  // model next to the agent name (e.g. "Dust with GPT-5.5 Light").
+  const perMessageModelLabel =
+    agentMessage.modelResolutionMethod === "user" && agentMessage.resolvedModel
+      ? getResolvedModelLabel(agentMessage.resolvedModel)
+      : null;
+
   const renderName = useCallback(
     () => (
       <span className="inline-flex items-center">
@@ -1060,6 +1069,11 @@ export function AgentMessage({
           canMention={canMention}
           isDisabled={isArchived}
         />
+        {perMessageModelLabel && (
+          <span className="pl-1 font-normal text-muted-foreground">
+            with {perMessageModelLabel}
+          </span>
+        )}
         {parentAgent && (
           <Chip
             label={`handoff from @${parentAgent.name}`}
@@ -1076,6 +1090,7 @@ export function AgentMessage({
       agentConfiguration.sId,
       canMention,
       isArchived,
+      perMessageModelLabel,
       parentAgent,
       agentMessage.status,
     ]

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx
@@ -69,6 +69,8 @@ const mockAgentMessage: LightAgentMessageType = {
   citations: {},
   generatedFiles: [],
   activitySteps: [],
+  resolvedModel: null,
+  modelResolutionMethod: null,
 };
 
 describe("InlineActivitySteps", () => {

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -66,6 +66,9 @@ interface InputBarProps {
   stickyMentions?: RichMention[];
   defaultAgentId?: string | null;
   isDefaultAgentLoading?: boolean;
+  // Model the current user's previous message ran on, used to derive the model
+  // picker's default. Null in a new conversation.
+  lastRequestedModel?: ModelSelectionType | null;
   defaultSkills?: InputBarContainerProps["defaultSkills"];
   isDefaultSkillsLoading?: boolean;
   actions?: InputBarContainerProps["actions"];
@@ -95,6 +98,7 @@ export const InputBar = React.memo(function InputBar({
   stickyMentions,
   defaultAgentId,
   isDefaultAgentLoading,
+  lastRequestedModel = null,
   defaultSkills,
   isDefaultSkillsLoading,
   actions = DEFAULT_INPUT_BAR_ACTIONS,
@@ -526,6 +530,7 @@ export const InputBar = React.memo(function InputBar({
             stickyMentions={stickyMentions}
             defaultAgentId={defaultAgentId}
             isDefaultAgentLoading={isDefaultAgentLoading}
+            lastRequestedModel={lastRequestedModel}
             defaultSkills={defaultSkills}
             isDefaultSkillsLoading={isDefaultSkillsLoading}
             fileUploaderService={fileUploaderService}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -66,8 +66,6 @@ interface InputBarProps {
   stickyMentions?: RichMention[];
   defaultAgentId?: string | null;
   isDefaultAgentLoading?: boolean;
-  // Model the current user's previous message ran on, used to derive the model
-  // picker's default. Null in a new conversation.
   lastRequestedModel?: ModelSelectionType | null;
   defaultSkills?: InputBarContainerProps["defaultSkills"];
   isDefaultSkillsLoading?: boolean;

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -54,6 +54,9 @@ interface InputBarButtonsProps {
   // When true, disables every picker (tools, attachment) in addition to the
   // agent selector which is muted via `disableAgentSelector`.
   isInputDisabled: boolean;
+  // Model the current user's previous message ran on, used to derive the model
+  // picker's default. Null in a new conversation.
+  lastRequestedModel: ModelSelectionType | null;
   onAgentRemove: () => void;
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
   onModelSelectionChange?: (
@@ -87,6 +90,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   hideCapabilities,
   isDefaultAgentUnavailable,
   isInputDisabled,
+  lastRequestedModel,
   onAgentRemove,
   onMCPServerViewSelect,
   onModelSelectionChange,
@@ -249,6 +253,8 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   const modelPickerButton = actions.includes("model-picker") && (
     <InputBarModelPicker
       agentModel={selectedAgentModel}
+      agentId={selectedAgent?.id ?? null}
+      lastRequestedModel={lastRequestedModel}
       owner={owner}
       buttonSize={buttonSize}
       side={conversation ? "top" : "bottom"}

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -54,8 +54,6 @@ interface InputBarButtonsProps {
   // When true, disables every picker (tools, attachment) in addition to the
   // agent selector which is muted via `disableAgentSelector`.
   isInputDisabled: boolean;
-  // Model the current user's previous message ran on, used to derive the model
-  // picker's default. Null in a new conversation.
   lastRequestedModel: ModelSelectionType | null;
   onAgentRemove: () => void;
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -206,6 +206,9 @@ export interface InputBarContainerProps {
   } | null;
   defaultAgentId?: string | null;
   isDefaultAgentLoading?: boolean;
+  // Model the current user's previous message ran on, used to derive the model
+  // picker's default. Null in a new conversation.
+  lastRequestedModel?: ModelSelectionType | null;
   // Skills pre-inserted into a new conversation's editor, as if manually added.
   defaultSkills?: DefaultSkillReference[];
   isDefaultSkillsLoading?: boolean;
@@ -264,6 +267,7 @@ const InputBarContainer = ({
   getDraft,
   defaultAgentId,
   isDefaultAgentLoading,
+  lastRequestedModel = null,
   defaultSkills,
   isDefaultSkillsLoading,
   isAgentBuilder = false,
@@ -1658,6 +1662,7 @@ const InputBarContainer = ({
                       hideCapabilities={hideCapabilities}
                       isDefaultAgentUnavailable={isDefaultAgentUnavailable}
                       isInputDisabled={disableInput}
+                      lastRequestedModel={lastRequestedModel}
                       onAgentRemove={() => setSelectedSingleAgent(null)}
                       onMCPServerViewSelect={onMCPServerViewSelect}
                       onModelSelectionChange={onModelSelectionChange}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -206,8 +206,6 @@ export interface InputBarContainerProps {
   } | null;
   defaultAgentId?: string | null;
   isDefaultAgentLoading?: boolean;
-  // Model the current user's previous message ran on, used to derive the model
-  // picker's default. Null in a new conversation.
   lastRequestedModel?: ModelSelectionType | null;
   // Skills pre-inserted into a new conversation's editor, as if manually added.
   defaultSkills?: DefaultSkillReference[];

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -77,19 +77,17 @@ export function InputBarModelPicker({
     useState<ModelProviderIdType | null>(null);
 
   const commitSelection = (selection: UserModelSelection) => {
-    const isAutoSelection = selection.kind === "auto";
-    const isAutoDefaultSelection = defaultSelection.kind === "auto";
-    const isSameModelSelectionAsAgent =
+    const isSelectionAuto = selection.kind === "auto";
+    const isDefaultAuto = defaultSelection.kind === "auto";
+    const isSelectionSameModelAsAgent =
       selection.kind === "model" &&
       defaultSelection.kind === "agent" &&
       selection.model.modelId === agentModel?.modelId &&
       selection.model.providerId === agentModel?.providerId &&
       selection.effort === agentModel?.reasoningEffort;
 
-    if (
-      (isAutoSelection && isAutoDefaultSelection) ||
-      isSameModelSelectionAsAgent
-    ) {
+    if ((isSelectionAuto && isDefaultAuto) || isSelectionSameModelAsAgent) {
+      // show default
       setUserOverride(null);
       return;
     }
@@ -109,21 +107,16 @@ export function InputBarModelPicker({
     disabled: !hasModelsPicker,
   });
 
-  // Derived picker default (see resolveDefaultSelection). Recomputes as the
-  // agent, the last message and the model list load in.
   const defaultSelection = useMemo(
     () => resolveDefaultSelection({ agentModel, lastRequestedModel, models }),
     [agentModel, lastRequestedModel, models]
   );
 
-  // What the picker shows: the manual override if set, else the derived default.
   const shown: Selection = userOverride ?? defaultSelection;
   const shownModelSelection = useMemo(() => toModelSelection(shown), [shown]);
 
-  // Keep the parent's send-time selection in sync with whatever the picker
-  // shows — including the derived default the user never explicitly picked (so a
-  // reload reuses the last message's model). `onSelectionChange` only stashes
-  // the value in a parent ref, so this triggers no parent re-render.
+  // Keep the parent's send-time selection in sync. `onSelectionChange` only
+  // stashes the value in a parent ref, so this triggers no parent re-render.
   useEffect(() => {
     if (!hasModelsPicker) {
       return;

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -5,12 +5,12 @@ import type {
   ProviderGroup,
   Selection,
   SuggestedModelWithReasoningEffort,
-  UserModelSelection,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import {
   getModelWithReasoningEffortKey,
   getModelWithReasoningEffortLabel,
   getSelectableReasoningEfforts,
+  resolveAgentDefaultModel,
   resolveDefaultSelection,
   SUGGESTED_PINS,
   toModelSelection,
@@ -68,16 +68,14 @@ export function InputBarModelPicker({
   // The list of models is hidden while "Auto" is on.
   const [expanded, setExpanded] = useState(false);
 
-  const [userOverride, setUserOverride] = useState<UserModelSelection | null>(
-    null
-  );
+  const [userOverride, setUserOverride] = useState<Selection | null>(null);
 
   // On mobile there are no nested submenus: the "More models" providers expand
   // inline below their name. This tracks the single provider currently expanded.
   const [expandedProvider, setExpandedProvider] =
     useState<ModelProviderIdType | null>(null);
 
-  const commitSelection = (next: UserModelSelection) => {
+  const commitSelection = (next: Selection) => {
     setUserOverride(next);
   };
 
@@ -181,6 +179,34 @@ export function InputBarModelPicker({
     }));
   }, [allModelsWithEfforts]);
 
+  const agentDefault = useMemo(
+    () => resolveAgentDefaultModel({ agentModel, models }),
+    [agentModel, models]
+  );
+  const agentDefaultKey = agentDefault
+    ? getModelWithReasoningEffortKey(
+        agentDefault.model.providerId,
+        agentDefault.model.modelId,
+        agentDefault.effort
+      )
+    : null;
+
+  // Drop the agent default from Suggested
+  const suggested = useMemo(
+    () =>
+      agentDefaultKey
+        ? suggestedModelsWithEfforts.filter(
+            (s) =>
+              getModelWithReasoningEffortKey(
+                s.model.providerId,
+                s.model.modelId,
+                s.effort
+              ) !== agentDefaultKey
+          )
+        : suggestedModelsWithEfforts,
+    [suggestedModelsWithEfforts, agentDefaultKey]
+  );
+
   const isSearching = search.trim() !== "";
 
   // While searching we show a single flat list over every model/effort.
@@ -221,13 +247,14 @@ export function InputBarModelPicker({
 
   const hasResults = isSearching
     ? filteredAll.length > 0
-    : suggestedModelsWithEfforts.length > 0 || moreByProvider.length > 0;
+    : !!agentDefault || suggested.length > 0 || moreByProvider.length > 0;
 
   // Collapse the correlated list booleans + data arrays into a single state so
   // the picker content receives one flat, exhaustively-typed prop.
   let listState: ModelPickerListState = {
     kind: "browse",
-    suggested: suggestedModelsWithEfforts,
+    agentDefault,
+    suggested,
     moreByProvider,
   };
   if (!showList) {
@@ -294,13 +321,18 @@ export function InputBarModelPicker({
         auto={auto}
         selectedKey={selectedKey}
         onToggleAuto={toggleAuto}
-        onSelectModel={(modelWithEffort: ModelWithReasoningEffort) =>
+        onSelectModel={(modelWithEffort: ModelWithReasoningEffort) => {
+          const key = getModelWithReasoningEffortKey(
+            modelWithEffort.model.providerId,
+            modelWithEffort.model.modelId,
+            modelWithEffort.effort
+          );
           commitSelection({
-            kind: "model",
+            kind: key === agentDefaultKey ? "agent" : "model",
             model: modelWithEffort.model,
             effort: modelWithEffort.effort,
-          })
-        }
+          });
+        }}
         expandedProvider={expandedProvider}
         onToggleProvider={(providerId) =>
           setExpandedProvider((current) =>

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -35,11 +35,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 interface InputBarModelPickerProps {
   agentModel: AgentModelConfigurationType | null;
-  // Identity of the agent the user is addressing. The manual override resets
-  // when this changes (keyed on identity, not the agent's model).
   agentId: string | null;
-  // Model the current user's previous message in this conversation ran on, used
-  // to derive the picker's default. Null in a new conversation.
   lastRequestedModel: ModelSelectionType | null;
   owner: LightWorkspaceType;
   buttonSize: "xs" | "sm";
@@ -72,9 +68,6 @@ export function InputBarModelPicker({
   // The list of models is hidden while "Auto" is on.
   const [expanded, setExpanded] = useState(false);
 
-  // The picker's only state: the user's manual override. Everything shown is
-  // `userOverride ?? <derived default>`. `null` means the user hasn't touched
-  // the picker, so the derived default is shown (and sent).
   const [userOverride, setUserOverride] = useState<UserModelSelection | null>(
     null
   );
@@ -88,11 +81,7 @@ export function InputBarModelPicker({
     setUserOverride(next);
   };
 
-  // Clear the manual override when the user switches which agent they address:
-  // an override should not leak across agents. Keyed on the agent's identity,
-  // not its model, so switching between two agents that share a model still
-  // resets. The initial null -> resolved-agent transition is a no-op (the
-  // override is already empty), so it never clobbers the derived default.
+  // Clear the manual override when the user switches which agent they address
   const prevAgentIdRef = useRef(agentId);
   if (agentId !== prevAgentIdRef.current) {
     prevAgentIdRef.current = agentId;

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -79,13 +79,17 @@ export function InputBarModelPicker({
   const commitSelection = (selection: UserModelSelection) => {
     const isAutoSelection = selection.kind === "auto";
     const isAutoDefaultSelection = defaultSelection.kind === "auto";
-    const isSameModelSelection =
+    const isSameModelSelectionAsAgent =
       selection.kind === "model" &&
-      defaultSelection.kind !== "auto" &&
-      selection.model === defaultSelection.model &&
-      selection.effort === defaultSelection.effort;
+      defaultSelection.kind === "agent" &&
+      selection.model.modelId === agentModel?.modelId &&
+      selection.model.providerId === agentModel?.providerId &&
+      selection.effort === agentModel?.reasoningEffort;
 
-    if ((isAutoSelection && isAutoDefaultSelection) || isSameModelSelection) {
+    if (
+      (isAutoSelection && isAutoDefaultSelection) ||
+      isSameModelSelectionAsAgent
+    ) {
       setUserOverride(null);
       return;
     }

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -5,11 +5,13 @@ import type {
   ProviderGroup,
   Selection,
   SuggestedModelWithReasoningEffort,
+  UserModelSelection,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import {
   getModelWithReasoningEffortKey,
   getModelWithReasoningEffortLabel,
   getSelectableReasoningEfforts,
+  resolveDefaultSelection,
   SUGGESTED_PINS,
   toModelSelection,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
@@ -29,10 +31,16 @@ import type {
 import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, DropdownMenu, DropdownMenuTrigger } from "@dust-tt/sparkle";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 interface InputBarModelPickerProps {
   agentModel: AgentModelConfigurationType | null;
+  // Identity of the agent the user is addressing. The manual override resets
+  // when this changes (keyed on identity, not the agent's model).
+  agentId: string | null;
+  // Model the current user's previous message in this conversation ran on, used
+  // to derive the picker's default. Null in a new conversation.
+  lastRequestedModel: ModelSelectionType | null;
   owner: LightWorkspaceType;
   buttonSize: "xs" | "sm";
   // Which side the dropdown opens toward. Mirrors the agent picker: "top" in an
@@ -45,6 +53,8 @@ interface InputBarModelPickerProps {
 
 export function InputBarModelPicker({
   agentModel,
+  agentId,
+  lastRequestedModel,
   owner,
   buttonSize,
   side = "top",
@@ -61,32 +71,32 @@ export function InputBarModelPicker({
 
   // The list of models is hidden while "Auto" is on.
   const [expanded, setExpanded] = useState(false);
-  const [selection, setSelection] = useState<Selection>({ kind: "auto" });
+
+  // The picker's only state: the user's manual override. Everything shown is
+  // `userOverride ?? <derived default>`. `null` means the user hasn't touched
+  // the picker, so the derived default is shown (and sent).
+  const [userOverride, setUserOverride] = useState<UserModelSelection | null>(
+    null
+  );
 
   // On mobile there are no nested submenus: the "More models" providers expand
   // inline below their name. This tracks the single provider currently expanded.
   const [expandedProvider, setExpandedProvider] =
     useState<ModelProviderIdType | null>(null);
 
-  // Commit a selection and notify the parent so it can attach (or, for "auto",
-  // clear) the per-message model override on the next send. Called from the
-  // user-driven handlers below and from the agent-change reset. `onSelectionChange`
-  // only stashes the value in a parent ref, so calling it here — including during
-  // the render-time reset — triggers no parent re-render.
-  const commitSelection = (next: Selection) => {
-    setSelection(next);
-    onSelectionChange?.(toModelSelection(next));
+  const commitSelection = (next: UserModelSelection) => {
+    setUserOverride(next);
   };
 
-  // Reset to Auto when the agent changes: a per-message override should not leak
-  // across agents.
-  const agentModelKey = agentModel
-    ? `${agentModel.providerId}/${agentModel.modelId}`
-    : null;
-  const prevAgentModelKeyRef = useRef(agentModelKey);
-  if (agentModelKey !== prevAgentModelKeyRef.current) {
-    prevAgentModelKeyRef.current = agentModelKey;
-    commitSelection({ kind: "auto" });
+  // Clear the manual override when the user switches which agent they address:
+  // an override should not leak across agents. Keyed on the agent's identity,
+  // not its model, so switching between two agents that share a model still
+  // resets. The initial null -> resolved-agent transition is a no-op (the
+  // override is already empty), so it never clobbers the derived default.
+  const prevAgentIdRef = useRef(agentId);
+  if (agentId !== prevAgentIdRef.current) {
+    prevAgentIdRef.current = agentId;
+    setUserOverride(null);
     setExpanded(false);
   }
 
@@ -94,6 +104,28 @@ export function InputBarModelPicker({
     owner,
     disabled: !hasModelsPicker,
   });
+
+  // Derived picker default (see resolveDefaultSelection). Recomputes as the
+  // agent, the last message and the model list load in.
+  const defaultSelection = useMemo(
+    () => resolveDefaultSelection({ agentModel, lastRequestedModel, models }),
+    [agentModel, lastRequestedModel, models]
+  );
+
+  // What the picker shows: the manual override if set, else the derived default.
+  const shown: Selection = userOverride ?? defaultSelection;
+  const shownModelSelection = useMemo(() => toModelSelection(shown), [shown]);
+
+  // Keep the parent's send-time selection in sync with whatever the picker
+  // shows — including the derived default the user never explicitly picked (so a
+  // reload reuses the last message's model). `onSelectionChange` only stashes
+  // the value in a parent ref, so this triggers no parent re-render.
+  useEffect(() => {
+    if (!hasModelsPicker) {
+      return;
+    }
+    onSelectionChange?.(shownModelSelection);
+  }, [hasModelsPicker, onSelectionChange, shownModelSelection]);
 
   const allModelsWithEfforts = useMemo<ModelWithReasoningEffort[]>(
     () =>
@@ -184,19 +216,19 @@ export function InputBarModelPicker({
   }, [allModelsWithEfforts, search]);
 
   const selectedKey =
-    selection.kind === "model"
-      ? getModelWithReasoningEffortKey(
-          selection.model.providerId,
-          selection.model.modelId,
-          selection.effort
-        )
-      : undefined;
+    shown.kind === "auto"
+      ? undefined
+      : getModelWithReasoningEffortKey(
+          shown.model.providerId,
+          shown.model.modelId,
+          shown.effort
+        );
 
-  // Auto is "on" while it is the committed selection and the list has not been
+  // Auto is "on" while it is the shown selection and the list has not been
   // manually expanded for browsing. It is hidden entirely while searching.
-  const isAutoOn = selection.kind === "auto" && !expanded;
+  const isAutoOn = shown.kind === "auto" && !expanded;
   const showAuto = !isSearching;
-  const showList = expanded || isSearching || selection.kind === "model";
+  const showList = expanded || isSearching || shown.kind !== "auto";
 
   const hasResults = isSearching
     ? filteredAll.length > 0
@@ -223,11 +255,11 @@ export function InputBarModelPicker({
 
   const label = isMobile
     ? "Model"
-    : `Model: ${getModelWithReasoningEffortLabel(selection)}`;
+    : `Model: ${getModelWithReasoningEffortLabel(shown)}`;
 
   const buttonIcon =
-    isMobile && selection.kind === "model"
-      ? getModelProviderLogo(selection.model.providerId, isDark)
+    isMobile && shown.kind !== "auto"
+      ? getModelProviderLogo(shown.model.providerId, isDark)
       : undefined;
 
   const toggleAuto = () => {

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -201,28 +201,16 @@ export function InputBarModelPicker({
       ? { model: selection.model, effort: selection.effort }
       : null;
   }, [agentModel, models]);
-  const agentDefaultKey = agentDefault
-    ? getModelWithReasoningEffortKey(
-        agentDefault.model.providerId,
-        agentDefault.model.modelId,
-        agentDefault.effort
-      )
-    : null;
-
   // Drop the agent default from Suggested
   const suggested = useMemo(
     () =>
-      agentDefaultKey
-        ? suggestedModelsWithEfforts.filter(
-            (s) =>
-              getModelWithReasoningEffortKey(
-                s.model.providerId,
-                s.model.modelId,
-                s.effort
-              ) !== agentDefaultKey
-          )
-        : suggestedModelsWithEfforts,
-    [suggestedModelsWithEfforts, agentDefaultKey]
+      suggestedModelsWithEfforts.filter(
+        (s) =>
+          agentDefault?.effort !== s.effort ||
+          agentDefault?.model.modelId !== s.model.modelId ||
+          agentDefault?.model.providerId !== s.model.providerId
+      ),
+    [suggestedModelsWithEfforts, agentDefault]
   );
 
   const isSearching = search.trim() !== "";

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -11,7 +11,6 @@ import {
   getModelWithReasoningEffortKey,
   getModelWithReasoningEffortLabel,
   getSelectableReasoningEfforts,
-  resolveAgentDefaultModel,
   resolveDefaultSelection,
   SUGGESTED_PINS,
   toModelSelection,
@@ -189,10 +188,19 @@ export function InputBarModelPicker({
     }));
   }, [allModelsWithEfforts]);
 
-  const agentDefault = useMemo(
-    () => resolveAgentDefaultModel({ agentModel, models }),
-    [agentModel, models]
-  );
+  // The agent's configured default, ignoring the last-requested model: reuse
+  // resolveDefaultSelection with no last-requested model, then keep only the
+  // agent-model outcome.
+  const agentDefault = useMemo<ModelWithReasoningEffort | null>(() => {
+    const selection = resolveDefaultSelection({
+      agentModel,
+      lastRequestedModel: null,
+      models,
+    });
+    return selection.kind === "agent"
+      ? { model: selection.model, effort: selection.effort }
+      : null;
+  }, [agentModel, models]);
   const agentDefaultKey = agentDefault
     ? getModelWithReasoningEffortKey(
         agentDefault.model.providerId,

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -5,6 +5,7 @@ import type {
   ProviderGroup,
   Selection,
   SuggestedModelWithReasoningEffort,
+  UserModelSelection,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import {
   getModelWithReasoningEffortKey,
@@ -75,8 +76,20 @@ export function InputBarModelPicker({
   const [expandedProvider, setExpandedProvider] =
     useState<ModelProviderIdType | null>(null);
 
-  const commitSelection = (next: Selection) => {
-    setUserOverride(next);
+  const commitSelection = (selection: UserModelSelection) => {
+    const isAutoSelection = selection.kind === "auto";
+    const isAutoDefaultSelection = defaultSelection.kind === "auto";
+    const isSameModelSelection =
+      selection.kind === "model" &&
+      defaultSelection.kind !== "auto" &&
+      selection.model === defaultSelection.model &&
+      selection.effort === defaultSelection.effort;
+
+    if ((isAutoSelection && isAutoDefaultSelection) || isSameModelSelection) {
+      setUserOverride(null);
+      return;
+    }
+    setUserOverride(selection);
   };
 
   // Clear the manual override when the user switches which agent they address
@@ -322,13 +335,8 @@ export function InputBarModelPicker({
         selectedKey={selectedKey}
         onToggleAuto={toggleAuto}
         onSelectModel={(modelWithEffort: ModelWithReasoningEffort) => {
-          const key = getModelWithReasoningEffortKey(
-            modelWithEffort.model.providerId,
-            modelWithEffort.model.modelId,
-            modelWithEffort.effort
-          );
           commitSelection({
-            kind: key === agentDefaultKey ? "agent" : "model",
+            kind: "model",
             model: modelWithEffort.model,
             effort: modelWithEffort.effort,
           });

--- a/front/components/assistant/conversation/input_bar/ModelPickerList.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerList.tsx
@@ -88,6 +88,24 @@ export function ModelPickerList({
     case "browse":
       return (
         <>
+          {listState.agentDefault && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel label="Default from agent" />
+              <DropdownMenuRadioGroup value={selectedKey}>
+                <ModelPickerLineItem
+                  key={getModelWithReasoningEffortKey(
+                    listState.agentDefault.model.providerId,
+                    listState.agentDefault.model.modelId,
+                    listState.agentDefault.effort
+                  )}
+                  modelWithEffort={listState.agentDefault}
+                  isMobile={isMobile}
+                  onSelect={onSelectModel}
+                />
+              </DropdownMenuRadioGroup>
+            </>
+          )}
           {listState.suggested.length > 0 && (
             <>
               <DropdownMenuSeparator />

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -42,7 +42,7 @@ export const SUGGESTED_PINS: {
 ];
 
 export const AUTO_TOOLTIP =
-  "Dust selects and switches model for cost efficient performance and reliability. When an agent is created using a specific model, we use this model.";
+  "Dust selects and switches model for cost efficient performance and reliability.";
 
 // Per reasoning-effort blurbs shown in each model's hover tooltip: what the
 // effort does, and what it is recommended for.
@@ -104,6 +104,7 @@ export type ModelPickerListState =
   | { kind: "search"; models: ModelWithReasoningEffort[] }
   | {
       kind: "browse";
+      agentDefault: ModelWithReasoningEffort | null;
       suggested: SuggestedModelWithReasoningEffort[];
       moreByProvider: ProviderGroup[];
     };
@@ -243,4 +244,21 @@ export function resolveDefaultSelection({
     model,
     effort: resolveEffort(model, agentModel.reasoningEffort),
   };
+}
+
+export function resolveAgentDefaultModel({
+  agentModel,
+  models,
+}: {
+  agentModel: AgentModelConfigurationType | null;
+  models: ModelConfigurationType[];
+}): ModelWithReasoningEffort | null {
+  if (!agentModel || agentModel.modelId === AUTO_MODEL_ID) {
+    return null;
+  }
+  const model = findAvailableModel(models, agentModel);
+  if (!model) {
+    return null;
+  }
+  return { model, effort: resolveEffort(model, agentModel.reasoningEffort) };
 }

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -1,4 +1,6 @@
+import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
 import type {
   ModelConfigurationType,
@@ -77,9 +79,19 @@ export interface ProviderGroup {
   models: { model: ModelConfigurationType; efforts: ReasoningEffort[] }[];
 }
 
-export type Selection =
+// A selection the user can actively make in the picker: either "Auto" or a
+// concrete model + effort.
+export type UserModelSelection =
   | { kind: "auto" }
   | { kind: "model"; model: ModelConfigurationType; effort: ReasoningEffort };
+
+// What the picker shows. On top of the user-pickable options, the derived
+// default can be the addressed agent's own configured model ("agent"): it
+// renders like a concrete model but is sent as *no* override, so the agent runs
+// its configured model and the resolution stays attributed to the agent.
+export type Selection =
+  | UserModelSelection
+  | { kind: "agent"; model: ModelConfigurationType; effort: ReasoningEffort };
 
 // The list body is a small state machine: hidden while Auto is on, then a
 // loading / empty / search-results / browse view depending on the models
@@ -125,12 +137,25 @@ export function getModelWithReasoningEffortLabel(selection: Selection): string {
   return `${model.displayName} ${capitalize(effort)}`;
 }
 
-// Converts the picker's local selection into the API model selection
+// Converts the picker's shown selection into the API model selection sent with
+// the message. See `Selection` above for why each kind maps the way it does.
 export function toModelSelection(
   selection: Selection
 ): ModelSelectionType | undefined {
   switch (selection.kind) {
     case "auto":
+      // Explicit auto override, so the backend routes through the auto model
+      // even when the addressed agent's own configured model is not auto.
+      // "none" is the auto model's only supported effort and keeps the value
+      // round-trippable (so a reload re-derives "Auto" from the stored request).
+      return {
+        providerId: AUTO_MODEL_ID,
+        modelId: AUTO_MODEL_ID,
+        reasoningEffort: "none",
+      };
+    case "agent":
+      // The picker shows the agent's own configured model as its default: send
+      // no override so the agent runs its configured model.
       return undefined;
     case "model":
       return {
@@ -142,4 +167,80 @@ export function toModelSelection(
       assertNeverAndIgnore(selection);
       return undefined;
   }
+}
+
+// Reasoning effort for a resolved model: honor the requested effort when the
+// model supports it, otherwise the model's default (or its first selectable
+// effort). Effort is never defaulted independently of the model.
+function resolveEffort(
+  model: ModelConfigurationType,
+  requested: ReasoningEffort | undefined
+): ReasoningEffort {
+  const selectable = getSelectableReasoningEfforts(model);
+  if (requested && selectable.includes(requested)) {
+    return requested;
+  }
+  if (selectable.includes(model.defaultReasoningEffort)) {
+    return model.defaultReasoningEffort;
+  }
+  return selectable[0] ?? model.defaultReasoningEffort;
+}
+
+function findAvailableModel(
+  models: ModelConfigurationType[],
+  selection: { providerId: string; modelId: string }
+): ModelConfigurationType | undefined {
+  return models.find(
+    (m) =>
+      m.providerId === selection.providerId && m.modelId === selection.modelId
+  );
+}
+
+// The picker's default selection when the user hasn't picked anything: the
+// model the current user's previous message ran on, falling back to the
+// addressed agent's configured model, falling back to "Auto". Purely derived
+// from its inputs — it recomputes as the agent, the last message, and the model
+// list load in, with no ordering dependency or seeding step.
+export function resolveDefaultSelection({
+  agentModel,
+  lastRequestedModel,
+  models,
+}: {
+  agentModel: AgentModelConfigurationType | null;
+  lastRequestedModel: ModelSelectionType | null;
+  models: ModelConfigurationType[];
+}): Selection {
+  // 1. Keep the model the current user's previous message ran on, if any.
+  if (lastRequestedModel) {
+    if (lastRequestedModel.modelId === AUTO_MODEL_ID) {
+      return { kind: "auto" };
+    }
+    const model = findAvailableModel(models, lastRequestedModel);
+    if (model) {
+      return {
+        kind: "model",
+        model,
+        effort: resolveEffort(model, lastRequestedModel.reasoningEffort),
+      };
+    }
+    // Last model no longer available (removed / BYOK revoked / still loading):
+    // fall back to the agent's default below.
+  }
+
+  // 2. No usable previous model: use the addressed agent's configured model.
+  //    An auto (or not-yet-resolved) agent shows "Auto".
+  if (!agentModel || agentModel.modelId === AUTO_MODEL_ID) {
+    return { kind: "auto" };
+  }
+  const model = findAvailableModel(models, agentModel);
+  if (!model) {
+    // Agent's model not (yet) available (e.g. models still loading): show Auto
+    // until it resolves.
+    return { kind: "auto" };
+  }
+  return {
+    kind: "agent",
+    model,
+    effort: resolveEffort(model, agentModel.reasoningEffort),
+  };
 }

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -126,16 +126,21 @@ export function getModelWithReasoningEffortKey(
 }
 
 export function getModelWithReasoningEffortLabel(selection: Selection): string {
-  if (selection.kind === "auto") {
-    return "Auto";
+  switch (selection.kind) {
+    case "auto":
+      return "Auto";
+    case "agent":
+      return "Default";
+    case "model": {
+      const { model, effort } = selection;
+      return effort === "none"
+        ? model.displayName
+        : `${model.displayName} ${capitalize(effort)}`;
+    }
+    default:
+      assertNeverAndIgnore(selection);
+      return "";
   }
-  const { model, effort } = selection;
-
-  if (effort === "none") {
-    return model.displayName;
-  }
-
-  return `${model.displayName} ${capitalize(effort)}`;
 }
 
 // Converts the picker's shown selection into the API model selection sent with

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -250,20 +250,3 @@ export function resolveDefaultSelection({
     effort: resolveEffort(model, agentModel.reasoningEffort),
   };
 }
-
-export function resolveAgentDefaultModel({
-  agentModel,
-  models,
-}: {
-  agentModel: AgentModelConfigurationType | null;
-  models: ModelConfigurationType[];
-}): ModelWithReasoningEffort | null {
-  if (!agentModel || agentModel.modelId === AUTO_MODEL_ID) {
-    return null;
-  }
-  const model = findAvailableModel(models, agentModel);
-  if (!model) {
-    return null;
-  }
-  return { model, effort: resolveEffort(model, agentModel.reasoningEffort) };
-}

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -79,16 +79,10 @@ export interface ProviderGroup {
   models: { model: ModelConfigurationType; efforts: ReasoningEffort[] }[];
 }
 
-// A selection the user can actively make in the picker: either "Auto" or a
-// concrete model + effort.
 export type UserModelSelection =
   | { kind: "auto" }
   | { kind: "model"; model: ModelConfigurationType; effort: ReasoningEffort };
 
-// What the picker shows. On top of the user-pickable options, the derived
-// default can be the addressed agent's own configured model ("agent"): it
-// renders like a concrete model but is sent as *no* override, so the agent runs
-// its configured model and the resolution stays attributed to the agent.
 export type Selection =
   | UserModelSelection
   | { kind: "agent"; model: ModelConfigurationType; effort: ReasoningEffort };
@@ -143,25 +137,18 @@ export function getModelWithReasoningEffortLabel(selection: Selection): string {
   }
 }
 
-// Converts the picker's shown selection into the API model selection sent with
-// the message. See `Selection` above for why each kind maps the way it does.
 export function toModelSelection(
   selection: Selection
 ): ModelSelectionType | undefined {
   switch (selection.kind) {
     case "auto":
-      // Explicit auto override, so the backend routes through the auto model
-      // even when the addressed agent's own configured model is not auto.
-      // "none" is the auto model's only supported effort and keeps the value
-      // round-trippable (so a reload re-derives "Auto" from the stored request).
       return {
         providerId: AUTO_MODEL_ID,
         modelId: AUTO_MODEL_ID,
         reasoningEffort: "none",
       };
     case "agent":
-      // The picker shows the agent's own configured model as its default: send
-      // no override so the agent runs its configured model.
+      // No override, use the agent model.
       return undefined;
     case "model":
       return {
@@ -175,23 +162,6 @@ export function toModelSelection(
   }
 }
 
-// Reasoning effort for a resolved model: honor the requested effort when the
-// model supports it, otherwise the model's default (or its first selectable
-// effort). Effort is never defaulted independently of the model.
-function resolveEffort(
-  model: ModelConfigurationType,
-  requested: ReasoningEffort | undefined
-): ReasoningEffort {
-  const selectable = getSelectableReasoningEfforts(model);
-  if (requested && selectable.includes(requested)) {
-    return requested;
-  }
-  if (selectable.includes(model.defaultReasoningEffort)) {
-    return model.defaultReasoningEffort;
-  }
-  return selectable[0] ?? model.defaultReasoningEffort;
-}
-
 function findAvailableModel(
   models: ModelConfigurationType[],
   selection: { providerId: string; modelId: string }
@@ -202,11 +172,6 @@ function findAvailableModel(
   );
 }
 
-// The picker's default selection when the user hasn't picked anything: the
-// model the current user's previous message ran on, falling back to the
-// addressed agent's configured model, falling back to "Auto". Purely derived
-// from its inputs — it recomputes as the agent, the last message, and the model
-// list load in, with no ordering dependency or seeding step.
 export function resolveDefaultSelection({
   agentModel,
   lastRequestedModel,
@@ -216,7 +181,6 @@ export function resolveDefaultSelection({
   lastRequestedModel: ModelSelectionType | null;
   models: ModelConfigurationType[];
 }): Selection {
-  // 1. Keep the model the current user's previous message ran on, if any.
   if (lastRequestedModel) {
     if (lastRequestedModel.modelId === AUTO_MODEL_ID) {
       return { kind: "auto" };
@@ -226,27 +190,22 @@ export function resolveDefaultSelection({
       return {
         kind: "model",
         model,
-        effort: resolveEffort(model, lastRequestedModel.reasoningEffort),
+        effort:
+          lastRequestedModel.reasoningEffort ?? model.defaultReasoningEffort,
       };
     }
-    // Last model no longer available (removed / BYOK revoked / still loading):
-    // fall back to the agent's default below.
   }
 
-  // 2. No usable previous model: use the addressed agent's configured model.
-  //    An auto (or not-yet-resolved) agent shows "Auto".
   if (!agentModel || agentModel.modelId === AUTO_MODEL_ID) {
     return { kind: "auto" };
   }
   const model = findAvailableModel(models, agentModel);
   if (!model) {
-    // Agent's model not (yet) available (e.g. models still loading): show Auto
-    // until it resolves.
     return { kind: "auto" };
   }
   return {
     kind: "agent",
     model,
-    effort: resolveEffort(model, agentModel.reasoningEffort),
+    effort: agentModel.reasoningEffort ?? model.defaultReasoningEffort,
   };
 }

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -176,6 +176,8 @@ export function createPlaceholderAgentMessage({
     citations: {},
     generatedFiles: [],
     activitySteps: [],
+    resolvedModel: null,
+    modelResolutionMethod: null,
     actions: [],
     richMentions: [],
     completionDurationMs: null,

--- a/front/components/providers/DustAvatarIcon.tsx
+++ b/front/components/providers/DustAvatarIcon.tsx
@@ -1,0 +1,18 @@
+import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
+import { cn } from "@dust-tt/sparkle";
+
+interface DustAvatarIconProps {
+  className?: string;
+}
+
+// Renders the @dust agent's avatar as an icon so the "auto" model shows the same
+// visual as the Dust agent rather than the generic Dust logo.
+export function DustAvatarIcon({ className }: DustAvatarIconProps) {
+  return (
+    <img
+      src={DUST_AVATAR_URL}
+      alt=""
+      className={cn("rounded-full object-cover", className)}
+    />
+  );
+}

--- a/front/components/providers/types.ts
+++ b/front/components/providers/types.ts
@@ -1,5 +1,6 @@
 export { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
 
+import { DustAvatarIcon } from "@app/components/providers/DustAvatarIcon";
 import type { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import {
   AnthropicLogo,
@@ -49,7 +50,7 @@ const MODEL_PROVIDER_LOGOS: ModelProviderLogos = {
     light: DustLogo,
   },
   auto: {
-    light: DustLogo,
+    light: DustAvatarIcon,
   },
 };
 

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -119,6 +119,8 @@ function makeLightAgentMessage(
     citations: {},
     generatedFiles: [],
     activitySteps: [],
+    resolvedModel: null,
+    modelResolutionMethod: null,
     ...overrides,
   };
 }

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -633,6 +633,7 @@ describe("tryCallMCPTool", () => {
       richMentions: [],
       costCredits: null,
       resolvedModel: null,
+      modelResolutionMethod: null,
     };
     const userMessage: UserMessageType = {
       id: -1,

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -200,5 +200,7 @@ export function getLightAgentMessageFromAgentMessage(
     costCredits: agentMessage.costCredits,
     subAgentCostCredits: agentMessage.subAgentCostCredits,
     activitySteps: [],
+    resolvedModel: agentMessage.resolvedModel,
+    modelResolutionMethod: agentMessage.modelResolutionMethod,
   };
 }

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -587,6 +587,7 @@ export const createAgentMessages = async (
             reactions: [],
             costCredits: null,
             resolvedModel: resolvedModelFromAgentMessageRow(agentMessageRow),
+            modelResolutionMethod: agentMessageRow.modelResolutionMethod,
           };
         }
       }

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -309,6 +309,7 @@ The following skills are available for use with the skill_management__enable_ski
       reactions: [],
       costCredits: null,
       resolvedModel: null,
+      modelResolutionMethod: null,
     } satisfies AgentMessageType;
 
     const steps = await getSteps(authenticator, {
@@ -440,6 +441,7 @@ describe("vision image rendering in getSteps", () => {
       reactions: [],
       costCredits: null,
       resolvedModel: null,
+      modelResolutionMethod: null,
     };
 
     return { auth: authenticator, message, model, workspaceId, conversationId };

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -140,6 +140,7 @@ describe("renderAllMessages", () => {
             reactions: [],
             costCredits: null,
             resolvedModel: null,
+            modelResolutionMethod: null,
           } satisfies AgentMessageType,
         ];
       }

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -36,6 +36,7 @@ import {
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import {
   getMinimumReasoningEffort,
@@ -360,6 +361,7 @@ function getModelConfig(
   reasoningEffort: ReasoningEffort;
 } | null {
   const candidates = [
+    AUTO_MODEL_CONFIG,
     CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
     GPT_5_5_MODEL_CONFIG,
   ];

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -48,6 +48,7 @@ import {
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import {
   FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG,
@@ -462,13 +463,13 @@ export function _getDustGlobalAgent(
   auth: Authenticator,
   args: DustLikeGlobalAgentArgs
 ): AgentConfigurationType | null {
+  // Default @dust to the "auto" model so Dust picks the best model per message.
+  // When "auto" isn't available for the workspace (no models_picker), the builder
+  // falls back to a whitelisted model.
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST,
     name: "dust",
-    preferredModelConfiguration: args.preferGpt55DefaultModel
-      ? GPT_5_5_MODEL_CONFIG
-      : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-    preferredReasoningEffort: "medium",
+    preferredModelConfiguration: AUTO_MODEL_CONFIG,
   });
 }
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -469,7 +469,10 @@ export function _getDustGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST,
     name: "dust",
-    preferredModelConfiguration: AUTO_MODEL_CONFIG,
+    preferredModelConfiguration: args.preferGpt55DefaultModel
+      ? GPT_5_5_MODEL_CONFIG
+      : AUTO_MODEL_CONFIG,
+    preferredReasoningEffort: "medium",
   });
 }
 

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -829,6 +829,7 @@ async function renderSingleAgentMessage(
     // batchRenderAgentMessages), so it is `null` for bulk conversation rendering.
     subAgentCostCredits,
     resolvedModel: resolvedModelFromAgentMessageRow(agentMessage),
+    modelResolutionMethod: agentMessage.modelResolutionMethod,
   } satisfies AgentMessageType;
 
   if (viewType === "full") {

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -2,12 +2,12 @@ import { getAutoModelForAuth } from "@app/lib/advanced_models/enabled_models";
 import { PREFERRED_LARGE_MODEL_CONFIGS } from "@app/lib/api/assistant/model_preferences";
 import { selectEnabledModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
-import type { ModelResolutionMethodType } from "@app/lib/models/agent/conversation";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import type {
   ModelConfigurationType,
+  ModelResolutionMethodType,
   ModelSelectionType,
   ReasoningEffort,
   ResolvedRequestedModel,

--- a/front/lib/llms/model_configurations.ts
+++ b/front/lib/llms/model_configurations.ts
@@ -2,8 +2,10 @@ import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import type {
   ModelConfigurationType,
+  ResolvedRequestedModel,
   SupportedModel,
 } from "@app/types/assistant/models/types";
+import capitalize from "lodash/capitalize";
 
 /**
  * Lazy-loaded cache for model configurations.
@@ -45,6 +47,24 @@ export function getSupportedModelConfig(
   );
 
   return config ?? null;
+}
+
+/**
+ * Human-readable label for a resolved model triplet (e.g. "GPT-5.5 Light"),
+ * matching the input-bar picker's labels. Returns null when the model is not
+ * known to this client build.
+ */
+export function getResolvedModelLabel(
+  resolvedModel: ResolvedRequestedModel
+): string | null {
+  const config = getSupportedModelConfig(resolvedModel);
+  if (!config) {
+    return null;
+  }
+  if (resolvedModel.reasoningEffort === "none") {
+    return config.displayName;
+  }
+  return `${config.displayName} ${capitalize(resolvedModel.reasoningEffort)}`;
 }
 
 /**

--- a/front/lib/llms/model_configurations.ts
+++ b/front/lib/llms/model_configurations.ts
@@ -2,10 +2,8 @@ import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import type {
   ModelConfigurationType,
-  ResolvedRequestedModel,
   SupportedModel,
 } from "@app/types/assistant/models/types";
-import capitalize from "lodash/capitalize";
 
 /**
  * Lazy-loaded cache for model configurations.
@@ -47,24 +45,6 @@ export function getSupportedModelConfig(
   );
 
   return config ?? null;
-}
-
-/**
- * Human-readable label for a resolved model triplet (e.g. "GPT-5.5 Light"),
- * matching the input-bar picker's labels. Returns null when the model is not
- * known to this client build.
- */
-export function getResolvedModelLabel(
-  resolvedModel: ResolvedRequestedModel
-): string | null {
-  const config = getSupportedModelConfig(resolvedModel);
-  if (!config) {
-    return null;
-  }
-  if (resolvedModel.reasoningEffort === "none") {
-    return config.displayName;
-  }
-  return `${config.displayName} ${capitalize(resolvedModel.reasoningEffort)}`;
 }
 
 /**

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -25,6 +25,8 @@ import type {
   ParticipantActionType,
   UserMessageOrigin,
 } from "@app/types/assistant/conversation";
+import type { ModelResolutionMethodType } from "@app/types/assistant/models/types";
+import { MODEL_RESOLUTION_METHODS } from "@app/types/assistant/models/types";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 
 export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
@@ -453,11 +455,6 @@ UserMessageModel.belongsTo(KeyModel, {
   foreignKey: { name: "userContextApiKeyId", allowNull: true },
   onDelete: "RESTRICT",
 });
-
-const MODEL_RESOLUTION_METHODS = ["agent", "user", "auto"] as const;
-
-export type ModelResolutionMethodType =
-  (typeof MODEL_RESOLUTION_METHODS)[number];
 
 export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -145,6 +145,7 @@ makeScript(
       reactions: [],
       costCredits: null,
       resolvedModel: null,
+      modelResolutionMethod: null,
     };
 
     const { serverToolsAndInstructions, error: mcpToolsListingError } =

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -620,6 +620,7 @@ export async function notifyWorkflowError(
     reactions: [],
     costCredits: null,
     resolvedModel: resolvedModelFromAgentMessageRow(messageRow.agentMessage),
+    modelResolutionMethod: messageRow.agentMessage.modelResolutionMethod,
 
     // HACKY: These last 3 fields are not used in the workflow error case but required in the type.
     configuration: null as unknown as LightAgentConfigurationType,

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -411,6 +411,7 @@ export class ConversationFactory {
       richMentions: [],
       costCredits: null,
       resolvedModel: null,
+      modelResolutionMethod: null,
     };
 
     if (!mcpAction) {

--- a/front/tests/utils/conversation_test_factories.ts
+++ b/front/tests/utils/conversation_test_factories.ts
@@ -126,6 +126,8 @@ export function mockAgentMessage(
     citations: {},
     generatedFiles: [],
     activitySteps: [],
+    resolvedModel: null,
+    modelResolutionMethod: null,
     actions: (params.actions ?? []).map(mockAction),
     feedback: (params.feedback ?? []).map((f) => ({
       thumbDirection: f.direction,

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -18,6 +18,7 @@ import type {
 } from "./agent";
 import type { MentionType, RichMention } from "./mentions";
 import type {
+  ModelResolutionMethodType,
   ModelSelectionType,
   ResolvedRequestedModel,
 } from "./models/types";
@@ -370,6 +371,10 @@ export type AgentMessageType = BaseAgentMessageType & {
   modelInteractionDurationMs: number | null;
   // Model's triplet used to generate the message. Legacy: null, the agent ran its own configured model.
   resolvedModel: ResolvedRequestedModel | null;
+  // How `resolvedModel` was chosen: "agent" (agent's configured model), "user"
+  // (per-message model picked from the input-bar picker), or "auto" (routed
+  // through the auto model). Legacy: null.
+  modelResolutionMethod: ModelResolutionMethodType | null;
 };
 
 export type AgentMessageTypeWithoutMentions = Omit<
@@ -391,6 +396,10 @@ export type LightAgentMessageType = BaseAgentMessageType & {
   citations: Record<string, CitationType>;
   generatedFiles: Omit<ActionGeneratedFileType, "snippet">[];
   activitySteps: InlineActivityStep[];
+  // Model's triplet used to generate the message, and how it was chosen. Used to
+  // label messages that ran on a per-message picker override. Legacy: null.
+  resolvedModel: ResolvedRequestedModel | null;
+  modelResolutionMethod: ModelResolutionMethodType | null;
 };
 
 // This type represents the agent message we can reconstruct by accumulating streaming events

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -5,7 +5,7 @@ export const AUTO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: AUTO_MODEL_ID,
   modelId: AUTO_MODEL_ID,
   displayName: "Auto: Dust handles model selection",
-  description: "Let's Dust select the best model for the task.",
+  description: "Let Dust select the best model for the task.",
   shortDescription: "Select the best model for the task.",
 
   // Everything below is just some value to make it compatible with the ModelConfigurationType.
@@ -20,9 +20,9 @@ export const AUTO_MODEL_CONFIG: ModelConfigurationType = {
   supportsVision: false,
   supportedReasoningEfforts: {
     none: true,
-    light: false,
-    medium: false,
-    high: false,
+    light: true,
+    medium: true,
+    high: true,
   },
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -4,7 +4,7 @@ export const AUTO_MODEL_ID = "auto" as const;
 export const AUTO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: AUTO_MODEL_ID,
   modelId: AUTO_MODEL_ID,
-  displayName: "Auto",
+  displayName: "Auto: Dust handles model selection",
   description: "Let's Dust select the best model for the task.",
   shortDescription: "Select the best model for the task.",
 

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -36,6 +36,13 @@ export type ResolvedRequestedModel = {
   reasoningEffort: ReasoningEffort;
 };
 
+// How an agent message's model was resolved: "agent" (ran the agent's own
+// configured model, no override), "user" (ran a per-message model picked from
+// the input-bar picker), or "auto" (resolved through the auto model).
+export const MODEL_RESOLUTION_METHODS = ["agent", "user", "auto"] as const;
+export type ModelResolutionMethodType =
+  (typeof MODEL_RESOLUTION_METHODS)[number];
+
 // z.object (not z.record) so every reasoning effort key is required.
 const ReasoningEffortSupportSchema = z.object({
   none: z.boolean(),


### PR DESCRIPTION
## Description

Makes the `auto` model the default for @dust, refreshes the auto branding, and reworks the input-bar model picker around the agent's configured default.

- **@dust defaults to `auto`**: `_getDustGlobalAgent` now uses `AUTO_MODEL_CONFIG` as its preferred model, so Dust picks the best model per message. When `auto` isn't available for the workspace (no `models_picker`), the builder falls back to a whitelisted model as before. `deep-dive` also adds `AUTO_MODEL_CONFIG` to its candidate list.
- **Auto branding**: the `auto` model now renders the @dust agent avatar (`DUST_AVATAR_URL`) via a small `DustAvatarIcon` component instead of the generic Dust logo, its display name becomes `Auto: Dust handles model selection`, the tooltip is trimmed, and `light`/`medium`/`high` reasoning efforts are enabled.
- **Model picker rework**: the picker now derives what it shows from `resolveDefaultSelection` (agent's configured model + the last requested model in the conversation) rather than always starting on Auto. A manual user override is tracked separately and cleared when switching agents. A new "Default from agent" section surfaces the agent's configured model (and drops it from Suggested to avoid duplication).
- **Per-message model surfacing**: adds `modelResolutionMethod` (`"agent" | "user" | "auto"`) alongside `resolvedModel` on agent messages, plumbed through the types, the Sequelize model, message rendering, and the private Swagger schema. Agent messages now show a `with <model>` label when a per-message model was picked from the input bar.

## Tests

Typecheck passes; `global_agents`, `models`, and `enabled_models` suites pass, along with the message-rendering and stream-hook tests updated for the new field.

The picker UI, the per-message `with <model>` label, and the auto-avatar branding were not exercised end-to-end (require the `models_picker` flag and a live workspace) — worth a manual pass on a flagged workspace.
