### PR TITLE
[front] fix import of `isDustLikeAgent`

### DIFF
--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -1,4 +1,4 @@
-import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/global_agents";
+import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/prompt_context";
 import {
   getPreviousMessageId,
   setPreviousMessageId,


### PR DESCRIPTION
## Description

Fixes import of `isDustLikeAgent`, that moved to a separate file in a commit separate from https://github.com/dust-tt/dust/pull/28734, which got crossed.
This PR fixes the import.

## Tests

- typecheck + lint.

## Risk

- Low.

## Deploy Plan

- Deploy front.
