### PR TITLE
[front] enh: make ask_user_question eager

### DIFF
--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -34,6 +34,7 @@ export const ASK_USER_QUESTION_TOOLS_METADATA = createToolsRecord({
     },
     enableAlerting: true,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Asking user...",
       done: "User answered",


### PR DESCRIPTION
## Description

This PR prevents deferring the `ask_user_question` tool.

Even with the tool mentioned extensively in the system prompt, it still seems to ask questions in plain text in some basic cases ([example](https://app.dust.tt/w/0ec9852c2f/conversation/Uvu3uso7oU)).
Usage also seems to have dropped (plotted [here](https://app.dust.tt/w/0ec9852c2f/conversation/nB5gXzZgGt#?spid=files&spt=files)).
The tool is searched often as well (11k times over the past 2 days, vs 13k for the bash tool, [logs](https://app.datadoghq.eu/logs?query=%22Anthropic%20tool%20search%20results%22%20service%3Afront-agent-loop-worker%20%40toolReferences%3Aask_user_question__ask_user_question&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1783416092813&to_ts=1783588892813&live=true)).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
