### PR TITLE
fix(front): render knowledge source picker as a single scrollable list

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
@@ -13,6 +13,7 @@ import {
   removeNodeFromTree,
 } from "@app/components/data_source_view/context/utils";
 import { isRemoteDatabase } from "@app/lib/data_sources";
+import { emptyArray } from "@app/lib/swr/swr";
 import { Checkbox, cn, Icon, Separator, Spinner } from "@dust-tt/sparkle";
 import type { ComponentType, ReactNode } from "react";
 import {
@@ -84,7 +85,7 @@ interface DataSourceListProps {
 }
 
 export function DataSourceList({
-  items = [],
+  items = emptyArray<DataSourceListItem>(),
   sections,
   onLoadMore,
   hasMore = false,

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
@@ -32,8 +32,18 @@ export interface DataSourceListItem {
   onClick?: () => void;
 }
 
-interface DataSourceListProps {
+export interface DataSourceListSection {
+  title: string;
   items: DataSourceListItem[];
+}
+
+interface DataSourceListProps {
+  items?: DataSourceListItem[];
+  /**
+   * Render items grouped under section headers within the same scroll
+   * container. When provided, takes precedence over `items`.
+   */
+  sections?: DataSourceListSection[];
   onLoadMore?: () => Promise<void>;
   hasMore?: boolean;
   isLoading?: boolean;
@@ -74,7 +84,8 @@ interface DataSourceListProps {
 }
 
 export function DataSourceList({
-  items,
+  items = [],
+  sections,
   onLoadMore,
   hasMore = false,
   isLoading = false,
@@ -146,13 +157,20 @@ export function DataSourceList({
     [navigationHistory]
   );
 
+  // Flatten sections into a single ordered list; `sections` takes precedence
+  // over `items` when both are provided.
+  const allItems = useMemo(
+    () => (sections ? sections.flatMap((section) => section.items) : items),
+    [sections, items]
+  );
+
   // Compute selectables items
   const selectableItems = useMemo(() => {
-    return items.filter((item) => {
+    return allItems.filter((item) => {
       const hideCheckbox = shouldHideCheckbox(item);
       return !hideCheckbox;
     });
-  }, [items, shouldHideCheckbox]);
+  }, [allItems, shouldHideCheckbox]);
 
   // Calculate select all state
   const selectAllState = useMemo(() => {
@@ -195,7 +213,7 @@ export function DataSourceList({
   ]);
 
   const handleSelectAll = useCallback(async () => {
-    const selectableItems = items.filter((item) => {
+    const selectableItems = allItems.filter((item) => {
       const hideCheckbox = shouldHideCheckbox(item);
       return !hideCheckbox;
     });
@@ -286,7 +304,7 @@ export function DataSourceList({
 
     field.onChange(newTreeValue);
   }, [
-    items,
+    allItems,
     shouldHideCheckbox,
     isRowSelected,
     selectAllState,
@@ -342,6 +360,67 @@ export function DataSourceList({
     [confirm, isRowSelected, removeNode, selectNode, onSelectionChange]
   );
 
+  const renderRow = useCallback(
+    (item: DataSourceListItem) => {
+      const selectionState = isItemSelected
+        ? isItemSelected(item)
+        : isRowSelected(item.id);
+      const hideCheckbox = shouldHideCheckbox(item);
+
+      const shouldShowCheckbox = showCheckboxOnlyForPartialSelection
+        ? selectionState === "partial"
+        : !hideCheckbox;
+
+      return (
+        <Fragment key={item.id}>
+          <div
+            className="flex cursor-pointer items-center justify-between rounded-md p-3 hover:bg-muted/60"
+            onClick={() => item.onClick?.()}
+          >
+            <div className="flex min-w-0 flex-1 items-center gap-3">
+              {shouldShowCheckbox ? (
+                <Checkbox
+                  checked={selectionState}
+                  disabled={hideCheckbox}
+                  onClick={(e) => e.stopPropagation()}
+                  onCheckedChange={(state) =>
+                    handleSelectionChange(item, state)
+                  }
+                />
+              ) : (
+                <div className="w-5" />
+              )}
+
+              {item.icon && <Icon size="sm" visual={item.icon} />}
+              <div className="truncate text-sm text-foreground">
+                {item.title}
+              </div>
+            </div>
+
+            {additionalColumns.length > 0 && (
+              <div className="ml-3 flex w-1/3 items-start gap-3 text-sm text-muted-foreground">
+                {additionalColumns.map((col, idx) => (
+                  <div key={idx} className="min-w-0 flex-1 truncate text-left">
+                    {col.render(item)}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <Separator />
+        </Fragment>
+      );
+    },
+    [
+      additionalColumns,
+      handleSelectionChange,
+      isItemSelected,
+      isRowSelected,
+      shouldHideCheckbox,
+      showCheckboxOnlyForPartialSelection,
+    ]
+  );
+
   return (
     <div
       ref={containerRef}
@@ -368,59 +447,16 @@ export function DataSourceList({
         </div>
       )}
       <Separator />
-      {items.map((item) => {
-        const selectionState = isItemSelected
-          ? isItemSelected(item)
-          : isRowSelected(item.id);
-        const hideCheckbox = shouldHideCheckbox(item);
-
-        const shouldShowCheckbox = showCheckboxOnlyForPartialSelection
-          ? selectionState === "partial"
-          : !hideCheckbox;
-
-        return (
-          <Fragment key={item.id}>
-            <div
-              className="flex cursor-pointer items-center justify-between rounded-md p-3 hover:bg-muted/60"
-              onClick={() => item.onClick?.()}
-            >
-              <div className="flex min-w-0 flex-1 items-center gap-3">
-                {shouldShowCheckbox ? (
-                  <Checkbox
-                    checked={selectionState}
-                    disabled={hideCheckbox}
-                    onClick={(e) => e.stopPropagation()}
-                    onCheckedChange={(state) =>
-                      handleSelectionChange(item, state)
-                    }
-                  />
-                ) : (
-                  <div className="w-5" />
-                )}
-
-                {item.icon && <Icon size="sm" visual={item.icon} />}
-                <div className="truncate text-sm text-foreground">
-                  {item.title}
-                </div>
+      {sections
+        ? sections.map((section) => (
+            <Fragment key={section.title}>
+              <div className="heading-sm bg-muted-background p-2 text-foreground">
+                {section.title}
               </div>
-
-              {additionalColumns.length > 0 && (
-                <div className="ml-3 flex w-1/3 items-start gap-3 text-sm text-muted-foreground">
-                  {additionalColumns.map((col, idx) => (
-                    <div
-                      key={idx}
-                      className="min-w-0 flex-1 truncate text-left"
-                    >
-                      {col.render(item)}
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-            <Separator />
-          </Fragment>
-        );
-      })}
+              {section.items.map(renderRow)}
+            </Fragment>
+          ))
+        : items.map(renderRow)}
 
       {/* Loading indicator at the bottom */}
       {isLoading && hasMore && (

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector.tsx
@@ -83,28 +83,23 @@ export function DataSourceSpaceSelector({
     [confirm, removeNode]
   );
 
+  const sections = useMemo(
+    () => [
+      { title: "From spaces:", items: spaceItems },
+      ...(projectItems.length > 0
+        ? [{ title: "From Pods:", items: projectItems }]
+        : []),
+    ],
+    [spaceItems, projectItems]
+  );
+
   return (
     <div className="flex h-full flex-col">
-      <div className="heading-sm bg-muted-background p-2 text-foreground">
-        From spaces:
-      </div>
       <DataSourceList
-        items={spaceItems}
+        sections={sections}
         showCheckboxOnlyForPartialSelection
         onSelectionChange={handleSpaceSelectionChange}
       />
-      {projectItems.length > 0 && (
-        <>
-          <div className="heading-sm bg-muted-background p-2 text-foreground">
-            From Pods:
-          </div>
-          <DataSourceList
-            items={projectItems}
-            showCheckboxOnlyForPartialSelection
-            onSelectionChange={handleSpaceSelectionChange}
-          />
-        </>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
closes https://github.com/dust-tt/tasks/issues/9007

## Description

In the add-knowledge flow, the source-selection screen rendered Spaces and Pods as two separate `DataSourceList` components, each its own `overflow-auto` scroll container stacked in a flex column. On workspaces with many Spaces, the Spaces list grew to fill the available height and scrolled internally, pushing the Pods section out of view entirely.

This makes it a single list: `DataSourceList` now accepts an optional `sections` prop (`{ title, items }[]`) that renders section headers and their rows inside the one existing scroll container. `DataSourceSpaceSelector` builds a single list with "From spaces:" and "From Pods:" headers, so both scroll together and Pods stay reachable regardless of how many Spaces exist.

- Extracted the row markup into a shared `renderRow` helper (no duplication between the `sections` and `items` paths).
- `items` is now optional; the five other `DataSourceList` call sites are unchanged.

## Tests

Manual: typecheck (`tsgo --noEmit`) and biome pass. Verified the picker renders one scrollable list with both section headers and that the Pods section stays visible/reachable when many Spaces are present.

## Risk

Low. `DataSourceList` change is additive (new optional `sections` prop, `items` made optional with a default). Existing callers that pass `items` are untouched. The select-all logic was repointed at a flattened `allItems`, which is equivalent to the previous behavior for the flat-`items` case.

## Deploy Plan

Standard front deploy, no migrations or coordination required.