### PR TITLE
Add cancel subscription for free plans

### DIFF
--- a/front/components/workspace/billing/FreePlanBilling.tsx
+++ b/front/components/workspace/billing/FreePlanBilling.tsx
@@ -1,5 +1,6 @@
 import { FreePlanSeatsSection } from "@app/components/workspace/billing/FreePlanSeatsSection";
 import { FreePlanUpgradeSection } from "@app/components/workspace/billing/FreePlanUpgradeSection";
+import { SubscriptionActionButtons } from "@app/components/workspace/billing/SubscriptionActionButtons";
 import { SubscriptionStatusChip } from "@app/components/workspace/billing/SubscriptionStatusChip";
 import type { SubscriptionType } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -13,11 +14,14 @@ interface FreePlanBillingProps {
 export function FreePlanBilling({ owner, subscription }: FreePlanBillingProps) {
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center gap-2">
-        <span className="text-base font-semibold text-foreground">
-          Business
-        </span>
-        <SubscriptionStatusChip />
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-base font-semibold text-foreground">
+            Business
+          </span>
+          <SubscriptionStatusChip />
+        </div>
+        <SubscriptionActionButtons />
       </div>
       <FreePlanSeatsSection owner={owner} subscription={subscription} />
       <FreePlanUpgradeSection

--- a/front/components/workspace/billing/SubscriptionActionButtons.tsx
+++ b/front/components/workspace/billing/SubscriptionActionButtons.tsx
@@ -1,4 +1,5 @@
 import { useSubscriptionContext } from "@app/components/workspace/billing/SubscriptionContext";
+import { isCreditPricedFreePlan } from "@app/lib/plans/plan_codes";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import {
   Button,
@@ -15,12 +16,16 @@ import {
 
 function CancelMetronomeSubscriptionDialog() {
   const {
+    subscription,
     periodEndLabel,
     isCancellingSubscription,
     cancelSubscription,
     showCancelDialog,
     setShowCancelDialog,
   } = useSubscriptionContext();
+  const isImmediateCancellation = isCreditPricedFreePlan(
+    subscription.plan.code
+  );
   // "July 12, 2026" → "July 12"
   const shortDate = periodEndLabel ? periodEndLabel.split(",")[0] : null;
 
@@ -37,7 +42,9 @@ function CancelMetronomeSubscriptionDialog() {
         <DialogHeader>
           <DialogTitle>Cancel your subscription</DialogTitle>
           <DialogDescription>
-            {periodEndLabel ? (
+            {isImmediateCancellation ? (
+              "Your subscription will end immediately."
+            ) : periodEndLabel ? (
               <>
                 Your plan will remain active until{" "}
                 <span className="font-bold">{periodEndLabel}</span>.
@@ -52,6 +59,10 @@ function CancelMetronomeSubscriptionDialog() {
             <div className="flex justify-center py-8">
               <Spinner variant="dark" size="md" />
             </div>
+          ) : isImmediateCancellation ? (
+            <ContentMessage size="sm" variant="highlight">
+              This ends your subscription right away and cannot be undone.
+            </ContentMessage>
           ) : (
             <div className="flex flex-col gap-4">
               {periodEndLabel && (

--- a/front/components/workspace/billing/SubscriptionContext.tsx
+++ b/front/components/workspace/billing/SubscriptionContext.tsx
@@ -4,7 +4,10 @@ import {
 } from "@app/hooks/useMetronomeContractLifecycleAction";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import type { MetronomeInvoiceSummary } from "@app/lib/metronome/invoice";
-import { isBusinessPlanPrefix } from "@app/lib/plans/plan_codes";
+import {
+  isBusinessPlanPrefix,
+  isCreditPricedFreePlan,
+} from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import { useMetronomeInvoice } from "@app/lib/swr/workspaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
@@ -102,7 +105,8 @@ export function SubscriptionProvider({
 
   const isCancellablePlan =
     isSubscriptionMetronomeBilled(subscription) &&
-    isBusinessPlanPrefix(subscription.plan.code);
+    (isBusinessPlanPrefix(subscription.plan.code) ||
+      isCreditPricedFreePlan(subscription.plan.code));
   const isCancellationScheduled =
     subscription.endDate !== null || subscription.requestCancelAt !== null;
   const subscriptionEndsAtMs =

--- a/front/hooks/useMetronomeContractLifecycleAction.ts
+++ b/front/hooks/useMetronomeContractLifecycleAction.ts
@@ -91,7 +91,7 @@ export function useCancelMetronomeContract({
     errorTitle: "Cancellation failed",
     errorDescription: "Failed to cancel your subscription.",
     successTitle: "Subscription cancelled",
-    successDescription: "Your subscription will end at the end of the period.",
+    successDescription: "Your subscription has been cancelled.",
   });
 
   return {

--- a/front/lib/metronome/contract_lifecycle.ts
+++ b/front/lib/metronome/contract_lifecycle.ts
@@ -4,6 +4,7 @@ import {
   reactivateMetronomeContract as reactivateMetronomeContractRaw,
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
+import { isCreditPricedFreePlan } from "@app/lib/plans/plan_codes";
 import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -14,7 +15,8 @@ export type ContractLifecycleError =
 
 /**
  * Schedule the workspace's Metronome contract to end at the current billing
- * period end, and mark the local subscription as canceled so the "ends on X"
+ * period end (or immediately for the free plan, which has nothing to bill
+ * out), and mark the local subscription as canceled so the "ends on X"
  * banner surfaces immediately.
  */
 export async function cancelWorkspaceContractAtPeriodEnd(
@@ -48,36 +50,44 @@ export async function cancelWorkspaceContractAtPeriodEnd(
     });
   }
 
-  const invoicesResult = await listMetronomeDraftInvoices(metronomeCustomerId);
-  if (invoicesResult.isErr()) {
-    return new Err({
-      kind: "upstream_error",
-      message: `Failed to fetch Metronome draft invoices: ${invoicesResult.error.message}`,
-    });
-  }
-
-  const nowMs = Date.now();
-  const currentInvoice = invoicesResult.value.find((inv) => {
-    if (inv.contract_id !== metronomeContractId) {
-      return false;
+  // The free plan is never billed, so there's no billing period to wait
+  // out: end the contract now instead of looking up an invoice period.
+  let periodEnd: Date;
+  if (isCreditPricedFreePlan(subscription.plan.code)) {
+    periodEnd = new Date();
+  } else {
+    const invoicesResult =
+      await listMetronomeDraftInvoices(metronomeCustomerId);
+    if (invoicesResult.isErr()) {
+      return new Err({
+        kind: "upstream_error",
+        message: `Failed to fetch Metronome draft invoices: ${invoicesResult.error.message}`,
+      });
     }
-    if (!inv.start_timestamp || !inv.end_timestamp) {
-      return false;
-    }
-    const startMs = new Date(inv.start_timestamp).getTime();
-    const endMs = new Date(inv.end_timestamp).getTime();
-    return startMs <= nowMs && nowMs < endMs;
-  });
 
-  if (!currentInvoice?.end_timestamp) {
-    return new Err({
-      kind: "invalid_state",
-      message:
-        "Could not determine the current billing period end from Metronome.",
+    const nowMs = Date.now();
+    const currentInvoice = invoicesResult.value.find((inv) => {
+      if (inv.contract_id !== metronomeContractId) {
+        return false;
+      }
+      if (!inv.start_timestamp || !inv.end_timestamp) {
+        return false;
+      }
+      const startMs = new Date(inv.start_timestamp).getTime();
+      const endMs = new Date(inv.end_timestamp).getTime();
+      return startMs <= nowMs && nowMs < endMs;
     });
-  }
 
-  const periodEnd = new Date(currentInvoice.end_timestamp);
+    if (!currentInvoice?.end_timestamp) {
+      return new Err({
+        kind: "invalid_state",
+        message:
+          "Could not determine the current billing period end from Metronome.",
+      });
+    }
+
+    periodEnd = new Date(currentInvoice.end_timestamp);
+  }
 
   const scheduleResult = await scheduleMetronomeContractEnd({
     metronomeCustomerId,


### PR DESCRIPTION
## Description

Free-plan (`CP_FREE_PLAN`) workspaces had no way to cancel/end their subscription from the billing page — the "Cancel subscription" button was only shown for Metronome-billed Business plans (`isCancellablePlan` required `isBusinessPlanPrefix`). This extends the existing cancel flow to the free plan too.

Every `CP_FREE_PLAN` subscription is backed by a real Metronome contract (provisioned at signup via `provisionMetronomeContract`, or attached via the `contract.start` webhook), so the free plan goes through **the exact same cancellation flow** as `CP_BUSINESS_PLAN` — `cancelWorkspaceContractAtPeriodEnd` schedules the real contract to end via Metronome, and the existing `contract.end` webhook handler picks it up from there (including launching the workspace scrub), with no new code path needed for that part.

The only difference for the free plan: since nothing is being billed, there's no reason to wait for a billing period end — and free-plan contracts may not reliably have a draft invoice to look one up from anyway (no billed seat subscription generating one). So `cancelWorkspaceContractAtPeriodEnd` skips the draft-invoice lookup for the free plan and schedules the contract to end immediately (`now`) instead of at the current period's end.

- `FreePlanBilling.tsx`: renders `<SubscriptionActionButtons />` next to the plan name/status chip, same as the paid billing page.
- `SubscriptionContext.tsx`: `isCancellablePlan` now also returns `true` for Metronome-billed `CP_FREE_PLAN` subscriptions (previously required `isBusinessPlanPrefix`).
- `lib/metronome/contract_lifecycle.ts`: `cancelWorkspaceContractAtPeriodEnd` now branches only on how to compute the end date (`now` for free plan vs. current-period-end from Metronome draft invoices for Business) — everything downstream (`scheduleMetronomeContractEnd`, `markAsCanceled`) is shared.
- `SubscriptionActionButtons.tsx`: cancel dialog shows "Your subscription will end immediately" for the free plan instead of the period-end copy.
- `useMetronomeContractLifecycleAction.ts`: fixed the success toast, which previously always claimed "will end at the end of the period" regardless of plan — now it just confirms the cancellation happened.

No route/API changes: this reuses the existing `PATCH /api/w/[wId]/metronome/contract` (`action: "cancel"`) endpoint end-to-end.

## Tests

- `npx tsgo --noEmit` passes.
- `biome check` passes on all touched files.
- Manually not verified in a running app (no local Metronome-backed free-plan workspace at hand); verified by code path tracing, cross-checked against how the existing Business cancel flow reaches the `contract.end` webhook and scrub launch.

## Risk

- Low blast radius: gating change is additive, existing Business-plan cancel behavior and code path are unchanged.
- Relies on Metronome accepting an immediate (`now`) `ending_before` for `scheduleMetronomeContractEnd` — this is an already-supported default elsewhere in the codebase (e.g. `SubscriptionResource.endActiveSubscription`, contract-swap-on-plan-change), not a novel usage.
- Contract end is rounded up to the next hour boundary by Metronome (`ceilToHourISO`), so "immediate" cancellation may take up to ~1h to actually reflect via the webhook/scrub trigger — acceptable given nothing is billed in the meantime.

## Deploy Plan

Standard deploy, no migration or coordination required.
