### PR TITLE
Fix getLatestMemberships : do not include future members

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -295,6 +295,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     );
   }
 
+  /**
+   * Returns the most recent membership row per (user, workspace), including
+   * revoked ones (endAt in the past). Excludes not-yet-started scheduled
+   * seat changes (startAt in the future) — use
+   * `getScheduledFutureMemberships` / `getScheduledMembershipsByUserIdInWorkspace`
+   * to read those separately.
+   */
   static async getLatestMemberships({
     users,
     workspace,
@@ -311,7 +318,11 @@ export class MembershipResource extends BaseResource<MembershipModel> {
           (resource) => new MembershipResource(MembershipModel, resource.get())
         );
 
-    const whereClause: WhereOptions<InferAttributes<MembershipModel>> = {};
+    const whereClause: WhereOptions<InferAttributes<MembershipModel>> = {
+      // Exclude not-yet-started scheduled seat changes: "latest" means the
+      // latest membership that has actually taken effect, not a future one.
+      startAt: { [Op.lte]: new Date() },
+    };
     if (roles) {
       whereClause.role = roles;
     }


### PR DESCRIPTION
## Description

`MembershipResource.getLatestMemberships` picked the "latest" membership row per
(user, workspace) purely by max `startAt`, with no filter excluding not-yet-started
rows. Since scheduled seat changes (`scheduleSeatChange`) write a future-dated row
(`startAt` in the future, same `role`, new `seatType`), that future row would win
over the currently-active one as soon as it existed.

Symptom: in the poke members list, a member with a scheduled seat-type change showed
the *future* seat type as their current one, and the "→ scheduled (date)" annotation
disappeared entirely (`columns.tsx` only renders it when `scheduledSeatType !== seatType`,
and both ended up equal to the future value).

Fix: add `startAt: { [Op.lte]: new Date() }` to `getLatestMemberships`'s where clause,
matching the convention already used by `getLatestMembershipOfUserInWorkspace` and
`getUserIdsWithRealSeatHistory` in the same file. "Latest" now means the latest
membership that has actually taken effect — revoked memberships are still included
(no `endAt` filter), only not-yet-started scheduled rows are excluded.

## Impact

`getLatestMemberships` is used by more than just the poke UI (ES indexation, Customer.io
sync, admin CLI, member lookup, the poke MCP tool, etc.). I audited every call site:
none relied on getting the future row, and most were latently exposed to the same class
of bug (e.g. Customer.io sync or search indexing could have picked up a not-yet-active
role/seat type). No regressions expected; sites that dedup by `workspaceId` only
(workspace search, scrub, hard-delete counting) are unaffected either way.

## Tests

Manual: verified `npx tsgo --noEmit` passes with no new errors. No existing test
exercised the future-row-wins-over-current bug; relying on the type-check plus the
call-site audit above.

## Risk

Low. The change only narrows results in a case that previously returned a value no
caller wanted (a not-yet-active future membership). Rollback is a one-line revert.

## Deploy Plan

Standard deploy, no migration or feature flag required.
