### PR TITLE
[front] fix: defer eager skill tools

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -959,16 +959,6 @@ export async function disambiguateServerNamesBySpace(
  * Deduplicates MCP server configurations by view ID and name.
  * Priority order: agent actions > client-side > skill servers > JIT servers.
  */
-function getMCPServerConfigurationDeduplicationKey(
-  config: MCPServerConfigurationType
-): string {
-  const viewId = isServerSideMCPServerConfiguration(config)
-    ? config.mcpServerViewId
-    : config.clientSideMcpServerId;
-
-  return `${viewId}:${slugify(config.name)}`;
-}
-
 export function deduplicateMCPServerConfigurations({
   agentActions,
   clientSideActions,
@@ -987,7 +977,10 @@ export function deduplicateMCPServerConfigurations({
     ...skillServers,
     ...jitServers,
   ].filter((config) => {
-    const key = getMCPServerConfigurationDeduplicationKey(config);
+    const viewId = isServerSideMCPServerConfiguration(config)
+      ? config.mcpServerViewId
+      : config.clientSideMcpServerId;
+    const key = `${viewId}:${slugify(config.name)}`;
 
     if (seen.has(key)) {
       return false;
@@ -1025,19 +1018,15 @@ export async function tryListMCPTools(
     skillServers,
     jitServers,
   });
-  const nonSkillServerKeys = new Set(
-    [
-      ...agentLoopListToolsContext.agentConfiguration.actions,
-      ...(agentLoopListToolsContext.clientSideActionConfigurations ?? []),
-    ].map(getMCPServerConfigurationDeduplicationKey)
+  const nonSkillServers = [
+    ...agentLoopListToolsContext.agentConfiguration.actions,
+    ...(agentLoopListToolsContext.clientSideActionConfigurations ?? []),
+    ...jitServers,
+  ];
+  const isSkillServerConfig = deduplicatedConfigs.map(
+    (config) =>
+      skillServers.includes(config) && !nonSkillServers.includes(config)
   );
-  const skillServerKeys = new Set(
-    skillServers.map(getMCPServerConfigurationDeduplicationKey)
-  );
-  const isSkillServerConfig = deduplicatedConfigs.map((config) => {
-    const key = getMCPServerConfigurationDeduplicationKey(config);
-    return skillServerKeys.has(key) && !nonSkillServerKeys.has(key);
-  });
 
   const mcpServerActions = await disambiguateServerNamesBySpace(
     auth,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -959,6 +959,16 @@ export async function disambiguateServerNamesBySpace(
  * Deduplicates MCP server configurations by view ID and name.
  * Priority order: agent actions > client-side > skill servers > JIT servers.
  */
+function getMCPServerConfigurationKey(
+  config: MCPServerConfigurationType
+): string {
+  const viewId = isServerSideMCPServerConfiguration(config)
+    ? config.mcpServerViewId
+    : config.clientSideMcpServerId;
+
+  return `${viewId}:${slugify(config.name)}`;
+}
+
 export function deduplicateMCPServerConfigurations({
   agentActions,
   clientSideActions,
@@ -977,10 +987,7 @@ export function deduplicateMCPServerConfigurations({
     ...skillServers,
     ...jitServers,
   ].filter((config) => {
-    const viewId = isServerSideMCPServerConfiguration(config)
-      ? config.mcpServerViewId
-      : config.clientSideMcpServerId;
-    const key = `${viewId}:${slugify(config.name)}`;
+    const key = getMCPServerConfigurationKey(config);
 
     if (seen.has(key)) {
       return false;
@@ -1018,15 +1025,20 @@ export async function tryListMCPTools(
     skillServers,
     jitServers,
   });
-  const nonSkillServers = [
-    ...agentLoopListToolsContext.agentConfiguration.actions,
-    ...(agentLoopListToolsContext.clientSideActionConfigurations ?? []),
-    ...jitServers,
-  ];
-  const isSkillServerConfig = deduplicatedConfigs.map(
-    (config) =>
-      skillServers.includes(config) && !nonSkillServers.includes(config)
+  const nonSkillServerKeys = new Set(
+    [
+      ...agentLoopListToolsContext.agentConfiguration.actions,
+      ...(agentLoopListToolsContext.clientSideActionConfigurations ?? []),
+      ...jitServers,
+    ].map(getMCPServerConfigurationKey)
   );
+  const skillServerKeys = new Set(
+    skillServers.map(getMCPServerConfigurationKey)
+  );
+  const isSkillServerConfig = deduplicatedConfigs.map((config) => {
+    const key = getMCPServerConfigurationKey(config);
+    return skillServerKeys.has(key) && !nonSkillServerKeys.has(key);
+  });
 
   const mcpServerActions = await disambiguateServerNamesBySpace(
     auth,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -959,6 +959,16 @@ export async function disambiguateServerNamesBySpace(
  * Deduplicates MCP server configurations by view ID and name.
  * Priority order: agent actions > client-side > skill servers > JIT servers.
  */
+function getMCPServerConfigurationDeduplicationKey(
+  config: MCPServerConfigurationType
+): string {
+  const viewId = isServerSideMCPServerConfiguration(config)
+    ? config.mcpServerViewId
+    : config.clientSideMcpServerId;
+
+  return `${viewId}:${slugify(config.name)}`;
+}
+
 export function deduplicateMCPServerConfigurations({
   agentActions,
   clientSideActions,
@@ -977,10 +987,7 @@ export function deduplicateMCPServerConfigurations({
     ...skillServers,
     ...jitServers,
   ].filter((config) => {
-    const viewId = isServerSideMCPServerConfiguration(config)
-      ? config.mcpServerViewId
-      : config.clientSideMcpServerId;
-    const key = `${viewId}:${slugify(config.name)}`;
+    const key = getMCPServerConfigurationDeduplicationKey(config);
 
     if (seen.has(key)) {
       return false;
@@ -1018,11 +1025,28 @@ export async function tryListMCPTools(
     skillServers,
     jitServers,
   });
+  const nonSkillServerKeys = new Set(
+    [
+      ...agentLoopListToolsContext.agentConfiguration.actions,
+      ...(agentLoopListToolsContext.clientSideActionConfigurations ?? []),
+    ].map(getMCPServerConfigurationDeduplicationKey)
+  );
+  const skillServerKeys = new Set(
+    skillServers.map(getMCPServerConfigurationDeduplicationKey)
+  );
+  const isSkillServerConfig = deduplicatedConfigs.map((config) => {
+    const key = getMCPServerConfigurationDeduplicationKey(config);
+    return skillServerKeys.has(key) && !nonSkillServerKeys.has(key);
+  });
 
   const mcpServerActions = await disambiguateServerNamesBySpace(
     auth,
     deduplicatedConfigs
   );
+  const mcpServerActionsWithOrigin = mcpServerActions.map((action, index) => ({
+    action,
+    isFromSkillServer: isSkillServerConfig[index],
+  }));
 
   // Pre-fetch all MCPServerViews for server-side configs to avoid N+1 queries.
   const serverSideViewIds = mcpServerActions
@@ -1038,8 +1062,8 @@ export async function tryListMCPTools(
 
   // Discover all tools exposed by all available MCP servers.
   const results = await concurrentExecutor(
-    mcpServerActions,
-    async (action) => {
+    mcpServerActionsWithOrigin,
+    async ({ action, isFromSkillServer }) => {
       let connectionParams: MCPConnectionParams;
       if (isServerSideMCPServerConfiguration(action)) {
         const mcpServerView = preFetchedMcpServerViews.get(
@@ -1181,6 +1205,7 @@ export async function tryListMCPTools(
 
         processedTools.push({
           ...toolConfig,
+          ...(isFromSkillServer ? { eager: undefined } : {}),
           originalName: toolConfig.name,
           mcpServerName: action.name,
           name: toolName,

--- a/front/lib/api/assistant/skill_actions.test.ts
+++ b/front/lib/api/assistant/skill_actions.test.ts
@@ -1,4 +1,7 @@
+import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configuration/helpers";
+import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
 import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
+import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SKILL_COMPANY_DATA_SERVER_NAME } from "@app/lib/resources/skill/code_defined/shared";
@@ -98,5 +101,70 @@ describe("resolveSkillMCPServers", () => {
         .flatMap(({ tools }) => tools)
         .some((tool) => tool.name.startsWith("data_sources_file_system__"))
     ).toBe(false);
+  });
+
+  it("keeps tools from skill servers deferred even when their metadata is eager", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    await MCPServerViewResource.ensureAllAutoToolsAreCreated(authenticator);
+
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [],
+    });
+    const { agentMessage } = await ConversationFactory.createAgentMessage(
+      authenticator,
+      {
+        workspace,
+        conversation,
+        agentConfig: agentConfiguration,
+      }
+    );
+
+    const autoInternalViews =
+      await MCPServerViewResource.getMCPServerViewsForAutoInternalToolsAsMap(
+        authenticator,
+        [SKILL_MANAGEMENT_SERVER_NAME]
+      );
+    const skillManagementView = autoInternalViews.get(
+      SKILL_MANAGEMENT_SERVER_NAME
+    );
+    expect(skillManagementView).toBeDefined();
+    if (!skillManagementView) {
+      throw new Error("Expected skill management MCP server view.");
+    }
+
+    const { error, serverToolsAndInstructions } = await tryListMCPTools(
+      authenticator,
+      {
+        agentConfiguration,
+        agentMessage,
+        clientSideActionConfigurations: [],
+        conversation,
+      },
+      {
+        jitServers: [],
+        skillServers: [
+          buildServerSideMCPServerConfiguration({
+            mcpServerView: skillManagementView,
+            serverNameOverride: SKILL_MANAGEMENT_SERVER_NAME,
+          }),
+        ],
+      }
+    );
+    expect(error).toBeUndefined();
+
+    const enableSkillTool = serverToolsAndInstructions
+      .flatMap(({ tools }) => tools)
+      .find(
+        (tool) =>
+          tool.name ===
+          `${SKILL_MANAGEMENT_SERVER_NAME}__${ENABLE_SKILL_TOOL_NAME}`
+      );
+    expect(enableSkillTool).toBeDefined();
+    expect(enableSkillTool?.eager).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Description

The `bash` tool was made eager in https://github.com/dust-tt/dust/pull/28661 and always added to Dust-like agents.
We are seeing examples of custom agents using the Computer skill and bursting the cache due to tools changes (example trace [here](https://langfuse.dust.tt/project/cmi4ft2qm00061707q4a9azyc/traces?filter=metadata%3BstringObject%3BconversationId%3B%3D%3BhWzzLtMKO4&peek=d80163aa0828b8c62293d7e5b3ef8132&timestamp=2026-07-09T07%3A08%3A27.626Z))

This PR makes skill-provided tools stay deferred even when their server metadata marks the tool as eager.
Agent-configured tools keep their existing eager promotion behavior (but you can't add bash to an agent).

## Tests

- Added a test.

## Risk

- Low.

## Deploy Plan

- Deploy front.
