### PR TITLE
Make previous-interactions pruning budget-driven instead of positional

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -1,6 +1,12 @@
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { tokenCountForTexts } from "@app/lib/tokenization";
-import type { ModelMessageTypeMultiActions } from "@app/types/assistant/generation";
+import type {
+  Content,
+  FunctionMessageTypeModel,
+  ModelMessageTypeMultiActions,
+  UserMessageTypeModel,
+} from "@app/types/assistant/generation";
+import { isTextContent } from "@app/types/assistant/generation";
 import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -72,6 +78,53 @@ function functionMessage(
     function_call_id: `${name}_call`,
     content,
   };
+}
+
+function isUserMessage(
+  message: ModelMessageTypeMultiActions
+): message is UserMessageTypeModel {
+  return message.role === "user";
+}
+
+function isFunctionMessage(
+  message: ModelMessageTypeMultiActions
+): message is FunctionMessageTypeModel {
+  return message.role === "function";
+}
+
+function textOf(content: Content): string | undefined {
+  return isTextContent(content) ? content.text : undefined;
+}
+
+function getFunctionMessage(
+  messages: ModelMessageTypeMultiActions[],
+  name?: string
+): FunctionMessageTypeModel {
+  const message = messages.find(
+    (m): m is FunctionMessageTypeModel =>
+      isFunctionMessage(m) && (name === undefined || m.name === name)
+  );
+  if (!message) {
+    throw new Error(
+      `Expected a function message${name ? ` named ${name}` : ""}`
+    );
+  }
+  return message;
+}
+
+// The previous-interaction messages built by the tests below are always named "i1_user",
+// "i1_tool", etc. This pulls out just those (never the current interaction's messages) as plain
+// comparable objects, regardless of whether they're user or function messages.
+function previousInteractionSummaries(
+  messages: ModelMessageTypeMultiActions[]
+): Array<{ role: string; name: string; content: string | Content[] }> {
+  return messages
+    .filter(
+      (m): m is UserMessageTypeModel | FunctionMessageTypeModel =>
+        isUserMessage(m) || isFunctionMessage(m)
+    )
+    .filter((m) => m.name.startsWith("i"))
+    .map((m) => ({ role: m.role, name: m.name, content: m.content }));
 }
 
 function mockTokenCounter({
@@ -198,11 +251,10 @@ describe("renderConversationForModel", () => {
       return;
     }
 
-    const functionOutput = res.value.modelConversation.messages.find(
-      (m) => m.role === "function"
+    const functionOutput = getFunctionMessage(
+      res.value.modelConversation.messages
     );
-    expect(functionOutput).toBeDefined();
-    expect((functionOutput as any).content).toContain(
+    expect(functionOutput.content).toContain(
       "This tool result is no longer available"
     );
     expect(res.value.prunedContext).toBe(true);
@@ -246,18 +298,18 @@ describe("renderConversationForModel", () => {
       return;
     }
 
-    const oldTool = res.value.modelConversation.messages.find(
-      (m: any) => m.role === "function" && m.name === "old_tool"
+    const oldTool = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "old_tool"
     );
-    const newTool = res.value.modelConversation.messages.find(
-      (m: any) => m.role === "function" && m.name === "new_tool"
+    const newTool = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "new_tool"
     );
-    expect(oldTool).toBeDefined();
-    expect((oldTool as any).content).toContain(
+    expect(oldTool.content).toContain(
       "This tool result is no longer available"
     );
-    expect(newTool).toBeDefined();
-    expect((newTool as any).content).toBe("new_function");
+    expect(newTool.content).toBe("new_function");
     expect(res.value.prunedContext).toBe(false);
   });
 
@@ -299,12 +351,12 @@ describe("renderConversationForModel", () => {
     const roles = res.value.modelConversation.messages.map((m) => m.role);
     expect(roles).not.toContain("content_fragment");
 
-    const firstUser = res.value.modelConversation.messages.find(
-      (m) => m.role === "user"
-    ) as any;
-    expect(firstUser).toBeDefined();
-    expect(firstUser.content[0].text).toBe("fragment_text");
-    expect(firstUser.content[1].text).toBe("user_text");
+    const firstUser = res.value.modelConversation.messages.find(isUserMessage);
+    if (!firstUser) {
+      throw new Error("Expected a user message");
+    }
+    expect(textOf(firstUser.content[0])).toBe("fragment_text");
+    expect(textOf(firstUser.content[1])).toBe("user_text");
   });
 
   it("returns an error when context window is still exceeded after pruning", async () => {
@@ -341,17 +393,21 @@ describe("renderConversationForModel", () => {
   });
 
   it("does not error when previousInteractions' floor alone overflows its budget, as long as the current interaction fits on its own", async () => {
-    // Three previous interactions, ALL inside the floor (PREVIOUS_INTERACTIONS_TO_PRESERVE = 3),
-    // each large enough that even fully redacted they still add up to more than
-    // budgetForInteractions (100 below). This is prunePreviousInteractions' own rare "real
-    // out-of-room" case (see its floor-redaction fallback).
+    // There are 3 previous interactions here, and PREVIOUS_INTERACTIONS_TO_PRESERVE is 3, so all
+    // 3 are kept in full and are never redacted. Each one is 340 tokens (20 + 20 + 300), so all 3
+    // together are 1020 tokens. The token budget for previous interactions is only 100 (set below
+    // via allowedTokenCount). There is no way to fit 1020 tokens of previous interactions into a
+    // budget of 100.
     //
-    // The current interaction is small and has no tool call of its own, so it comfortably fits
-    // budgetForInteractions on its own. The fix under test: the hard error check compares the
-    // current interaction against the FULL fixed pool (budgetForInteractions), not against
-    // whatever's nominally left after previousInteractions (which went negative here). So this
-    // must still succeed, leaning on the pre-existing "select interactions that fit" loop to trim
-    // previousInteractions down further rather than failing the whole render.
+    // The current interaction, on the other hand, is tiny: just 20 tokens (10 + 10), no tool call.
+    // It fits into the 100 token budget on its own, easily.
+    //
+    // What this test checks: the render must still succeed. It would be wrong to compute
+    // "100 minus the 1020 tokens previous interactions actually take" and use that negative
+    // number to decide if the current interaction fits, because that would make even a tiny
+    // current interaction look too big and fail the whole request. The current interaction only
+    // needs to fit the 100 token budget by itself. Previous interactions get trimmed down
+    // separately to make room.
     vi.mocked(renderAllMessages).mockResolvedValue([
       userMessage("floor1_user"),
       assistantMessage("floor1_assistant"),
@@ -403,18 +459,17 @@ describe("renderConversationForModel", () => {
     }
 
     const currentUser = res.value.modelConversation.messages.find(
-      (m: any) => m.role === "user" && m.content[0].text === "cur_user"
+      (m) => isUserMessage(m) && textOf(m.content[0]) === "cur_user"
     );
     expect(currentUser).toBeDefined();
 
     // previousInteractions couldn't all survive, but the render degraded gracefully instead of
     // failing outright: at least one floor interaction made it through, redacted.
-    const survivingFloorTools = res.value.modelConversation.messages.filter(
-      (m: any) => m.role === "function"
-    );
+    const survivingFloorTools =
+      res.value.modelConversation.messages.filter(isFunctionMessage);
     expect(survivingFloorTools.length).toBeGreaterThan(0);
     for (const tool of survivingFloorTools) {
-      expect((tool as any).content).toContain("no longer available");
+      expect(tool.content).toContain("no longer available");
     }
   });
 
@@ -554,8 +609,8 @@ describe("renderConversationForModel", () => {
     }
 
     const names = res.value.modelConversation.messages
-      .filter((m: any) => m.role === "function")
-      .map((m: any) => m.name);
+      .filter(isFunctionMessage)
+      .map((m) => m.name);
     expect(names).toEqual(["tool_07", "tool_08"]);
     expect(names).not.toContain("tool_01");
     expect(names).not.toContain("tool_02");
@@ -636,16 +691,14 @@ describe("renderConversationForModel", () => {
       return;
     }
 
-    const previousMessagesAtTurnT = turnT.value.modelConversation.messages
-      .filter(
-        (m: any) => typeof m.name === "string" && m.name.startsWith("i") // i1_tool..i4_tool, not "cur_*"
-      )
-      .map((m: any) => ({ role: m.role, name: m.name, content: m.content }));
+    const previousMessagesAtTurnT = previousInteractionSummaries(
+      turnT.value.modelConversation.messages
+    );
 
     // All four previous interactions are rendered in full at turn T.
     const toolNamesAtTurnT = previousMessagesAtTurnT
-      .filter((m: any) => m.role === "function")
-      .map((m: any) => m.name);
+      .filter((m) => m.role === "function")
+      .map((m) => m.name);
     expect(toolNamesAtTurnT).toEqual([
       "i1_tool",
       "i2_tool",
@@ -653,10 +706,8 @@ describe("renderConversationForModel", () => {
       "i4_tool",
     ]);
     for (const i of [1, 2, 3, 4]) {
-      const tool = previousMessagesAtTurnT.find(
-        (m: any) => m.name === `i${i}_tool`
-      ) as any;
-      expect(tool.content).toBe(`i${i}_tool_content`);
+      const tool = previousMessagesAtTurnT.find((m) => m.name === `i${i}_tool`);
+      expect(tool?.content).toBe(`i${i}_tool_content`);
     }
 
     // Turn T+1: i1..i4 are byte-for-byte identical to turn T. The ONLY change is that this
@@ -683,12 +734,9 @@ describe("renderConversationForModel", () => {
       return;
     }
 
-    const previousMessagesAtTurnTPlus1 =
+    const previousMessagesAtTurnTPlus1 = previousInteractionSummaries(
       turnTPlus1.value.modelConversation.messages
-        .filter(
-          (m: any) => typeof m.name === "string" && m.name.startsWith("i")
-        )
-        .map((m: any) => ({ role: m.role, name: m.name, content: m.content }));
+    );
 
     // Byte-identical to turn T: none of i1..i4 moved, despite the current interaction growing
     // from 20 to 220 tokens.
@@ -697,11 +745,10 @@ describe("renderConversationForModel", () => {
     // The current interaction itself is free to vary. It's new content, never previously cached,
     // and its own tool result gets progressively pruned since it doesn't fit its ideal share of
     // the budget on its own.
-    const currentToolAtTurnTPlus1 =
-      turnTPlus1.value.modelConversation.messages.find(
-        (m: any) => m.name === "cur_tool_big"
-      ) as any;
-    expect(currentToolAtTurnTPlus1).toBeDefined();
+    const currentToolAtTurnTPlus1 = getFunctionMessage(
+      turnTPlus1.value.modelConversation.messages,
+      "cur_tool_big"
+    );
     expect(currentToolAtTurnTPlus1.content).toContain("no longer available");
   });
 

--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -340,6 +340,84 @@ describe("renderConversationForModel", () => {
     }
   });
 
+  it("does not error when previousInteractions' floor alone overflows its budget, as long as the current interaction fits on its own", async () => {
+    // Three previous interactions, ALL inside the floor (PREVIOUS_INTERACTIONS_TO_PRESERVE = 3),
+    // each large enough that even fully redacted they still add up to more than
+    // budgetForInteractions (100 below). This is prunePreviousInteractions' own rare "real
+    // out-of-room" case (see its floor-redaction fallback).
+    //
+    // The current interaction is small and has no tool call of its own, so it comfortably fits
+    // budgetForInteractions on its own. The fix under test: the hard error check compares the
+    // current interaction against the FULL fixed pool (budgetForInteractions), not against
+    // whatever's nominally left after previousInteractions (which went negative here). So this
+    // must still succeed, leaning on the pre-existing "select interactions that fit" loop to trim
+    // previousInteractions down further rather than failing the whole render.
+    vi.mocked(renderAllMessages).mockResolvedValue([
+      userMessage("floor1_user"),
+      assistantMessage("floor1_assistant"),
+      functionMessage("floor1_tool", "floor1_tool_content"),
+      userMessage("floor2_user"),
+      assistantMessage("floor2_assistant"),
+      functionMessage("floor2_tool", "floor2_tool_content"),
+      userMessage("floor3_user"),
+      assistantMessage("floor3_assistant"),
+      functionMessage("floor3_tool", "floor3_tool_content"),
+      userMessage("cur_user"),
+      assistantMessage("cur_assistant"),
+    ]);
+    mockTokenCounter({
+      byContains: {
+        floor1_user: 20,
+        floor1_assistant: 20,
+        floor1_tool_content: 300,
+        floor2_user: 20,
+        floor2_assistant: 20,
+        floor2_tool_content: 300,
+        floor3_user: 20,
+        floor3_assistant: 20,
+        floor3_tool_content: 300,
+        cur_user: 10,
+        cur_assistant: 10,
+      },
+    });
+
+    const res = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model,
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      // budgetForInteractions = 100: far less than the floor's real size (3 * 340 = 1020) or even
+      // its fully-redacted minimum (3 * 64 = 192), but comfortably more than the current
+      // interaction's own 20 tokens.
+      allowedTokenCount: computeAllowedTokenCount({
+        promptTokens: 10,
+        toolsTokens: 10,
+        interactionTokens: 100,
+      }),
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      return;
+    }
+
+    const currentUser = res.value.modelConversation.messages.find(
+      (m: any) => m.role === "user" && m.content[0].text === "cur_user"
+    );
+    expect(currentUser).toBeDefined();
+
+    // previousInteractions couldn't all survive, but the render degraded gracefully instead of
+    // failing outright: at least one floor interaction made it through, redacted.
+    const survivingFloorTools = res.value.modelConversation.messages.filter(
+      (m: any) => m.role === "function"
+    );
+    expect(survivingFloorTools.length).toBeGreaterThan(0);
+    for (const tool of survivingFloorTools) {
+      expect((tool as any).content).toContain("no longer available");
+    }
+  });
+
   it("bubbles prompt/tools tokenization errors", async () => {
     vi.mocked(renderAllMessages).mockResolvedValue([userMessage("u1")]);
     vi.mocked(tokenCountForTexts).mockImplementation(async (texts) => {
@@ -485,6 +563,146 @@ describe("renderConversationForModel", () => {
     expect(names).not.toContain("tool_04");
     expect(names).not.toContain("tool_05");
     expect(names).not.toContain("tool_06");
+  });
+
+  it("renders previous interactions identically across turns, regardless of how big the current interaction happens to be", async () => {
+    // Four previous interactions (i1..i4), each 70 tokens (10 user + 10 assistant + 50 tool),
+    // comfortably within budgetForInteractions on their own. Prior to the fix, this scenario used
+    // to drop i2/i3/i4 entirely on the turn where the current interaction grew large, purely
+    // because current and previousInteractions shared one live pool in the final selection loop.
+    // Now previousInteractions gets a fixed, current-independent claim on the budget, so its
+    // rendering must be byte-identical across both calls below.
+    const previousInteractionMessages = [
+      userMessage("i1_user"),
+      assistantMessage("i1_assistant"),
+      functionMessage("i1_tool", "i1_tool_content"),
+      userMessage("i2_user"),
+      assistantMessage("i2_assistant"),
+      functionMessage("i2_tool", "i2_tool_content"),
+      userMessage("i3_user"),
+      assistantMessage("i3_assistant"),
+      functionMessage("i3_tool", "i3_tool_content"),
+      userMessage("i4_user"),
+      assistantMessage("i4_assistant"),
+      functionMessage("i4_tool", "i4_tool_content"),
+    ];
+    const byContains = {
+      i1_user: 10,
+      i1_assistant: 10,
+      i1_tool_content: 50,
+      i2_user: 10,
+      i2_assistant: 10,
+      i2_tool_content: 50,
+      i3_user: 10,
+      i3_assistant: 10,
+      i3_tool_content: 50,
+      i4_user: 10,
+      i4_assistant: 10,
+      i4_tool_content: 50,
+      cur_user_small: 10,
+      cur_assistant_small: 10,
+      cur_user_big: 10,
+      cur_assistant_big: 10,
+      cur_tool_big_content: 200,
+    };
+
+    // Same allowedTokenCount on both calls, same model, same context window. The only thing that
+    // differs between "turn T" and "turn T+1" is how big the new current-turn content is.
+    // budgetForInteractions = 400 comfortably covers i1..i4 (4 * 70 = 280) on its own.
+    const allowedTokenCount = computeAllowedTokenCount({
+      promptTokens: 10,
+      toolsTokens: 10,
+      interactionTokens: 400,
+    });
+
+    // Turn T: current interaction is small (20 tokens: just user + assistant, no tool call).
+    vi.mocked(renderAllMessages).mockResolvedValue([
+      ...previousInteractionMessages,
+      userMessage("cur_user_small"),
+      assistantMessage("cur_assistant_small"),
+    ]);
+    mockTokenCounter({ byContains });
+
+    const turnT = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model,
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      allowedTokenCount,
+    });
+    expect(turnT.isOk()).toBe(true);
+    if (turnT.isErr()) {
+      return;
+    }
+
+    const previousMessagesAtTurnT = turnT.value.modelConversation.messages
+      .filter(
+        (m: any) => typeof m.name === "string" && m.name.startsWith("i") // i1_tool..i4_tool, not "cur_*"
+      )
+      .map((m: any) => ({ role: m.role, name: m.name, content: m.content }));
+
+    // All four previous interactions are rendered in full at turn T.
+    const toolNamesAtTurnT = previousMessagesAtTurnT
+      .filter((m: any) => m.role === "function")
+      .map((m: any) => m.name);
+    expect(toolNamesAtTurnT).toEqual([
+      "i1_tool",
+      "i2_tool",
+      "i3_tool",
+      "i4_tool",
+    ]);
+    for (const i of [1, 2, 3, 4]) {
+      const tool = previousMessagesAtTurnT.find(
+        (m: any) => m.name === `i${i}_tool`
+      ) as any;
+      expect(tool.content).toBe(`i${i}_tool_content`);
+    }
+
+    // Turn T+1: i1..i4 are byte-for-byte identical to turn T. The ONLY change is that this
+    // turn's new current interaction now includes a big tool call (220 tokens instead of 20),
+    // exactly like a user turn that happens to trigger a large tool result.
+    vi.mocked(renderAllMessages).mockResolvedValue([
+      ...previousInteractionMessages,
+      userMessage("cur_user_big"),
+      assistantMessage("cur_assistant_big"),
+      functionMessage("cur_tool_big", "cur_tool_big_content"),
+    ]);
+    mockTokenCounter({ byContains });
+
+    const turnTPlus1 = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model,
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      allowedTokenCount, // same context window budget as turn T
+    });
+    expect(turnTPlus1.isOk()).toBe(true);
+    if (turnTPlus1.isErr()) {
+      return;
+    }
+
+    const previousMessagesAtTurnTPlus1 =
+      turnTPlus1.value.modelConversation.messages
+        .filter(
+          (m: any) => typeof m.name === "string" && m.name.startsWith("i")
+        )
+        .map((m: any) => ({ role: m.role, name: m.name, content: m.content }));
+
+    // Byte-identical to turn T: none of i1..i4 moved, despite the current interaction growing
+    // from 20 to 220 tokens.
+    expect(previousMessagesAtTurnTPlus1).toEqual(previousMessagesAtTurnT);
+
+    // The current interaction itself is free to vary. It's new content, never previously cached,
+    // and its own tool result gets progressively pruned since it doesn't fit its ideal share of
+    // the budget on its own.
+    const currentToolAtTurnTPlus1 =
+      turnTPlus1.value.modelConversation.messages.find(
+        (m: any) => m.name === "cur_tool_big"
+      ) as any;
+    expect(currentToolAtTurnTPlus1).toBeDefined();
+    expect(currentToolAtTurnTPlus1.content).toContain("no longer available");
   });
 
   it("prepends leading messages", async () => {

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -144,10 +144,33 @@ export async function renderConversationForModel(
     TOKENS_MARGIN;
 
   const interactions = groupMessagesIntoInteractions(messagesWithTokens);
+
+  // Previous interactions get first, fixed claim on the token budget, independent of how big this
+  // turn's own new content happens to be. This is what keeps their rendering stable across turns.
+  // The budget prunePreviousInteractions works against never depends on a live, per-turn
+  // quantity. The current interaction (this turn's own new content, never previously cached)
+  // absorbs whatever budget remains, with its own progressive-pruning safety net below.
+  const budgetForInteractions = allowedTokenCount - baseTokens;
+
+  const previousInteractions = prunePreviousInteractions(
+    interactions.slice(0, -1),
+    budgetForInteractions,
+    PREVIOUS_INTERACTIONS_TO_PRESERVE
+  );
+  const previousInteractionsTokens = previousInteractions.reduce(
+    (sum, interaction) => sum + getInteractionTokenCount(interaction),
+    0
+  );
+
   let currentInteraction = interactions[interactions.length - 1];
   let currentInteractionTokens = getInteractionTokenCount(currentInteraction);
 
-  let availableTokens = allowedTokenCount - baseTokens;
+  // Ideally, the current interaction gets whatever's left after previousInteractions. But
+  // previousInteractions is capped by construction (see prunePreviousInteractions), so this can
+  // only go negative in the rare case where even the (redacted) floor alone didn't fit. In that
+  // case we still only require the current interaction to fit the full fixed pool on its own,
+  // matching the pre-existing hard safety net below.
+  const currentBudget = budgetForInteractions - previousInteractionsTokens;
 
   const logDetails = {
     workspaceId: conversation.owner.sId,
@@ -171,31 +194,33 @@ export async function renderConversationForModel(
     pokeUrl: `https://poke.dust.tt/${conversation.owner.sId}/conversation/${conversation.sId}`,
   };
 
-  if (currentInteractionTokens > availableTokens) {
-    // The last interaction does not fit within the token budget.
-    // We apply progressive pruning to that interaction until it fits within the token budget.
+  if (currentInteractionTokens > currentBudget) {
+    // The last interaction does not fit within its ideal share of the token budget.
+    // We apply progressive pruning to that interaction until it fits.
     currentInteraction = progressivelyPruneInteraction(
       currentInteraction,
-      availableTokens
+      currentBudget
     );
     if (currentInteraction.prunedContext) {
       logger.warn(
         {
           ...logDetails,
           currentInteractionTokens,
-          availableTokens,
+          currentBudget,
         },
         "Last tool result was pruned to fit in context window."
       );
     }
     currentInteractionTokens = getInteractionTokenCount(currentInteraction);
-    if (currentInteractionTokens > availableTokens) {
+    // The hard requirement is only that the current interaction fits the full fixed pool on its
+    // own: previousInteractions can still be trimmed further below (oldest first) to make room.
+    if (currentInteractionTokens > budgetForInteractions) {
       logger.error(
         {
           ...logDetails,
           failureStage: "interaction_exceeds_after_pruning",
           currentInteractionTokens,
-          availableTokens,
+          budgetForInteractions,
         },
         "Render Conversation V2: No interactions fit in context window."
       );
@@ -203,17 +228,7 @@ export async function renderConversationForModel(
         new Error("Context window exceeded: at least one message is required")
       );
     }
-    availableTokens -= currentInteractionTokens;
   }
-
-  let previousInteractions = interactions.slice(0, -1);
-
-  // prune previous interactions.
-  previousInteractions = prunePreviousInteractions(
-    previousInteractions,
-    availableTokens,
-    PREVIOUS_INTERACTIONS_TO_PRESERVE
-  );
 
   const prunedInteractions = [...previousInteractions, currentInteraction];
 
@@ -268,7 +283,7 @@ export async function renderConversationForModel(
         ...logDetails,
         failureStage: "no_interactions_selected",
         tokensUsed,
-        availableTokens,
+        budgetForInteractions,
         selectedMessageCount: selected.length,
       },
       "Render Conversation V2: No interactions fit in context window."

--- a/front/lib/api/assistant/conversation_rendering/pruning.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.test.ts
@@ -16,6 +16,23 @@ import { describe, expect, it } from "vitest";
 // sliding-window rule from the token-budget rule.
 const HUGE_BUDGET = 1_000_000;
 
+/**
+ * A deterministic pseudo-random number generator, used instead of Math.random() so a failing
+ * test prints a seed that reproduces the exact same failure when rerun.
+ *
+ * This is a linear congruential generator: state = (state * multiplier + increment) mod m,
+ * the same simple formula behind C's rand(). 1103515245 and 12345 are its standard multiplier
+ * and increment constants. Masking with 0x7fffffff keeps state a positive 31-bit integer, and
+ * dividing by that same value scales the result into [0, 1), like Math.random().
+ */
+function makeDeterministicRng(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    return state / 0x7fffffff;
+  };
+}
+
 function withTokens<T extends ModelMessageTypeMultiActions>(
   message: T,
   tokenCount: number
@@ -178,16 +195,8 @@ describe("prunePreviousInteractions", () => {
   });
 
   it("never returns interactions whose combined token count exceeds maxTokens, across a wide randomized sweep (short of the floor's own unavoidable minimum)", () => {
-    function makeRng(seed: number) {
-      let s = seed;
-      return () => {
-        s = (s * 1103515245 + 12345) & 0x7fffffff;
-        return s / 0x7fffffff;
-      };
-    }
-
     for (let seed = 1; seed <= 2000; seed++) {
-      const rng = makeRng(seed);
+      const rng = makeDeterministicRng(seed);
       const n = 1 + Math.floor(rng() * 15);
       const toPreserve = 1 + Math.floor(rng() * 4);
       const items: InteractionWithTokens[] = [];
@@ -269,15 +278,10 @@ describe("prunePreviousInteractions across a growing conversation (realistic, va
   }
 
   it("keeps most turns byte-stable and never un-redacts an interaction, simulating a long conversation with realistic variable tool-result sizes", () => {
-    // Deterministic pseudo-random sizes (no Math.random, so a failure is reproducible from the
-    // seed alone). Mostly small-to-medium tool results, with an occasional large one. Mirrors the
-    // real spread of interaction sizes observed in production (roughly 200 to 9000 characters per
-    // tool result).
-    let seed = 42;
-    const nextRandom = () => {
-      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
-      return seed / 0x7fffffff;
-    };
+    // Mostly small-to-medium tool results, with an occasional large one. Mirrors the real spread
+    // of interaction sizes observed in production (roughly 200 to 9000 characters per tool
+    // result).
+    const nextRandom = makeDeterministicRng(42);
     const nextInteractionSizeTokens = () =>
       nextRandom() < 0.15
         ? 500 + Math.floor(nextRandom() * 2500) // occasional large tool result

--- a/front/lib/api/assistant/conversation_rendering/pruning.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.test.ts
@@ -1,0 +1,332 @@
+import { groupMessagesIntoInteractions } from "@app/lib/api/assistant/conversation/interactions";
+import type {
+  InteractionWithTokens,
+  MessageWithTokens,
+} from "@app/lib/api/assistant/conversation_rendering/pruning";
+import {
+  getInteractionTokenCount,
+  PRUNING_CHECKPOINT_TOKENS,
+  pruneAllToolResults,
+  prunePreviousInteractions,
+} from "@app/lib/api/assistant/conversation_rendering/pruning";
+import type { ModelMessageTypeMultiActions } from "@app/types/assistant/generation";
+import { describe, expect, it } from "vitest";
+
+// Never enough to force budget-driven pruning in these tests: they isolate the
+// sliding-window rule from the token-budget rule.
+const HUGE_BUDGET = 1_000_000;
+
+function withTokens<T extends ModelMessageTypeMultiActions>(
+  message: T,
+  tokenCount: number
+): T & { tokenCount: number } {
+  return { ...message, tokenCount };
+}
+
+function buildTurnWithSize(
+  index: number,
+  toolTokens: number
+): MessageWithTokens[] {
+  return [
+    withTokens(
+      {
+        role: "user" as const,
+        name: "user",
+        content: [{ type: "text" as const, text: `u${index}` }],
+      },
+      10
+    ),
+    withTokens(
+      {
+        role: "assistant" as const,
+        name: "assistant",
+        content: `a${index}`,
+        contents: [{ type: "text_content" as const, value: `a${index}` }],
+      },
+      10
+    ),
+    withTokens(
+      {
+        role: "function" as const,
+        name: `tool_${index}`,
+        function_call_id: `tool_${index}_call`,
+        content: `result_${index}`,
+      },
+      toolTokens
+    ),
+  ];
+}
+
+function buildTurn(index: number): MessageWithTokens[] {
+  return buildTurnWithSize(index, 10);
+}
+
+function toolResultOf(
+  interactions: ReturnType<typeof prunePreviousInteractions>,
+  index: number
+) {
+  const message = interactions[index].messages.find(
+    (m) => m.role === "function"
+  );
+  if (!message || message.role !== "function") {
+    throw new Error(`Expected interaction ${index} to have a tool result`);
+  }
+  return message.content;
+}
+
+function isRedacted(content: unknown): boolean {
+  return typeof content === "string" && content.includes("no longer available");
+}
+
+describe("prunePreviousInteractions", () => {
+  it("keeps everything untouched when the budget comfortably covers the full history", () => {
+    // Unlike the old sliding-window rule, there is no more forced redaction beyond the floor when
+    // the budget was never actually a constraint.
+    const messages = [1, 2, 3, 4].flatMap(buildTurn);
+    const previousInteractions = groupMessagesIntoInteractions(messages);
+    const pruned = prunePreviousInteractions(
+      previousInteractions,
+      HUGE_BUDGET,
+      3
+    );
+
+    expect(toolResultOf(pruned, 0)).toBe("result_1");
+    expect(toolResultOf(pruned, 1)).toBe("result_2");
+    expect(toolResultOf(pruned, 2)).toBe("result_3");
+    expect(toolResultOf(pruned, 3)).toBe("result_4");
+  });
+
+  it("keeps the floor fully intact and redacts only the oldest, over-budget interaction", () => {
+    const messages = [1, 2, 3, 4].flatMap((i) => buildTurnWithSize(i, 40)); // 60 tokens each
+    const previousInteractions = groupMessagesIntoInteractions(messages);
+    // Floor (last 3) alone = 180, comfortably within budget. Adding interaction 1 (60 more) tips
+    // it over 230, but redacting interaction 1 alone (60 -> 44) brings it back under.
+    const pruned = prunePreviousInteractions(previousInteractions, 230, 3);
+
+    expect(isRedacted(toolResultOf(pruned, 0))).toBe(true);
+    expect(toolResultOf(pruned, 1)).toBe("result_2");
+    expect(toolResultOf(pruned, 2)).toBe("result_3");
+    expect(toolResultOf(pruned, 3)).toBe("result_4");
+  });
+
+  it("renders an already-settled old interaction identically across turns when using the same fixed budget, instead of flipping every time a new turn is appended", () => {
+    // Same scale as the batching test below: budget = PRUNING_CHECKPOINT_TOKENS, 60-token
+    // interactions. n=90 and n=91 both sit inside the same stable stretch (redaction only needed
+    // past interaction ~84, frontier doesn't move again until well past n=105), so an interaction
+    // deep in the already-redacted region (well before the frontier) must render identically
+    // whether or not the newest turn has arrived yet.
+    const toolTokens = 40;
+    const floor = 3;
+    const budget = PRUNING_CHECKPOINT_TOKENS;
+    const DEEP_INDEX = 10; // well before the frontier (~84) in both cases
+
+    const buildHistory = (n: number) =>
+      groupMessagesIntoInteractions(
+        Array.from({ length: n }, (_, i) => i + 1).flatMap((i) =>
+          buildTurnWithSize(i, toolTokens)
+        )
+      );
+
+    const prunedAtN = prunePreviousInteractions(
+      buildHistory(90),
+      budget,
+      floor
+    );
+    const prunedAtNPlus1 = prunePreviousInteractions(
+      buildHistory(91),
+      budget,
+      floor
+    );
+
+    expect(isRedacted(toolResultOf(prunedAtN, DEEP_INDEX))).toBe(true);
+    expect(toolResultOf(prunedAtNPlus1, DEEP_INDEX)).toBe(
+      toolResultOf(prunedAtN, DEEP_INDEX)
+    );
+  });
+
+  it("batches redaction across a checkpoint boundary instead of advancing on every single turn", () => {
+    // Interaction size chosen so ~83 turns fit before redaction is even needed (budget =
+    // PRUNING_CHECKPOINT_TOKENS), and then several turns' worth of growth accumulate between
+    // checkpoint crossings. This exercises the batching behavior at a realistic scale instead of
+    // tiny numbers where every eligible interaction gets redacted in one shot.
+    const toolTokens = 40; // interaction = 60 tokens
+    const floor = 3;
+    const budget = PRUNING_CHECKPOINT_TOKENS;
+
+    const frontierAt = (n: number) => {
+      const messages = Array.from({ length: n }, (_, i) => i + 1).flatMap((i) =>
+        buildTurnWithSize(i, toolTokens)
+      );
+      const previous = groupMessagesIntoInteractions(messages);
+      const pruned = prunePreviousInteractions(previous, budget, floor);
+      return pruned.findIndex((interaction) => {
+        const content = toolResultOf([interaction], 0);
+        return !isRedacted(content);
+      });
+    };
+
+    // Once redaction is needed at all (n large enough), the boundary between redacted and full
+    // interactions should stay put for a long run of consecutive turns rather than advancing on
+    // every single one. Sample a 20-turn window known to sit inside such a stable stretch for
+    // these parameters.
+    const boundaries = new Set<number>();
+    for (let n = 87; n <= 106; n++) {
+      boundaries.add(frontierAt(n));
+    }
+
+    expect(boundaries.size).toBeLessThan(5);
+  });
+
+  it("never returns interactions whose combined token count exceeds maxTokens, across a wide randomized sweep (short of the floor's own unavoidable minimum)", () => {
+    function makeRng(seed: number) {
+      let s = seed;
+      return () => {
+        s = (s * 1103515245 + 12345) & 0x7fffffff;
+        return s / 0x7fffffff;
+      };
+    }
+
+    for (let seed = 1; seed <= 2000; seed++) {
+      const rng = makeRng(seed);
+      const n = 1 + Math.floor(rng() * 15);
+      const toPreserve = 1 + Math.floor(rng() * 4);
+      const items: InteractionWithTokens[] = [];
+      for (let i = 0; i < n; i++) {
+        const roll = rng();
+        const toolTokens =
+          roll < 0.1
+            ? 20 + Math.floor(rng() * 3000)
+            : 5 + Math.floor(rng() * 150);
+        items.push({ messages: buildTurnWithSize(i, toolTokens) });
+      }
+      const maxTokens = 10 + Math.floor(rng() * 500);
+
+      const pruned = prunePreviousInteractions(items, maxTokens, toPreserve);
+      const total = pruned.reduce(
+        (sum, interaction) => sum + getInteractionTokenCount(interaction),
+        0
+      );
+
+      // The floor's own redacted-to-the-max size is the true floor of what's achievable. The
+      // function can't do better than that even in the rare out-of-room case.
+      const floorStart = Math.max(items.length - toPreserve, 0);
+      const floorMinimum = items
+        .slice(floorStart)
+        .reduce(
+          (sum, interaction) =>
+            sum + getInteractionTokenCount(pruneAllToolResults(interaction)),
+          0
+        );
+
+      expect(
+        total,
+        `seed=${seed} n=${n} toPreserve=${toPreserve} maxTokens=${maxTokens} total=${total} floorMinimum=${floorMinimum}`
+      ).toBeLessThanOrEqual(Math.max(maxTokens, floorMinimum));
+    }
+  });
+
+  it("drops already-redacted interactions entirely, oldest first, when even full redaction isn't enough", () => {
+    // 6 previous interactions, floor=3, tiny budget: even redacting everything eligible plus the
+    // floor won't fit, so the oldest, already-redacted interactions must be dropped entirely.
+    const messages = [1, 2, 3, 4, 5, 6].flatMap((i) =>
+      buildTurnWithSize(i, 90)
+    );
+    const previousInteractions = groupMessagesIntoInteractions(messages);
+    const pruned = prunePreviousInteractions(previousInteractions, 189, 3);
+
+    expect(pruned.length).toBeLessThan(previousInteractions.length);
+    const total = pruned.reduce(
+      (sum, interaction) => sum + getInteractionTokenCount(interaction),
+      0
+    );
+    // Whatever remains is at least redacted. The function did everything it could.
+    for (const interaction of pruned) {
+      expect(isRedacted(toolResultOf([interaction], 0))).toBe(true);
+    }
+    expect(total).toBeGreaterThan(0);
+  });
+});
+
+describe("prunePreviousInteractions across a growing conversation (realistic, variable-size workload)", () => {
+  // Whether each previous interaction was redacted, keyed by the interaction's OWN identity (its
+  // tool name), not its array position. Array position is not a stable identity across turns.
+  // Interactions are appended at the end, and the drop-tier can remove interactions from the
+  // start, so results from two different turns can't be compared index-by-index. The only valid
+  // comparison is "what happened to interaction N specifically?".
+  function redactionStatusById(
+    interactions: ReturnType<typeof prunePreviousInteractions>
+  ): Map<number, "redacted" | "full"> {
+    const statusById = new Map<number, "redacted" | "full">();
+    for (const interaction of interactions) {
+      const fn = interaction.messages.find((m) => m.role === "function");
+      if (!fn || fn.role !== "function") {
+        throw new Error("Expected a function message in every interaction");
+      }
+      const id = Number(fn.name.replace("tool_", ""));
+      statusById.set(id, isRedacted(fn.content) ? "redacted" : "full");
+    }
+    return statusById;
+  }
+
+  it("keeps most turns byte-stable and never un-redacts an interaction, simulating a long conversation with realistic variable tool-result sizes", () => {
+    // Deterministic pseudo-random sizes (no Math.random, so a failure is reproducible from the
+    // seed alone). Mostly small-to-medium tool results, with an occasional large one. Mirrors the
+    // real spread of interaction sizes observed in production (roughly 200 to 9000 characters per
+    // tool result).
+    let seed = 42;
+    const nextRandom = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+    const nextInteractionSizeTokens = () =>
+      nextRandom() < 0.15
+        ? 500 + Math.floor(nextRandom() * 2500) // occasional large tool result
+        : 50 + Math.floor(nextRandom() * 400); // typical tool result
+
+    const TOTAL_TURNS = 80;
+    const FLOOR = 3;
+    // Order of magnitude of a real allowedTokenCount - baseTokens: large enough that many turns
+    // of small talk fit before any redaction is needed at all, matching the real production
+    // observation that redaction is a late, occasional event, not a per-turn certainty.
+    const BUDGET = 20_000;
+
+    const interactionSizes: number[] = [];
+    let mutationTurnCount = 0;
+    let reversalCount = 0;
+    let statusAtPreviousTurn = new Map<number, "redacted" | "full">();
+
+    for (let turn = 1; turn <= TOTAL_TURNS; turn++) {
+      interactionSizes.push(nextInteractionSizeTokens());
+
+      const history = groupMessagesIntoInteractions(
+        interactionSizes.flatMap((toolTokens, i) =>
+          buildTurnWithSize(i + 1, toolTokens)
+        )
+      );
+      const statusAtThisTurn = redactionStatusById(
+        prunePreviousInteractions(history, BUDGET, FLOOR)
+      );
+
+      for (const [id, previousStatus] of statusAtPreviousTurn) {
+        // Missing from this turn's map means the interaction was dropped entirely. That's also a
+        // mutation, just never a reversal (dropped is strictly "more pruned", not less).
+        const currentStatus = statusAtThisTurn.get(id);
+        if (currentStatus !== previousStatus) {
+          mutationTurnCount++;
+          if (previousStatus === "redacted" && currentStatus === "full") {
+            reversalCount++;
+          }
+          break; // one mutated interaction is enough to mark this turn as a mutation-turn
+        }
+      }
+
+      statusAtPreviousTurn = statusAtThisTurn;
+    }
+
+    // The fixed budget plus checkpoint-anchored frontier means most turns render previous
+    // interactions byte-identically to the turn before. Mutation is the occasional exception, not,
+    // as with the old sliding-window rule, something that happens on nearly every turn.
+    expect(mutationTurnCount).toBeLessThan(TOTAL_TURNS * 0.2);
+    expect(reversalCount).toBe(0);
+  });
+});

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -203,12 +203,17 @@ export function prunePreviousInteractions(
       let effectiveFrontier = neededFrontier;
       for (let i = neededFrontier; i < floorStart; i++) {
         effectiveFrontier = i;
+        if (i === 0) {
+          // Index 0 is trivially always a checkpoint: it's the start of the conversation.
+          break;
+        }
         const bucketAtI = Math.floor(prefixSum[i] / PRUNING_CHECKPOINT_TOKENS);
-        const bucketBefore =
-          i === 0
-            ? -1
-            : Math.floor(prefixSum[i - 1] / PRUNING_CHECKPOINT_TOKENS);
-        if (bucketAtI > bucketBefore) {
+        const bucketBefore = Math.floor(
+          prefixSum[i - 1] / PRUNING_CHECKPOINT_TOKENS
+        );
+        if (bucketAtI !== bucketBefore) {
+          // We fell into a different bucket than the previous interaction, so this is a
+          // checkpoint too.
           break;
         }
       }

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -6,6 +6,12 @@ const PRUNED_TOOL_RESULT_PLACEHOLDER =
   "</dust_system>";
 const PRUNED_TOOL_RESULT_TOKENS = 24;
 
+// Batch granularity for the redaction checkpoint in prunePreviousInteractions. Same idea as the
+// `clear_at_least` setting on provider-native context-editing features. Don't invalidate a cached
+// prefix for a handful of tokens. Only redact once enough new content has accumulated to make the
+// cache-write cost worthwhile. Starting point, tune against production cache-miss metrics.
+export const PRUNING_CHECKPOINT_TOKENS = 5000;
+
 export type MessageWithTokens = ModelMessageTypeMultiActions & {
   tokenCount: number;
 };
@@ -111,40 +117,135 @@ export function progressivelyPruneInteraction(
 }
 
 /**
- * Prunes all tool results from a list of interactions, attempting to fully preserve up to n
- * interactions (starting from the last). As soon as we reach n interactions, or as soon as an
- * interaction does not fit within the token budget, we'll fully prune the remaining interactions.
+ * Prunes tool results from previous interactions to fit within maxTokens, fully preserving the
+ * last interactionsToPreserve interactions whenever the budget allows it. Guarantees the returned
+ * interactions' combined token count never exceeds maxTokens, short of interactionsToPreserve's
+ * own redacted floor alone exceeding it. That's a real out-of-room case left for the caller to
+ * handle.
+ *
+ * The redaction boundary is computed from each interaction's ORIGINAL (pre-redaction) size. That
+ * value never changes once an interaction is permanent history. It's then snapped back to the
+ * nearest checkpoint in a prefix sum computed from the start of the conversation (see
+ * PRUNING_CHECKPOINT_TOKENS). Because both of these are pure functions of immutable history plus
+ * fixed constants, the same input history always yields the same redaction decisions across calls.
+ * Those decisions only change once enough new content has accumulated to cross the next
+ * checkpoint, not on every single turn. That's what keeps the rendered previous interactions
+ * byte-stable across most turns and therefore reusable from the model provider's prompt cache.
+ * Callers relying on this stability must always pass the SAME maxTokens across turns, not one
+ * derived from a live, per-turn quantity like the current interaction's own size. See
+ * renderConversationForModel for how that's arranged.
+ *
+ * If even fully redacting everything outside the floor isn't enough, for example many old
+ * interactions whose placeholders alone add up, already-redacted interactions are dropped
+ * entirely, oldest first, up to but never into the floor. This is a rare out-of-room
+ * fallback, not routine operation.
  */
 export function prunePreviousInteractions(
   inputInteractions: InteractionWithTokens[],
   maxTokens: number,
   interactionsToPreserve: number
 ): InteractionWithTokens[] {
-  const interactions = [...inputInteractions];
+  let interactions = [...inputInteractions];
+  const n = interactions.length;
+  if (n === 0) {
+    return interactions;
+  }
 
-  let shouldPrune = false;
-  let availableTokens = maxTokens;
-  for (let i = interactions.length - 1; i >= 0; i--) {
-    // We prune if we've pruned the last interaction, or if we've reached the number of interactions
-    // to preserve.
-    shouldPrune =
-      shouldPrune || i < interactions.length - interactionsToPreserve;
+  // Original sizes are permanent. They never change once an interaction is history, regardless of
+  // how it eventually gets redacted. redactedTokens is what each interaction would cost if
+  // redacted, computed without mutating anything yet, purely to size the redaction savings.
+  const originalTokens = interactions.map((interaction) =>
+    getInteractionTokenCount(interaction)
+  );
+  const redactedTokens = interactions.map((interaction) =>
+    getInteractionTokenCount(pruneAllToolResults(interaction))
+  );
 
-    let interactionTokens = getInteractionTokenCount(interactions[i]);
-    if (interactionTokens > availableTokens) {
-      // If the interaction does not fit the context we prune it and prune all the ones after.
-      shouldPrune = true;
+  // Prefix sum from the START of the conversation. The value at a fixed index never changes
+  // across turns: it only depends on interactions that are already permanent by the time that
+  // index exists.
+  const prefixSum: number[] = [];
+  let running = 0;
+  for (const tokens of originalTokens) {
+    running += tokens;
+    prefixSum.push(running);
+  }
+
+  // The last interactionsToPreserve interactions are a hard floor: never redacted by this
+  // function, regardless of budget. (If the floor alone exceeds maxTokens, that's a real
+  // out-of-room situation handled by the caller's own downstream safety nets, not here.)
+  const floorStart = Math.max(n - interactionsToPreserve, 0);
+
+  let totalIfNothingRedacted = 0;
+  for (let i = 0; i < n; i++) {
+    totalIfNothingRedacted += originalTokens[i];
+  }
+
+  if (totalIfNothingRedacted > maxTokens) {
+    // Redact starting from the OLDEST eligible interaction forward, tracking the actual running
+    // total (not just whether original sizes would exceed budget), until it fits. This is the
+    // minimal redaction needed. Nothing above this frontier is touched.
+    let total = totalIfNothingRedacted;
+    let neededFrontier = -1;
+    for (let i = 0; i < floorStart && total > maxTokens; i++) {
+      total -= originalTokens[i] - redactedTokens[i];
+      neededFrontier = i;
     }
 
-    if (shouldPrune) {
-      // We are pruning all previous interactions. We simply prune all tool results and update the
-      // available tokens.
-      interactions[i] = pruneAllToolResults(interactions[i]);
-      interactionTokens = getInteractionTokenCount(interactions[i]);
-    }
+    if (neededFrontier >= 0) {
+      // Round the frontier FORWARD to the next checkpoint at or after neededFrontier. A checkpoint
+      // is a position where the immutable prefix sum crosses a multiple of
+      // PRUNING_CHECKPOINT_TOKENS. This deliberately redacts a bit more than strictly necessary
+      // right now, so the same boundary keeps satisfying the budget for several subsequent turns
+      // instead of creeping forward by one interaction on almost every single turn. Never extends
+      // past floorStart - 1, so the budget is still always respected even if no checkpoint is
+      // found in range.
+      let effectiveFrontier = neededFrontier;
+      for (let i = neededFrontier; i < floorStart; i++) {
+        effectiveFrontier = i;
+        const bucketAtI = Math.floor(prefixSum[i] / PRUNING_CHECKPOINT_TOKENS);
+        const bucketBefore =
+          i === 0
+            ? -1
+            : Math.floor(prefixSum[i - 1] / PRUNING_CHECKPOINT_TOKENS);
+        if (bucketAtI > bucketBefore) {
+          break;
+        }
+      }
 
-    // We update the available tokens.
-    availableTokens -= interactionTokens;
+      for (let i = 0; i <= effectiveFrontier; i++) {
+        interactions[i] = pruneAllToolResults(interactions[i]);
+      }
+    }
+  }
+
+  let totalTokens = interactions.reduce(
+    (sum, interaction) => sum + getInteractionTokenCount(interaction),
+    0
+  );
+
+  // Still over budget after the redaction pass above. Either many old, already-redacted
+  // placeholders add up, or some eligible interactions above the frontier are themselves large.
+  // Drop already-redacted-or-eligible interactions entirely, oldest first, up to but never into
+  // the floor. This is strictly less disruptive than touching the floor, so it's always tried
+  // first.
+  let dropUpToIndex = -1;
+  for (let i = 0; i < Math.min(floorStart, n) && totalTokens > maxTokens; i++) {
+    totalTokens -= getInteractionTokenCount(interactions[i]);
+    dropUpToIndex = i;
+  }
+  if (dropUpToIndex >= 0) {
+    interactions = interactions.slice(dropUpToIndex + 1);
+  }
+
+  // Absolute last resort: even with every eligible interaction dropped entirely, the floor's own
+  // real size alone still doesn't fit. Redact floor interactions too, oldest first. This only
+  // kicks in as a last resort, not routine operation, so it's fine for it to be driven by the
+  // floor's live size rather than a checkpoint.
+  for (let i = 0; i < interactions.length && totalTokens > maxTokens; i++) {
+    const before = getInteractionTokenCount(interactions[i]);
+    interactions[i] = pruneAllToolResults(interactions[i]);
+    totalTokens -= before - getInteractionTokenCount(interactions[i]);
   }
 
   return interactions;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Anthropic prompt caching was missing billions of tokens, and the root cause traced back to how we render previous interactions on every LLM call. The existing logic always redacted tool results **beyond the last three interactions** regardless of how much context budget was actually available, and a separate selection step could drop whole interactions based on how big the current turn's own new content happened to be. Both of these are driven by a moving reference point that shifts on every single turn, which means the request sent to the model changes in ways that break the cached prefix almost every time, even in conversations nowhere near their context limit.

The fix reworks pruning so previous interactions get a fixed budget claim that never depends on the size of the newest turn, and redaction is now driven by actual token pressure rather than position, with decisions snapped to periodic checkpoints so the same content survives unchanged across many consecutive turns instead of shifting each time. The current turn absorbs whatever budget is left, which is safe since it's new content that was never cached to begin with. A safety fallback still exists for the rare case where even the protected recent interactions don't fit, but it no longer fires as the everyday mechanism.

This does change behavior in one visible way worth calling out: previously, anything past the last three interactions was always stripped down regardless of how much room was left. Now that only happens when the budget genuinely requires it, so in conversations with headroom the model will see more of its own recent tool history in full than it did before.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
