### PR TITLE
[front] Make MCP tool descriptions collapsible in Manage Tool (#9509)

### DIFF
--- a/front/components/actions/mcp/MCPServerDetailsInfo.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsInfo.tsx
@@ -11,7 +11,12 @@ import {
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Separator } from "@dust-tt/sparkle";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Separator,
+} from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
 type MCPServerDetailsInfoProps = {
@@ -48,9 +53,14 @@ export function MCPServerDetailsInfo({
               {asDisplayName(tool.name)}
             </div>
             {tool.description && (
-              <p className="text-sm text-muted-foreground">
-                {tool.description}
-              </p>
+              <Collapsible>
+                <CollapsibleTrigger label="Description" variant="secondary" />
+                <CollapsibleContent>
+                  <p className="whitespace-pre-wrap break-words pt-1 text-sm text-muted-foreground">
+                    {tool.description}
+                  </p>
+                </CollapsibleContent>
+              </Collapsible>
             )}
           </div>
         ))}

--- a/front/components/actions/mcp/ToolsList.test.tsx
+++ b/front/components/actions/mcp/ToolsList.test.tsx
@@ -28,8 +28,8 @@ vi.mock("@dust-tt/sparkle", () => ({
   ),
   Collapsible: ({ children }: any) => <div>{children}</div>,
   CollapsibleContent: ({ children }: any) => <div>{children}</div>,
-  CollapsibleTrigger: ({ children }: any) => (
-    <button type="button">{children}</button>
+  CollapsibleTrigger: ({ children, label }: any) => (
+    <button type="button">{children ?? label}</button>
   ),
   ContentMessage: ({ children }: any) => <div>{children}</div>,
   DropdownMenu: ({ children }: any) => <div>{children}</div>,

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -85,7 +85,14 @@ function ToolItem({
         </h4>
       </div>
       {tool.description && (
-        <p className="text-sm text-muted-foreground">{tool.description}</p>
+        <Collapsible>
+          <CollapsibleTrigger label="Description" variant="secondary" />
+          <CollapsibleContent>
+            <p className="whitespace-pre-wrap break-words pt-1 text-sm text-muted-foreground">
+              {tool.description}
+            </p>
+          </CollapsibleContent>
+        </Collapsible>
       )}
       {toolEnabled && (
         <Card variant="primary" className="flex-col">


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9509


https://github.com/user-attachments/assets/3dc5f982-8cb4-4303-865a-fbc297b7130b



Tool descriptions in the Manage Tool sheet were rendered in a plain <p>, so HTML collapsed their newlines into a single run-on line, making them unreadable. These descriptions come from arbitrary MCP servers and are plain text (often with meaningful single newlines and code/JSON-like examples), not Markdown.

Render each description with whitespace-pre-wrap break-words to preserve its formatting, and tuck it behind a collapsed-by-default sparkle Collapsible "Description" toggle so long descriptions no longer clutter the list while the tool name and stake dropdown stay visible.

Tool names and stakes are kept non-collapsible since they are the main information.
## Tests

Local

## Risk

Low

## Deploy Plan

Front