### PR TITLE
Fix test and avoid huge tsgo memory usage

### DIFF
--- a/front-api/tsconfig.json
+++ b/front-api/tsconfig.json
@@ -1,10 +1,23 @@
 {
   "extends": "../front/tsconfig.json",
   "compilerOptions": {
+    "checkers": 1,
     "paths": {
-      "@app/*": ["../front/*"],
-      "@front-api/*": ["./*"]
+      "@app/*": [
+        "../front/*"
+      ],
+      "@front-api/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["**/*.ts", "../front/global.d.ts"]
+  "include": [
+    "**/*.ts",
+    "../front/global.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "app"
+  ]
 }

--- a/front-spa/tsconfig.json
+++ b/front-spa/tsconfig.json
@@ -1,8 +1,13 @@
 {
   "compilerOptions": {
+    "checkers": 1,
     "target": "esnext",
     "useDefineForClassFields": true,
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "module": "esnext",
     "skipLibCheck": true,
@@ -16,10 +21,24 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "paths": {
-      "@spa/*": ["./src/*"],
-      "@dust-tt/front/*": ["../front/*"],
-      "@app/*": ["../front/*"]
+      "@spa/*": [
+        "./src/*"
+      ],
+      "@dust-tt/front/*": [
+        "../front/*"
+      ],
+      "@app/*": [
+        "../front/*"
+      ]
     }
   },
-  "include": ["src", "../front"]
+  "include": [
+    "src",
+    "../front"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "app"
+  ]
 }

--- a/front/lib/api/llm/getImageGenerationLLM.test.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.test.ts
@@ -5,7 +5,7 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetLlmCredentials = vi.hoisted(() => vi.fn());
-const mockIsProviderWhitelisted = vi.hoisted(() => vi.fn());
+const mockIsProviderWhitelistedForAuth = vi.hoisted(() => vi.fn());
 const mockGoogleImageGenerationLLM = vi.hoisted(() => vi.fn());
 const mockOpenAIImageGenerationLLM = vi.hoisted(() => vi.fn());
 const mockGetCurrentRegion = vi.hoisted(() => vi.fn());
@@ -15,7 +15,7 @@ vi.mock("@app/lib/api/provider_credentials", () => ({
 }));
 
 vi.mock("@app/lib/api/assistant/models", () => ({
-  isProviderWhitelisted: mockIsProviderWhitelisted,
+  isProviderWhitelistedForAuth: mockIsProviderWhitelistedForAuth,
 }));
 
 vi.mock("@app/lib/api/llm/clients/google/imageGeneration", () => ({
@@ -106,7 +106,7 @@ describe("getImageGenerationLLM", () => {
     auth = makeAuth();
 
     mockGetLlmCredentials.mockResolvedValue(CREDENTIALS);
-    mockIsProviderWhitelisted.mockReturnValue(false);
+    mockIsProviderWhitelistedForAuth.mockReturnValue(false);
     mockGetCurrentRegion.mockReturnValue("us-central1");
 
     mockGoogleImageGenerationLLM.mockImplementation(function (_auth, args) {
@@ -118,7 +118,7 @@ describe("getImageGenerationLLM", () => {
   });
 
   it("returns OpenAI gpt-image-2 when openai is whitelisted", async () => {
-    mockIsProviderWhitelisted.mockImplementation(
+    mockIsProviderWhitelistedForAuth.mockImplementation(
       (_auth, providerId) => providerId === "openai"
     );
 
@@ -136,7 +136,7 @@ describe("getImageGenerationLLM", () => {
   });
 
   it("prefers OpenAI over Gemini when both providers are whitelisted", async () => {
-    mockIsProviderWhitelisted.mockReturnValue(true);
+    mockIsProviderWhitelistedForAuth.mockReturnValue(true);
 
     const llm = await getImageGenerationLLM(auth);
 
@@ -152,7 +152,7 @@ describe("getImageGenerationLLM", () => {
   });
 
   it("falls back to Gemini when openai is not whitelisted", async () => {
-    mockIsProviderWhitelisted.mockImplementation(
+    mockIsProviderWhitelistedForAuth.mockImplementation(
       (_auth, providerId) => providerId === "google_ai_studio"
     );
 
@@ -179,7 +179,7 @@ describe("getImageGenerationLLM", () => {
 
   it("falls back to Gemini in the EU region even when openai is whitelisted", async () => {
     mockGetCurrentRegion.mockReturnValue("europe-west1");
-    mockIsProviderWhitelisted.mockReturnValue(true);
+    mockIsProviderWhitelistedForAuth.mockReturnValue(true);
 
     const llm = await getImageGenerationLLM(auth);
 
@@ -196,7 +196,7 @@ describe("getImageGenerationLLM", () => {
 
   it("falls back to OpenAI gpt-image-1.5 in the EU region when only openai is whitelisted", async () => {
     mockGetCurrentRegion.mockReturnValue("europe-west1");
-    mockIsProviderWhitelisted.mockImplementation(
+    mockIsProviderWhitelistedForAuth.mockImplementation(
       (_auth, providerId) => providerId === "openai"
     );
 

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
+    "checkers": 1,
     "target": "es6",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -17,7 +22,9 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@app/*": ["./*"]
+      "@app/*": [
+        "./*"
+      ]
     }
   },
   "include": [
@@ -29,5 +36,9 @@
     "**/*.mjs",
     "./.eslintrc.js"
   ],
-  "exclude": ["node_modules", "dist", "app"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "app"
+  ]
 }


### PR DESCRIPTION
## Description

Two independent fixes:

- **tsgo memory**: Added `"checkers": 1` to `compilerOptions` in `front/`, `front-api/`, and `front-spa/` `tsconfig.json` to cap the number of checker goroutines used by the experimental TypeScript Go compiler. Also added explicit `exclude` arrays (`node_modules`, `dist`, `app`) to `front-api` and `front-spa` configs so tsgo doesn't traverse build artifacts.
- **Broken test**: Updated `getImageGenerationLLM.test.ts` to mock `isProviderWhitelistedForAuth` instead of the now-renamed `isProviderWhitelisted`.

## Tests

- Existing Vitest tests for `getImageGenerationLLM` pass after the mock rename.
- tsgo memory reduction verified by observing lower goroutine/checker usage locally.

## Risk

Low. tsconfig changes are tooling-only and don't affect emitted output or runtime behavior. The test fix aligns with an already-merged function rename.

## Deploy Plan

No deploy needed — tsconfig and test-only changes.
