### PR TITLE
feat: check feature flag when inviting business admins

### DIFF
--- a/front-api/routes/w/[wId]/invitations/[iId]/index.ts
+++ b/front-api/routes/w/[wId]/invitations/[iId]/index.ts
@@ -3,6 +3,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { getFeatureFlags } from "@app/lib/auth";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import type { PostMemberInvitationsResponseBody } from "@app/types/api/invitation";
 import { PostMemberInvitationBodySchema } from "@app/types/api/invitation";
@@ -60,6 +61,20 @@ app.post(
           message: "You do not have permission to manage admin invitations.",
         },
       });
+    }
+
+    if (body.initialRole === "business_admin") {
+      const featureFlags = await getFeatureFlags(auth);
+      if (!featureFlags.includes("admin_governance")) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "You cannot assign the business admin role as the feature is not enabled for this workspace.",
+          },
+        });
+      }
     }
 
     await invitation.updateStatus(body.status);

--- a/front-api/routes/w/[wId]/invitations/index.ts
+++ b/front-api/routes/w/[wId]/invitations/index.ts
@@ -1,4 +1,5 @@
 import { handleMembershipInvitations } from "@app/lib/api/invitation";
+import { getFeatureFlags } from "@app/lib/auth";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import type {
   GetWorkspaceInvitationsResponseBody,
@@ -65,6 +66,20 @@ app.post(
           message: "You do not have permission to invite admins.",
         },
       });
+    }
+
+    if (invitationRequests.some((r) => r.role === "business_admin")) {
+      const featureFlags = await getFeatureFlags(auth);
+      if (!featureFlags.includes("admin_governance")) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "You cannot assign the business admin role as the feature is not enabled for this workspace.",
+          },
+        });
+      }
     }
 
     const invitationRes = await handleMembershipInvitations(auth, {


### PR DESCRIPTION
## Description

This PR gates the assignment of the `business_admin` role during invitations behind the `admin_governance` feature flag.

- In the invitation update endpoint (`[iId]/index.ts`), a check is added: if the requested `initialRole` is `business_admin` and the `admin_governance` feature flag is not enabled for the workspace, the API returns a `403 workspace_auth_error`.
- The same feature flag import and guard is added to the invitation creation endpoint (`invitations/index.ts`), preventing new invitations with the `business_admin` role from being sent if the flag is absent.


Note that it was already not possible from the UI to assign the business admin role without the feature flag. This adds a check on the endpoints.

## Tests

Manually.

## Risks

Low — the change only adds a guard around an existing code path. Workspaces without the `admin_governance` flag will no longer be able to assign the `business_admin` role via invitations, which is the intended behaviour.

## Deploy Plan

Standard deployment.