### PR TITLE
Sandbox functions: scope pod tool output files by invocation

### DIFF
--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -478,7 +478,7 @@ describe("processToolResults", () => {
   });
 
   async function setupSandboxFunctionTest() {
-    const { auth, workspace, invocation, globalSpace } =
+    const { auth, workspace, invocation, globalSpace, podSpace } =
       await createPersistedSandboxFunctionInvocationTokenTestContext();
     const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
       name: "common_utilities",
@@ -505,8 +505,53 @@ describe("processToolResults", () => {
       },
     };
 
-    return { auth, workspace, action, toolContext };
+    return { auth, workspace, action, invocation, podSpace, toolContext };
   }
+
+  it(`should offload registered resource blocks to ${TOOL_OUTPUTS_FOLDER_NAME}/{invocationId}/ in a sandbox function run context`, async () => {
+    const { auth, workspace, invocation, podSpace, toolContext } =
+      await setupSandboxFunctionTest();
+
+    const dataSourceNodeResult: DataSourceNodeContentType = {
+      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_NODE_CONTENT,
+      uri: "notion://page/def456",
+      text: "# Function Notion Page\n\nSome content here.",
+      metadata: {
+        nodeId: "def456",
+        title: "Function Notion Page",
+        path: "/workspace/Function Notion Page",
+        parentTitle: null,
+        lastUpdatedAt: "2026-01-01T00:00:00Z",
+        sourceUrl: null,
+        mimeType: "application/vnd.notion.page",
+        hasChildren: false,
+        connectorProvider: null,
+      },
+    };
+
+    await processToolResults(auth, {
+      localLogger: logger.child({ test: true }),
+      toolContext,
+      toolCallResultContent: [
+        {
+          type: "resource",
+          resource: dataSourceNodeResult,
+        },
+      ],
+    });
+
+    const toolOutputWrite = fileStorageMock.saveFileCalls.find((call) =>
+      call.filePath.includes(`${TOOL_OUTPUTS_FOLDER_NAME}/`)
+    );
+    expect(toolOutputWrite).toBeDefined();
+    // Pod tool outputs are scoped by invocation so concurrent or successive invocations of the
+    // same pod cannot mix their outputs.
+    expect(toolOutputWrite?.filePath).toMatch(
+      new RegExp(
+        `w/${workspace.sId}/pods/${podSpace.sId}/files/${TOOL_OUTPUTS_FOLDER_NAME}/${invocation.sId}/\\d+_function_notion_page\\.md$`
+      )
+    );
+  });
 
   it("should write the full content array to a single GCS object in a sandbox function run context", async () => {
     const { auth, workspace, action, toolContext } =

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -478,8 +478,14 @@ describe("processToolResults", () => {
   });
 
   async function setupSandboxFunctionTest() {
-    const { auth, workspace, invocation, globalSpace, podSpace } =
-      await createPersistedSandboxFunctionInvocationTokenTestContext();
+    const {
+      auth,
+      workspace,
+      invocation,
+      globalSpace,
+      podSpace,
+      sandboxFunction,
+    } = await createPersistedSandboxFunctionInvocationTokenTestContext();
     const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
       name: "common_utilities",
       useCase: null,
@@ -505,11 +511,18 @@ describe("processToolResults", () => {
       },
     };
 
-    return { auth, workspace, action, invocation, podSpace, toolContext };
+    return {
+      auth,
+      workspace,
+      action,
+      podSpace,
+      sandboxFunction,
+      toolContext,
+    };
   }
 
-  it(`should offload registered resource blocks to ${TOOL_OUTPUTS_FOLDER_NAME}/{invocationId}/ in a sandbox function run context`, async () => {
-    const { auth, workspace, invocation, podSpace, toolContext } =
+  it(`should offload registered resource blocks to ${TOOL_OUTPUTS_FOLDER_NAME}/{slug}/ in a sandbox function run context`, async () => {
+    const { auth, workspace, podSpace, sandboxFunction, toolContext } =
       await setupSandboxFunctionTest();
 
     const dataSourceNodeResult: DataSourceNodeContentType = {
@@ -544,11 +557,11 @@ describe("processToolResults", () => {
       call.filePath.includes(`${TOOL_OUTPUTS_FOLDER_NAME}/`)
     );
     expect(toolOutputWrite).toBeDefined();
-    // Pod tool outputs are scoped by invocation so concurrent or successive invocations of the
-    // same pod cannot mix their outputs.
+    // Pod tool outputs are scoped by function slug so functions of the same pod cannot mix
+    // their outputs.
     expect(toolOutputWrite?.filePath).toMatch(
       new RegExp(
-        `w/${workspace.sId}/pods/${podSpace.sId}/files/${TOOL_OUTPUTS_FOLDER_NAME}/${invocation.sId}/\\d+_function_notion_page\\.md$`
+        `w/${workspace.sId}/pods/${podSpace.sId}/files/${TOOL_OUTPUTS_FOLDER_NAME}/${sandboxFunction.slug}/\\d+_function_notion_page\\.md$`
       )
     );
   });

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -76,14 +76,14 @@ function getToolOutputsScopedPath(
         })
       );
     case "sandbox_function":
-      // Scoped by invocation: a pod outlives its invocations, so a flat folder would mix
-      // outputs across invocations and the function could not tell its own apart. The
-      // invocation folder is visible in-sandbox at
-      // /files/pod-{pId}/.tool_outputs/{invocationId}/.
+      // Scoped by function slug (unique within the pod): a pod outlives its functions, so a
+      // flat folder would mix outputs across functions. The slug is preferred over the
+      // invocation sId as it is shorter and less error-prone for the model to reference. The
+      // folder is visible in-sandbox at /files/pod-{pId}/.tool_outputs/{slug}/.
       return new Ok(
         podScopedPath(
           runContext.invocation.sandboxFunction.space.sId,
-          `${TOOL_OUTPUTS_FOLDER_NAME}/${runContext.invocation.sId}/${fileName}`
+          `${TOOL_OUTPUTS_FOLDER_NAME}/${runContext.invocation.sandboxFunction.slug}/${fileName}`
         )
       );
     default:

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -67,18 +67,24 @@ function getToolOutputsScopedPath(
     );
   }
 
-  const rel = `${TOOL_OUTPUTS_FOLDER_NAME}/${fileName}`;
   switch (runContext.contextType) {
     case "agent_loop":
       return new Ok(
         conversationScopedPath({
           conversationId: runContext.conversation.sId,
-          rel,
+          rel: `${TOOL_OUTPUTS_FOLDER_NAME}/${fileName}`,
         })
       );
     case "sandbox_function":
+      // Scoped by invocation: a pod outlives its invocations, so a flat folder would mix
+      // outputs across invocations and the function could not tell its own apart. The
+      // invocation folder is visible in-sandbox at
+      // /files/pod-{pId}/.tool_outputs/{invocationId}/.
       return new Ok(
-        podScopedPath(runContext.invocation.sandboxFunction.space.sId, rel)
+        podScopedPath(
+          runContext.invocation.sandboxFunction.space.sId,
+          `${TOOL_OUTPUTS_FOLDER_NAME}/${runContext.invocation.sId}/${fileName}`
+        )
       );
     default:
       return assertNever(runContext);

--- a/front/tests/utils/SandboxTokenFactory.ts
+++ b/front/tests/utils/SandboxTokenFactory.ts
@@ -140,9 +140,18 @@ export async function createSandboxFunctionInvocationTokenTestContext({
 // them back (calling MCP tools from a function invocation).
 export async function createPersistedSandboxFunctionInvocationTokenTestContext() {
   const context = await createSandboxTokenTestContext();
-  const { auth, workspace } = context;
+  const { workspace } = context;
 
-  const podSpace = await SpaceFactory.project(workspace);
+  // Make the user a member of the pod space and refresh the auth so its groups include the pod
+  // editor group, matching production where the invocation-token auth is granted the pod space
+  // groups (pod-scoped writes like DustFileSystem.forPod require read access on the space).
+  const user = context.auth.getNonNullableUser();
+  const podSpace = await SpaceFactory.project(workspace, user.id);
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
   const file = await FileFactory.create(auth, null, {
     contentType: sandboxFunctionContentType,
     fileName: "greet.ts",
@@ -183,6 +192,7 @@ export async function createPersistedSandboxFunctionInvocationTokenTestContext()
 
   return {
     ...context,
+    auth,
     podSpace,
     sandboxFunction,
     invocation,


### PR DESCRIPTION
Follow up of #28664 / #28666. 

Tools called from sandbox function invocations offload their outputs (registered resources, oversized text) to the pod's `.tool_outputs/` folder, which the function reads through the `/files/pod-{pId}` mount. That folder was flat: a pod outlives its invocations, so outputs from successive or concurrent invocations mixed together and a function could not tell its own apart.

Offloads from a sandbox function run context now land under `.tool_outputs/{invocationId}/`, visible in-sandbox at `/files/pod-{pId}/.tool_outputs/{invocationId}/`. The output blocks keep carrying the scoped path, so the function reads exactly its own files. A fresh per-invocation directory also avoids gcsfuse negative-stat-cache staleness on repeated paths. Conversation flavor unchanged. User-facing generated files (images, blobs) keep landing at the pod root per `writeToPodFolder`'s convention.

Note: Pre-existing flat files under `.tool_outputs/` are left in place, no move or backfill: readers use the path embedded in their output blocks, so old blocks keep resolving. The flat folder just stops accumulating.

Drive-by 🚗: `createPersistedSandboxFunctionInvocationTokenTestContext` created the pod space with no members, so `DustFileSystem.forPod` silently failed `canRead` under test and offloads degraded to a "Failed to save the tool output" block, making the offload path effectively untestable. The user now joins the pod editor group and the auth is refreshed, matching production where the invocation-token auth is granted the pod space groups.

## Tests

New `mcp_execution` test asserting the invocation-scoped path for an offloaded resource block in a sandbox function run context. Existing: `mcp_execution` (12) and all front-api sandbox suites (41) pass with the factory change.

## Risk

Path change only affects the sandbox function flavor, which shipped days ago; readers use the path embedded in the output blocks, so no stored data references break in either direction. Worst case, functions look for outputs at the old flat path. Safe to rollback.

## Deploy Plan

- [ ] Deploy front