### PR TITLE
Deprecate agentName in tool validation metadata

### DIFF
--- a/cli/dust-cli/src/ui/commands/Chat.tsx
+++ b/cli/dust-cli/src/ui/commands/Chat.tsx
@@ -2052,7 +2052,7 @@ const CliChat: FC<CliChatProps> = ({
                   : inlineSelector.mode === "approval" &&
                       pendingApproval &&
                       pendingApproval.type === "tool_approve_execution"
-                    ? `Tool Approval Required: agent wants to use ${pendingApproval.metadata.toolName}, what do you want to do? `
+                    ? `Tool Approval Required: the agent wants to use ${pendingApproval.metadata.toolName}, what do you want to do? `
                     : inlineSelector.mode === "diff" && pendingDiffApproval
                       ? `Changes Preview: ${pendingDiffApproval.filePath} `
                       : mentionPrefix

--- a/cli/dust-cli/src/ui/commands/Chat.tsx
+++ b/cli/dust-cli/src/ui/commands/Chat.tsx
@@ -433,7 +433,7 @@ const CliChat: FC<CliChatProps> = ({
       // For low stake tools, check cache first
       if (event.stake === "low") {
         const cachedApproval = await toolsCache.getCachedApproval({
-          agentName: event.metadata.agentName,
+          agentName: "agent",
           mcpServerName: event.metadata.mcpServerName,
           toolName: event.metadata.toolName,
         });
@@ -490,7 +490,7 @@ const CliChat: FC<CliChatProps> = ({
         // Cache the approval if requested and it's a low stake tool
         if (cacheApproval && pendingApproval.stake === "low") {
           await toolsCache.setCachedApproval({
-            agentName: pendingApproval.metadata.agentName,
+            agentName: "agent",
             mcpServerName: pendingApproval.metadata.mcpServerName,
             toolName: pendingApproval.metadata.toolName,
           });
@@ -2055,7 +2055,7 @@ const CliChat: FC<CliChatProps> = ({
                   : inlineSelector.mode === "approval" &&
                       pendingApproval &&
                       pendingApproval.type === "tool_approve_execution"
-                    ? `Tool Approval Required: ${pendingApproval.metadata.agentName} wants to use ${pendingApproval.metadata.toolName}, what do you want to do? `
+                    ? `Tool Approval Required: agent wants to use ${pendingApproval.metadata.toolName}, what do you want to do? `
                     : inlineSelector.mode === "diff" && pendingDiffApproval
                       ? `Changes Preview: ${pendingDiffApproval.filePath} `
                       : mentionPrefix

--- a/cli/dust-cli/src/ui/commands/Chat.tsx
+++ b/cli/dust-cli/src/ui/commands/Chat.tsx
@@ -433,7 +433,6 @@ const CliChat: FC<CliChatProps> = ({
       // For low stake tools, check cache first
       if (event.stake === "low") {
         const cachedApproval = await toolsCache.getCachedApproval({
-          agentName: "agent",
           mcpServerName: event.metadata.mcpServerName,
           toolName: event.metadata.toolName,
         });
@@ -490,7 +489,6 @@ const CliChat: FC<CliChatProps> = ({
         // Cache the approval if requested and it's a low stake tool
         if (cacheApproval && pendingApproval.stake === "low") {
           await toolsCache.setCachedApproval({
-            agentName: "agent",
             mcpServerName: pendingApproval.metadata.mcpServerName,
             toolName: pendingApproval.metadata.toolName,
           });
@@ -813,7 +811,6 @@ const CliChat: FC<CliChatProps> = ({
       if (selectedAgent) {
         // Pre-cache the Edit tool to avoid approval prompts
         await toolsCache.setCachedApproval({
-          agentName: selectedAgent.name,
           mcpServerName: "fs-cli",
           toolName: "edit_file",
         });

--- a/cli/dust-cli/src/utils/toolsCache.ts
+++ b/cli/dust-cli/src/utils/toolsCache.ts
@@ -68,7 +68,7 @@ export class ToolsCache {
     toolName,
   }: ToolsCacheKeyParams): Promise<boolean | null> {
     const cache = await this.loadCache();
-    const toolKey = this.createToolKey({ agentName, mcpServerName, toolName });
+    const toolKey = this.createToolKey({ mcpServerName, toolName });
     const cachedEntry = cache.find((entry) => entry === toolKey);
 
     if (!cachedEntry) {

--- a/cli/dust-cli/src/utils/toolsCache.ts
+++ b/cli/dust-cli/src/utils/toolsCache.ts
@@ -7,7 +7,6 @@ interface ToolsCacheOptions {
 }
 
 type ToolsCacheKeyParams = {
-  agentName: string;
   mcpServerName: string;
   toolName: string;
 };
@@ -58,15 +57,13 @@ export class ToolsCache {
   }
 
   private createToolKey({
-    agentName,
     mcpServerName,
     toolName,
   }: ToolsCacheKeyParams): string {
-    return `${agentName}:${mcpServerName}:${toolName}`;
+    return `${mcpServerName}:${toolName}`;
   }
 
   public async getCachedApproval({
-    agentName,
     mcpServerName,
     toolName,
   }: ToolsCacheKeyParams): Promise<boolean | null> {
@@ -82,12 +79,11 @@ export class ToolsCache {
   }
 
   public async setCachedApproval({
-    agentName,
     mcpServerName,
     toolName,
   }: ToolsCacheKeyParams): Promise<void> {
     const cache = await this.loadCache();
-    const toolKey = this.createToolKey({ agentName, mcpServerName, toolName });
+    const toolKey = this.createToolKey({ mcpServerName, toolName });
     await this.saveCache([...cache, toolKey]);
   }
 

--- a/connectors/src/api/webhooks/teams/adaptive_cards.ts
+++ b/connectors/src/api/webhooks/teams/adaptive_cards.ts
@@ -402,7 +402,7 @@ export function createBasicToolApprovalAdaptiveCard(data: {
         items: [
           {
             type: "TextBlock",
-            text: `Agent is requesting permission to use tool **${data.toolName}**`,
+            text: `The agent is requesting permission to use tool **${data.toolName}**`,
             wrap: true,
             spacing: "Small",
           },

--- a/connectors/src/api/webhooks/teams/adaptive_cards.ts
+++ b/connectors/src/api/webhooks/teams/adaptive_cards.ts
@@ -367,7 +367,6 @@ export function createErrorAdaptiveCard({
  * Creates the basic Adaptive Card for tool execution approval for everyone (read-only, no actions)
  */
 export function createBasicToolApprovalAdaptiveCard(data: {
-  agentName: string;
   toolName: string;
   conversationId: string;
   messageId: string;
@@ -403,7 +402,7 @@ export function createBasicToolApprovalAdaptiveCard(data: {
         items: [
           {
             type: "TextBlock",
-            text: `Agent **@${data.agentName}** is requesting permission to use tool **${data.toolName}**`,
+            text: `Agent is requesting permission to use tool **${data.toolName}**`,
             wrap: true,
             spacing: "Small",
           },

--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -488,7 +488,6 @@ async function streamAgentResponse({
         // Send approval card in thread with user-specific view
         // The original user sees interactive buttons, others see a read-only message
         const approvalCard = createBasicToolApprovalAdaptiveCard({
-          agentName: "agent",
           toolName: event.metadata.toolName,
           conversationId: event.conversationId,
           messageId: event.messageId,

--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -488,7 +488,7 @@ async function streamAgentResponse({
         // Send approval card in thread with user-specific view
         // The original user sees interactive buttons, others see a read-only message
         const approvalCard = createBasicToolApprovalAdaptiveCard({
-          agentName: event.metadata.agentName,
+          agentName: "agent",
           toolName: event.metadata.toolName,
           conversationId: event.conversationId,
           messageId: event.messageId,

--- a/connectors/src/api/webhooks/webhook_slack_bot_interaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot_interaction.ts
@@ -103,7 +103,6 @@ const AnswerUserQuestionButtonSchema = t.type({
 
 export type RequestToolPermissionActionValueParsed = {
   status: "approved" | "rejected";
-  agentName: string;
   toolName: string;
 };
 
@@ -371,7 +370,6 @@ const _webhookSlackBotInteractionsAPIHandler = async (
         const valueValidation = t
           .type({
             status: t.union([t.literal("approved"), t.literal("rejected")]),
-            agentName: t.string,
             toolName: t.string,
           })
           .decode(JSON.parse(action.value));
@@ -390,9 +388,9 @@ const _webhookSlackBotInteractionsAPIHandler = async (
           return;
         }
 
-        const { status: approved, agentName, toolName } = valueValidation.right;
+        const { status: approved, toolName } = valueValidation.right;
 
-        const text = `Agent \`${agentName}\`'s request to use tool \`${toolName}\` was ${
+        const text = `Agent's request to use tool \`${toolName}\` was ${
           approved === "approved" ? "✅ approved" : "❌ rejected"
         }`;
 

--- a/connectors/src/api/webhooks/webhook_slack_bot_interaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot_interaction.ts
@@ -390,7 +390,7 @@ const _webhookSlackBotInteractionsAPIHandler = async (
 
         const { status: approved, toolName } = valueValidation.right;
 
-        const text = `Agent's request to use tool \`${toolName}\` was ${
+        const text = `The agent's request to use tool \`${toolName}\` was ${
           approved === "approved" ? "✅ approved" : "❌ rejected"
         }`;
 

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -447,7 +447,7 @@ export function makeToolValidationBlock({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `Agent is requesting permission to use tool \`${toolName}\``,
+        text: `The agent is requesting permission to use tool \`${toolName}\``,
       },
     },
     {
@@ -501,7 +501,7 @@ export function makeToolAuthenticationBlock({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `Agent requires personal authentication for \`${serverName}\``,
+        text: `The agent requires personal authentication for \`${serverName}\``,
       },
     },
     {
@@ -609,7 +609,7 @@ export function makeToolFileAuthorizationBlock({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `Agent requires file authorization for \`${fileName}\``,
+        text: `The agent requires file authorization for \`${fileName}\``,
       },
     },
     {

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -436,11 +436,9 @@ export function makePlanMessage({
  * This is used when an agent sends a tool_approve_execution event to Slack.
  */
 export function makeToolValidationBlock({
-  agentName,
   toolName,
   id,
 }: {
-  agentName: string;
   toolName: string;
   id: string;
 }) {
@@ -449,7 +447,7 @@ export function makeToolValidationBlock({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `Agent \`${agentName}\` is requesting permission to use tool \`${toolName}\``,
+        text: `Agent is requesting permission to use tool \`${toolName}\``,
       },
     },
     {
@@ -466,7 +464,6 @@ export function makeToolValidationBlock({
           style: "primary",
           value: JSON.stringify({
             status: "approved",
-            agentName,
             toolName,
           } as RequestToolPermissionActionValueParsed),
           action_id: APPROVE_TOOL_EXECUTION,
@@ -481,7 +478,6 @@ export function makeToolValidationBlock({
           style: "danger",
           value: JSON.stringify({
             status: "rejected",
-            agentName,
             toolName,
           } as RequestToolPermissionActionValueParsed),
           action_id: REJECT_TOOL_EXECUTION,
@@ -492,12 +488,10 @@ export function makeToolValidationBlock({
 }
 
 export function makeToolAuthenticationBlock({
-  agentName,
   serverName,
   conversationUrl,
   value,
 }: {
-  agentName: string;
   serverName: string;
   conversationUrl: string;
   value: string;
@@ -507,7 +501,7 @@ export function makeToolAuthenticationBlock({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `Agent \`${agentName}\` requires personal authentication for \`${serverName}\``,
+        text: `Agent requires personal authentication for \`${serverName}\``,
       },
     },
     {
@@ -602,12 +596,10 @@ export function makeUserQuestionBlock({
   return blocks;
 }
 export function makeToolFileAuthorizationBlock({
-  agentName,
   fileName,
   conversationUrl,
   value,
 }: {
-  agentName: string;
   fileName: string;
   conversationUrl: string;
   value: string;
@@ -617,7 +609,7 @@ export function makeToolFileAuthorizationBlock({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `Agent \`${agentName}\` requires file authorization for \`${fileName}\``,
+        text: `Agent requires file authorization for \`${fileName}\``,
       },
     },
     {

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -541,7 +541,7 @@ async function streamAgentAnswerToSlack(
         const postResult = await postUserActionEphemeral({
           text: "Approve tool execution",
           blocks: makeToolValidationBlock({
-            agentName: event.metadata.agentName,
+            agentName: "agent",
             toolName: event.metadata.toolName,
             id: JSON.stringify(blockId),
           }),
@@ -564,7 +564,7 @@ async function streamAgentAnswerToSlack(
           const postResult = await postUserActionEphemeral({
             text: "Personal authentication required",
             blocks: makeToolAuthenticationBlock({
-              agentName: event.metadata.agentName,
+              agentName: "agent",
               serverName: event.metadata.mcpServerDisplayName,
               conversationUrl,
               value: JSON.stringify({
@@ -603,7 +603,7 @@ async function streamAgentAnswerToSlack(
           const postResult = await postUserActionEphemeral({
             text: "File authorization required",
             blocks: makeToolFileAuthorizationBlock({
-              agentName: event.metadata.agentName,
+              agentName: "agent",
               fileName: event.fileAuthError.fileName,
               conversationUrl,
               value: JSON.stringify({

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -541,7 +541,6 @@ async function streamAgentAnswerToSlack(
         const postResult = await postUserActionEphemeral({
           text: "Approve tool execution",
           blocks: makeToolValidationBlock({
-            agentName: "agent",
             toolName: event.metadata.toolName,
             id: JSON.stringify(blockId),
           }),
@@ -564,7 +563,6 @@ async function streamAgentAnswerToSlack(
           const postResult = await postUserActionEphemeral({
             text: "Personal authentication required",
             blocks: makeToolAuthenticationBlock({
-              agentName: "agent",
               serverName: event.metadata.mcpServerDisplayName,
               conversationUrl,
               value: JSON.stringify({
@@ -603,7 +601,6 @@ async function streamAgentAnswerToSlack(
           const postResult = await postUserActionEphemeral({
             text: "File authorization required",
             blocks: makeToolFileAuthorizationBlock({
-              agentName: "agent",
               fileName: event.fileAuthError.fileName,
               conversationUrl,
               value: JSON.stringify({

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -234,13 +234,13 @@ export function MCPToolValidationRequired({
     }
     if (toolOverride?.title) {
       return toolOverride.title(
-        blockedAction.metadata.agentName,
+        "agent",
         blockedAction.inputs
       );
     }
     const subject =
       blockedAction.metadata.displayedAs === "agent"
-        ? blockedAction.metadata.agentName
+        ? "agent"
         : blockedAction.metadata.mcpServerName;
     return `Allow ${asDisplayName(subject)} to ${asDisplayName(blockedAction.metadata.toolName)}?`;
   }
@@ -251,7 +251,7 @@ export function MCPToolValidationRequired({
     }
     if (toolOverride?.alwaysAllowLabel) {
       return toolOverride.alwaysAllowLabel(
-        blockedAction.metadata.agentName,
+        "agent",
         blockedAction.inputs
       );
     }
@@ -269,7 +269,7 @@ export function MCPToolValidationRequired({
         }
         return JSON.stringify(value);
       });
-    return `Always allow @${blockedAction.metadata.agentName} to ${asDisplayName(blockedAction.metadata.toolName)} ${
+    return `Always allow @agent to ${asDisplayName(blockedAction.metadata.toolName)} ${
       argValues.length > 0
         ? ` for the following parameters: ${argValues.join(", ")}`
         : ""

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -34,11 +34,8 @@ import {
 import { useMemo, useState } from "react";
 
 type ToolOverride = {
-  title?: (agentName: string, inputs: Record<string, unknown>) => string;
-  alwaysAllowLabel?: (
-    agentName: string,
-    inputs: Record<string, unknown>
-  ) => string;
+  title?: (inputs: Record<string, unknown>) => string;
+  alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
   detailsExpanded?: boolean;
 };
 
@@ -48,64 +45,59 @@ const MCP_TOOL_OVERRIDES: Partial<
 > = {
   "dust-chrome-extension": {
     interact_with_page: {
-      title: (agentName, inputs) =>
-        `Allow ${asDisplayName(agentName)} to ${inputs.humanReadableDescription}?`,
-      alwaysAllowLabel: (agentName, inputs) =>
+      title: (inputs) => `Allow agent to ${inputs.humanReadableDescription}?`,
+      alwaysAllowLabel: () =>
         "Allow all the interactions with this tab",
     },
   },
   "dust-firefox-extension": {
     interact_with_page: {
-      title: (agentName, inputs) =>
-        `Allow ${asDisplayName(agentName)} to ${inputs.humanReadableDescription}?`,
+      title: (inputs) => `Allow agent to ${inputs.humanReadableDescription}?`,
       alwaysAllowLabel: () => "Allow all the interactions with this tab",
     },
   },
   sandbox: {
     add_egress_domain: {
-      title: (agentName) =>
-        `Allow ${asDisplayName(agentName)} to add a domain to the Computer?`,
+      title: () => `Allow agent to add a domain to the Computer?`,
       detailsExpanded: true,
     },
   },
   [POD_TASKS_SERVER_NAME]: {
     [CREATE_TASKS_TOOL_NAME]: {
-      title: (agentName, inputs) => {
+      title: (inputs) => {
         if (!isPodTasksCreateTasksInput(inputs)) {
-          return `Allow ${asDisplayName(agentName)} to create tasks?`;
+          return `Allow agent to create tasks?`;
         }
         const count = inputs.tasks.length;
-        return `Allow ${asDisplayName(agentName)} to create ${count} task${count === 1 ? "" : "s"}?`;
+        return `Allow agent to create ${count} task${count === 1 ? "" : "s"}?`;
       },
-      alwaysAllowLabel: (agentName) =>
-        `Always allow ${asDisplayName(agentName)} to create tasks`,
+      alwaysAllowLabel: () => `Always allow agent to create tasks`,
     },
     [UPDATE_TASKS_TOOL_NAME]: {
-      title: (agentName, inputs) => {
+      title: (inputs) => {
         if (!isPodTasksUpdateTasksInput(inputs)) {
-          return `Allow ${asDisplayName(agentName)} to update tasks?`;
+          return `Allow agent to update tasks?`;
         }
         const count = inputs.tasks.length;
         const doneCount = inputs.tasks.filter(
           (task) => task.doneRationale
         ).length;
         if (doneCount > 0 && doneCount === count) {
-          return `Allow ${asDisplayName(agentName)} to mark ${count} task${count === 1 ? "" : "s"} as done?`;
+          return `Allow agent to mark ${count} task${count === 1 ? "" : "s"} as done?`;
         }
         if (doneCount > 0) {
-          return `Allow ${asDisplayName(agentName)} to update ${count} task${count === 1 ? "" : "s"} (${doneCount} marked as done)?`;
+          return `Allow agent to update ${count} task${count === 1 ? "" : "s"} (${doneCount} marked as done)?`;
         }
-        return `Allow ${asDisplayName(agentName)} to update ${count} task${count === 1 ? "" : "s"}?`;
+        return `Allow agent to update ${count} task${count === 1 ? "" : "s"}?`;
       },
-      alwaysAllowLabel: (agentName) =>
-        `Always allow ${asDisplayName(agentName)} to update tasks`,
+      alwaysAllowLabel: () => `Always allow agent to update tasks`,
     },
   },
   [POD_MANAGER_SERVER_NAME]: {
     [UPDATE_MEMBERS_TOOL_NAME]: {
-      title: (agentName, inputs) => {
+      title: (inputs) => {
         if (!isPodManagerUpdateMembersInput(inputs)) {
-          return `Allow ${asDisplayName(agentName)} to update Pod members?`;
+          return `Allow agent to update Pod members?`;
         }
         const addCount = Object.keys(inputs.membersToAdd ?? {}).length;
         const removeCount = inputs.membersToRemove?.length ?? 0;
@@ -116,24 +108,21 @@ const MCP_TOOL_OVERRIDES: Partial<
         if (removeCount > 0) {
           parts.push(`remove ${removeCount}`);
         }
-        return `Allow ${asDisplayName(agentName)} to ${parts.join(" and ")} Pod user${addCount + removeCount === 1 ? "" : "s"}?`;
+        return `Allow agent to ${parts.join(" and ")} Pod user${addCount + removeCount === 1 ? "" : "s"}?`;
       },
-      alwaysAllowLabel: (agentName) =>
-        `Always allow ${asDisplayName(agentName)} to update Pod members`,
+      alwaysAllowLabel: () =>
+        `Always allow agent to update Pod members`,
     },
   },
   [WAKEUPS_SERVER_NAME]: {
     schedule_wakeup: {
-      title: (agentName) =>
-        `Allow ${asDisplayName(agentName)} to schedule a wake-up?`,
+      title: () => `Allow agent to schedule a wake-up?`,
     },
     list_wakeups: {
-      title: (agentName) =>
-        `Allow ${asDisplayName(agentName)} to list wake-ups?`,
+      title: () => `Allow agent to list wake-ups?`,
     },
     cancel_wakeup: {
-      title: (agentName) =>
-        `Allow ${asDisplayName(agentName)} to cancel a wake-up?`,
+      title: () => `Allow agent to cancel a wake-up?`,
     },
   },
 };
@@ -233,7 +222,7 @@ export function MCPToolValidationRequired({
       return `Permission needed for ${asDisplayName(blockedAction.metadata.mcpServerName)}.`;
     }
     if (toolOverride?.title) {
-      return toolOverride.title("agent", blockedAction.inputs);
+      return toolOverride.title(blockedAction.inputs);
     }
     const subject =
       blockedAction.metadata.displayedAs === "agent"
@@ -247,7 +236,7 @@ export function MCPToolValidationRequired({
       return "Always allow";
     }
     if (toolOverride?.alwaysAllowLabel) {
-      return toolOverride.alwaysAllowLabel("agent", blockedAction.inputs);
+      return toolOverride.alwaysAllowLabel(blockedAction.inputs);
     }
 
     if (blockedAction.approvalArgsLabel) {

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -233,10 +233,7 @@ export function MCPToolValidationRequired({
       return `Permission needed for ${asDisplayName(blockedAction.metadata.mcpServerName)}.`;
     }
     if (toolOverride?.title) {
-      return toolOverride.title(
-        "agent",
-        blockedAction.inputs
-      );
+      return toolOverride.title("agent", blockedAction.inputs);
     }
     const subject =
       blockedAction.metadata.displayedAs === "agent"
@@ -250,10 +247,7 @@ export function MCPToolValidationRequired({
       return "Always allow";
     }
     if (toolOverride?.alwaysAllowLabel) {
-      return toolOverride.alwaysAllowLabel(
-        "agent",
-        blockedAction.inputs
-      );
+      return toolOverride.alwaysAllowLabel("agent", blockedAction.inputs);
     }
 
     if (blockedAction.approvalArgsLabel) {

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -46,8 +46,7 @@ const MCP_TOOL_OVERRIDES: Partial<
   "dust-chrome-extension": {
     interact_with_page: {
       title: (inputs) => `Allow agent to ${inputs.humanReadableDescription}?`,
-      alwaysAllowLabel: () =>
-        "Allow all the interactions with this tab",
+      alwaysAllowLabel: () => "Allow all the interactions with this tab",
     },
   },
   "dust-firefox-extension": {
@@ -110,8 +109,7 @@ const MCP_TOOL_OVERRIDES: Partial<
         }
         return `Allow agent to ${parts.join(" and ")} Pod user${addCount + removeCount === 1 ? "" : "s"}?`;
       },
-      alwaysAllowLabel: () =>
-        `Always allow agent to update Pod members`,
+      alwaysAllowLabel: () => `Always allow agent to update Pod members`,
     },
   },
   [WAKEUPS_SERVER_NAME]: {

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -263,7 +263,7 @@ export function MCPToolValidationRequired({
         }
         return JSON.stringify(value);
       });
-    return `Always allow @agent to ${asDisplayName(blockedAction.metadata.toolName)} ${
+    return `Always allow agent to ${asDisplayName(blockedAction.metadata.toolName)} ${
       argValues.length > 0
         ? ` for the following parameters: ${argValues.join(", ")}`
         : ""

--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -176,7 +176,7 @@ export function ToolValidationDetails({
         input={blockedAction.inputs}
         owner={owner}
         user={user}
-        agentName={blockedAction.metadata.agentName}
+        agentName="agent"
         conversationId={conversationId}
       />
     );

--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -176,7 +176,6 @@ export function ToolValidationDetails({
         input={blockedAction.inputs}
         owner={owner}
         user={user}
-        agentName="agent"
         conversationId={conversationId}
       />
     );

--- a/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
@@ -21,7 +21,6 @@ interface PodTasksUpdateValidationDetailsProps {
   input: PodTasksUpdateTasksInput;
   owner: LightWorkspaceType;
   user: UserType;
-  agentName: string;
   conversationId?: string | null;
 }
 
@@ -43,7 +42,6 @@ interface TaskUpdateRowProps {
   workspaceId: string;
   taskInput: PodTasksUpdateTaskItemInput;
   user: UserType;
-  agentName: string;
 }
 
 interface FormatAssigneeLabelParams {
@@ -165,12 +163,7 @@ function AssigneeChangeRow({
   return <ChangeRow label="Assignee" before={beforeLabel} after={afterLabel} />;
 }
 
-function TaskUpdateRow({
-  workspaceId,
-  taskInput,
-  user,
-  agentName,
-}: TaskUpdateRowProps) {
+function TaskUpdateRow({ workspaceId, taskInput, user }: TaskUpdateRowProps) {
   const {
     task: currentTask,
     isWorkspacePodTaskLoading: isWorkspaceProjectTaskLoading,
@@ -273,9 +266,7 @@ function TaskUpdateRow({
                   Marked done by
                 </span>
                 <span className="text-sm font-medium text-foreground">
-                  {taskInput.markAsDoneByType === "user"
-                    ? "You"
-                    : `@${agentName}`}
+                  {taskInput.markAsDoneByType === "user" ? "you" : "agent"}
                 </span>
               </div>
             )}
@@ -344,9 +335,7 @@ function TaskUpdateRow({
                   Marked done by
                 </span>
                 <span className="text-sm font-medium text-foreground">
-                  {taskInput.markAsDoneByType === "user"
-                    ? "You"
-                    : `@${agentName}`}
+                  {taskInput.markAsDoneByType === "user" ? "you" : "agent"}
                 </span>
               </div>
             )}
@@ -371,7 +360,6 @@ export function PodTasksUpdateValidationDetails({
   input,
   owner,
   user,
-  agentName,
   conversationId,
 }: PodTasksUpdateValidationDetailsProps) {
   const { podLabel, isPodLabelLoading } = usePodLabel({
@@ -386,7 +374,7 @@ export function PodTasksUpdateValidationDetails({
   return (
     <div className="flex flex-col gap-3 pt-2">
       <p className="text-sm text-muted-foreground">
-        @{agentName} wants to update{" "}
+        Agent wants to update{" "}
         <span className="font-medium text-foreground">{taskCount}</span> task
         {taskCount === 1 ? "" : "s"} in{" "}
         <span className="font-medium text-foreground">
@@ -402,7 +390,6 @@ export function PodTasksUpdateValidationDetails({
             workspaceId={owner.sId}
             taskInput={taskInput}
             user={user}
-            agentName={agentName}
           />
         ))}
       </div>

--- a/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
@@ -374,7 +374,7 @@ export function PodTasksUpdateValidationDetails({
   return (
     <div className="flex flex-col gap-3 pt-2">
       <p className="text-sm text-muted-foreground">
-        Agent wants to update{" "}
+        The agent wants to update{" "}
         <span className="font-medium text-foreground">{taskCount}</span> task
         {taskCount === 1 ? "" : "s"} in{" "}
         <span className="font-medium text-foreground">

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -60,7 +60,10 @@ export type MCPValidationOutputType = (typeof MCP_VALIDATION_OUTPUTS)[number];
 export type MCPValidationMetadataType = {
   toolName: string;
   mcpServerName: string;
-  agentName: string;
+  // Deprecated (2026-07-09): no longer read by any client. Optional to match the public schema,
+  // but still emitted while already-deployed CLI and extension versions (which require it in
+  // their event schemas) cycle out. Remove from emit sites and schemas then.
+  agentName?: string;
   pubsubMessageId?: string;
   icon?: InternalAllowedIconType | CustomResourceIconType;
   displayedAs?: "agent" | "server";

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -60,10 +60,10 @@ export type MCPValidationOutputType = (typeof MCP_VALIDATION_OUTPUTS)[number];
 export type MCPValidationMetadataType = {
   toolName: string;
   mcpServerName: string;
-  // Deprecated (2026-07-09): no longer read by any client. Optional to match the public schema,
-  // but still emitted while already-deployed CLI and extension versions (which require it in
-  // their event schemas) cycle out. Remove from emit sites and schemas then.
-  agentName?: string;
+  // Deprecated (2026-07-09): no longer read by any client, but still required at parse time by
+  // already-deployed CLI and extension versions. Typed as the literal to force emit sites to the
+  // placeholder constant; remove the field entirely once old clients have cycled out.
+  agentName: "agent";
   pubsubMessageId?: string;
   icon?: InternalAllowedIconType | CustomResourceIconType;
   displayedAs?: "agent" | "server";

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -82,19 +82,17 @@ export async function getExitOrPauseEvents(
           resumeState: state,
         });
 
-        // Forward any UI-facing blocking events the tool collected, plus a
-        // `tool_paused` sentinel. The sentinel keeps the pause-decision on
-        // the event channel even when `blockingEvents` is empty — the case
-        // for any future tool whose blocking event is published upstream
-        // out-of-band (e.g. sandbox bash, where the child's blocking event
-        // is published by `createSandboxChildAction` and never flows
-        // through bash's return). Without it, `runToolWithStreaming` would
-        // fall through to `markAsSucceeded` on an already-blocked action.
-        // Appended LAST so the for-await in `executeToolStreaming` processes
-        // every blocking event before the sentinel triggers the return.
+        // Forward any UI-facing blocking events the tool collected, plus a `tool_paused` sentinel.
+        // The sentinel keeps the pause-decision on the event channel even when `blockingEvents` is
+        // empty — the case for any future tool whose blocking event is published upstream
+        // out-of-band (e.g. sandbox bash, where the child's blocking event is published by
+        // `createSandboxChildAction` and never flows through bash's return). Without it,
+        // `runToolWithStreaming` would fall through to `markAsSucceeded` on an already-blocked
+        // action.  Appended LAST so the for-await in `executeToolStreaming` processes every
+        // blocking event before the sentinel triggers the return.
         return [
-          // Blocking events are parsed with the public client schemas where agentName is
-          // optional; normalize to the placeholder constant expected internally.
+          // Blocking events are parsed with the public client schemas where agentName is optional;
+          // normalize to the placeholder constant expected internally.
           ...blockingEvents.map((event) => ({
             ...event,
             metadata: { ...event.metadata, agentName: "agent" as const },

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -10,7 +10,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import type { MCPApproveExecutionEvent } from "@dust-tt/client";
+import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { assertNever, isAgentPauseOutputResourceType } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -93,7 +93,12 @@ export async function getExitOrPauseEvents(
         // Appended LAST so the for-await in `executeToolStreaming` processes
         // every blocking event before the sentinel triggers the return.
         return [
-          ...blockingEvents,
+          // Blocking events are parsed with the public client schemas where agentName is
+          // optional; normalize to the placeholder constant expected internally.
+          ...blockingEvents.map((event) => ({
+            ...event,
+            metadata: { ...event.metadata, agentName: "agent" as const },
+          })),
           {
             type: "tool_paused",
             created: Date.now(),
@@ -127,7 +132,7 @@ export async function getExitOrPauseEvents(
             metadata: {
               toolName: action.toolConfiguration.originalName,
               mcpServerName: action.toolConfiguration.mcpServerName,
-              agentName: agentConfiguration.name,
+              agentName: "agent",
               mcpServerDisplayName: action.toolConfiguration.mcpServerName,
               mcpServerId: action.toolConfiguration.toolServerId,
             },
@@ -178,7 +183,7 @@ export async function getExitOrPauseEvents(
             metadata: {
               toolName: action.toolConfiguration.originalName,
               mcpServerName: action.toolConfiguration.mcpServerName,
-              agentName: agentConfiguration.name,
+              agentName: "agent",
               mcpServerDisplayName: action.toolConfiguration.mcpServerName,
               mcpServerId: action.toolConfiguration.toolServerId,
             },
@@ -217,7 +222,7 @@ export async function getExitOrPauseEvents(
             metadata: {
               toolName: action.toolConfiguration.originalName,
               mcpServerName: action.toolConfiguration.mcpServerName,
-              agentName: agentConfiguration.name,
+              agentName: "agent",
             },
             inputs: action.augmentedInputs,
             question,

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -1,4 +1,5 @@
 import type {
+  MCPApproveExecutionEvent,
   ToolAskUserQuestionEvent,
   ToolEarlyExitEvent,
   ToolFileAuthRequiredEvent,
@@ -10,7 +11,6 @@ import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { assertNever, isAgentPauseOutputResourceType } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 

--- a/front/lib/api/actions/servers/run_agent/types.ts
+++ b/front/lib/api/actions/servers/run_agent/types.ts
@@ -1,13 +1,15 @@
 import type {
-  ToolAskUserQuestionEvent,
-  ToolFileAuthRequiredEvent,
-  ToolPersonalAuthRequiredEvent,
-} from "@app/lib/actions/mcp_internal_actions/events";
-import type {
   BlockedAwaitingInputOutputResourceType,
   SingleResourceToolOutput,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { MCPApproveExecutionEvent } from "@dust-tt/client";
+// Client event types: blocking events are collected from the child agent stream parsed with the
+// public client schemas and serialized back into a client-shaped tool output resource.
+import type {
+  MCPApproveExecutionEvent,
+  ToolAskUserQuestionEvent,
+  ToolFileAuthRequiredEvent,
+  ToolPersonalAuthRequiredEvent,
+} from "@dust-tt/client";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 export interface ChildAgentBlob {

--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -368,7 +368,7 @@ function makeBlockedAction(): BlockedToolExecution {
     metadata: {
       toolName: "write_report",
       mcpServerName: "project_tools",
-      agentName: "approvals",
+      agentName: "agent",
     },
     inputs: {
       title: "Q2 report",

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -225,7 +225,7 @@ export async function createSandboxChildAction(
       metadata: {
         toolName: fullToolConfiguration.originalName,
         mcpServerName: fullToolConfiguration.mcpServerName,
-        agentName: agentConfiguration.name,
+        agentName: "agent",
         icon: fullToolConfiguration.icon,
         displayedAs: getInternalMCPServerDisplayedAs(
           fullToolConfiguration.toolServerId

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -158,7 +158,7 @@ describe("listBlockedActionsForConversation", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].status).toBe("blocked_validation_required");
-    expect(result[0].metadata.agentName).toBe("Test Agent");
+    expect(result[0].metadata.agentName).toBe("agent");
   });
 
   it("should only return blocked actions, not succeeded ones", async () => {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -471,7 +471,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         metadata: {
           toolName: action.toolConfiguration.originalName,
           mcpServerName: action.toolConfiguration.mcpServerName,
-          agentName: agentConfiguration.name,
+          agentName: "agent",
           icon: action.toolConfiguration.icon,
         },
         argumentsRequiringApproval:

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -296,7 +296,7 @@ async function createActionForTool(
             metadata: {
               toolName: actionConfiguration.originalName,
               mcpServerName: actionConfiguration.mcpServerName,
-              agentName: agentConfiguration.name,
+              agentName: "agent",
               icon: actionConfiguration.icon,
               displayedAs: getInternalMCPServerDisplayedAs(
                 actionConfiguration.toolServerId

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1305,7 +1305,9 @@ const MCPStakeLevelSchema = z
   .optional();
 
 const MCPValidationMetadataSchema = z.object({
-  agentName: z.string(),
+  // Deprecated (2026-07-09): no longer read by clients, will stop being sent once old clients
+  // have cycled out.
+  agentName: z.string().optional(),
   icon: z
     .union([MCPInternalActionIconSchema, MCPExternalActionIconSchema])
     .optional(),


### PR DESCRIPTION
## Description

First step of removing `agentName` from tool validation metadata (`MCPValidationMetadataType`) which is conversation specific in a world where tool lifecycle should not.

This means we won't show agent name in confirmation windows in product but I believe this is fine loss for more generic events.

The field is part of the public event schemas (`tool_approve_execution`, personal/file auth, ask user question) and already-deployed CLI and extension versions require it at parse time, so removal is staged:

- `front`: `agentName` is typed as the literal `"agent"`, forcing every emit site to the placeholder constant while the wire keeps satisfying old clients' required-string parsing. All emit sites updated accordingly.
- `sdks/js`: `agentName` becomes optional in `MCPValidationMetadataSchema` (kept `z.string()`, not a literal, so events published before the deploy and replayed from Redis still parse).
- All reader sites will survive disappearance of the field from the server once this code is live: web approval dialogs (`MCPToolValidationRequired`, `ToolValidationDetails`), the CLI approval prompt and approval cache keys (approvals are no longer scoped per agent), the Slack/Teams connectors' approval and auth cards and the extension.


Note: `RunAgentBlockingEvent` is now fully client-typed (the events are collected from the child agent stream parsed with the public client schemas and serialized back into a client-shaped resource); `getExitOrPauseEvents` normalizes them to the internal shape when forwarding.

We will be able to drop agentName entirely in a couple days once the clients are all cycled out and in the meantime we'll have the hard-coded `agentName: "agent"` even in non conversation-tied tool execution related events.

Obviously this could break external clients subscribed to these events and exepecting an agentName in the future once we remove it.... but probability is low IMHO. No breakage possible for now.

## Tests

- `lib/resources/agent_mcp_action_resource.test.ts`, `lib/actions/mcp_internal_actions/exit_events.test.ts`, `lib/api/assistant/email/email_trigger.test.ts`, `lib/actions/mcp_execution.test.ts` pass. Typecheck across `front`, `sdks/js`, `cli`, `connectors`.
- tested locally

## Risk

Low. The field is still emitted (as `"agent"`), so old clients keep parsing; only display strings change ("agent" instead of the agent name in approval dialogs, CLI prompts, and Slack/Teams cards), and CLI cached approvals are now keyed per tool instead of per agent-tool pair.

## Deploy Plan

- deploy `front`
- deploy `connectors`
- publish `@dust-tt/client`, release the CLI, and publish the extension (so clients tolerant of the field's absence start cycling in)