### PR TITLE
fix(sparkle): right-align NavigationListItem suffix

### DIFF
--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -173,7 +173,7 @@ const NavigationListItem = React.forwardRef<
             {suffix && (
               <div
                 className={cn(
-                  "flex grow flex-shrink-0 items-center",
+                  "flex grow flex-shrink-0 items-center justify-end",
                   moreMenu &&
                     "group-focus-within/menu-item:hidden group-hover/menu-item:hidden"
                 )}


### PR DESCRIPTION
## Description

The wake-up indicator in the conversation list sidebar sat mid-row (right after the title) and disappeared on hover when the more-menu button appears, which read as a glitch.

This right-aligns the `NavigationListItem` suffix so it sits flush against the right edge — exactly where the more-menu button shows up — so the hover swap reads as an intentional replacement. Also right-aligns the "Archived" chip on pods in sidebar search results (the only other suffix usage), which reads better there too.

<img width="341" height="352" alt="Screenshot 2026-07-09 at 12 44 18" src="https://github.com/user-attachments/assets/4fe698e0-6c9e-4aa6-a262-5c5ab812ba3f" />

## Tests

N/A, tested locally.
Available in SPA preview below

## Risk

Low. One-line CSS change scoped to the `NavigationListItem` suffix container.

## Deploy Plan

- publish `sparkle`
- deploy `front`