### PR TITLE
fix(triggers): keep trigger pod when editing from agent details panel

### DIFF
--- a/front/components/assistant/details/AgentDetailsSheet.tsx
+++ b/front/components/assistant/details/AgentDetailsSheet.tsx
@@ -65,6 +65,7 @@ function triggerTypeToBuilderType(
         naturalLanguageDescription: trigger.naturalLanguageDescription,
         configuration: trigger.configuration,
         editor: trigger.editor,
+        spaceId: trigger.spaceId,
       };
     case "webhook":
       return {
@@ -79,6 +80,7 @@ function triggerTypeToBuilderType(
         webhookSourceViewId: trigger.webhookSourceViewId,
         executionPerDayLimitOverride: trigger.executionPerDayLimitOverride,
         executionMode: trigger.executionMode,
+        spaceId: trigger.spaceId,
       };
     default:
       assertNever(trigger);


### PR DESCRIPTION
## Description

Setting a pod for a trigger was lost when editing the trigger's configuration from the agent details panel.

Root cause: `triggerTypeToBuilderType` (in `AgentDetailsSheet.tsx`), which converts a fetched trigger into the edit-form model, dropped `spaceId`. Because that field seeds the pod selector's default value, opening a trigger for edit always reset the selector to "My conversations (default)", and saving then overwrote the previously-selected pod with `null`.

The omission type-checked because `spaceId` is `.optional()` on the builder trigger schema. The full agent builder surface was unaffected — it seeds the form directly from the raw API triggers (which include `spaceId`) rather than going through this converter. This is why the earlier fix (#28533), which patched the payload builder in `useTriggerSheetState`, didn't fully resolve it: the value was already lost one step upstream, at form seeding.

Fix carries `spaceId` through both branches (schedule and webhook) of the converter.

## Tests

Typecheck passes (`tsgo --noEmit`). The existing `front-api` trigger tests already cover the API PATCH/POST persistence of `spaceId` and passed throughout — the gap was purely in the React form-seeding layer, which those tests don't exercise. Verified the flow manually by tracing seed → selector default → payload.

## Risk

Very low. Two-line change that only adds a previously-missing field to an object literal; no behavior change beyond correctly carrying the pod through edit. Safe to roll back.

## Deploy Plan

Standard front deploy. No migration or coordination required.