### PR TITLE
Carry tool approval events in the sandbox function invocation event loop

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -160,6 +160,10 @@ async function waitForSandboxFunctionInvocationResult({
           case "sandbox_function_invocation_result":
             finish({ result: eventPayload.data.result });
             break;
+          case "tool_approve_execution":
+            // TODO(SANDBOX_FUNCTIONS): surface a tool approval flow to the user and post the
+            // validation back; not emitted by the tool execution activity yet.
+            break;
           default:
             assertNeverAndIgnore(eventPayload.data);
         }

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -8,8 +8,8 @@ import type {
   MCPServerAvailability,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
-  AgentLoopToolExecution,
   AgentLoopMCPApproveExecutionEvent,
+  AgentLoopToolExecution,
   MCPApproveExecutionEvent,
   ToolAskUserQuestionEvent,
   ToolFileAuthRequiredEvent,

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -9,6 +9,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   AgentLoopToolExecution,
+  AgentLoopMCPApproveExecutionEvent,
   MCPApproveExecutionEvent,
   ToolAskUserQuestionEvent,
   ToolFileAuthRequiredEvent,
@@ -280,7 +281,7 @@ export function isAgentLoopToolNotificationEvent(
 // AgentActionRunningEvents are events related action execution within an agent loop.
 export type AgentActionRunningEvents =
   | AgentLoopToolParamsEvent
-  | MCPApproveExecutionEvent
+  | AgentLoopMCPApproveExecutionEvent
   | AgentLoopToolNotificationEvent;
 
 const MAX_DESCRIPTION_LENGTH = 1024;

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -109,9 +109,19 @@ export type ToolFileAuthRequiredEvent =
   | AgentLoopToolFileAuthRequiredEvent
   | SandboxFunctionToolFileAuthRequiredEvent;
 
-export interface MCPApproveExecutionEvent extends AgentLoopToolExecution {
+export interface AgentLoopMCPApproveExecutionEvent
+  extends AgentLoopToolExecution {
   type: "tool_approve_execution";
 }
+
+export interface SandboxFunctionMCPApproveExecutionEvent
+  extends SandboxFunctionToolExecution {
+  type: "tool_approve_execution";
+}
+
+export type MCPApproveExecutionEvent =
+  | AgentLoopMCPApproveExecutionEvent
+  | SandboxFunctionMCPApproveExecutionEvent;
 
 export interface AgentLoopToolAskUserQuestionEvent
   extends AgentLoopToolExecution {

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -7,7 +7,7 @@ import {
   getInternalMCPServerDisplayedAs,
   getInternalMCPServerNameFromSId,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
+import type { AgentLoopMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
 import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
@@ -211,7 +211,7 @@ export async function createSandboxChildAction(
     const internalMCPServerName = getInternalMCPServerNameFromSId(
       fullToolConfiguration.toolServerId
     );
-    const approvalRequirementEvent: MCPApproveExecutionEvent = {
+    const approvalRequirementEvent: AgentLoopMCPApproveExecutionEvent = {
       type: "tool_approve_execution",
       actionId: action.sId,
       configurationId: fullToolConfiguration.sId,

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -4,7 +4,7 @@ import {
   getInternalMCPServerDisplayedAs,
   getInternalMCPServerNameFromSId,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
+import type { AgentLoopMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
@@ -62,7 +62,7 @@ export async function createToolActionsActivity(
 
   const actionBlobs: ActionBlob[] = [];
   const approvalEvents: Omit<
-    MCPApproveExecutionEvent,
+    AgentLoopMCPApproveExecutionEvent,
     "isLastBlockingEventForStep"
   >[] = [];
 
@@ -138,7 +138,7 @@ async function createActionForTool(
 ): Promise<{
   actionBlob: ActionBlob;
   approvalEventData?: Omit<
-    MCPApproveExecutionEvent,
+    AgentLoopMCPApproveExecutionEvent,
     "isLastBlockingEventForStep"
   >;
 } | void> {

--- a/front/temporal/agent_loop/lib/deferred_events.ts
+++ b/front/temporal/agent_loop/lib/deferred_events.ts
@@ -1,8 +1,8 @@
 import type {
+  AgentLoopMCPApproveExecutionEvent,
   AgentLoopToolAskUserQuestionEvent,
   AgentLoopToolFileAuthRequiredEvent,
   AgentLoopToolPersonalAuthRequiredEvent,
-  AgentLoopMCPApproveExecutionEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
 import type { ModelId } from "@app/types/shared/model_id";
 

--- a/front/temporal/agent_loop/lib/deferred_events.ts
+++ b/front/temporal/agent_loop/lib/deferred_events.ts
@@ -2,7 +2,7 @@ import type {
   AgentLoopToolAskUserQuestionEvent,
   AgentLoopToolFileAuthRequiredEvent,
   AgentLoopToolPersonalAuthRequiredEvent,
-  MCPApproveExecutionEvent,
+  AgentLoopMCPApproveExecutionEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
 import type { ModelId } from "@app/types/shared/model_id";
 
@@ -12,7 +12,7 @@ import type { ModelId } from "@app/types/shared/model_id";
  * rather than immediately when they occur.
  */
 type DeferrableEvent =
-  | MCPApproveExecutionEvent
+  | AgentLoopMCPApproveExecutionEvent
   | AgentLoopToolAskUserQuestionEvent
   | AgentLoopToolFileAuthRequiredEvent
   | AgentLoopToolPersonalAuthRequiredEvent;

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -49,8 +49,6 @@ export type SandboxFunctionInvocationResultEvent = {
 export type SandboxFunctionInvocationEvent =
   | SandboxFunctionInvocationCreatedEvent
   | SandboxFunctionInvocationResultEvent
-  // Tool approval request surfaced by a tool running within the invocation. Not emitted by the
-  // tool execution activity yet; carried in the union so clients can already type their handling.
   | SandboxFunctionMCPApproveExecutionEvent;
 
 export type PostSandboxFunctionInvocationRequestBody = {

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -1,3 +1,4 @@
+import type { SandboxFunctionMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import type { ToolExecutionBaseStatus } from "@app/lib/actions/statuses";
 
 export const SANDBOX_FUNCTION_INVOCATION_STATUSES = ["created"] as const;
@@ -47,7 +48,10 @@ export type SandboxFunctionInvocationResultEvent = {
 
 export type SandboxFunctionInvocationEvent =
   | SandboxFunctionInvocationCreatedEvent
-  | SandboxFunctionInvocationResultEvent;
+  | SandboxFunctionInvocationResultEvent
+  // Tool approval request surfaced by a tool running within the invocation. Not emitted by the
+  // tool execution activity yet; carried in the union so clients can already type their handling.
+  | SandboxFunctionMCPApproveExecutionEvent;
 
 export type PostSandboxFunctionInvocationRequestBody = {
   input?: unknown;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -1,5 +1,5 @@
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
+import type { AgentLoopMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
@@ -843,6 +843,6 @@ export type ConversationMCPServerViewType = BaseConversationMCPServerViewType &
   );
 
 export type MCPActionValidationRequest = Omit<
-  MCPApproveExecutionEvent,
+  AgentLoopMCPApproveExecutionEvent,
   "type" | "created" | "configurationId"
 >;


### PR DESCRIPTION
## Description

Groundwork for tool approval support in the viz wrapper for sandbox functions: the invocation event loop is typed for `tool_approve_execution` end to end, ahead of the tool execution activity emitting it.

- `MCPApproveExecutionEvent` follows the same disjunction pattern as the other tool events: `AgentLoopMCPApproveExecutionEvent` | `SandboxFunctionMCPApproveExecutionEvent`.
- `SandboxFunctionInvocationEvent` carries `SandboxFunctionMCPApproveExecutionEvent`, so the whole publish/SSE path (`publishSandboxFunctionInvocationEvent` → `/api/sse/.../invocations/:invocationId/events`) is typed for it.
- The viz host bridge (`VisualizationActionIframe`) handles the new union member with a no-op `tool_approve_execution` case and a TODO for the approval flow.
- Agent-loop consumers are pinned to the `AgentLoop` variant where the union would widen or collapse them: `AgentActionRunningEvents`, `DeferrableEvent`, the approval event constructors, and the two `Omit<...>` derivations (`create_tool_actions`, `MCPActionValidationRequest`) which would otherwise silently drop `conversationId` / `messageId` (`Omit` over a union keeps common keys only).

No behavior change: the event is not emitted yet.

## Tests

`lib/actions/mcp_execution.test.ts`, `lib/actions/mcp_internal_actions/exit_events.test.ts`, `temporal/agent_loop/activities/common.test.ts`, `lib/resources/sandbox_function_mcp_action_resource.test.ts` pass. Typecheck clean.

## Risk

None. Type-level only, no emitter yet; published event payloads unchanged.

## Deploy Plan

- deploy `front`