### PR TITLE
[dsbx] feat: db query runs DML, refuses DDL

### DIFF
--- a/cli/dust-sandbox/functions-runner/db/commands.test.ts
+++ b/cli/dust-sandbox/functions-runner/db/commands.test.ts
@@ -10,7 +10,7 @@ import { DbCommandError } from "./common.ts";
 import {
   QUERY_INLINE_PAYLOAD_CAP_BYTES,
   QUERY_INLINE_ROW_CAP,
-  queryReadonly,
+  runQuery,
 } from "./query.ts";
 import { reconcile } from "./reconcile.ts";
 import { generateSchemaFileText } from "./schema.ts";
@@ -313,7 +313,7 @@ describe("db query", () => {
     await withDir(async (dir) => {
       const dbPath = await seeded(dir);
       const result = unwrap(
-        queryReadonly(dbPath, "SELECT handle FROM users ORDER BY handle")
+        runQuery(dbPath, "SELECT handle FROM users ORDER BY handle")
       );
       expect(result.columns).toEqual(["handle"]);
       expect(result.rows).toEqual([{ handle: "alice" }, { handle: "bob" }]);
@@ -337,7 +337,7 @@ describe("db query", () => {
       db.close();
 
       const result = unwrap(
-        queryReadonly(dbPath, "SELECT label FROM notes ORDER BY id")
+        runQuery(dbPath, "SELECT label FROM notes ORDER BY id")
       );
       expect(result.rows.length).toBe(QUERY_INLINE_ROW_CAP);
       expect(result.row_count).toBe(QUERY_INLINE_ROW_CAP + 1);
@@ -358,23 +358,83 @@ describe("db query", () => {
     });
   });
 
-  test("rejects writes (read-only + query_only)", async () => {
+  test("runs DML and reports the affected rows", async () => {
     await withDir(async (dir) => {
       const dbPath = await seeded(dir);
+
+      const insert = unwrap(
+        runQuery(
+          dbPath,
+          "INSERT INTO users (handle, created_at) VALUES ('eve', 3)"
+        )
+      );
+      expect(insert.changes).toBe(1);
+      expect(insert.rows).toEqual([]);
+      expect(insert.row_count).toBe(0);
+
+      const update = unwrap(
+        runQuery(
+          dbPath,
+          "UPDATE users SET created_at = 9 WHERE handle != 'eve'"
+        )
+      );
+      expect(update.changes).toBe(2);
+
+      const check = unwrap(runQuery(dbPath, "SELECT count(*) AS n FROM users"));
+      expect(check.rows).toEqual([{ n: 3 }]);
+      expect(check.changes).toBeNull();
+    });
+  });
+
+  test("returns RETURNING rows from DML", async () => {
+    await withDir(async (dir) => {
+      const dbPath = await seeded(dir);
+      const result = unwrap(
+        runQuery(
+          dbPath,
+          "DELETE FROM users WHERE handle = 'alice' RETURNING handle"
+        )
+      );
+      expect(result.rows).toEqual([{ handle: "alice" }]);
+      expect(result.row_count).toBe(1);
+    });
+  });
+
+  test("rolls back a failed DML statement", async () => {
+    await withDir(async (dir) => {
+      const dbPath = await seeded(dir);
+      // handle is NOT NULL: the statement fails after the transaction opened.
       await expectDbError(
-        () =>
-          queryReadonly(
-            dbPath,
-            "INSERT INTO users (handle, created_at) VALUES ('eve', 3)"
-          ),
+        () => runQuery(dbPath, "INSERT INTO users (created_at) VALUES (3)"),
         "query_failed",
-        /readonly/i
+        /NOT NULL/i
       );
-      // Nothing was written.
-      const check = unwrap(
-        queryReadonly(dbPath, "SELECT count(*) AS n FROM users")
-      );
+      const check = unwrap(runQuery(dbPath, "SELECT count(*) AS n FROM users"));
       expect(check.rows).toEqual([{ n: 2 }]);
+    });
+  });
+
+  test("refuses DDL, PRAGMA, ATTACH and transaction control with a typed error", async () => {
+    await withDir(async (dir) => {
+      const dbPath = await seeded(dir);
+      for (const sql of [
+        "CREATE TABLE sneaky (id INTEGER)",
+        "DROP TABLE users",
+        "ALTER TABLE users ADD sneaky TEXT",
+        "PRAGMA journal_mode = DELETE",
+        "ATTACH DATABASE '/tmp/other.db' AS other",
+        "BEGIN",
+        "VACUUM",
+      ]) {
+        await expectDbError(
+          () => runQuery(dbPath, sql),
+          "disallowed_statement",
+          /only SELECT and DML/
+        );
+      }
+      // The schema and the WAL journal mode are untouched.
+      expect(tableNames(dbPath)).toEqual(["messages", "settings", "users"]);
+      expect(journalMode(dbPath)).toBe("wal");
     });
   });
 
@@ -382,15 +442,14 @@ describe("db query", () => {
     await withDir(async (dir) => {
       const dbPath = await seeded(dir);
       await expectDbError(
-        () =>
-          queryReadonly(dbPath, "SELECT handle FROM users; DELETE FROM users"),
+        () => runQuery(dbPath, "SELECT handle FROM users; DELETE FROM users"),
         "query_failed",
         /multiple SQL statements/
       );
 
       // A trailing semicolon (and semicolons inside string literals) are fine.
       const trailing = unwrap(
-        queryReadonly(
+        runQuery(
           dbPath,
           "SELECT count(*) AS n FROM users WHERE handle != 'a;b';"
         )
@@ -403,8 +462,7 @@ describe("db query", () => {
     await withDir(async (dir) => {
       const dbPath = await seeded(dir);
       await expectDbError(
-        () =>
-          queryReadonly(dbPath, "SELECT handle FROM users WHERE handle = ?"),
+        () => runQuery(dbPath, "SELECT handle FROM users WHERE handle = ?"),
         "query_failed",
         /parameters are not supported/
       );
@@ -424,7 +482,7 @@ describe("db query", () => {
       db.close();
 
       const result = unwrap(
-        queryReadonly(dbPath, "SELECT label FROM notes ORDER BY id")
+        runQuery(dbPath, "SELECT label FROM notes ORDER BY id")
       );
       expect(result.rows.length).toBe(1);
       expect(result.row_count).toBe(3);
@@ -443,7 +501,7 @@ describe("db query", () => {
     await withDir(async (dir) => {
       const dbPath = await seeded(dir);
       const result = unwrap(
-        queryReadonly(
+        runQuery(
           dbPath,
           "SELECT 42 AS small, 9007199254740993 AS big, x'41' AS data"
         )
@@ -459,7 +517,7 @@ describe("db query", () => {
     await withDir(async (dir) => {
       const dbPath = await seeded(dir);
       await expectDbError(
-        () => queryReadonly(dbPath, "   \n "),
+        () => runQuery(dbPath, "   \n "),
         "empty_sql",
         /no SQL statement/
       );
@@ -469,9 +527,9 @@ describe("db query", () => {
   test("errors with database_not_found on a missing database", async () => {
     await withDir(async (dir) => {
       await expectDbError(
-        () => queryReadonly(join(dir, "nope.db"), "SELECT 1"),
+        () => runQuery(join(dir, "nope.db"), "SELECT 1"),
         "database_not_found",
-        /cannot open database/
+        /no database at/
       );
     });
   });

--- a/cli/dust-sandbox/functions-runner/db/query.ts
+++ b/cli/dust-sandbox/functions-runner/db/query.ts
@@ -1,19 +1,22 @@
-// `dsbx db query` runner backend: read-only SQL against a live pod database. Expected
+// `dsbx db query` runner backend: one SQL statement against a live pod database. Expected
 // refusals come back as Err (ERR1), never thrown.
 //
-// The database is opened read-only AND with `PRAGMA query_only = ON` (defense in depth), so
-// any write attempt fails. Small results return entirely in the stdout envelope; once a result
-// crosses the inline bounds, the COMPLETE result set is written to a spill file (one JSON
-// object per line) and the envelope carries the file path, a note saying so, and the first
-// rows as a preview. Nothing is ever silently dropped. Spill files land in the sandbox's /tmp
-// and live as long as the sandbox does — no cleanup pass exists.
+// SELECT and DML (INSERT/UPDATE/DELETE/REPLACE, optionally WITH) are allowed; everything else
+// — DDL, PRAGMA, ATTACH, transaction control — is refused, so the schema can only evolve
+// through reconcile and the file's WAL setup cannot be broken from a query. Writes run in one
+// transaction with a schema-version re-check as a second barrier behind the keyword gate.
+// Small results return entirely in the stdout envelope; once a result crosses the inline
+// bounds, the COMPLETE result set is written to a spill file (one JSON object per line) and
+// the envelope carries the file path, a note saying so, and the first rows as a preview.
+// Nothing is ever silently dropped. Spill files land in the sandbox's /tmp and live as long
+// as the sandbox does — no cleanup pass exists.
 
-import type { Statement } from "bun:sqlite";
-import { closeSync, openSync, writeSync } from "node:fs";
+import { Database, type Statement } from "bun:sqlite";
+import { closeSync, existsSync, openSync, writeSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DB_BUSY_TIMEOUT_MS, DbCommandError } from "./common.ts";
 import { Err, Ok, type Result } from "../result.ts";
-import { DbCommandError, openReadonly } from "./common.ts";
 
 // Inline envelope bounds: a result within both stays entirely on stdout; beyond either, it
 // spills to a file. Bounds exist for stdout (which lands in the caller's context), not for
@@ -21,17 +24,33 @@ import { DbCommandError, openReadonly } from "./common.ts";
 export const QUERY_INLINE_ROW_CAP = 100;
 export const QUERY_INLINE_PAYLOAD_CAP_BYTES = 100_000;
 
+// First keyword of an allowed statement. WITH can only precede SELECT/INSERT/UPDATE/DELETE
+// and VALUES is a bare row constructor, so nothing here can carry DDL: SQLite triggers cannot
+// contain DDL, and direct sqlite_master edits need the (blocked) writable_schema pragma.
+const ALLOWED_KEYWORDS = new Set([
+  "select",
+  "values",
+  "with",
+  "insert",
+  "update",
+  "delete",
+  "replace",
+]);
+
 export interface QueryOutcome {
   columns: string[];
   rows: Record<string, unknown>[];
   row_count: number;
+  // Rows affected, for statements that return no columns (plain INSERT/UPDATE/DELETE);
+  // null for result-returning statements.
+  changes: number | null;
   // Set when the result crossed the inline bounds: `rows` is then a preview and the complete
   // result set is at this path, one JSON object per line.
   results_file: string | null;
   note: string | null;
 }
 
-export function queryReadonly(
+export function runQuery(
   dbPath: string,
   sql: string
 ): Result<QueryOutcome, DbCommandError> {
@@ -42,7 +61,21 @@ export function queryReadonly(
     );
   }
 
-  const opened = openReadonly(dbPath, { safeIntegers: true });
+  // Keyword gate BEFORE preparing: some pragmas take effect during SQL compilation
+  // (https://sqlite.org/pragma.html), so the raw text is gated first. A leading comment
+  // defeats the match and fails closed.
+  const keyword = trimmed.match(/^[A-Za-z]+/)?.[0].toLowerCase();
+  if (keyword === undefined || !ALLOWED_KEYWORDS.has(keyword)) {
+    return new Err(
+      new DbCommandError(
+        "disallowed_statement",
+        "only SELECT and DML (INSERT/UPDATE/DELETE/REPLACE, optionally WITH) are allowed; " +
+          "schema changes go through reconcile"
+      )
+    );
+  }
+
+  const opened = openReadwrite(dbPath);
   if (opened.isErr()) {
     return opened;
   }
@@ -89,10 +122,123 @@ export function queryReadonly(
       );
     }
 
-    return collectRows(statement);
+    if (keyword === "select" || keyword === "values") {
+      return collectRows(statement);
+    }
+
+    // One transaction per write statement, with a schema-version re-check as the second
+    // barrier behind the keyword gate: a statement that still changed the schema rolls back
+    // instead of committing. WITH-prefixed reads also land here and pay the write lock for
+    // their duration — accepted, distinguishing them would mean parsing the statement.
+    db.exec("BEGIN IMMEDIATE;");
+    let result: Result<QueryOutcome, DbCommandError>;
+    try {
+      const versionBefore = schemaVersion(db);
+      result =
+        statement.columnNames.length === 0
+          ? runChanges(statement)
+          : collectRows(statement);
+      if (result.isOk() && schemaVersion(db) !== versionBefore) {
+        result = new Err(
+          new DbCommandError(
+            "disallowed_statement",
+            "the statement changed the database schema; schema changes go through reconcile"
+          )
+        );
+      }
+    } catch (e) {
+      // Unexpected (collectRows/runChanges wrap their own failures): rollback and rethrow.
+      rollbackQuietly(db);
+      throw e;
+    }
+    if (result.isErr()) {
+      rollbackQuietly(db);
+      return result;
+    }
+    db.exec("COMMIT;");
+    return result;
   } finally {
     db.close();
   }
+}
+
+function rollbackQuietly(db: Database): void {
+  try {
+    db.exec("ROLLBACK;");
+  } catch {
+    // Some failures roll the transaction back on their own; the original error is the one
+    // to surface.
+  }
+}
+
+// Open read-write, must-exist: databases are only ever created by reconcile.
+function openReadwrite(dbPath: string): Result<Database, DbCommandError> {
+  if (!existsSync(dbPath)) {
+    return new Err(
+      new DbCommandError(
+        "database_not_found",
+        `no database at ${dbPath}; it is created by the first reconcile that claims it`
+      )
+    );
+  }
+  let db: Database;
+  try {
+    // safeIntegers reads INTEGER columns as bigint instead of a possibly-lossy JS number
+    // (SQLite integers are 64-bit, JS numbers are exact only to 2^53):
+    // https://bun.com/docs/api/sqlite#datatypes
+    db = new Database(dbPath, {
+      readwrite: true,
+      create: false,
+      safeIntegers: true,
+    });
+  } catch (e) {
+    // The file exists, so a failed open is infrastructure (permissions, corruption), not a
+    // correctable input.
+    return new Err(
+      new DbCommandError(
+        "internal",
+        `cannot open database at ${dbPath}: ${
+          e instanceof Error ? e.message : String(e)
+        }`
+      )
+    );
+  }
+  db.exec(`PRAGMA busy_timeout = ${DB_BUSY_TIMEOUT_MS};`);
+  return new Ok(db);
+}
+
+// SQLite bumps schema_version on every schema change:
+// https://sqlite.org/pragma.html#pragma_schema_version
+function schemaVersion(db: Database): bigint {
+  const row = db
+    .query<{ schema_version: bigint | number }, []>("PRAGMA schema_version")
+    .get();
+  return BigInt(row?.schema_version ?? 0);
+}
+
+// Execute a no-result statement (plain INSERT/UPDATE/DELETE) and report the affected rows.
+function runChanges(
+  statement: Statement
+): Result<QueryOutcome, DbCommandError> {
+  let changes: number;
+  try {
+    changes = Number(statement.run().changes);
+  } catch (e) {
+    return new Err(
+      new DbCommandError(
+        "query_failed",
+        e instanceof Error ? e.message : String(e)
+      )
+    );
+  }
+  return new Ok({
+    columns: [],
+    rows: [],
+    row_count: 0,
+    changes,
+    results_file: null,
+    note: null,
+  });
 }
 
 // Execute a result-returning statement, spilling beyond the inline bounds.
@@ -147,6 +293,7 @@ function collectRows(
     columns: statement.columnNames,
     rows: preview,
     row_count: rowCount,
+    changes: null,
     results_file: spillPath,
     note:
       spillPath === null

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -5,12 +5,13 @@
 //   runner build <src> <outBundle> <outSchema>   bundle + extract schema to files
 //   runner db-reconcile <dbPath> <schemaFile>    additive-only DDL reconcile -> stdout envelope
 //   runner db-schema <dbPath> <outSchemaTs>      regenerate drizzle schema file -> file + envelope
-//   runner db-query <dbPath>                     stdin SQL -> stdout rows envelope (read-only;
-//                                                large results spill to a file the envelope names)
+//   runner db-query <dbPath>                     stdin SQL -> stdout rows envelope (SELECT/DML
+//                                                only, DDL refused; large results spill to a file
+//                                                the envelope names)
 
 import { build } from "./build.ts";
 import { errorEnvelope } from "./db/common.ts";
-import { queryReadonly } from "./db/query.ts";
+import { runQuery } from "./db/query.ts";
 import { reconcile } from "./db/reconcile.ts";
 import { generateSchemaFileText } from "./db/schema.ts";
 import { invoke } from "./invoke.ts";
@@ -114,7 +115,7 @@ async function dbQueryHandler(args: string[]): Promise<number> {
     return emitDbBadArgs("usage: runner db-query <dbPath> (SQL on stdin)");
   }
   const sql = await Bun.stdin.text();
-  const result = queryReadonly(dbPath, sql);
+  const result = runQuery(dbPath, sql);
   if (result.isErr()) {
     process.stdout.write(`${JSON.stringify(errorEnvelope(result.error))}\n`);
     return 1;

--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -8,16 +8,16 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
  *
  * `db(name)` returns a cached Drizzle instance over the pod's live SQLite
  * database at `${DUST_POD_DATABASES_DIR}/{name}.db`. Databases are created by
- * the publish pipeline (`dsbx db reconcile`), never here: the file is opened
+ * `dsbx db reconcile` (the db_reconcile tool), never here: the file is opened
  * must-exist so a typo'd name errors clearly instead of minting an empty
  * database. Functions that never call `db()` pay nothing.
  *
  * Disk guardrails — pod state must not fill the sandbox disk by accident:
  *
  * - `db()` cannot create database files (must-exist open), so the set of
- *   databases is fixed at publish time. Total pod-state footprint is the
- *   number of declared databases times the per-database cap; bounding the
- *   count is the publish pipeline's job.
+ *   databases is fixed by what reconcile has created. Total pod-state
+ *   footprint is the number of databases times the per-database cap;
+ *   bounding the count is the reconcile path's job.
  * - Each database is capped via `PRAGMA max_page_count` at the byte quota
  *   front chooses and passes per exec (1 GiB in production — see
  *   {@link POD_DATABASE_MAX_SIZE_BYTES_ENV}). Writes past the cap fail with
@@ -99,9 +99,9 @@ export class PodDatabaseNotDeclaredError extends PodDatabaseError {
   constructor(dbName: string, path: string) {
     super(
       `Pod database "${dbName}" does not exist (no database file at ${path}). ` +
-        `Databases are created by the first publish that declares them: add ` +
-        `"${dbName}" to a function's schema.databases, define its tables in ` +
-        `databases/${dbName}.db.ts, and publish that function.`
+        `Databases are created by their first reconcile: define the tables in ` +
+        `databases/${dbName}.db.ts, apply it with the db_reconcile tool, and ` +
+        `declare "${dbName}" in the function's schema.databases.`
     );
     this.name = "PodDatabaseNotDeclaredError";
   }
@@ -269,7 +269,7 @@ function podDatabaseMaxSizeBytes(): number {
 /**
  * Per-connection settings, re-applied on every open. `journal_mode = WAL` is
  * not set here: it is a persistent per-database setting, applied once when
- * the publish pipeline creates the file.
+ * reconcile creates the file.
  */
 function applyPragmas(sqlite: PodSqliteDatabase, maxSizeBytes: number): void {
   // WAL allows a single writer at a time: concurrent function invocations —
@@ -318,7 +318,7 @@ const instances = new Map<string, PodDatabase>();
  *   DUST_POD_DATABASE_MAX_SIZE_BYTES is absent or invalid — db() only works
  *   in functions launched by `dsbx function run`.
  * @throws PodDatabaseNotDeclaredError when no database file exists — databases
- *   are created by the first publish that declares them.
+ *   are created by their first reconcile.
  * @throws PodDatabaseFullError (from queries) when the database hits its quota.
  */
 export function db(name: string): PodDatabase {

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -137,7 +137,7 @@ describe("must-exist open", () => {
 
   test("the error tells the agent databases are created by publish", () => {
     const name = uniqueName("missing");
-    expect(() => db(name)).toThrow(/created by the first publish/);
+    expect(() => db(name)).toThrow(/created by their first reconcile/);
     expect(() => db(name)).toThrow(new RegExp(`databases/${name}\\.db\\.ts`));
   });
 

--- a/cli/dust-sandbox/src/commands/db/mod.rs
+++ b/cli/dust-sandbox/src/commands/db/mod.rs
@@ -53,7 +53,7 @@ pub enum DbCommand {
     },
     /// List pod databases with sizes
     List,
-    /// Execute read-only SQL (from stdin) against a pod database
+    /// Execute one SQL statement (from stdin) against a pod database (SELECT/DML; DDL is refused)
     Query {
         /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
         name: String,

--- a/cli/dust-sandbox/src/commands/db/query.rs
+++ b/cli/dust-sandbox/src/commands/db/query.rs
@@ -2,11 +2,11 @@ use anyhow::Result;
 
 use super::{db_file_path, spawn_runner};
 
-/// Execute read-only SQL (from stdin) against the pod database `name`. The
-/// runner opens the database read-only with `PRAGMA query_only=ON` and returns
-/// rows in the stdout JSON envelope; a result crossing the inline bounds is
-/// written in full to a spill file the envelope names. Runs as `agent-proxied`
-/// like `function run`.
+/// Execute one SQL statement (from stdin) against the pod database `name`.
+/// The runner allows SELECT and DML but refuses DDL/PRAGMA/ATTACH, so the
+/// schema only evolves through reconcile. Rows come back in the stdout JSON
+/// envelope; a result crossing the inline bounds is written in full to a
+/// spill file the envelope names. Runs as `agent-proxied` like `function run`.
 pub async fn cmd_db_query(name: &str) -> Result<()> {
     let db_path = db_file_path(name)?;
 


### PR DESCRIPTION
db query moves from read-only to SELECT + DML
(INSERT/UPDATE/DELETE/REPLACE, optionally WITH): the database opens
read-write must-exist, the raw statement's first keyword is gated BEFORE
sqlite3_prepare (some pragmas take effect at compile time), and every
write runs in one BEGIN IMMEDIATE transaction with a schema_version
re-check as the second barrier — DDL, PRAGMA, ATTACH, transaction control
and VACUUM are refused, so the schema still only evolves through
reconcile and the WAL journal mode litestream depends on cannot be broken
from a query. Plain DML reports the affected-row count in a new
`changes` envelope field; RETURNING flows through the spill-capped row
path. queryReadonly is renamed runQuery accordingly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
