### PR TITLE
fix(front-api): restrict API key full-secret visibility to its creator

### DIFF
--- a/front-api/routes/w/[wId]/keys/[id]/disable.ts
+++ b/front-api/routes/w/[wId]/keys/[id]/disable.ts
@@ -25,6 +25,7 @@ app.post(
   validate("param", KeyIdParamSchema),
   async (ctx): HandlerResult<PostKeysResponseBody> => {
     const auth = ctx.get("auth");
+    const user = auth.getNonNullableUser();
     const owner = auth.getNonNullableWorkspace();
 
     const { id } = ctx.req.valid("param");
@@ -61,7 +62,7 @@ app.post(
 
     return ctx.json({
       key: {
-        ...key.toJSON(),
+        ...key.toJSON(user.id),
         status: "disabled",
       },
     });

--- a/front-api/routes/w/[wId]/keys/[id]/index.ts
+++ b/front-api/routes/w/[wId]/keys/[id]/index.ts
@@ -52,6 +52,7 @@ app.patch(
   validate("json", PatchKeyBodySchema),
   async (ctx): HandlerResult<PatchKeyResponseBody> => {
     const auth = ctx.get("auth");
+    const user = auth.getNonNullableUser();
     const owner = auth.getNonNullableWorkspace();
 
     const { id } = ctx.req.valid("param");
@@ -162,7 +163,7 @@ app.patch(
         workspace: owner,
         id,
       });
-      return ctx.json({ key: (updated ?? key).toJSON() });
+      return ctx.json({ key: (updated ?? key).toJSON(user.id) });
     }
 
     // Legacy USD monthly cap.
@@ -215,7 +216,7 @@ app.patch(
     });
 
     return ctx.json({
-      key: key.toJSON(),
+      key: key.toJSON(user.id),
     });
   }
 );

--- a/front-api/routes/w/[wId]/keys/index.test.ts
+++ b/front-api/routes/w/[wId]/keys/index.test.ts
@@ -1,0 +1,66 @@
+import { KeyResource } from "@app/lib/resources/key_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { redactString } from "@app/types/shared/utils/string_utils";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+describe("GET /api/w/:wId/keys — secret visibility", () => {
+  it("returns the full secret to the admin who created the key", async () => {
+    const { workspace, user, globalGroup } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const key = await KeyResource.makeNew(
+      {
+        name: "creator-key",
+        workspaceId: workspace.id,
+        userId: user.id,
+        isSystem: false,
+        status: "active",
+        role: "builder",
+      },
+      [globalGroup]
+    );
+
+    const res = await honoApp.request(`/api/w/${workspace.sId}/keys`);
+    expect(res.status).toBe(200);
+
+    const { keys } = await res.json();
+    const returned = keys.find(
+      (k: { name: string }) => k.name === "creator-key"
+    );
+    expect(returned.secret).toBe(key.secret);
+  });
+
+  it("redacts the secret for an admin who did not create the key", async () => {
+    // First admin creates the key.
+    const { workspace, user, globalGroup } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const key = await KeyResource.makeNew(
+      {
+        name: "other-admin-key",
+        workspaceId: workspace.id,
+        userId: user.id,
+        isSystem: false,
+        status: "active",
+        role: "builder",
+      },
+      [globalGroup]
+    );
+
+    // A different admin in the same workspace lists the keys.
+    await createPrivateApiMockRequest({ role: "admin", workspace });
+
+    const res = await honoApp.request(`/api/w/${workspace.sId}/keys`);
+    expect(res.status).toBe(200);
+
+    const { keys } = await res.json();
+    const returned = keys.find(
+      (k: { name: string }) => k.name === "other-admin-key"
+    );
+    expect(returned.secret).toBe(redactString(key.secret, 4));
+    expect(returned.secret).not.toBe(key.secret);
+  });
+});

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -47,12 +47,13 @@ app.get(
   ensureIsAdmin(),
   async (ctx): HandlerResult<GetKeysResponseBody> => {
     const auth = ctx.get("auth");
+    const user = auth.getNonNullableUser();
     const owner = auth.getNonNullableWorkspace();
 
     const keys = await KeyResource.listNonSystemKeysByWorkspace(owner);
 
     return ctx.json({
-      keys: keys.map((k) => k.toJSON()),
+      keys: keys.map((k) => k.toJSON(user.id)),
     });
   }
 );
@@ -277,7 +278,7 @@ app.post(
 
     return ctx.json(
       {
-        key: created.toJSON(),
+        key: created.toJSON(user.id),
       },
       201
     );

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -328,16 +328,21 @@ export class KeyResource extends BaseResource<KeyModel> {
     );
   }
 
-  toJSON(): KeyType {
-    // We only display the full secret key for the first 10 minutes after creation.
+  toJSON(requestingUserModelId: ModelId): KeyType {
+    // We only display the full secret key to the admin who created it, and only
+    // for the first 10 minutes after creation. Every other admin (or the
+    // creator past the window) sees a redacted value.
     const currentTime = new Date();
     const createdAt = new Date(this.createdAt);
     const timeDifference = Math.abs(
       currentTime.getTime() - createdAt.getTime()
     );
     const differenceInMinutes = Math.ceil(timeDifference / (1000 * 60));
+    const isCreator = this.userId === requestingUserModelId;
     const secret =
-      differenceInMinutes > 10 ? redactString(this.secret, 4) : this.secret;
+      isCreator && differenceInMinutes <= 10
+        ? this.secret
+        : redactString(this.secret, 4);
 
     return {
       id: this.id,


### PR DESCRIPTION
closes https://github.com/dust-tt/tasks/issues/9532

## Description

In the workspace **API keys** admin page, a freshly generated key's full secret is shown for the first 10 minutes after creation. Until now that window was purely time-based: **any** admin who opened the page during those 10 minutes could see the full secret of a key they did not create.

`KeyResource.toJSON()` decided secret visibility from `createdAt` alone and had no notion of who was asking. This changes `toJSON()` to take the requesting user's model id and only return the full secret when the requester is the key's creator (`key.userId`) **and** the request is within the 10-minute window. Every other admin — and the creator once the window closes — gets the redacted value.

All five call sites in `front-api` (list, create, patch ×2, disable) already have the authenticated user in scope and now pass `user.id`. The `KeyType` shape is unchanged (`secret` stays a redacted string, never null), so no frontend changes are required.

## Tests

Added `front-api/routes/w/[wId]/keys/index.test.ts` covering the list endpoint:
- The admin who created a key sees the full secret within the window.
- A different admin in the same workspace sees the redacted secret.

Both pass. `front` and `front-api` typecheck clean; biome and the pre-commit hooks pass.

## Risk

Low. The change only tightens what is returned — it never exposes more than before. Edge case: keys whose creator has since been removed (`userId` is null via `onDelete: SET NULL`) will always be redacted, which is the correct posture (a key's full secret is only recoverable at creation time). Easy to roll back (revert-only, no migration).

## Deploy Plan

Standard `front` + `front-api` deploy. No migration, no config, no coordinated client release.