### PR TITLE
Mark the trailing tool result with a cache breakpoint on Vertex in the legacy Anthropic client

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -181,11 +181,20 @@ async function toolResultToParam(
 
 async function functionMessage(
   message: FunctionMessageTypeModel,
-  { convertToBase64 }: { convertToBase64: boolean }
+  { isLast, convertToBase64 }: { isLast: boolean; convertToBase64: boolean }
 ): Promise<MessageParam> {
+  const toolResult = await toolResultToParam(message, { convertToBase64 });
+
+  // On Vertex the trailing breakpoint must be explicit (isLast is only set
+  // there), and tool loops end every iteration on a tool result. Without this
+  // marker the conversation tail is reprocessed uncached on each iteration.
   return {
     role: "user",
-    content: [await toolResultToParam(message, { convertToBase64 })],
+    content: [
+      isLast
+        ? { ...toolResult, cache_control: { type: "ephemeral" } }
+        : toolResult,
+    ],
   };
 }
 
@@ -337,6 +346,7 @@ export async function toMessage(
       });
     case "function":
       return functionMessage(message, {
+        isLast,
         convertToBase64: convertToBase64 ?? false,
       });
     case "assistant":


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
On Vertex AI, prompt caching requires an explicit breakpoint since automatic caching isn't supported there. The legacy Anthropic client already handled this for the last message when it was plain user text, but silently dropped the flag whenever the last message was a tool result, which is exactly the shape of every iteration of a tool-calling loop. As a result, conversations that ended a turn on a tool result were reprocessing the full conversation tail uncached on every iteration on Vertex, adding latency and cost with no benefit. This fix threads the same "is this the last message" signal through to the tool result path so the breakpoint gets set there too, matching the behavior already used for plain text turns. Direct Anthropic API traffic is unaffected since it relies on automatic caching rather than this explicit marker.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
