### PR TITLE
[front] Fix Agent Builder editor margins and update save/cancel/leave buttons

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -583,7 +583,19 @@ export default function AgentBuilder({
     });
   };
 
-  const { isDirty, isSubmitting } = form.formState;
+  const { isSubmitting, dirtyFields } = form.formState;
+
+  // `instructionsHtml` mirrors the editor content as serialized HTML (used for
+  // sidekick block targeting). Its value can differ from the stored baseline
+  // without any real user edit — e.g. regenerated block ids or legacy markup
+  // that the editor no longer reproduces verbatim — so it must not, on its own,
+  // count as an unsaved change. Real edits live in `instructions` and the other
+  // form fields. We therefore derive "unsaved changes" from the set of dirty
+  // fields, ignoring `instructionsHtml`, rather than from the whole-form
+  // `isDirty`.
+  const hasUnsavedChanges = Object.keys(dirtyFields).some(
+    (field) => field !== "instructionsHtml"
+  );
 
   const hasAgentDataLoadError =
     isActionsError || isSkillsError || !!isTriggersError || isEditorsError;
@@ -630,7 +642,7 @@ export default function AgentBuilder({
   };
 
   // Disable navigation lock during save process for new agents
-  useNavigationLock((isDirty || !!duplicateAgentId) && !isSaving);
+  useNavigationLock((hasUnsavedChanges || !!duplicateAgentId) && !isSaving);
 
   const saveLabel = isSubmitting ? "Saving..." : "Save";
 
@@ -676,7 +688,7 @@ export default function AgentBuilder({
             setIsCreatedDialogOpen={setIsCreatedDialogOpen}
             isNewAgent={!!duplicateAgentId || !agentConfiguration}
             isDuplicate={!!duplicateAgentId}
-            hasUnsavedChanges={isDirty}
+            hasUnsavedChanges={hasUnsavedChanges}
             templateInfo={
               assistantTemplate
                 ? {

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -676,6 +676,7 @@ export default function AgentBuilder({
             setIsCreatedDialogOpen={setIsCreatedDialogOpen}
             isNewAgent={!!duplicateAgentId || !agentConfiguration}
             isDuplicate={!!duplicateAgentId}
+            hasUnsavedChanges={isDirty}
             templateInfo={
               assistantTemplate
                 ? {
@@ -725,6 +726,7 @@ interface AgentBuilderContentProps {
   isDuplicate: boolean;
   templateInfo?: TemplateInfo;
   conversationId?: string;
+  hasUnsavedChanges: boolean;
 }
 
 function AgentBuilderContent({
@@ -749,6 +751,7 @@ function AgentBuilderContent({
   isDuplicate,
   templateInfo,
   conversationId,
+  hasUnsavedChanges,
 }: AgentBuilderContentProps) {
   const { owner } = useAgentBuilderContext();
   const confirm = useContext(ConfirmContext);
@@ -867,6 +870,7 @@ function AgentBuilderContent({
             isEditorGateVisible={isEditorGateVisible}
             isAddingSelfAsEditor={isAddingSelfAsEditor}
             onAddSelfAsEditor={onAddSelfAsEditor}
+            hasUnsavedChanges={hasUnsavedChanges}
           />
         }
         rightPanel={

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -9,6 +9,7 @@ import {
   BarFooter,
   BarHeader,
   Button,
+  cn,
   ScrollArea,
   XClose,
 } from "@dust-tt/sparkle";
@@ -89,26 +90,33 @@ export function AgentBuilderLeftPanel({
           />
         </div>
       </ScrollArea>
-      {hasUnsavedChanges && (
-        <BarFooter
-          variant="default"
-          className="justify-between"
-          leftActions={
-            <Button
-              variant="outline"
-              label="Cancel"
-              onClick={handleCancel}
-              type="button"
-            />
-          }
-          rightActions={
-            <BarFooter.ButtonBar
-              variant="validate"
-              saveButtonProps={saveButtonProps}
-            />
-          }
-        />
-      )}
+      <div
+        className={cn(
+          "grid shrink-0 transition-[grid-template-rows] duration-300 ease-in-out",
+          hasUnsavedChanges ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        )}
+      >
+        <div className="overflow-hidden">
+          <BarFooter
+            variant="default"
+            className="justify-between"
+            leftActions={
+              <Button
+                variant="outline"
+                label="Cancel"
+                onClick={handleCancel}
+                type="button"
+              />
+            }
+            rightActions={
+              <BarFooter.ButtonBar
+                variant="validate"
+                saveButtonProps={saveButtonProps}
+              />
+            }
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -50,7 +50,6 @@ export function AgentBuilderLeftPanel({
     <div className="flex h-full w-full flex-col">
       <BarHeader
         variant="default"
-        className="mx-4"
         title={title}
         rightActions={
           <Button
@@ -62,7 +61,7 @@ export function AgentBuilderLeftPanel({
         }
       />
       <ScrollArea className="flex-1">
-        <div className="mx-auto space-y-10 p-8 2xl:max-w-5xl">
+        <div className="mx-auto space-y-10 p-4 2xl:max-w-5xl">
           {editorGateMessage}
           <AgentBuilderInstructionsBlock
             agentConfigurationId={agentConfigurationId}
@@ -88,7 +87,7 @@ export function AgentBuilderLeftPanel({
       </ScrollArea>
       <BarFooter
         variant="default"
-        className="mx-4 justify-between"
+        className="justify-between"
         leftActions={
           <Button
             variant="outline"

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -27,6 +27,7 @@ interface AgentBuilderLeftPanelProps {
   isEditorGateVisible: boolean;
   isAddingSelfAsEditor: boolean;
   onAddSelfAsEditor: () => void;
+  hasUnsavedChanges: boolean;
 }
 
 export function AgentBuilderLeftPanel({
@@ -40,6 +41,7 @@ export function AgentBuilderLeftPanel({
   isEditorGateVisible,
   isAddingSelfAsEditor,
   onAddSelfAsEditor,
+  hasUnsavedChanges,
 }: AgentBuilderLeftPanelProps) {
   const { owner } = useAgentBuilderContext();
 
@@ -52,12 +54,14 @@ export function AgentBuilderLeftPanel({
         variant="default"
         title={title}
         rightActions={
-          <Button
-            icon={XClose}
-            onClick={handleCancel}
-            variant="ghost"
-            type="button"
-          />
+          hasUnsavedChanges ? undefined : (
+            <Button
+              icon={XClose}
+              onClick={handleCancel}
+              variant="ghost"
+              type="button"
+            />
+          )
         }
       />
       <ScrollArea className="flex-1">
@@ -85,24 +89,26 @@ export function AgentBuilderLeftPanel({
           />
         </div>
       </ScrollArea>
-      <BarFooter
-        variant="default"
-        className="justify-between"
-        leftActions={
-          <Button
-            variant="outline"
-            label="Cancel"
-            onClick={handleCancel}
-            type="button"
-          />
-        }
-        rightActions={
-          <BarFooter.ButtonBar
-            variant="validate"
-            saveButtonProps={saveButtonProps}
-          />
-        }
-      />
+      {hasUnsavedChanges && (
+        <BarFooter
+          variant="default"
+          className="justify-between"
+          leftActions={
+            <Button
+              variant="outline"
+              label="Cancel"
+              onClick={handleCancel}
+              type="button"
+            />
+          }
+          rightActions={
+            <BarFooter.ButtonBar
+              variant="validate"
+              saveButtonProps={saveButtonProps}
+            />
+          }
+        />
+      )}
     </div>
   );
 }

--- a/front/components/agent_builder/AgentBuilderSectionContainer.tsx
+++ b/front/components/agent_builder/AgentBuilderSectionContainer.tsx
@@ -16,7 +16,7 @@ export function AgentBuilderSectionContainer({
   children,
 }: AgentBuilderSectionContainerProps) {
   return (
-    <section className="flex flex-col gap-3 px-6">
+    <section className="flex flex-col gap-3">
       <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-end">
         <div>
           <div className="flex flex-row items-center gap-2">

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -168,7 +168,7 @@ export function AgentBuilderSpacesBlock({
   }, [globalSpace, nonGlobalSpacesWithRestrictions]);
 
   return (
-    <div className="space-y-3 px-6">
+    <div className="space-y-3">
       <div className="flex items-start justify-between">
         <div>
           <h2 className="heading-lg text-foreground">Spaces and Pods</h2>

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -247,16 +247,25 @@ export function AgentBuilderInstructionsEditor({
     return extensions;
   }, [owner.sId, suggestionHandler]);
 
-  // Debounce serialization to prevent performance issues
+  // Debounce serialization to prevent performance issues. Fire on the leading
+  // edge as well so the form dirty state (and the save bar / close button it
+  // drives) flips immediately on the first edit; rapid typing still coalesces
+  // to the trailing edge.
   const debouncedUpdate = useMemo(
     () =>
-      debounce((editor: CoreEditor | ReactEditor) => {
-        if (!isInstructionDiffMode && !editor.isDestroyed) {
-          field.onChange(editor.getMarkdown());
-          // Strip style/class/id attributes to store clean HTML structure.
-          instructionsHtmlField.onChange(stripHtmlAttributes(editor.getHTML()));
-        }
-      }, INSTRUCTIONS_DEBOUNCE_MS),
+      debounce(
+        (editor: CoreEditor | ReactEditor) => {
+          if (!isInstructionDiffMode && !editor.isDestroyed) {
+            field.onChange(editor.getMarkdown());
+            // Strip style/class/id attributes to store clean HTML structure.
+            instructionsHtmlField.onChange(
+              stripHtmlAttributes(editor.getHTML())
+            );
+          }
+        },
+        INSTRUCTIONS_DEBOUNCE_MS,
+        { leading: true, trailing: true }
+      ),
     [field, instructionsHtmlField, isInstructionDiffMode]
   );
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9010

<img width="1512" height="862" alt="Screenshot 2026-07-09 at 14 16 53" src="https://github.com/user-attachments/assets/969f910f-aaa2-4b64-b396-21f4fbd6f43b" />


Align the left-panel content with the top/bottom bars. The content was inset by two stacking layers of horizontal padding (the wrapper plus each section's own px-6), pushing it ~24px further right than the header and footer on both sides.

Make the content wrapper the single source of horizontal padding (p-4), drop the redundant px-6 from AgentBuilderSectionContainer and AgentBuilderSpacesBlock, and remove the mx-4 margins from the bars so the header, content, and footer all sit at a consistent 16px inset.
## Tests

Local

## Risk

Low

## Deploy Plan

Front