### PR TITLE
fix(front): treat maxImagesPerWeek=-1 as unlimited for image generation

### DIFF
--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -155,6 +155,11 @@ export async function checkImageGenerationRateLimit(
   const { limits } = auth.getNonNullablePlan();
   const { maxImagesPerWeek } = limits.capabilities.images;
 
+  // -1 means unlimited: skip the rate limit check entirely.
+  if (maxImagesPerWeek === -1) {
+    return new Ok(undefined);
+  }
+
   const remaining = await rateLimiter({
     key: `${IMAGE_GENERATION_RATE_LIMITER_KEY}_${workspace.sId}`,
     maxPerTimeframe: maxImagesPerWeek,


### PR DESCRIPTION
## Description

Since Jul 7, credit-priced plans set `maxImagesPerWeek` to `-1` (unlimited) in US and EU. But `checkImageGenerationRateLimit` passed the value straight into `rateLimiter` as `maxPerTimeframe`, and `rateLimiter` throws on any negative value:

```
maxPerTimeframe must be a non-negative integer.
```

As a result, **every** image generation call on those plans failed. Repro: ask any agent on a `-1`-capped plan to generate an image.

This PR adds the same `-1`-means-unlimited guard the message rate limiter already uses (`lib/triggers/rate_limits.ts`): when `maxImagesPerWeek === -1`, skip the rate-limit check entirely and return `Ok`.

- Plans with `-1` → unlimited, no limiter call.
- Plans with a positive cap → unchanged.
- Free plans (`0`) → still blocked as before.

PR #28555 aligned only the dev-init seed data and did not add this guard.

## Tests

Manual reasoning against the repro path; `tsgo --noEmit` clean. No existing tests cover this helper, and per the workspace convention (functional endpoint tests, not unit tests) none were added. Happy to add coverage if desired.

## Risk

Very low. Single-line guard following an existing, proven pattern. Behavior only changes for `-1` plans (currently broken → now working); positive-cap and `0`-cap plans are byte-for-byte unchanged. Trivially rollback-able.

## Deploy Plan

Standard front deploy. No migration or data change required (the plan rows already hold `-1`).