### PR TITLE
[preview] front: use NewButton/NewInput via sparkle compatibility shim

### DIFF
--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -1,20 +1,47 @@
 import { Slot } from "@radix-ui/react-slot";
-import { Counter } from "@sparkle/components/Counter";
-import { Icon } from "@sparkle/components/Icon";
+import type { LinkWrapperProps } from "@sparkle/components/LinkWrapper";
 import {
-  LinkWrapper,
-  type LinkWrapperProps,
-} from "@sparkle/components/LinkWrapper";
-import type { SpinnerProps } from "@sparkle/components/Spinner";
-import { Spinner } from "@sparkle/components/Spinner";
-import { Tooltip } from "@sparkle/components/Tooltip";
-import { ChevronDown } from "@sparkle/icons/v2-stroke";
+  NewButton,
+  type NewButtonSizeType,
+  type NewButtonVariantType,
+} from "@sparkle/components/NewButton";
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
-import { useEffect, useMemo, useState } from "react";
 
-const PULSE_ANIMATION_DURATION = 1;
+// Preview-branch shim: delegates Button → NewButton.
+// Keeps all old type exports so existing import sites don't break.
+
+// ── Variant / size mapping ────────────────────────────────────────────────────
+
+function mapButtonVariant(v: ButtonVariantType): NewButtonVariantType {
+  switch (v) {
+    case "highlight-secondary":
+      return "highlight-ghost";
+    case "warning-secondary":
+      return "warning-ghost";
+    default:
+      return v;
+  }
+}
+
+function mapButtonSize(s: ButtonSize): NewButtonSizeType {
+  switch (s) {
+    case "xmini":
+    case "mini":
+    case "icon-xs":
+    case "xs":
+      return "xs";
+    case "icon":
+    case "sm":
+      return "sm";
+    case "icon-sm":
+    case "md":
+      return "md";
+  }
+}
+
+// ── Type exports (kept for backward compat) ───────────────────────────────────
 
 export const BUTTON_VARIANTS = [
   "primary",
@@ -43,16 +70,8 @@ export type RegularButtonSize = (typeof REGULAR_BUTTON_SIZES)[number];
 export type IconOnlySize = (typeof ICON_ONLY_SIZES)[number];
 export type ButtonSize = RegularButtonSize | IconOnlySize;
 
-function isSmallButtonSize(
-  size: ButtonSize | undefined
-): size is (typeof SMALL_BUTTON_SIZES)[number] {
-  return (
-    size !== undefined &&
-    SMALL_BUTTON_SIZES.includes(size as (typeof SMALL_BUTTON_SIZES)[number])
-  );
-}
+// ── MetaButton (kept for backward compat — some consumers import it) ──────────
 
-// Define button styling with cva
 const buttonVariants = cva(
   cn(
     "inline-flex items-center justify-center whitespace-nowrap ring-offset-background transition-colors ring-inset select-none",
@@ -61,101 +80,16 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        primary: cn(
-          "border border-transparent",
-          "bg-primary-800",
-          "text-primary-50",
-          "hover:bg-primary-light",
-          "active:bg-primary-dark",
-          "disabled:bg-primary-muted disabled:text-highlight-on/60"
-        ),
-        highlight: cn(
-          "border border-transparent",
-          "bg-highlight",
-          "text-highlight-on",
-          "hover:bg-highlight-light",
-          "active:bg-highlight-dark",
-          "disabled:bg-highlight-muted disabled:text-highlight-on/60"
-        ),
-        "highlight-secondary": cn(
-          "border",
-          "border-border",
-          "text-highlight-500",
-          "bg-background",
-          "hover:text-highlight-500",
-          "hover:bg-highlight-50",
-          "hover:border-primary-150",
-          "active:bg-primary-300",
-          "disabled:text-primary-muted",
-          "disabled:border-primary-100",
-          "disabled:hover:bg-background",
-          "disabled:hover:border-primary-100",
-          "disabled:hover:text-primary-muted"
-        ),
-        warning: cn(
-          "border border-transparent",
-          "bg-warning",
-          "text-warning-on",
-          "hover:bg-warning-light",
-          "active:bg-warning-dark",
-          "disabled:bg-warning-muted disabled:text-highlight-on/60"
-        ),
-        "warning-secondary": cn(
-          "border",
-          "border-border",
-          "text-warning-500",
-          "bg-background",
-          "hover:text-warning-500",
-          "hover:bg-warning-50",
-          "hover:border-primary-150",
-          "active:bg-primary-300",
-          "disabled:text-primary-muted",
-          "disabled:border-primary-100",
-          "disabled:hover:bg-background",
-          "disabled:hover:border-primary-100",
-          "disabled:hover:text-primary-muted"
-        ),
-        outline: cn(
-          "border",
-          "border-border",
-          "text-primary",
-          "bg-background",
-          "hover:text-primary",
-          "hover:bg-primary-100",
-          "hover:border-primary-150",
-          "active:bg-primary-300",
-          "disabled:text-primary-muted",
-          "disabled:border-primary-100",
-          "disabled:hover:bg-background",
-          "disabled:hover:border-primary-100",
-          "disabled:hover:text-primary-muted"
-        ),
-        ghost: cn(
-          "border",
-          "border-transparent",
-          "text-foreground",
-          "hover:bg-hover",
-          "hover:text-primary-900",
-          "hover:border-transparent",
-          "active:bg-primary-300",
-          "disabled:text-faint",
-          "disabled:hover:bg-transparent",
-          "disabled:hover:border-transparent",
-          "disabled:hover:text-faint"
-        ),
-        "ghost-secondary": cn(
-          "border",
-          "border-transparent",
-          "text-muted-foreground",
-          "hover:bg-hover",
-          "hover:text-primary-900",
-          "hover:border-transparent",
-          "active:bg-primary-300",
-          "disabled:text-faint",
-          "disabled:hover:bg-transparent",
-          "disabled:hover:border-transparent",
-          "disabled:hover:text-faint"
-        ),
+        primary: "border border-transparent bg-primary-800 text-primary-50",
+        highlight: "border border-transparent bg-highlight text-highlight-on",
+        "highlight-secondary":
+          "border border-border text-highlight-500 bg-background",
+        warning: "border border-transparent bg-warning text-warning-on",
+        "warning-secondary":
+          "border border-border text-warning-500 bg-background",
+        outline: "border border-border text-primary bg-background",
+        ghost: "border border-transparent text-foreground",
+        "ghost-secondary": "border border-transparent text-muted-foreground",
       },
       size: {
         "icon-xs": "h-6 w-6 gap-1 shrink-0",
@@ -187,76 +121,6 @@ const buttonVariants = cva(
   }
 );
 
-const labelVariants = cva("", {
-  variants: {
-    size: {
-      "icon-xs": "hidden",
-      icon: "hidden",
-      "icon-sm": "hidden",
-      xmini: "",
-      mini: "",
-      xs: "",
-      sm: "",
-      md: "",
-    },
-    hasLighterFont: {
-      true: "",
-      false: "",
-    },
-  },
-  compoundVariants: [
-    { size: "xmini", hasLighterFont: false, className: "label-xs" },
-    { size: "mini", hasLighterFont: false, className: "label-xs" },
-    { size: "xs", hasLighterFont: false, className: "label-xs" },
-    { size: "sm", hasLighterFont: false, className: "label-sm" },
-    { size: "md", hasLighterFont: false, className: "label-base" },
-    {
-      size: "xmini",
-      hasLighterFont: true,
-      className: "text-xs font-normal",
-    },
-    {
-      size: "mini",
-      hasLighterFont: true,
-      className: "text-xs font-normal",
-    },
-    { size: "xs", hasLighterFont: true, className: "text-xs font-normal" },
-    { size: "sm", hasLighterFont: true, className: "text-sm font-normal" },
-    {
-      size: "md",
-      hasLighterFont: true,
-      className: "text-base font-normal",
-    },
-  ],
-  defaultVariants: {
-    size: "sm",
-  },
-});
-
-type SpinnerVariant = NonNullable<SpinnerProps["variant"]>;
-
-const spinnerVariantsMap: Record<ButtonVariantType, SpinnerVariant> = {
-  primary: "revert",
-  highlight: "light",
-  "highlight-secondary": "mono",
-  warning: "light",
-  "warning-secondary": "mono",
-  outline: "mono",
-  ghost: "mono",
-  "ghost-secondary": "mono",
-};
-
-const chevronVariantMap = {
-  primary: "text-faint",
-  outline: "text-faint",
-  ghost: "text-faint",
-  "ghost-secondary": "text-faint",
-  highlight: "text-white/60",
-  "highlight-secondary": "text-highlight-500",
-  warning: "text-white/60",
-  "warning-secondary": "text-warning-500",
-} as const;
-
 export interface MetaButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
@@ -278,10 +142,7 @@ const MetaButton = React.forwardRef<HTMLButtonElement, MetaButtonProps>(
     ref
   ) => {
     const Comp = asChild ? Slot : "button";
-
-    // Determine rounded variant based on isRounded prop
     const rounded = isRounded ? "full" : size;
-
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, rounded, className }))}
@@ -295,10 +156,7 @@ const MetaButton = React.forwardRef<HTMLButtonElement, MetaButtonProps>(
 );
 MetaButton.displayName = "MetaButton";
 
-type IconSizeType = "xs" | "sm" | "md";
-type CounterSizeType = "xs" | "sm" | "md";
-
-export const ICON_SIZE_MAP: Record<ButtonSize, IconSizeType> = {
+export const ICON_SIZE_MAP: Record<ButtonSize, "xs" | "sm" | "md"> = {
   "icon-xs": "xs",
   icon: "sm",
   "icon-sm": "sm",
@@ -309,52 +167,7 @@ export const ICON_SIZE_MAP: Record<ButtonSize, IconSizeType> = {
   md: "md",
 };
 
-const COUNTER_SIZE_MAP: Record<ButtonSize, CounterSizeType> = {
-  "icon-xs": "xs",
-  icon: "xs",
-  "icon-sm": "sm",
-  xmini: "xs",
-  mini: "xs",
-  xs: "xs",
-  sm: "sm",
-  md: "md",
-};
-
-const loadingContainerVariants = cva("-mx-0.5", {
-  variants: {
-    size: {
-      "icon-xs": "w-5 px-0.5",
-      icon: "w-5 px-0.5",
-      "icon-sm": "",
-      xmini: "w-5 px-0.5",
-      mini: "w-5 px-0.5",
-      xs: "w-5 px-0.5",
-      sm: "",
-      md: "",
-    },
-  },
-  defaultVariants: {
-    size: "sm",
-  },
-});
-
-const selectButtonSizeVariants = cva("", {
-  variants: {
-    size: {
-      "icon-xs": "w-auto px-1.5",
-      xmini: "w-auto px-1.5",
-      mini: "w-auto px-2",
-      icon: "w-auto px-2",
-      "icon-sm": "",
-      xs: "",
-      sm: "",
-      md: "",
-    },
-  },
-  defaultVariants: {
-    size: "sm",
-  },
-});
+// ── Props types ───────────────────────────────────────────────────────────────
 
 type CommonButtonProps = Omit<MetaButtonProps, "children"> &
   Omit<LinkWrapperProps, "children"> & {
@@ -372,10 +185,6 @@ type CommonButtonProps = Omit<MetaButtonProps, "children"> &
 
 export type ButtonIconType = React.ComponentType | React.ReactElement;
 
-function isReactElement(visual: ButtonIconType): visual is React.ReactElement {
-  return React.isValidElement(visual);
-}
-
 export type IconOnlyButtonProps = CommonButtonProps & {
   size: IconOnlySize;
   icon: ButtonIconType;
@@ -390,171 +199,62 @@ export type RegularButtonProps = CommonButtonProps & {
 
 export type ButtonProps = IconOnlyButtonProps | RegularButtonProps;
 
+// ── Shim ──────────────────────────────────────────────────────────────────────
+
+// briefPulse, isRounded, hasLighterFont have no NewButton equivalent — silently dropped.
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
+      variant = "primary",
+      size = "sm",
       label,
       icon,
-      className,
-      isLoading = false,
-      variant = "primary",
+      isSelect,
+      isLoading,
+      isPulsing,
+      isCounter,
+      counterValue,
       tooltip,
       tooltipShortcut,
-      isSelect = false,
-      isPulsing = false,
-      briefPulse = false,
-      isCounter = false,
-      counterValue,
-      size = "sm",
-      isRounded = false,
-      hasLighterFont = false,
       href,
       target,
       rel,
       replace,
       shallow,
+      className,
+      disabled,
       "aria-label": ariaLabel,
-      ...props
+      briefPulse: _briefPulse,
+      isRounded: _isRounded,
+      hasLighterFont: _hasLighterFont,
+      ...htmlProps
     },
     ref
   ) => {
-    const iconSize = ICON_SIZE_MAP[size];
-    const counterSize = COUNTER_SIZE_MAP[size];
-
-    const [isPulsingBriefly, setIsPulsingBriefly] = useState(false);
-
-    useEffect(() => {
-      if (!briefPulse) {
-        return;
-      }
-      const startPulse = () => {
-        setIsPulsingBriefly(true);
-        setTimeout(
-          () => setIsPulsingBriefly(false),
-          PULSE_ANIMATION_DURATION * 3000
-        );
-      };
-      startPulse();
-    }, [briefPulse]);
-
-    const renderIcon = (visual: ButtonIconType, extraClass = "") => {
-      if (isReactElement(visual)) {
-        return <span className={cn(extraClass, "shrink-0")}>{visual}</span>;
-      }
-
-      return (
-        <Icon visual={visual} size={iconSize} className={cn(extraClass)} />
-      );
-    };
-    const renderChevron = (visual: React.ComponentType, extraClass = "") => (
-      <Icon
-        visual={visual}
-        size={iconSize}
-        className={cn(variant ? chevronVariantMap[variant] : "", extraClass)}
-      />
-    );
-
-    const showCounter = isCounter && counterValue != null;
-    const showContainer = label || showCounter;
-
-    const content = (
-      <>
-        {isLoading ? (
-          <div className={loadingContainerVariants({ size })}>
-            <Spinner
-              size={isSmallButtonSize(size) ? "xs" : iconSize}
-              variant={(variant && spinnerVariantsMap[variant]) || "gray400"}
-            />
-          </div>
-        ) : (
-          icon && renderIcon(icon, "-mx-0.5")
-        )}
-
-        {showContainer && (
-          <div
-            className={cn(
-              "flex items-center gap-2",
-              labelVariants({ size, hasLighterFont })
-            )}
-          >
-            {label}
-            {showCounter && (
-              <Counter
-                value={Number(counterValue)}
-                variant={variant || "primary"}
-                size={counterSize}
-                isInButton={true}
-              />
-            )}
-          </div>
-        )}
-        {isSelect && renderChevron(ChevronDown, isLoading ? "" : "-mr-1")}
-      </>
-    );
-
-    const pointerEventProps = useMemo(() => {
-      if (isLoading || props.disabled) {
-        return {
-          onPointerDown: (e: React.PointerEvent<HTMLButtonElement>) => {
-            e.preventDefault();
-            e.stopPropagation();
-          },
-        };
-      }
-      return {};
-    }, [isLoading, props.disabled]);
-
-    // We cannot skip a button tag when it's disabled. We need
-    // to apply disabled class manually (currently it has :disabled pseudo-class, which won't work if it's not a button)
-    // and disable pointer events.
-    const shouldUseSlot = !!href && !props.disabled;
-
-    const innerContent = shouldUseSlot ? <span>{content}</span> : content;
-
-    const innerButton = (
-      <MetaButton
+    return (
+      <NewButton
         ref={ref}
-        size={size}
-        variant={variant}
-        isRounded={isRounded}
-        disabled={isLoading || props.disabled}
-        className={cn(
-          (isPulsing || isPulsingBriefly) && "animate-ring-pulse",
-          isSelect && selectButtonSizeVariants({ size }),
-          className
-        )}
-        aria-label={ariaLabel || tooltip || label}
-        asChild={shouldUseSlot}
-        {...props}
-        {...pointerEventProps}
-      >
-        {innerContent}
-      </MetaButton>
-    );
-
-    const wrappedContent = tooltip ? (
-      <Tooltip
-        trigger={innerButton}
-        tooltipTriggerAsChild={true}
-        label={tooltip}
-        shortcut={tooltipShortcut}
-      />
-    ) : (
-      innerButton
-    );
-
-    return href ? (
-      <LinkWrapper
+        variant={mapButtonVariant(variant ?? "primary")}
+        size={mapButtonSize(size ?? "sm")}
+        label={label}
+        icon={icon}
+        isSelect={isSelect}
+        isLoading={isLoading}
+        isPulsing={isPulsing}
+        isCounter={isCounter}
+        counterValue={counterValue}
+        tooltip={tooltip}
+        tooltipShortcut={tooltipShortcut}
         href={href}
         target={target}
         rel={rel}
         replace={replace}
         shallow={shallow}
-      >
-        {wrappedContent}
-      </LinkWrapper>
-    ) : (
-      wrappedContent
+        className={className}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        {...htmlProps}
+      />
     );
   }
 );

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -1,14 +1,10 @@
-import { Icon } from "@sparkle/components/Icon";
-import { InfoCircle } from "@sparkle/icons/v2-stroke";
-import { cn } from "@sparkle/lib/utils";
-import { cva } from "class-variance-authority";
+import { NewInput } from "@sparkle/components/NewInput";
 import React, { forwardRef } from "react";
-import { Label } from "./Label";
 
 const MESSAGE_STATUS = ["info", "default", "error"] as const;
-
 type MessageStatus = (typeof MESSAGE_STATUS)[number];
 
+// Preview-branch shim: keeps old InputProps type, delegates to NewInput.
 export interface InputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "value"> {
   message?: string | null;
@@ -20,115 +16,10 @@ export interface InputProps
   label?: string;
 }
 
-const INPUT_STATES = ["error", "disabled", "default"];
-
-type InputStateType = (typeof INPUT_STATES)[number];
-
-const messageVariantStyles: Record<MessageStatus, string> = {
-  info: "text-muted-foreground",
-  default: "text-muted-foreground",
-  error: "text-foreground-warning",
-};
-
-const stateVariantStyles: Record<InputStateType, string> = {
-  default: cn(
-    "border-border",
-    "ring-highlight/0",
-    "focus-visible:border-border-focus",
-    "focus-visible:outline-hidden focus-visible:ring-2",
-    "focus-visible:ring-highlight/20"
-  ),
-  disabled: cn(
-    "disabled:cursor-not-allowed",
-    "disabled:text-muted-foreground",
-    "disabled:border-border"
-  ),
-  error: cn(
-    "border-border-warning/40",
-    "ring-warning/0",
-    "focus-visible:border-border-warning",
-    "focus-visible:outline-hidden focus-visible:ring-2",
-    "focus-visible:ring-warning/10"
-  ),
-};
-
-const messageVariant = cva("", {
-  variants: {
-    status: messageVariantStyles,
-  },
-  defaultVariants: {
-    status: "info",
-  },
-});
-
-const inputStyleClasses = cva(
-  cn(
-    "text-sm rounded-xl flex h-9 w-full px-3 py-1.5",
-    "text-foreground",
-    "bg-background",
-    "border border-border focus-visible:ring",
-    "file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground",
-    "placeholder:text-muted-foreground"
-  ),
-  {
-    variants: {
-      state: stateVariantStyles,
-    },
-    defaultVariants: {
-      state: "default",
-    },
-  }
-);
-
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  (
-    {
-      className,
-      containerClassName,
-      message,
-      messageStatus,
-      value,
-      label,
-      isError,
-      disabled,
-      ...props
-    },
-    ref
-  ) => {
-    const state =
-      isError || (message && messageStatus === "error")
-        ? "error"
-        : disabled
-          ? "disabled"
-          : "default";
-    return (
-      <div className={cn("flex flex-col gap-1", containerClassName)}>
-        {label && (
-          <Label htmlFor={props.name} className="mb-1">
-            {label}
-          </Label>
-        )}
-        <input
-          ref={ref}
-          className={cn("ring-inset", inputStyleClasses({ state }), className)}
-          data-1p-ignore={props.type !== "password"}
-          value={value ?? undefined}
-          disabled={disabled}
-          {...props}
-        />
-        {message && (
-          <div
-            className={cn(
-              "flex items-center gap-1 text-xs",
-              messageVariant({ status: messageStatus })
-            )}
-          >
-            {messageStatus === "info" && <Icon visual={InfoCircle} size="xs" />}
-            {message}
-          </div>
-        )}
-      </div>
-    );
+  // Destructure the HTML `size` attr (number) so it doesn't conflict with NewInput's size prop.
+  ({ size: _htmlSize, ...props }, ref) => {
+    return <NewInput ref={ref} size="sm" {...props} />;
   }
 );
 

--- a/sparkle/src/components/NewButton.tsx
+++ b/sparkle/src/components/NewButton.tsx
@@ -63,7 +63,8 @@ const newButtonVariants = cva(
         primary: cn(
           OVERLAY,
           "bg-linear-to-b from-primary-700 to-primary-800",
-          "dark:from-primary-800 dark:to-primary-900",
+          "dark:from-stone-50 dark:to-stone-150",
+          "dark:border dark:border-border-dark",
           "text-primary-50",
           RAISED_SHADOW,
           "data-[disabled]:from-primary-300 data-[disabled]:to-primary-400",
@@ -74,7 +75,7 @@ const newButtonVariants = cva(
         highlight: cn(
           OVERLAY,
           "bg-linear-to-b from-highlight-400 to-highlight-500",
-          "dark:from-highlight-600 dark:to-highlight-500",
+          "dark:from-blue-500 dark:to-blue-600",
           "text-white",
           RAISED_SHADOW,
           "data-[disabled]:from-highlight-200 data-[disabled]:to-highlight-300",
@@ -85,7 +86,7 @@ const newButtonVariants = cva(
         warning: cn(
           OVERLAY,
           "bg-linear-to-b from-warning-400 to-warning-500",
-          "dark:from-warning-600 dark:to-warning-500",
+          "dark:from-red-500 dark:to-red-600",
           "text-white",
           RAISED_SHADOW,
           "data-[disabled]:from-warning-200 data-[disabled]:to-warning-300",
@@ -97,9 +98,9 @@ const newButtonVariants = cva(
           OVERLAY,
           // overflow-hidden + after:rounded-none clips the hover overlay flush to the border-radius.
           "overflow-hidden after:rounded-none",
-          "border border-border-dark dark:border-stone-800",
+          "border border-border-dark dark:border-stone-750",
           "bg-linear-to-b from-primary-50 to-primary-100",
-          "dark:from-stone-800 dark:to-stone-900",
+          "dark:from-stone-775 dark:to-stone-775",
           "text-muted-foreground dark:text-primary-900",
           RAISED_SHADOW,
           // Dark: a real drop shadow (not a glow) since the button surface is dark.

--- a/sparkle/src/components/NewButton.tsx
+++ b/sparkle/src/components/NewButton.tsx
@@ -98,9 +98,9 @@ const newButtonVariants = cva(
           OVERLAY,
           // overflow-hidden + after:rounded-none clips the hover overlay flush to the border-radius.
           "overflow-hidden after:rounded-none",
-          "border border-border-dark dark:border-stone-750",
+          "border border-border-dark dark:border-stone-775",
           "bg-linear-to-b from-primary-50 to-primary-100",
-          "dark:from-stone-775 dark:to-stone-775",
+          "dark:from-stone-800 dark:to-stone-800",
           "text-muted-foreground dark:text-primary-900",
           RAISED_SHADOW,
           // Dark: a real drop shadow (not a glow) since the button surface is dark.

--- a/sparkle/src/components/NewButton.tsx
+++ b/sparkle/src/components/NewButton.tsx
@@ -64,12 +64,13 @@ const newButtonVariants = cva(
           OVERLAY,
           "bg-linear-to-b from-primary-700 to-primary-800",
           "dark:from-stone-50 dark:to-stone-150",
-          "dark:border dark:border-border-dark",
           "text-primary-50",
           RAISED_SHADOW,
           "data-[disabled]:from-primary-300 data-[disabled]:to-primary-400",
           "dark:data-[disabled]:opacity-50",
           // Dark: light button surface → darken on hover instead of lighten.
+          // Dark: light button → drop shadow uses black (not white foreground token) to avoid glow.
+          "dark:shadow-[inset_0_0_1px_0_rgba(255,255,255,0.5),0_0_0.5px_0_var(--color-border-dark),0_1px_1.5px_0_rgba(0,0,0,0.1)]",
           "dark:hover:after:bg-black/[0.04] dark:active:after:bg-black/[0.04]"
         ),
         highlight: cn(
@@ -78,6 +79,7 @@ const newButtonVariants = cva(
           "dark:from-blue-500 dark:to-blue-600",
           "text-white",
           RAISED_SHADOW,
+          "dark:shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_var(--color-border-dark),0_1px_1.5px_0_rgba(0,0,0,0.1)]",
           "data-[disabled]:from-highlight-200 data-[disabled]:to-highlight-300",
           // Dark disabled: lock gradient (prevent ramp flip) then fade with opacity.
           "dark:data-[disabled]:from-highlight-600 dark:data-[disabled]:to-highlight-500",
@@ -89,6 +91,7 @@ const newButtonVariants = cva(
           "dark:from-red-500 dark:to-red-600",
           "text-white",
           RAISED_SHADOW,
+          "dark:shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_var(--color-border-dark),0_1px_1.5px_0_rgba(0,0,0,0.1)]",
           "data-[disabled]:from-warning-200 data-[disabled]:to-warning-300",
           // Dark disabled: lock gradient (prevent ramp flip) then fade with opacity.
           "dark:data-[disabled]:from-warning-600 dark:data-[disabled]:to-warning-500",
@@ -102,9 +105,7 @@ const newButtonVariants = cva(
           "bg-linear-to-b from-primary-50 to-primary-100",
           "dark:from-stone-800 dark:to-stone-800",
           "text-muted-foreground dark:text-primary-900",
-          RAISED_SHADOW,
-          // Dark: a real drop shadow (not a glow) since the button surface is dark.
-          "dark:shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_var(--color-border-dark),0_0.5px_1px_0_rgba(0,0,0,0.06)]",
+          "shadow-[inset_0_0_1px_0_rgba(255,255,255,0.08),0_0_0.5px_0_var(--color-border-dark),0_0.5px_1px_0_rgba(0,0,0,0.06)]",
           "hover:after:bg-black/[0.02] active:after:bg-black/[0.02]",
           "data-[disabled]:text-faint",
           "dark:data-[disabled]:opacity-50"

--- a/sparkle/src/components/NewButton.tsx
+++ b/sparkle/src/components/NewButton.tsx
@@ -97,9 +97,9 @@ const newButtonVariants = cva(
           OVERLAY,
           // overflow-hidden + after:rounded-none clips the hover overlay flush to the border-radius.
           "overflow-hidden after:rounded-none",
-          "border border-border-dark dark:border-primary-200",
+          "border border-border-dark dark:border-stone-800",
           "bg-linear-to-b from-primary-50 to-primary-100",
-          "dark:from-primary-150 dark:to-primary-200",
+          "dark:from-stone-800 dark:to-stone-900",
           "text-muted-foreground dark:text-primary-900",
           RAISED_SHADOW,
           // Dark: a real drop shadow (not a glow) since the button surface is dark.

--- a/sparkle/src/components/NewInput.tsx
+++ b/sparkle/src/components/NewInput.tsx
@@ -75,9 +75,9 @@ const innerInputVariants = cva(
   {
     variants: {
       size: {
-        xs: "px-2",
-        sm: "px-3",
-        md: "px-3",
+        xs: "px-2 text-xs",
+        sm: "px-3 text-sm",
+        md: "px-3 text-sm",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary

Preview-only branch — **not intended to merge**.

- Replaces `sparkle/src/components/Button.tsx` with a compatibility shim that delegates every `<Button>` call to `<NewButton>`, mapping the old API automatically
- Replaces `sparkle/src/components/Input.tsx` similarly, delegating to `<NewInput>`
- Zero changes to any `front/` file — all ~109 Button import sites and ~37 Input import sites pick up the new design automatically

### Variant mapping (Button → NewButton)
| Old | New |
|-----|-----|
| `primary` | `primary` |
| `highlight` | `highlight` |
| `highlight-secondary` | `highlight-ghost` |
| `warning` | `warning` |
| `warning-secondary` | `warning-ghost` |
| `outline` | `outline` |
| `ghost` | `ghost` |
| `ghost-secondary` | `ghost-secondary` |

### Size mapping
| Old | New |
|-----|-----|
| `xmini`, `mini`, `icon-xs`, `xs` | `xs` |
| `sm`, `icon` | `sm` |
| `md`, `icon-sm` | `md` |

### Dropped props (silently ignored)
`briefPulse`, `isRounded`, `hasLighterFont`

## Screens that may look off
- **Any toolbar/nav with `size="icon"` buttons** — now renders as `sm` (32px) instead of 28px, slightly larger
- **`xmini`/`mini` buttons** — collapsed to `xs` (24px); any layout that relied on the exact 24/28px heights may shift
- **`highlight-secondary` / `warning-secondary`** — now render as ghost-style (transparent bg, colored text) rather than bordered outline — visual change is intentional

🤖 Generated with [Claude Code](https://claude.com/claude-code)