### PR TITLE
Give Frame source files a larger edit size cap

### DIFF
--- a/front/lib/api/actions/servers/files/tools/create.test.ts
+++ b/front/lib/api/actions/servers/files/tools/create.test.ts
@@ -106,4 +106,25 @@ describe("createHandler", () => {
       "application/vnd.dust.frame"
     );
   });
+
+  it("overwrites an existing frame file well over the generic 50 KB limit", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    fileStorageMock.setFileMetadata(() => ({
+      contentType: "application/vnd.dust.frame",
+      size: "100",
+    }));
+    const content = "// padding\n".repeat(6000); // ~66 KB
+
+    const result = await createHandler(
+      {
+        path: `conversation-${conversation.sId}/interactive.tsx`,
+        content,
+        content_type: "text/plain",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
+  });
 });

--- a/front/lib/api/actions/servers/files/tools/create.test.ts
+++ b/front/lib/api/actions/servers/files/tools/create.test.ts
@@ -1,5 +1,6 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { ToolContextType } from "@app/lib/actions/types";
+import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
 import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -113,7 +114,7 @@ describe("createHandler", () => {
       contentType: "application/vnd.dust.frame",
       size: "100",
     }));
-    const content = "// padding\n".repeat(6000); // ~66 KB
+    const content = "x".repeat(CREATE_CONTENT_MAX_BYTES + 1);
 
     const result = await createHandler(
       {

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -11,6 +11,7 @@ import {
   scopedPathsFromArgs,
 } from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
 import { frameSourceUpdatedNotice } from "@app/lib/api/actions/servers/files/tools/utils";
+import { FRAME_SOURCE_MAX_BYTES } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { getFilePreviewDirectiveInstruction } from "@app/lib/markdown/file_preview";
 import {
   isAllSupportedFileContentType,
@@ -31,16 +32,6 @@ export async function createHandler(
   const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
-  }
-
-  const contentBuffer = Buffer.from(content, "utf8");
-  if (contentBuffer.byteLength > CREATE_CONTENT_MAX_BYTES) {
-    return new Err(
-      new MCPError(
-        `Content exceeds the ${CREATE_CONTENT_MAX_BYTES / 1024} KB limit.`,
-        { tracked: false }
-      )
-    );
   }
 
   const fsResult = await getDustFileSystemForAgentLoop(
@@ -68,6 +59,18 @@ export async function createHandler(
       // Keep the frame content type on the mount so the file stays recognized as a Frame.
       writeContentType = statResult.value.contentType;
     }
+  }
+
+  const contentBuffer = Buffer.from(content, "utf8");
+  const maxBytes = isFrameSourceOverwrite
+    ? FRAME_SOURCE_MAX_BYTES
+    : CREATE_CONTENT_MAX_BYTES;
+  if (contentBuffer.byteLength > maxBytes) {
+    return new Err(
+      new MCPError(`Content exceeds the ${maxBytes / 1024} KB limit.`, {
+        tracked: false,
+      })
+    );
   }
 
   const writeResult = await dustFs.write(path, contentBuffer, writeContentType);

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -7,6 +7,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
+import { frameContentType } from "@app/types/files";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -238,6 +239,53 @@ describe("editHandler", () => {
     const result = await editHandler(
       {
         path: `conversation-${conversation.sId}/big.txt`,
+        old_string: "a",
+        new_string: "b",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("KB limit");
+    }
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("edits a Frame source file well over the generic 50 KB limit", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    // A Frame template can legitimately exceed the generic files-server cap.
+    const padding = "// padding\n".repeat(6000); // ~66 KB
+    mockStoredFile(
+      `${padding}export default function App() { return <h1>Old</h1>; }\n`,
+      frameContentType
+    );
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/App.tsx`,
+        old_string: "Old",
+        new_string: "New",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    expect(fileStorageMock.saveFileCalls[0].content.toString("utf8")).toContain(
+      "New"
+    );
+  });
+
+  it("returns Err when a Frame source file exceeds its own, larger size limit", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    fileStorageMock.setFileMetadata(() => ({
+      contentType: frameContentType,
+      size: String(2 * 1024 * 1024),
+    }));
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/App.tsx`,
         old_string: "a",
         new_string: "b",
       },

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -1,6 +1,8 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { ToolContextType } from "@app/lib/actions/types";
+import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
 import { editHandler } from "@app/lib/api/actions/servers/files/tools/edit";
+import { FRAME_SOURCE_MAX_BYTES } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -233,7 +235,7 @@ describe("editHandler", () => {
     const { auth, conversation } = await setupProjectConversation();
     fileStorageMock.setFileMetadata(() => ({
       contentType: "text/plain",
-      size: String(51 * 1024),
+      size: String(CREATE_CONTENT_MAX_BYTES + 1),
     }));
 
     const result = await editHandler(
@@ -255,9 +257,9 @@ describe("editHandler", () => {
   it("edits a Frame source file well over the generic 50 KB limit", async () => {
     const { auth, conversation } = await setupProjectConversation();
     // A Frame template can legitimately exceed the generic files-server cap.
-    const padding = "// padding\n".repeat(6000); // ~66 KB
+    const padding = "x".repeat(CREATE_CONTENT_MAX_BYTES + 1);
     mockStoredFile(
-      `${padding}export default function App() { return <h1>Old</h1>; }\n`,
+      `// ${padding}\nexport default function App() { return <h1>Old</h1>; }\n`,
       frameContentType
     );
 
@@ -280,7 +282,7 @@ describe("editHandler", () => {
     const { auth, conversation } = await setupProjectConversation();
     fileStorageMock.setFileMetadata(() => ({
       contentType: frameContentType,
-      size: String(2 * 1024 * 1024),
+      size: String(FRAME_SOURCE_MAX_BYTES + 1),
     }));
 
     const result = await editHandler(

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -18,6 +18,7 @@ import {
   frameSourceUpdatedNotice,
   isReadableAsText,
 } from "@app/lib/api/actions/servers/files/tools/utils";
+import { FRAME_SOURCE_MAX_BYTES } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
 import {
   isInteractiveContentType,
@@ -80,10 +81,11 @@ export async function editHandler(
     );
   }
 
-  if (sizeBytes > CREATE_CONTENT_MAX_BYTES) {
+  const maxBytes = isFrameSource ? FRAME_SOURCE_MAX_BYTES : CREATE_CONTENT_MAX_BYTES;
+  if (sizeBytes > maxBytes) {
     return new Err(
       new MCPError(
-        `\`${path}\` exceeds the ${CREATE_CONTENT_MAX_BYTES / 1024} KB limit and cannot be edited with this tool.`,
+        `\`${path}\` exceeds the ${maxBytes / 1024} KB limit and cannot be edited with this tool.`,
         { tracked: false }
       )
     );
@@ -131,10 +133,10 @@ export async function editHandler(
   }
 
   const updatedBuffer = Buffer.from(updatedContent, "utf8");
-  if (updatedBuffer.byteLength > CREATE_CONTENT_MAX_BYTES) {
+  if (updatedBuffer.byteLength > maxBytes) {
     return new Err(
       new MCPError(
-        `Edited content exceeds the ${CREATE_CONTENT_MAX_BYTES / 1024} KB limit.`,
+        `Edited content exceeds the ${maxBytes / 1024} KB limit.`,
         { tracked: false }
       )
     );

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -81,7 +81,9 @@ export async function editHandler(
     );
   }
 
-  const maxBytes = isFrameSource ? FRAME_SOURCE_MAX_BYTES : CREATE_CONTENT_MAX_BYTES;
+  const maxBytes = isFrameSource
+    ? FRAME_SOURCE_MAX_BYTES
+    : CREATE_CONTENT_MAX_BYTES;
   if (sizeBytes > maxBytes) {
     return new Err(
       new MCPError(
@@ -135,10 +137,9 @@ export async function editHandler(
   const updatedBuffer = Buffer.from(updatedContent, "utf8");
   if (updatedBuffer.byteLength > maxBytes) {
     return new Err(
-      new MCPError(
-        `Edited content exceeds the ${maxBytes / 1024} KB limit.`,
-        { tracked: false }
-      )
+      new MCPError(`Edited content exceeds the ${maxBytes / 1024} KB limit.`, {
+        tracked: false,
+      })
     );
   }
 

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -12,7 +12,8 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const INTERACTIVE_CONTENT_SERVER_NAME = "interactive_content" as const;
 
-const MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024; // 1MB
+// Frame sources can legitimately be large, e.g. a server-fetched template.
+export const FRAME_SOURCE_MAX_BYTES = 1 * 1024 * 1024; // 1MB
 
 export const CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME =
   "create_interactive_content_file";
@@ -75,7 +76,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
         ),
       source: z
         .string()
-        .max(MAX_FILE_SIZE_BYTES)
+        .max(FRAME_SOURCE_MAX_BYTES)
         .describe(
           "When mode='template': a reference to an existing document to use as a template. " +
             "Accepts either a knowledge base node ID or a scoped file system path " +


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Removing the file-id Frame edit tool for file-system conversations left large Frames with no working edit path (see  https://github.com/dust-tt/dust/pull/28413). The replacement (path-based file editing) enforces a 50 KB cap sized for small generic text and code files, and applies it uniformly regardless of content type, including to Frame sources. The old tool never had any size limit at all, so any Frame template over 50 KB, entirely normal since a template can be fetched server-side at creation with no size restriction, became uneditable the moment that removal shipped, with no fallback for a conversation without Computer access.

Frame sources now get their own, much larger cap when editing or overwriting them through the file tools, matching the limit a Frame is already allowed at creation time. Generic files are unaffected. Confirmed with a real Frame well over the old cap that a small, targeted edit succeeds where it previously failed outright, and that the same larger cap still rejects genuinely oversized content.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
