### PR TITLE
Point the Pods skill at pod_manager's semantic search tool

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/build_pod_search_data_sources.ts
+++ b/front/lib/api/actions/servers/pod_manager/build_pod_search_data_sources.ts
@@ -92,7 +92,7 @@ function podDataSourceFilter(
 
 /**
  * Data sources for semantic search over a Pod, scoped to files (Pod files, metadata,
- * searchable context nodes), conversations (transcripts in the dust_project connector), or
+ * searchable content nodes), conversations (transcripts in the dust_project connector), or
  * both. The Pod data source view mixes files and conversations; scope selects via parents
  * filters on that view.
  */

--- a/front/lib/api/actions/servers/pod_manager/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/index.ts
@@ -13,7 +13,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
  * - File operations: list, add, update, and remove project knowledge files
  * - Linked data: add/remove Company Data nodes from project context
  * - Metadata operations: edit description, add/edit URLs
- * - Retrieval: recent documents from the project data source and context nodes
+ * - Retrieval: recent documents from the project data source and content nodes
  * - Semantic search: project knowledge, project conversations, or both
  */
 function createServer(

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -283,7 +283,9 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   retrieve_recent_documents: {
     description:
-      "Fetch the most recent documents from this Pod's knowledge data source and from any content nodes linked in the Pod context, in reverse chronological order up to the retrieval limit. Respects optional time window. Optionally restrict to subtrees using nodeIds.",
+      "Fetch the most recent documents from this Pod's knowledge data source and from any content nodes linked in the " +
+      "Pod context, in reverse chronological order up to the retrieval limit. Respects optional time window. " +
+      "Optionally restrict to subtrees using nodeIds.",
     schema: {
       timeFrame: IncludeInputSchema.shape.timeFrame,
       nodeIds: SearchWithNodesInputSchema.shape.nodeIds,
@@ -302,9 +304,10 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   [SEMANTIC_SEARCH_TOOL_NAME]: {
     description:
-      "Find and search for information about a topic or question across " +
-      "Pod files, linked context nodes, and Pod conversation transcripts " +
-      "using semantic retrieval. Scope selects files, conversations, or both.",
+      "Find and search for information about a topic or question across Pod " +
+      "files, content nodes attached to the Pod, and Pod conversation " +
+      "transcripts using semantic retrieval. The searchScope parameter " +
+      "allows selecting files, conversations, or both.",
     schema: {
       query: z
         .string()

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -971,7 +971,7 @@ export function createProjectManagerTools(
         if (dataSources.length === 0) {
           return new Err(
             new MCPError(
-              "No Pod data source or Pod context nodes available to retrieve from.",
+              "No Pod data source or Pod content nodes available to retrieve from.",
               { tracked: false }
             )
           );

--- a/front/lib/resources/skill/code_defined/global/projects.ts
+++ b/front/lib/resources/skill/code_defined/global/projects.ts
@@ -1,6 +1,10 @@
 import { SEARCH_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
-import { POD_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/pod_manager/metadata";
+import {
+  POD_MANAGER_SERVER_NAME,
+  SEMANTIC_SEARCH_TOOL_NAME,
+} from "@app/lib/api/actions/servers/pod_manager/metadata";
 import {
   formatPodAgentsMdPromptSection,
   readPodAgentsMdContent,
@@ -57,12 +61,13 @@ Use the \`sId\` from \`pod_tasks\` tools (e.g. \`list_tasks\`, \`create_tasks\`)
 
 When you need to find information, use this order (skip steps if the relevant tools are not in your tool list):
 1. **Pod overview**: \`${POD_MANAGER_SERVER_NAME}\` \`get_information\` returns the Pod URL, description, and what is attached to the Pod.
-2. **Pod files**: read and search \`pod-{podId}/<rel>\` files through the sandbox or the \`${FILES_SERVER_NAME}\` MCP tools.
-3. **Company-wide**: If still insufficient, use \`company_data_*\` tools and \`${SEARCH_SERVER_NAME}\` for broader company data sources.
+2. **Topic or question**: \`${getPrefixedToolName(POD_MANAGER_SERVER_NAME, SEMANTIC_SEARCH_TOOL_NAME)}\` searches Pod files, linked context nodes, and Pod conversation transcripts by meaning. Use it when you have a topic or question rather than a specific file path.
+3. **Known file path**: read the file directly under \`pod-{podId}/<rel>\` through the sandbox or the \`${FILES_SERVER_NAME}\` MCP tools.
+4. **Company-wide**: If still insufficient, use \`company_data_*\` tools and \`${SEARCH_SERVER_NAME}\` for broader company data sources.
 `,
 
   mcpServers: [{ name: "pod_manager" }, { name: "pod_tasks" }],
-  version: 3,
+  version: 4,
   icon: "ActionFolderIcon",
   isRestricted: undefined,
   getAutoEnabledOrEquippedForAgentLoop: ({ conversation }) =>

--- a/front/lib/resources/skill/code_defined/global/projects.ts
+++ b/front/lib/resources/skill/code_defined/global/projects.ts
@@ -61,7 +61,7 @@ Use the \`sId\` from \`pod_tasks\` tools (e.g. \`list_tasks\`, \`create_tasks\`)
 
 When you need to find information, use this order (skip steps if the relevant tools are not in your tool list):
 1. **Pod overview**: \`${POD_MANAGER_SERVER_NAME}\` \`get_information\` returns the Pod URL, description, and what is attached to the Pod.
-2. **Topic or question**: \`${getPrefixedToolName(POD_MANAGER_SERVER_NAME, SEMANTIC_SEARCH_TOOL_NAME)}\` searches Pod files, linked context nodes, and Pod conversation transcripts by meaning. Use it when you have a topic or question rather than a specific file path.
+2. **Topic or question**: \`${getPrefixedToolName(POD_MANAGER_SERVER_NAME, SEMANTIC_SEARCH_TOOL_NAME)}\` searches Pod files, linked content nodes, and Pod conversation transcripts by meaning. Use it when you have a topic or question rather than a specific file path.
 3. **Known file path**: read the file directly under \`pod-{podId}/<rel>\` through the sandbox or the \`${FILES_SERVER_NAME}\` MCP tools.
 4. **Company-wide**: If still insufficient, use \`company_data_*\` tools and \`${SEARCH_SERVER_NAME}\` for broader company data sources.
 `,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See Slack thread:  [here](https://dust4ai.slack.com/archives/C0BCDAL5ZTM/p1783588699670459) 

The Pods skill instructions told agents to check the Pod overview, read files directly, or fall back to company-wide search, but never named the semantic search tool that `pod_manager` exposes for querying Pod files, linked context nodes, and conversation transcripts by meaning. Because that tool is loaded lazily through tool search rather than always present in context, an agent had no way to discover it existed unless it happened to guess the right search terms. This adds an explicit step naming the tool and describing when to reach for it.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
