### PR TITLE
Add: convenient method to give user permission on a resource.

### DIFF
--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -1,7 +1,9 @@
 import { Authenticator } from "@app/lib/auth";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
-import type { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -331,6 +333,155 @@ describe("GroupPermissionResource", () => {
           ],
         })
       ).rejects.toThrow(/instance-level/);
+    });
+  });
+
+  describe("grantToUser / revokeFromUser", () => {
+    it("creates a regular_auto group, grants access, and adds the user", async () => {
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+
+      const result = await GroupPermissionResource.grantToUser(auth, {
+        user: user.toJSON(),
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 42,
+      });
+      expect(result.isOk()).toBe(true);
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupModelIds: (
+          await GroupResource.listAllWorkspaceGroups(auth, {
+            groupKinds: ["regular_auto"],
+          })
+        ).map((group) => group.id),
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 42,
+      });
+      expect(grants).toHaveLength(1);
+
+      const group = await GroupResource.fetchByModelIds(auth, [
+        grants[0].groupId,
+      ]);
+      expect(group[0].kind).toBe("regular_auto");
+      expect(await group[0].isMember(user)).toBe(true);
+    });
+
+    it("reuses the existing regular_auto group for a second user", async () => {
+      const user1 = await UserFactory.basic();
+      const user2 = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user1, { role: "user" });
+      await MembershipFactory.associate(workspace, user2, { role: "user" });
+
+      await GroupPermissionResource.grantToUser(auth, {
+        user: user1.toJSON(),
+        permissionType: "write",
+        resourceType: "agent",
+        resourceId: 7,
+      });
+      await GroupPermissionResource.grantToUser(auth, {
+        user: user2.toJSON(),
+        permissionType: "write",
+        resourceType: "agent",
+        resourceId: 7,
+      });
+
+      const autoGroups = await GroupResource.listAllWorkspaceGroups(auth, {
+        groupKinds: ["regular_auto"],
+      });
+      const grantGroups = [];
+      for (const group of autoGroups) {
+        const grants = await GroupPermissionResource.listForGroups(auth, {
+          groupModelIds: [group.id],
+          permissionType: "write",
+          resourceType: "agent",
+          resourceId: 7,
+        });
+        if (grants.length > 0) {
+          grantGroups.push(group);
+        }
+      }
+      expect(grantGroups).toHaveLength(1);
+      expect(await grantGroups[0].isMember(user1)).toBe(true);
+      expect(await grantGroups[0].isMember(user2)).toBe(true);
+    });
+
+    it("revokes access and deletes the group when the last member is removed", async () => {
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+
+      await GroupPermissionResource.grantToUser(auth, {
+        user: user.toJSON(),
+        permissionType: "read",
+        resourceType: "skill",
+        resourceId: 99,
+      });
+
+      const result = await GroupPermissionResource.revokeFromUser(auth, {
+        user: user.toJSON(),
+        permissionType: "read",
+        resourceType: "skill",
+        resourceId: 99,
+      });
+      expect(result.isOk()).toBe(true);
+
+      const autoGroups = await GroupResource.listAllWorkspaceGroups(auth, {
+        groupKinds: ["regular_auto"],
+      });
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupModelIds: autoGroups.map((group) => group.id),
+        permissionType: "read",
+        resourceType: "skill",
+        resourceId: 99,
+      });
+      expect(grants).toHaveLength(0);
+    });
+
+    it("keeps the group when other members remain", async () => {
+      const user1 = await UserFactory.basic();
+      const user2 = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user1, { role: "user" });
+      await MembershipFactory.associate(workspace, user2, { role: "user" });
+
+      await GroupPermissionResource.grantToUser(auth, {
+        user: user1.toJSON(),
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 5,
+      });
+      await GroupPermissionResource.grantToUser(auth, {
+        user: user2.toJSON(),
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 5,
+      });
+
+      const result = await GroupPermissionResource.revokeFromUser(auth, {
+        user: user1.toJSON(),
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 5,
+      });
+      expect(result.isOk()).toBe(true);
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupModelIds: (
+          await GroupResource.listAllWorkspaceGroups(auth, {
+            groupKinds: ["regular_auto"],
+          })
+        ).map((group) => group.id),
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 5,
+      });
+      expect(grants).toHaveLength(1);
+
+      const [group] = await GroupResource.fetchByModelIds(auth, [
+        grants[0].groupId,
+      ]);
+      expect(await group.isMember(user1)).toBe(false);
+      expect(await group.isMember(user2)).toBe(true);
     });
   });
 });

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -3,6 +3,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { assertValidGrant } from "@app/lib/resources/group_permission_registry";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { withTransaction } from "@app/lib/utils/sql_utils";
@@ -15,6 +16,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
+import type { UserType } from "@app/types/user";
 import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
@@ -66,6 +68,26 @@ interface ListForGroupsSpec {
   permissionType?: PermissionType;
   resourceType?: GroupPermissionResourceType;
   resourceId?: number;
+}
+
+interface UserGrantSpec {
+  user: UserType;
+  permissionType: PermissionType;
+  resourceType: GroupPermissionResourceType;
+  resourceId: number;
+  transaction?: Transaction;
+}
+
+function autoGroupName({
+  permissionType,
+  resourceType,
+  resourceId,
+}: {
+  permissionType: PermissionType;
+  resourceType: GroupPermissionResourceType;
+  resourceId: number;
+}): string {
+  return `Group for permission ${permissionType} on ${resourceType} (${resourceId})`;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -127,6 +149,161 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     });
 
     return new this(GroupPermissionModel, row.get());
+  }
+
+  // Find the regular_auto group that already holds an instance-level grant for the given tuple.
+  // At most one such group is expected per (permissionType, resourceType, resourceId).
+  private static async findRegularAutoGroupForGrant(
+    auth: Authenticator,
+    {
+      permissionType,
+      resourceType,
+      resourceId,
+      transaction,
+    }: {
+      permissionType: PermissionType;
+      resourceType: GroupPermissionResourceType;
+      resourceId: number;
+      transaction?: Transaction;
+    }
+  ): Promise<GroupResource | null> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const grants = await GroupPermissionModel.findAll({
+      where: {
+        workspaceId,
+        permissionType,
+        resourceType,
+        resourceId,
+      },
+      transaction,
+    });
+    if (grants.length === 0) {
+      return null;
+    }
+
+    const groupIds = [...new Set(grants.map((grant) => grant.groupId))];
+    const groups = await GroupResource.fetchByModelIds(auth, groupIds, {
+      transaction,
+    });
+
+    return groups.find((group) => group.kind === "regular_auto") ?? null;
+  }
+
+  // Grant a user access to a resource by adding them to the regular_auto group that holds the
+  // grant. Creates the group and calls grant() on first use. Idempotent for repeat grants to the
+  // same user.
+  static async grantToUser(
+    auth: Authenticator,
+    {
+      user,
+      permissionType,
+      resourceType,
+      resourceId,
+      transaction,
+    }: UserGrantSpec
+  ): Promise<Result<undefined, Error>> {
+    return withTransaction(async (t) => {
+      let group = await this.findRegularAutoGroupForGrant(auth, {
+        permissionType,
+        resourceType,
+        resourceId,
+        transaction: t,
+      });
+
+      if (!group) {
+        group = await GroupResource.makeNew(
+          {
+            name: autoGroupName({ permissionType, resourceType, resourceId }),
+            kind: "regular_auto",
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+          { transaction: t }
+        );
+        await this.grant(auth, {
+          group,
+          permissionType,
+          resourceType,
+          resourceId,
+          transaction: t,
+        });
+      }
+
+      const addResult = await group.dangerouslyAddMember(auth, {
+        user,
+        transaction: t,
+      });
+      if (addResult.isErr()) {
+        return addResult;
+      }
+
+      return new Ok(undefined);
+    }, transaction);
+  }
+
+  // Revoke a user's access by removing them from the regular_auto group that holds the grant. If the
+  // user was the last member, revokes the grant and deletes the group. No-op when the user is not a
+  // member of the backing group.
+  static async revokeFromUser(
+    auth: Authenticator,
+    {
+      user,
+      permissionType,
+      resourceType,
+      resourceId,
+      transaction,
+    }: UserGrantSpec
+  ): Promise<Result<undefined, Error>> {
+    return withTransaction(async (t) => {
+      const group = await this.findRegularAutoGroupForGrant(auth, {
+        permissionType,
+        resourceType,
+        resourceId,
+        transaction: t,
+      });
+      if (!group) {
+        return new Ok(undefined);
+      }
+
+      const membership = await GroupMembershipModel.findOne({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          groupId: group.id,
+          userId: user.id,
+          status: "active",
+          startAt: { [Op.lte]: new Date() },
+          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+        },
+        transaction: t,
+      });
+      if (!membership) {
+        return new Ok(undefined);
+      }
+
+      const memberCount = await group.getMemberCount(auth);
+      const removeResult = await group.dangerouslyRemoveMember(auth, {
+        user,
+        transaction: t,
+      });
+      if (removeResult.isErr()) {
+        return removeResult;
+      }
+
+      if (memberCount === 1) {
+        await this.revoke(auth, {
+          group,
+          permissionType,
+          resourceType,
+          resourceId,
+          transaction: t,
+        });
+        const deleteResult = await group.delete(auth, { transaction: t });
+        if (deleteResult.isErr()) {
+          return deleteResult;
+        }
+      }
+
+      return new Ok(undefined);
+    }, transaction);
   }
 
   // Revoke a single instance-level grant. No-op if absent. Type-wide (-1) grants are removed via


### PR DESCRIPTION
## Description

Adds `GroupPermissionResource.grantToUser` and `revokeFromUser` — two high-level static helpers that manage per-user instance-level permissions without callers needing to know about the backing `regular_auto` group mechanics.

- `grantToUser` finds the existing `regular_auto` group for a `(permissionType, resourceType, resourceId)` tuple, or creates one and calls `grant()` on first use, then adds the user via `dangerouslyAddMember`. Idempotent.
- `revokeFromUser` removes the user from the backing group. If they were the last member, it revokes the grant and deletes the group. No-op if the user is not a member.

Both methods are fully transactional via `withTransaction` and accept an optional outer `transaction`.

## Tests

Added Vitest unit tests in `group_permission_resource.test.ts` covering: create-on-first-grant, group reuse for a second user, revoke-with-group-cleanup when last member removed, and revoke-while-other-members-remain.

## Risk

Low. Purely additive — new static methods on an existing resource, no schema changes, no existing call sites modified.

## Deploy Plan

Deploy front.
