### PR TITLE
feat: rename isRegular to isRegularAuto for groups

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -39,7 +39,7 @@ app.get(
 
     const allGroups = space.groups.filter((g) =>
       space.managementMode === "manual"
-        ? g.isRegular() || g.kind === "space_editors"
+        ? g.isRegularAuto() || g.kind === "space_editors"
         : g.kind === "provisioned"
     );
 

--- a/front-api/routes/w/[wId]/advanced_models/index.test.ts
+++ b/front-api/routes/w/[wId]/advanced_models/index.test.ts
@@ -191,7 +191,7 @@ describe("POST/DELETE /api/w/:wId/advanced_models/allowed/groups", () => {
 
   it("allows admins to add, list, and remove group allowed models", async () => {
     const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
-    const group = await GroupFactory.regular(
+    const group = await GroupFactory.regularAuto(
       workspace,
       "Advanced models group"
     );

--- a/front-api/routes/w/[wId]/files/[fileId]/edit-text.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/edit-text.test.ts
@@ -224,7 +224,7 @@ describe("POST /api/w/:wId/files/:fileId/edit-text", () => {
     });
 
     const space = await SpaceFactory.regular(workspace);
-    const memberGroup = space.groups.find((g) => g.isRegular());
+    const memberGroup = space.groups.find((g) => g.isRegularAuto());
     await memberGroup?.dangerouslyAddMembers(auth, { users: [user.toJSON()] });
 
     const file = await FileFactory.create(auth, user, {
@@ -288,7 +288,7 @@ describe("POST /api/w/:wId/files/:fileId/edit-text", () => {
 
     const otherUser = await UserFactory.basic();
     const space = await SpaceFactory.regular(workspace);
-    const memberGroup = space.groups.find((g) => g.isRegular());
+    const memberGroup = space.groups.find((g) => g.isRegularAuto());
     await memberGroup?.dangerouslyAddMembers(auth, {
       users: [otherUser.toJSON()],
     });

--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -22,7 +22,7 @@ describe("GET /api/w/:wId/groups", () => {
       role: "admin",
     });
 
-    const group = await GroupFactory.regular(workspace, "Engineering");
+    const group = await GroupFactory.regularAuto(workspace, "Engineering");
     await GroupFactory.withMembers(auth, group, [user]);
 
     const response = await getGroups(workspace);
@@ -49,7 +49,7 @@ describe("GET /api/w/:wId/groups", () => {
       role: "admin",
     });
 
-    const group = await GroupFactory.regular(workspace, "Design");
+    const group = await GroupFactory.regularAuto(workspace, "Design");
 
     const extraUsers = await Promise.all([
       UserFactory.basic(),
@@ -86,7 +86,7 @@ describe("GET /api/w/:wId/groups", () => {
       role: "admin",
     });
 
-    await GroupFactory.regular(workspace, "Empty");
+    await GroupFactory.regularAuto(workspace, "Empty");
 
     const response = await getGroups(workspace);
 
@@ -104,7 +104,7 @@ describe("GET /api/w/:wId/groups", () => {
       role: "admin",
     });
 
-    const group = await GroupFactory.regular(workspace, "Backend");
+    const group = await GroupFactory.regularAuto(workspace, "Backend");
     await GroupFactory.withMembers(auth, group, [user]);
 
     const response = await getGroups(workspace, { kind: "regular_auto" });

--- a/front-api/routes/w/[wId]/pods/[podId]/tasks/seed.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/tasks/seed.test.ts
@@ -71,7 +71,7 @@ describe("POST /api/w/:wId/pods/:podId/tasks/seed", () => {
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const memberGroup = regularSpace.groups.find((g) => g.isRegular());
+    const memberGroup = regularSpace.groups.find((g) => g.isRegularAuto());
     if (memberGroup) {
       await memberGroup.dangerouslyAddMembers(adminAuth, {
         users: [user.toJSON()],

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -837,7 +837,7 @@ describe("POST /api/w/:wId/skills", () => {
     const { auth, workspace, user } = await setupTest("admin");
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const memberGroup = await GroupFactory.regular(
+    const memberGroup = await GroupFactory.regularAuto(
       workspace,
       "Tool Space Members"
     );
@@ -938,7 +938,7 @@ describe("POST /api/w/:wId/skills", () => {
     const { auth, workspace, user } = await setupTest("admin");
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const memberGroup = await GroupFactory.regular(
+    const memberGroup = await GroupFactory.regularAuto(
       workspace,
       "Knowledge Space Members"
     );

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.test.ts
@@ -20,7 +20,7 @@ async function addUserToProject(
   user: UserResource,
   options: { asEditor?: boolean } = {}
 ) {
-  const memberGroup = project.groups.find((g) => g.isRegular());
+  const memberGroup = project.groups.find((g) => g.isRegularAuto());
   const editorGroup = project.groups.find((g) => g.kind === "space_editors");
 
   if (memberGroup) {
@@ -46,7 +46,7 @@ describe("POST /api/w/:wId/spaces/:spaceId/leave", () => {
       );
 
       const regularSpace = await SpaceFactory.regular(workspace);
-      const memberGroup = regularSpace.groups.find((g) => g.isRegular());
+      const memberGroup = regularSpace.groups.find((g) => g.isRegularAuto());
       if (memberGroup) {
         await memberGroup.dangerouslyAddMembers(adminAuth, {
           users: [user.toJSON()],
@@ -122,7 +122,7 @@ describe("POST /api/w/:wId/spaces/:spaceId/leave", () => {
       expect(response.status).toBe(200);
       expect((await response.json()).success).toBe(true);
 
-      const memberGroup = project.groups.find((g) => g.isRegular());
+      const memberGroup = project.groups.find((g) => g.isRegularAuto());
       if (memberGroup) {
         const isMember = await memberGroup.isMember(user);
         expect(isMember).toBe(false);

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
@@ -40,7 +40,7 @@ app.post(
 
     const user = auth.getNonNullableUser();
 
-    const memberGroup = space.groups.find((g) => g.isRegular());
+    const memberGroup = space.groups.find((g) => g.isRegularAuto());
     const editorGroup = space.groups.find((g) => g.kind === "space_editors");
 
     if (editorGroup) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.test.ts
@@ -160,7 +160,7 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_tasks/:taskId", () => {
       workspace.sId
     );
     const memberGroup =
-      project.groups.find((g) => g.isRegular()) ?? project.groups[0]!;
+      project.groups.find((g) => g.isRegularAuto()) ?? project.groups[0]!;
     await GroupFactory.withMembers(adminAuth, memberGroup, [otherUser]);
 
     const todo = await ProjectTaskFactory.create(workspace, project, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
@@ -91,7 +91,7 @@ describe("POST /api/w/:wId/spaces/:spaceId/project_tasks/mark_read", () => {
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const memberGroup = regularSpace.groups.find((g) => g.isRegular());
+    const memberGroup = regularSpace.groups.find((g) => g.isRegularAuto());
     if (memberGroup) {
       await memberGroup.dangerouslyAddMembers(adminAuth, {
         users: [user.toJSON()],

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -652,9 +652,11 @@ describe("retryAgentMessage", () => {
       const user = auth.getNonNullableUser();
       const userJson = user.toJSON();
 
-      const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+      const projectSpaceGroup = projectSpace.groups.find((g) =>
+        g.isRegularAuto()
+      );
       const anotherProjectSpaceGroup = anotherProjectSpace.groups.find((g) =>
-        g.isRegular()
+        g.isRegularAuto()
       );
 
       if (projectSpaceGroup) {
@@ -2355,7 +2357,9 @@ describe("postUserMessage", () => {
       );
 
       // Add member user to the project space group
-      const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+      const projectSpaceGroup = projectSpace.groups.find((g) =>
+        g.isRegularAuto()
+      );
       if (projectSpaceGroup) {
         const addRes = await projectSpaceGroup.dangerouslyAddMember(
           internalAdminAuth,
@@ -2727,9 +2731,11 @@ describe("postUserMessage", () => {
       );
       const user = auth.getNonNullableUser();
 
-      const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+      const projectSpaceGroup = projectSpace.groups.find((g) =>
+        g.isRegularAuto()
+      );
       const anotherProjectSpaceGroup = anotherProjectSpace.groups.find((g) =>
-        g.isRegular()
+        g.isRegularAuto()
       );
 
       if (projectSpaceGroup) {
@@ -3685,9 +3691,11 @@ describe("postNewContentFragment", () => {
     // SpaceFactory.project creates a group and associates it with the space
     // We need to add the user to those groups
     // The groups are available on space.groups
-    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const projectSpaceGroup = projectSpace.groups.find((g) =>
+      g.isRegularAuto()
+    );
     const anotherProjectSpaceGroup = anotherProjectSpace.groups.find((g) =>
-      g.isRegular()
+      g.isRegularAuto()
     );
 
     if (projectSpaceGroup) {

--- a/front/lib/api/assistant/conversation/branches.test.ts
+++ b/front/lib/api/assistant/conversation/branches.test.ts
@@ -49,7 +49,7 @@ describe("mergeConversationBranch", () => {
       workspace.sId
     );
 
-    const projectGroup = projectSpace.groups.find((g) => g.isRegular());
+    const projectGroup = projectSpace.groups.find((g) => g.isRegularAuto());
     if (!projectGroup) {
       throw new Error("Project group should exist.");
     }
@@ -72,7 +72,9 @@ describe("mergeConversationBranch", () => {
       throw new Error(addProjectMemberToProjectRes.error.message);
     }
 
-    const restrictedGroup = restrictedSpace.groups.find((g) => g.isRegular());
+    const restrictedGroup = restrictedSpace.groups.find((g) =>
+      g.isRegularAuto()
+    );
     if (!restrictedGroup) {
       throw new Error("Restricted space group should exist.");
     }

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -46,7 +46,7 @@ describe("canAgentBeUsedInProjectConversation", () => {
       ReturnType<Authenticator["getNonNullableUser"]>["toJSON"]
     >
   ) {
-    const regularGroup = space.groups.find((g) => g.isRegular());
+    const regularGroup = space.groups.find((g) => g.isRegularAuto());
     if (!regularGroup) {
       throw new Error("Expected a regular group on the space");
     }
@@ -724,9 +724,11 @@ describe("updateConversationRequirements", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const projectSpaceGroup = projectSpace.groups.find((g) =>
+      g.isRegularAuto()
+    );
     const anotherProjectSpaceGroup = anotherProjectSpace.groups.find((g) =>
-      g.isRegular()
+      g.isRegularAuto()
     );
 
     if (projectSpaceGroup) {
@@ -1354,7 +1356,7 @@ describe("rebuildConversationRequirements", () => {
     const userJson = auth.getNonNullableUser().toJSON();
 
     for (const space of [projectSpace, regularSpace, anotherRegularSpace]) {
-      const group = space.groups.find((g) => g.isRegular());
+      const group = space.groups.find((g) => g.isRegularAuto());
       if (!group) {
         continue;
       }

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -66,7 +66,7 @@ describe("selected conversation Spaces", () => {
   }
 
   function regularGroup(space: SpaceResource) {
-    const group = space.groups.find((g) => g.isRegular());
+    const group = space.groups.find((g) => g.isRegularAuto());
     if (!group) {
       throw new Error("Expected regular member group on Space");
     }

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -80,7 +80,9 @@ describe("moveConversationToProject", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const projectSpaceGroup = projectSpace.groups.find((g) =>
+      g.isRegularAuto()
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -141,7 +143,9 @@ describe("moveConversationToProject", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const projectSpaceGroup = projectSpace.groups.find((g) =>
+      g.isRegularAuto()
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -301,7 +305,9 @@ describe("moveConversationToProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const projectSpaceGroup = projectSpace.groups.find((g) =>
+      g.isRegularAuto()
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -497,7 +503,9 @@ describe("moveConversationToProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const projectSpaceGroup = projectSpace.groups.find((g) =>
+      g.isRegularAuto()
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -600,7 +608,7 @@ describe("moveConversationToProject", () => {
     // Create destination project and add user as member
     const destinationProject = await SpaceFactory.project(workspace);
     const destinationProjectGroup = destinationProject.groups.find((g) =>
-      g.isRegular()
+      g.isRegularAuto()
     );
     if (!destinationProjectGroup) {
       throw new Error("Destination project regular group not found");
@@ -665,7 +673,9 @@ describe("moveConversationToProject", () => {
     );
 
     // Add current user as member (but not editor) of source project
-    const sourceProjectGroup = sourceProject.groups.find((g) => g.isRegular());
+    const sourceProjectGroup = sourceProject.groups.find((g) =>
+      g.isRegularAuto()
+    );
     if (!sourceProjectGroup) {
       throw new Error("Source project regular group not found");
     }
@@ -676,7 +686,7 @@ describe("moveConversationToProject", () => {
     // Create destination project and add user as member
     const destinationProject = await SpaceFactory.project(workspace);
     const destinationProjectGroup = destinationProject.groups.find((g) =>
-      g.isRegular()
+      g.isRegularAuto()
     );
     if (!destinationProjectGroup) {
       throw new Error("Destination project regular group not found");
@@ -725,7 +735,9 @@ describe("moveConversationToProject", () => {
     );
 
     // Add user as member of the project
-    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const projectSpaceGroup = projectSpace.groups.find((g) =>
+      g.isRegularAuto()
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -782,7 +794,9 @@ describe("moveConversationOutOfProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const projectSpaceGroup = projectSpace.groups.find((g) =>
+      g.isRegularAuto()
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -861,7 +875,9 @@ describe("moveConversationOutOfProject", () => {
     );
 
     // Add current user as member (but not editor) of project.
-    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const projectSpaceGroup = projectSpace.groups.find((g) =>
+      g.isRegularAuto()
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -922,7 +938,9 @@ describe("moveConversationOutOfProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const projectSpaceGroup = projectSpace.groups.find((g) =>
+      g.isRegularAuto()
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -1078,7 +1096,9 @@ describe("moveConversationOutOfProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find((g) => g.isRegular());
+    const projectSpaceGroup = projectSpace.groups.find((g) =>
+      g.isRegularAuto()
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -27,7 +27,7 @@ describe("Authenticator.hasWorkspacePermission", () => {
 
   // Build a non-admin member of `group` (if given) and return their authenticator.
   async function memberAuthInGroup(
-    group?: Awaited<ReturnType<typeof GroupFactory.regular>>
+    group?: Awaited<ReturnType<typeof GroupFactory.regularAuto>>
   ): Promise<Authenticator> {
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
@@ -59,7 +59,7 @@ describe("Authenticator.hasWorkspacePermission", () => {
   });
 
   it("returns true when one of the caller's groups holds the -1 grant", async () => {
-    const group = await GroupFactory.regular(workspace, "eng");
+    const group = await GroupFactory.regularAuto(workspace, "eng");
     await GroupPermissionResource.grantTypeWide(adminAuth, {
       group,
       ...CAPABILITY,
@@ -98,7 +98,7 @@ describe("Authenticator.hasWorkspacePermission", () => {
   });
 
   it("matches a wildcard grant against any capability", async () => {
-    const group = await GroupFactory.regular(workspace, "superadmins");
+    const group = await GroupFactory.regularAuto(workspace, "superadmins");
     await GroupPermissionResource.grantTypeWide(adminAuth, {
       group,
       permissionType: "*",

--- a/front/lib/resources/advanced_model_resource.test.ts
+++ b/front/lib/resources/advanced_model_resource.test.ts
@@ -216,7 +216,7 @@ describe("AdvancedModelResource admin management", () => {
 
   it("should add, list, and remove group allowed advanced models", async () => {
     const workspace = await WorkspaceFactory.basic();
-    const group = await GroupFactory.regular(
+    const group = await GroupFactory.regularAuto(
       workspace,
       "Advanced models group"
     );
@@ -344,7 +344,7 @@ describe("AdvancedModelResource.resolveAllowedAdvancedModels", () => {
     const workspace = await WorkspaceFactory.basic();
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
-    const group = await GroupFactory.regular(workspace, "Engineering");
+    const group = await GroupFactory.regularAuto(workspace, "Engineering");
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
@@ -381,7 +381,7 @@ describe("AdvancedModelResource.resolveAllowedAdvancedModels", () => {
     const workspace = await WorkspaceFactory.basic();
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
-    const group = await GroupFactory.regular(workspace, "Engineering");
+    const group = await GroupFactory.regularAuto(workspace, "Engineering");
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
@@ -454,8 +454,11 @@ describe("AdvancedModelResource.resolveAllowedAdvancedModels", () => {
     const workspace = await WorkspaceFactory.basic();
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
-    const memberGroup = await GroupFactory.regular(workspace, "Member group");
-    const otherGroup = await GroupFactory.regular(workspace, "Other group");
+    const memberGroup = await GroupFactory.regularAuto(
+      workspace,
+      "Member group"
+    );
+    const otherGroup = await GroupFactory.regularAuto(workspace, "Other group");
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );

--- a/front/lib/resources/conversation_selected_space_resource.test.ts
+++ b/front/lib/resources/conversation_selected_space_resource.test.ts
@@ -24,7 +24,7 @@ describe("ConversationSelectedSpaceResource", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const memberGroup = space.groups.find((group) => group.isRegular());
+    const memberGroup = space.groups.find((group) => group.isRegularAuto());
     if (!memberGroup) {
       throw new Error("Expected regular member group on Space");
     }

--- a/front/lib/resources/group_permission_governance.test.ts
+++ b/front/lib/resources/group_permission_governance.test.ts
@@ -21,8 +21,8 @@ describe("GroupPermissionResource — governance state (reads)", () => {
   beforeEach(async () => {
     workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);
-    groupA = await GroupFactory.regular(workspace, "A");
-    groupB = await GroupFactory.regular(workspace, "B");
+    groupA = await GroupFactory.regularAuto(workspace, "A");
+    groupB = await GroupFactory.regularAuto(workspace, "B");
     auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     const fetched = await GroupResource.internalFetchWorkspaceGlobalGroup(

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -16,8 +16,8 @@ describe("GroupPermissionResource", () => {
   beforeEach(async () => {
     workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);
-    groupA = await GroupFactory.regular(workspace, "A");
-    groupB = await GroupFactory.regular(workspace, "B");
+    groupA = await GroupFactory.regularAuto(workspace, "A");
+    groupB = await GroupFactory.regularAuto(workspace, "B");
     auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   });
 
@@ -80,7 +80,10 @@ describe("GroupPermissionResource", () => {
     it("rejects a group from another workspace", async () => {
       const otherWorkspace = await WorkspaceFactory.basic();
       await GroupFactory.defaults(otherWorkspace);
-      const otherGroup = await GroupFactory.regular(otherWorkspace, "other");
+      const otherGroup = await GroupFactory.regularAuto(
+        otherWorkspace,
+        "other"
+      );
 
       await expect(
         GroupPermissionResource.grant(auth, {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1510,7 +1510,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     >
   > {
     assert(
-      this.isRegular() ||
+      this.isRegularAuto() ||
         this.kind === "space_editors" ||
         this.kind === "agent_editors" ||
         this.kind === "skill_editors" ||
@@ -1687,7 +1687,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     >
   > {
     assert(
-      this.isRegular() ||
+      this.isRegularAuto() ||
         this.kind === "space_editors" ||
         this.kind === "agent_editors" ||
         this.kind === "skill_editors" ||
@@ -1838,7 +1838,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     const user = auth.getNonNullableUser();
     const workspace = auth.getNonNullableWorkspace();
 
-    if (!this.isRegular() && this.kind !== "space_editors") {
+    if (!this.isRegularAuto() && this.kind !== "space_editors") {
       return new Err(
         new DustError(
           "system_or_global_group",
@@ -2371,7 +2371,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     return this.kind === "global";
   }
 
-  isRegular(): boolean {
+  isRegularAuto(): boolean {
     return this.kind === "regular_auto";
   }
 

--- a/front/lib/resources/models_tier_resource.test.ts
+++ b/front/lib/resources/models_tier_resource.test.ts
@@ -16,7 +16,7 @@ describe("ModelsTierResource permissions", () => {
   beforeEach(async () => {
     workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);
-    group = await GroupFactory.regular(workspace, "tier-users");
+    group = await GroupFactory.regularAuto(workspace, "tier-users");
     auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   });
 

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1368,7 +1368,7 @@ describe("SpaceResource", () => {
 
     it("should return project spaces only for members", async () => {
       const projectSpace = await SpaceFactory.project(workspace);
-      const projectGroup = projectSpace.groups.find((g) => g.isRegular());
+      const projectGroup = projectSpace.groups.find((g) => g.isRegularAuto());
 
       // User is not a member, should not see it
       const userSpaces =

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1282,7 +1282,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   private getSpaceManualMemberGroup(): GroupResource {
-    const regularGroups = this.groups.filter((group) => group.isRegular());
+    const regularGroups = this.groups.filter((group) => group.isRegularAuto());
     assert(
       regularGroups.length === 1,
       `Expected exactly one regular group for the space, but found ${regularGroups.length}.`
@@ -1624,7 +1624,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     allGroupMemberships: GroupMembershipModel[];
   }> {
     const groupsToProcess = this.groups.filter((g) => {
-      return g.isRegular() || g.kind === "space_editors";
+      return g.isRegularAuto() || g.kind === "space_editors";
     });
 
     // Fetch all group memberships to get the startAt date (will be the joinedAt date returned for each member)

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -29,7 +29,7 @@ makeScript(
           const auth = await Authenticator.internalAdminForWorkspace(w.sId);
           const pods = await SpaceResource.listProjectSpaces(auth);
           for (const pod of pods) {
-            const regularGroups = pod.groups.filter((g) => g.isRegular());
+            const regularGroups = pod.groups.filter((g) => g.isRegularAuto());
             if (regularGroups.length === 1) {
               const group = regularGroups[0];
               const newName = `${pod.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${pod.name}`;

--- a/front/tests/utils/GroupFactory.ts
+++ b/front/tests/utils/GroupFactory.ts
@@ -8,7 +8,7 @@ export class GroupFactory {
     return GroupResource.makeDefaultsForWorkspace(workspace);
   }
 
-  static async regular(workspace: WorkspaceType, name: string) {
+  static async regularAuto(workspace: WorkspaceType, name: string) {
     return GroupResource.makeNew({
       name,
       kind: "regular_auto",


### PR DESCRIPTION
## Description

This PR renames the `isRegular()` method to `isRegularAuto()` on group resources and the `regular` method on GroupFactory to `regularAuto`

## Tests

## Risks

Low. This is a pure renaming refactor with no behavioral changes.

## Deploy Plan

Standard deployment.