### PR TITLE
toolCostCategoryMissing

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2136,6 +2136,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
+    "set_user_status": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
     "write_canvas": {
       "freeUsage": false,
       "toolCostCategory": "advanced",

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -567,6 +567,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
       running: "Setting Slack status",
       done: "Set Slack status",
     },
+    toolCostCategory: "advanced",
+    freeUsage: false,
   },
 });
 


### PR DESCRIPTION
## Description

The `set_status` tool in the Slack personal MCP server metadata was missing the required `toolCostCategory` and `freeUsage` fields. This adds `toolCostCategory: "advanced"` and `freeUsage: false` to align it with all other tools in the same server, ensuring correct AWU billing categorization at runtime.

## Tests

Verified by the existing lint/type checks that enforce these fields on all internal MCP tool definitions.

## Risk

Low — this is a one-line metadata fix. The `set_status` tool was likely defaulting to `"advanced"` / `false` already (as per the fallback in `getToolBillingInfo`), so no billing behavior changes are expected.

## Deploy Plan

Deploy front.