### PR TITLE
feat: script to backfill regular groups to regular_auto

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2196,18 +2196,18 @@ export class GroupResource extends BaseResource<GroupModel> {
   // Backfill helper for the `regular` -> `regular_auto` rename.
   static async updateKindToRegularAutoByIds({
     workspaceId,
-    groupIds,
+    groupModelIds,
   }: {
     workspaceId: ModelId;
-    groupIds: ModelId[];
+    groupModelIds: ModelId[];
   }): Promise<number> {
-    if (groupIds.length === 0) {
+    if (groupModelIds.length === 0) {
       return 0;
     }
 
     const [affectedCount] = await GroupModel.update(
       { kind: "regular_auto" },
-      { where: { workspaceId, id: { [Op.in]: groupIds } } }
+      { where: { workspaceId, id: { [Op.in]: groupModelIds } } }
     );
 
     return affectedCount;

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2193,6 +2193,26 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new Ok(undefined);
   }
 
+  // Backfill helper for the `regular` -> `regular_auto` rename.
+  static async updateKindToRegularAutoByIds({
+    workspaceId,
+    groupIds,
+  }: {
+    workspaceId: ModelId;
+    groupIds: ModelId[];
+  }): Promise<number> {
+    if (groupIds.length === 0) {
+      return 0;
+    }
+
+    const [affectedCount] = await GroupModel.update(
+      { kind: "regular_auto" },
+      { where: { workspaceId, id: { [Op.in]: groupIds } } }
+    );
+
+    return affectedCount;
+  }
+
   // Deletion
 
   async delete(

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2193,26 +2193,6 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new Ok(undefined);
   }
 
-  // Backfill helper for the `regular` -> `regular_auto` rename.
-  static async updateKindToRegularAutoByIds({
-    workspaceId,
-    groupModelIds,
-  }: {
-    workspaceId: ModelId;
-    groupModelIds: ModelId[];
-  }): Promise<number> {
-    if (groupModelIds.length === 0) {
-      return 0;
-    }
-
-    const [affectedCount] = await GroupModel.update(
-      { kind: "regular_auto" },
-      { where: { workspaceId, id: { [Op.in]: groupModelIds } } }
-    );
-
-    return affectedCount;
-  }
-
   // Deletion
 
   async delete(

--- a/front/scripts/backfill_regular_groups_to_regular_auto.ts
+++ b/front/scripts/backfill_regular_groups_to_regular_auto.ts
@@ -6,9 +6,11 @@
  */
 
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { ModelId } from "@app/types/shared/model_id";
+import { Op } from "sequelize";
 
 // Number of group ids rewritten per SQL update.
 const BATCH_SIZE = 500;
@@ -21,6 +23,26 @@ function chunkArray<T>(arr: T[], size: number): T[][] {
     chunks.push(arr.slice(i, i + size));
   }
   return chunks;
+}
+
+// Backfill helper for the `regular` -> `regular_auto` rename.
+async function updateKindToRegularAutoByIds({
+  workspaceId,
+  groupModelIds,
+}: {
+  workspaceId: ModelId;
+  groupModelIds: ModelId[];
+}): Promise<number> {
+  if (groupModelIds.length === 0) {
+    return 0;
+  }
+
+  const [affectedCount] = await GroupModel.update(
+    { kind: "regular_auto" },
+    { where: { workspaceId, id: { [Op.in]: groupModelIds } } }
+  );
+
+  return affectedCount;
 }
 
 makeScript(
@@ -67,11 +89,10 @@ makeScript(
         let updatedForWorkspace = 0;
         const batches: ModelId[][] = chunkArray(groupModelIds, BATCH_SIZE);
         for (const batch of batches) {
-          updatedForWorkspace +=
-            await GroupResource.updateKindToRegularAutoByIds({
-              workspaceId: workspace.id,
-              groupModelIds: batch,
-            });
+          updatedForWorkspace += await updateKindToRegularAutoByIds({
+            workspaceId: workspace.id,
+            groupModelIds: batch,
+          });
         }
 
         // The system-key group cache stores each group's kind; invalidate it so

--- a/front/scripts/backfill_regular_groups_to_regular_auto.ts
+++ b/front/scripts/backfill_regular_groups_to_regular_auto.ts
@@ -49,28 +49,28 @@ makeScript(
 
         totalWorkspacesWithLegacyGroups++;
 
-        const groupIds = legacyGroups.map((g) => g.id);
+        const groupModelIds = legacyGroups.map((g) => g.id);
 
         if (!execute) {
           logger.info(
             {
               workspaceId: workspace.sId,
               workspaceModelId: workspace.id,
-              count: groupIds.length,
+              count: groupModelIds.length,
             },
             "[DRY-RUN] Would rewrite regular groups to regular_auto"
           );
-          totalUpdated += groupIds.length;
+          totalUpdated += groupModelIds.length;
           return;
         }
 
         let updatedForWorkspace = 0;
-        const batches: ModelId[][] = chunkArray(groupIds, BATCH_SIZE);
+        const batches: ModelId[][] = chunkArray(groupModelIds, BATCH_SIZE);
         for (const batch of batches) {
           updatedForWorkspace +=
             await GroupResource.updateKindToRegularAutoByIds({
               workspaceId: workspace.id,
-              groupIds: batch,
+              groupModelIds: batch,
             });
         }
 

--- a/front/scripts/backfill_regular_groups_to_regular_auto.ts
+++ b/front/scripts/backfill_regular_groups_to_regular_auto.ts
@@ -1,0 +1,108 @@
+/**
+ * Backfill existing `regular` group kinds to `regular_auto`.
+ *
+ * Idempotent: workspaces with no remaining `regular` groups are skipped.
+ *
+ */
+
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { ModelId } from "@app/types/shared/model_id";
+
+// Number of group ids rewritten per SQL update.
+const BATCH_SIZE = 500;
+// Number of workspaces processed in parallel.
+const WORKSPACE_CONCURRENCY = 2;
+
+function chunkArray<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
+
+makeScript(
+  {
+    fromWorkspaceId: {
+      type: "number",
+      required: false,
+      description: "Resume from this workspace model id (inclusive).",
+    },
+  },
+  async ({ execute, fromWorkspaceId }, logger) => {
+    let totalWorkspacesWithLegacyGroups = 0;
+    let totalUpdated = 0;
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const legacyGroups =
+          await GroupResource.internalFetchAllWorkspaceGroups({
+            workspaceId: workspace.id,
+            groupKinds: ["regular"],
+          });
+
+        if (legacyGroups.length === 0) {
+          return;
+        }
+
+        totalWorkspacesWithLegacyGroups++;
+
+        const groupIds = legacyGroups.map((g) => g.id);
+
+        if (!execute) {
+          logger.info(
+            {
+              workspaceId: workspace.sId,
+              workspaceModelId: workspace.id,
+              count: groupIds.length,
+            },
+            "[DRY-RUN] Would rewrite regular groups to regular_auto"
+          );
+          totalUpdated += groupIds.length;
+          return;
+        }
+
+        let updatedForWorkspace = 0;
+        const batches: ModelId[][] = chunkArray(groupIds, BATCH_SIZE);
+        for (const batch of batches) {
+          updatedForWorkspace +=
+            await GroupResource.updateKindToRegularAutoByIds({
+              workspaceId: workspace.id,
+              groupIds: batch,
+            });
+        }
+
+        // The system-key group cache stores each group's kind; invalidate it so
+        // it does not serve stale `regular` values until its TTL expires.
+        await GroupResource.invalidateWorkspaceGroupsFromSystemKeyCache(
+          workspace.id
+        );
+
+        totalUpdated += updatedForWorkspace;
+
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            workspaceModelId: workspace.id,
+            count: updatedForWorkspace,
+          },
+          "Rewrote regular groups to regular_auto"
+        );
+      },
+      { concurrency: WORKSPACE_CONCURRENCY, fromWorkspaceId }
+    );
+
+    logger.info(
+      {
+        execute,
+        totalWorkspacesWithLegacyGroups,
+        totalUpdated,
+      },
+      execute
+        ? "Backfill complete"
+        : "[DRY-RUN] Backfill summary (no changes written)"
+    );
+  }
+);


### PR DESCRIPTION
## Description

This PR adds a backfill script to migrate existing `regular` group kinds to the new `regular_auto` kind as part of the `regular` → `regular_auto` group-kind rename.

## Tests

Manually.

## Risks

Low — the script is idempotent and supports dry-run mode. It must be run after https://github.com/dust-tt/dust/pull/28726 and https://github.com/dust-tt/dust/pull/28727 are deployed.

## Deploy Plan

1. Ensure https://github.com/dust-tt/dust/pull/28726 and https://github.com/dust-tt/dust/pull/28727 are deployed
2. Run the script