### PR TITLE
[front] ToolValidationDetails: display objects and do not truncate

### DIFF
--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -40,10 +40,9 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  Markdown,
 } from "@dust-tt/sparkle";
 import { useMemo } from "react";
-
-const MAX_DISPLAY_VALUE_LENGTH = 300;
 
 function humanizeFieldName(name: string): string {
   return name
@@ -57,7 +56,9 @@ function formatDisplayValue(value: unknown): string | null {
     return null;
   }
   if (typeof value === "object") {
-    return null;
+    // Render objects/arrays as formatted JSON, same as GenericActionDetails.
+    // No truncation: the container is overflow-auto.
+    return JSON.stringify(value, null, 2);
   }
   if (typeof value === "boolean") {
     return value ? "Yes" : "No";
@@ -65,15 +66,17 @@ function formatDisplayValue(value: unknown): string | null {
   if (!isString(value)) {
     return null;
   }
-  if (value.length <= MAX_DISPLAY_VALUE_LENGTH) {
-    return value;
-  }
-  return `${value.slice(0, MAX_DISPLAY_VALUE_LENGTH)}…`;
+  // Return the full string — no truncation, user needs the full payload to approve.
+  return value;
 }
 
 interface DisplayableInput {
   label: string;
   value: string;
+  // Whether `value` was produced from an object/array input (as opposed to a
+  // string that merely looks like JSON), so it can be rendered as a
+  // collapsible JSON code block.
+  isJson: boolean;
 }
 
 interface ToolValidationDetailsProps {
@@ -120,11 +123,12 @@ export function ToolValidationDetails({
     return Object.entries(blockedAction.inputs)
       .map(([key, value]) => {
         if (isSkillAuthoringUpdate && key === "sId") {
-          return { label: "Skill", value: resolvedSkillName };
+          return { label: "Skill", value: resolvedSkillName, isJson: false };
         }
         return {
           label: humanizeFieldName(key),
           value: formatDisplayValue(value),
+          isJson: value !== null && typeof value === "object",
         };
       })
       .filter((entry): entry is DisplayableInput => entry.value !== null);
@@ -208,14 +212,27 @@ export function ToolValidationDetails({
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="max-h-80 space-y-2 overflow-auto rounded-lg bg-muted p-3 text-sm">
-          {displayableInputs.map(({ label, value }) => (
-            <div key={label} className="flex flex-col gap-0.5">
-              <span className="text-xs font-medium text-muted-foreground">
-                {label}
-              </span>
-              <span className="whitespace-pre-wrap break-words">{value}</span>
-            </div>
-          ))}
+          {displayableInputs.map(({ label, value, isJson }) =>
+            isJson ? (
+              <Collapsible key={label}>
+                <CollapsibleTrigger>
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {label}
+                  </span>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <Markdown content={`\`\`\`json\n${value}\n\`\`\``} />
+                </CollapsibleContent>
+              </Collapsible>
+            ) : (
+              <div key={label} className="flex flex-col gap-0.5">
+                <span className="text-xs font-medium text-muted-foreground">
+                  {label}
+                </span>
+                <span className="whitespace-pre-wrap break-words">{value}</span>
+              </div>
+            )
+          )}
         </div>
       </CollapsibleContent>
     </Collapsible>


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6816
=> Fix tool validation popup dropping object inputs (e.g. Jira create_issue/update_issue)

### Summary
* ToolValidationDetails (the pre-execution approval popup) silently excluded any tool input whose value was an object or array, since formatDisplayValue returned null for typeof value === "object". For tools like Jira's create_issue ({ issueData: <object> }), this meant the entire "Details" section was suppressed — users had to approve the call without seeing what it would do.
* String inputs longer than 300 characters were also truncated with …, hiding part of the payload.

### Fix
Align ToolValidationDetails with GenericActionDetails (used for post-approval execution display), which already shows full JSON payloads:
* Objects/arrays are now JSON.stringify'd and rendered as a formatted JSON code block (via Markdown with a ```json fence), instead of being dropped.
* String truncation is removed — full values are shown.
* Each JSON field is wrapped in its own nested Collapsible, collapsed by default, with the field name as the toggle. This keeps the popup compact when a tool has multiple object payloads (e.g. update_issue's issueKey + updateData), while still letting the user expand exactly the field they want to inspect before approving.
* DisplayableInput now carries an explicit isJson flag set from the input's original runtime type (typeof value === "object"), computed once when building the list. Earlier this was inferred by re-parsing the stringified value with isValidJSON, which would misclassify a plain text field as JSON if its content happened to parse as valid JSON (e.g. a purely numeric string like "12345", or literal "true"/"false"). Tracking the original type avoids that false positive — only genuine object/array inputs get the collapsible JSON treatment; plain strings/booleans always render inline.

### Out of scope / unchanged
* Custom renderers (Ashby, Pod Tasks, Pod Manager) short-circuit before this code path and are untouched.
* null and non-boolean, non-string primitives are still excluded, as before.


## Tests

Tested locally
<img width="528" height="352" alt="image" src="https://github.com/user-attachments/assets/8d53f1fb-335f-495f-b1ca-9ed6931dd779" />
<img width="546" height="637" alt="image" src="https://github.com/user-attachments/assets/fad1cb12-8525-4c54-9a58-f49dc090cbb3" />


## Risk

Low, UI only for tool validation

## Deploy Plan

Deploy front