### PR TITLE
Rename ToolContext* types (remove -Type) suffix

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -21,7 +21,7 @@ import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_ac
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPConnectionParams } from "@app/lib/actions/mcp_metadata";
 import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import type { ServerSideMCPToolTypeWithStakeAndRetryPolicy } from "@app/lib/api/mcp";
 import { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
@@ -720,7 +720,7 @@ describe("tryCallMCPTool", () => {
     }
 
     // Create agent loop run context
-    const agentLoopRunContext: AgentLoopRunContextType = {
+    const agentLoopRunContext: AgentLoopRunContext = {
       contextType: "agent_loop",
       agentConfiguration,
       model: {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -66,10 +66,10 @@ import {
 } from "@app/lib/actions/tool_interruptions";
 import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
-  type AgentLoopListToolsContextType,
+  type AgentLoopListToolsContext,
   isAgentLoopRunContext,
   isSandboxFunctionRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import {
   isClientSideMCPToolConfiguration,
@@ -345,7 +345,7 @@ export async function runToolCallWithDetachedSignal<T>(
 export async function* tryCallMCPTool(
   auth: Authenticator,
   inputs: Record<string, unknown> | undefined,
-  toolContext: ToolContextType,
+  toolContext: ToolContext,
   {
     progressToken,
     makeToolNotificationEvent,
@@ -761,7 +761,7 @@ type ServerSideMCPConnectionError =
 async function connectServerSideMCP(
   auth: Authenticator,
   toolConfiguration: ServerSideMCPToolConfigurationType,
-  toolContext: ToolContextType
+  toolContext: ToolContext
 ): Promise<Result<Client, ServerSideMCPConnectionError>> {
   const mcpServerView = await MCPServerViewResource.fetchById(
     auth,
@@ -893,7 +893,7 @@ function makeClientSideMCPConnectionParams(
 }
 
 type AgentLoopListToolsContextWithoutConfigurationType = Omit<
-  AgentLoopListToolsContextType,
+  AgentLoopListToolsContext,
   "agentActionConfiguration"
 >;
 
@@ -1403,7 +1403,7 @@ export async function buildToolConfigurationsFromRawTools(
 async function listMCPServerToolsAndServerInstructions(
   auth: Authenticator,
   config: MCPServerConfigurationType,
-  agentLoopListToolsContext: AgentLoopListToolsContextType,
+  agentLoopListToolsContext: AgentLoopListToolsContext,
   connectionParams: MCPConnectionParams
 ): Promise<
   Result<{ instructions?: string; tools: MCPToolConfigurationType[] }, Error>

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -12,7 +12,7 @@ import {
   processToolResults,
 } from "@app/lib/actions/mcp_execution";
 import type { DataSourceNodeContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
@@ -118,7 +118,7 @@ async function setupTest({
   const modelConfig = getSupportedModelConfig(agentModel);
   assert(modelConfig, "Supported model config should exist");
 
-  const toolContext: ToolContextType = {
+  const toolContext: ToolContext = {
     runContext: {
       contextType: "agent_loop",
       agentConfiguration,
@@ -502,7 +502,7 @@ describe("processToolResults", () => {
 
     fileStorageMock.reset();
 
-    const toolContext: ToolContextType = {
+    const toolContext: ToolContext = {
       runContext: {
         contextType: "sandbox_function",
         action,

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -17,7 +17,7 @@ import {
 import { handleBase64Upload } from "@app/lib/actions/mcp_utils";
 import type {
   ActionGeneratedFileType,
-  ToolContextType,
+  ToolContext,
   ToolOutputItemType,
 } from "@app/lib/actions/types";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
@@ -75,7 +75,7 @@ export async function processToolNotification(
   {
     toolContext,
   }: {
-    toolContext: ToolContextType;
+    toolContext: ToolContext;
   }
 ): Promise<{
   event: ToolNotificationEvent;
@@ -171,7 +171,7 @@ export async function processToolResults(
   }: {
     localLogger: Logger;
     toolCallResultContent: CallToolResult["content"];
-    toolContext: ToolContextType;
+    toolContext: ToolContext;
   }
 ): Promise<{
   outputItems: ToolOutputItemType[];

--- a/front/lib/actions/mcp_internal_actions/exit_events.test.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.test.ts
@@ -1,6 +1,6 @@
 import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/exit_events";
 import { makeMCPToolExit } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { describe, expect, it } from "vitest";
 
@@ -26,7 +26,7 @@ describe("getExitOrPauseEvents", () => {
           },
           agentMessage: { sId: "agent-message-id" },
           conversation: { sId: "conversation-id" },
-        } as AgentLoopRunContextType,
+        } as AgentLoopRunContext,
       },
     });
 

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -6,7 +6,7 @@ import type {
   ToolPausedEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { pauseSandboxBashForBlockedChild } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
@@ -30,7 +30,7 @@ export async function getExitOrPauseEvents(
     toolContext,
   }: {
     outputItems: MCPActionOutputItemWithContent[];
-    toolContext: ToolContextType;
+    toolContext: ToolContext;
   }
 ): Promise<
   (

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -2,7 +2,7 @@ import { MCPServerNotFoundError } from "@app/lib/actions/mcp_errors";
 import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import { getInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/servers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -10,7 +10,7 @@ export const connectToInternalMCPServer = async (
   mcpServerId: string,
   transport: InMemoryWithAuthTransport,
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<McpServer> => {
   const res = getInternalMCPServerNameAndWorkspaceId(mcpServerId);
   if (res.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -1,6 +1,6 @@
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { ADVANCED_SEARCH_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
@@ -93,7 +93,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
  * Check if we are in advanced search mode,
  * relying on a magic value stored in the additionalConfiguration.
  */
-function isAdvancedSearchMode(toolContext?: ToolContextType) {
+function isAdvancedSearchMode(toolContext?: ToolContext) {
   return (
     (toolContext?.runContext &&
       isLightServerSideMCPToolConfiguration(
@@ -121,7 +121,7 @@ export async function getInternalMCPServer(
     internalMCPServerName: InternalMCPServerNameType;
     mcpServerId: string;
   },
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<McpServer> {
   switch (internalMCPServerName) {
     case "github":

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -1,6 +1,6 @@
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPError } from "@app/lib/actions/mcp_errors";
-import type { ToolRunContextType } from "@app/lib/actions/types";
+import type { ToolRunContext } from "@app/lib/actions/types";
 import type {
   InternalMCPServerDefinitionType,
   MCPToolType,
@@ -22,7 +22,7 @@ export type ToolHandlerExtra = RequestHandlerExtra<
   ServerNotification
 > & {
   auth: Authenticator;
-  runContext: ToolRunContextType;
+  runContext: ToolRunContext;
 };
 
 export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;

--- a/front/lib/actions/mcp_internal_actions/tools/tags/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/tags/utils.ts
@@ -1,4 +1,4 @@
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
@@ -12,7 +12,7 @@ function hasTagAutoMode(dataSourceConfigurations: DataSourceConfiguration[]) {
   );
 }
 
-export function shouldAutoGenerateTags(toolContext: ToolContextType): boolean {
+export function shouldAutoGenerateTags(toolContext: ToolContext): boolean {
   const { listToolsContext, runContext } = toolContext;
   if (
     !!listToolsContext?.agentActionConfiguration &&

--- a/front/lib/actions/mcp_internal_actions/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { Authenticator } from "@app/lib/auth";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -74,7 +74,7 @@ async function callTestTool(auth: Authenticator, toolName: string) {
       conversation: { sId: "conversation-id" },
       agentMessage: { sId: "message-id" },
     },
-  } as unknown as ToolContextType;
+  } as unknown as ToolContext;
   const server = new McpServer({ name: "admin_guard_test", version: "1.0.0" });
   for (const tool of TEST_TOOLS) {
     registerTool(auth, toolContext, server, tool, {

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -1,4 +1,4 @@
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -46,10 +46,10 @@ vi.mock("@app/lib/api/file_system", async (importOriginal) => {
   };
 });
 
-function makeToolContext(conversation: ConversationType): ToolContextType {
+function makeToolContext(conversation: ConversationType): ToolContext {
   return {
     runContext: { contextType: "agent_loop", conversation },
-  } as unknown as ToolContextType;
+  } as unknown as ToolContext;
 }
 
 function makeReadableStream(content: string): Readable {

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -1,6 +1,6 @@
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { resolveFile } from "@app/lib/api/actions/servers/files/tools/utils";
 import {
@@ -53,7 +53,7 @@ export type ConversationFileRef = {
 export async function resolveConversationFileRef(
   auth: Authenticator,
   fileId: string,
-  toolContext: ToolContextType | undefined
+  toolContext: ToolContext | undefined
 ): Promise<Result<ConversationFileRef, string>> {
   // Canonical scoped paths (conversation-{id}/..., pod-{id}/...) produced by the new
   // DustFileSystem layer. Resolved directly — no conversation context needed.
@@ -161,7 +161,7 @@ export async function resolveConversationFileRef(
 export async function getFileFromConversationAttachment(
   auth: Authenticator,
   fileId: string,
-  toolContext: ToolContextType
+  toolContext: ToolContext
 ): Promise<
   Result<
     {

--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
@@ -1,4 +1,4 @@
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import {
   getSmallWhitelistedModel,
@@ -32,7 +32,7 @@ export async function summarizeWithLLM({
 }: {
   auth: Authenticator;
   content: string;
-  agentLoopRunContext: AgentLoopRunContextType;
+  agentLoopRunContext: AgentLoopRunContext;
 }): Promise<Result<string, Error>> {
   const toSummarize = content.slice(0, MAX_CHARACTERS_TO_SUMMARIZE);
 

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -6,8 +6,8 @@ import type {
 import {
   isAgentLoopRunContext,
   isSandboxFunctionRunContext,
-  type ToolContextType,
-  type ToolRunContextType,
+  type ToolContext,
+  type ToolRunContext,
 } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { getStatsDClient } from "@app/lib/utils/statsd";
@@ -29,7 +29,7 @@ const MAX_LOGGED_ERROR_MESSAGE_LENGTH = 200;
 
 export function registerTool(
   auth: Authenticator,
-  toolContext: ToolContextType | undefined,
+  toolContext: ToolContext | undefined,
   server: McpServer,
   tool: ToolDefinition,
   { monitoringName }: { monitoringName: string }
@@ -121,7 +121,7 @@ function withToolLogging<T>(
   }: {
     toolNameForMonitoring: string;
     // Undefined at listing-phase registration; always set when the callback actually runs.
-    runContext: ToolRunContextType | undefined;
+    runContext: ToolRunContext | undefined;
     enableAlerting?: boolean;
   },
   toolCallback: (

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -32,7 +32,7 @@ import {
   MCPOAuthProvider,
   MCPOAuthProviderError,
 } from "@app/lib/actions/mcp_oauth_provider";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_client_side";
 import type {
   MCPServerType,
@@ -359,7 +359,7 @@ export async function connectToMCPServer(
     toolContext,
   }: {
     params: MCPConnectionParams;
-    toolContext?: ToolContextType;
+    toolContext?: ToolContext;
   }
 ): Promise<
   Result<Client, Error | MCPServerPersonalAuthenticationRequiredError>

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -15,7 +15,7 @@ import {
   TOOL_GENERATED_FILE_MIME_TYPE,
   TOOL_GENERATED_FILE_PATH_MIME_TYPE,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { isEnableSkillResultOutput } from "@app/lib/api/actions/servers/skill_management/rendering";
 import {
@@ -181,7 +181,7 @@ export async function handleBase64Upload(
     base64Data: string;
     mimeType: string;
     fileName: string;
-    toolContext: ToolContextType;
+    toolContext: ToolContext;
   }
 ): Promise<{
   content: CallToolResult["content"][number];

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -193,9 +193,7 @@ export type AgentLoopListToolsContext = {
 
 // Context available to tool handlers at execution time: tools only ever run on a connection
 // established with a run context, never on a listing-phase connection.
-export type ToolRunContext =
-  | AgentLoopRunContext
-  | SandboxFunctionRunContext;
+export type ToolRunContext = AgentLoopRunContext | SandboxFunctionRunContext;
 
 export function isSandboxFunctionRunContext(
   value: ToolRunContext | undefined

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -164,7 +164,7 @@ export type ToolOutputItemType = {
   workspaceId: ModelId;
 };
 
-export type AgentLoopRunContextType = {
+export type AgentLoopRunContext = {
   contextType: "agent_loop";
   action: AgentMCPActionResource;
   agentConfiguration: AgentConfigurationWithoutModelType;
@@ -176,14 +176,14 @@ export type AgentLoopRunContextType = {
   userMessage: UserMessageType;
 };
 
-export type SandboxFunctionRunContextType = {
+export type SandboxFunctionRunContext = {
   contextType: "sandbox_function";
   action: SandboxFunctionMCPActionResource;
   invocation: SandboxFunctionInvocationResource;
   toolConfiguration: LightMCPToolConfigurationType;
 };
 
-export type AgentLoopListToolsContextType = {
+export type AgentLoopListToolsContext = {
   agentConfiguration: AgentConfigurationWithoutModelType;
   agentActionConfiguration: MCPServerConfigurationType;
   clientSideActionConfigurations?: ClientSideMCPServerConfigurationType[];
@@ -193,28 +193,28 @@ export type AgentLoopListToolsContextType = {
 
 // Context available to tool handlers at execution time: tools only ever run on a connection
 // established with a run context, never on a listing-phase connection.
-export type ToolRunContextType =
-  | AgentLoopRunContextType
-  | SandboxFunctionRunContextType;
+export type ToolRunContext =
+  | AgentLoopRunContext
+  | SandboxFunctionRunContext;
 
 export function isSandboxFunctionRunContext(
-  value: ToolRunContextType | undefined
-): value is SandboxFunctionRunContextType {
+  value: ToolRunContext | undefined
+): value is SandboxFunctionRunContext {
   return value?.contextType === "sandbox_function";
 }
 
 export function isAgentLoopRunContext(
-  value: ToolRunContextType | undefined
-): value is AgentLoopRunContextType {
+  value: ToolRunContext | undefined
+): value is AgentLoopRunContext {
   return value?.contextType === "agent_loop";
 }
 
-export type ToolContextType =
+export type ToolContext =
   | {
-      runContext: ToolRunContextType;
+      runContext: ToolRunContext;
       listToolsContext?: never;
     }
   | {
       runContext?: never;
-      listToolsContext: AgentLoopListToolsContextType;
+      listToolsContext: AgentLoopListToolsContext;
     };

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -3,7 +3,7 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
   ACTIVATION_RECOMMENDATIONS_SERVER_NAME,
@@ -131,7 +131,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(ACTIVATION_RECOMMENDATIONS_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/agent_memory/index.ts
+++ b/front/lib/api/actions/servers/agent_memory/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/agent_memory/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(AGENT_MEMORY_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/agent_router/index.ts
+++ b/front/lib/api/actions/servers/agent_router/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { AGENT_ROUTER_SERVER_NAME } from "@app/lib/api/actions/servers/agent_router/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/agent_router/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(AGENT_ROUTER_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/agent_sidekick_agent_state/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("agent_sidekick_agent_state");
 

--- a/front/lib/api/actions/servers/agent_sidekick_context/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { AGENT_SIDEKICK_CONTEXT_TOOL_NAME } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/agent_sidekick_context/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("agent_sidekick_context");
 

--- a/front/lib/api/actions/servers/agent_sidekick_helpers.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_helpers.ts
@@ -1,8 +1,8 @@
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { getSidekickMetadataFromContext } from "@app/lib/api/actions/servers/helpers";
 
 export function getAgentConfigurationIdFromContext(
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): string | null {
   return (
     getSidekickMetadataFromContext(toolContext)
@@ -11,7 +11,7 @@ export function getAgentConfigurationIdFromContext(
 }
 
 export function getAgentConfigurationVersionFromContext(
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): number | null {
   return (
     getSidekickMetadataFromContext(toolContext)

--- a/front/lib/api/actions/servers/agent_templates/index.ts
+++ b/front/lib/api/actions/servers/agent_templates/index.ts
@@ -3,7 +3,7 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   AGENT_TEMPLATES_SERVER_NAME,
   AGENT_TEMPLATES_TOOLS_METADATA,
@@ -51,7 +51,7 @@ const TOOLS = buildTools(AGENT_TEMPLATES_TOOLS_METADATA, handlers);
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(AGENT_TEMPLATES_SERVER_NAME);
   for (const tool of TOOLS) {

--- a/front/lib/api/actions/servers/ashby/index.ts
+++ b/front/lib/api/actions/servers/ashby/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { ASHBY_SERVER } from "@app/lib/api/actions/servers/ashby/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/ashby/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("ashby");
 

--- a/front/lib/api/actions/servers/ask_user_question/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/ask_user_question/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("ask_user_question");
 

--- a/front/lib/api/actions/servers/clari_copilot/index.ts
+++ b/front/lib/api/actions/servers/clari_copilot/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { CLARI_COPILOT_SERVER } from "@app/lib/api/actions/servers/clari_copilot/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/clari_copilot/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("clari_copilot");
 

--- a/front/lib/api/actions/servers/common_utilities/index.ts
+++ b/front/lib/api/actions/servers/common_utilities/index.ts
@@ -2,7 +2,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import {
   COMMON_UTILITIES_SERVER_NAME,
@@ -14,7 +14,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(COMMON_UTILITIES_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/confluence/index.ts
+++ b/front/lib/api/actions/servers/confluence/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { CONFLUENCE_TOOL_NAME } from "@app/lib/api/actions/servers/confluence/metadata";
 import { createConfluenceTools } from "@app/lib/api/actions/servers/confluence/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("confluence");
 

--- a/front/lib/api/actions/servers/conversation_files/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/index.ts
@@ -2,7 +2,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { CONVERSATION_FILES_SERVER_NAME } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import {
@@ -14,7 +14,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 async function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("conversation_files");
 

--- a/front/lib/api/actions/servers/data_sources_file_system/index.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/index.ts
@@ -1,7 +1,7 @@
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   TOOLS_WITH_TAGS,
   TOOLS_WITHOUT_TAGS,
@@ -11,7 +11,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("data_sources_file_system");
 

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
@@ -8,7 +8,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
@@ -76,7 +76,7 @@ export async function cat(
     limit?: number;
     grep?: string;
   },
-  { auth, toolContext }: { auth: Authenticator; toolContext?: ToolContextType }
+  { auth, toolContext }: { auth: Authenticator; toolContext?: ToolContext }
 ) {
   if (!toolContext?.runContext) {
     return new Err(new MCPError("No conversation context available"));

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -14,7 +14,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/types";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
@@ -45,7 +45,7 @@ export async function search(
     tagsIn,
     tagsNot,
   }: SearchWithNodesInputType & TagsInputType,
-  { auth, toolContext }: { auth: Authenticator; toolContext?: ToolContextType }
+  { auth, toolContext }: { auth: Authenticator; toolContext?: ToolContext }
 ): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const credentials = await getLlmCredentials(auth);

--- a/front/lib/api/actions/servers/data_warehouses/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/data_warehouses/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("data_warehouses");
 

--- a/front/lib/api/actions/servers/databricks/index.ts
+++ b/front/lib/api/actions/servers/databricks/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/databricks/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("databricks");
 

--- a/front/lib/api/actions/servers/exa/index.ts
+++ b/front/lib/api/actions/servers/exa/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/exa/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("exa_people_and_company");
 

--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -1,6 +1,6 @@
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type { ToolRunContextType } from "@app/lib/actions/types";
+import type { ToolRunContext } from "@app/lib/actions/types";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import type { CoreDataSourceSearchCriteria } from "@app/lib/api/assistant/process_data_sources";
 import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
@@ -129,7 +129,7 @@ export async function generateProcessToolOutput({
   objective,
 }: {
   auth: Authenticator;
-  runContext: ToolRunContextType;
+  runContext: ToolRunContext;
   outputs: ProcessActionOutputsType | null;
   jsonSchema: JSONSchema;
   timeFrame: TimeFrame | null;

--- a/front/lib/api/actions/servers/extract_data/index.ts
+++ b/front/lib/api/actions/servers/extract_data/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createExtractDataTools } from "@app/lib/api/actions/servers/extract_data/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("extract_data");
 

--- a/front/lib/api/actions/servers/extract_data/tools/index.test.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.test.ts
@@ -1,5 +1,5 @@
 import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   generateProcessToolOutput,
   getCoreDataSourceSearchCriterias,
@@ -39,7 +39,7 @@ const CONFIGURED_TIME_FRAME = {
   unit: "day" as const,
 };
 
-function makeRunContext(): ToolContextType {
+function makeRunContext(): ToolContext {
   const toolConfiguration: LightServerSideMCPToolConfigurationType = {
     id: -1,
     sId: "tool-configuration-id",
@@ -77,7 +77,7 @@ function makeRunContext(): ToolContextType {
       conversation: {},
       toolConfiguration,
     },
-  } as unknown as ToolContextType;
+  } as unknown as ToolContext;
 }
 
 describe("createExtractDataTools", () => {

--- a/front/lib/api/actions/servers/extract_data/tools/index.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.ts
@@ -6,7 +6,7 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
@@ -35,7 +35,7 @@ import type { TimeFrame } from "@app/types/shared/utils/time_frame";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
-function getServerSideConfiguration(toolContext?: ToolContextType) {
+function getServerSideConfiguration(toolContext?: ToolContext) {
   if (
     toolContext?.listToolsContext &&
     isServerSideMCPServerConfiguration(
@@ -60,7 +60,7 @@ function getServerSideConfiguration(toolContext?: ToolContextType) {
 // Create tools with access to auth via closure
 export function createExtractDataTools(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ) {
   const areTagsDynamic = toolContext
     ? shouldAutoGenerateTags(toolContext)

--- a/front/lib/api/actions/servers/fathom/index.ts
+++ b/front/lib/api/actions/servers/fathom/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/fathom/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("fathom");
 

--- a/front/lib/api/actions/servers/file_generation/index.ts
+++ b/front/lib/api/actions/servers/file_generation/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { FILE_GENERATION_TOOL_NAME } from "@app/lib/api/actions/servers/file_generation/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/file_generation/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("file_generation");
 

--- a/front/lib/api/actions/servers/files/index.ts
+++ b/front/lib/api/actions/servers/files/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/files/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(FILES_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContextType } from "@app/lib/actions/types";
+import type { ToolRunContext } from "@app/lib/actions/types";
 import { copyHandler } from "@app/lib/api/actions/servers/files/tools/copy";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -18,7 +18,7 @@ function makeExtra(
   const runContext = {
     contextType: "agent_loop",
     conversation,
-  } as unknown as ToolRunContextType;
+  } as unknown as ToolRunContext;
   return { auth, runContext } as unknown as ToolHandlerExtra;
 }
 

--- a/front/lib/api/actions/servers/files/tools/create.test.ts
+++ b/front/lib/api/actions/servers/files/tools/create.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContextType } from "@app/lib/actions/types";
+import type { ToolRunContext } from "@app/lib/actions/types";
 import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
 import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
 import { createConversation } from "@app/lib/api/assistant/conversation";
@@ -18,7 +18,7 @@ function makeExtra(
   const runContext = {
     contextType: "agent_loop",
     conversation,
-  } as unknown as ToolRunContextType;
+  } as unknown as ToolRunContext;
   return { auth, runContext } as unknown as ToolHandlerExtra;
 }
 

--- a/front/lib/api/actions/servers/files/tools/delete.test.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContextType } from "@app/lib/actions/types";
+import type { ToolRunContext } from "@app/lib/actions/types";
 import { deleteHandler } from "@app/lib/api/actions/servers/files/tools/delete";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -24,7 +24,7 @@ function makeExtra(
   const runContext = {
     contextType: "agent_loop",
     conversation,
-  } as unknown as ToolRunContextType;
+  } as unknown as ToolRunContext;
   return { auth, runContext } as unknown as ToolHandlerExtra;
 }
 

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContextType } from "@app/lib/actions/types";
+import type { ToolRunContext } from "@app/lib/actions/types";
 import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
 import { editHandler } from "@app/lib/api/actions/servers/files/tools/edit";
 import { FRAME_SOURCE_MAX_BYTES } from "@app/lib/api/actions/servers/interactive_content/metadata";
@@ -27,7 +27,7 @@ function makeExtra(
   const runContext = {
     contextType: "agent_loop",
     conversation,
-  } as unknown as ToolRunContextType;
+  } as unknown as ToolRunContext;
   return { auth, runContext } as unknown as ToolHandlerExtra;
 }
 

--- a/front/lib/api/actions/servers/files/tools/list.test.ts
+++ b/front/lib/api/actions/servers/files/tools/list.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContextType } from "@app/lib/actions/types";
+import type { ToolRunContext } from "@app/lib/actions/types";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -60,7 +60,7 @@ function makeExtra(
   const runContext = {
     contextType: "agent_loop",
     conversation,
-  } as unknown as ToolRunContextType;
+  } as unknown as ToolRunContext;
   return { auth, runContext } as unknown as ToolHandlerExtra;
 }
 

--- a/front/lib/api/actions/servers/files/tools/move.test.ts
+++ b/front/lib/api/actions/servers/files/tools/move.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContextType } from "@app/lib/actions/types";
+import type { ToolRunContext } from "@app/lib/actions/types";
 import { moveHandler } from "@app/lib/api/actions/servers/files/tools/move";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -18,7 +18,7 @@ function makeExtra(
   const runContext = {
     contextType: "agent_loop",
     conversation,
-  } as unknown as ToolRunContextType;
+  } as unknown as ToolRunContext;
   return { auth, runContext } as unknown as ToolHandlerExtra;
 }
 

--- a/front/lib/api/actions/servers/freshservice/index.ts
+++ b/front/lib/api/actions/servers/freshservice/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/freshservice/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("freshservice");
 

--- a/front/lib/api/actions/servers/front/index.ts
+++ b/front/lib/api/actions/servers/front/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/front/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("front");
 

--- a/front/lib/api/actions/servers/github/index.ts
+++ b/front/lib/api/actions/servers/github/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createGithubTools } from "@app/lib/api/actions/servers/github/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("github");
 

--- a/front/lib/api/actions/servers/gmail/index.ts
+++ b/front/lib/api/actions/servers/gmail/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { GMAIL_TOOL_NAME } from "@app/lib/api/actions/servers/gmail/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/gmail/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("gmail");
 

--- a/front/lib/api/actions/servers/gong/index.ts
+++ b/front/lib/api/actions/servers/gong/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/gong/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("gong");
 

--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -1,6 +1,6 @@
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { google } from "googleapis";
@@ -175,7 +175,7 @@ export function normalizeTimezone(
   return null;
 }
 
-export function getUserTimezone(toolContext?: ToolContextType): string | null {
+export function getUserTimezone(toolContext?: ToolContext): string | null {
   if (isAgentLoopRunContext(toolContext?.runContext)) {
     const content = toolContext?.runContext?.conversation?.content;
     if (!content) {

--- a/front/lib/api/actions/servers/google_calendar/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/google_calendar/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("google_calendar");
 

--- a/front/lib/api/actions/servers/google_drive/index.ts
+++ b/front/lib/api/actions/servers/google_drive/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { GOOGLE_DRIVE_TOOL_NAME } from "@app/lib/api/actions/servers/google_drive/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/google_drive/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 async function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("google_drive");
 

--- a/front/lib/api/actions/servers/google_sheets/index.ts
+++ b/front/lib/api/actions/servers/google_sheets/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   GOOGLE_SHEETS_SERVER,
   GOOGLE_SHEETS_TOOL_NAME,
@@ -11,7 +11,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("google_sheets");
 

--- a/front/lib/api/actions/servers/helpers.ts
+++ b/front/lib/api/actions/servers/helpers.ts
@@ -1,6 +1,6 @@
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import type { ConversationMetadata } from "@app/types/assistant/conversation";
 
@@ -41,7 +41,7 @@ export function isSidekickConversation(
  * Both variants contain the conversation, so we check both to access conversation metadata.
  */
 export function getSidekickMetadataFromContext(
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): SidekickMetadata | null {
   const metadata =
     (isAgentLoopRunContext(toolContext?.runContext)

--- a/front/lib/api/actions/servers/http_client/index.ts
+++ b/front/lib/api/actions/servers/http_client/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { HTTP_CLIENT_TOOL_NAME } from "@app/lib/api/actions/servers/http_client/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/http_client/tools";
 import { TOOLS as WEB_TOOLS } from "@app/lib/api/actions/servers/web_search_browse/tools";
@@ -9,7 +9,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(HTTP_CLIENT_TOOL_NAME);
 

--- a/front/lib/api/actions/servers/http_client/tools/index.ts
+++ b/front/lib/api/actions/servers/http_client/tools/index.ts
@@ -4,7 +4,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
   DEFAULT_TIMEOUT_MS,
@@ -33,7 +33,7 @@ const SAFE_RESPONSE_HEADERS = ["content-type", "content-length"];
 
 async function getBearerToken(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<string | null> {
   const toolConfig = toolContext?.runContext?.toolConfiguration;
   if (

--- a/front/lib/api/actions/servers/hubspot/index.ts
+++ b/front/lib/api/actions/servers/hubspot/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { HUBSPOT_SERVER } from "@app/lib/api/actions/servers/hubspot/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/hubspot/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("hubspot");
 

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -6,7 +6,7 @@ import type {
 import { resolveConversationFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import { uploadBase64ImageToFileStorage } from "@app/lib/api/files/upload";
@@ -209,7 +209,7 @@ export function trackTokenUsage({
 
 export async function uploadAndFormatImageResponse(
   auth: Authenticator,
-  toolContext: ToolContextType | undefined,
+  toolContext: ToolContext | undefined,
   images: Base64ImageData[],
   fileName: string
 ): Promise<
@@ -297,7 +297,7 @@ async function processSingleImageFile(
     maxImageSize: number;
     supportedContentTypes: string[];
     providerId: ModelProviderIdType;
-    toolContext: ToolContextType | undefined;
+    toolContext: ToolContext | undefined;
   }
 ): Promise<Ok<ReferenceImageFile> | Err<MCPError>> {
   const workspace = auth.getNonNullableWorkspace();
@@ -365,7 +365,7 @@ export async function processImageFileIds(
     providerId,
   }: {
     imageFileIds: string[];
-    toolContext: ToolContextType | undefined;
+    toolContext: ToolContext | undefined;
     supportedContentTypes: string[];
     providerId: ModelProviderIdType;
   }

--- a/front/lib/api/actions/servers/image_generation/index.ts
+++ b/front/lib/api/actions/servers/image_generation/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { IMAGE_GENERATION_SERVER_NAME } from "@app/lib/api/actions/servers/image_generation/metadata";
 import { createImageGenerationTools } from "@app/lib/api/actions/servers/image_generation/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(IMAGE_GENERATION_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -4,7 +4,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   checkImageGenerationRateLimit,
   computeImageGenerationCostDetails,
@@ -28,7 +28,7 @@ import { startObservation } from "@langfuse/tracing";
 
 export function createImageGenerationTools(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof IMAGE_GENERATION_TOOLS_METADATA> = {
     generate_image: async (

--- a/front/lib/api/actions/servers/include_data/index.ts
+++ b/front/lib/api/actions/servers/include_data/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createIncludeDataTools } from "@app/lib/api/actions/servers/include_data/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("include_data");
 

--- a/front/lib/api/actions/servers/include_data/tools/index.ts
+++ b/front/lib/api/actions/servers/include_data/tools/index.ts
@@ -3,7 +3,7 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K } from "@app/lib/api/actions/servers/data_sources_file_system/tools/search";
 import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
@@ -17,7 +17,7 @@ import type { Authenticator } from "@app/lib/auth";
 // Create tools with access to auth via closure
 export function createIncludeDataTools(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ) {
   const areTagsDynamic = toolContext
     ? shouldAutoGenerateTags(toolContext)

--- a/front/lib/api/actions/servers/interactive_content/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { INTERACTIVE_CONTENT_SERVER_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { createInteractiveContentTools } from "@app/lib/api/actions/servers/interactive_content/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 async function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<McpServer> {
   const server = makeInternalMCPServer(INTERACTIVE_CONTENT_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/interactive_content/template_utils.ts
+++ b/front/lib/api/actions/servers/interactive_content/template_utils.ts
@@ -3,7 +3,7 @@ import {
   makeCoreSearchNodesFilters,
   type ResolvedDataSourceConfiguration,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import { getSkillDataSourceConfigurations } from "@app/lib/api/assistant/skill_actions";
@@ -22,7 +22,7 @@ const MAX_TEMPLATE_SIZE_BYTES = 1 * 1024 * 1024; // 1MB
 
 async function fetchTemplateFromCanonicalPath(
   auth: Authenticator,
-  runContext: AgentLoopRunContextType,
+  runContext: AgentLoopRunContext,
   canonicalPath: string
 ): Promise<Result<string, MCPError>> {
   const { conversation } = runContext;
@@ -97,7 +97,7 @@ async function fetchTemplateFromCanonicalPath(
  */
 export async function fetchTemplateContent(
   auth: Authenticator,
-  runContext: AgentLoopRunContextType,
+  runContext: AgentLoopRunContext,
   {
     templateRef,
   }: {

--- a/front/lib/api/actions/servers/interactive_content/tools/index.test.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.test.ts
@@ -1,4 +1,4 @@
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
@@ -11,13 +11,13 @@ import { describe, expect, it } from "vitest";
 
 function toolContextWithUseFileSystem(
   useFileSystem: boolean | undefined
-): ToolContextType {
+): ToolContext {
   return {
     runContext: {
       contextType: "agent_loop",
       conversation: { metadata: { useFileSystem } },
     },
-  } as unknown as ToolContextType;
+  } as unknown as ToolContext;
 }
 
 describe("createInteractiveContentTools", () => {

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -7,7 +7,7 @@ import type {
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { buildInteractiveContentFileNotification } from "@app/lib/api/actions/servers/interactive_content/helpers";
 import {
@@ -39,7 +39,7 @@ import assert from "assert";
 
 export async function createInteractiveContentTools(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<ToolDefinition[]> {
   const handlers: ToolHandlers<typeof INTERACTIVE_CONTENT_TOOLS_METADATA> = {
     create_interactive_content_file: async (

--- a/front/lib/api/actions/servers/jira/index.ts
+++ b/front/lib/api/actions/servers/jira/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/jira/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("jira");
 

--- a/front/lib/api/actions/servers/jit_testing/index.ts
+++ b/front/lib/api/actions/servers/jit_testing/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { JIT_TESTING_TOOL_NAME } from "@app/lib/api/actions/servers/jit_testing/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/jit_testing/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(JIT_TESTING_TOOL_NAME);
 

--- a/front/lib/api/actions/servers/luma/index.ts
+++ b/front/lib/api/actions/servers/luma/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createLumaTools } from "@app/lib/api/actions/servers/luma/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("luma");
 

--- a/front/lib/api/actions/servers/luma/tools/index.ts
+++ b/front/lib/api/actions/servers/luma/tools/index.ts
@@ -5,7 +5,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import type { LumaClient } from "@app/lib/api/actions/servers/luma/client";
 import { getLumaClient } from "@app/lib/api/actions/servers/luma/client";
 import { LUMA_TOOLS_METADATA } from "@app/lib/api/actions/servers/luma/metadata";
@@ -33,7 +33,7 @@ async function withClient(
 
 export function createLumaTools(
   _auth: Authenticator,
-  _toolContext?: ToolContextType
+  _toolContext?: ToolContext
 ) {
   const handlers: ToolHandlers<typeof LUMA_TOOLS_METADATA> = {
     get_authenticated_user: async (_params, extra: ToolHandlerExtra) => {

--- a/front/lib/api/actions/servers/microsoft/utils.ts
+++ b/front/lib/api/actions/servers/microsoft/utils.ts
@@ -1,4 +1,4 @@
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -132,7 +132,7 @@ export interface TeamsUser {
 
 export async function getAllowedLabelsForMCPServer(
   auth: Authenticator,
-  toolContext: ToolContextType | undefined
+  toolContext: ToolContext | undefined
 ): Promise<string[]> {
   const toolConfig = toolContext?.runContext?.toolConfiguration;
   const internalMCPServerId =

--- a/front/lib/api/actions/servers/microsoft_drive/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { MICROSOFT_DRIVE_SERVER_NAME } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/microsoft_drive/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(MICROSOFT_DRIVE_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/microsoft_excel/index.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { MICROSOFT_EXCEL_SERVER_NAME } from "@app/lib/api/actions/servers/microsoft_excel/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/microsoft_excel/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(MICROSOFT_EXCEL_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/microsoft_teams/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { MICROSOFT_TEAMS_SERVER_NAME } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/microsoft_teams/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(MICROSOFT_TEAMS_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/missing_action_catcher/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createMissingActionCatcherTools } from "@app/lib/api/actions/servers/missing_action_catcher/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("missing_action_catcher");
 

--- a/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
@@ -1,13 +1,13 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { Err, Ok } from "@app/types/shared/result";
 
 // This server has dynamically created tools based on the agentLoopContext.
 // The tool name comes from the context at runtime.
 // TODO(spolu): move to AgentLoopRunContextType
 export function createMissingActionCatcherTools(
-  agentLoopContext?: ToolContextType
+  agentLoopContext?: ToolContext
 ): ToolDefinition[] {
   if (agentLoopContext) {
     const actionName = agentLoopContext.runContext

--- a/front/lib/api/actions/servers/monday/index.ts
+++ b/front/lib/api/actions/servers/monday/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/monday/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("monday");
 

--- a/front/lib/api/actions/servers/notion/index.ts
+++ b/front/lib/api/actions/servers/notion/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { NOTION_TOOL_NAME } from "@app/lib/api/actions/servers/notion/metadata";
 import { createNotionTools } from "@app/lib/api/actions/servers/notion/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("notion");
 

--- a/front/lib/api/actions/servers/notion/tools/index.ts
+++ b/front/lib/api/actions/servers/notion/tools/index.ts
@@ -10,7 +10,7 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { NOTION_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import { NOTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/notion/metadata";
@@ -70,7 +70,7 @@ async function withNotionClient<T>(
 }
 
 export function createNotionTools(
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof NOTION_TOOLS_METADATA> = {
     search: async (

--- a/front/lib/api/actions/servers/notion/tools/index.ts
+++ b/front/lib/api/actions/servers/notion/tools/index.ts
@@ -69,9 +69,7 @@ async function withNotionClient<T>(
   }
 }
 
-export function createNotionTools(
-  toolContext?: ToolContext
-): ToolDefinition[] {
+export function createNotionTools(toolContext?: ToolContext): ToolDefinition[] {
   const handlers: ToolHandlers<typeof NOTION_TOOLS_METADATA> = {
     search: async (
       { query, type, relativeTimeFrame },

--- a/front/lib/api/actions/servers/openai_usage/index.ts
+++ b/front/lib/api/actions/servers/openai_usage/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createOpenAIUsageTools } from "@app/lib/api/actions/servers/openai_usage/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("openai_usage");
 

--- a/front/lib/api/actions/servers/openai_usage/tools/index.ts
+++ b/front/lib/api/actions/servers/openai_usage/tools/index.ts
@@ -5,7 +5,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import type { OpenAIUsageClient } from "@app/lib/api/actions/servers/openai_usage/client";
 import { getOpenAIUsageClient } from "@app/lib/api/actions/servers/openai_usage/client";
 import { OPENAI_USAGE_TOOLS_METADATA } from "@app/lib/api/actions/servers/openai_usage/metadata";
@@ -31,7 +31,7 @@ async function withClient(
 
 export function createOpenAIUsageTools(
   _auth: Authenticator,
-  _toolContext?: ToolContextType
+  _toolContext?: ToolContext
 ) {
   const handlers: ToolHandlers<typeof OPENAI_USAGE_TOOLS_METADATA> = {
     get_completions_usage: async (params, extra: ToolHandlerExtra) => {

--- a/front/lib/api/actions/servers/outlook/calendar_server.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_server.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/outlook/tools/calendar";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("outlook_calendar");
 

--- a/front/lib/api/actions/servers/outlook/mail_server.ts
+++ b/front/lib/api/actions/servers/outlook/mail_server.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { OUTLOOK_TOOL_NAME } from "@app/lib/api/actions/servers/outlook/mail_metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/outlook/tools/mail";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("outlook");
 

--- a/front/lib/api/actions/servers/plan_mode/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { PLAN_MODE_SERVER_NAME } from "@app/lib/api/actions/servers/plan_mode/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/plan_mode/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(PLAN_MODE_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -104,9 +104,7 @@ export async function buildProjectRetrieveDataSources(
  */
 export async function getPod(
   auth: Authenticator,
-  from:
-    | { toolContext?: ToolContext }
-    | { dustPod?: DustPodConfigurationType }
+  from: { toolContext?: ToolContext } | { dustPod?: DustPodConfigurationType }
 ): Promise<Result<PodContext, MCPError>> {
   if ("dustPod" in from && from.dustPod) {
     const { dustPod } = from;
@@ -228,9 +226,7 @@ export function checkWritePermission(
  */
 export async function getWritablePodContext(
   auth: Authenticator,
-  from:
-    | { toolContext?: ToolContext }
-    | { dustPod?: DustPodConfigurationType }
+  from: { toolContext?: ToolContext } | { dustPod?: DustPodConfigurationType }
 ): Promise<Result<PodContext, MCPError>> {
   const contextRes = await getPod(auth, from);
   if (contextRes.isErr()) {

--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -8,7 +8,7 @@ import { parsePodConfigurationURI } from "@app/lib/actions/mcp_internal_actions/
 import {
   isAgentLoopRunContext,
   isSandboxFunctionRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import type { DataSourceFilter } from "@app/lib/api/assistant/configuration/types";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
@@ -105,7 +105,7 @@ export async function buildProjectRetrieveDataSources(
 export async function getPod(
   auth: Authenticator,
   from:
-    | { toolContext?: ToolContextType }
+    | { toolContext?: ToolContext }
     | { dustPod?: DustPodConfigurationType }
 ): Promise<Result<PodContext, MCPError>> {
   if ("dustPod" in from && from.dustPod) {
@@ -229,7 +229,7 @@ export function checkWritePermission(
 export async function getWritablePodContext(
   auth: Authenticator,
   from:
-    | { toolContext?: ToolContextType }
+    | { toolContext?: ToolContext }
     | { dustPod?: DustPodConfigurationType }
 ): Promise<Result<PodContext, MCPError>> {
   const contextRes = await getPod(auth, from);

--- a/front/lib/api/actions/servers/pod_manager/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { POD_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/pod_manager/metadata";
 import { createProjectManagerTools } from "@app/lib/api/actions/servers/pod_manager/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -18,7 +18,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
  */
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(POD_MANAGER_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -8,7 +8,7 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import {
   FILES_LIST_ACTION_NAME,
@@ -103,7 +103,7 @@ function formatListedConversationWithoutMessages(
 
 export function createProjectManagerTools(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof POD_MANAGER_TOOLS_METADATA> = {
     add_content_node: async (params) => {

--- a/front/lib/api/actions/servers/pod_tasks/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { POD_TASKS_SERVER_NAME } from "@app/lib/api/actions/servers/pod_tasks/metadata";
 import { createProjectTasksTools } from "@app/lib/api/actions/servers/pod_tasks/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(POD_TASKS_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/pod_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/tools/index.ts
@@ -6,7 +6,7 @@ import type {
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import {
   getPod,
@@ -204,7 +204,7 @@ function formatTaskListingLine(row: ProjectTaskResource): string {
 
 export function createProjectTasksTools(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): ToolDefinition[] {
   const owner = auth.getNonNullableWorkspace();
   const handlers: ToolHandlers<typeof POD_TASKS_TOOLS_METADATA> = {

--- a/front/lib/api/actions/servers/poke/index.ts
+++ b/front/lib/api/actions/servers/poke/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/poke/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("poke");
 

--- a/front/lib/api/actions/servers/primitive_types_debugger/index.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/primitive_types_debugger/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("primitive_types_debugger");
 

--- a/front/lib/api/actions/servers/productboard/index.ts
+++ b/front/lib/api/actions/servers/productboard/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createProductboardTools } from "@app/lib/api/actions/servers/productboard/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("productboard");
 

--- a/front/lib/api/actions/servers/query_tables_v2/index.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TABLE_QUERY_V2_SERVER_NAME } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/query_tables_v2/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(TABLE_QUERY_V2_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/run_agent/conversation.test.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.test.ts
@@ -1,4 +1,4 @@
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { getOrCreateConversation } from "@app/lib/api/actions/servers/run_agent/conversation";
 import type { Authenticator } from "@app/lib/auth";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -17,7 +17,7 @@ function buildRunAgentFixtures({ spaceId }: { spaceId: string | null }): {
   mainConversation: ConversationType;
   originMessage: AgentMessageType;
   mainAgent: AgentConfigurationType;
-  agentLoopContext: AgentLoopRunContextType;
+  agentLoopContext: AgentLoopRunContext;
 } {
   const userMessage: UserMessageType = {
     id: -1,
@@ -90,7 +90,7 @@ function buildRunAgentFixtures({ spaceId }: { spaceId: string | null }): {
     stepContext: {
       resumeState: null,
     },
-  } as AgentLoopRunContextType;
+  } as AgentLoopRunContext;
 
   const mainConversation = {
     sId: generateRandomModelSId(),

--- a/front/lib/api/actions/servers/run_agent/conversation.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.ts
@@ -1,5 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import {
   appendFilePathsHintToQuery,
   copyConversationFilesIntoSub,
@@ -45,7 +45,7 @@ function isUserSideError(error: APIError): boolean {
 export async function getOrCreateConversation(
   api: DustAPI,
   auth: Authenticator,
-  agentLoopContext: AgentLoopRunContextType,
+  agentLoopContext: AgentLoopRunContext,
   {
     childAgentBlob,
     childAgentId,

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -22,7 +22,7 @@ import {
 import {
   type ActionGeneratedFileType,
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
@@ -181,7 +181,7 @@ const runAgent = async (
     childAgentBlob,
   }: {
     auth: Authenticator;
-    toolContext?: ToolContextType;
+    toolContext?: ToolContext;
     sendNotification?: (
       notification: MCPProgressNotificationType
     ) => Promise<void>;
@@ -756,7 +756,7 @@ const runAgent = async (
   );
 };
 
-function isRunAgentHandoffMode(toolContext?: ToolContextType): boolean {
+function isRunAgentHandoffMode(toolContext?: ToolContext): boolean {
   if (!toolContext) {
     return false;
   }
@@ -845,7 +845,7 @@ async function leakyGetAgentNameAndDescriptionForChildAgent(
 
 async function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("run_agent");
 

--- a/front/lib/api/actions/servers/run_dust_app/helpers.ts
+++ b/front/lib/api/actions/servers/run_dust_app/helpers.ts
@@ -12,8 +12,8 @@ import type {
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
-  AgentLoopRunContextType,
-  ToolRunContextType,
+  AgentLoopRunContext,
+  ToolRunContext,
 } from "@app/lib/actions/types";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { getDatasetSchema } from "@app/lib/api/datasets";
@@ -159,7 +159,7 @@ export async function prepareAppContext(
 
 export async function processDustFileOutput(
   auth: Authenticator,
-  runContext: ToolRunContextType,
+  runContext: ToolRunContext,
   sanitizedOutput: DustFileOutput,
   conversation: ConversationWithoutContentType,
   appName: string
@@ -286,7 +286,7 @@ export async function processDustFileOutput(
 export async function prepareParamsWithHistory(
   params: { [p: string]: unknown },
   schema: DatasetSchema | null,
-  agentLoopRunContext: AgentLoopRunContextType,
+  agentLoopRunContext: AgentLoopRunContext,
   auth: Authenticator
 ): Promise<{ [p: string]: unknown }> {
   if (

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -9,7 +9,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfigurationWithName,
@@ -51,7 +51,7 @@ import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
  */
 export default async function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("run_dust_app");
   const owner = auth.getNonNullableWorkspace();

--- a/front/lib/api/actions/servers/salesforce/index.ts
+++ b/front/lib/api/actions/servers/salesforce/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createSalesforceTools } from "@app/lib/api/actions/servers/salesforce/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("salesforce");
 

--- a/front/lib/api/actions/servers/salesloft/index.ts
+++ b/front/lib/api/actions/servers/salesloft/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createSalesloftTools } from "@app/lib/api/actions/servers/salesloft/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("salesloft");
 

--- a/front/lib/api/actions/servers/salesloft/tools/index.ts
+++ b/front/lib/api/actions/servers/salesloft/tools/index.ts
@@ -4,7 +4,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   formatActionAsString,
   getActionsWithDetails,
@@ -16,7 +16,7 @@ import { Err, Ok } from "@app/types/shared/result";
 
 export function createSalesloftTools(
   auth: Authenticator,
-  _toolContext?: ToolContextType
+  _toolContext?: ToolContext
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof SALESLOFT_TOOLS_METADATA> = {
     get_actions: async ({ include_due_actions_only }, extra) => {

--- a/front/lib/api/actions/servers/sandbox/index.ts
+++ b/front/lib/api/actions/servers/sandbox/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { createSandboxTools } from "@app/lib/api/actions/servers/sandbox/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 async function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("sandbox");
 

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -7,7 +7,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   isAgentLoopRunContext,
   isSandboxResumeState,
@@ -226,7 +226,7 @@ function isSandboxAgentEgressRequestsAllowed(auth: Authenticator): boolean {
 
 export async function createSandboxTools(
   auth: Authenticator,
-  _toolContext?: ToolContextType
+  _toolContext?: ToolContext
 ): Promise<ToolDefinition[]> {
   const handlers: ToolHandlers<typeof SANDBOX_TOOLS_METADATA> = {
     bash: runSandboxBashTool,

--- a/front/lib/api/actions/servers/sandbox_functions/index.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/sandbox_functions/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(SANDBOX_FUNCTIONS_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/schedules_management/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createSchedulesManagementTools } from "@app/lib/api/actions/servers/schedules_management/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("schedules_management");
 

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -3,7 +3,7 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { SCHEDULES_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/schedules_management/metadata";
 import { generateScheduleRule } from "@app/lib/api/assistant/configuration/triggers";
@@ -35,7 +35,7 @@ function renderSchedule(schedule: ScheduleTriggerType): string {
   return lines.join("\n");
 }
 
-function getUserTimezone(toolContext?: ToolContextType): string | null {
+function getUserTimezone(toolContext?: ToolContext): string | null {
   if (!isAgentLoopRunContext(toolContext?.runContext)) {
     return null;
   }
@@ -51,7 +51,7 @@ function getUserTimezone(toolContext?: ToolContextType): string | null {
 
 export function createSchedulesManagementTools(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ) {
   const handlers: ToolHandlers<typeof SCHEDULES_MANAGEMENT_TOOLS_METADATA> = {
     create_schedule: async ({ name, schedule, prompt, timezone }) => {

--- a/front/lib/api/actions/servers/search/index.ts
+++ b/front/lib/api/actions/servers/search/index.ts
@@ -1,7 +1,7 @@
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   SEARCH_SERVER,
   SEARCH_SERVER_NAME,
@@ -15,7 +15,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(SEARCH_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/search/tools/index.ts
+++ b/front/lib/api/actions/servers/search/tools/index.ts
@@ -10,7 +10,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K } from "@app/lib/api/actions/servers/data_sources_file_system/tools/search";
 import {
@@ -56,7 +56,7 @@ export async function searchFunction(
     nodeIds?: string[];
     tagsIn?: string[];
     tagsNot?: string[];
-    toolContext?: ToolContextType;
+    toolContext?: ToolContext;
   }
 ): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);

--- a/front/lib/api/actions/servers/skill_authoring/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { SKILL_AUTHORING_SERVER_NAME } from "@app/lib/api/actions/servers/skill_authoring/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/skill_authoring/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(SKILL_AUTHORING_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/skill_management/index.ts
+++ b/front/lib/api/actions/servers/skill_management/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/skill_management/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("skill_management");
 

--- a/front/lib/api/actions/servers/slab/index.ts
+++ b/front/lib/api/actions/servers/slab/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/slab/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("slab");
 

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -2,7 +2,7 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import {
   formatSlackMessageForLLM,
@@ -753,7 +753,7 @@ export async function executeListPublicChannels(
 
 export async function executePostMessage(
   auth: Authenticator,
-  toolContext: ToolContextType,
+  toolContext: ToolContext,
   {
     accessToken,
     to,
@@ -928,7 +928,7 @@ export async function executeUpdateMessage({
 
 export async function executeScheduleMessage(
   auth: Authenticator,
-  toolContext: ToolContextType,
+  toolContext: ToolContext,
   {
     accessToken,
     to,

--- a/front/lib/api/actions/servers/slack_bot/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createSlackBotTools } from "@app/lib/api/actions/servers/slack_bot/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 async function createServer(
   auth: Authenticator,
   mcpServerId: string,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("slack_bot");
 

--- a/front/lib/api/actions/servers/slack_bot/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/tools/index.ts
@@ -4,7 +4,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   executeListPublicChannels,
   executePostMessage,
@@ -20,7 +20,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 export function createSlackBotTools(
   auth: Authenticator,
   mcpServerId: string,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof SLACK_BOT_TOOLS_METADATA> = {
     post_message: async (

--- a/front/lib/api/actions/servers/slack_personal/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -18,7 +18,7 @@ const localLogger = logger.child({ module: "mcp_slack_personal" });
 async function createServer(
   auth: Authenticator,
   mcpServerId: string,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("slack");
 

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -9,7 +9,7 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { SLACK_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import {
@@ -371,7 +371,7 @@ export interface SlackPersonalToolsResult {
 export function createSlackPersonalTools(
   auth: Authenticator,
   mcpServerId: string,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): SlackPersonalToolsResult {
   const allowFooterRemoval =
     auth.workspace()?.metadata?.slackPersonalAllowFooterRemoval ?? false;

--- a/front/lib/api/actions/servers/snowflake/index.ts
+++ b/front/lib/api/actions/servers/snowflake/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/snowflake/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("snowflake");
 

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -3,7 +3,7 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { SnowflakeClient } from "@app/lib/api/actions/servers/snowflake/client";
 import {
@@ -35,7 +35,7 @@ interface SnowflakeQueryTagMetadata {
 // Builds Snowflake query tag for agent-level usage tracking.
 // Enables customers to track query costs per agent in QUERY_HISTORY.
 function buildQueryTagMetadata(
-  toolContext?: ToolContextType,
+  toolContext?: ToolContext,
   auth?: Authenticator
 ): string | undefined {
   if (!toolContext?.runContext || !auth) {
@@ -71,7 +71,7 @@ async function getClientFromAuthInfo(
       }
     | null
     | undefined,
-  toolContext?: ToolContextType,
+  toolContext?: ToolContext,
   auth?: Authenticator
 ): Promise<Result<SnowflakeClient, MCPError>> {
   const queryTagMetadata = buildQueryTagMetadata(toolContext, auth);

--- a/front/lib/api/actions/servers/sound_studio/index.ts
+++ b/front/lib/api/actions/servers/sound_studio/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { SOUND_STUDIO_SERVER_NAME } from "@app/lib/api/actions/servers/sound_studio/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/sound_studio/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(SOUND_STUDIO_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/speech_generator/index.ts
+++ b/front/lib/api/actions/servers/speech_generator/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { SPEECH_GENERATOR_SERVER_NAME } from "@app/lib/api/actions/servers/speech_generator/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/speech_generator/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(SPEECH_GENERATOR_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/statuspage/index.ts
+++ b/front/lib/api/actions/servers/statuspage/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createStatuspageTools } from "@app/lib/api/actions/servers/statuspage/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("statuspage");
 

--- a/front/lib/api/actions/servers/statuspage/tools/index.ts
+++ b/front/lib/api/actions/servers/statuspage/tools/index.ts
@@ -5,7 +5,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import type { StatuspageClient } from "@app/lib/api/actions/servers/statuspage/client";
 import { getStatuspageClient } from "@app/lib/api/actions/servers/statuspage/client";
 import { STATUSPAGE_TOOLS_METADATA } from "@app/lib/api/actions/servers/statuspage/metadata";
@@ -32,7 +32,7 @@ async function withClient(
 
 export function createStatuspageTools(
   _auth: Authenticator,
-  _toolContext?: ToolContextType
+  _toolContext?: ToolContext
 ) {
   const handlers: ToolHandlers<typeof STATUSPAGE_TOOLS_METADATA> = {
     list_pages: async (_params, extra: ToolHandlerExtra) => {

--- a/front/lib/api/actions/servers/toolsets/index.ts
+++ b/front/lib/api/actions/servers/toolsets/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/toolsets/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("toolsets");
 

--- a/front/lib/api/actions/servers/ukg_ready/index.ts
+++ b/front/lib/api/actions/servers/ukg_ready/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/ukg_ready/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("ukg_ready");
 

--- a/front/lib/api/actions/servers/user_analytics/index.ts
+++ b/front/lib/api/actions/servers/user_analytics/index.ts
@@ -2,7 +2,7 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   USER_ANALYTICS_SERVER_NAME,
   USER_ANALYTICS_TOOLS_METADATA,
@@ -175,7 +175,7 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(USER_ANALYTICS_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/user_mentions/index.ts
+++ b/front/lib/api/actions/servers/user_mentions/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { USER_MENTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/user_mentions/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/user_mentions/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(USER_MENTIONS_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/val_town/helpers.ts
+++ b/front/lib/api/actions/servers/val_town/helpers.ts
@@ -1,4 +1,4 @@
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
@@ -20,7 +20,7 @@ export function isValTownError(error: unknown): error is ValTownError {
 
 export async function getValTownClient(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): Promise<ValTown | null> {
   const toolConfig = toolContext?.runContext?.toolConfiguration;
   if (

--- a/front/lib/api/actions/servers/val_town/index.ts
+++ b/front/lib/api/actions/servers/val_town/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createValTownTools } from "@app/lib/api/actions/servers/val_town/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("val_town");
 

--- a/front/lib/api/actions/servers/val_town/tools/index.ts
+++ b/front/lib/api/actions/servers/val_town/tools/index.ts
@@ -1,7 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import {
   getValTownClient,
   isValTownError,
@@ -18,7 +18,7 @@ const API_KEY_NOT_CONFIGURED_ERROR =
 
 export function createValTownTools(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ) {
   const handlers: ToolHandlers<typeof VAL_TOWN_TOOLS_METADATA> = {
     create_val: async ({ name, privacy, description, orgId }) => {

--- a/front/lib/api/actions/servers/vanta/index.ts
+++ b/front/lib/api/actions/servers/vanta/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/vanta/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("vanta");
 

--- a/front/lib/api/actions/servers/wakeups/index.ts
+++ b/front/lib/api/actions/servers/wakeups/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { WAKEUPS_SERVER_NAME } from "@app/lib/api/actions/servers/wakeups/metadata";
 import { createWakeupsTools } from "@app/lib/api/actions/servers/wakeups/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(WAKEUPS_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/wakeups/tools/index.ts
+++ b/front/lib/api/actions/servers/wakeups/tools/index.ts
@@ -3,7 +3,7 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   isAgentLoopRunContext,
-  type ToolContextType,
+  type ToolContext,
 } from "@app/lib/actions/types";
 import { WAKEUPS_TOOLS_METADATA } from "@app/lib/api/actions/servers/wakeups/metadata";
 import type { Authenticator } from "@app/lib/auth";
@@ -92,7 +92,7 @@ function parseWhen(when: string):
   return null;
 }
 
-function getUserTimezone(toolContext?: ToolContextType): string | null {
+function getUserTimezone(toolContext?: ToolContext): string | null {
   if (!isAgentLoopRunContext(toolContext?.runContext)) {
     return null;
   }
@@ -127,7 +127,7 @@ function renderWakeUp(wakeUp: WakeUpType): string {
 
 export function createWakeupsTools(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ) {
   const handlers: ToolHandlers<typeof WAKEUPS_TOOLS_METADATA> = {
     schedule_wakeup: async ({ when, reason, timezone }) => {

--- a/front/lib/api/actions/servers/web_search_browse/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { WEB_SEARCH_BROWSE_SERVER_NAME } from "@app/lib/api/actions/servers/web_search_browse/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/web_search_browse/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(WEB_SEARCH_BROWSE_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/workday/index.ts
+++ b/front/lib/api/actions/servers/workday/index.ts
@@ -1,10 +1,10 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/workday/tools";
 import type { Authenticator } from "@app/lib/auth";
 
-function createServer(auth: Authenticator, toolContext?: ToolContextType) {
+function createServer(auth: Authenticator, toolContext?: ToolContext) {
   const server = makeInternalMCPServer("workday");
 
   for (const tool of TOOLS) {

--- a/front/lib/api/actions/servers/workspace_analytics/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/index.ts
@@ -1,13 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { TOOLS } from "@app/lib/api/actions/servers/workspace_analytics/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("workspace_analytics");
 

--- a/front/lib/api/actions/servers/zendesk/index.ts
+++ b/front/lib/api/actions/servers/zendesk/index.ts
@@ -1,6 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/zendesk/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  toolContext?: ToolContextType
+  toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer("zendesk");
 

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -1,6 +1,6 @@
 import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
 import { isResourceContentWithText } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { ToolRunContextType } from "@app/lib/actions/types";
+import type { ToolRunContext } from "@app/lib/actions/types";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import {
   conversationScopedPath,
@@ -34,7 +34,7 @@ export interface PersistedToolOutput {
  */
 async function getDustFileSystemForRunContext(
   auth: Authenticator,
-  runContext: ToolRunContextType
+  runContext: ToolRunContext
 ): Promise<Result<DustFileSystem, Error>> {
   switch (runContext.contextType) {
     case "agent_loop":
@@ -50,7 +50,7 @@ async function getDustFileSystemForRunContext(
 }
 
 function getToolOutputsScopedPath(
-  runContext: ToolRunContextType,
+  runContext: ToolRunContext,
   fileName: string
 ): string {
   switch (runContext.contextType) {
@@ -158,7 +158,7 @@ export async function writeToPodFolder(
  */
 export async function writeToToolOutputsFolder(
   auth: Authenticator,
-  runContext: ToolRunContextType,
+  runContext: ToolRunContext,
   {
     fileName,
     content,
@@ -196,7 +196,7 @@ export async function writeToToolOutputsFolder(
  */
 export async function persistToolOutput(
   auth: Authenticator,
-  runContext: ToolRunContextType,
+  runContext: ToolRunContext,
   block: CallToolResult["content"][number],
   { toolName, serverName }: { toolName: string; serverName: string }
 ): Promise<Result<PersistedToolOutput | null, Error>> {

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -18,10 +18,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/events";
 import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/exit_events";
 import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
-import type {
-  ToolContext,
-  ToolOutputItemType,
-} from "@app/lib/actions/types";
+import type { ToolContext, ToolOutputItemType } from "@app/lib/actions/types";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -19,7 +19,7 @@ import type {
 import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/exit_events";
 import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import type {
-  ToolContextType,
+  ToolContext,
   ToolOutputItemType,
 } from "@app/lib/actions/types";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
@@ -43,7 +43,7 @@ export async function* runToolWithStreaming(
   {
     toolContext,
   }: {
-    toolContext: ToolContextType;
+    toolContext: ToolContext;
   },
   options?: { signal?: AbortSignal }
 ): AsyncGenerator<

--- a/front/lib/api/poke/mcp_diagnostics.ts
+++ b/front/lib/api/poke/mcp_diagnostics.ts
@@ -16,7 +16,7 @@ import {
 } from "@app/lib/actions/mcp_metadata";
 import { getMCPConnectionAccessToken } from "@app/lib/actions/mcp_oauth_access_token";
 import { MCPOAuthProvider } from "@app/lib/actions/mcp_oauth_provider";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import {
   MCP_DIAGNOSTIC_CHECK_NAMES,
@@ -602,7 +602,7 @@ async function runConnectListToolsCheck(
 
   const toolContext =
     connectionType === "personal"
-      ? { runContext: {} as AgentLoopRunContextType }
+      ? { runContext: {} as AgentLoopRunContext }
       : undefined;
 
   const connectRes = await connectToMCPServer(auth, {

--- a/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
@@ -3,7 +3,7 @@ import {
   processToolNotification,
   processToolResults,
 } from "@app/lib/actions/mcp_execution";
-import type { SandboxFunctionRunContextType } from "@app/lib/actions/types";
+import type { SandboxFunctionRunContext } from "@app/lib/actions/types";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
@@ -55,7 +55,7 @@ export async function runSandboxFunctionToolActivity(
     workspaceId: auth.getNonNullableWorkspace().sId,
   });
 
-  const runContext: SandboxFunctionRunContextType = {
+  const runContext: SandboxFunctionRunContext = {
     contextType: "sandbox_function",
     action,
     invocation,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,5 +1,5 @@
 import { isAgentLoopToolNotificationEvent } from "@app/lib/actions/mcp";
-import type { ToolContextType } from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { isLightClientSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
@@ -229,7 +229,7 @@ async function executeToolStreaming(
     ? updateResourceAndPublishEvent
     : () => {};
 
-  const toolContext: ToolContextType = {
+  const toolContext: ToolContext = {
     runContext: {
       contextType: "agent_loop",
       action,


### PR DESCRIPTION
## Description

Rename of `TooContext*Type` types to `ToolContext*` as these are not really serialised or sent over the network.

## Tests

Covered by existing tests and type-checker. Tested locally.

## Risk

None. Can be reverted.

## Deploy Plan

N/A pure type.