### PR TITLE
Pricing: compute the billing period from the contract anniversary day

### DIFF
--- a/front-api/routes/w/[wId]/credits/members-usage.test.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.test.ts
@@ -40,10 +40,13 @@ const MEMBER_USAGE = {
   spendLimitWarningAlertId: null,
 };
 
+const CREDITS_RESET_AT = "2026-08-01T00:00:00.000Z";
+
 beforeEach(() => {
   vi.mocked(membersUsage.getMembersUsage).mockResolvedValue({
     members: [MEMBER_USAGE],
     total: 1,
+    creditsResetAt: CREDITS_RESET_AT,
   });
 });
 
@@ -73,6 +76,7 @@ describe("GET /api/w/[wId]/credits/members-usage", () => {
     expect(await response.json()).toEqual({
       members: [MEMBER_USAGE],
       total: 1,
+      creditsResetAt: CREDITS_RESET_AT,
     });
     expect(membersUsage.getMembersUsage).toHaveBeenCalled();
   });
@@ -89,6 +93,7 @@ describe("GET /api/w/[wId]/credits/members-usage", () => {
     expect(await response.json()).toEqual({
       members: [MEMBER_USAGE],
       total: 1,
+      creditsResetAt: CREDITS_RESET_AT,
     });
   });
 });

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -450,6 +450,7 @@ export function UsagePage() {
 
   const {
     membersUsage,
+    creditsResetAt,
     isMembersUsageLoading,
     isMembersUsageRefreshing,
     totalMembersUsage,
@@ -915,6 +916,7 @@ export function UsagePage() {
   const membersTable = (
     <MembersUsageTable
       members={membersUsage}
+      creditsResetAt={creditsResetAt}
       isLoading={isMembersUsageLoading}
       isRefreshing={isMembersUsageRefreshing}
       readOnly={isReadOnly}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -607,6 +607,9 @@ function buildColumns({
 
 interface MembersUsageTableProps {
   members: MemberUsageType[];
+  // End of the current billing period (workspace-level, from the members-usage
+  // response) shown under the credits column header. Null hides the line.
+  creditsResetAt: string | null;
   isLoading: boolean;
   isRefreshing?: boolean;
   totalAllowedUsagePendingMemberIds: ReadonlySet<string>;
@@ -640,6 +643,7 @@ interface MembersUsageTableProps {
 
 export function MembersUsageTable({
   members,
+  creditsResetAt,
   isLoading,
   isRefreshing = false,
   totalAllowedUsagePendingMemberIds,
@@ -789,15 +793,6 @@ export function MembersUsageTable({
       onEditSpendLimit,
       onEditAdvancedModels,
     ]
-  );
-
-  // All paid seats share the workspace billing period, so the first member
-  // carrying a reset date is enough to label the column header.
-  const creditsResetAt = useMemo(
-    () =>
-      members.find((m) => m.nextCreditResetAt !== null)?.nextCreditResetAt ??
-      null,
-    [members]
   );
 
   const columns = useMemo(

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -134,6 +134,10 @@ export type MemberUsageType = {
 export type GetMembersUsageResponseBody = {
   members: MemberUsageType[];
   total: number;
+  // ISO end of the current billing period: when per-seat credits next reset.
+  // Optional for backward compatibility.
+  // null when Metronome is not configured or the period cannot be resolved.
+  creditsResetAt: string | null;
 };
 
 // Workspace seats have a zero AWU allocation, so `buildSeatDataByUserId` skips
@@ -196,6 +200,26 @@ type ConsumedCreditsBucket = {
 type ConsumedCreditsAggs = {
   by_user?: estypes.AggregationsMultiBucketAggregateBase<ConsumedCreditsBucket>;
 };
+
+// End of the workspace's current billing period — the instant per-seat credits
+// next reset. Reads the same cached period `fetchConsumedAwuCreditsByUserId`
+// scopes the consumed totals to, so the two always agree. Null when Metronome
+// is not set up for the workspace or the period cannot be resolved.
+async function fetchCreditsResetAt(
+  workspace: LightWorkspaceType
+): Promise<string | null> {
+  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+    workspace.sId
+  );
+  if (periodResult.isErr()) {
+    logger.warn(
+      { err: periodResult.error, workspaceId: workspace.sId },
+      "[MembersUsage] Failed to resolve billing period for credits reset date"
+    );
+    return null;
+  }
+  return periodResult.value?.cycleEnd.toISOString() ?? null;
+}
 
 // Per-user consumed AWU credits for the current billing cycle, summed from the
 // analytics index (`cost.full_awu`, precomputed at index time) by Elasticsearch.
@@ -1218,6 +1242,10 @@ export async function getMembersUsage({
   const { metronomeCustomerId } = workspace;
   const metronomeContractId = subscription?.metronomeContractId ?? null;
 
+  // Resolved up front (Redis-cached) so even empty pages carry the reset date
+  // for the table header.
+  const creditsResetAt = await fetchCreditsResetAt(workspace);
+
   // When a seat-type and/or group filter is active, resolve the matching user
   // sIds up front and restrict the search to their intersection, so pagination
   // and the returned `total` reflect the filtered set. No match (in any active
@@ -1229,7 +1257,7 @@ export async function getMembersUsage({
     groupId: paginationParams.groupId,
   });
   if (restrictToUserIds !== undefined && restrictToUserIds.length === 0) {
-    return { members: [], total: 0 };
+    return { members: [], total: 0, creditsResetAt };
   }
 
   const usersResult = await resolveMembersUsagePageUsers({
@@ -1240,13 +1268,13 @@ export async function getMembersUsage({
   });
 
   if (usersResult.isErr()) {
-    return { members: [], total: 0 };
+    return { members: [], total: 0, creditsResetAt };
   }
 
   const { users, total } = usersResult.value;
 
   if (users.length === 0) {
-    return { members: [], total };
+    return { members: [], total, creditsResetAt };
   }
 
   // The workspace-wide default pool cap lives on the credit-usage
@@ -1510,5 +1538,6 @@ export async function getMembersUsage({
   return {
     members: membersUsage,
     total,
+    creditsResetAt,
   };
 }

--- a/front/lib/client/subscription.test.ts
+++ b/front/lib/client/subscription.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getBillingCycle, getBillingCycleFromDay } from "./subscription";
+import {
+  clampToMonth,
+  getBillingCycle,
+  getBillingCycleFromDay,
+} from "./subscription";
 
 describe("subscription billing cycle utilities", () => {
   describe("getBillingCycleFromDay", () => {
@@ -102,15 +106,50 @@ describe("subscription billing cycle utilities", () => {
     });
 
     describe("edge case: billing day at end of month (28-31)", () => {
-      it("handles billing day 31 in months with fewer days", () => {
+      it("clamps the boundary to the last day of shorter months", () => {
         // Feb 15, 2026 (Feb has 28 days), billing starts on day 31
         const referenceDate = new Date(Date.UTC(2026, 1, 15, 12, 0, 0));
         const result = getBillingCycleFromDay(31, referenceDate, true);
 
-        // JavaScript Date handles overflow - Feb 31 becomes Mar 3
-        // This is existing behavior we're documenting
-        expect(result.cycleStart.getUTCMonth()).toBe(0); // January
-        expect(result.cycleEnd.getUTCMonth()).toBe(2); // March (Feb 31 overflows)
+        expect(result.cycleStart.toISOString()).toBe(
+          "2026-01-31T00:00:00.000Z"
+        );
+        expect(result.cycleEnd.toISOString()).toBe("2026-02-28T00:00:00.000Z");
+      });
+
+      it("selects the cycle containing the reference date right after a clamped boundary (Jan 31 anchor, March 2)", () => {
+        // Anchor on the 31st; on March 2 the current cycle started on the
+        // clamped Feb 28 boundary, not on Jan 31 — and it ends on Mar 31.
+        const referenceDate = new Date(Date.UTC(2026, 2, 2, 12, 0, 0));
+        const result = getBillingCycleFromDay(31, referenceDate, true);
+
+        expect(result.cycleStart.toISOString()).toBe(
+          "2026-02-28T00:00:00.000Z"
+        );
+        expect(result.cycleEnd.toISOString()).toBe("2026-03-31T00:00:00.000Z");
+      });
+
+      it("starts a new cycle on the clamped boundary day itself", () => {
+        // Feb 28, 2026, billing day 31: the Feb boundary clamps to Feb 28, so
+        // a new cycle starts that day.
+        const referenceDate = new Date(Date.UTC(2026, 1, 28, 12, 0, 0));
+        const result = getBillingCycleFromDay(31, referenceDate, true);
+
+        expect(result.cycleStart.toISOString()).toBe(
+          "2026-02-28T00:00:00.000Z"
+        );
+        expect(result.cycleEnd.toISOString()).toBe("2026-03-31T00:00:00.000Z");
+      });
+
+      it("keeps day 31 boundaries in 31-day months", () => {
+        // Mar 31, 2026, billing day 31: cycle runs Mar 31 → Apr 30 (clamped).
+        const referenceDate = new Date(Date.UTC(2026, 2, 31, 12, 0, 0));
+        const result = getBillingCycleFromDay(31, referenceDate, true);
+
+        expect(result.cycleStart.toISOString()).toBe(
+          "2026-03-31T00:00:00.000Z"
+        );
+        expect(result.cycleEnd.toISOString()).toBe("2026-04-30T00:00:00.000Z");
       });
     });
 
@@ -168,6 +207,27 @@ describe("subscription billing cycle utilities", () => {
         expect(utcResult.cycleStart.getUTCDate()).toBe(10);
         // Local result uses local methods, but at noon UTC most places see same day
       });
+    });
+  });
+
+  describe("clampToMonth", () => {
+    it("returns the date unchanged when it is in the expected month", () => {
+      const date = new Date(Date.UTC(2026, 1, 15));
+      expect(clampToMonth(date, 1, true)).toBe(date);
+    });
+
+    it("clamps an overflowed date back to the last day of the expected month", () => {
+      // Feb 31, 2026 overflows to Mar 3; expected month is February.
+      const overflowed = new Date(Date.UTC(2026, 1, 31));
+      const result = clampToMonth(overflowed, 1, true);
+      expect(result.toISOString()).toBe("2026-02-28T00:00:00.000Z");
+    });
+
+    it("normalizes out-of-range month indices", () => {
+      // Month index 13 = February of the following year.
+      const overflowed = new Date(Date.UTC(2026, 13, 31));
+      const result = clampToMonth(overflowed, 13, true);
+      expect(result.toISOString()).toBe("2027-02-28T00:00:00.000Z");
     });
   });
 

--- a/front/lib/client/subscription.test.ts
+++ b/front/lib/client/subscription.test.ts
@@ -141,6 +141,30 @@ describe("subscription billing cycle utilities", () => {
         expect(result.cycleEnd.toISOString()).toBe("2026-03-31T00:00:00.000Z");
       });
 
+      it("keeps the anchor time-of-day on boundaries, including clamped ones", () => {
+        // Anchor: day 31 at 14:00 UTC (hour-aligned contract start).
+        const anchor = new Date(Date.UTC(2026, 0, 31, 14, 0, 0));
+        const referenceDate = new Date(Date.UTC(2026, 2, 2, 12, 0, 0));
+        const result = getBillingCycleFromDay(31, referenceDate, true, anchor);
+
+        expect(result.cycleStart.toISOString()).toBe(
+          "2026-02-28T14:00:00.000Z"
+        );
+        expect(result.cycleEnd.toISOString()).toBe("2026-03-31T14:00:00.000Z");
+      });
+
+      it("keeps a reference before the anchor hour on the boundary day in the previous cycle", () => {
+        // Feb 4 at 09:00, boundary at 14:00: the new cycle hasn't started yet.
+        const anchor = new Date(Date.UTC(2026, 0, 4, 14, 0, 0));
+        const referenceDate = new Date(Date.UTC(2026, 1, 4, 9, 0, 0));
+        const result = getBillingCycleFromDay(4, referenceDate, true, anchor);
+
+        expect(result.cycleStart.toISOString()).toBe(
+          "2026-01-04T14:00:00.000Z"
+        );
+        expect(result.cycleEnd.toISOString()).toBe("2026-02-04T14:00:00.000Z");
+      });
+
       it("keeps day 31 boundaries in 31-day months", () => {
         // Mar 31, 2026, billing day 31: cycle runs Mar 31 → Apr 30 (clamped).
         const referenceDate = new Date(Date.UTC(2026, 2, 31, 12, 0, 0));

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -96,9 +96,32 @@ export interface BillingCycle {
 }
 
 /**
+ * A calendar day beyond the target month's length overflows into the next
+ * month when constructing a Date (e.g. Feb 31 → Mar 3). Bring such dates back
+ * to the last day of the expected month (day 0 of the month the date
+ * overflowed into).
+ *
+ * `month` is the expected JS month index and may be outside 0-11 (e.g. built
+ * from `referenceMonth + 1`); it is normalized before comparison.
+ */
+export function clampToMonth(date: Date, month: number, useUTC: boolean): Date {
+  const expectedMonth = ((month % 12) + 12) % 12;
+  const actualMonth = useUTC ? date.getUTCMonth() : date.getMonth();
+  if (actualMonth === expectedMonth) {
+    return date;
+  }
+  return useUTC
+    ? new Date(Date.UTC(date.getUTCFullYear(), actualMonth, 0))
+    : new Date(date.getFullYear(), actualMonth, 0);
+}
+
+/**
  * Calculate the billing cycle for a given day of the month.
  * Example: if billing starts on the 4th, the cycle is from the 4th of one month
  * to the 4th of the next month (exclusive).
+ *
+ * A start day beyond a month's length is clamped to that month's last day
+ * (day 31 → Feb 28), matching the usual billing anniversary convention.
  *
  * @param billingCycleStartDay - The day of the month when the billing cycle starts (1-31)
  * @param referenceDate - The date to calculate the cycle for (defaults to now)
@@ -113,30 +136,25 @@ export function getBillingCycleFromDay(
     ? referenceDate.getUTCFullYear()
     : referenceDate.getFullYear();
   const month = useUTC ? referenceDate.getUTCMonth() : referenceDate.getMonth();
-  const day = useUTC ? referenceDate.getUTCDate() : referenceDate.getDate();
 
-  let cycleStart: Date;
-  let cycleEnd: Date;
+  // The anchor-day boundary in the month `monthOffset` months from the
+  // reference month, clamped to that month's last day when the month is
+  // shorter than the anchor day.
+  const boundary = (monthOffset: number): Date => {
+    const candidate = useUTC
+      ? new Date(
+          Date.UTC(year, month + monthOffset, billingCycleStartDay, 0, 0, 0, 0)
+        )
+      : new Date(year, month + monthOffset, billingCycleStartDay);
+    return clampToMonth(candidate, month + monthOffset, useUTC);
+  };
 
-  if (day >= billingCycleStartDay) {
-    // Billing cycle started this month, ends next month
-    cycleStart = useUTC
-      ? new Date(Date.UTC(year, month, billingCycleStartDay, 0, 0, 0, 0))
-      : new Date(year, month, billingCycleStartDay);
-    cycleEnd = useUTC
-      ? new Date(Date.UTC(year, month + 1, billingCycleStartDay, 0, 0, 0, 0))
-      : new Date(year, month + 1, billingCycleStartDay);
-  } else {
-    // Billing cycle started last month, ends this month
-    cycleStart = useUTC
-      ? new Date(Date.UTC(year, month - 1, billingCycleStartDay, 0, 0, 0, 0))
-      : new Date(year, month - 1, billingCycleStartDay);
-    cycleEnd = useUTC
-      ? new Date(Date.UTC(year, month, billingCycleStartDay, 0, 0, 0, 0))
-      : new Date(year, month, billingCycleStartDay);
+  // The cycle containing the reference date starts on the latest boundary at
+  // or before it: this month's boundary once reached, last month's otherwise.
+  if (boundary(0).getTime() <= referenceDate.getTime()) {
+    return { cycleStart: boundary(0), cycleEnd: boundary(1) };
   }
-
-  return { cycleStart, cycleEnd };
+  return { cycleStart: boundary(-1), cycleEnd: boundary(0) };
 }
 
 /**

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -110,9 +110,29 @@ export function clampToMonth(date: Date, month: number, useUTC: boolean): Date {
   if (actualMonth === expectedMonth) {
     return date;
   }
+  // Overflow only shifts days, so the date's time-of-day is the intended
+  // boundary time — keep it on the clamped result.
   return useUTC
-    ? new Date(Date.UTC(date.getUTCFullYear(), actualMonth, 0))
-    : new Date(date.getFullYear(), actualMonth, 0);
+    ? new Date(
+        Date.UTC(
+          date.getUTCFullYear(),
+          actualMonth,
+          0,
+          date.getUTCHours(),
+          date.getUTCMinutes(),
+          date.getUTCSeconds(),
+          date.getUTCMilliseconds()
+        )
+      )
+    : new Date(
+        date.getFullYear(),
+        actualMonth,
+        0,
+        date.getHours(),
+        date.getMinutes(),
+        date.getSeconds(),
+        date.getMilliseconds()
+      );
 }
 
 /**
@@ -126,16 +146,41 @@ export function clampToMonth(date: Date, month: number, useUTC: boolean): Date {
  * @param billingCycleStartDay - The day of the month when the billing cycle starts (1-31)
  * @param referenceDate - The date to calculate the cycle for (defaults to now)
  * @param useUTC - Whether to use UTC dates (for backend) or local dates (for frontend display)
+ * @param boundaryTimeOfDay - Time-of-day for cycle boundaries. Defaults to
+ * midnight; pass the billing anchor (e.g. the Metronome contract start, which
+ * is hour-aligned) to keep boundaries on its exact time.
  */
 export function getBillingCycleFromDay(
   billingCycleStartDay: number,
   referenceDate: Date = new Date(),
-  useUTC: boolean = false
+  useUTC: boolean = false,
+  boundaryTimeOfDay?: Date
 ): BillingCycle {
   const year = useUTC
     ? referenceDate.getUTCFullYear()
     : referenceDate.getFullYear();
   const month = useUTC ? referenceDate.getUTCMonth() : referenceDate.getMonth();
+
+  const hours = boundaryTimeOfDay
+    ? useUTC
+      ? boundaryTimeOfDay.getUTCHours()
+      : boundaryTimeOfDay.getHours()
+    : 0;
+  const minutes = boundaryTimeOfDay
+    ? useUTC
+      ? boundaryTimeOfDay.getUTCMinutes()
+      : boundaryTimeOfDay.getMinutes()
+    : 0;
+  const seconds = boundaryTimeOfDay
+    ? useUTC
+      ? boundaryTimeOfDay.getUTCSeconds()
+      : boundaryTimeOfDay.getSeconds()
+    : 0;
+  const milliseconds = boundaryTimeOfDay
+    ? useUTC
+      ? boundaryTimeOfDay.getUTCMilliseconds()
+      : boundaryTimeOfDay.getMilliseconds()
+    : 0;
 
   // The anchor-day boundary in the month `monthOffset` months from the
   // reference month, clamped to that month's last day when the month is
@@ -143,9 +188,25 @@ export function getBillingCycleFromDay(
   const boundary = (monthOffset: number): Date => {
     const candidate = useUTC
       ? new Date(
-          Date.UTC(year, month + monthOffset, billingCycleStartDay, 0, 0, 0, 0)
+          Date.UTC(
+            year,
+            month + monthOffset,
+            billingCycleStartDay,
+            hours,
+            minutes,
+            seconds,
+            milliseconds
+          )
         )
-      : new Date(year, month + monthOffset, billingCycleStartDay);
+      : new Date(
+          year,
+          month + monthOffset,
+          billingCycleStartDay,
+          hours,
+          minutes,
+          seconds,
+          milliseconds
+        );
     return clampToMonth(candidate, month + monthOffset, useUTC);
   };
 

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -1,4 +1,5 @@
 import type { BillingCycle } from "@app/lib/client/subscription";
+import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import {
   ceilToHourISO,
   createMetronomeContract,
@@ -465,20 +466,27 @@ export async function applySeatRateOverrides({
 function billingPeriodFromContract(
   contract: CachedContract
 ): Result<BillingCycle, Error> {
-  const currentPeriod = contract.subscriptions
-    ?.map((s) => s.billing_periods?.current)
-    .find((bp) => bp !== undefined);
-
-  if (!currentPeriod) {
+  // Per-seat credits recur MONTHLY even on annually-billed seats (see
+  // `getNextSeatCreditRenewalDate`), on the grid anchored at the contract
+  // start — so the credit cycle is the current month of the contract
+  // anniversary day, regardless of any subscription's billing frequency.
+  // Boundaries are midnight-UTC; Metronome's actual boundaries sit on the
+  // contract's start hour, a divergence we accept for simplicity.
+  const hasCurrentPeriod = (contract.subscriptions ?? []).some(
+    (s) => s.billing_periods?.current !== undefined
+  );
+  if (!hasCurrentPeriod) {
     return new Err(
       new Error("No current billing period found on Metronome contract")
     );
   }
-
-  return new Ok({
-    cycleStart: new Date(currentPeriod.starting_at),
-    cycleEnd: new Date(currentPeriod.ending_before),
-  });
+  return new Ok(
+    getBillingCycleFromDay(
+      new Date(contract.starting_at).getUTCDate(),
+      new Date(),
+      true
+    )
+  );
 }
 
 /**

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -470,8 +470,8 @@ function billingPeriodFromContract(
   // `getNextSeatCreditRenewalDate`), on the grid anchored at the contract
   // start — so the credit cycle is the current month of the contract
   // anniversary day, regardless of any subscription's billing frequency.
-  // Boundaries are midnight-UTC; Metronome's actual boundaries sit on the
-  // contract's start hour, a divergence we accept for simplicity.
+  // Boundaries keep the contract start's (hour-aligned) time-of-day, matching
+  // Metronome's period boundaries.
   const hasCurrentPeriod = (contract.subscriptions ?? []).some(
     (s) => s.billing_periods?.current !== undefined
   );
@@ -480,11 +480,13 @@ function billingPeriodFromContract(
       new Error("No current billing period found on Metronome contract")
     );
   }
+  const contractStart = new Date(contract.starting_at);
   return new Ok(
     getBillingCycleFromDay(
-      new Date(contract.starting_at).getUTCDate(),
+      contractStart.getUTCDate(),
       new Date(),
-      true
+      true,
+      contractStart
     )
   );
 }

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -505,6 +505,7 @@ export function useMembersUsage({
 
   return {
     membersUsage: data?.members ?? emptyArray(),
+    creditsResetAt: data?.creditsResetAt ?? null,
     isMembersUsageLoading: !error && !data && !disabled,
     isMembersUsageRefreshing: isLoading && !!data && !disabled,
     isMembersUsageError: !!error,


### PR DESCRIPTION
## Description

Stacked on #28756.

`billingPeriodFromContract` read `billing_periods.current` from whichever subscription came first on the contract. An annual subscription's current period spans a full year, stretching the credit cycle (usage windows, credits reset date) far past the monthly credit reset. Per-seat credits recur MONTHLY anchored at the contract start regardless of billing frequency, so:

- `billingPeriodFromContract` now derives the cycle from the contract anniversary day-of-month via `getBillingCycleFromDay` (still `Err` when the contract has no current billing period at all, preserving the covering-contract retry in `fetchBillingPeriodRecordForWorkspace`). This converges it with the purchase-limits and analytics paths that already use `getBillingCycleFromDay`. Cycle boundaries keep the contract start's (hour-aligned) time-of-day via the optional `boundaryTimeOfDay` param, matching Metronome's period boundaries; other callers keep the midnight default.
- `getBillingCycleFromDay` is fixed for anchor days 29–31 via a new `clampToMonth` helper: boundaries clamp to the last day of shorter months (Feb 31 → Feb 28, not Mar 3), and cycle selection compares against the clamped boundary so the returned window always contains the reference date (previously, anchor 31 on March 2 returned a window that excluded today).

Affects all `getCachedMetronomeCurrentBillingPeriod` consumers (members usage, per-user / per-API-key usage windows, programmatic usage, reinforcement billing) and existing `getBillingCycleFromDay` callers — behavior only changes for day-29+ anchors, where the old windows were wrong.

## Tests

`subscription.test.ts`: the test documenting the old overflow behavior now asserts the clamped result; new cases for the Jan-31 anchor on March 2, a reference date on the clamped boundary itself, day-31 in a 31-day month, and `clampToMonth` directly. `contracts.test.ts` passes unchanged. tsgo clean.

## Risk

Medium-low: billing-period *display and analytics windows* shift for day-29+ anchored workspaces (previously incorrect). No billing behavior changes — Metronome owns the actual credit resets.
