### PR TITLE
fix(slack): include message attachments and blocks in conversation context

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -79,7 +79,11 @@ import {
   removeNulls,
 } from "@dust-tt/client";
 import type { WebClient } from "@slack/web-api";
-import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
+import type {
+  Attachment,
+  DescriptionBlockElement,
+  MessageElement,
+} from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
 import removeMarkdown from "remove-markdown";
 
 const SLACK_RATE_LIMIT_ERROR_MARKDOWN =
@@ -1413,6 +1417,56 @@ export async function getBotEnabled(
   return new Ok(slackConfig.botEnabled);
 }
 
+function renderSlackAttachmentsToText(attachments?: Attachment[]): string {
+  if (!attachments?.length) {
+    return "";
+  }
+  return attachments
+    .filter(
+      (a) => !a.is_msg_unfurl && !a.is_reply_unfurl && !a.is_thread_root_unfurl
+    )
+    .map((a, index) => {
+      const fieldsText = (a.fields ?? [])
+        .map((field) =>
+          field.title && field.value
+            ? `${field.title}: ${field.value}`
+            : field.value || field.title || null
+        )
+        .filter((v): v is string => v !== null);
+      const parts = [
+        a.pretext,
+        a.title ? `*${a.title}*` : null,
+        a.text,
+        ...fieldsText,
+        a.footer,
+        a.fallback,
+      ].filter((v): v is string => v !== null && v !== undefined);
+      return `[Attachment ${index + 1}]\n${parts.join("\n")}`;
+    })
+    .join("\n\n");
+}
+
+function renderSlackBlocksToText(blocks?: DescriptionBlockElement[]): string {
+  if (!blocks?.length) {
+    return "";
+  }
+  const blockTexts = blocks
+    .map((block) => {
+      const blockText = block.text;
+      const mainText =
+        typeof blockText === "object" ? blockText?.text : blockText;
+      const fieldsText = (block.fields ?? [])
+        .map((field) => field?.text)
+        .filter((v): v is string => v !== null && v !== undefined)
+        .join("\n");
+      return [mainText, fieldsText]
+        .filter((v): v is string => v !== null && v !== undefined)
+        .join("\n");
+    })
+    .filter((v): v is string => v !== null && v !== undefined && v !== "");
+  return blockTexts.join("\n");
+}
+
 async function makeContentFragments(
   slackClient: WebClient,
   dustAPI: DustAPI,
@@ -1676,10 +1730,24 @@ async function makeContentFragments(
     ? `$url: ${url}\n${sectionHeader}${sectionFullText(document)}`
     : `$url: ${url}\n${sectionHeader}`;
 
+  // Append Slack message attachments (e.g. Grafana/Datadog alerts) and Block Kit
+  // blocks as text, so the agent can see content that lives outside message.text.
+  // This only affects the bot thread-context content fragment, not channel sync.
+  const attachmentsText = allMessages
+    .map((message) => {
+      const attachmentText = renderSlackAttachmentsToText(message.attachments);
+      const blockText = renderSlackBlocksToText(message.blocks);
+      return [attachmentText, blockText].filter((v) => v !== "").join("\n");
+    })
+    .filter((v) => v !== "")
+    .map((v) => `\n${v}`)
+    .join("");
+  const fullSection = section + attachmentsText;
+
   const contentType = "text/vnd.dust.attachment.slack.thread";
   const fileName = `slack_thread-${channelName}-${threadTs}.txt`;
 
-  const blob = new Blob([section]);
+  const blob = new Blob([fullSection]);
   const fileSize = blob.size;
 
   const fileRes = await dustAPI.uploadFile({


### PR DESCRIPTION
## Description

The Slack connector only reads `message.text` — legacy `attachments[]` (Grafana alerts) and Block Kit `blocks[]` (Datadog alerts) are silently dropped from the thread-context content fragment shown to the agent.

See text example here https://app.dust.tt/w/ed3dc1294e/conversation/aHmapiO2jW , see last line from @grafana:
```
$url: https://imperatorz.slack.com/archives/C0670S8HDJT/p1783501271377789?thread_ts=1783501271.377789&cid=C0670S8HDJT
This only shows user-generated messages since 1783501271.377789 in #bot-squad-order-management-alerts. Look at the conversation history for the full thread.
$title: Thread in #bot-squad-order-management-alerts: ...
$createdAt: 2026-07-08T09:01:11.000Z
$updatedAt: 2026-07-08T09:01:11.000Z
>> @grafana [20260708 09:01]:
```

Add two helpers in `bot.ts`:
- `renderSlackAttachmentsToText` — renders legacy attachment fields (pretext, title, text, fields, footer, fallback) to text. Excludes unfurl attachments (already handled by `formatSlackMessageUnfurlAttachments`).
- `renderSlackBlocksToText` — renders Block Kit section/header/context block text to plain text.

Both are applied in `makeContentFragments` only, appending to the thread-context `.txt` file. Does not touch `formatMessagesForUpsert`, so the temporal channel-sync pipeline is unaffected.

## Tests

- `tsc --noEmit` (connectors) — no new errors (pre-existing errors unchanged)
- Manual: Grafana alert with `attachments[]` in a Slack thread — title, text, and fields now appear in the thread-context content fragment

## Risk

Low. Surgical scope — only `makeContentFragments` in `bot.ts` is affected. The channel-sync pipeline (`temporal/activities.ts`) calls `formatMessagesForUpsert` which is untouched. Purely additive string concatenation. Safe to rollback: revert one file.

## Deploy Plan

No special steps — picked up on next `connectors` deploy.
