### PR TITLE
fix(front): clean requestedSpaceIds on all skills referencing a deleted space

### DIFF
--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -162,19 +162,22 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
       const mcpServerViewIds = mcpServerViews.map((v) => v.id);
       const dataSourceViewIds = dataSourceViews.map((v) => v.id);
 
-      // Find all skills that reference MCP server views or data source views from this space.
-      const [skillsWithMCPViews, skillsWithDataSourceViews] = await Promise.all(
-        [
+      // Find all skills that reference this space, either through an MCP server
+      // view / data source view located in it, or directly via requestedSpaceIds
+      // (a skill can request a space without holding a live view in it).
+      const [skillsWithMCPViews, skillsWithDataSourceViews, skillsWithSpace] =
+        await Promise.all([
           SkillResource.listByMCPServerViewIds(auth, mcpServerViewIds),
           SkillResource.listByDataSourceViewIds(auth, dataSourceViewIds),
-        ]
-      );
+          SkillResource.listByRequestedSpaceId(auth, space.id),
+        ]);
 
       // Merge and deduplicate skills.
       const skillMap = new Map<number, SkillResource>();
       for (const skill of [
         ...skillsWithMCPViews,
         ...skillsWithDataSourceViews,
+        ...skillsWithSpace,
       ]) {
         skillMap.set(skill.id, skill);
       }
@@ -183,28 +186,6 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
       // Create sets for quick lookup.
       const mcpServerViewIdSet = new Set(mcpServerViewIds);
       const dataSourceViewIdSet = new Set(dataSourceViewIds);
-
-      // Collect all agent IDs that currently reference this space BEFORE calling updateSkill.
-      // updateSkill creates its own independent transaction for each skill, so its agent
-      // updates commit before the outer transaction. By collecting upfront, we can update
-      // all affected agents (direct references and skill-driven references) atomically
-      // with the space soft-delete in the outer transaction below.
-      const agentsReferencingSpace = await AgentConfigurationModel.findAll({
-        attributes: ["id"],
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          status: "active",
-          requestedSpaceIds: {
-            [Op.contains]: [space.id],
-          },
-        },
-      });
-      const agentIdsToClean = agentsReferencingSpace.map((a) => a.id);
-
-      logger.info(
-        { ...logContext, agentCount: agentIdsToClean.length },
-        "softDeleteSpace: cleaning up agent requestedSpaceIds"
-      );
 
       // Update each skill to remove MCP server views and attached knowledge from the deleted space.
       // Note: updateSkill manages its own transaction, so we call it sequentially.
@@ -269,44 +250,46 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
         });
       }
 
-      // Update requestedSpaceIds for all agents collected above, atomically with the
-      // space soft-delete. We do a fresh read here (inside the outer transaction) so
-      // we get the current state after updateSkill's inner transactions have committed.
-      // This covers both direct references and skill-driven references that updateSkill
-      // may have already cleaned up (no-op) or missed (still need cleanup).
-      if (agentIdsToClean.length > 0) {
-        const agentsToUpdate = await AgentConfigurationModel.findAll({
-          attributes: ["id", "requestedSpaceIds"],
-          where: {
-            id: { [Op.in]: agentIdsToClean },
-            workspaceId: auth.getNonNullableWorkspace().id,
-            status: "active",
-          },
-          transaction: t,
-        });
+      // Strip the space from every agent still referencing it, atomically with
+      // the space soft-delete. We query fresh here (inside the outer transaction,
+      // after updateSkill's inner transactions have committed) rather than a
+      // snapshot taken before the skill loop: cleaning a skill recomputes the
+      // requestedSpaceIds of every agent using it, so the set of agents still
+      // referencing this space can change during the loop. This catches both
+      // direct references and skill-driven references left over after the loop.
+      const agentsToClean = await AgentConfigurationModel.findAll({
+        attributes: ["id", "requestedSpaceIds"],
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          status: "active",
+          requestedSpaceIds: { [Op.contains]: [space.id] },
+        },
+        transaction: t,
+      });
 
-        await concurrentExecutor(
-          agentsToUpdate.filter((a) => a.requestedSpaceIds.includes(space.id)),
-          async (agent) => {
-            const newSpaceIds = agent.requestedSpaceIds.filter(
-              (id) => id !== space.id
-            );
-            const res = await updateAgentRequirements(
-              auth,
-              {
-                agentModelId: agent.id,
-                newSpaceIds,
-              },
-              { transaction: t }
-            );
+      logger.info(
+        { ...logContext, agentCount: agentsToClean.length },
+        "softDeleteSpace: cleaning up agent requestedSpaceIds"
+      );
 
-            if (res.isErr()) {
-              throw res.error;
-            }
-          },
-          { concurrency: 4 }
-        );
-      }
+      await concurrentExecutor(
+        agentsToClean,
+        async (agent) => {
+          const newSpaceIds = agent.requestedSpaceIds.filter(
+            (id) => id !== space.id
+          );
+          const res = await updateAgentRequirements(
+            auth,
+            { agentModelId: agent.id, newSpaceIds },
+            { transaction: t }
+          );
+
+          if (res.isErr()) {
+            throw res.error;
+          }
+        },
+        { concurrency: 4 }
+      );
 
       // Finally, soft delete the space.
       const res = await space.delete(auth, {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1379,6 +1379,26 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
+   * List active skills whose requestedSpaceIds contains the given space. Used
+   * during space deletion to find skills that reference the space even when
+   * they have no MCP server view or data source view located in it.
+   */
+  static async listByRequestedSpaceId(
+    auth: Authenticator,
+    spaceModelId: ModelId
+  ): Promise<SkillResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        requestedSpaceIds: {
+          [Op.contains]: [spaceModelId],
+        },
+        status: "active",
+      },
+      onlyCustom: true,
+    });
+  }
+
+  /**
    * List enabled skills for a conversation.
    * If agentConfiguration is provided, includes both agent-enabled and conversation-enabled skills.
    * Otherwise, returns only conversation-enabled skills (JIT).

--- a/front/migrations/20260708_strip_space_from_requested_space_ids.ts
+++ b/front/migrations/20260708_strip_space_from_requested_space_ids.ts
@@ -1,0 +1,108 @@
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+// Every table that carries a `requestedSpaceIds` bigint[] column. `skill_versions`
+// inherits the column from `SkillConfigurationModel` via SKILL_MODEL_ATTRIBUTES, so
+// it must be included alongside `skill_configurations`.
+const TABLES = [
+  "agent_configurations",
+  "skill_configurations",
+  "skill_versions",
+] as const;
+
+type CountRow = { count: string };
+
+// True when the row's requestedSpaceIds overlaps the target spaces, i.e. it still
+// references at least one of them.
+function referencesTargetSpaces(spaceIdsLiteral: string): string {
+  return `"requestedSpaceIds" && ${spaceIdsLiteral}`;
+}
+
+// The requestedSpaceIds array rebuilt with the target spaces removed, keeping the
+// remaining ids in their original order.
+function requestedSpaceIdsWithoutTargets(spaceIdsLiteral: string): string {
+  return `ARRAY(
+    SELECT id
+    FROM unnest("requestedSpaceIds") AS id
+    WHERE id <> ALL (${spaceIdsLiteral})
+  )`;
+}
+
+async function stripFromTable(
+  table: string,
+  spaceIdsLiteral: string,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const [{ count }] = await frontSequelize.query<CountRow>(
+    `SELECT COUNT(*) AS count
+     FROM "${table}"
+     WHERE ${referencesTargetSpaces(spaceIdsLiteral)}`,
+    { type: QueryTypes.SELECT }
+  );
+  const affected = Number(count);
+
+  if (affected === 0) {
+    logger.info({ table }, "No rows reference the target spaces, skipping");
+    return;
+  }
+
+  if (!execute) {
+    logger.info(
+      { table, affected },
+      "Would strip target spaces from requestedSpaceIds"
+    );
+    return;
+  }
+
+  await frontSequelize.query(
+    `UPDATE "${table}"
+     SET "requestedSpaceIds" = ${requestedSpaceIdsWithoutTargets(spaceIdsLiteral)}
+     WHERE ${referencesTargetSpaces(spaceIdsLiteral)}`,
+    { type: QueryTypes.UPDATE }
+  );
+
+  logger.info(
+    { table, affected },
+    "Stripped target spaces from requestedSpaceIds"
+  );
+}
+
+makeScript(
+  {
+    spaceIds: {
+      type: "array",
+      description:
+        "Space model ids (numeric) to strip from every requestedSpaceIds column",
+      required: true,
+    },
+  },
+  async ({ spaceIds, execute }, logger) => {
+    const parsed = spaceIds.map((s) => Number(s));
+    if (parsed.some((n) => !Number.isSafeInteger(n) || n <= 0)) {
+      logger.error({ spaceIds }, "spaceIds must be positive integers");
+      return;
+    }
+
+    // Safe integer interpolation (validated above); enables set-based updates
+    // without fetching every row.
+    const spaceIdsLiteral = `ARRAY[${parsed.join(",")}]::bigint[]`;
+
+    logger.info(
+      { spaceIds: parsed, execute },
+      "Starting requestedSpaceIds strip"
+    );
+
+    for (const table of TABLES) {
+      await stripFromTable(table, spaceIdsLiteral, execute, logger);
+    }
+
+    logger.info(
+      { spaceIds: parsed, execute },
+      execute ? "Completed requestedSpaceIds strip" : "Dry run completed"
+    );
+  }
+);

--- a/front/migrations/20260708_strip_space_from_requested_space_ids.ts
+++ b/front/migrations/20260708_strip_space_from_requested_space_ids.ts
@@ -37,38 +37,55 @@ async function stripFromTable(
   execute: boolean,
   logger: Logger
 ): Promise<void> {
-  const [{ count }] = await frontSequelize.query<CountRow>(
-    `SELECT COUNT(*) AS count
-     FROM "${table}"
-     WHERE ${referencesTargetSpaces(spaceIdsLiteral)}`,
-    { type: QueryTypes.SELECT }
-  );
-  const affected = Number(count);
+  if (!execute) {
+    const [{ count }] = await frontSequelize.query<CountRow>(
+      `SELECT COUNT(*) AS count
+       FROM "${table}"
+       WHERE ${referencesTargetSpaces(spaceIdsLiteral)}`,
+      { type: QueryTypes.SELECT }
+    );
+    const affected = Number(count);
 
-  if (affected === 0) {
-    logger.info({ table }, "No rows reference the target spaces, skipping");
+    if (affected === 0) {
+      logger.info({ table }, "No rows reference the target spaces, skipping");
+    } else {
+      logger.info(
+        { table, affected },
+        "Would strip target spaces from requestedSpaceIds"
+      );
+    }
     return;
   }
 
-  if (!execute) {
+  await frontSequelize.transaction(async (transaction) => {
+    // Lock the matching rows so their requestedSpaceIds cannot change between
+    // the count and the update.
+    const locked = await frontSequelize.query<{ id: string }>(
+      `SELECT id
+       FROM "${table}"
+       WHERE ${referencesTargetSpaces(spaceIdsLiteral)}
+       FOR UPDATE`,
+      { type: QueryTypes.SELECT, transaction }
+    );
+    const affected = locked.length;
+
+    if (affected === 0) {
+      logger.info({ table }, "No rows reference the target spaces, skipping");
+      return;
+    }
+
+    await frontSequelize.query(
+      `UPDATE "${table}"
+       SET "requestedSpaceIds" = ${requestedSpaceIdsWithoutTargets(spaceIdsLiteral)}
+       WHERE ${referencesTargetSpaces(spaceIdsLiteral)}`,
+      { type: QueryTypes.UPDATE, transaction }
+    );
+
     logger.info(
       { table, affected },
-      "Would strip target spaces from requestedSpaceIds"
+      "Stripped target spaces from requestedSpaceIds"
     );
-    return;
-  }
-
-  await frontSequelize.query(
-    `UPDATE "${table}"
-     SET "requestedSpaceIds" = ${requestedSpaceIdsWithoutTargets(spaceIdsLiteral)}
-     WHERE ${referencesTargetSpaces(spaceIdsLiteral)}`,
-    { type: QueryTypes.UPDATE }
-  );
-
-  logger.info(
-    { table, affected },
-    "Stripped target spaces from requestedSpaceIds"
-  );
+  });
 }
 
 makeScript(


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9500

Deleting a space could leave skills and agents referencing the now-deleted space in their `requestedSpaceIds`, which hides them from every user (the visibility gate drops any agent whose requested spaces can't all be resolved).

Root cause: on deletion, affected skills were discovered **only** through the MCP server views / data source views located in the space. A skill can reference a space via `requestedSpaceIds` without holding a live view in it, so those skills were never cleaned. Because an agent's `requestedSpaceIds` is recomputed as the union of its own capabilities plus each attached skill's `requestedSpaceIds`, the stale space stuck to the skill and got re-applied to agents on the next recompute.

Changes:
- Discover affected skills directly by `requestedSpaceIds` as well (new `SkillResource.listByRequestedSpaceId`), mirroring the existing agent lookup, so the skill (the durable source) is always cleaned.
- Strip agents with a fresh in-transaction query after the skill loop instead of a snapshot captured before it, so agents whose refs change during skill cleanup are caught.
- Add a migration to strip a given space id from every `requestedSpaceIds` column (`agent_configurations`, `skill_configurations`, `skill_versions`) to repair rows already affected by past deletions.

## Tests

Typechecked the changed files. 

## Risk

Low.

## Deploy Plan

Deploy normally. Run the migration once as a dry run, confirm the affected counts, then `--execute` with the orphaned space ids to repair existing rows.