### PR TITLE
feat: create regular_auto groups

### DIFF
--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -107,7 +107,7 @@ describe("GET /api/w/:wId/groups", () => {
     const group = await GroupFactory.regular(workspace, "Backend");
     await GroupFactory.withMembers(auth, group, [user]);
 
-    const response = await getGroups(workspace, { kind: "regular" });
+    const response = await getGroups(workspace, { kind: "regular_auto" });
 
     expect(response.status).toBe(200);
     const { groups } = await response.json();

--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -112,9 +112,9 @@ describe("GET /api/w/:wId/groups", () => {
     expect(response.status).toBe(200);
     const { groups } = await response.json();
 
-    expect(groups.every((g: { kind: string }) => g.kind === "regular")).toBe(
-      true
-    );
+    expect(
+      groups.every((g: { kind: string }) => g.kind === "regular_auto")
+    ).toBe(true);
     const backendGroup = groups.find(
       (g: { name: string }) => g.name === "Backend"
     );

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -106,6 +106,25 @@ describe("createSpaceAndGroup", () => {
       }
     });
 
+    it("should create the member group with kind regular_auto", async () => {
+      const result = await createSpaceAndGroup(adminAuth, {
+        name: "Kind Check Space",
+        isRestricted: true,
+        spaceKind: "regular",
+        managementMode: "manual",
+        memberIds: [user1.sId],
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const memberGroup = result.value.groups.find((g) =>
+          g.name.startsWith("Group for space Kind Check Space")
+        );
+        expect(memberGroup).toBeDefined();
+        expect(memberGroup?.kind).toBe("regular_auto");
+      }
+    });
+
     it("should create a regular space with group management mode", async () => {
       const provisionedGroup = await GroupResource.makeNew({
         name: "Provisioned Group",

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -511,7 +511,7 @@ export async function createSpaceAndGroup(
         {
           name: `${spaceKind === "project" ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${name}`,
           workspaceId: owner.id,
-          kind: "regular",
+          kind: "regular_auto",
         },
         { transaction: t }
       );

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -116,7 +116,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Test Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       await regularGroup.dangerouslyAddMembers(authenticator, {
         users: [user.toJSON()],
@@ -168,7 +168,7 @@ describe("GroupResource", () => {
       const sales = await GroupResource.makeNew({
         name: "Sales",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       await sales.dangerouslyAddMembers(authenticator, {
         users: [user.toJSON()],
@@ -214,7 +214,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Auth Test Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       await regularGroup.dangerouslyAddMembers(authenticator, {
         users: [user.toJSON()],
@@ -264,7 +264,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Suspend Test Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       await regularGroup.dangerouslyAddMembers(authenticator, {
         users: [user.toJSON()],
@@ -297,7 +297,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Cache Invalidation Test",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       await regularGroup.dangerouslyAddMembers(authenticator, {
         users: [user.toJSON()],
@@ -318,7 +318,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Restore Test Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       await regularGroup.dangerouslyAddMembers(authenticator, {
         users: [user.toJSON()],
@@ -352,7 +352,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Restore Cache Test",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       await regularGroup.dangerouslyAddMembers(authenticator, {
         users: [user.toJSON()],
@@ -380,7 +380,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Migration Test Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       await regularGroup.dangerouslyAddMembers(authenticator, {
         users: [secondaryUser.toJSON()],
@@ -428,7 +428,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Duplicate Migration Test",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
 
       await regularGroup.dangerouslyAddMembers(authenticator, {
@@ -471,7 +471,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Cache Migration Test",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       await regularGroup.dangerouslyAddMembers(authenticator, {
         users: [secondaryUser.toJSON()],
@@ -511,7 +511,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Add Member Cache Test",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       await regularGroup.dangerouslyAddMembers(authenticator, {
         users: [user.toJSON()],
@@ -524,7 +524,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Remove Member Cache Test",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       await regularGroup.dangerouslyAddMembers(authenticator, {
         users: [user.toJSON()],
@@ -545,7 +545,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Delete Group Cache Test",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       await regularGroup.dangerouslyAddMembers(authenticator, {
         users: [user.toJSON()],
@@ -571,7 +571,7 @@ describe("GroupResource", () => {
         {
           name: "makeNew Initial Member Cache Test",
           workspaceId: workspace.id,
-          kind: "regular",
+          kind: "regular_auto",
         },
         { memberIds: [user.id] }
       );
@@ -602,7 +602,7 @@ describe("GroupResource", () => {
           {
             name: "Transaction Cache Test",
             workspaceId: workspace.id,
-            kind: "regular",
+            kind: "regular_auto",
           },
           { memberIds: [user.id], transaction }
         );
@@ -627,7 +627,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Pool Cap Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       expect(regularGroup.poolCapAwuCredits).toBeNull();
 
@@ -702,7 +702,7 @@ describe("GroupResource", () => {
         {
           name: "Regular capped",
           workspaceId: workspace.id,
-          kind: "regular",
+          kind: "regular_auto",
         },
         { memberIds: [user.id, user2.id] }
       );
@@ -745,7 +745,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Listed Regular Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       const key = await KeyFactory.system(systemGroup);
 
@@ -777,7 +777,7 @@ describe("GroupResource", () => {
       const newGroup = await GroupResource.makeNew({
         name: "Cache Invalidation Regular",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
 
       expect(inMemoryCache.has(cacheKey)).toBe(false);
@@ -790,7 +790,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Delete Invalidates System Key Cache",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       const key = await KeyFactory.system(systemGroup);
       const cacheKey = getCacheKeyForWorkspaceGroupsFromSystemKey(workspace.id);
@@ -812,7 +812,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Name Before",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       const key = await KeyFactory.system(systemGroup);
       const cacheKey = getCacheKeyForWorkspaceGroupsFromSystemKey(workspace.id);
@@ -849,7 +849,7 @@ describe("GroupResource", () => {
           {
             name: "Deferred Invalidation Group",
             workspaceId: workspace.id,
-            kind: "regular",
+            kind: "regular_auto",
           },
           { transaction }
         );
@@ -875,7 +875,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Regular",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
       const regularAutoGroup = await GroupResource.makeNew({
         name: "Regular Auto",

--- a/front/lib/resources/group_space_resource.test.ts
+++ b/front/lib/resources/group_space_resource.test.ts
@@ -39,7 +39,7 @@ describe("GroupSpaceMemberResource", () => {
       const testGroup = await GroupResource.makeNew({
         name: "Test Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
 
       const groupSpaceMember = await GroupSpaceMemberResource.makeNew(auth, {
@@ -144,7 +144,7 @@ describe("GroupSpaceEditorResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Regular Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
 
       await expect(
@@ -220,7 +220,7 @@ describe("GroupSpaceEditorResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Regular Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
 
       // Delete existing editor groups
@@ -293,7 +293,7 @@ describe("GroupSpaceViewerResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Regular Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
 
       await expect(
@@ -349,7 +349,7 @@ describe("GroupSpaceViewerResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Regular Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
 
       // Create a GroupSpaceModel with a non-global group

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -73,7 +73,7 @@ describe("SpaceResource", () => {
       regularGroup = await GroupResource.makeNew({
         name: "Test Regular Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
 
       regularSpace = await SpaceResource.makeNew(
@@ -713,7 +713,7 @@ describe("SpaceResource", () => {
         projectMemberGroup = await GroupResource.makeNew({
           name: "Project Members Group",
           workspaceId: workspace.id,
-          kind: "regular",
+          kind: "regular_auto",
         });
       });
 
@@ -1313,7 +1313,7 @@ describe("SpaceResource", () => {
       regularGroup = await GroupResource.makeNew({
         name: "Regular Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
 
       const openSpace = await SpaceResource.makeNew(
@@ -1333,7 +1333,7 @@ describe("SpaceResource", () => {
       restrictedGroup = await GroupResource.makeNew({
         name: "Restricted Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "regular_auto",
       });
 
       const restrictedSpace = await SpaceResource.makeNew(
@@ -1499,7 +1499,7 @@ describe("SpaceResource", () => {
         regularGroup = await GroupResource.makeNew({
           name: "Regular Group",
           workspaceId: workspace.id,
-          kind: "regular",
+          kind: "regular_auto",
         });
 
         const openSpace = await SpaceResource.makeNew(
@@ -1522,7 +1522,7 @@ describe("SpaceResource", () => {
         restrictedGroup = await GroupResource.makeNew({
           name: "Restricted Group",
           workspaceId: workspace.id,
-          kind: "regular",
+          kind: "regular_auto",
         });
 
         const restrictedSpace = await SpaceResource.makeNew(
@@ -1564,7 +1564,7 @@ describe("SpaceResource", () => {
         regularGroup = await GroupResource.makeNew({
           name: "Project Group",
           workspaceId: workspace.id,
-          kind: "regular",
+          kind: "regular_auto",
         });
 
         const projectSpace = await SpaceResource.makeNew(
@@ -1588,7 +1588,7 @@ describe("SpaceResource", () => {
         restrictedGroup = await GroupResource.makeNew({
           name: "Project Group",
           workspaceId: workspace.id,
-          kind: "regular",
+          kind: "regular_auto",
         });
 
         const projectSpace = await SpaceResource.makeNew(

--- a/front/scripts/dev/seed_conversations.ts
+++ b/front/scripts/dev/seed_conversations.ts
@@ -95,7 +95,7 @@ async function createProject(
     memberGroup = await GroupResource.makeNew({
       name: memberGroupName,
       workspaceId: workspace.id,
-      kind: "regular",
+      kind: "regular_auto",
     });
   }
 

--- a/front/scripts/move_company_space_to_restricted.ts
+++ b/front/scripts/move_company_space_to_restricted.ts
@@ -161,7 +161,7 @@ makeScript(
       const memberGroup = await GroupResource.makeNew(
         {
           name: `${SPACE_GROUP_PREFIX} ${spaceName}`,
-          kind: "regular",
+          kind: "regular_auto",
           workspaceId: workspace.id,
         },
         { transaction: t }

--- a/front/scripts/seed/factories/seedSpace.ts
+++ b/front/scripts/seed/factories/seedSpace.ts
@@ -28,7 +28,7 @@ export async function seedSpace(
     const group = await GroupResource.makeNew({
       name: `Group for ${RESTRICTED_SPACE_NAME}`,
       workspaceId: workspace.id,
-      kind: "regular",
+      kind: "regular_auto",
     });
 
     // Create the restricted space

--- a/front/tests/utils/GroupFactory.ts
+++ b/front/tests/utils/GroupFactory.ts
@@ -11,7 +11,7 @@ export class GroupFactory {
   static async regular(workspace: WorkspaceType, name: string) {
     return GroupResource.makeNew({
       name,
-      kind: "regular",
+      kind: "regular_auto",
       workspaceId: workspace.id,
     });
   }

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -59,7 +59,7 @@ export class SpaceFactory {
     const group = await GroupResource.makeNew({
       name: `${SPACE_GROUP_PREFIX} ${name}`,
       workspaceId: workspace.id,
-      kind: "regular",
+      kind: "regular_auto",
     });
 
     return SpaceResource.makeNew(
@@ -88,7 +88,7 @@ export class SpaceFactory {
     const group = await GroupResource.makeNew({
       name: `${PROJECT_GROUP_PREFIX} ${name}`,
       workspaceId: workspace.id,
-      kind: "regular",
+      kind: "regular_auto",
     });
 
     // Create an editor group with the creator as a member if creatorId is provided


### PR DESCRIPTION
## Description

This PR changes the kind of member groups automatically created alongside spaces from `"regular"` to `"regular_auto"`.

- In `createSpaceAndGroup`, the group created for a space now has `kind: "regular_auto"` instead of `kind: "regular"`.
- A new test is added to `spaces.test.ts` to assert that the member group kind is `"regular_auto"` when creating a space.
- All existing test fixtures in `group_resource.test.ts` that were using `kind: "regular"` for space-associated groups are updated to `kind: "regular_auto"`.

## Tests

Automated — new and updated unit tests in `spaces.test.ts` and `group_resource.test.ts` cover the behavior.

## Risks

Low.

## Deploy Plan
Deploy after https://github.com/dust-tt/dust/pull/28726 has been deployed