### PR TITLE
[front] fix: clarify skill_authoring skill update permission error

### DIFF
--- a/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
@@ -197,7 +197,9 @@ describe("skill_authoring tools", () => {
     if (otherUpdateResult.isOk()) {
       throw new Error("Expected another builder not to update the skill.");
     }
-    expect(otherUpdateResult.error.message).toBe("Skill not found.");
+    expect(otherUpdateResult.error.message).toBe(
+      "You need to be added as an editor of this skill before you can make changes."
+    );
 
     const updateResult = await getTool(UPDATE_SKILL_TOOL_NAME).handler(
       {

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -500,7 +500,11 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
     }
 
     if (!skill.canWrite(auth)) {
-      return new Err(new MCPError("Skill not found."));
+      return new Err(
+        new MCPError(
+          "You need to be added as an editor of this skill before you can make changes."
+        )
+      );
     }
 
     // Resolve the new instructions: undefined keeps the existing ones, a full


### PR DESCRIPTION
## Description

The skill authoring update tool returned a generic error `Skill not found.` when the skill existed but the builder was not an editor.

This PR keeps the missing-skill behavior unchanged and makes the update permission failure actionable by telling the agent the user needs to be added as a skill editor before changing it. The existence of the skill is already known to the user at this point, so this does not leak anything.

## Tests

- Updated existing tests.

## Risk

- Low. Only affects error messages.

## Deploy Plan

- Deploy front.
