### PR TITLE
feat(activation): agent_templates MCP server + action_card directive + quick reply improvements

### DIFF
--- a/front/components/assistant/AgentMessageMarkdown.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.tsx
@@ -14,7 +14,6 @@ import {
   preprocessInstructionBlocks,
 } from "@app/components/markdown/InstructionBlock";
 import { quickReplyDirective } from "@app/components/markdown/QuickReplyBlock";
-import { actionCardDirective } from "@app/components/markdown/ActionCardDirective";
 import {
   getTaskDirectiveBlock,
   taskDirective,

--- a/front/components/assistant/AgentMessageMarkdown.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.tsx
@@ -14,6 +14,7 @@ import {
   preprocessInstructionBlocks,
 } from "@app/components/markdown/InstructionBlock";
 import { quickReplyDirective } from "@app/components/markdown/QuickReplyBlock";
+import { actionCardDirective } from "@app/components/markdown/ActionCardDirective";
 import {
   getTaskDirectiveBlock,
   taskDirective,

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -24,9 +24,7 @@ import {
   useConversationContextUsage,
 } from "@app/hooks/conversations";
 import { CONTEXT_USAGE_PERCENT_THRESHOLDS } from "@app/hooks/conversations/useConversationContextUsage";
-import {
-  useAccessibleAgentIds,
-} from "@app/lib/swr/assistants";
+import { useAccessibleAgentIds } from "@app/lib/swr/assistants";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
 import { classNames } from "@app/lib/utils";

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -24,7 +24,9 @@ import {
   useConversationContextUsage,
 } from "@app/hooks/conversations";
 import { CONTEXT_USAGE_PERCENT_THRESHOLDS } from "@app/hooks/conversations/useConversationContextUsage";
-import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
+import {
+  useAccessibleAgentIds,
+} from "@app/lib/swr/assistants";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
 import { classNames } from "@app/lib/utils";
@@ -77,13 +79,9 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
   const agentBuilderContext = context.agentBuilderContext;
 
   const isMobile = useIsMobile();
-  const { agentConfigurations } = useUnifiedAgentConfigurations({
+  const accessibleAgentIds = useAccessibleAgentIds({
     workspaceId: context.owner.sId,
   });
-  const accessibleAgentIds = useMemo(
-    () => new Set(agentConfigurations.map((a) => a.sId)),
-    [agentConfigurations]
-  );
   const methods = useVirtuosoMethods<VirtuosoMessage>();
   const { bottomOffset, listOffset, visibleListHeight } = useVirtuosoLocation();
   const {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -66,6 +66,8 @@ import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
 import { getFilePreviewDirectivePaths } from "@app/lib/markdown/file_preview";
+import { extractFromString } from "@app/lib/mentions/format";
+import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import datadogLogger from "@app/logger/datadogLogger";
@@ -79,6 +81,10 @@ import { isLightAgentMessageType } from "@app/types/assistant/conversation";
 import type {
   RichAgentMention,
   RichMention,
+} from "@app/types/assistant/mentions";
+import {
+  isAgentMention,
+  toRichAgentMentionType,
 } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import {
@@ -316,6 +322,10 @@ export function AgentMessage({
     VirtuosoMessage,
     VirtuosoMessageListContext
   >();
+
+  const { agentConfigurations } = useUnifiedAgentConfigurations({
+    workspaceId: owner.sId,
+  });
 
   const isTriggeredByCurrentUser = useMemo(
     () => triggeringUser?.sId === user.sId,
@@ -952,13 +962,25 @@ export function AgentMessage({
 
   const handleQuickReply = useCallback(
     async (reply: string) => {
-      const mention: RichAgentMention = {
-        id: agentMessage.configuration.sId,
-        type: "agent",
-        label: agentMessage.configuration.name,
-        pictureUrl: agentMessage.configuration.pictureUrl ?? "",
-        description: "",
-      };
+      const parsedMention = extractFromString(reply).find(isAgentMention);
+      const matchedAgent = parsedMention
+        ? agentConfigurations.find(
+            (a) => a.sId === parsedMention.configurationId
+          )
+        : undefined;
+      const currentAgent = agentConfigurations.find(
+        (a) => a.sId === agentMessage.configuration.sId
+      );
+      const resolvedConfig = matchedAgent ?? currentAgent;
+      const mention: RichAgentMention = resolvedConfig
+        ? toRichAgentMentionType(resolvedConfig)
+        : {
+            id: agentMessage.configuration.sId,
+            type: "agent",
+            label: agentMessage.configuration.name,
+            pictureUrl: agentMessage.configuration.pictureUrl,
+            description: "",
+          };
 
       const result = await handleSubmit(reply, [mention], {
         uploaded: [],
@@ -973,7 +995,12 @@ export function AgentMessage({
         });
       }
     },
-    [agentMessage.configuration, handleSubmit, sendNotification]
+    [
+      agentConfigurations,
+      agentMessage.configuration,
+      handleSubmit,
+      sendNotification,
+    ]
   );
 
   const canMention =

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -71,10 +71,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
-    "get_agent_template": {
-      "freeUsage": true,
-      "toolCostCategory": "basic",
-    },
     "get_available_agents": {
       "freeUsage": true,
       "toolCostCategory": "basic",
@@ -107,10 +103,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
-    "search_agent_templates": {
-      "freeUsage": true,
-      "toolCostCategory": "basic",
-    },
     "search_knowledge": {
       "freeUsage": true,
       "toolCostCategory": "basic",
@@ -140,6 +132,16 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "toolCostCategory": "basic",
     },
     "update_suggestions_state": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
+  "agent_templates": {
+    "get_agent_template": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "search_agent_templates": {
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
@@ -2532,7 +2534,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "describe_skill": "never_ask",
     "get_agent_feedback": "never_ask",
     "get_agent_insights": "never_ask",
-    "get_agent_template": "never_ask",
     "get_available_agents": "never_ask",
     "get_available_models": "never_ask",
     "get_available_skills": "never_ask",
@@ -2541,7 +2542,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "inspect_conversation": "never_ask",
     "inspect_message": "never_ask",
     "list_suggestions": "never_ask",
-    "search_agent_templates": "never_ask",
     "search_knowledge": "never_ask",
     "suggest_knowledge": "never_ask",
     "suggest_model": "never_ask",
@@ -2550,6 +2550,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "suggest_sub_agent": "never_ask",
     "suggest_tools": "never_ask",
     "update_suggestions_state": "never_ask",
+  },
+  "agent_templates": {
+    "get_agent_template": "never_ask",
+    "search_agent_templates": "never_ask",
   },
   "ashby": {
     "create_candidate_note": "high",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -12,6 +12,7 @@ import {
 } from "@app/lib/api/actions/servers/agent_router/metadata";
 import { AGENT_SIDEKICK_AGENT_STATE_SERVER } from "@app/lib/api/actions/servers/agent_sidekick_agent_state/metadata";
 import { AGENT_SIDEKICK_CONTEXT_SERVER } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
+import { AGENT_TEMPLATES_SERVER } from "@app/lib/api/actions/servers/agent_templates/metadata";
 import { ASHBY_SERVER } from "@app/lib/api/actions/servers/ashby/metadata";
 import { ASK_USER_QUESTION_SERVER } from "@app/lib/api/actions/servers/ask_user_question/metadata";
 import { CLARI_COPILOT_SERVER } from "@app/lib/api/actions/servers/clari_copilot/metadata";
@@ -156,6 +157,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "user_analytics",
   "agent_sidekick_agent_state",
   "agent_sidekick_context",
+  "agent_templates",
   "agent_memory",
   "agent_router",
   ASHBY_SERVER_NAME,
@@ -1217,6 +1219,17 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: ACTIVATION_RECOMMENDATIONS_SERVER,
+  },
+  agent_templates: {
+    id: 1041,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isPreview: false,
+    isRestricted: undefined,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: AGENT_TEMPLATES_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -35,7 +35,8 @@
     { "name": "workspace_analytics", "id": 1035 },
     { "name": "sandbox_functions", "id": 1037 },
     { "name": "user_analytics", "id": 1039 },
-    { "name": "activation_recommendations", "id": 1040 }
+    { "name": "activation_recommendations", "id": 1040 },
+    { "name": "agent_templates", "id": 1041 }
   ],
   "manual": [
     { "name": "github", "id": 1 },

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -10,6 +10,7 @@ import { default as agentMemoryServer } from "@app/lib/api/actions/servers/agent
 import { default as agentRouterServer } from "@app/lib/api/actions/servers/agent_router";
 import { default as agentSidekickAgentStateServer } from "@app/lib/api/actions/servers/agent_sidekick_agent_state";
 import { default as agentSidekickContextServer } from "@app/lib/api/actions/servers/agent_sidekick_context";
+import { default as agentTemplatesServer } from "@app/lib/api/actions/servers/agent_templates";
 import { default as ashbyServer } from "@app/lib/api/actions/servers/ashby";
 import { default as askUserQuestionServer } from "@app/lib/api/actions/servers/ask_user_question";
 import { default as clariCopilotServer } from "@app/lib/api/actions/servers/clari_copilot";
@@ -227,6 +228,8 @@ export async function getInternalMCPServer(
       return agentSidekickAgentStateServer(auth, toolContext);
     case "agent_sidekick_context":
       return agentSidekickContextServer(auth, toolContext);
+    case "agent_templates":
+      return agentTemplatesServer(auth, toolContext);
     case "exa_people_and_company":
       return exaServer(auth, toolContext);
     case "fathom":

--- a/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
@@ -1,6 +1,5 @@
 import { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { getSuggestedTemplatesForQuery } from "@app/lib/api/assistant/template_suggestion";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
@@ -18,7 +17,6 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { TemplateFactory } from "@app/tests/utils/TemplateFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
@@ -40,11 +38,6 @@ vi.mock("@app/lib/api/assistant/feedback", () => ({
   getAgentFeedbacks: vi.fn(),
 }));
 
-// Mock template suggestion for query-based search.
-vi.mock("@app/lib/api/assistant/template_suggestion", () => ({
-  getSuggestedTemplatesForQuery: vi.fn(),
-}));
-
 // Mock the helper that extracts agent configuration ID from context.
 vi.mock("@app/lib/api/actions/servers/agent_sidekick_helpers", () => ({
   getAgentConfigurationIdFromContext: vi.fn(),
@@ -53,17 +46,14 @@ vi.mock("@app/lib/api/actions/servers/agent_sidekick_helpers", () => ({
 // Reset only file-local mocks between tests.
 // Avoid vi.resetAllMocks() as it resets global mocks like the Redis mock from vite.setup.ts.
 beforeEach(async () => {
-  const [overview, feedback, templateSuggestion, sidekickHelpers] =
-    await Promise.all([
-      import("@app/lib/api/assistant/observability/overview"),
-      import("@app/lib/api/assistant/feedback"),
-      import("@app/lib/api/assistant/template_suggestion"),
-      import("@app/lib/api/actions/servers/agent_sidekick_helpers"),
-    ]);
+  const [overview, feedback, sidekickHelpers] = await Promise.all([
+    import("@app/lib/api/assistant/observability/overview"),
+    import("@app/lib/api/assistant/feedback"),
+    import("@app/lib/api/actions/servers/agent_sidekick_helpers"),
+  ]);
 
   vi.mocked(overview.fetchAgentOverview).mockReset();
   vi.mocked(feedback.getAgentFeedbacks).mockReset();
-  vi.mocked(templateSuggestion.getSuggestedTemplatesForQuery).mockReset();
   vi.mocked(sidekickHelpers.getAgentConfigurationIdFromContext).mockReset();
 });
 
@@ -2050,266 +2040,6 @@ describe("agent_sidekick_context tools", () => {
     });
   });
 
-  describe("search_agent_templates", () => {
-    it("returns at most 10 published templates when no jobType", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
-
-      // Create 12 published templates.
-      for (let i = 0; i < 12; i++) {
-        await TemplateFactory.published();
-      }
-      // Draft should not appear.
-      await TemplateFactory.draft();
-
-      const tool = getToolByName("search_agent_templates");
-      const result = await tool.handler({}, createTestExtra(authenticator));
-
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        const content = result.value[0];
-        expect(content.type).toBe("text");
-        if (content.type === "text") {
-          expect(content.text).toMatch(/Found 10 template\(s\):/);
-          expect((content.text.match(/## Template/g) ?? []).length).toBe(10);
-        }
-      }
-    });
-
-    it("filters templates by jobType tags", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
-
-      const salesTemplate = await TemplateFactory.published();
-      await salesTemplate.updateAttributes({ tags: ["SALES"] });
-
-      const engineeringTemplate = await TemplateFactory.published();
-      await engineeringTemplate.updateAttributes({ tags: ["ENGINEERING"] });
-
-      const tool = getToolByName("search_agent_templates");
-      const result = await tool.handler(
-        { jobType: "sales" },
-        createTestExtra(authenticator)
-      );
-
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        const content = result.value[0];
-        expect(content.type).toBe("text");
-        if (content.type === "text") {
-          expect(content.text).toContain(`sId: ${salesTemplate.sId}`);
-          expect(content.text).not.toContain(engineeringTemplate.sId);
-        }
-      }
-    });
-
-    it("returns at most 10 templates for unknown jobType", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
-
-      // Create 12 published templates.
-      for (let i = 0; i < 12; i++) {
-        await TemplateFactory.published();
-      }
-
-      const tool = getToolByName("search_agent_templates");
-      const result = await tool.handler(
-        { jobType: "unknown_type" },
-        createTestExtra(authenticator)
-      );
-
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        const content = result.value[0];
-        expect(content.type).toBe("text");
-        if (content.type === "text") {
-          // Unknown jobType -> empty matchingTags -> limited to 10.
-          expect(content.text).toMatch(/Found 10 template\(s\):/);
-        }
-      }
-    });
-
-    it("returns expected fields per template", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
-
-      const template = await TemplateFactory.published();
-      await template.updateAttributes({
-        tags: ["SALES"],
-        sidekickInstructions: "Test sidekick instructions",
-      });
-
-      const tool = getToolByName("search_agent_templates");
-      const result = await tool.handler(
-        { jobType: "sales" },
-        createTestExtra(authenticator)
-      );
-
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        const content = result.value[0];
-        expect(content.type).toBe("text");
-        if (content.type === "text") {
-          expect(content.text).toContain(`sId: ${template.sId}`);
-          expect(content.text).toContain(`handle: ${template.handle}`);
-          expect(content.text).toContain(
-            (template.userFacingDescription ?? "").trim()
-          );
-          expect(content.text).toContain(
-            (template.agentFacingDescription ?? "").trim()
-          );
-          expect(content.text).toContain("Test sidekick instructions");
-          expect(content.text).toContain("tags: SALES");
-        }
-      }
-    });
-
-    it("uses LLM-based fuzzy matching when query is provided", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
-
-      const template1 = await TemplateFactory.published();
-      await TemplateFactory.published();
-
-      vi.mocked(getSuggestedTemplatesForQuery).mockResolvedValueOnce(
-        new Ok([template1])
-      );
-
-      const tool = getToolByName("search_agent_templates");
-      const result = await tool.handler(
-        { query: "help me draft sales emails" },
-        createTestExtra(authenticator)
-      );
-
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        const content = result.value[0];
-        expect(content.type).toBe("text");
-        if (content.type === "text") {
-          expect(content.text).toMatch(/Found 1 template\(s\):/);
-          expect(content.text).toContain(`sId: ${template1.sId}`);
-        }
-      }
-
-      expect(getSuggestedTemplatesForQuery).toHaveBeenCalledOnce();
-    });
-
-    it("returns error when query-based search fails", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
-
-      await TemplateFactory.published();
-
-      vi.mocked(getSuggestedTemplatesForQuery).mockResolvedValueOnce(
-        new Err(new Error("LLM call failed"))
-      );
-
-      const tool = getToolByName("search_agent_templates");
-      const result = await tool.handler(
-        { query: "something" },
-        createTestExtra(authenticator)
-      );
-
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect(result.error.message).toContain("LLM call failed");
-      }
-    });
-
-    it("combines jobType tag filtering with query-based search", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
-
-      const salesTemplate = await TemplateFactory.published();
-      await salesTemplate.updateAttributes({ tags: ["SALES"] });
-
-      const engineeringTemplate = await TemplateFactory.published();
-      await engineeringTemplate.updateAttributes({ tags: ["ENGINEERING"] });
-
-      vi.mocked(getSuggestedTemplatesForQuery).mockResolvedValueOnce(
-        new Ok([salesTemplate])
-      );
-
-      const tool = getToolByName("search_agent_templates");
-      const result = await tool.handler(
-        { jobType: "sales", query: "sales email drafter" },
-        createTestExtra(authenticator)
-      );
-
-      expect(result.isOk()).toBe(true);
-      // Query branch was used with tag-filtered candidates.
-      expect(getSuggestedTemplatesForQuery).toHaveBeenCalledOnce();
-      const callArgs = vi.mocked(getSuggestedTemplatesForQuery).mock.calls[0];
-      const passedTemplates = callArgs[1].templates;
-      const passedIds = passedTemplates.map((t) => t.sId);
-      expect(passedIds).toContain(salesTemplate.sId);
-      expect(passedIds).not.toContain(engineeringTemplate.sId);
-    });
-  });
-
-  describe("get_agent_template", () => {
-    it("returns template with sidekickInstructions", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
-
-      // Create a template with sidekickInstructions.
-      const template = await TemplateFactory.published();
-      await template.updateAttributes({
-        sidekickInstructions: "Test sidekick instructions for this template",
-      });
-
-      const tool = getToolByName("get_agent_template");
-      const result = await tool.handler(
-        { templateId: template.sId },
-        createTestExtra(authenticator)
-      );
-
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        const content = result.value[0];
-        expect(content.type).toBe("text");
-        if (content.type === "text") {
-          expect(content.text).toContain(`sId: ${template.sId}`);
-          expect(content.text).toContain(`handle: ${template.handle}`);
-          expect(content.text).toContain(
-            "Test sidekick instructions for this template"
-          );
-        }
-      }
-    });
-
-    it("returns null sidekickInstructions when not set", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
-
-      // Create a template without sidekickInstructions.
-      const template = await TemplateFactory.published();
-      await template.updateAttributes({ sidekickInstructions: null });
-
-      const tool = getToolByName("get_agent_template");
-      const result = await tool.handler(
-        { templateId: template.sId },
-        createTestExtra(authenticator)
-      );
-
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        const content = result.value[0];
-        expect(content.type).toBe("text");
-        if (content.type === "text") {
-          expect(content.text).toContain(`sId: ${template.sId}`);
-          expect(content.text).not.toContain("sidekickInstructions:");
-        }
-      }
-    });
-
-    it("returns error for non-existent template", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
-
-      const tool = getToolByName("get_agent_template");
-      const result = await tool.handler(
-        { templateId: "non-existent-template-id" },
-        createTestExtra(authenticator)
-      );
-
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect(result.error.message).toContain("Template not found");
-        expect(result.error.message).toContain("non-existent-template-id");
-      }
-    });
-  });
 
   describe("inspect_conversation", () => {
     it("returns conversation with user and agent messages", async () => {

--- a/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
@@ -23,7 +23,6 @@ import type {
   AgentMessageType,
   ConversationType,
 } from "@app/types/assistant/conversation";
-import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -2039,7 +2038,6 @@ describe("agent_sidekick_context tools", () => {
       }
     });
   });
-
 
   describe("inspect_conversation", () => {
     it("returns conversation with user and agent messages", async () => {

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -516,48 +516,6 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  search_agent_templates: {
-    description:
-      "Search published agent templates. Use jobType for tag-based filtering or query for semantic search. " +
-      "Returns full template details including sidekickInstructions.",
-    schema: {
-      jobType: z
-        .string()
-        .optional()
-        .describe(
-          "User's job type to filter templates by relevant tags (e.g. 'sales', 'engineering', 'legal'). If omitted, returns all published templates."
-        ),
-      query: z
-        .string()
-        .optional()
-        .describe(
-          "Free-text query to semantically search templates. Use when the user describes a specific use case not covered by jobType tags."
-        ),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Searching templates",
-      done: "Search templates",
-    },
-    toolCostCategory: "basic",
-    freeUsage: true,
-  },
-  get_agent_template: {
-    description:
-      "Fetch template-specific guidance for the current agent. " +
-      "Use this tool when the agent was created from a template to retrieve specialized sidekickInstructions that define how you should assist with this agent type. " +
-      "These instructions may contain domain-specific rules, preferred approaches, or constraints you should follow.",
-    schema: {
-      templateId: z.string().describe("The sId of the template to retrieve"),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Fetching template",
-      done: "Fetch template",
-    },
-    toolCostCategory: "basic",
-    freeUsage: true,
-  },
   inspect_conversation: {
     description:
       "Inspect a conversation to get its shape and summary. Returns the conversation title, " +

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -33,10 +33,6 @@ import {
 import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import {
-  formatTemplatesAsText,
-  getTemplatesForSidekick,
-} from "@app/lib/api/assistant/sidekick_templates";
-import {
   describeMcpServer,
   getAvailableModelsForWorkspace,
   listAvailableSkills,
@@ -57,7 +53,6 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { TemplateResource } from "@app/lib/resources/template_resource";
 import logger from "@app/logger/logger";
 import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
 import type {
@@ -75,7 +70,6 @@ import { isModelProviderId } from "@app/types/assistant/models/providers";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isContentFragmentType } from "@app/types/content_fragment";
 import { CoreAPI } from "@app/types/core/core_api";
-import { isJobType } from "@app/types/job_type";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -1787,43 +1781,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       {
         type: "text" as const,
         text: JSON.stringify({ results }, null, 2),
-      },
-    ]);
-  },
-
-  search_agent_templates: async ({ jobType, query }, { auth }) => {
-    const res = await getTemplatesForSidekick({
-      auth,
-      jobType: jobType && isJobType(jobType) ? jobType : undefined,
-      query,
-      limit: 10,
-    });
-    if (res.isErr()) {
-      return new Err(new MCPError(res.error.message, { tracked: false }));
-    }
-    return new Ok([
-      {
-        type: "text" as const,
-        text: formatTemplatesAsText(res.value),
-      },
-    ]);
-  },
-
-  get_agent_template: async ({ templateId }, _extra) => {
-    const template = await TemplateResource.fetchByExternalId(templateId);
-
-    if (!template) {
-      return new Err(
-        new MCPError(`Template not found: ${templateId}`, {
-          tracked: false,
-        })
-      );
-    }
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text: formatTemplatesAsText([template]),
       },
     ]);
   },

--- a/front/lib/api/actions/servers/agent_templates/agent_templates.test.ts
+++ b/front/lib/api/actions/servers/agent_templates/agent_templates.test.ts
@@ -1,5 +1,5 @@
 import { getSuggestedTemplatesForQuery } from "@app/lib/api/assistant/template_suggestion";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { TemplateFactory } from "@app/tests/utils/TemplateFactory";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/api/actions/servers/agent_templates/agent_templates.test.ts
+++ b/front/lib/api/actions/servers/agent_templates/agent_templates.test.ts
@@ -1,0 +1,291 @@
+import { getSuggestedTemplatesForQuery } from "@app/lib/api/assistant/template_suggestion";
+import { Authenticator } from "@app/lib/auth";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { TemplateFactory } from "@app/tests/utils/TemplateFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TOOLS } from "./index";
+
+vi.mock("@app/lib/api/assistant/template_suggestion", () => ({
+  getSuggestedTemplatesForQuery: vi.fn(),
+}));
+
+beforeEach(async () => {
+  const templateSuggestion = await import(
+    "@app/lib/api/assistant/template_suggestion"
+  );
+  vi.mocked(templateSuggestion.getSuggestedTemplatesForQuery).mockReset();
+});
+
+function getToolByName(name: string) {
+  const tool = TOOLS.find((t) => t.name === name);
+  if (!tool) {
+    throw new Error(`Tool ${name} not found`);
+  }
+  return tool;
+}
+
+function createTestExtra(auth: Authenticator) {
+  return {
+    signal: new AbortController().signal,
+    auth,
+    toolContext: undefined,
+  } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
+}
+
+describe("agent_templates tools", () => {
+  describe("search_agent_templates", () => {
+    it("returns at most 10 published templates when no jobType", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      for (let i = 0; i < 12; i++) {
+        await TemplateFactory.published();
+      }
+      await TemplateFactory.draft();
+
+      const tool = getToolByName("search_agent_templates");
+      const result = await tool.handler({}, createTestExtra(authenticator));
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          expect(content.text).toMatch(/Found 10 template\(s\):/);
+          expect((content.text.match(/## Template/g) ?? []).length).toBe(10);
+        }
+      }
+    });
+
+    it("filters templates by jobType tags", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      const salesTemplate = await TemplateFactory.published();
+      await salesTemplate.updateAttributes({ tags: ["SALES"] });
+
+      const engineeringTemplate = await TemplateFactory.published();
+      await engineeringTemplate.updateAttributes({ tags: ["ENGINEERING"] });
+
+      const tool = getToolByName("search_agent_templates");
+      const result = await tool.handler(
+        { jobType: "sales" },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          expect(content.text).toContain(`sId: ${salesTemplate.sId}`);
+          expect(content.text).not.toContain(engineeringTemplate.sId);
+        }
+      }
+    });
+
+    it("returns at most 10 templates for unknown jobType", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      for (let i = 0; i < 12; i++) {
+        await TemplateFactory.published();
+      }
+
+      const tool = getToolByName("search_agent_templates");
+      const result = await tool.handler(
+        { jobType: "unknown_type" },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          expect(content.text).toMatch(/Found 10 template\(s\):/);
+        }
+      }
+    });
+
+    it("returns expected fields per template", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      const template = await TemplateFactory.published();
+      await template.updateAttributes({
+        tags: ["SALES"],
+        sidekickInstructions: "Test sidekick instructions",
+      });
+
+      const tool = getToolByName("search_agent_templates");
+      const result = await tool.handler(
+        { jobType: "sales" },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          expect(content.text).toContain(`sId: ${template.sId}`);
+          expect(content.text).toContain(`handle: ${template.handle}`);
+          expect(content.text).toContain(
+            (template.userFacingDescription ?? "").trim()
+          );
+          expect(content.text).toContain(
+            (template.agentFacingDescription ?? "").trim()
+          );
+          expect(content.text).toContain("Test sidekick instructions");
+          expect(content.text).toContain("tags: SALES");
+        }
+      }
+    });
+
+    it("uses LLM-based fuzzy matching when query is provided", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      const template1 = await TemplateFactory.published();
+      await TemplateFactory.published();
+
+      vi.mocked(getSuggestedTemplatesForQuery).mockResolvedValueOnce(
+        new Ok([template1])
+      );
+
+      const tool = getToolByName("search_agent_templates");
+      const result = await tool.handler(
+        { query: "help me draft sales emails" },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          expect(content.text).toMatch(/Found 1 template\(s\):/);
+          expect(content.text).toContain(`sId: ${template1.sId}`);
+        }
+      }
+
+      expect(getSuggestedTemplatesForQuery).toHaveBeenCalledOnce();
+    });
+
+    it("returns error when query-based search fails", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      await TemplateFactory.published();
+
+      vi.mocked(getSuggestedTemplatesForQuery).mockResolvedValueOnce(
+        new Err(new Error("LLM call failed"))
+      );
+
+      const tool = getToolByName("search_agent_templates");
+      const result = await tool.handler(
+        { query: "something" },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("LLM call failed");
+      }
+    });
+
+    it("combines jobType tag filtering with query-based search", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      const salesTemplate = await TemplateFactory.published();
+      await salesTemplate.updateAttributes({ tags: ["SALES"] });
+
+      const engineeringTemplate = await TemplateFactory.published();
+      await engineeringTemplate.updateAttributes({ tags: ["ENGINEERING"] });
+
+      vi.mocked(getSuggestedTemplatesForQuery).mockResolvedValueOnce(
+        new Ok([salesTemplate])
+      );
+
+      const tool = getToolByName("search_agent_templates");
+      const result = await tool.handler(
+        { jobType: "sales", query: "sales email drafter" },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(getSuggestedTemplatesForQuery).toHaveBeenCalledOnce();
+      const callArgs = vi.mocked(getSuggestedTemplatesForQuery).mock.calls[0];
+      const passedTemplates = callArgs[1].templates;
+      const passedIds = passedTemplates.map((t) => t.sId);
+      expect(passedIds).toContain(salesTemplate.sId);
+      expect(passedIds).not.toContain(engineeringTemplate.sId);
+    });
+  });
+
+  describe("get_agent_template", () => {
+    it("returns template with sidekickInstructions", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      const template = await TemplateFactory.published();
+      await template.updateAttributes({
+        sidekickInstructions: "Test sidekick instructions for this template",
+      });
+
+      const tool = getToolByName("get_agent_template");
+      const result = await tool.handler(
+        { templateId: template.sId },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          expect(content.text).toContain(`sId: ${template.sId}`);
+          expect(content.text).toContain(`handle: ${template.handle}`);
+          expect(content.text).toContain(
+            "Test sidekick instructions for this template"
+          );
+        }
+      }
+    });
+
+    it("returns null sidekickInstructions when not set", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      const template = await TemplateFactory.published();
+      await template.updateAttributes({ sidekickInstructions: null });
+
+      const tool = getToolByName("get_agent_template");
+      const result = await tool.handler(
+        { templateId: template.sId },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          expect(content.text).toContain(`sId: ${template.sId}`);
+          expect(content.text).not.toContain("sidekickInstructions:");
+        }
+      }
+    });
+
+    it("returns error for non-existent template", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      const tool = getToolByName("get_agent_template");
+      const result = await tool.handler(
+        { templateId: "non-existent-template-id" },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("Template not found");
+        expect(result.error.message).toContain("non-existent-template-id");
+      }
+    });
+  });
+});

--- a/front/lib/api/actions/servers/agent_templates/index.ts
+++ b/front/lib/api/actions/servers/agent_templates/index.ts
@@ -1,0 +1,58 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { ToolContextType } from "@app/lib/actions/types";
+import {
+  AGENT_TEMPLATES_SERVER_NAME,
+  AGENT_TEMPLATES_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/agent_templates/metadata";
+import {
+  formatTemplatesAsText,
+  getTemplatesForSidekick,
+} from "@app/lib/api/assistant/sidekick_templates";
+import type { Authenticator } from "@app/lib/auth";
+import { TemplateResource } from "@app/lib/resources/template_resource";
+import { isJobType } from "@app/types/job_type";
+import { Err, Ok } from "@app/types/shared/result";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const handlers: ToolHandlers<typeof AGENT_TEMPLATES_TOOLS_METADATA> = {
+  search_agent_templates: async ({ jobType, query }, { auth }) => {
+    const res = await getTemplatesForSidekick({
+      auth,
+      jobType: jobType && isJobType(jobType) ? jobType : undefined,
+      query,
+      limit: 10,
+    });
+    if (res.isErr()) {
+      return new Err(new MCPError(res.error.message, { tracked: false }));
+    }
+    return new Ok([{ type: "text" as const, text: formatTemplatesAsText(res.value) }]);
+  },
+
+  get_agent_template: async ({ templateId }) => {
+    const template = await TemplateResource.fetchByExternalId(templateId);
+    if (!template) {
+      return new Err(
+        new MCPError(`Template not found: ${templateId}`, { tracked: false })
+      );
+    }
+    return new Ok([{ type: "text" as const, text: formatTemplatesAsText([template]) }]);
+  },
+};
+
+const TOOLS = buildTools(AGENT_TEMPLATES_TOOLS_METADATA, handlers);
+
+function createServer(auth: Authenticator, toolContext?: ToolContextType): McpServer {
+  const server = makeInternalMCPServer(AGENT_TEMPLATES_SERVER_NAME);
+  for (const tool of TOOLS) {
+    registerTool(auth, toolContext, server, tool, {
+      monitoringName: AGENT_TEMPLATES_SERVER_NAME,
+    });
+  }
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/agent_templates/index.ts
+++ b/front/lib/api/actions/servers/agent_templates/index.ts
@@ -29,7 +29,9 @@ const handlers: ToolHandlers<typeof AGENT_TEMPLATES_TOOLS_METADATA> = {
     if (res.isErr()) {
       return new Err(new MCPError(res.error.message, { tracked: false }));
     }
-    return new Ok([{ type: "text" as const, text: formatTemplatesAsText(res.value) }]);
+    return new Ok([
+      { type: "text" as const, text: formatTemplatesAsText(res.value) },
+    ]);
   },
 
   get_agent_template: async ({ templateId }) => {
@@ -39,13 +41,18 @@ const handlers: ToolHandlers<typeof AGENT_TEMPLATES_TOOLS_METADATA> = {
         new MCPError(`Template not found: ${templateId}`, { tracked: false })
       );
     }
-    return new Ok([{ type: "text" as const, text: formatTemplatesAsText([template]) }]);
+    return new Ok([
+      { type: "text" as const, text: formatTemplatesAsText([template]) },
+    ]);
   },
 };
 
 const TOOLS = buildTools(AGENT_TEMPLATES_TOOLS_METADATA, handlers);
 
-function createServer(auth: Authenticator, toolContext?: ToolContextType): McpServer {
+function createServer(
+  auth: Authenticator,
+  toolContext?: ToolContextType
+): McpServer {
   const server = makeInternalMCPServer(AGENT_TEMPLATES_SERVER_NAME);
   for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {

--- a/front/lib/api/actions/servers/agent_templates/index.ts
+++ b/front/lib/api/actions/servers/agent_templates/index.ts
@@ -62,4 +62,5 @@ function createServer(
   return server;
 }
 
+export { TOOLS };
 export default createServer;

--- a/front/lib/api/actions/servers/agent_templates/metadata.ts
+++ b/front/lib/api/actions/servers/agent_templates/metadata.ts
@@ -1,0 +1,71 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const AGENT_TEMPLATES_SERVER_NAME = "agent_templates" as const;
+
+export const AGENT_TEMPLATES_TOOLS_METADATA = createToolsRecord({
+  search_agent_templates: {
+    description:
+      "Search published agent templates. Use jobType for tag-based filtering or query for semantic search. Returns template details including instructions.",
+    schema: {
+      jobType: z
+        .string()
+        .optional()
+        .describe(
+          "User's job type to filter templates by relevant tags (e.g. 'sales', 'engineering', 'legal'). If omitted, returns all published templates."
+        ),
+      query: z
+        .string()
+        .optional()
+        .describe(
+          "Free-text query to semantically search templates. Use when the user describes a specific use case not covered by jobType tags."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Searching templates",
+      done: "Search templates",
+    },
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
+  get_agent_template: {
+    description:
+      "Fetch the full details of an agent template by id, including its instructions and guidance.",
+    schema: {
+      templateId: z.string().describe("The sId of the template to retrieve."),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Fetching template",
+      done: "Fetch template",
+    },
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
+});
+
+export const AGENT_TEMPLATES_SERVER = {
+  serverInfo: {
+    name: AGENT_TEMPLATES_SERVER_NAME,
+    version: "1.0.0",
+    description: "Search and retrieve agent templates.",
+    authorization: null,
+    icon: "ActionDocumentTextIcon",
+    documentationUrl: null,
+  },
+  tools: Object.values(AGENT_TEMPLATES_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+    toolCostCategory: t.toolCostCategory,
+    freeUsage: t.freeUsage,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(AGENT_TEMPLATES_TOOLS_METADATA).map((t) => [t.name, t.stake])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -319,8 +319,15 @@ export function _getSidekickGlobalAgent(
       })
     : null;
 
+  const templatesAction = sidekickContext?.mcpServerViews?.templates
+    ? buildServerSideMCPServerConfiguration({
+        mcpServerView: sidekickContext.mcpServerViews.templates,
+      })
+    : null;
+
   const actions = [
     ...(contextAction ? [contextAction] : []),
+    ...(templatesAction ? [templatesAction] : []),
     ...(companyDataAction ? [companyDataAction] : []),
   ];
 

--- a/front/lib/api/assistant/global_agents/sidekick_context.ts
+++ b/front/lib/api/assistant/global_agents/sidekick_context.ts
@@ -1,4 +1,5 @@
 import { AGENT_SIDEKICK_CONTEXT_TOOL_NAME } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
+import { AGENT_TEMPLATES_SERVER_NAME } from "@app/lib/api/actions/servers/agent_templates/metadata";
 import type {
   AvailableSkill,
   AvailableTool,
@@ -27,6 +28,7 @@ interface SidekickUserMetadata {
 export interface SidekickContext {
   mcpServerViews: {
     context: MCPServerViewResource;
+    templates: MCPServerViewResource | null;
   } | null;
 }
 
@@ -261,12 +263,17 @@ export async function buildSidekickContext(
     return null;
   }
 
-  const context =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+  const [context, templates] = await Promise.all([
+    MCPServerViewResource.getMCPServerViewForAutoInternalTool(
       auth,
       AGENT_SIDEKICK_CONTEXT_TOOL_NAME
-    );
+    ),
+    MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      AGENT_TEMPLATES_SERVER_NAME
+    ),
+  ]);
   return {
-    mcpServerViews: context ? { context } : null,
+    mcpServerViews: context ? { context, templates } : null,
   };
 }

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -34,6 +34,7 @@ Before providing a new use case for the user, you MUST acquire context to inform
   - From \`get_workspace_activity\`: look for social proof — skills or agents that colleagues use regularly. "Teammates run this weekly" is proof the task exists in this workspace and is more persuasive than any generic pitch.
 - NEVER recommend the usage of agents other than customer agents OR the "Dust" default agent.
 - Never repeat recommendations the user has already executed or dismissed.
+- ALWAYS recommend a use case that can be executed immediately. We want to show the user value as soon as possible.
 
 ## What makes a recommendation high-value
 
@@ -105,7 +106,7 @@ Set \`collapsibleLabel\` to the specific concept name, not a generic phrase: "Le
 
 ## Executing
 
-Once the user accepts, start executing immediately — no preamble, no acknowledgement, no clarifying questions. Call the tools and produce the output:
+Once the user accepts, execute for real — this is where the value must become visible, not claimed:
 - End with the artifact itself: the rendered Frame, the drafted message, the created item, the actual briefing text.
 - Name what was touched as you go ("pulled from your Notion and HubSpot together") so the user sees the cross-tool reach rather than being told about it.
 

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -21,7 +21,7 @@ Your job is to find work the user already does and use Dust to help them do it f
 Before providing a new use case for the user, you MUST acquire context to inform your recommendation:
 - Call \`get_personal_usage\` to understand what the user has already used in the last 30 days.
 - Call \`get_workspace_activity\` to understand what the workspace has used in the last 30 days.
-- Call \`list_skills\` to see what skills are pinned or available.
+- Call \`list_skills\` with \`filter: "agent_discoverable"\` to see skills this agent can directly invoke.
 - Call \`list_recommendations\` to see what recommendations have already been shown to the user. Do not repeat recommendations the user has already executed or dismissed.
 - If a **Pod ID** is present in the context above, call \`list_conversations\` with \`includeMessages=true\` to scan the most recent Pod conversations. Use the message content to understand what the user has been working on inside this Pod — treat it as the strongest signal for what a relevant recommendation looks like.
 
@@ -56,10 +56,10 @@ Every recommendation must meet the following requirements:
 ## Recommendation Flow
 
 Surface exactly one new recommendation per turn. Follow this priority order:
-1. Pre-selected skills — Call \`list_skills\` to see what skills are pinned or available. Prioritize any that align with the user's stated goals or role.
-2. Existing agents in this workspace — Call \`list_all_published_agents\`. Prefer agents with observed colleague usage, and say so.
-3. Curated use cases by job type — If no agents are a clear fit, suggest a curated use case matched to the user's role. Lean toward Frames, write/action tools, or recurring workflows over read/search-only use cases.
-4. Personalized daily task manager — Connect primary daily sources (Slack, email, calendar) and set up a daily briefing. It requires no usage history, so it is always available as the thin-signal fallback.
+1. Pre-selected skills — Search for agent discoverable skills. Only mention a skill in \`actionMessage\` if it appeared in this list.
+2. Existing agents in this workspace — Call \`list_all_published_agents\`. Prefer agents with observed colleague usage, and say so. Only directly invoke an agent if it appeared in \`list_all_published_agents\`.
+3. Curated use cases by job type — If no skills or agents are a clear fit, call \`search_agent_templates\` with the user's job type to find standard use cases matched to their role. Lean toward Frames, write/action tools, or recurring workflows over read/search-only use cases. Usage data may surface patterns from skills or agents the user already runs — use those as inspiration for the recommendation idea only; do not attempt to invoke them unless they appeared in the respective discovery call above.
+4. Personalized daily task manager — Pull from primary daily sources (Slack, email, calendar) and produce today's actual briefing in this conversation. On accept, run it immediately — do not ask about scheduling first. It requires no usage history, so it is always available as the thin-signal fallback.
 
 ## How to present a recommendation
 
@@ -86,7 +86,7 @@ This is a container directive: the opening \`:::action_card{...}\` line holds th
 - \`description\`: one sentence a stranger could visualize. Name what appears in the output, not what it "turns into".
 - \`cta\`: short accept button label, e.g. "Try it", "Save it", "Set it up". This is display-only.
 - \`dismiss\`: short reject button label, e.g. "Not now", "Not for me", "Already doing this". This is display-only.
-- \`actionMessage\`: message sent to you when the user clicks the accept button, e.g. "Yes, let's do it", "Go ahead". Defaults to "Accept" if omitted.
+- \`actionMessage\`: message sent when the user clicks the accept button. Can be plain text (e.g. "Yes, let's do it") to re-invoke you, or include a \`:mention[Name]{sId=<sId>}\` directive to hand off directly to a agent (from \`list_all_published_agents\`). Never include a mention for a agent you did not see in the respective discovery call. Example: \`":mention[Skill Authoring]{sId=abc123} Set up the daily briefing skill"\`. Defaults to "Accept" if omitted.
 - \`dismissMessage\`: message sent to you when the user clicks the dismiss button, e.g. "Not for me", "Skip this one". Defaults to "Dismiss" if omitted.
 - \`collapsibleLabel\`: label for the collapsible section. Required if collapsible content is included; omit otherwise. See "Inline education" below.
 - collapsible content (the lines between the attribute line and closing \`:::\`): optional inline education markdown. See "Inline education" below.
@@ -108,6 +108,7 @@ Set \`collapsibleLabel\` to the specific concept name, not a generic phrase: "Le
 Once the user accepts, execute for real — this is where the value must become visible, not claimed:
 - End with the artifact itself: the rendered Frame, the drafted message, the created item, the actual briefing text.
 - Name what was touched as you go ("pulled from your Notion and HubSpot together") so the user sees the cross-tool reach rather than being told about it.
+- For recurring use cases (daily briefings, weekly digests, recurring reports): run it now — produce today's actual output in this conversation. Do not open with questions about scheduling or setup. The artifact comes first; skill and trigger offers come after the user has seen it.
 
 When a required source is not connected, drive the connection — never dead-end.
 If execution needs a data source that isn't connected, do not ask the user to
@@ -253,6 +254,7 @@ export const activationSkill = {
   mcpServers: [
     { name: "user_analytics" },
     { name: "agent_router" },
+    { name: "agent_templates" },
     { name: "skill_authoring" },
     { name: "schedules_management" },
     { name: "files" },

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -59,7 +59,7 @@ Surface exactly one new recommendation per turn. Follow this priority order:
 1. Pre-selected skills — Search for agent discoverable skills. Only mention a skill in \`actionMessage\` if it appeared in this list.
 2. Existing agents in this workspace — Call \`list_all_published_agents\`. Prefer agents with observed colleague usage, and say so. Only directly invoke an agent if it appeared in \`list_all_published_agents\`.
 3. Curated use cases by job type — If no skills or agents are a clear fit, call \`search_agent_templates\` with the user's job type to find standard use cases matched to their role. Lean toward Frames, write/action tools, or recurring workflows over read/search-only use cases. Usage data may surface patterns from skills or agents the user already runs — use those as inspiration for the recommendation idea only; do not attempt to invoke them unless they appeared in the respective discovery call above.
-4. Personalized daily task manager — Pull from primary daily sources (Slack, email, calendar) and produce today's actual briefing in this conversation. On accept, run it immediately — do not ask about scheduling first. It requires no usage history, so it is always available as the thin-signal fallback.
+4. Personalized daily task manager — Connect primary daily sources (Slack, email, calendar) and set up a daily briefing. It requires no usage history, so it is always available as the thin-signal fallback.
 
 ## How to present a recommendation
 
@@ -105,10 +105,9 @@ Set \`collapsibleLabel\` to the specific concept name, not a generic phrase: "Le
 
 ## Executing
 
-Once the user accepts, execute for real — this is where the value must become visible, not claimed:
+Once the user accepts, start executing immediately — no preamble, no acknowledgement, no clarifying questions. Call the tools and produce the output:
 - End with the artifact itself: the rendered Frame, the drafted message, the created item, the actual briefing text.
 - Name what was touched as you go ("pulled from your Notion and HubSpot together") so the user sees the cross-tool reach rather than being told about it.
-- For recurring use cases (daily briefings, weekly digests, recurring reports): run it now — produce today's actual output in this conversation. Do not open with questions about scheduling or setup. The artifact comes first; skill and trigger offers come after the user has seen it.
 
 When a required source is not connected, drive the connection — never dead-end.
 If execution needs a data source that isn't connected, do not ask the user to

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -16,27 +16,52 @@ const ACTIVATION_BEHAVIOR = `
 Recommend the next best action for the user to get more value from Dust. Help them execute it in this conversation, then convert it into a saved skill and a recurring schedule.
 Your job is to find work the user already does and use Dust to help them do it faster.
 
-## User Context
+## Workflow Steps
+
+Every activation conversation follows the same arc. Each stage is detailed in its own section below:
+
+1. Recommend — gather context, then surface exactly one high-value action as a card (Stage 1 below).
+2. Execute — once the user accepts, run it for real and make the result fully visible in the conversation (Stage 2 below).
+3. Save as a Skill — offer to save exactly what just ran as a reusable Skill (Stages 3–5 below).
+4. Schedule it — offer to put that Skill on a recurring schedule, letting the user pick the cadence (Stages 3–5 below).
+5. Recap — close with a short summary of everything that now exists (Stages 3–5 below).
+
+Stages 1–2 produce a single win. Stages 3–5 are what turn that win into recurring value — after a successful execution, never stop at the artifact.
+
+## Stage 1 — Recommend
+
+Choose exactly one high-value action from the user's real work and present it as a card. Everything in this stage serves that single decision: gather context, apply the requirements, pick from the priority order, then present the card.
+
+### Gather context first
 
 Before providing a new use case for the user, you MUST acquire context to inform your recommendation:
 - Call \`get_personal_usage\` to understand what the user has already used in the last 30 days.
 - Call \`get_workspace_activity\` to understand what the workspace has used in the last 30 days.
 - Call \`list_skills\` with \`filter: "agent_discoverable"\` to see skills this agent can directly invoke.
 - Call \`list_recommendations\` to see what recommendations have already been shown to the user. Do not repeat recommendations the user has already executed or dismissed.
-- If a **Pod ID** is present in the context above, call \`list_conversations\` with \`includeMessages=true\` to scan the most recent Pod conversations. Use the message content to understand what the user has been working on inside this Pod — treat it as the strongest signal for what a relevant recommendation looks like.
+- If a Pod ID is present in the context above, call \`list_conversations\` with \`includeMessages=true\` to scan the most recent Pod conversations. Use the message content to understand what the user has been working on inside this Pod — treat it as the strongest signal for what a relevant recommendation looks like.
 
-## Guidelines
+### What counts as a valid recommendation
 
-- Never recommend actions that are ONLY acting on Dust resources. Skills and tools related to Dust itself (i.e. Activation Skill) do not count as substantive personal usage. Ignore them when deciding what the user "already uses".
-- Do not recommend skills, tools, or agents that already appear in the user's personal usage results (they are already using those)
-- Mine usage data for evidence of tasks, not just exclusion:
+- ALWAYS mine usage data for evidence of tasks, not just exclusion:
   - From \`get_personal_usage\`: look for repeated manual patterns — the same kind of request made multiple times. A repeated pattern is proof of the type of tasks relevant for users and the strongest possible recommendation basis.
   - From \`get_workspace_activity\`: look for social proof — skills or agents that colleagues use regularly. "Teammates run this weekly" is proof the task exists in this workspace and is more persuasive than any generic pitch.
-- NEVER recommend the usage of agents other than customer agents OR the "Dust" default agent.
-- Never repeat recommendations the user has already executed or dismissed.
-- ALWAYS recommend a use case that can be executed immediately. We want to show the user value as soon as possible.
 
-## What makes a recommendation high-value
+Recommendations MUST meet the following requirements:
+- Its subject is the user's real domain work — the outputs and tasks of their actual job. Never recommend meta-work about Dust itself: analyzing their Dust usage, activation, onboarding, or "productivity/adoption" is never a valid recommendation, however much such activity dominates their usage data.
+- It replaces, shortens, or improves a task relevant to the user. It must be a tangible example of an activity that will improve the user's productivity.
+- It names actual tools, agents, skills, or usage patterns. Not a category ("automate your reporting") but an instance ("the pipeline summary you rebuild from HubSpot every week").
+- It is executable right now, in this conversation, with tools that are already connected. Never recommend connecting a new tool or data source — tool setup is an admin action outside the user's control. Only build on what is already available in the workspace context provided to you. We want to show the user value as soon as possible.
+- Executing it ends in a tangible artifact: a Frame, a drafted message, a created issue, a briefing. Never advice, tips, or a description of what's possible.
+- It can plausibly become a saved skill or a recurring schedule.
+
+- NEVER recommend actions that are ONLY acting on Dust resources. Skills and tools related to Dust itself (i.e. Activation Skill) do not count as substantive personal usage. Ignore them when deciding what the user "already uses".
+- NEVER recommend skills, tools, or agents that already appear in the user's personal usage results (they are already using those)
+- NEVER recommend the usage of agents other than customer agents OR the "Dust" default agent.
+- NEVER repeat recommendations the user has already executed or dismissed.
+- NEVER start a conversation by recommending the creation of a trigger or skill before the user has executed the recommendation.
+
+### What makes a recommendation high-value
 
 Prioritize recommendations that exploit Dust's core differentiators over generic AI chat:
 1. Write and action tools — tools that take real-world actions, not just read or search. These eliminate context-switching and are a clear ROI.
@@ -44,18 +69,7 @@ Prioritize recommendations that exploit Dust's core differentiators over generic
 3. Recurring triggers and skills — converting a manual task into a scheduled automation. A daily briefing, a weekly digest, a recurring report. This is the strongest habit-forming lever: Dust delivers value without the user initiating it. Default to daily or weekly cadence.
 4. Custom workspace agents or skills — encode this workspace's specific context, tools, and knowledge base. Higher-value than generic chat because they can't be replicated with a public AI tool.
 
-## Recommendation Requirements
-
-Every recommendation must meet the following requirements:
-- Its subject is the user's real domain work — the outputs and tasks of their actual job. Never recommend meta-work about Dust itself: analyzing their Dust usage, activation, onboarding, or "productivity/adoption" is never a valid recommendation, however much such activity dominates their usage data.
-- It replaces, shortens, or improves a task relevant to the user. It must be a tangible example of an activity that will improve the user's productivity.
-- It names actual tools, agents, skills, or usage patterns. Not a category ("automate your reporting") but an instance ("the pipeline summary you rebuild from HubSpot every week").
-- It is executable right now, in this conversation, with tools that are already connected. Never recommend connecting a new tool or data source — tool setup is an admin action outside the user's control. Only build on what is already available in the workspace context provided to you.
-- Executing it ends in a tangible artifact: a Frame, a drafted message, a created issue, a briefing. Never advice, tips, or a description of what's possible.
-- It can plausibly become a saved skill or a recurring schedule.
-- Never start by recommending the creation of a trigger or skill before the user has executed the recommendation.
-
-## Recommendation Flow
+### Priority order
 
 Surface exactly one new recommendation per turn. Follow this priority order:
 1. Pre-selected skills — Search for agent discoverable skills. Only mention a skill in \`actionMessage\` if it appeared in this list.
@@ -63,9 +77,11 @@ Surface exactly one new recommendation per turn. Follow this priority order:
 3. Curated use cases by job type — If no skills or agents are a clear fit, call \`search_agent_templates\` with the user's job type to find standard use cases matched to their role. Lean toward Frames, write/action tools, or recurring workflows over read/search-only use cases. Usage data may surface patterns from skills or agents the user already runs — use those as inspiration for the recommendation idea only; do not attempt to invoke them unless they appeared in the respective discovery call above.
 4. Personalized daily task manager — Connect primary daily sources (Slack, email, calendar) and set up a daily briefing. It requires no usage history, so it is always available as the thin-signal fallback.
 
-## How to present a recommendation
+### Presenting the card
 
 Always start by surfacing a recommendation card — never open with a question. If you need more context from the user (e.g. after several dismissals), use the \`ask_question\` tool as a follow-up, never up front.
+
+The card format below is shared infrastructure — the same \`:::action_card\` directive is reused for the conversion cards in stages 3–4.
 
 Every recommendation follows this chain — if any link is missing, fall to a lower tier rather than surfacing it incomplete:
 1. Name the task they already do, and its current cost, stated naturally as an observation about their work. Vary the phrasing — never use a fixed template.
@@ -99,17 +115,20 @@ When the user responds to any card:
 - If they accept (the \`actionMessage\` arrives), call \`update_recommendation\` with \`status: "executed"\`, then proceed with execution.
 - If they decline (the \`dismissMessage\` arrives), call \`update_recommendation\` with \`status: "dismissed"\`. For a new recommendation, surface the next one. For a conversion card, follow the post-execution flow below.
 
-### Inline education
+#### Inline education
 
 Every recommendation card must carry a short, focused explainer that teaches the Dust concept behind the action — education rides along with every card, never as a separate flow.
 Use the **Dust Support** skill to generate content, including a Markdown-like description of the concept and a link to the relevant documentation page.
 Set \`collapsibleLabel\` to the specific concept name, not a generic phrase: "Learn more about Frames", "Learn more about triggers", "Learn more about Skills". The label tells the user exactly what they'll learn before they expand it.
 
-## Executing
+## Stage 2 — Execute
 
 Once the user accepts, execute for real — this is where the value must become visible, not claimed:
-- End with the artifact itself: the rendered Frame, the drafted message, the created item, the actual briefing text.
+- Make the result 100% visible in this conversation. The user must see exactly what was produced without downloading a file, opening another tab, or navigating anywhere. Render the artifact inline: the Frame, the full drafted message, the actual briefing text.
+- When the result is a side effect elsewhere (a created Jira issue, a sent email, an updated CRM record), reproduce the concrete outcome inline so it is unmistakable. Never just report that "it's done" — show what was done.
 - Name what was touched as you go ("pulled from your Notion and HubSpot together") so the user sees the cross-tool reach rather than being told about it.
+
+### When a required source isn't connected
 
 When a required source is not connected, drive the connection — never dead-end.
 If execution needs a data source that isn't connected, do not ask the user to
@@ -130,26 +149,29 @@ available. Instead:
    completes it ("here's the briefing from Slack alone; connect your calendar
    and it includes your day").
 
+## Stages 3–5 — Turn the win into a habit
 
-Immediately after surfacing a recommendation, call \`create_recommendation\` with the recommendation text and your internal rationale.
+Execution (stage 2) just succeeded — this is where a one-off becomes recurring value, so do not stop at the artifact. The flow is mandatory and opinionated: move through it step by step, one card per turn, do not present it as a menu of options, and do not skip steps unless the user declines.
 
-When the user responds to a recommendation:
-- If they accept (e.g. "Let's try it", "Yes"), call \`update_recommendation\` with \`status: "executed"\`, then proceed with execution.
-- If they decline (e.g. "Not for me", "Skip"), call \`update_recommendation\` with \`status: "dismissed"\`, then generate a new recommendation.
-- After creating a skill or trigger from a recommendation, call \`update_recommendation\` again with the corresponding \`createdSkillId\` or \`createdTriggerId\`.
+Both offers below (the skill and the trigger) work the same way. Follow this exact sequence each time:
 
-## After Successful Use Case Execution
+1. Send the card at the END of the message you're already writing — never as a standalone message. The skill card is appended to the end of the execution result (right after you echo the value); the trigger card is appended to the end of the message confirming the skill was saved. This message just presents the offer: it MUST NOT call \`create_skill\`, \`update_skill\`, or \`create_trigger\`. Keep the card short — what the workflow does, when it runs, why it's worth it — and never put the full definition in it. (\`create_recommendation\`, which is silent, is fine to call here.)
+2. When the user clicks accept, act right away in the next turn: call \`update_recommendation\` with \`status: "executed"\`, then call the write tool with the full change (\`create_skill\`/\`create_trigger\` with the COMPLETE definition, or \`update_skill\` with the edit). That tool call opens Dust's standard approval dialog — that dialog, showing the full change, is where the user actually reviews and confirms, so don't re-ask or re-confirm before it. (One exception: the trigger's cadence isn't chosen yet, so ask it with \`ask_question\` first — that's gathering a real parameter, not re-confirming.)
 
-This flow is mandatory and opinionated — move through it step by step, one card per turn. Do not present it as a menu of options, and do not skip steps unless the user declines.
+Because the real review happens at that approval dialog, tell the user it's coming: the card \`cta\` uses "Review & create" / "Review & schedule" (never "Create it" or "Done"), and the card \`description\` ends by saying the approval with the full definition follows before anything is created.
 
-1. Echo the value — one sentence stating concretely what was produced, from which sources, and what manual task it replaces ("that combined 3 sources into the briefing you'd otherwise assemble by hand every morning"). One sentence, not a celebration.
-2. Offer the skill as a card — in the same message as the value echo, render a conversion card proposing to save exactly what just ran as a reusable skill. The card must be specific to the work just done: title names the workflow ("Weekly pipeline recap"), \`label\` names what it captures ("From the report we just built"), \`description\` states what saving it means ("Rerun this exact HubSpot + Slack recap anytime in one click"). On accept: call \`update_recommendation\` with \`status: "executed"\`, create the skill with the \`skill_authoring\` tools, then call \`update_recommendation\` again with \`createdSkillId\`.
-3. Offer the trigger as a card — once the skill is saved, in the same message that confirms it, render a second conversion card proposing the schedule. Default the cadence to the cadence of the manual task it replaces, and put the concrete schedule in the card itself: \`label\` like "Runs every Monday, 8am", \`description\` stating what arrives and when ("The recap lands in this conversation before your Monday pipeline review"). On accept: call \`update_recommendation\` with \`status: "executed"\`, create the trigger with the \`schedules_management\` tools, then call \`update_recommendation\` again with \`createdTriggerId\`.
+1. Echo the value (the hinge out of execution) — one sentence stating concretely what was produced, from which sources, and what manual task it replaces ("that combined 3 sources into the briefing you'd otherwise assemble by hand every morning"). One sentence, not a celebration. This bridges directly into the skill offer below.
+2. Offer the skill as a card (stage 3):
+   - A similar Skill already exists → do NOT create a duplicate. By default, do NOT offer to change it either. Move to the trigger step. Only offer an update when BOTH are true — the run just exposed a concrete gap the existing Skill genuinely does not cover, and the user is allowed to edit that Skill (it is one they can write to / your tools can modify). In that narrow case, render the card with \`title="Update a Skill"\`, \`subtitle\` naming the existing Skill, \`cta="Review & update"\`, and a \`description\` stating the specific improvement; on accept call \`update_recommendation\` with \`status: "executed"\`, then \`update_skill\` on that skill id with a targeted \`old_string\`/\`new_string\` edit. If you cannot edit the Skill or there is no clear gap, never push an update.
+   - Nothing similar exists → offer to create it. In the same message as the value echo, render the card: \`title="Create a Skill"\` (not "Save this workflow"), \`subtitle\` names the specific workflow it captures ("Weekly pipeline recap"), \`description\` states what saving it means and ends with the required review sentence ("Rerun this exact HubSpot + Slack recap anytime in one click. Accepting opens the standard approval showing the full definition before anything is created."). Set \`cta="Review & create"\` and omit \`dismiss\`. Do NOT call \`create_skill\` in this turn — the card is only the offer. On accept: call \`update_recommendation\` with \`status: "executed"\`, then call \`create_skill\` with the complete skill definition (the approval dialog showing that definition is where the user reviews it).
+   - Either way, on tool approval call \`update_recommendation\` again with \`createdSkillId\`; on tool rejection call \`update_recommendation\` with \`status: "dismissed"\` and close the loop warmly.
+3. Offer the trigger as a card (stage 4) — once the Skill exists (whether you created it, updated an existing one, or found it already covered the workflow), in the same message that confirms it, render a conversion card proposing the schedule. Header wording names the concrete Dust action: \`title="Schedule this Skill"\`, \`subtitle\` names what it produces ("Weekly pipeline recap"), \`description\` states what a schedule means and ends with the required review sentence, adapted for the cadence step ("The recap runs on its own and lands in this conversation — no need to ask. Accepting lets you pick the schedule, then opens the standard approval before anything is created."). Set \`cta="Review & schedule"\` and omit \`dismiss\`. Do NOT call \`create_trigger\` in this turn, and do NOT assume a cadence or time — the card is only the offer. When the user clicks: call \`update_recommendation\` with \`status: "executed"\`, then use \`ask_question\` to let the user choose the cadence — offer 2–4 concrete options matched to the task ("Every weekday, 8am", "Weekly on Monday, 8am", "Weekly on Friday, 5pm") rather than guessing (this is the one permitted parameter question, not a re-confirmation). Once they pick, immediately call \`create_trigger\` with the complete trigger definition using the chosen cadence. On tool approval: call \`update_recommendation\` again with \`createdTriggerId\`. On tool rejection: call \`update_recommendation\` with \`status: "dismissed"\` and confirm the skill is saved and where to find it.
 4. Handle declines gracefully — if the user declines the skill card, do not offer the trigger (a schedule needs the saved workflow); mark it dismissed and close the loop warmly. If they decline the trigger card, confirm the skill is saved and where to find it. In both cases, stop — do not immediately surface a new recommendation unless the user asks.
+5. Recap what was built (stage 5) — once the flow completes (or ends because the user declined a step), close with a short recap of everything created in this conversation so the user leaves with a clear picture of what now exists: the artifact produced, the Skill saved (and how to rerun it), and the Trigger scheduled (and when it next runs). A few lines — a summary.
 
 Never bundle these into one combined ask ("want me to save this as a skill and schedule it?"). One card, one decision, one turn.
 
-## Quality
+## Quality principles (apply to every stage)
 
 - Be concise. Every message should be actionable in under 30 seconds of reading.
 - Never block the user. If they want to skip, change direction, ask an unrelated question, or leave, let them.

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -53,6 +53,7 @@ Every recommendation must meet the following requirements:
 - It is executable right now, in this conversation, with tools that are already connected. Never recommend connecting a new tool or data source — tool setup is an admin action outside the user's control. Only build on what is already available in the workspace context provided to you.
 - Executing it ends in a tangible artifact: a Frame, a drafted message, a created issue, a briefing. Never advice, tips, or a description of what's possible.
 - It can plausibly become a saved skill or a recurring schedule.
+- Never start by recommending the creation of a trigger or skill before the user has executed the recommendation.
 
 ## Recommendation Flow
 
@@ -75,15 +76,15 @@ Every offer — new recommendations and post-execution conversion offers alike �
 1. Call \`create_recommendation\` with the recommendation text and your internal rationale.
 2. Using the \`recommendationId\` returned, render the card on its own line:
 
-:::action_card{title="<short title, 3–6 words>" sId=<recommendationId> icon=<icon name> subtitle="<context line>" description="<one sentence>" cta="<accept label>" dismiss="<reject label>" actionMessage="<message sent on accept>" dismissMessage="<message sent on dismiss>" collapsibleLabel="<collapsible trigger label>"}
+:::action_card{title="<short title>" sId=<recommendationId> icon=<icon name> subtitle="<context line>" description="<one sentence>" cta="<accept label>" dismiss="<reject label>" actionMessage="<message sent on accept>" dismissMessage="<message sent on dismiss>" collapsibleLabel="<collapsible trigger label>"}
 <inline education — real markdown: bold, links, bullet lists>
 :::
 
 This is a container directive: the opening \`:::action_card{...}\` line holds the attributes, the optional lines that follow are collapsible content (the inline education), and a closing \`:::\` line ends it. The collapsible content is rendered as real markdown, so put the explainer there — never in an attribute. Omit the collapsible lines if no education content is needed.
 
-- \`title\`: short generic headline shown prominently (3–5 words), e.g. "Recommendation for you".
+- \`title\`: short generic headline shown prominently (2-4 words), e.g. "Recommendation for you".
 - \`icon\`: icon shown next to the card. Pick the one that matches the Dust concept behind the recommendation: \`ActionListCheckIcon\` (skill), \`ActionCalendarCheckIcon\` (trigger/schedule), \`ActionDashboardIcon\` (Frame/dashboard), \`ActionCloudArrowLeftRightIcon\` (connection), \`ActionRobotIcon\` (agent), \`ActionMailIcon\` (briefing/digest), \`ActionSparklesIcon\` (generic). Defaults to \`ActionRobotIcon\` if omitted.
-- \`subtitle\`: optional context line shown below the title. 3-5 word specific title for the recommendation: "Generate daily brief".
+- \`subtitle\`: optional context line shown below the title. 2-4 word specific title for the recommendation: "Generate daily brief".
 - \`description\`: one sentence a stranger could visualize. Name what appears in the output, not what it "turns into".
 - \`cta\`: short accept button label, e.g. "Try it", "Save it", "Set it up". This is display-only.
 - \`dismiss\`: short reject button label, e.g. "Not now", "Not for me", "Already doing this". This is display-only.

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -235,6 +235,18 @@ export function useUnifiedAgentConfigurations({
   };
 }
 
+export function useAccessibleAgentIds({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Set<string> {
+  const { agentConfigurations } = useUnifiedAgentConfigurations({ workspaceId });
+  return useMemo(
+    () => new Set(agentConfigurations.map((a) => a.sId)),
+    [agentConfigurations]
+  );
+}
+
 export function useAgentConfiguration({
   workspaceId,
   agentConfigurationId,

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -240,7 +240,9 @@ export function useAccessibleAgentIds({
 }: {
   workspaceId: string;
 }): Set<string> {
-  const { agentConfigurations } = useUnifiedAgentConfigurations({ workspaceId });
+  const { agentConfigurations } = useUnifiedAgentConfigurations({
+    workspaceId,
+  });
   return useMemo(
     () => new Set(agentConfigurations.map((a) => a.sId)),
     [agentConfigurations]


### PR DESCRIPTION
## Summary
- Moving agent templates tool from sidekick MCP server to a dedicated MCP server so they can be leveraged by activation as well. No logic changes there at all.
- Minor activation skill prompting changes based on testing
- Allowing use reply static message to include an agent mention

## Testing
<img width="761" height="632" alt="Screenshot 2026-07-08 at 12 14 34 PM" src="https://github.com/user-attachments/assets/a4b3bfbc-c8f9-4b36-89e8-338d900cda2b" />

## Risk

- Low - not customer facing yet

## Deploy
1. Deploy front