### PR TITLE
Pricing: usage page credits reset date from the workspace billing period

### DIFF
--- a/front-api/routes/w/[wId]/credits/members-usage.test.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.test.ts
@@ -40,10 +40,13 @@ const MEMBER_USAGE = {
   spendLimitWarningAlertId: null,
 };
 
+const CREDITS_RESET_AT = "2026-08-01T00:00:00.000Z";
+
 beforeEach(() => {
   vi.mocked(membersUsage.getMembersUsage).mockResolvedValue({
     members: [MEMBER_USAGE],
     total: 1,
+    creditsResetAt: CREDITS_RESET_AT,
   });
 });
 
@@ -73,6 +76,7 @@ describe("GET /api/w/[wId]/credits/members-usage", () => {
     expect(await response.json()).toEqual({
       members: [MEMBER_USAGE],
       total: 1,
+      creditsResetAt: CREDITS_RESET_AT,
     });
     expect(membersUsage.getMembersUsage).toHaveBeenCalled();
   });
@@ -89,6 +93,7 @@ describe("GET /api/w/[wId]/credits/members-usage", () => {
     expect(await response.json()).toEqual({
       members: [MEMBER_USAGE],
       total: 1,
+      creditsResetAt: CREDITS_RESET_AT,
     });
   });
 });

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -450,6 +450,7 @@ export function UsagePage() {
 
   const {
     membersUsage,
+    creditsResetAt,
     isMembersUsageLoading,
     isMembersUsageRefreshing,
     totalMembersUsage,
@@ -915,6 +916,7 @@ export function UsagePage() {
   const membersTable = (
     <MembersUsageTable
       members={membersUsage}
+      creditsResetAt={creditsResetAt}
       isLoading={isMembersUsageLoading}
       isRefreshing={isMembersUsageRefreshing}
       readOnly={isReadOnly}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -607,6 +607,9 @@ function buildColumns({
 
 interface MembersUsageTableProps {
   members: MemberUsageType[];
+  // End of the current billing period (workspace-level, from the members-usage
+  // response) shown under the credits column header. Null hides the line.
+  creditsResetAt: string | null;
   isLoading: boolean;
   isRefreshing?: boolean;
   totalAllowedUsagePendingMemberIds: ReadonlySet<string>;
@@ -640,6 +643,7 @@ interface MembersUsageTableProps {
 
 export function MembersUsageTable({
   members,
+  creditsResetAt,
   isLoading,
   isRefreshing = false,
   totalAllowedUsagePendingMemberIds,
@@ -789,15 +793,6 @@ export function MembersUsageTable({
       onEditSpendLimit,
       onEditAdvancedModels,
     ]
-  );
-
-  // All paid seats share the workspace billing period, so the first member
-  // carrying a reset date is enough to label the column header.
-  const creditsResetAt = useMemo(
-    () =>
-      members.find((m) => m.nextCreditResetAt !== null)?.nextCreditResetAt ??
-      null,
-    [members]
   );
 
   const columns = useMemo(

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -134,6 +134,10 @@ export type MemberUsageType = {
 export type GetMembersUsageResponseBody = {
   members: MemberUsageType[];
   total: number;
+  // ISO end of the current billing period: when per-seat credits next reset.
+  // Optional for backward compatibility.
+  // null when Metronome is not configured or the period cannot be resolved.
+  creditsResetAt: string | null;
 };
 
 // Workspace seats have a zero AWU allocation, so `buildSeatDataByUserId` skips
@@ -196,6 +200,26 @@ type ConsumedCreditsBucket = {
 type ConsumedCreditsAggs = {
   by_user?: estypes.AggregationsMultiBucketAggregateBase<ConsumedCreditsBucket>;
 };
+
+// End of the workspace's current billing period — the instant per-seat credits
+// next reset. Reads the same cached period `fetchConsumedAwuCreditsByUserId`
+// scopes the consumed totals to, so the two always agree. Null when Metronome
+// is not set up for the workspace or the period cannot be resolved.
+async function fetchCreditsResetAt(
+  workspace: LightWorkspaceType
+): Promise<string | null> {
+  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+    workspace.sId
+  );
+  if (periodResult.isErr()) {
+    logger.warn(
+      { err: periodResult.error, workspaceId: workspace.sId },
+      "[MembersUsage] Failed to resolve billing period for credits reset date"
+    );
+    return null;
+  }
+  return periodResult.value?.cycleEnd.toISOString() ?? null;
+}
 
 // Per-user consumed AWU credits for the current billing cycle, summed from the
 // analytics index (`cost.full_awu`, precomputed at index time) by Elasticsearch.
@@ -1218,6 +1242,10 @@ export async function getMembersUsage({
   const { metronomeCustomerId } = workspace;
   const metronomeContractId = subscription?.metronomeContractId ?? null;
 
+  // Resolved up front (Redis-cached) so even empty pages carry the reset date
+  // for the table header.
+  const creditsResetAt = await fetchCreditsResetAt(workspace);
+
   // When a seat-type and/or group filter is active, resolve the matching user
   // sIds up front and restrict the search to their intersection, so pagination
   // and the returned `total` reflect the filtered set. No match (in any active
@@ -1229,7 +1257,7 @@ export async function getMembersUsage({
     groupId: paginationParams.groupId,
   });
   if (restrictToUserIds !== undefined && restrictToUserIds.length === 0) {
-    return { members: [], total: 0 };
+    return { members: [], total: 0, creditsResetAt };
   }
 
   const usersResult = await resolveMembersUsagePageUsers({
@@ -1240,13 +1268,13 @@ export async function getMembersUsage({
   });
 
   if (usersResult.isErr()) {
-    return { members: [], total: 0 };
+    return { members: [], total: 0, creditsResetAt };
   }
 
   const { users, total } = usersResult.value;
 
   if (users.length === 0) {
-    return { members: [], total };
+    return { members: [], total, creditsResetAt };
   }
 
   // The workspace-wide default pool cap lives on the credit-usage
@@ -1510,5 +1538,6 @@ export async function getMembersUsage({
   return {
     members: membersUsage,
     total,
+    creditsResetAt,
   };
 }

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -505,6 +505,7 @@ export function useMembersUsage({
 
   return {
     membersUsage: data?.members ?? emptyArray(),
+    creditsResetAt: data?.creditsResetAt ?? null,
     isMembersUsageLoading: !error && !data && !disabled,
     isMembersUsageRefreshing: isLoading && !!data && !disabled,
     isMembersUsageError: !!error,


### PR DESCRIPTION
## Description

Rely on server side rendering of the period end for credits instead of taking the period of a random user.

THe way we compute this period will evolve in follow up PR: https://github.com/dust-tt/dust/pull/28757

Follow-up (stacked): fix how the billing period itself is computed for contracts where the first subscription is annual.

## Tests


## Risk

Low: additive response field; header falls back to hidden when null.

## Deploy plan

Deploy front