### PR TITLE
feat: introduce regular_auto group kind

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/groups/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/index.ts
@@ -13,7 +13,13 @@ app.get("/", async (ctx): HandlerResult<PokeListGroups> => {
   const auth = ctx.get("auth");
 
   const groups = await GroupResource.listAllWorkspaceGroups(auth, {
-    groupKinds: ["global", "regular", "space_editors", "provisioned"],
+    groupKinds: [
+      "global",
+      "regular",
+      "regular_auto",
+      "space_editors",
+      "provisioned",
+    ],
   });
 
   return ctx.json({ groups: groups.map((g) => g.toJSON()) });

--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -39,7 +39,7 @@ app.get(
 
     const allGroups = space.groups.filter((g) =>
       space.managementMode === "manual"
-        ? g.kind === "regular" || g.kind === "space_editors"
+        ? g.isRegular() || g.kind === "space_editors"
         : g.kind === "provisioned"
     );
 

--- a/front-api/routes/w/[wId]/files/[fileId]/edit-text.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/edit-text.test.ts
@@ -224,7 +224,7 @@ describe("POST /api/w/:wId/files/:fileId/edit-text", () => {
     });
 
     const space = await SpaceFactory.regular(workspace);
-    const memberGroup = space.groups.find((g) => g.kind === "regular");
+    const memberGroup = space.groups.find((g) => g.isRegular());
     await memberGroup?.dangerouslyAddMembers(auth, { users: [user.toJSON()] });
 
     const file = await FileFactory.create(auth, user, {
@@ -288,7 +288,7 @@ describe("POST /api/w/:wId/files/:fileId/edit-text", () => {
 
     const otherUser = await UserFactory.basic();
     const space = await SpaceFactory.regular(workspace);
-    const memberGroup = space.groups.find((g) => g.kind === "regular");
+    const memberGroup = space.groups.find((g) => g.isRegular());
     await memberGroup?.dangerouslyAddMembers(auth, {
       users: [otherUser.toJSON()],
     });

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -32,7 +32,7 @@ app.get(
       ? Array.isArray(kind)
         ? kind
         : [kind]
-      : ["global", "regular", "space_editors"];
+      : ["global", "regular", "regular_auto", "space_editors"];
 
     const groups: GroupResource[] = spaceId
       ? await GroupResource.listForSpaceById(auth, spaceId, { groupKinds })

--- a/front-api/routes/w/[wId]/pods/[podId]/tasks/seed.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/tasks/seed.test.ts
@@ -71,7 +71,7 @@ describe("POST /api/w/:wId/pods/:podId/tasks/seed", () => {
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const memberGroup = regularSpace.groups.find((g) => g.kind === "regular");
+    const memberGroup = regularSpace.groups.find((g) => g.isRegular());
     if (memberGroup) {
       await memberGroup.dangerouslyAddMembers(adminAuth, {
         users: [user.toJSON()],

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.test.ts
@@ -20,7 +20,7 @@ async function addUserToProject(
   user: UserResource,
   options: { asEditor?: boolean } = {}
 ) {
-  const memberGroup = project.groups.find((g) => g.kind === "regular");
+  const memberGroup = project.groups.find((g) => g.isRegular());
   const editorGroup = project.groups.find((g) => g.kind === "space_editors");
 
   if (memberGroup) {
@@ -46,7 +46,7 @@ describe("POST /api/w/:wId/spaces/:spaceId/leave", () => {
       );
 
       const regularSpace = await SpaceFactory.regular(workspace);
-      const memberGroup = regularSpace.groups.find((g) => g.kind === "regular");
+      const memberGroup = regularSpace.groups.find((g) => g.isRegular());
       if (memberGroup) {
         await memberGroup.dangerouslyAddMembers(adminAuth, {
           users: [user.toJSON()],
@@ -122,7 +122,7 @@ describe("POST /api/w/:wId/spaces/:spaceId/leave", () => {
       expect(response.status).toBe(200);
       expect((await response.json()).success).toBe(true);
 
-      const memberGroup = project.groups.find((g) => g.kind === "regular");
+      const memberGroup = project.groups.find((g) => g.isRegular());
       if (memberGroup) {
         const isMember = await memberGroup.isMember(user);
         expect(isMember).toBe(false);

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
@@ -40,7 +40,7 @@ app.post(
 
     const user = auth.getNonNullableUser();
 
-    const memberGroup = space.groups.find((g) => g.kind === "regular");
+    const memberGroup = space.groups.find((g) => g.isRegular());
     const editorGroup = space.groups.find((g) => g.kind === "space_editors");
 
     if (editorGroup) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.test.ts
@@ -160,7 +160,7 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_tasks/:taskId", () => {
       workspace.sId
     );
     const memberGroup =
-      project.groups.find((g) => g.kind === "regular") ?? project.groups[0]!;
+      project.groups.find((g) => g.isRegular()) ?? project.groups[0]!;
     await GroupFactory.withMembers(adminAuth, memberGroup, [otherUser]);
 
     const todo = await ProjectTaskFactory.create(workspace, project, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
@@ -91,7 +91,7 @@ describe("POST /api/w/:wId/spaces/:spaceId/project_tasks/mark_read", () => {
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const memberGroup = regularSpace.groups.find((g) => g.kind === "regular");
+    const memberGroup = regularSpace.groups.find((g) => g.isRegular());
     if (memberGroup) {
       await memberGroup.dangerouslyAddMembers(adminAuth, {
         users: [user.toJSON()],

--- a/front/lib/api/actions/servers/poke/tools/users.ts
+++ b/front/lib/api/actions/servers/poke/tools/users.ts
@@ -42,7 +42,13 @@ export const userHandlers: UserHandlers = {
     const targetAuth = targetAuthResult.value;
 
     const groups = await GroupResource.listAllWorkspaceGroups(targetAuth, {
-      groupKinds: ["global", "regular", "space_editors", "provisioned"],
+      groupKinds: [
+        "global",
+        "regular",
+        "regular_auto",
+        "space_editors",
+        "provisioned",
+      ],
     });
 
     return jsonResponse({

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -652,11 +652,9 @@ describe("retryAgentMessage", () => {
       const user = auth.getNonNullableUser();
       const userJson = user.toJSON();
 
-      const projectSpaceGroup = projectSpace.groups.find(
-        (g) => g.kind === "regular"
-      );
-      const anotherProjectSpaceGroup = anotherProjectSpace.groups.find(
-        (g) => g.kind === "regular"
+      const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+      const anotherProjectSpaceGroup = anotherProjectSpace.groups.find((g) =>
+        g.isRegular()
       );
 
       if (projectSpaceGroup) {
@@ -2357,9 +2355,7 @@ describe("postUserMessage", () => {
       );
 
       // Add member user to the project space group
-      const projectSpaceGroup = projectSpace.groups.find(
-        (g) => g.kind === "regular"
-      );
+      const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
       if (projectSpaceGroup) {
         const addRes = await projectSpaceGroup.dangerouslyAddMember(
           internalAdminAuth,
@@ -2731,11 +2727,9 @@ describe("postUserMessage", () => {
       );
       const user = auth.getNonNullableUser();
 
-      const projectSpaceGroup = projectSpace.groups.find(
-        (g) => g.kind === "regular"
-      );
-      const anotherProjectSpaceGroup = anotherProjectSpace.groups.find(
-        (g) => g.kind === "regular"
+      const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+      const anotherProjectSpaceGroup = anotherProjectSpace.groups.find((g) =>
+        g.isRegular()
       );
 
       if (projectSpaceGroup) {
@@ -3691,11 +3685,9 @@ describe("postNewContentFragment", () => {
     // SpaceFactory.project creates a group and associates it with the space
     // We need to add the user to those groups
     // The groups are available on space.groups
-    const projectSpaceGroup = projectSpace.groups.find(
-      (g) => g.kind === "regular"
-    );
-    const anotherProjectSpaceGroup = anotherProjectSpace.groups.find(
-      (g) => g.kind === "regular"
+    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const anotherProjectSpaceGroup = anotherProjectSpace.groups.find((g) =>
+      g.isRegular()
     );
 
     if (projectSpaceGroup) {

--- a/front/lib/api/assistant/conversation/branches.test.ts
+++ b/front/lib/api/assistant/conversation/branches.test.ts
@@ -49,7 +49,7 @@ describe("mergeConversationBranch", () => {
       workspace.sId
     );
 
-    const projectGroup = projectSpace.groups.find((g) => g.kind === "regular");
+    const projectGroup = projectSpace.groups.find((g) => g.isRegular());
     if (!projectGroup) {
       throw new Error("Project group should exist.");
     }
@@ -72,9 +72,7 @@ describe("mergeConversationBranch", () => {
       throw new Error(addProjectMemberToProjectRes.error.message);
     }
 
-    const restrictedGroup = restrictedSpace.groups.find(
-      (g) => g.kind === "regular"
-    );
+    const restrictedGroup = restrictedSpace.groups.find((g) => g.isRegular());
     if (!restrictedGroup) {
       throw new Error("Restricted space group should exist.");
     }

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -46,7 +46,7 @@ describe("canAgentBeUsedInProjectConversation", () => {
       ReturnType<Authenticator["getNonNullableUser"]>["toJSON"]
     >
   ) {
-    const regularGroup = space.groups.find((g) => g.kind === "regular");
+    const regularGroup = space.groups.find((g) => g.isRegular());
     if (!regularGroup) {
       throw new Error("Expected a regular group on the space");
     }
@@ -724,11 +724,9 @@ describe("updateConversationRequirements", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroup = projectSpace.groups.find(
-      (g) => g.kind === "regular"
-    );
-    const anotherProjectSpaceGroup = anotherProjectSpace.groups.find(
-      (g) => g.kind === "regular"
+    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const anotherProjectSpaceGroup = anotherProjectSpace.groups.find((g) =>
+      g.isRegular()
     );
 
     if (projectSpaceGroup) {
@@ -1356,7 +1354,7 @@ describe("rebuildConversationRequirements", () => {
     const userJson = auth.getNonNullableUser().toJSON();
 
     for (const space of [projectSpace, regularSpace, anotherRegularSpace]) {
-      const group = space.groups.find((g) => g.kind === "regular");
+      const group = space.groups.find((g) => g.isRegular());
       if (!group) {
         continue;
       }

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -66,7 +66,7 @@ describe("selected conversation Spaces", () => {
   }
 
   function regularGroup(space: SpaceResource) {
-    const group = space.groups.find((g) => g.kind === "regular");
+    const group = space.groups.find((g) => g.isRegular());
     if (!group) {
       throw new Error("Expected regular member group on Space");
     }

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -80,9 +80,7 @@ describe("moveConversationToProject", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroup = projectSpace.groups.find(
-      (g) => g.kind === "regular"
-    );
+    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -143,9 +141,7 @@ describe("moveConversationToProject", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroup = projectSpace.groups.find(
-      (g) => g.kind === "regular"
-    );
+    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -305,9 +301,7 @@ describe("moveConversationToProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find(
-      (g) => g.kind === "regular"
-    );
+    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -503,9 +497,7 @@ describe("moveConversationToProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find(
-      (g) => g.kind === "regular"
-    );
+    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -607,8 +599,8 @@ describe("moveConversationToProject", () => {
 
     // Create destination project and add user as member
     const destinationProject = await SpaceFactory.project(workspace);
-    const destinationProjectGroup = destinationProject.groups.find(
-      (g) => g.kind === "regular"
+    const destinationProjectGroup = destinationProject.groups.find((g) =>
+      g.isRegular()
     );
     if (!destinationProjectGroup) {
       throw new Error("Destination project regular group not found");
@@ -673,9 +665,7 @@ describe("moveConversationToProject", () => {
     );
 
     // Add current user as member (but not editor) of source project
-    const sourceProjectGroup = sourceProject.groups.find(
-      (g) => g.kind === "regular"
-    );
+    const sourceProjectGroup = sourceProject.groups.find((g) => g.isRegular());
     if (!sourceProjectGroup) {
       throw new Error("Source project regular group not found");
     }
@@ -685,8 +675,8 @@ describe("moveConversationToProject", () => {
 
     // Create destination project and add user as member
     const destinationProject = await SpaceFactory.project(workspace);
-    const destinationProjectGroup = destinationProject.groups.find(
-      (g) => g.kind === "regular"
+    const destinationProjectGroup = destinationProject.groups.find((g) =>
+      g.isRegular()
     );
     if (!destinationProjectGroup) {
       throw new Error("Destination project regular group not found");
@@ -735,9 +725,7 @@ describe("moveConversationToProject", () => {
     );
 
     // Add user as member of the project
-    const projectSpaceGroup = projectSpace.groups.find(
-      (g) => g.kind === "regular"
-    );
+    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -794,9 +782,7 @@ describe("moveConversationOutOfProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find(
-      (g) => g.kind === "regular"
-    );
+    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -875,9 +861,7 @@ describe("moveConversationOutOfProject", () => {
     );
 
     // Add current user as member (but not editor) of project.
-    const projectSpaceGroup = projectSpace.groups.find(
-      (g) => g.kind === "regular"
-    );
+    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -938,9 +922,7 @@ describe("moveConversationOutOfProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find(
-      (g) => g.kind === "regular"
-    );
+    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -1096,9 +1078,7 @@ describe("moveConversationOutOfProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find(
-      (g) => g.kind === "regular"
-    );
+    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }

--- a/front/lib/resources/conversation_selected_space_resource.test.ts
+++ b/front/lib/resources/conversation_selected_space_resource.test.ts
@@ -24,7 +24,7 @@ describe("ConversationSelectedSpaceResource", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const memberGroup = space.groups.find((group) => group.kind === "regular");
+    const memberGroup = space.groups.find((group) => group.isRegular());
     if (!memberGroup) {
       throw new Error("Expected regular member group on Space");
     }

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -865,4 +865,77 @@ describe("GroupResource", () => {
       }
     });
   });
+
+  // Transitional coverage for the `regular` -> `regular_auto` rename: a
+  // `regular_auto` group must behave identically to a `regular` one across the
+  // double-read paths. These tests use `regular_auto` so they survive the
+  // eventual contract step (removal of `regular`).
+  describe("regular_auto behaves like regular (rename double-read)", () => {
+    it("isRegular() is true for both regular and regular_auto", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Regular",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      const regularAutoGroup = await GroupResource.makeNew({
+        name: "Regular Auto",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+
+      expect(regularGroup.isRegular()).toBe(true);
+      expect(regularAutoGroup.isRegular()).toBe(true);
+    });
+
+    it("listAllWorkspaceGroups includes regular_auto groups", async () => {
+      const regularAutoGroup = await GroupResource.makeNew({
+        name: "Regular Auto",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+
+      const groups = await GroupResource.listAllWorkspaceGroups(authenticator);
+
+      expect(groups.map((g) => g.id)).toContain(regularAutoGroup.id);
+    });
+
+    it("dangerouslyListUserGroupsForAuth returns regular_auto groups the user belongs to", async () => {
+      const regularAutoGroup = await GroupResource.makeNew({
+        name: "Regular Auto",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      await regularAutoGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      const groupIds = await GroupResource.dangerouslyListUserGroupsForAuth({
+        user,
+        workspace,
+      });
+
+      expect(groupIds).toContain(globalGroup.id);
+      expect(groupIds).toContain(regularAutoGroup.id);
+    });
+
+    it("allows adding and removing members on a regular_auto group", async () => {
+      const regularAutoGroup = await GroupResource.makeNew({
+        name: "Regular Auto",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+
+      const addResult = await regularAutoGroup.dangerouslyAddMembers(
+        authenticator,
+        { users: [user.toJSON()] }
+      );
+      expect(addResult.isOk()).toBe(true);
+
+      const removeResult = await regularAutoGroup.dangerouslyRemoveMembers(
+        authenticator,
+        { users: [user.toJSON()] }
+      );
+      expect(removeResult.isOk()).toBe(true);
+    });
+  });
 });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -637,6 +637,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     groupKinds = [
       "global",
       "regular",
+      "regular_auto",
       "space_editors",
       "system",
       "provisioned",
@@ -1025,7 +1026,13 @@ export class GroupResource extends BaseResource<GroupModel> {
     options: { groupKinds?: GroupKind[] } = {}
   ): Promise<GroupResource[]> {
     const {
-      groupKinds = ["global", "regular", "space_editors", "provisioned"],
+      groupKinds = [
+        "global",
+        "regular",
+        "regular_auto",
+        "space_editors",
+        "provisioned",
+      ],
     } = options;
     const groups = await this.baseFetch(auth, {
       where: {
@@ -1190,7 +1197,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   static async listGroupNamesByUserModelIdInWorkspace({
     workspace,
     userModelIds,
-    groupKinds = ["regular", "provisioned"],
+    groupKinds = ["regular", "regular_auto", "provisioned"],
   }: {
     workspace: LightWorkspaceType;
     userModelIds: ModelId[];
@@ -1510,7 +1517,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     >
   > {
     assert(
-      this.kind === "regular" ||
+      this.isRegular() ||
         this.kind === "space_editors" ||
         this.kind === "agent_editors" ||
         this.kind === "skill_editors" ||
@@ -1554,10 +1561,11 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
-    // Users can only be added to regular, space_editors, agent_editors, skill_editors or provisioned groups.
+    // Users can only be added to regular, regular_auto, space_editors, agent_editors, skill_editors or provisioned groups.
     if (
       ![
         "regular",
+        "regular_auto",
         "space_editors",
         "agent_editors",
         "skill_editors",
@@ -1687,7 +1695,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     >
   > {
     assert(
-      this.kind === "regular" ||
+      this.isRegular() ||
         this.kind === "space_editors" ||
         this.kind === "agent_editors" ||
         this.kind === "skill_editors" ||
@@ -1725,10 +1733,11 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
-    // Users can only be removed from regular, space_editors, agent_editors, skill_editors or provisioned groups.
+    // Users can only be removed from regular, regular_auto, space_editors, agent_editors, skill_editors or provisioned groups.
     if (
       ![
         "regular",
+        "regular_auto",
         "space_editors",
         "agent_editors",
         "skill_editors",
@@ -1838,7 +1847,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     const user = auth.getNonNullableUser();
     const workspace = auth.getNonNullableWorkspace();
 
-    if (this.kind !== "regular" && this.kind !== "space_editors") {
+    if (!this.isRegular() && this.kind !== "space_editors") {
       return new Err(
         new DustError(
           "system_or_global_group",
@@ -2366,7 +2375,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   isRegular(): boolean {
-    return this.kind === "regular";
+    return this.kind === "regular" || this.kind === "regular_auto";
   }
 
   isSpaceEditor(): boolean {

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -6,6 +6,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { GroupKind } from "@app/types/groups";
 import type {
   CombinedResourcePermissions,
   GroupPermission,
@@ -105,9 +106,11 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
       );
       if (filterOnManagementMode) {
         // Keep only regular groups in manual mode, provisioned groups in provisioned mode
-        const filterOnKind =
-          space.managementMode === "manual" ? "regular" : "provisioned";
-        if (groupModel.kind !== filterOnKind) {
+        const filterOnKind: GroupKind[] =
+          space.managementMode === "manual"
+            ? ["regular", "regular_auto"]
+            : ["provisioned"];
+        if (!filterOnKind.includes(groupModel.kind)) {
           return null;
         }
       }

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -221,7 +221,7 @@ export abstract class GroupSpaceBaseResource extends BaseResource<GroupSpaceMode
           id: this.groupId,
           workspaceId: auth.getNonNullableWorkspace().id,
           // Delete the corresponding group if it's regular or space_editors (system, global, provisioned groups should not be deleted)
-          kind: ["regular", "space_editors"],
+          kind: ["regular", "regular_auto", "space_editors"],
         },
         transaction,
       });

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1368,9 +1368,7 @@ describe("SpaceResource", () => {
 
     it("should return project spaces only for members", async () => {
       const projectSpace = await SpaceFactory.project(workspace);
-      const projectGroup = projectSpace.groups.find(
-        (g) => g.kind === "regular"
-      );
+      const projectGroup = projectSpace.groups.find((g) => g.isRegular());
 
       // User is not a member, should not see it
       const userSpaces =
@@ -1818,6 +1816,62 @@ describe("SpaceResource cleanup on delete", () => {
 
       // Verify they match exactly
       expect(modelsWithSpaceFK).toEqual(knownModels);
+    });
+  });
+
+  // Transitional coverage for the `regular` -> `regular_auto` rename. A manual
+  // space whose member group is `regular_auto` must resolve through
+  // getSpaceManualMemberGroup (which asserts exactly one regular member group),
+  // otherwise member-facing operations throw for not-yet-backfilled spaces.
+  describe("regular_auto member group (rename double-read)", () => {
+    let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+    let adminAuth: Authenticator;
+
+    beforeEach(async () => {
+      workspace = await WorkspaceFactory.basic();
+      const adminUser = await UserFactory.basic();
+
+      const { globalGroup, systemGroup } =
+        await GroupFactory.defaults(workspace);
+
+      await MembershipFactory.associate(workspace, adminUser, {
+        role: "admin",
+      });
+
+      const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceResource.makeDefaultsForWorkspace(internalAdminAuth, {
+        globalGroup,
+        systemGroup,
+      });
+
+      adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        adminUser.sId,
+        workspace.sId
+      );
+    });
+
+    it("resolves the member group and renames it on updateName", async () => {
+      const memberGroup = await GroupResource.makeNew({
+        name: "Regular Auto Member Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      const space = await SpaceResource.makeNew(
+        {
+          name: "Regular Auto Space",
+          kind: "regular",
+          workspaceId: workspace.id,
+          managementMode: "manual",
+        },
+        { members: [memberGroup] }
+      );
+
+      const result = await space.updateName(adminAuth, "Renamed Space");
+
+      expect(result.isOk()).toBe(true);
+      expect(space.name).toBe("Renamed Space");
     });
   });
 });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1282,9 +1282,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   private getSpaceManualMemberGroup(): GroupResource {
-    const regularGroups = this.groups.filter(
-      (group) => group.kind === "regular"
-    );
+    const regularGroups = this.groups.filter((group) => group.isRegular());
     assert(
       regularGroups.length === 1,
       `Expected exactly one regular group for the space, but found ${regularGroups.length}.`
@@ -1626,7 +1624,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     allGroupMemberships: GroupMembershipModel[];
   }> {
     const groupsToProcess = this.groups.filter((g) => {
-      return g.kind === "regular" || g.kind === "space_editors";
+      return g.isRegular() || g.kind === "space_editors";
     });
 
     // Fetch all group memberships to get the startAt date (will be the joinedAt date returned for each member)

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -26,6 +26,7 @@ import { isRoleType } from "./user";
  */
 export const GROUP_KINDS = [
   "regular",
+  "regular_auto",
   // space_editors is used to know if a member of a manual group can edit the group
   "space_editors",
   "global",
@@ -78,6 +79,7 @@ export type GroupType = {
 export const GroupKindCodec = z.enum([
   "global",
   "regular",
+  "regular_auto",
   "space_editors",
   "agent_editors",
   "skill_editors",


### PR DESCRIPTION
## Description

This PR introduces the `regular_auto` group kind as the first step of a rename from `regular` to `regular_auto`, preparing the codebase for the transition.

- Adds `regular_auto` as a new group kind alongside the existing `regular` kind
- Updates the `isRegular()` method on `GroupResource` to returns `true` for both `regular` and `regular_auto` kinds
- Replaces all `g.kind === "regular"` comparisons with `g.isRegular()` to handle both kinds uniformly throughout the codebase
- Updates group listing endpoints (poke admin and regular API) to include `regular_auto` in the default set of returned group kinds

## Tests

Manually. Existing tests are updated to use `isRegular()` in place of direct kind comparisons.

## Risks

Low. The change is additive and backward-compatible — existing `regular` groups are unaffected. The `isRegular()` helper ensures both kinds are handled consistently everywhere during the transition.

## Deploy Plan

Standard deployment.