### PR TITLE
Add agrements checkboxes in topup

### DIFF
--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -27,6 +27,7 @@ import {
 } from "@app/types/shared/utils/assert_never";
 import {
   Button,
+  Checkbox,
   CheckCircle,
   Dialog,
   DialogContainer,
@@ -35,6 +36,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Hoverable,
   Icon,
   Input,
   Spinner,
@@ -393,6 +395,8 @@ export function BuyAwuCreditsDialog({
   currentTotalPoolCredits,
 }: BuyAwuCreditsDialogProps) {
   const [amountInput, setAmountInput] = useState<string>("");
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
+  const [acceptedNonRefundable, setAcceptedNonRefundable] = useState(false);
   const [purchaseState, setPurchaseState] = useState<PurchaseState>("idle");
   const [errorMessage, setErrorMessage] = useState<string>("");
   // Ignore polled attempts older than the one we just started, so a cached
@@ -438,6 +442,8 @@ export function BuyAwuCreditsDialog({
 
   const resetModalStateAndClose = useCallback(() => {
     setAmountInput("");
+    setAcceptedTerms(false);
+    setAcceptedNonRefundable(false);
     setPurchaseState("idle");
     setErrorMessage("");
     setPurchaseStartedAtMs(null);
@@ -493,7 +499,11 @@ export function BuyAwuCreditsDialog({
     currencyToAwuCredits(parsedAmount, currency) / (1 - discountPercent / 100)
   );
 
-  const canPurchase = isValidAmount && !amountExceedsMax;
+  const canPurchase =
+    isValidAmount &&
+    !amountExceedsMax &&
+    acceptedTerms &&
+    acceptedNonRefundable;
 
   const handlePurchase = async () => {
     setPurchaseStartedAtMs(Date.now());
@@ -693,6 +703,45 @@ export function BuyAwuCreditsDialog({
                     </div>
                   </div>
                 )}
+
+              <div className="flex flex-col gap-3 border-t border-border pt-4">
+                <label className="flex cursor-pointer items-start gap-3">
+                  <Checkbox
+                    checked={acceptedTerms}
+                    onCheckedChange={() => setAcceptedTerms(!acceptedTerms)}
+                  />
+                  <span className="text-sm text-foreground">
+                    I agree to the{" "}
+                    <Hoverable
+                      href="https://dust.tt/terms"
+                      variant="highlight"
+                      target="_blank"
+                    >
+                      Terms & Conditions
+                    </Hoverable>{" "}
+                    and{" "}
+                    <Hoverable
+                      href="https://dust.tt/privacy"
+                      variant="highlight"
+                      target="_blank"
+                    >
+                      Privacy Policy
+                    </Hoverable>
+                  </span>
+                </label>
+
+                <label className="flex cursor-pointer items-start gap-3">
+                  <Checkbox
+                    checked={acceptedNonRefundable}
+                    onCheckedChange={() =>
+                      setAcceptedNonRefundable(!acceptedNonRefundable)
+                    }
+                  />
+                  <span className="text-sm text-foreground">
+                    I understand credits are non-refundable after purchase
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         );


### PR DESCRIPTION
## Description

Same as programmatic usage credits modal : 

<img width="572" height="686" alt="Screenshot 2026-07-09 at 14 04 09" src="https://github.com/user-attachments/assets/9f12e656-b7b0-4700-b769-3f7163ec487a" />
the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
