### PR TITLE
[marketing] Migrate Button → LegacyButton (prep for sparkle redesign)

### DIFF
--- a/marketing/components/RegionSelectionModal.tsx
+++ b/marketing/components/RegionSelectionModal.tsx
@@ -1,6 +1,6 @@
 import { useSignUpModal } from "@marketing/hooks/useSignUpModal";
 import { appendUTMParams } from "@marketing/lib/utils/utm";
-import { Button, Check, cn } from "@dust-tt/sparkle";
+import { LegacyButton as Button, Check, cn } from "@dust-tt/sparkle";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { useState } from "react";
 

--- a/marketing/components/UTMButton.tsx
+++ b/marketing/components/UTMButton.tsx
@@ -2,7 +2,7 @@
 
 import { appendUTMParams } from "@marketing/lib/utils/utm";
 import type { RegularButtonProps } from "@dust-tt/sparkle";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 
 interface UTMButtonProps extends Omit<RegularButtonProps, "href"> {
   href?: string;

--- a/marketing/components/academy/AcademyComponents.tsx
+++ b/marketing/components/academy/AcademyComponents.tsx
@@ -14,7 +14,13 @@ import {
   ACADEMY_LOCALES,
 } from "@marketing/lib/contentful/types";
 import { LinkWrapper, useAppRouter } from "@marketing/lib/platform";
-import { Button, cn, Eye, SearchInput, Tooltip } from "@dust-tt/sparkle";
+import {
+  LegacyButton as Button,
+  cn,
+  Eye,
+  SearchInput,
+  Tooltip,
+} from "@dust-tt/sparkle";
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 

--- a/marketing/components/blog/BlogComponents.tsx
+++ b/marketing/components/blog/BlogComponents.tsx
@@ -6,7 +6,7 @@ import {
   classNames,
   formatTimestampToFriendlyDate,
 } from "@marketing/lib/utils";
-import { Button, Chip, LinkWrapper } from "@dust-tt/sparkle";
+import { LegacyButton as Button, Chip, LinkWrapper } from "@dust-tt/sparkle";
 import Image from "next/image";
 
 export const BLOG_PAGE_SIZE = 12;

--- a/marketing/components/contentful/richTextRenderer.tsx
+++ b/marketing/components/contentful/richTextRenderer.tsx
@@ -24,7 +24,7 @@ import type {
   Text,
 } from "@contentful/rich-text-types";
 import { BLOCKS, INLINES, MARKS } from "@contentful/rich-text-types";
-import { Button, cn } from "@dust-tt/sparkle";
+import { LegacyButton as Button, cn } from "@dust-tt/sparkle";
 import Image from "next/image";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";

--- a/marketing/components/home/Carousel.tsx
+++ b/marketing/components/home/Carousel.tsx
@@ -1,6 +1,10 @@
 import { classNames } from "@marketing/lib/utils";
 import type { RegularButtonProps } from "@dust-tt/sparkle";
-import { Button, ChevronLeft, ChevronRight } from "@dust-tt/sparkle";
+import {
+  LegacyButton as Button,
+  ChevronLeft,
+  ChevronRight,
+} from "@dust-tt/sparkle";
 import type { UseEmblaCarouselType } from "embla-carousel-react";
 import useEmblaCarousel from "embla-carousel-react";
 import * as React from "react";

--- a/marketing/components/home/EbookForm.tsx
+++ b/marketing/components/home/EbookForm.tsx
@@ -9,7 +9,13 @@ import { clientFetch } from "@marketing/lib/egress/client";
 import { useGeolocation } from "@marketing/lib/swr/geo";
 import { getStoredUTMParams } from "@marketing/lib/utils/utm";
 import { normalizeError } from "@marketing/types/shared/utils/error_utils";
-import { Button, Checkbox, Input, Label, Spinner } from "@dust-tt/sparkle";
+import {
+  LegacyButton as Button,
+  Checkbox,
+  Input,
+  Label,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState } from "react";
 import { useController, useForm } from "react-hook-form";

--- a/marketing/components/home/FunctionCard.tsx
+++ b/marketing/components/home/FunctionCard.tsx
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { H3 } from "@marketing/components/home/ContentComponents";
-import { Button, ChevronRight, Icon } from "@dust-tt/sparkle";
+import { LegacyButton as Button, ChevronRight, Icon } from "@dust-tt/sparkle";
 import { cva } from "class-variance-authority";
 import Link from "next/link";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`

--- a/marketing/components/home/LandingLayout.tsx
+++ b/marketing/components/home/LandingLayout.tsx
@@ -26,7 +26,7 @@ import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames, getFaviconPath } from "@marketing/lib/utils";
 import { getOrCreateAnonymousId } from "@marketing/lib/utils/anonymous_id";
 import { appendUTMParams } from "@marketing/lib/utils/utm";
-import { Button, cn } from "@dust-tt/sparkle";
+import { LegacyButton as Button, cn } from "@dust-tt/sparkle";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import Script from "next/script";

--- a/marketing/components/home/OpenDustButton.tsx
+++ b/marketing/components/home/OpenDustButton.tsx
@@ -3,7 +3,7 @@ import { DUST_HAS_SESSION, hasSessionIndicator } from "@marketing/lib/cookies";
 import { useLandingAuthContext } from "@marketing/lib/swr/website";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { appendUTMParams } from "@marketing/lib/utils/utm";
-import { ArrowRight, Button } from "@dust-tt/sparkle";
+import { ArrowRight, LegacyButton as Button } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 

--- a/marketing/components/home/TrustedBy.tsx
+++ b/marketing/components/home/TrustedBy.tsx
@@ -5,7 +5,7 @@ import { isEUCountry } from "@marketing/lib/geo/eu-detection";
 import { useGeolocation } from "@marketing/lib/swr/geo";
 import { TRACKING_AREAS, trackEvent } from "@marketing/lib/tracking";
 import { useSignUpModal } from "@marketing/hooks/useSignUpModal";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";

--- a/marketing/components/home/content/ChatGptEnterprise/ChatGptEnterpriseHeroSection.tsx
+++ b/marketing/components/home/content/ChatGptEnterprise/ChatGptEnterpriseHeroSection.tsx
@@ -1,7 +1,7 @@
 // biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { appendUTMParams } from "@marketing/lib/utils/utm";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import { motion } from "framer-motion";
 import Image from "next/image";
 import type { ReactNode } from "react";

--- a/marketing/components/home/content/Competitor/FinalCTASection.tsx
+++ b/marketing/components/home/content/Competitor/FinalCTASection.tsx
@@ -4,7 +4,7 @@ import {
   P,
 } from "@marketing/components/home/ContentComponents";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
-import { Button, Rocket02 } from "@dust-tt/sparkle";
+import { LegacyButton as Button, Rocket02 } from "@dust-tt/sparkle";
 
 import type { FinalCTAConfig } from "./types";
 

--- a/marketing/components/home/content/Glean/GleanHeroSection.tsx
+++ b/marketing/components/home/content/Glean/GleanHeroSection.tsx
@@ -1,7 +1,7 @@
 // biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { appendUTMParams } from "@marketing/lib/utils/utm";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import { motion } from "framer-motion";
 import Image from "next/image";
 import type { ReactNode } from "react";

--- a/marketing/components/home/content/Industry/IndustryTemplate.tsx
+++ b/marketing/components/home/content/Industry/IndustryTemplate.tsx
@@ -16,7 +16,7 @@ import TrustedBy from "@marketing/components/home/TrustedBy";
 import { useAppRouter } from "@marketing/lib/platform";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button, Chip } from "@dust-tt/sparkle";
+import { LegacyButton as Button, Chip } from "@dust-tt/sparkle";
 import Link from "next/link";
 import type { ReactElement } from "react";
 

--- a/marketing/components/home/content/Landing/LandingEmailSignup.tsx
+++ b/marketing/components/home/content/Landing/LandingEmailSignup.tsx
@@ -4,7 +4,13 @@ import { useEnrichmentSubmit } from "@marketing/components/home/content/Landing/
 import { DUST_HAS_SESSION, hasSessionIndicator } from "@marketing/lib/cookies";
 import type { TrackingArea } from "@marketing/lib/tracking";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
-import { ArrowRight, Button, cn, Icon, Spinner } from "@dust-tt/sparkle";
+import {
+  ArrowRight,
+  LegacyButton as Button,
+  cn,
+  Icon,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";

--- a/marketing/components/home/content/Product/HeroOfficeSection.tsx
+++ b/marketing/components/home/content/Product/HeroOfficeSection.tsx
@@ -6,7 +6,7 @@ import { mountFloorScene } from "@marketing/components/home/content/Product/hero
 import type { TeamMember } from "@marketing/components/home/content/shared/team";
 import { useSignUpModal } from "@marketing/hooks/useSignUpModal";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useEffect, useRef } from "react";
 

--- a/marketing/components/home/content/Product/HomeAIOperatorsCTASection.tsx
+++ b/marketing/components/home/content/Product/HomeAIOperatorsCTASection.tsx
@@ -2,7 +2,7 @@
 import { HomeReveal } from "@marketing/components/home/content/Product/HomeReveal";
 import { useSignUpModal } from "@marketing/hooks/useSignUpModal";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 
 type CTAStatAccent = "blue" | "golden" | "green";

--- a/marketing/components/home/content/Product/JustUseDustSection.tsx
+++ b/marketing/components/home/content/Product/JustUseDustSection.tsx
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { H2 } from "@marketing/components/home/ContentComponents";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 
 export function JustUseDustSection() {

--- a/marketing/components/home/content/Product/PlatformIntroSection.tsx
+++ b/marketing/components/home/content/Product/PlatformIntroSection.tsx
@@ -1,6 +1,6 @@
 import { H1, P } from "@marketing/components/home/ContentComponents";
 import { classNames } from "@marketing/lib/utils";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 
 export function PlatformIntroSection() {
   return (

--- a/marketing/components/home/content/Product/ProductIntroSection.tsx
+++ b/marketing/components/home/content/Product/ProductIntroSection.tsx
@@ -2,7 +2,7 @@
 import { H1, P } from "@marketing/components/home/ContentComponents";
 import { HeroVisual } from "@marketing/components/home/content/Product/HeroVisual";
 import TrustedBy from "@marketing/components/home/TrustedBy";
-import { Button, Rocket02 } from "@dust-tt/sparkle";
+import { LegacyButton as Button, Rocket02 } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useState } from "react";
 

--- a/marketing/components/home/content/Solutions/HeroSection.tsx
+++ b/marketing/components/home/content/Solutions/HeroSection.tsx
@@ -1,7 +1,12 @@
 // biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { Grid, H1, H3, P } from "@marketing/components/home/ContentComponents";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
-import { Button, Div3D, Hover3D, Rocket02 } from "@dust-tt/sparkle";
+import {
+  LegacyButton as Button,
+  Div3D,
+  Hover3D,
+  Rocket02,
+} from "@dust-tt/sparkle";
 import Link from "next/link";
 import type { FC } from "react";
 

--- a/marketing/components/home/content/SqAgent/SqCtaSection.tsx
+++ b/marketing/components/home/content/SqAgent/SqCtaSection.tsx
@@ -1,6 +1,6 @@
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { appendUTMParams } from "@marketing/lib/utils/utm";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 
 interface SqCtaSectionProps {
   title: string;

--- a/marketing/components/pages/CustomErrorPage.tsx
+++ b/marketing/components/pages/CustomErrorPage.tsx
@@ -1,5 +1,5 @@
 import { LinkWrapper } from "@marketing/lib/platform";
-import { AlertCircle, Button, Icon } from "@dust-tt/sparkle";
+import { AlertCircle, LegacyButton as Button, Icon } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
 interface CustomErrorPageProps {

--- a/marketing/pages/home/api-pricing.tsx
+++ b/marketing/pages/home/api-pricing.tsx
@@ -13,7 +13,7 @@ import {
   MODEL_PROVIDER_IDS,
 } from "@marketing/types/assistant/models/providers";
 import type { ModelProviderIdType } from "@marketing/types/assistant/models/types";
-import { Button, SearchInput } from "@dust-tt/sparkle";
+import { LegacyButton as Button, SearchInput } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`

--- a/marketing/pages/home/brand-resources.tsx
+++ b/marketing/pages/home/brand-resources.tsx
@@ -8,7 +8,7 @@ import {
 import type { LandingLayoutProps } from "@marketing/components/home/LandingLayout";
 import LandingLayout from "@marketing/components/home/LandingLayout";
 import { PageMetadata } from "@marketing/components/home/PageMetadata";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 

--- a/marketing/pages/home/frames.tsx
+++ b/marketing/pages/home/frames.tsx
@@ -13,7 +13,13 @@ import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import TrustedBy from "@marketing/components/home/TrustedBy";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button, CheckCircle, Icon, Lock01, Planet } from "@dust-tt/sparkle";
+import {
+  LegacyButton as Button,
+  CheckCircle,
+  Icon,
+  Lock01,
+  Planet,
+} from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 

--- a/marketing/pages/home/landing-security.tsx
+++ b/marketing/pages/home/landing-security.tsx
@@ -11,7 +11,7 @@ import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import { HomeTrustedMarqueeCompact } from "@marketing/components/home/content/Product/HomeTrustedSection";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { cn } from "@marketing/components/poke/shadcn/lib/utils";
-import { ArrowRight, Button, Icon } from "@dust-tt/sparkle";
+import { ArrowRight, LegacyButton as Button, Icon } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement, ReactNode } from "react";

--- a/marketing/pages/home/partner.tsx
+++ b/marketing/pages/home/partner.tsx
@@ -11,7 +11,7 @@ import {
   PartnerIdealPartners,
   PartnerSocialProof,
 } from "@marketing/components/home/PartnerHero";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import type { GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/marketing/pages/home/security.tsx
+++ b/marketing/pages/home/security.tsx
@@ -10,7 +10,12 @@ import type { LandingLayoutProps } from "@marketing/components/home/LandingLayou
 import LandingLayout from "@marketing/components/home/LandingLayout";
 import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import { classNames } from "@marketing/lib/utils";
-import { ArrowRight, Button, Div3D, Hover3D } from "@dust-tt/sparkle";
+import {
+  ArrowRight,
+  LegacyButton as Button,
+  Div3D,
+  Hover3D,
+} from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 

--- a/marketing/pages/home/slack/slack-integration.tsx
+++ b/marketing/pages/home/slack/slack-integration.tsx
@@ -13,7 +13,7 @@ import LandingLayout from "@marketing/components/home/LandingLayout";
 import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import TrustedBy from "@marketing/components/home/TrustedBy";
 import { classNames } from "@marketing/lib/utils";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import type { ReactElement, ReactNode } from "react";
 

--- a/marketing/pages/home/solutions/customer-support.tsx
+++ b/marketing/pages/home/solutions/customer-support.tsx
@@ -24,7 +24,7 @@ import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import TrustedBy from "@marketing/components/home/TrustedBy";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/marketing/pages/home/solutions/data-analytics.tsx
+++ b/marketing/pages/home/solutions/data-analytics.tsx
@@ -20,7 +20,7 @@ import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import TrustedBy from "@marketing/components/home/TrustedBy";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/marketing/pages/home/solutions/dust-platform.tsx
+++ b/marketing/pages/home/solutions/dust-platform.tsx
@@ -12,7 +12,12 @@ import LandingLayout from "@marketing/components/home/LandingLayout";
 import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button, Div3D, Hover3D, Rocket02 } from "@dust-tt/sparkle";
+import {
+  LegacyButton as Button,
+  Div3D,
+  Hover3D,
+  Rocket02,
+} from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/marketing/pages/home/solutions/engineering.tsx
+++ b/marketing/pages/home/solutions/engineering.tsx
@@ -24,7 +24,7 @@ import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import TrustedBy from "@marketing/components/home/TrustedBy";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/marketing/pages/home/solutions/it.tsx
+++ b/marketing/pages/home/solutions/it.tsx
@@ -22,7 +22,7 @@ import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import TrustedBy from "@marketing/components/home/TrustedBy";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/marketing/pages/home/solutions/knowledge.tsx
+++ b/marketing/pages/home/solutions/knowledge.tsx
@@ -24,7 +24,7 @@ import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import TrustedBy from "@marketing/components/home/TrustedBy";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/marketing/pages/home/solutions/legal.tsx
+++ b/marketing/pages/home/solutions/legal.tsx
@@ -24,7 +24,7 @@ import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import TrustedBy from "@marketing/components/home/TrustedBy";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/marketing/pages/home/solutions/marketing.tsx
+++ b/marketing/pages/home/solutions/marketing.tsx
@@ -24,7 +24,7 @@ import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import TrustedBy from "@marketing/components/home/TrustedBy";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/marketing/pages/home/solutions/productivity.tsx
+++ b/marketing/pages/home/solutions/productivity.tsx
@@ -24,7 +24,7 @@ import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import TrustedBy from "@marketing/components/home/TrustedBy";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/marketing/pages/home/solutions/recruiting-people.tsx
+++ b/marketing/pages/home/solutions/recruiting-people.tsx
@@ -24,7 +24,7 @@ import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import TrustedBy from "@marketing/components/home/TrustedBy";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/marketing/pages/home/solutions/sales.tsx
+++ b/marketing/pages/home/solutions/sales.tsx
@@ -26,7 +26,7 @@ import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import TrustedBy from "@marketing/components/home/TrustedBy";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { classNames } from "@marketing/lib/utils";
-import { Button } from "@dust-tt/sparkle";
+import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/marketing/pages/home/vulnerability.tsx
+++ b/marketing/pages/home/vulnerability.tsx
@@ -9,7 +9,7 @@ import type { LandingLayoutProps } from "@marketing/components/home/LandingLayou
 import LandingLayout from "@marketing/components/home/LandingLayout";
 import { PageMetadata } from "@marketing/components/home/PageMetadata";
 import { classNames } from "@marketing/lib/utils";
-import { ArrowRight, Button } from "@dust-tt/sparkle";
+import { ArrowRight, LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";


### PR DESCRIPTION
## Summary

- Replaces all `Button` imports from `@dust-tt/sparkle` with `LegacyButton as Button` across the marketing site (43 files)
- No visual change — `LegacyButton` is the exact same component
- Prepares marketing to be safely decoupled from the new `NewButton` redesign

## Merge order


## Test plan

- [ ] Verify marketing site builds without errors after sparkle publish
- [ ] No visual regression on any marketing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)