### PR TITLE
feat(activation): orchestrator and CLI skeleton (S2-1, S2-3)

### DIFF
--- a/front/lib/api/activation/orchestrator.ts
+++ b/front/lib/api/activation/orchestrator.ts
@@ -1,16 +1,16 @@
 import { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { ModelId } from "@app/types/shared/model_id";
 
 export type NudgePlan = {
   podId: string;
-  spaceId: number;
-  targetUserId: number;
+  spaceModelId: ModelId;
+  targetUserModelId: ModelId;
 };
 
 export type SkippedUser = {
-  userId: number;
+  userModelId: ModelId;
   podId: string;
 };
 
@@ -20,30 +20,30 @@ export type OrchestratorResult = {
 };
 
 /**
- * Returns a map of spaceId → active member userIds for each pod
+ * Returns a map of space model id → active member user model ids for each pod.
  */
 async function fetchPodMembers(
   auth: Authenticator,
-  spaceIds: number[]
-): Promise<Map<number, number[]>> {
-  if (spaceIds.length === 0) {
+  spaceModelIds: ModelId[]
+): Promise<Map<ModelId, ModelId[]>> {
+  if (spaceModelIds.length === 0) {
     return new Map();
   }
 
-  const spaces = await SpaceResource.fetchByModelIds(auth, spaceIds);
+  const spaces = await SpaceResource.fetchByModelIds(auth, spaceModelIds);
+  const membersBySpaceModelId =
+    await SpaceResource.fetchDistinctActiveManualGroupMembersBySpaces(
+      auth,
+      spaces
+    );
 
-  const result = new Map<number, number[]>();
-  await concurrentExecutor(
-    spaces,
-    async (space) => {
-      const members = await space.fetchDistinctActiveManualGroupMembers(auth);
-      result.set(
-        space.id,
-        members.map((u) => u.id)
-      );
-    },
-    { concurrency: 5 }
-  );
+  const result = new Map<ModelId, ModelId[]>();
+  for (const [spaceModelId, members] of membersBySpaceModelId) {
+    result.set(
+      spaceModelId,
+      members.map((u) => u.id)
+    );
+  }
   return result;
 }
 
@@ -52,10 +52,10 @@ async function fetchPodMembers(
  */
 export async function determineEligibleActivationUsers({
   workspaceId,
-  userIdFilter,
+  userModelIdFilter,
 }: {
   workspaceId: string;
-  userIdFilter: number | null;
+  userModelIdFilter: ModelId | null;
 }): Promise<OrchestratorResult> {
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
@@ -71,20 +71,20 @@ export async function determineEligibleActivationUsers({
   for (const pod of pods) {
     const members = podMembers.get(pod.spaceId) ?? [];
 
-    for (const userId of members) {
-      if (userIdFilter !== null && userId !== userIdFilter) {
+    for (const userModelId of members) {
+      if (userModelIdFilter !== null && userModelId !== userModelIdFilter) {
         continue;
       }
 
-      if (!isEligibleForActivation(userId)) {
-        skipped.push({ userId, podId: pod.sId });
+      if (!isEligibleForActivation(userModelId)) {
+        skipped.push({ userModelId, podId: pod.sId });
         continue;
       }
 
       eligible.push({
         podId: pod.sId,
-        spaceId: pod.spaceId,
-        targetUserId: userId,
+        spaceModelId: pod.spaceId,
+        targetUserModelId: userModelId,
       });
     }
   }
@@ -93,6 +93,6 @@ export async function determineEligibleActivationUsers({
 }
 
 // TODO: This is a placeholder for the actual eligibility logic
-function isEligibleForActivation(userId: number): boolean {
+function isEligibleForActivation(userModelId: ModelId): boolean {
   return true;
 }

--- a/front/lib/api/activation/orchestrator.ts
+++ b/front/lib/api/activation/orchestrator.ts
@@ -1,16 +1,16 @@
 import { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { ModelId } from "@app/types/shared/model_id";
+import type { UserResource } from "@app/lib/resources/user_resource";
 
 export type NudgePlan = {
   podId: string;
-  spaceModelId: ModelId;
-  targetUserModelId: ModelId;
+  spaceId: string;
+  targetUserId: string;
 };
 
 export type SkippedUser = {
-  userModelId: ModelId;
+  userId: string;
   podId: string;
 };
 
@@ -20,71 +20,55 @@ export type OrchestratorResult = {
 };
 
 /**
- * Returns a map of space model id → active member user model ids for each pod.
+ * Determines which users are eligible for activation based on the workspace and user filter
  */
-async function fetchPodMembers(
-  auth: Authenticator,
-  spaceModelIds: ModelId[]
-): Promise<Map<ModelId, ModelId[]>> {
-  if (spaceModelIds.length === 0) {
-    return new Map();
-  }
+export async function determineEligibleActivationUsers({
+  workspaceId,
+  userId,
+}: {
+  workspaceId: string;
+  userId: string | null;
+}): Promise<OrchestratorResult> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
-  const spaces = await SpaceResource.fetchByModelIds(auth, spaceModelIds);
+  const pods = await ProjectMetadataResource.fetchActivationPods(auth);
+
+  const spaces = await SpaceResource.fetchByModelIds(
+    auth,
+    pods.map((p) => p.spaceId)
+  );
+  const spaceByModelId = new Map(spaces.map((space) => [space.id, space]));
   const membersBySpaceModelId =
     await SpaceResource.fetchDistinctActiveManualGroupMembersBySpaces(
       auth,
       spaces
     );
 
-  const result = new Map<ModelId, ModelId[]>();
-  for (const [spaceModelId, members] of membersBySpaceModelId) {
-    result.set(
-      spaceModelId,
-      members.map((u) => u.id)
-    );
-  }
-  return result;
-}
-
-/**
- * Determines which users are eligible for activation based on the workspace and user filter
- */
-export async function determineEligibleActivationUsers({
-  workspaceId,
-  userModelIdFilter,
-}: {
-  workspaceId: string;
-  userModelIdFilter: ModelId | null;
-}): Promise<OrchestratorResult> {
-  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
-
-  const pods = await ProjectMetadataResource.fetchActivationPods(auth);
-  const podMembers = await fetchPodMembers(
-    auth,
-    pods.map((p) => p.spaceId)
-  );
-
   const eligible: NudgePlan[] = [];
   const skipped: SkippedUser[] = [];
 
   for (const pod of pods) {
-    const members = podMembers.get(pod.spaceId) ?? [];
+    const space = spaceByModelId.get(pod.spaceId);
+    if (!space) {
+      continue;
+    }
 
-    for (const userModelId of members) {
-      if (userModelIdFilter !== null && userModelId !== userModelIdFilter) {
+    const members = membersBySpaceModelId.get(pod.spaceId) ?? [];
+
+    for (const member of members) {
+      if (userId !== null && member.sId !== userId) {
         continue;
       }
 
-      if (!isEligibleForActivation(userModelId)) {
-        skipped.push({ userModelId, podId: pod.sId });
+      if (!isEligibleForActivation(member)) {
+        skipped.push({ userId: member.sId, podId: pod.sId });
         continue;
       }
 
       eligible.push({
         podId: pod.sId,
-        spaceModelId: pod.spaceId,
-        targetUserModelId: userModelId,
+        spaceId: space.sId,
+        targetUserId: member.sId,
       });
     }
   }
@@ -93,6 +77,6 @@ export async function determineEligibleActivationUsers({
 }
 
 // TODO: This is a placeholder for the actual eligibility logic
-function isEligibleForActivation(userModelId: ModelId): boolean {
+function isEligibleForActivation(user: UserResource): boolean {
   return true;
 }

--- a/front/lib/api/activation/orchestrator.ts
+++ b/front/lib/api/activation/orchestrator.ts
@@ -1,0 +1,98 @@
+import { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+
+export type NudgePlan = {
+  podId: string;
+  spaceId: number;
+  targetUserId: number;
+};
+
+export type SkippedUser = {
+  userId: number;
+  podId: string;
+};
+
+export type OrchestratorResult = {
+  eligible: NudgePlan[];
+  skipped: SkippedUser[];
+};
+
+/**
+ * Returns a map of spaceId → active member userIds for each pod
+ */
+async function fetchPodMembers(
+  auth: Authenticator,
+  spaceIds: number[]
+): Promise<Map<number, number[]>> {
+  if (spaceIds.length === 0) {
+    return new Map();
+  }
+
+  const spaces = await SpaceResource.fetchByModelIds(auth, spaceIds);
+
+  const result = new Map<number, number[]>();
+  await concurrentExecutor(
+    spaces,
+    async (space) => {
+      const members = await space.fetchDistinctActiveManualGroupMembers(auth);
+      result.set(
+        space.id,
+        members.map((u) => u.id)
+      );
+    },
+    { concurrency: 5 }
+  );
+  return result;
+}
+
+/**
+ * Determines which users are eligible for activation based on the workspace and user filter
+ */
+export async function determineEligibleActivationUsers({
+  workspaceId,
+  userIdFilter,
+}: {
+  workspaceId: string;
+  userIdFilter: number | null;
+}): Promise<OrchestratorResult> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+
+  const pods = await ProjectMetadataResource.fetchActivationPods(auth);
+  const podMembers = await fetchPodMembers(
+    auth,
+    pods.map((p) => p.spaceId)
+  );
+
+  const eligible: NudgePlan[] = [];
+  const skipped: SkippedUser[] = [];
+
+  for (const pod of pods) {
+    const members = podMembers.get(pod.spaceId) ?? [];
+
+    for (const userId of members) {
+      if (userIdFilter !== null && userId !== userIdFilter) {
+        continue;
+      }
+
+      if (!isEligibleForActivation(userId)) {
+        skipped.push({ userId, podId: pod.sId });
+        continue;
+      }
+
+      eligible.push({
+        podId: pod.sId,
+        spaceId: pod.spaceId,
+        targetUserId: userId,
+      });
+    }
+  }
+
+  return { eligible, skipped };
+}
+
+// TODO: This is a placeholder for the actual eligibility logic
+function isEligibleForActivation(userId: number): boolean {
+  return true;
+}

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -114,6 +114,22 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     );
   }
 
+  static async fetchActivationPods(
+    auth: Authenticator
+  ): Promise<ProjectMetadataResource[]> {
+    const models = await ProjectMetadataModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        provisioningSource: "activation" satisfies ProvisioningSource,
+        archivedAt: null,
+      },
+    });
+
+    return models.map((model) =>
+      ProjectMetadataResource.fromModel(model, model.spaceId)
+    );
+  }
+
   static async removeSkillFromAllDefaultSkills(
     auth: Authenticator,
     skillId: string,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1684,6 +1684,65 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return [...byId.values()];
   }
 
+  /**
+   * Batched variant of {@link SpaceResource.fetchDistinctActiveManualGroupMembers}
+   * across many spaces. Fetches every group's active memberships in a single
+   * query (and the referenced users in a single query), avoiding the N+1 that
+   * calling the per-space method in a loop would incur. Returns a map from
+   * space model id to its distinct active members.
+   */
+  static async fetchDistinctActiveManualGroupMembersBySpaces(
+    auth: Authenticator,
+    spaces: SpaceResource[]
+  ): Promise<Map<ModelId, UserResource[]>> {
+    const result = new Map<ModelId, UserResource[]>();
+    if (spaces.length === 0) {
+      return result;
+    }
+
+    // Manual groups (regular + editor) per space, plus the flat set of them all.
+    const manualGroupsBySpaceModelId = new Map<ModelId, GroupResource[]>();
+    const allGroups: GroupResource[] = [];
+    for (const space of spaces) {
+      const groups = space.groups.filter(
+        (g) => g.kind === "regular" || g.kind === "space_editors"
+      );
+      manualGroupsBySpaceModelId.set(space.id, groups);
+      allGroups.push(...groups);
+    }
+
+    // Single query for the active memberships across every group.
+    const userModelIdsByGroupModelId =
+      await GroupResource.getActiveMembershipsForGroups(auth, allGroups);
+
+    // Single query for all the users referenced by those memberships.
+    const allUserModelIds = new Set<ModelId>();
+    for (const userModelIds of Object.values(userModelIdsByGroupModelId)) {
+      for (const userModelId of userModelIds) {
+        allUserModelIds.add(userModelId);
+      }
+    }
+    const users = await UserResource.fetchByModelIds([...allUserModelIds]);
+    const usersByModelId = new Map(users.map((u) => [u.id, u]));
+
+    // Reassemble the distinct member set for each space.
+    for (const space of spaces) {
+      const groups = manualGroupsBySpaceModelId.get(space.id) ?? [];
+      const byId = new Map<ModelId, UserResource>();
+      for (const group of groups) {
+        for (const userModelId of userModelIdsByGroupModelId[group.id] ?? []) {
+          const user = usersByModelId.get(userModelId);
+          if (user && !byId.has(user.id)) {
+            byId.set(user.id, user);
+          }
+        }
+      }
+      result.set(space.id, [...byId.values()]);
+    }
+
+    return result;
+  }
+
   toJSON(): SpaceType {
     return {
       createdAt: this.createdAt.getTime(),

--- a/front/temporal/activation/admin/cli.ts
+++ b/front/temporal/activation/admin/cli.ts
@@ -6,13 +6,13 @@ const cliLogger = logger.child({ component: "activation.orchestrator.cli" });
 
 function usage() {
   cliLogger.info(`Usage:
-  run --workspace <sId> [--dry-run] [--execute] [--user <userId>]
+  run --workspace <sId> [--dry-run] [--execute] [--user <sId>]
 
 Options:
   --workspace <sId>    Workspace sId to run against (required)
   --dry-run            Print the nudge plan, touch nothing (default)
   --execute            Fire real nudges
-  --user <userId>     Restrict to a single user (model id)`);
+  --user <sId>         Restrict to a single user (sId)`);
 }
 
 const main = async () => {
@@ -36,21 +36,20 @@ const main = async () => {
     process.exit(1);
   }
 
-  const userModelIdFilter: number | null =
-    argv["user"] != null ? parseInt(argv["user"], 10) : null;
+  const userId: string | null = argv["user"] ?? null;
   const dryRun = !argv["execute"];
 
-  cliLogger.info({ workspaceId, userModelIdFilter, dryRun }, "starting run");
+  cliLogger.info({ workspaceId, userId, dryRun }, "starting run");
 
   const { eligible, skipped } = await determineEligibleActivationUsers({
     workspaceId,
-    userModelIdFilter,
+    userId,
   });
 
   cliLogger.info(
     {
       workspaceId,
-      userModelIdFilter,
+      userId,
       eligibleCount: eligible.length,
       skippedCount: skipped.length,
     },
@@ -59,13 +58,13 @@ const main = async () => {
 
   for (const plan of eligible) {
     cliLogger.info(
-      { userModelId: plan.targetUserModelId, podId: plan.podId },
+      { userId: plan.targetUserId, podId: plan.podId },
       "User eligible for nudge"
     );
   }
   for (const s of skipped) {
     cliLogger.info(
-      { userModelId: s.userModelId, podId: s.podId },
+      { userId: s.userId, podId: s.podId },
       "User skipped for nudge"
     );
   }

--- a/front/temporal/activation/admin/cli.ts
+++ b/front/temporal/activation/admin/cli.ts
@@ -1,0 +1,73 @@
+import {
+  determineEligibleActivationUsers,
+} from "@app/lib/api/activation/orchestrator";
+import logger from "@app/logger/logger";
+import parseArgs from "minimist";
+
+const cliLogger = logger.child({ component: "activation.orchestrator.cli" });
+
+function usage() {
+  console.error(`Usage:
+  run --workspace <sId> [--dry-run] [--execute] [--user <userId>]
+
+Options:
+  --workspace <sId>    Workspace sId to run against (required)
+  --dry-run            Print the nudge plan, touch nothing (default)
+  --execute            Fire real nudges
+  --user <userId>     Restrict to a single user (model id)`);
+}
+
+const main = async () => {
+  const argv = parseArgs(process.argv.slice(2), {
+    string: ["workspace", "user"],
+    boolean: ["dry-run", "execute"],
+    default: { "dry-run": true, execute: false },
+  });
+
+  const [command] = argv._;
+
+  if (command !== "run") {
+    usage();
+    process.exit(1);
+  }
+
+  const workspaceId: string | undefined = argv["workspace"];
+  if (!workspaceId) {
+    console.error("Error: --workspace is required");
+    usage();
+    process.exit(1);
+  }
+
+  const userIdFilter: number | null =
+    argv["user"] != null ? parseInt(argv["user"], 10) : null;
+  const dryRun = !argv["execute"];
+
+  cliLogger.info({ workspaceId, userIdFilter, dryRun }, "starting run");
+
+  const { eligible, skipped } = await determineEligibleActivationUsers({
+    workspaceId,
+    userIdFilter,
+  });
+
+  cliLogger.info(
+    { workspaceId, userIdFilter, eligibleCount: eligible.length, skippedCount: skipped.length },
+    "Nudge plan"
+  );
+
+  for (const plan of eligible) {
+    cliLogger.info({ userId: plan.targetUserId, podId: plan.podId }, "User eligible for nudge");
+  }
+  for (const s of skipped) {
+    cliLogger.info({ userId: s.userId, podId: s.podId }, "User skipped for nudge");
+  }
+};
+
+main()
+  .then(() => {
+    cliLogger.info("done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    cliLogger.error({ err }, "fatal error");
+    process.exit(1);
+  });

--- a/front/temporal/activation/admin/cli.ts
+++ b/front/temporal/activation/admin/cli.ts
@@ -1,13 +1,11 @@
-import {
-  determineEligibleActivationUsers,
-} from "@app/lib/api/activation/orchestrator";
+import { determineEligibleActivationUsers } from "@app/lib/api/activation/orchestrator";
 import logger from "@app/logger/logger";
 import parseArgs from "minimist";
 
 const cliLogger = logger.child({ component: "activation.orchestrator.cli" });
 
 function usage() {
-  console.error(`Usage:
+  cliLogger.info(`Usage:
   run --workspace <sId> [--dry-run] [--execute] [--user <userId>]
 
 Options:
@@ -33,32 +31,43 @@ const main = async () => {
 
   const workspaceId: string | undefined = argv["workspace"];
   if (!workspaceId) {
-    console.error("Error: --workspace is required");
+    cliLogger.error("--workspace is required");
     usage();
     process.exit(1);
   }
 
-  const userIdFilter: number | null =
+  const userModelIdFilter: number | null =
     argv["user"] != null ? parseInt(argv["user"], 10) : null;
   const dryRun = !argv["execute"];
 
-  cliLogger.info({ workspaceId, userIdFilter, dryRun }, "starting run");
+  cliLogger.info({ workspaceId, userModelIdFilter, dryRun }, "starting run");
 
   const { eligible, skipped } = await determineEligibleActivationUsers({
     workspaceId,
-    userIdFilter,
+    userModelIdFilter,
   });
 
   cliLogger.info(
-    { workspaceId, userIdFilter, eligibleCount: eligible.length, skippedCount: skipped.length },
+    {
+      workspaceId,
+      userModelIdFilter,
+      eligibleCount: eligible.length,
+      skippedCount: skipped.length,
+    },
     "Nudge plan"
   );
 
   for (const plan of eligible) {
-    cliLogger.info({ userId: plan.targetUserId, podId: plan.podId }, "User eligible for nudge");
+    cliLogger.info(
+      { userModelId: plan.targetUserModelId, podId: plan.podId },
+      "User eligible for nudge"
+    );
   }
   for (const s of skipped) {
-    cliLogger.info({ userId: s.userId, podId: s.podId }, "User skipped for nudge");
+    cliLogger.info(
+      { userModelId: s.userModelId, podId: s.podId },
+      "User skipped for nudge"
+    );
   }
 };
 


### PR DESCRIPTION
## Summary

- https://github.com/dust-tt/tasks/issues/9515
- This is just a skeleton of a script that will eventually be used to send recommendations to in-scope users. For now, it just queries the activation pods, iterates through the users, and no-ops.

## Testing

It picked up 1 eligible user — userId: 1 in pod pmd_Q8Ac4uf35L. The full path works end to end.

## Risk
* Low - just CLI for now

## Deploy
1. Deploy front