### PR TITLE
Sandbox functions: run tools through runToolWithStreaming instead of tryCallMCPTool

### DIFF
--- a/front/lib/api/mcp/run_tool.test.ts
+++ b/front/lib/api/mcp/run_tool.test.ts
@@ -1,0 +1,130 @@
+import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
+import type { SandboxFunctionRunContext } from "@app/lib/actions/types";
+import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
+import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/actions/mcp_actions", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/actions/mcp_actions")>();
+  return {
+    ...actual,
+    tryCallMCPTool: vi.fn(),
+  };
+});
+
+function mockToolCallResult(result: CallToolResult) {
+  vi.mocked(tryCallMCPTool).mockImplementation(async function* () {
+    return result;
+  });
+}
+
+async function setupSandboxFunctionRun() {
+  const { auth, workspace, invocation, globalSpace } =
+    await createPersistedSandboxFunctionInvocationTokenTestContext();
+  const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
+    name: "common_utilities",
+    useCase: null,
+  });
+  const view = await MCPServerViewFactory.create(
+    workspace,
+    server.id,
+    globalSpace
+  );
+  const action = await SandboxFunctionMCPActionFactory.create(auth, {
+    invocation,
+    mcpServerView: view,
+  });
+
+  fileStorageMock.reset();
+
+  const runContext: SandboxFunctionRunContext = {
+    contextType: "sandbox_function",
+    action,
+    invocation,
+    toolConfiguration: action.toolConfiguration,
+  };
+
+  return { auth, workspace, action, runContext };
+}
+
+async function collectEvents(
+  stream: ReturnType<typeof runToolWithStreaming>
+): Promise<string[]> {
+  const eventTypes: string[] = [];
+  for await (const event of stream) {
+    eventTypes.push(event.type);
+  }
+  return eventTypes;
+}
+
+describe("runToolWithStreaming (sandbox function run context)", () => {
+  it("should mark the action succeeded and persist the output to a single GCS object", async () => {
+    const { auth, workspace, action, runContext } =
+      await setupSandboxFunctionRun();
+
+    const content: CallToolResult["content"] = [{ type: "text", text: "42" }];
+    mockToolCallResult({ isError: false, content });
+
+    const eventTypes = await collectEvents(
+      runToolWithStreaming(auth, { toolContext: { runContext } })
+    );
+
+    expect(eventTypes).toEqual(["tool_success"]);
+
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        auth,
+        action.id
+      );
+    expect(refetched?.status).toBe("succeeded");
+    expect(refetched?.executionDurationMs).toEqual(expect.any(Number));
+    expect(refetched?.outputGcsPath).toBe(
+      `w/${workspace.sId}/mcp_output_items/${action.sId}/output.json`
+    );
+
+    const outputWrite = fileStorageMock.saveFileCalls.find((call) =>
+      call.filePath.endsWith(`mcp_output_items/${action.sId}/output.json`)
+    );
+    expect(outputWrite).toBeDefined();
+    expect(JSON.parse(outputWrite?.content.toString() ?? "")).toEqual(content);
+  });
+
+  it("should mark the action errored and persist the error content on a tool error", async () => {
+    const { auth, action, runContext } = await setupSandboxFunctionRun();
+
+    const errorContent: CallToolResult["content"] = [
+      { type: "text", text: "tool exploded" },
+    ];
+    mockToolCallResult({ isError: true, content: errorContent });
+
+    // `handleMCPActionError` yields tool_success so the agent loop continues; the sandbox
+    // activity drains it.
+    const eventTypes = await collectEvents(
+      runToolWithStreaming(auth, { toolContext: { runContext } })
+    );
+
+    expect(eventTypes).toEqual(["tool_success"]);
+
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        auth,
+        action.id
+      );
+    expect(refetched?.status).toBe("errored");
+
+    const outputWrite = fileStorageMock.saveFileCalls.find((call) =>
+      call.filePath.endsWith(`mcp_output_items/${action.sId}/output.json`)
+    );
+    expect(outputWrite).toBeDefined();
+    expect(JSON.parse(outputWrite?.content.toString() ?? "")).toEqual(
+      errorContent
+    );
+  });
+});

--- a/front/lib/resources/sandbox_function_mcp_action_resource.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.ts
@@ -169,7 +169,10 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
   }: {
     executionDurationMs: number;
   }): Promise<void> {
-    await this.update({ status: "succeeded", executionDurationMs });
+    await this.update({
+      status: "succeeded",
+      executionDurationMs: Math.round(executionDurationMs),
+    });
   }
 
   async markAsErrored({
@@ -177,7 +180,10 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
   }: {
     executionDurationMs: number;
   }): Promise<void> {
-    await this.update({ status: "errored", executionDurationMs });
+    await this.update({
+      status: "errored",
+      executionDurationMs: Math.round(executionDurationMs),
+    });
   }
 
   private outputGcsPathFor(auth: Authenticator): string {

--- a/front/temporal/agent_loop/activities/run_sandbox_function_tool.test.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_tool.test.ts
@@ -1,0 +1,144 @@
+import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import { runSandboxFunctionToolActivity } from "@app/temporal/agent_loop/activities/run_sandbox_function_tool";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
+import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
+import type { AgentPauseOutputResourceType } from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/actions/mcp_actions", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/actions/mcp_actions")>();
+  return {
+    ...actual,
+    tryCallMCPTool: vi.fn(),
+  };
+});
+
+// The activity reads the temporal cancellation signal and heartbeats; neither exists outside a
+// real activity context.
+vi.mock("@temporalio/activity", () => ({
+  Context: {
+    current: () => ({ cancellationSignal: new AbortController().signal }),
+  },
+  heartbeat: vi.fn(),
+}));
+
+function mockToolCallResult(result: CallToolResult) {
+  vi.mocked(tryCallMCPTool).mockImplementation(async function* () {
+    return result;
+  });
+}
+
+async function setupActivityRun() {
+  const { auth, workspace, invocation, globalSpace } =
+    await createPersistedSandboxFunctionInvocationTokenTestContext();
+  const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
+    name: "common_utilities",
+    useCase: null,
+  });
+  const view = await MCPServerViewFactory.create(
+    workspace,
+    server.id,
+    globalSpace
+  );
+  const action = await SandboxFunctionMCPActionFactory.create(auth, {
+    invocation,
+    mcpServerView: view,
+  });
+
+  fileStorageMock.reset();
+
+  return { auth, workspace, action };
+}
+
+describe("runSandboxFunctionToolActivity", () => {
+  it("should mark the action succeeded on a normal tool result", async () => {
+    const { auth, action } = await setupActivityRun();
+
+    mockToolCallResult({
+      isError: false,
+      content: [{ type: "text", text: "42" }],
+    });
+
+    await runSandboxFunctionToolActivity(auth.toJSON(), {
+      actionModelId: action.id,
+    });
+
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        auth,
+        action.id
+      );
+    expect(refetched?.status).toBe("succeeded");
+  });
+
+  it("should fail closed to errored when the tool requires personal authentication", async () => {
+    const { auth, action } = await setupActivityRun();
+
+    // Pause resources yield events without a terminal status; with no pause surface for function
+    // invocations the activity must fail closed, otherwise the action stays `running` and the
+    // poll hangs until token expiry. The resource lands in the output so the function sees what
+    // the tool needs.
+    const authRequiredResource: AgentPauseOutputResourceType = {
+      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
+      type: "tool_personal_auth_required",
+      provider: "google_drive",
+      text: "Personal authentication required.",
+      uri: "",
+    };
+    const content: CallToolResult["content"] = [
+      { type: "resource", resource: authRequiredResource },
+    ];
+    mockToolCallResult({ isError: false, content });
+
+    await runSandboxFunctionToolActivity(auth.toJSON(), {
+      actionModelId: action.id,
+    });
+
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        auth,
+        action.id
+      );
+    expect(refetched?.status).toBe("errored");
+
+    const outputWrite = fileStorageMock.saveFileCalls.find((call) =>
+      call.filePath.endsWith(`mcp_output_items/${action.sId}/output.json`)
+    );
+    expect(outputWrite).toBeDefined();
+    expect(JSON.parse(outputWrite?.content.toString() ?? "")).toEqual(content);
+  });
+
+  it("should fail closed to errored on a non-error early exit", async () => {
+    const { auth, action } = await setupActivityRun();
+
+    const earlyExitResource: AgentPauseOutputResourceType = {
+      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
+      type: "tool_early_exit",
+      text: "Done early.",
+      isError: false,
+      uri: "",
+    };
+    mockToolCallResult({
+      isError: false,
+      content: [{ type: "resource", resource: earlyExitResource }],
+    });
+
+    await runSandboxFunctionToolActivity(auth.toJSON(), {
+      actionModelId: action.id,
+    });
+
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        auth,
+        action.id
+      );
+    expect(refetched?.status).toBe("errored");
+  });
+});

--- a/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
@@ -1,22 +1,16 @@
-import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
-import {
-  processToolNotification,
-  processToolResults,
-} from "@app/lib/actions/mcp_execution";
+import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import type { SandboxFunctionRunContext } from "@app/lib/actions/types";
+import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import {
-  drainAsyncGenerator,
-  withPeriodicHeartbeat,
-} from "@app/lib/utils/async_utils";
+import { getShutdownSignal } from "@app/lib/shutdown_signal";
+import { drainAsyncGenerator } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import { TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS } from "@app/temporal/agent_loop/config";
 import type { ModelId } from "@app/types/shared/model_id";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { heartbeat } from "@temporalio/activity";
+import { Context } from "@temporalio/activity";
 
 export async function runSandboxFunctionToolActivity(
   authType: AuthenticatorType,
@@ -64,68 +58,48 @@ export async function runSandboxFunctionToolActivity(
 
   const startTimeMs = performance.now();
 
-  // `processToolNotification` persists `store_resource` progress output on the action. The event
-  // it returns has no stream to reach yet (there is no invocation event stream), so we drain the
-  // generator for the tool result (its return value) and discard the events.
+  // `runToolWithStreaming` executes the tool and persists the output. Its events are drained:
+  // there is no invocation event stream to forward them to yet.
   // TODO(2026-07-08 SANDBOX_FUNCTIONS): forward these events to the invocation event stream once
   // it exists (e.g. viz progress).
-  const toolCallResult = await drainAsyncGenerator(
-    tryCallMCPTool(
-      auth,
-      action.inputs,
-      { runContext },
-      {
-        progressToken: action.id,
-        makeToolNotificationEvent: async (notification) => {
-          const { event } = await processToolNotification(auth, notification, {
-            toolContext: { runContext },
-          });
-          return event;
-        },
-      }
-    )
-  );
+  const abortSignal = AbortSignal.any([
+    Context.current().cancellationSignal,
+    getShutdownSignal(),
+  ]);
 
-  // Persist the output through the same result processing as the agent loop: the full content
-  // array goes to the action's single GCS output object. Error content is persisted too, the
-  // poll endpoint returns it alongside the errored status. Processing can take minutes when
-  // handling files, so heartbeat while it runs.
   try {
-    await withPeriodicHeartbeat(
-      () =>
-        processToolResults(auth, {
-          localLogger,
-          toolCallResultContent: toolCallResult.content,
-          toolContext: { runContext },
-        }),
-      {
-        intervalMs: TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS,
-        heartbeatFn: () => {
-          heartbeat();
-          localLogger.info("MCP tool result processing heartbeat");
-        },
-      }
+    await drainAsyncGenerator(
+      runToolWithStreaming(
+        auth,
+        { toolContext: { runContext } },
+        { signal: abortSignal }
+      )
     );
+
+    // Pause resources make the run yield events and return without a terminal status. There is
+    // no pause surface for function invocations yet, so fail closed to errored rather than leave
+    // the action `running` with the poll hanging until token expiry. The pause resource is
+    // persisted in the output, so the function sees what the tool needs (e.g. which provider to
+    // authenticate) and handles it on its side. Approval bubbling replaces this with
+    // `blocked_validation_required` plus an invocation stream event.
+    if (!isToolExecutionStatusFinal(action.status)) {
+      await action.markAsErrored({
+        executionDurationMs: performance.now() - startTimeMs,
+      });
+    }
   } catch (err) {
-    // `processToolResults` throws when output cannot be persisted (no acceptable degraded
-    // state). The agent loop lets that abort the step; here there is no step to abort, so catch
-    // it and mark the action errored, otherwise it would stay `running` and the poll never
-    // reaches a terminal status.
+    // The run throws when output cannot be persisted, and for `retry_on_interrupt` tools on
+    // worker shutdown (a throw meant to trigger a Temporal retry that this workflow never grants,
+    // maximumAttempts is 1). In both cases mark the action errored: a failed activity would leave
+    // it `running` with the poll hanging until token expiry, and the calling frame is the retry
+    // layer for functions. TODO(2026-07-09 SANDBOX_FUNCTIONS): honor retry_on_interrupt with a
+    // retryable proxy dispatched on the action's retryPolicy, like the agent loop workflow.
     localLogger.error(
       { err: normalizeError(err) },
-      "Failed to persist sandbox function tool output, marking action as errored"
+      "Failed to run sandbox function tool, marking action as errored"
     );
     await action.markAsErrored({
-      executionDurationMs: Math.round(performance.now() - startTimeMs),
+      executionDurationMs: performance.now() - startTimeMs,
     });
-    return;
-  }
-
-  const executionDurationMs = Math.round(performance.now() - startTimeMs);
-
-  if (toolCallResult.isError) {
-    await action.markAsErrored({ executionDurationMs });
-  } else {
-    await action.markAsSucceeded({ executionDurationMs });
   }
 }


### PR DESCRIPTION
Follow up of #28712, which made `runToolWithStreaming` tool-context dependent. This PR makes `runSandboxFunctionToolActivity` actually use it: the activity was still hand-rolling the orchestration (`tryCallMCPTool` + notification persistence + heartbeat-wrapped `processToolResults` + status transitions), duplicating the shared layer. It now fetches the action and invocation, builds the run context, and drains `runToolWithStreaming` (no invocation event stream to forward events to yet).

One behavior this PR must own: for a sandbox function context, `getExitOrPauseEvents` emits invocation-scoped events without setting a status (there is no pause surface for invocations yet), so a pause resource (personal auth required, blocked awaiting input, early exit) would leave the action `running` with the poll hanging until token expiry. The activity fails closed: any run ending without a terminal status marks the action errored, with the pause resource persisted in the output so the function sees what the tool needs and handles it on its side. Approval bubbling will replace this with `blocked_validation_required` + invocation stream events.

Also:
- The activity passes the temporal cancellation + shutdown signal to the run, like the agent loop activity.
- `markAsSucceeded` / `markAsErrored` on the sandbox action resource now round `executionDurationMs` like the agent resource does: the shared layer passes floats into an INTEGER column (the old activity rounded at call sites).
- On worker shutdown, `retry_on_interrupt` tool throws are caught and mark the action errored: the workflow runs with `maximumAttempts: 1`, so a rethrow would fail the workflow and leave the action `running`. Dated TODO to honor the policy with a retryable proxy like the agent loop workflow.

## Tests

New: `lib/api/mcp/run_tool.test.ts` drives `runToolWithStreaming` with a sandbox function run context through the real persistence path (only `tryCallMCPTool` mocked): success and tool error. New: `temporal/agent_loop/activities/run_sandbox_function_tool.test.ts` covers the activity end-to-end (temporal context mocked): normal success, fail-closed on personal-auth-required with the resource persisted, fail-closed on early exit. Existing: `mcp_execution` and all agent-loop temporal suites pass.

## Risk

The agent loop path is untouched (the shared layer landed in #28712). Worst case, sandbox function tool calls fail. Safe to rollback.

## Deploy Plan

- [ ] Deploy front