### PR TITLE
fix(connectors): handle path-backed generated files in Slack handler

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -35,6 +35,7 @@ import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import { redisClient } from "@connectors/types/shared/redis_client";
 import type {
+  ActionGeneratedFileType,
   AgentActionPublicType,
   AgentEvent,
   ConversationPublicType,
@@ -766,7 +767,15 @@ async function streamAgentAnswerToSlack(
           authResult.ok &&
           authResult.response_metadata?.scopes?.includes("files:write")
         ) {
-          const files = actions.flatMap((action) => action.generatedFiles);
+          // Path-backed generated files have no fileId and cannot be downloaded by id, skip them.
+          const files = actions
+            .flatMap((action) => action.generatedFiles)
+            .filter(
+              (
+                file
+              ): file is Extract<ActionGeneratedFileType, { fileId: string }> =>
+                file.fileId !== null
+            );
           filesUploaded = await getFilesFromDust(files, dustAPI);
         }
 


### PR DESCRIPTION
## Description

The connectors build (and deploy) is broken on main since #28704, which changed the SDK `ActionGeneratedFileSchema` to allow path-backed generated files (`fileId: null` with `filePath`). The Slack stream handler passes `action.generatedFiles` straight into `getFilesFromDust`, which requires `fileId: string`, causing a `tsgo` error.

Filter out path-backed files before downloading by id. They cannot be fetched via `downloadFile({ fileID })` anyway, and were previously filtered out server-side before #28704, so runtime behavior is unchanged.

## Tests

Reproduced the CI error on clean main with `npx tsgo --noEmit` in `connectors/`, verified it passes with the fix.

## Risk

None. Type-level fix restoring the pre-#28704 behavior for Slack file uploads.

## Deploy Plan

- deploy `connectors`