### PR TITLE
Tool runner: make runToolWithStreaming tool-context dependent

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -8,9 +8,9 @@ import type {
   MCPServerAvailability,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
+  AgentLoopToolExecution,
   MCPApproveExecutionEvent,
   ToolAskUserQuestionEvent,
-  ToolExecution,
   ToolFileAuthRequiredEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
@@ -162,7 +162,7 @@ export type LightMCPToolConfigurationType =
 
 export type { FileAuthorizationInfo };
 
-export type BlockedToolExecution = ToolExecution &
+export type BlockedToolExecution = AgentLoopToolExecution &
   (
     | {
         status: "blocked_validation_required";

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -5,15 +5,12 @@ import type {
 import type { UserQuestion } from "@app/lib/actions/types";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 
-export interface ToolExecution<
+interface ToolExecutionBase<
   T extends MCPValidationMetadataType = MCPValidationMetadataType,
 > {
-  conversationId: string;
-  messageId: string;
   actionId: string;
   // User might be undefined if the run was initiated through the public API using an API key.
   userId?: string;
-  configurationId: string;
   created: number;
 
   stake?: MCPToolStakeLevelType;
@@ -28,6 +25,24 @@ export interface ToolExecution<
   approvalArgsLabel?: string;
 }
 
+// Tool execution scoped to an agent loop run: carries the conversation-scoped identifiers used on
+// the conversation message channel.
+export interface AgentLoopToolExecution<
+  T extends MCPValidationMetadataType = MCPValidationMetadataType,
+> extends ToolExecutionBase<T> {
+  conversationId: string;
+  messageId: string;
+  configurationId: string;
+}
+
+// Tool execution scoped to a sandbox function invocation.
+export interface SandboxFunctionToolExecution<
+  T extends MCPValidationMetadataType = MCPValidationMetadataType,
+> extends ToolExecutionBase<T> {
+  sandboxFunctionId: string;
+  invocationId: string;
+}
+
 type ToolPersonalAuthError = {
   mcpServerId: string;
   provider: OAuthProvider;
@@ -36,18 +51,28 @@ type ToolPersonalAuthError = {
   message: string;
 };
 
+type ToolAuthMetadataType = MCPValidationMetadataType & {
+  mcpServerId: string;
+  mcpServerDisplayName: string;
+};
+
 // Event sent when personal authentication is required for a tool call.
 // This is a non-terminal event that pauses the workflow until authentication is completed.
-export interface ToolPersonalAuthRequiredEvent
-  extends ToolExecution<
-    MCPValidationMetadataType & {
-      mcpServerId: string;
-      mcpServerDisplayName: string;
-    }
-  > {
+export interface AgentLoopToolPersonalAuthRequiredEvent
+  extends AgentLoopToolExecution<ToolAuthMetadataType> {
   type: "tool_personal_auth_required";
   authError: ToolPersonalAuthError;
 }
+
+export interface SandboxFunctionToolPersonalAuthRequiredEvent
+  extends SandboxFunctionToolExecution<ToolAuthMetadataType> {
+  type: "tool_personal_auth_required";
+  authError: ToolPersonalAuthError;
+}
+
+export type ToolPersonalAuthRequiredEvent =
+  | AgentLoopToolPersonalAuthRequiredEvent
+  | SandboxFunctionToolPersonalAuthRequiredEvent;
 
 type ToolFileAuthError = {
   fileId: string;
@@ -60,36 +85,64 @@ type ToolFileAuthError = {
 
 // Pauses agent execution to prompt user for file access consent (e.g., Google Drive).
 // Non-terminal because the tool can resume once the user authorizes the file.
-export interface ToolFileAuthRequiredEvent
-  extends ToolExecution<
-    MCPValidationMetadataType & {
-      mcpServerId: string;
-      mcpServerDisplayName: string;
-    }
-  > {
+export interface AgentLoopToolFileAuthRequiredEvent
+  extends AgentLoopToolExecution<ToolAuthMetadataType> {
   type: "tool_file_auth_required";
   fileAuthError: ToolFileAuthError;
 }
 
-export interface MCPApproveExecutionEvent extends ToolExecution {
+export interface SandboxFunctionToolFileAuthRequiredEvent
+  extends SandboxFunctionToolExecution<ToolAuthMetadataType> {
+  type: "tool_file_auth_required";
+  fileAuthError: ToolFileAuthError;
+}
+
+export type ToolFileAuthRequiredEvent =
+  | AgentLoopToolFileAuthRequiredEvent
+  | SandboxFunctionToolFileAuthRequiredEvent;
+
+export interface MCPApproveExecutionEvent extends AgentLoopToolExecution {
   type: "tool_approve_execution";
 }
 
-export interface ToolAskUserQuestionEvent extends ToolExecution {
+export interface AgentLoopToolAskUserQuestionEvent
+  extends AgentLoopToolExecution {
   type: "tool_ask_user_question";
   question: UserQuestion;
 }
 
-export type ToolEarlyExitEvent = {
+export interface SandboxFunctionToolAskUserQuestionEvent
+  extends SandboxFunctionToolExecution {
+  type: "tool_ask_user_question";
+  question: UserQuestion;
+}
+
+export type ToolAskUserQuestionEvent =
+  | AgentLoopToolAskUserQuestionEvent
+  | SandboxFunctionToolAskUserQuestionEvent;
+
+type ToolEarlyExitEventBase = {
   type: "tool_early_exit";
   created: number;
-  configurationId: string;
-  messageId: string;
-  conversationId: string;
   text: string;
   isError: boolean;
   reason?: "deploy_interruption" | "user_cancellation" | "none";
 };
+
+export type AgentLoopToolEarlyExitEvent = ToolEarlyExitEventBase & {
+  configurationId: string;
+  messageId: string;
+  conversationId: string;
+};
+
+export type SandboxFunctionToolEarlyExitEvent = ToolEarlyExitEventBase & {
+  sandboxFunctionId: string;
+  invocationId: string;
+};
+
+export type ToolEarlyExitEvent =
+  | AgentLoopToolEarlyExitEvent
+  | SandboxFunctionToolEarlyExitEvent;
 
 /**
  * Internal signal emitted by `getExitOrPauseEvents` whenever it processes a
@@ -105,11 +158,23 @@ export type ToolEarlyExitEvent = {
  * (to skip `markAsSucceeded`) and `executeToolStreaming` (to set
  * `shouldPauseAgentLoop`).
  */
-export type ToolPausedEvent = {
+type ToolPausedEventBase = {
   type: "tool_paused";
   created: number;
+  actionId: string;
+};
+
+export type AgentLoopToolPausedEvent = ToolPausedEventBase & {
   configurationId: string;
   messageId: string;
   conversationId: string;
-  actionId: string;
 };
+
+export type SandboxFunctionToolPausedEvent = ToolPausedEventBase & {
+  sandboxFunctionId: string;
+  invocationId: string;
+};
+
+export type ToolPausedEvent =
+  | AgentLoopToolPausedEvent
+  | SandboxFunctionToolPausedEvent;

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -5,6 +5,19 @@ import type {
 import type { UserQuestion } from "@app/lib/actions/types";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 
+// Identifiers scoping an event to the run context it was emitted from, mirroring the contextType
+// split of AgentLoopRunContextType / SandboxFunctionRunContextType.
+export type AgentLoopEventScope = {
+  configurationId: string;
+  messageId: string;
+  conversationId: string;
+};
+
+export type SandboxFunctionEventScope = {
+  sandboxFunctionId: string;
+  invocationId: string;
+};
+
 interface ToolExecutionBase<
   T extends MCPValidationMetadataType = MCPValidationMetadataType,
 > {
@@ -29,19 +42,14 @@ interface ToolExecutionBase<
 // the conversation message channel.
 export interface AgentLoopToolExecution<
   T extends MCPValidationMetadataType = MCPValidationMetadataType,
-> extends ToolExecutionBase<T> {
-  conversationId: string;
-  messageId: string;
-  configurationId: string;
-}
+> extends ToolExecutionBase<T>,
+    AgentLoopEventScope {}
 
 // Tool execution scoped to a sandbox function invocation.
 export interface SandboxFunctionToolExecution<
   T extends MCPValidationMetadataType = MCPValidationMetadataType,
-> extends ToolExecutionBase<T> {
-  sandboxFunctionId: string;
-  invocationId: string;
-}
+> extends ToolExecutionBase<T>,
+    SandboxFunctionEventScope {}
 
 type ToolPersonalAuthError = {
   mcpServerId: string;
@@ -129,16 +137,11 @@ type ToolEarlyExitEventBase = {
   reason?: "deploy_interruption" | "user_cancellation" | "none";
 };
 
-export type AgentLoopToolEarlyExitEvent = ToolEarlyExitEventBase & {
-  configurationId: string;
-  messageId: string;
-  conversationId: string;
-};
+export type AgentLoopToolEarlyExitEvent = ToolEarlyExitEventBase &
+  AgentLoopEventScope;
 
-export type SandboxFunctionToolEarlyExitEvent = ToolEarlyExitEventBase & {
-  sandboxFunctionId: string;
-  invocationId: string;
-};
+export type SandboxFunctionToolEarlyExitEvent = ToolEarlyExitEventBase &
+  SandboxFunctionEventScope;
 
 export type ToolEarlyExitEvent =
   | AgentLoopToolEarlyExitEvent
@@ -164,16 +167,11 @@ type ToolPausedEventBase = {
   actionId: string;
 };
 
-export type AgentLoopToolPausedEvent = ToolPausedEventBase & {
-  configurationId: string;
-  messageId: string;
-  conversationId: string;
-};
+export type AgentLoopToolPausedEvent = ToolPausedEventBase &
+  AgentLoopEventScope;
 
-export type SandboxFunctionToolPausedEvent = ToolPausedEventBase & {
-  sandboxFunctionId: string;
-  invocationId: string;
-};
+export type SandboxFunctionToolPausedEvent = ToolPausedEventBase &
+  SandboxFunctionEventScope;
 
 export type ToolPausedEvent =
   | AgentLoopToolPausedEvent

--- a/front/lib/actions/mcp_internal_actions/exit_events.test.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.test.ts
@@ -1,12 +1,7 @@
 import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/exit_events";
 import { makeMCPToolExit } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type {
-  AgentMessageType,
-  ConversationWithoutContentType,
-} from "@app/types/assistant/conversation";
 import { describe, expect, it } from "vitest";
 
 describe("getExitOrPauseEvents", () => {
@@ -19,14 +14,20 @@ describe("getExitOrPauseEvents", () => {
 
     const events = await getExitOrPauseEvents({} as Authenticator, {
       outputItems: output.content.map((content) => ({ content })),
-      action: {} as AgentMCPActionResource,
-      agentConfiguration: {
-        sId: "agent-configuration-id",
-      } as AgentConfigurationType,
-      agentMessage: { sId: "agent-message-id" } as AgentMessageType,
-      conversation: {
-        sId: "conversation-id",
-      } as ConversationWithoutContentType,
+      toolContext: {
+        // The early exit path only reads identifiers off the run context; a partial mock is
+        // enough here.
+        runContext: {
+          contextType: "agent_loop",
+          action: { functionCallName: "test_tool", augmentedInputs: {} },
+          agentConfiguration: {
+            sId: "agent-configuration-id",
+            name: "Test Agent",
+          },
+          agentMessage: { sId: "agent-message-id" },
+          conversation: { sId: "conversation-id" },
+        } as AgentLoopRunContextType,
+      },
     });
 
     expect(events).toHaveLength(1);

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -102,33 +102,23 @@ export async function getExitOrPauseEvents(
     case "tool_blocked_awaiting_input": {
       const { blockingEvents, state } = exitOutputItem;
 
-      // Assert (vs guarding the mutations like the cases below): here the mutations ARE the
-      // semantics. The whole point is to atomically flip the action to
-      // blocked_child_action_input_required and persist the resumeState in the step context so
-      // the loop pauses and can later resume exactly where it stopped. Skipping them would return
-      // [...blockingEvents, tool_paused] backed by no persisted state at all: a pause signal that
-      // nothing can ever resume, silently swallowing the tool's blocking behavior. Today the
-      // resource only comes from tools unavailable to sandbox functions (sandbox bash, which is
-      // conversation-bound by definition, and run_agent, which is conversation-tied for now).
+      if (isAgentLoopRunContext(runContext)) {
+        // Update the action status to blocked_child_action_input_required to break the agent loop.
+        await runContext.action.updateStatus(
+          "blocked_child_action_input_required"
+        );
+
+        // Update the step context to save the resume state.
+        await runContext.action.updateStepContext({
+          ...runContext.action.stepContext,
+          resumeState: state,
+        });
+      }
+
       // TODO(SANDBOX_FUNCTIONS): supporting run_agent from a sandbox function requires
       // invocation-level pause/resume semantics (persisted resume state on the invocation and a
       // way for the caller to resume); wire them here then. Until that exists, failing loudly
       // beats emitting a plausible-looking but broken pause.
-      assert(
-        isAgentLoopRunContext(runContext),
-        "tool_blocked_awaiting_input requires an agent loop run context."
-      );
-
-      // Update the action status to blocked_child_action_input_required to break the agent loop.
-      await runContext.action.updateStatus(
-        "blocked_child_action_input_required"
-      );
-
-      // Update the step context to save the resume state.
-      await runContext.action.updateStepContext({
-        ...runContext.action.stepContext,
-        resumeState: state,
-      });
 
       // Forward any UI-facing blocking events the tool collected, plus a `tool_paused` sentinel.
       // The sentinel keeps the pause-decision on the event channel even when `blockingEvents` is

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -6,13 +6,13 @@ import type {
   ToolPausedEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
+import type { ToolContextType } from "@app/lib/actions/types";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { pauseSandboxBashForBlockedChild } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { assertNever, isAgentPauseOutputResourceType } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import assert from "assert";
 
 type MCPActionOutputItemWithContent = {
   content: CallToolResult["content"][number];
@@ -27,16 +27,10 @@ export async function getExitOrPauseEvents(
   auth: Authenticator,
   {
     outputItems,
-    action,
-    agentConfiguration,
-    agentMessage,
-    conversation,
+    toolContext,
   }: {
     outputItems: MCPActionOutputItemWithContent[];
-    action: AgentMCPActionResource;
-    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
-    agentMessage: AgentLoopExecutionData["agentMessage"];
-    conversation: ConversationWithoutContentType;
+    toolContext: ToolContextType;
   }
 ): Promise<
   (
@@ -48,119 +42,185 @@ export async function getExitOrPauseEvents(
     | ToolPausedEvent
   )[]
 > {
+  const { runContext } = toolContext;
+  assert(runContext, "getExitOrPauseEvents requires a tool run context.");
+
   const exitOutputItem = outputItems
     .map((item) => item.content)
     .find(isAgentPauseOutputResourceType)?.resource;
 
-  if (exitOutputItem) {
-    switch (exitOutputItem.type) {
-      case "tool_early_exit": {
-        const { isError, reason, text } = exitOutputItem;
-        const eventIsError = reason === "user_cancellation" ? false : isError;
+  if (!exitOutputItem) {
+    return [];
+  }
 
-        return [
-          {
-            type: "tool_early_exit",
-            created: Date.now(),
-            configurationId: agentConfiguration.sId,
-            conversationId: conversation.sId,
-            messageId: agentMessage.sId,
-            text: text,
-            isError: eventIsError,
-            reason,
+  const { action, toolConfiguration } = runContext;
+
+  // Identifiers scoping the events to the run context they were emitted from, plus the tool call
+  // name and inputs as issued in that context.
+  const { eventScope, toolCallName, inputs } = (() => {
+    switch (runContext.contextType) {
+      case "agent_loop":
+        return {
+          eventScope: {
+            configurationId: runContext.agentConfiguration.sId,
+            conversationId: runContext.conversation.sId,
+            messageId: runContext.agentMessage.sId,
           },
-        ];
-      }
-      case "tool_blocked_awaiting_input": {
-        const { blockingEvents, state } = exitOutputItem;
-        // Update the action status to blocked_child_action_input_required to break the agent loop.
-        await action.updateStatus("blocked_child_action_input_required");
-
-        // Update the step context to save the resume state.
-        await action.updateStepContext({
-          ...action.stepContext,
-          resumeState: state,
-        });
-
-        // Forward any UI-facing blocking events the tool collected, plus a `tool_paused` sentinel.
-        // The sentinel keeps the pause-decision on the event channel even when `blockingEvents` is
-        // empty — the case for any future tool whose blocking event is published upstream
-        // out-of-band (e.g. sandbox bash, where the child's blocking event is published by
-        // `createSandboxChildAction` and never flows through bash's return). Without it,
-        // `runToolWithStreaming` would fall through to `markAsSucceeded` on an already-blocked
-        // action.  Appended LAST so the for-await in `executeToolStreaming` processes every
-        // blocking event before the sentinel triggers the return.
-        return [
-          // Blocking events are parsed with the public client schemas where agentName is optional;
-          // normalize to the placeholder constant expected internally.
-          ...blockingEvents.map((event) => ({
-            ...event,
-            metadata: { ...event.metadata, agentName: "agent" as const },
-          })),
-          {
-            type: "tool_paused",
-            created: Date.now(),
-            configurationId: agentConfiguration.sId,
-            messageId: agentMessage.sId,
-            conversationId: conversation.sId,
-            actionId: action.sId,
+          toolCallName: runContext.action.functionCallName ?? "unknown",
+          inputs: runContext.action.augmentedInputs,
+        };
+      case "sandbox_function":
+        return {
+          eventScope: {
+            sandboxFunctionId: runContext.invocation.sandboxFunction.sId,
+            invocationId: runContext.invocation.sId,
           },
-        ];
-      }
-      case "tool_personal_auth_required": {
-        const { provider, scope } = exitOutputItem;
+          toolCallName: runContext.action.toolName,
+          inputs: runContext.action.inputs,
+        };
+      default:
+        return assertNever(runContext);
+    }
+  })();
 
-        const authErrorMessage =
-          `The tool ${action.functionCallName} requires personal ` +
-          `authentication, please authenticate to use it.`;
+  switch (exitOutputItem.type) {
+    case "tool_early_exit": {
+      const { isError, reason, text } = exitOutputItem;
+      const eventIsError = reason === "user_cancellation" ? false : isError;
 
+      return [
+        {
+          type: "tool_early_exit",
+          created: Date.now(),
+          ...eventScope,
+          text: text,
+          isError: eventIsError,
+          reason,
+        },
+      ];
+    }
+    case "tool_blocked_awaiting_input": {
+      const { blockingEvents, state } = exitOutputItem;
+
+      // Assert (vs guarding the mutations like the cases below): here the mutations ARE the
+      // semantics. The whole point is to atomically flip the action to
+      // blocked_child_action_input_required and persist the resumeState in the step context so
+      // the loop pauses and can later resume exactly where it stopped. Skipping them would return
+      // [...blockingEvents, tool_paused] backed by no persisted state at all: a pause signal that
+      // nothing can ever resume, silently swallowing the tool's blocking behavior. Today the
+      // resource only comes from tools unavailable to sandbox functions (sandbox bash, which is
+      // conversation-bound by definition, and run_agent, which is conversation-tied for now).
+      // TODO(SANDBOX_FUNCTIONS): supporting run_agent from a sandbox function requires
+      // invocation-level pause/resume semantics (persisted resume state on the invocation and a
+      // way for the caller to resume); wire them here then. Until that exists, failing loudly
+      // beats emitting a plausible-looking but broken pause.
+      assert(
+        isAgentLoopRunContext(runContext),
+        "tool_blocked_awaiting_input requires an agent loop run context."
+      );
+
+      // Update the action status to blocked_child_action_input_required to break the agent loop.
+      await runContext.action.updateStatus(
+        "blocked_child_action_input_required"
+      );
+
+      // Update the step context to save the resume state.
+      await runContext.action.updateStepContext({
+        ...runContext.action.stepContext,
+        resumeState: state,
+      });
+
+      // Forward any UI-facing blocking events the tool collected, plus a `tool_paused` sentinel.
+      // The sentinel keeps the pause-decision on the event channel even when `blockingEvents` is
+      // empty — the case for any future tool whose blocking event is published upstream out-of-band
+      // (e.g. sandbox bash, where the child's blocking event is published by
+      // `createSandboxChildAction` and never flows through bash's return). Without it,
+      // `runToolWithStreaming` would fall through to `markAsSucceeded` on an already-blocked
+      // action.Appended LAST so the for-await in `executeToolStreaming` processes every blocking
+      // event before the sentinel triggers the return.
+      return [
+        // Blocking events are parsed with the public client schemas where agentName is optional;
+        // normalize to the placeholder constant expected internally.
+        ...blockingEvents.map((event) => ({
+          ...event,
+          metadata: { ...event.metadata, agentName: "agent" as const },
+        })),
+        {
+          type: "tool_paused",
+          created: Date.now(),
+          ...eventScope,
+          actionId: action.sId,
+        },
+      ];
+    }
+    case "tool_personal_auth_required": {
+      const { provider, scope } = exitOutputItem;
+
+      const authErrorMessage =
+        `The tool ${toolCallName} requires personal ` +
+        `authentication, please authenticate to use it.`;
+
+      // The blocked statuses only exist on agent MCP actions; sandbox function invocations observe
+      // the returned event instead.
+      if (isAgentLoopRunContext(runContext)) {
         // Update the action to mark it as blocked because of a personal authentication error.
-        await action.updateStatus("blocked_authentication_required");
-        await pauseSandboxBashForBlockedChild(auth, action, conversation);
-
-        return [
-          {
-            type: "tool_personal_auth_required",
-            created: Date.now(),
-            configurationId: agentConfiguration.sId,
-            userId: auth.user()?.sId,
-            messageId: agentMessage.sId,
-            conversationId: conversation.sId,
-            actionId: action.sId,
-            metadata: {
-              toolName: action.toolConfiguration.originalName,
-              mcpServerName: action.toolConfiguration.mcpServerName,
-              agentName: "agent",
-              mcpServerDisplayName: action.toolConfiguration.mcpServerName,
-              mcpServerId: action.toolConfiguration.toolServerId,
-            },
-            inputs: action.augmentedInputs,
-            authError: {
-              mcpServerId: action.toolConfiguration.toolServerId,
-              provider,
-              toolName: action.functionCallName ?? "unknown",
-              message: authErrorMessage,
-              ...(scope && {
-                scope,
-              }),
-            },
-          },
-        ];
+        await runContext.action.updateStatus("blocked_authentication_required");
+        await pauseSandboxBashForBlockedChild(
+          auth,
+          runContext.action,
+          runContext.conversation
+        );
       }
-      case "tool_file_auth_required": {
-        const { fileId, fileName, connectionId, mimeType_file } =
-          exitOutputItem;
 
-        const fileAuthErrorMessage =
-          `The tool ${action.functionCallName} requires file authorization ` +
-          `for ${fileName}, please authorize the file to continue.`;
+      return [
+        {
+          type: "tool_personal_auth_required",
+          created: Date.now(),
+          ...eventScope,
+          userId: auth.user()?.sId,
+          actionId: action.sId,
+          metadata: {
+            toolName: toolConfiguration.originalName,
+            mcpServerName: toolConfiguration.mcpServerName,
+            agentName: "agent",
+            mcpServerDisplayName: toolConfiguration.mcpServerName,
+            mcpServerId: toolConfiguration.toolServerId,
+          },
+          inputs,
+          authError: {
+            mcpServerId: toolConfiguration.toolServerId,
+            provider,
+            toolName: toolCallName,
+            message: authErrorMessage,
+            ...(scope && {
+              scope,
+            }),
+          },
+        },
+      ];
+    }
+    case "tool_file_auth_required": {
+      const { fileId, fileName, connectionId, mimeType_file } = exitOutputItem;
 
-        await action.updateStatus("blocked_file_authorization_required");
-        await pauseSandboxBashForBlockedChild(auth, action, conversation);
+      const fileAuthErrorMessage =
+        `The tool ${toolCallName} requires file authorization ` +
+        `for ${fileName}, please authorize the file to continue.`;
+
+      // The blocked statuses and step context only exist on agent MCP actions; sandbox function
+      // invocations observe the returned event instead.
+      if (isAgentLoopRunContext(runContext)) {
+        await runContext.action.updateStatus(
+          "blocked_file_authorization_required"
+        );
+        await pauseSandboxBashForBlockedChild(
+          auth,
+          runContext.action,
+          runContext.conversation
+        );
 
         // Persisted here so the blocked action can be reconstructed on page reload.
-        await action.updateStepContext({
-          ...action.stepContext,
+        await runContext.action.updateStepContext({
+          ...runContext.action.stepContext,
           fileAuthorizationInfo: {
             fileId,
             fileName,
@@ -168,70 +228,72 @@ export async function getExitOrPauseEvents(
             mimeType: mimeType_file,
           },
         });
-
-        return [
-          {
-            type: "tool_file_auth_required",
-            created: Date.now(),
-            configurationId: agentConfiguration.sId,
-            userId: auth.user()?.sId,
-            messageId: agentMessage.sId,
-            conversationId: conversation.sId,
-            actionId: action.sId,
-            metadata: {
-              toolName: action.toolConfiguration.originalName,
-              mcpServerName: action.toolConfiguration.mcpServerName,
-              agentName: "agent",
-              mcpServerDisplayName: action.toolConfiguration.mcpServerName,
-              mcpServerId: action.toolConfiguration.toolServerId,
-            },
-            inputs: action.augmentedInputs,
-            fileAuthError: {
-              fileId,
-              fileName,
-              connectionId,
-              mimeType: mimeType_file,
-              toolName: action.functionCallName ?? "unknown",
-              message: fileAuthErrorMessage,
-            },
-          },
-        ];
       }
-      case "tool_user_answer_required": {
-        const { question } = exitOutputItem;
 
-        await action.updateStatus("blocked_user_answer_required");
-        await pauseSandboxBashForBlockedChild(auth, action, conversation);
+      return [
+        {
+          type: "tool_file_auth_required",
+          created: Date.now(),
+          ...eventScope,
+          userId: auth.user()?.sId,
+          actionId: action.sId,
+          metadata: {
+            toolName: toolConfiguration.originalName,
+            mcpServerName: toolConfiguration.mcpServerName,
+            agentName: "agent",
+            mcpServerDisplayName: toolConfiguration.mcpServerName,
+            mcpServerId: toolConfiguration.toolServerId,
+          },
+          inputs,
+          fileAuthError: {
+            fileId,
+            fileName,
+            connectionId,
+            mimeType: mimeType_file,
+            toolName: toolCallName,
+            message: fileAuthErrorMessage,
+          },
+        },
+      ];
+    }
+    case "tool_user_answer_required": {
+      const { question } = exitOutputItem;
 
-        await action.updateStepContext({
-          ...action.stepContext,
+      // The blocked statuses and step context only exist on agent MCP actions; sandbox function
+      // invocations observe the returned event instead.
+      if (isAgentLoopRunContext(runContext)) {
+        await runContext.action.updateStatus("blocked_user_answer_required");
+        await pauseSandboxBashForBlockedChild(
+          auth,
+          runContext.action,
+          runContext.conversation
+        );
+
+        await runContext.action.updateStepContext({
+          ...runContext.action.stepContext,
           resumeState: { type: "user_question", question },
         });
+      }
 
-        return [
-          {
-            type: "tool_ask_user_question",
-            created: Date.now(),
-            configurationId: agentConfiguration.sId,
-            userId: auth.user()?.sId,
-            messageId: agentMessage.sId,
-            conversationId: conversation.sId,
-            actionId: action.sId,
-            metadata: {
-              toolName: action.toolConfiguration.originalName,
-              mcpServerName: action.toolConfiguration.mcpServerName,
-              agentName: "agent",
-            },
-            inputs: action.augmentedInputs,
-            question,
+      return [
+        {
+          type: "tool_ask_user_question",
+          created: Date.now(),
+          ...eventScope,
+          userId: auth.user()?.sId,
+          actionId: action.sId,
+          metadata: {
+            toolName: toolConfiguration.originalName,
+            mcpServerName: toolConfiguration.mcpServerName,
+            agentName: "agent",
           },
-        ];
-      }
-      default: {
-        assertNever(exitOutputItem);
-      }
+          inputs,
+          question,
+        },
+      ];
+    }
+    default: {
+      assertNever(exitOutputItem);
     }
   }
-
-  return [];
 }

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -1,8 +1,8 @@
 import type { AgentActionRunningEvents } from "@app/lib/actions/mcp";
 import type {
-  ToolAskUserQuestionEvent,
-  ToolFileAuthRequiredEvent,
-  ToolPersonalAuthRequiredEvent,
+  AgentLoopToolAskUserQuestionEvent,
+  AgentLoopToolFileAuthRequiredEvent,
+  AgentLoopToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
 import type {
   AgentActionSuccessEvent,
@@ -38,9 +38,9 @@ export type AgentMessageEvents =
   | AgentToolCallStartedEvent
   | GenerationTokensEvent
   | ToolErrorEvent
-  | ToolAskUserQuestionEvent
-  | ToolFileAuthRequiredEvent
-  | ToolPersonalAuthRequiredEvent;
+  | AgentLoopToolAskUserQuestionEvent
+  | AgentLoopToolFileAuthRequiredEvent
+  | AgentLoopToolPersonalAuthRequiredEvent;
 
 export type ConversationEvents =
   | ConversationTitleEvent

--- a/front/lib/api/mcp/error.ts
+++ b/front/lib/api/mcp/error.ts
@@ -3,10 +3,11 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 type HandleErrorParams = {
-  action: AgentMCPActionResource;
+  action: AgentMCPActionResource | SandboxFunctionMCPActionResource;
   errorContent: CallToolResult["content"];
   status: ToolExecutionStatus;
   executionDurationMs: number;

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -19,42 +19,31 @@ import type {
 import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/exit_events";
 import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import type {
-  AgentLoopRunContextType,
+  ToolContextType,
   ToolOutputItemType,
 } from "@app/lib/actions/types";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS } from "@app/temporal/agent_loop/config";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { heartbeat } from "@temporalio/activity";
+import assert from "assert";
 
 /**
- * Runs a tool with streaming for the given MCP action configuration.
+ * Runs a tool with streaming for the given tool context.
  *
  * All errors within this function must be handled through `handleMCPActionError`
  * to ensure consistent error reporting and proper conversation flow control.
- * TODO(DURABLE_AGENTS 2025-08-05): This function is going to be used only to execute the tool.
  */
 export async function* runToolWithStreaming(
   auth: Authenticator,
   {
-    action,
-    agentConfiguration,
-    model,
-    agentMessage,
-    conversation,
-    userMessage,
+    toolContext,
   }: {
-    action: AgentMCPActionResource;
-    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
-    model: AgentLoopExecutionData["model"];
-    agentMessage: AgentLoopExecutionData["agentMessage"];
-    conversation: AgentLoopExecutionData["conversation"];
-    userMessage: AgentLoopExecutionData["userMessage"];
+    toolContext: ToolContextType;
   },
   options?: { signal?: AbortSignal }
 ): AsyncGenerator<
@@ -69,52 +58,54 @@ export async function* runToolWithStreaming(
   | ToolPausedEvent,
   void
 > {
-  const { toolConfiguration, status, augmentedInputs: inputs } = action;
+  const { runContext } = toolContext;
+  assert(runContext, "runToolWithStreaming requires a tool run context.");
+
+  const { action, toolConfiguration } = runContext;
+  const { status } = action;
 
   const signal = options?.signal;
 
+  // Inputs as issued in the run context.
+  const inputs = isAgentLoopRunContext(runContext)
+    ? runContext.action.augmentedInputs
+    : runContext.action.inputs;
+
   const localLogger = logger.child({
     actionConfigurationId: toolConfiguration.sId,
-    conversationId: conversation.sId,
-    messageId: agentMessage.sId,
-    workspaceId: conversation.owner.sId,
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    ...(isAgentLoopRunContext(runContext)
+      ? {
+          conversationId: runContext.conversation.sId,
+          messageId: runContext.agentMessage.sId,
+        }
+      : {
+          sandboxFunctionId: runContext.invocation.sandboxFunction.sId,
+          invocationId: runContext.invocation.sId,
+        }),
   });
 
-  const agentLoopRunContext: AgentLoopRunContextType = {
-    contextType: "agent_loop",
-    action,
-    agentConfiguration,
-    model,
-    agentMessage,
-    conversation,
-    stepContext: action.stepContext,
-    toolConfiguration,
-    userMessage,
-  };
-
-  await action.updateStatus("running");
+  // Sandbox function actions are created in running status.
+  if (isAgentLoopRunContext(runContext)) {
+    await runContext.action.updateStatus("running");
+  }
   const startDate = performance.now();
 
   const intermediateOutputItems: ToolOutputItemType[] = [];
 
-  const toolCallResult = yield* tryCallMCPTool(
-    auth,
-    inputs,
-    { runContext: agentLoopRunContext },
-    {
-      progressToken: action.id,
-      makeToolNotificationEvent: async (notification) => {
-        const { event, outputItems } = await processToolNotification(
-          auth,
-          notification,
-          { toolContext: { runContext: agentLoopRunContext } }
-        );
-        intermediateOutputItems.push(...outputItems);
-        return event;
-      },
-      signal,
-    }
-  );
+  const toolCallResult = yield* tryCallMCPTool(auth, inputs, toolContext, {
+    progressToken: action.id,
+    makeToolNotificationEvent: async (notification) => {
+      const { event, outputItems } = await processToolNotification(
+        auth,
+        notification,
+        { toolContext }
+      );
+      intermediateOutputItems.push(...outputItems);
+      return event;
+    },
+    signal,
+  });
 
   // Err here means an exception ahead of calling the tool, like a connection error, an input
   // validation error, or any other kind of error from MCP, but not a tool error, which are returned
@@ -137,7 +128,7 @@ export async function* runToolWithStreaming(
       processToolResults(auth, {
         localLogger,
         toolCallResultContent: toolCallResult.content,
-        toolContext: { runContext: agentLoopRunContext },
+        toolContext,
       }),
     {
       intervalMs: TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS,
@@ -152,10 +143,7 @@ export async function* runToolWithStreaming(
   // This could be an authentication, validation, or unconditional exit from the action.
   const agentPauseEvents = await getExitOrPauseEvents(auth, {
     outputItems,
-    action,
-    agentConfiguration,
-    agentMessage,
-    conversation,
+    toolContext,
   });
 
   if (agentPauseEvents.length > 0) {

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,4 +1,5 @@
 import { isAgentLoopToolNotificationEvent } from "@app/lib/actions/mcp";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { isLightClientSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
@@ -228,19 +229,24 @@ async function executeToolStreaming(
     ? updateResourceAndPublishEvent
     : () => {};
 
-  const eventStream = runToolWithStreaming(
-    auth,
-    {
+  const toolContext: ToolContextType = {
+    runContext: {
+      contextType: "agent_loop",
       action,
       agentConfiguration,
       model,
       agentMessage,
       conversation,
+      stepContext: action.stepContext,
+      toolConfiguration: action.toolConfiguration,
       userMessage,
     },
-    {
-      signal: abortSignal,
-    }
+  };
+
+  const eventStream = runToolWithStreaming(
+    auth,
+    { toolContext },
+    { signal: abortSignal }
   );
 
   for await (const event of eventStream) {
@@ -378,6 +384,13 @@ async function executeToolStreaming(
       case "tool_file_auth_required":
       case "tool_approve_execution":
       case "tool_ask_user_question":
+        // The agent loop activity always runs tools with an agent loop context, so sandbox
+        // function scoped events cannot surface here.
+        assert(
+          "conversationId" in event,
+          "Unexpected sandbox function tool event in the agent loop."
+        );
+
         updateActiveObservation(
           {
             output: { status: event.type },

--- a/front/temporal/agent_loop/lib/deferred_events.ts
+++ b/front/temporal/agent_loop/lib/deferred_events.ts
@@ -1,8 +1,8 @@
 import type {
+  AgentLoopToolAskUserQuestionEvent,
+  AgentLoopToolFileAuthRequiredEvent,
+  AgentLoopToolPersonalAuthRequiredEvent,
   MCPApproveExecutionEvent,
-  ToolAskUserQuestionEvent,
-  ToolFileAuthRequiredEvent,
-  ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
 import type { ModelId } from "@app/types/shared/model_id";
 
@@ -13,9 +13,9 @@ import type { ModelId } from "@app/types/shared/model_id";
  */
 type DeferrableEvent =
   | MCPApproveExecutionEvent
-  | ToolAskUserQuestionEvent
-  | ToolFileAuthRequiredEvent
-  | ToolPersonalAuthRequiredEvent;
+  | AgentLoopToolAskUserQuestionEvent
+  | AgentLoopToolFileAuthRequiredEvent
+  | AgentLoopToolPersonalAuthRequiredEvent;
 
 /**
  * Context information needed to send a deferred event.


### PR DESCRIPTION
## Description

Step towards conversation-free tool execution (sandbox function invocations): the tool runner is now driven entirely by the tool context.

- `runToolWithStreaming(auth, { toolContext }, options)`: no more `action` / `agentConfiguration` / `model` / `agentMessage` / `conversation` / `userMessage` parameters. Inputs (`augmentedInputs` vs `inputs`), logger fields, and the initial `updateStatus("running")` (agent loop only — sandbox actions are created running) are resolved from the run context. `executeToolStreaming` keeps its signature and builds the context.
- `ToolExecution` is split into `AgentLoopToolExecution` (conversation-scoped identifiers) and `SandboxFunctionToolExecution` (`sandboxFunctionId` / `invocationId`) over a shared base, and all exit/pause events get both variants: `ToolPersonalAuthRequiredEvent`, `ToolFileAuthRequiredEvent`, `ToolAskUserQuestionEvent`, `ToolEarlyExitEvent`, `ToolPausedEvent`. Both variants share the single validation metadata type (`agentName` is the hardcoded `"agent"` placeholder from #28717, pending removal). The publish path (`AgentMessageEvents`, `DeferrableEvent`) and `BlockedToolExecution` stay pinned to the agent loop variants: no wire shape changes.
- `getExitOrPauseEvents(auth, { outputItems, toolContext })` builds the variant matching the run context (identifiers, tool call name, and inputs derived through an exhaustive switch). For auth and user-question exits, the agent-loop-only mutations (blocked statuses, resume step context, sandbox bash pause) are guarded but the event is returned in both contexts: sandbox function invocations observe the returned event instead. For `tool_blocked_awaiting_input` the blocked status and resume state are likewise persisted in agent loop contexts only; its emitters (sandbox bash, run_agent) are unavailable to sandbox functions today, and supporting run_agent there requires invocation-level pause/resume semantics first (TODO in place).
- `handleMCPActionError` accepts both action resources (all calls are polymorphic).

## Tests

`lib/actions/mcp_execution.test.ts`, `lib/actions/mcp_actions.test.ts`, `lib/actions/mcp_internal_actions/exit_events.test.ts`, `temporal/agent_loop/activities/common.test.ts` pass.

## Risk

Medium. The agent loop tool execution path is refactored in place: behavior is intended to be identical (same events, same payloads, same mutations), but this is the core tool execution flow. The sandbox function paths have no caller yet.

## Deploy Plan

- deploy `front`

