### PR TITLE
[front] refactor: move group pool cap to a dedicated group_pool_caps table

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/groups/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/index.ts
@@ -2,29 +2,49 @@ import type { PokeListGroups } from "@app/lib/api/poke/groups";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import groupId from "./[groupId]";
+
+const ListGroupsQuerySchema = z.object({
+  // When "true", each group also carries its pool cap (one extra batched
+  // query). Accepted but not yet honored: the cap is still returned
+  // unconditionally so front-end bundles that predate the flag keep working.
+  // A follow-up makes the cap conditional on this flag, once the bundles
+  // sending it are deployed everywhere.
+  withPoolCaps: z.enum(["true", "false"]).optional(),
+});
 
 // Mounted at /api/poke/workspaces/:wId/groups.
 const app = pokeApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<PokeListGroups> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  validate("query", ListGroupsQuerySchema),
+  async (ctx): HandlerResult<PokeListGroups> => {
+    const auth = ctx.get("auth");
 
-  const groups = await GroupResource.listAllWorkspaceGroups(auth);
-  const memberCounts = await GroupResource.getMemberCountsForGroups(
-    auth,
-    groups
-  );
+    const groups = await GroupResource.listAllWorkspaceGroups(auth);
+    const memberCounts = await GroupResource.getMemberCountsForGroups(
+      auth,
+      groups
+    );
+    const poolCaps = await GroupResource.getPoolCapAwuCreditsForGroups(
+      auth,
+      groups
+    );
 
-  return ctx.json({
-    groups: groups.map((group) => ({
-      ...group.toJSON(),
-      memberCount: memberCounts.get(group.id) ?? 0,
-    })),
-  });
-});
+    return ctx.json({
+      groups: groups.map((group) => ({
+        ...group.toJSON(),
+        memberCount: memberCounts.get(group.id) ?? 0,
+        poolCapAwuCredits: poolCaps.get(group.id) ?? null,
+      })),
+    });
+  }
+);
 
 app.route("/:groupId", groupId);
 

--- a/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
@@ -233,7 +233,7 @@ describe("/api/w/[wId]/groups/[groupId]/spend_limit", () => {
       if (reloaded.isErr()) {
         throw reloaded.error;
       }
-      expect(reloaded.value.poolCapAwuCredits).toBe(25_000);
+      expect(await reloaded.value.getPoolCapAwuCredits()).toBe(25_000);
     });
 
     it("clears the cap and the alerts for unlimited", async () => {
@@ -263,7 +263,7 @@ describe("/api/w/[wId]/groups/[groupId]/spend_limit", () => {
       if (reloaded.isErr()) {
         throw reloaded.error;
       }
-      expect(reloaded.value.poolCapAwuCredits).toBeNull();
+      expect(await reloaded.value.getPoolCapAwuCredits()).toBeNull();
     });
   });
 });

--- a/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
@@ -238,7 +238,7 @@ describe("/api/w/[wId]/groups/[groupId]/spend_limit", () => {
       if (reloaded.isErr()) {
         throw reloaded.error;
       }
-      expect(reloaded.value.poolCapAwuCredits).toBe(25_000);
+      expect(await reloaded.value.getPoolCapAwuCredits()).toBe(25_000);
     });
 
     it("clears the cap and the alerts for unlimited", async () => {
@@ -268,7 +268,7 @@ describe("/api/w/[wId]/groups/[groupId]/spend_limit", () => {
       if (reloaded.isErr()) {
         throw reloaded.error;
       }
-      expect(reloaded.value.poolCapAwuCredits).toBeNull();
+      expect(await reloaded.value.getPoolCapAwuCredits()).toBeNull();
     });
   });
 });

--- a/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
@@ -138,7 +138,7 @@ describe("/api/w/[wId]/groups/[groupId]/spend_limit", () => {
       if (reloaded.isErr()) {
         throw reloaded.error;
       }
-      expect(reloaded.value.poolCapAwuCredits).toBe(1500);
+      expect(await reloaded.value.getPoolCapAwuCredits()).toBe(1500);
     });
   });
 

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -16,7 +16,10 @@ import groupDetail from "./[groupId]";
 import spendLimit from "./[groupId]/spend_limit";
 
 export type GetGroupsResponseBody = {
-  groups: (GroupType & { memberCount: number })[];
+  groups: (GroupType & {
+    memberCount: number;
+    poolCapAwuCredits: number | null;
+  })[];
 };
 
 const GetGroupsQuerySchema = z.object({
@@ -49,10 +52,15 @@ app.get(
       auth,
       groups
     );
+    const poolCaps = await GroupResource.getPoolCapAwuCreditsForGroups(
+      auth,
+      groups
+    );
 
     const groupsWithMemberCount = groups.map((group) => ({
       ...group.toJSON(),
       memberCount: memberCounts.get(group.id) ?? 0,
+      poolCapAwuCredits: poolCaps.get(group.id) ?? null,
     }));
 
     return ctx.json({ groups: groupsWithMemberCount });

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -32,6 +32,12 @@ const GetGroupsQuerySchema = z.object({
   // When "true", each group also carries its member sIds (one extra batched
   // query) instead of just memberCount.
   withMembers: z.enum(["true", "false"]).optional(),
+  // When "true", each group also carries its pool cap (one extra batched
+  // query). Accepted but not yet honored: the cap is still returned
+  // unconditionally so front-end bundles that predate the flag keep working.
+  // A follow-up makes the cap conditional on this flag, once the bundles
+  // sending it are deployed everywhere.
+  withPoolCaps: z.enum(["true", "false"]).optional(),
 });
 
 // Mounted at /api/w/:wId/groups.

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -21,7 +21,10 @@ import groupDetail from "./[groupId]";
 import spendLimit from "./[groupId]/spend_limit";
 
 export type GetGroupsResponseBody = {
-  groups: (GroupType & { memberCount: number })[];
+  groups: (GroupType & {
+    memberCount: number;
+    poolCapAwuCredits: number | null;
+  })[];
 };
 
 const GetGroupsQuerySchema = z.object({
@@ -57,11 +60,21 @@ app.get(
       groupKinds,
     });
 
+    const groupsJSON =
+      withMembers === "true"
+        ? await GroupResource.fetchJSONWithMembers(auth, groups)
+        : await GroupResource.toJSONWithMemberCounts(auth, groups);
+
+    const poolCaps = await GroupResource.getPoolCapAwuCreditsForGroups(
+      auth,
+      groups
+    );
+
     return ctx.json({
-      groups:
-        withMembers === "true"
-          ? await GroupResource.fetchJSONWithMembers(auth, groups)
-          : await GroupResource.toJSONWithMemberCounts(auth, groups),
+      groups: groupsJSON.map((group) => ({
+        ...group,
+        poolCapAwuCredits: poolCaps.get(group.id) ?? null,
+      })),
     });
   }
 );

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -96,6 +96,7 @@ import {
 } from "@app/lib/resources/storage/models/files";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
+import { GroupPoolCapModel } from "@app/lib/resources/storage/models/group_pool_caps";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
@@ -166,6 +167,7 @@ export function loadAllModels() {
     MembershipUpgradeRequestModel,
     MembershipInvitationModel,
     GroupModel,
+    GroupPoolCapModel,
     GroupMembershipModel,
     TagModel,
     SpaceModel,

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -102,6 +102,7 @@ import {
 } from "@app/lib/resources/storage/models/files";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
+import { GroupPoolCapModel } from "@app/lib/resources/storage/models/group_pool_caps";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import { KillSwitchModel } from "@app/lib/resources/storage/models/kill_switches";
@@ -173,6 +174,7 @@ export function loadAllModels() {
     MembershipUpgradeRequestModel,
     MembershipInvitationModel,
     GroupModel,
+    GroupPoolCapModel,
     GroupMembershipModel,
     TagModel,
     SpaceModel,

--- a/front/components/poke/credits/PokeMemberSpendLimitModal.tsx
+++ b/front/components/poke/credits/PokeMemberSpendLimitModal.tsx
@@ -25,7 +25,7 @@ interface PokeMemberSpendLimitModalProps {
   isOpen: boolean;
   onClose: () => void;
   member: MemberUsageType | null;
-  groups: GroupType[];
+  groups: (GroupType & { poolCapAwuCredits: number | null })[];
 }
 
 type GroupRow = {
@@ -81,7 +81,7 @@ export function PokeMemberSpendLimitModal({
     ? String(extraAwuCredits)
     : "0";
 
-  const memberGroups: GroupType[] = removeNulls(
+  const memberGroups = removeNulls(
     (displayedMember?.groups ?? []).map((groupName) =>
       groups.find((g) => g.name === groupName)
     )

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -250,7 +250,7 @@ export function PoolUsagePage() {
     [isSeatBased]
   );
 
-  const { data: allGroups } = usePokeGroups({ owner });
+  const { data: allGroups } = usePokeGroups({ owner, withPoolCaps: true });
   const groups = useMemo(
     () => allGroups.filter((group) => isCapEligibleGroupKind(group.kind)),
     [allGroups]

--- a/front/components/workspace/GroupsUsageTable.tsx
+++ b/front/components/workspace/GroupsUsageTable.tsx
@@ -80,6 +80,7 @@ export function GroupsUsageTable({
   const { groups, isGroupsLoading } = useGroups({
     owner,
     kinds: [...CAP_ELIGIBLE_GROUP_KINDS],
+    withPoolCaps: true,
   });
   const { doUpdateGroupSpendLimit } = useUpdateGroupSpendLimit({
     workspaceId: owner.sId,

--- a/front/lib/api/groups/spend_limit.test.ts
+++ b/front/lib/api/groups/spend_limit.test.ts
@@ -127,7 +127,7 @@ describe("setGroupSpendLimit", () => {
     if (reloaded.isErr()) {
       throw reloaded.error;
     }
-    expect(reloaded.value.poolCapAwuCredits).toBe(25_000);
+    expect(await reloaded.value.getPoolCapAwuCredits()).toBe(25_000);
 
     // Metronome threshold = 8_000 (seat) + 25_000 (group) = 33_000.
     expect(
@@ -172,7 +172,7 @@ describe("setGroupSpendLimit", () => {
     if (reloaded.isErr()) {
       throw reloaded.error;
     }
-    expect(reloaded.value.poolCapAwuCredits).toBeNull();
+    expect(await reloaded.value.getPoolCapAwuCredits()).toBeNull();
 
     expect(
       groupCapAlert.clearMetronomeGroupCapAlertForSeatType

--- a/front/lib/api/groups/spend_limit.test.ts
+++ b/front/lib/api/groups/spend_limit.test.ts
@@ -130,7 +130,7 @@ describe("setGroupSpendLimit", () => {
     if (reloaded.isErr()) {
       throw reloaded.error;
     }
-    expect(reloaded.value.poolCapAwuCredits).toBe(25_000);
+    expect(await reloaded.value.getPoolCapAwuCredits()).toBe(25_000);
 
     // Metronome threshold = 8_000 (seat) + 25_000 (group) = 33_000.
     expect(
@@ -175,7 +175,7 @@ describe("setGroupSpendLimit", () => {
     if (reloaded.isErr()) {
       throw reloaded.error;
     }
-    expect(reloaded.value.poolCapAwuCredits).toBeNull();
+    expect(await reloaded.value.getPoolCapAwuCredits()).toBeNull();
 
     expect(
       groupCapAlert.clearMetronomeGroupCapAlertForSeatType

--- a/front/lib/api/groups/spend_limit.test.ts
+++ b/front/lib/api/groups/spend_limit.test.ts
@@ -252,7 +252,7 @@ describe("setGroupSpendLimit", () => {
     if (reloaded.isErr()) {
       throw reloaded.error;
     }
-    expect(reloaded.value.poolCapAwuCredits).toBe(10_000);
+    expect(await reloaded.value.getPoolCapAwuCredits()).toBe(10_000);
     expect(workosAudit.emitAuditLogEvent).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/groups/spend_limit.ts
+++ b/front/lib/api/groups/spend_limit.ts
@@ -261,11 +261,11 @@ export async function setGroupSpendLimit(
   }
 
   const poolCapAwuCredits = limit.kind === "limited" ? limit.awuCredits : null;
-  const previousPoolCapAwuCredits = group.poolCapAwuCredits;
+  const previousPoolCapAwuCredits = await group.getPoolCapAwuCredits();
 
-  // Persist the admin's intent first: the group column is the source of truth,
-  // the Metronome alerts below are derived enforcement (a failed sync can be
-  // retried and re-derives from this value).
+  // Persist the admin's intent first: the group_pool_caps row is the source of
+  // truth, the Metronome alerts below are derived enforcement (a failed sync
+  // can be retried and re-derives from this value).
   const updateResult = await group.updatePoolCap(poolCapAwuCredits);
   if (updateResult.isErr()) {
     return new Err(

--- a/front/lib/api/poke/groups.ts
+++ b/front/lib/api/poke/groups.ts
@@ -5,7 +5,7 @@ import type { GroupType } from "@app/types/groups";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 
 export type PokeListGroups = {
-  groups: GroupType[];
+  groups: (GroupType & { poolCapAwuCredits: number | null })[];
 };
 
 export type PokeGetGroupDetails = {

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -629,7 +629,7 @@ describe("GroupResource", () => {
         workspaceId: workspace.id,
         kind: "regular_auto",
       });
-      expect(regularGroup.poolCapAwuCredits).toBeNull();
+      expect(await regularGroup.getPoolCapAwuCredits()).toBeNull();
 
       const setResult = await regularGroup.updatePoolCap(authenticator, 5000);
       expect(setResult.isOk()).toBe(true);
@@ -641,7 +641,7 @@ describe("GroupResource", () => {
       if (afterSet.isErr()) {
         throw afterSet.error;
       }
-      expect(afterSet.value.poolCapAwuCredits).toBe(5000);
+      expect(await afterSet.value.getPoolCapAwuCredits()).toBe(5000);
 
       const clearResult = await regularGroup.updatePoolCap(authenticator, null);
       expect(clearResult.isOk()).toBe(true);
@@ -653,7 +653,58 @@ describe("GroupResource", () => {
       if (afterClear.isErr()) {
         throw afterClear.error;
       }
-      expect(afterClear.value.poolCapAwuCredits).toBeNull();
+      expect(await afterClear.value.getPoolCapAwuCredits()).toBeNull();
+    });
+  });
+
+  describe("getPoolCapAwuCredits", () => {
+    it("returns the group's cap and null when the group carries none", async () => {
+      const cappedGroup = await GroupResource.makeNew({
+        name: "Capped Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      await cappedGroup.updatePoolCap(authenticator, 1234);
+
+      const uncappedGroup = await GroupResource.makeNew({
+        name: "Uncapped Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+
+      expect(await cappedGroup.getPoolCapAwuCredits()).toBe(1234);
+      expect(await uncappedGroup.getPoolCapAwuCredits()).toBeNull();
+    });
+  });
+
+  describe("getPoolCapAwuCreditsForGroups", () => {
+    it("returns a map of caps for the capped groups only", async () => {
+      const cappedGroup = await GroupResource.makeNew({
+        name: "Batch Capped Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      await cappedGroup.updatePoolCap(authenticator, 700);
+
+      const uncappedGroup = await GroupResource.makeNew({
+        name: "Batch Uncapped Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+
+      const caps = await GroupResource.getPoolCapAwuCreditsForGroups(
+        authenticator,
+        [cappedGroup, uncappedGroup]
+      );
+
+      expect(caps.get(cappedGroup.id)).toBe(700);
+      expect(caps.has(uncappedGroup.id)).toBe(false);
+
+      const emptyCaps = await GroupResource.getPoolCapAwuCreditsForGroups(
+        authenticator,
+        []
+      );
+      expect(emptyCaps.size).toBe(0);
     });
   });
 

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -883,7 +883,7 @@ describe("GroupResource", () => {
         workspaceId: workspace.id,
         kind: "regular_auto",
       });
-      await cappedGroup.updatePoolCap(authenticator, 1234);
+      await cappedGroup.updatePoolCap(1234);
 
       const uncappedGroup = await GroupResource.makeNew({
         name: "Uncapped Group",
@@ -903,7 +903,7 @@ describe("GroupResource", () => {
         workspaceId: workspace.id,
         kind: "regular_auto",
       });
-      await cappedGroup.updatePoolCap(authenticator, 700);
+      await cappedGroup.updatePoolCap(700);
 
       const uncappedGroup = await GroupResource.makeNew({
         name: "Batch Uncapped Group",

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -848,7 +848,7 @@ describe("GroupResource", () => {
         workspaceId: workspace.id,
         kind: "regular_manual",
       });
-      expect(regularGroup.poolCapAwuCredits).toBeNull();
+      expect(await regularGroup.getPoolCapAwuCredits()).toBeNull();
 
       const setResult = await regularGroup.updatePoolCap(5000);
       expect(setResult.isOk()).toBe(true);
@@ -860,7 +860,7 @@ describe("GroupResource", () => {
       if (afterSet.isErr()) {
         throw afterSet.error;
       }
-      expect(afterSet.value.poolCapAwuCredits).toBe(5000);
+      expect(await afterSet.value.getPoolCapAwuCredits()).toBe(5000);
 
       const clearResult = await regularGroup.updatePoolCap(null);
       expect(clearResult.isOk()).toBe(true);
@@ -872,7 +872,58 @@ describe("GroupResource", () => {
       if (afterClear.isErr()) {
         throw afterClear.error;
       }
-      expect(afterClear.value.poolCapAwuCredits).toBeNull();
+      expect(await afterClear.value.getPoolCapAwuCredits()).toBeNull();
+    });
+  });
+
+  describe("getPoolCapAwuCredits", () => {
+    it("returns the group's cap and null when the group carries none", async () => {
+      const cappedGroup = await GroupResource.makeNew({
+        name: "Capped Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      await cappedGroup.updatePoolCap(authenticator, 1234);
+
+      const uncappedGroup = await GroupResource.makeNew({
+        name: "Uncapped Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+
+      expect(await cappedGroup.getPoolCapAwuCredits()).toBe(1234);
+      expect(await uncappedGroup.getPoolCapAwuCredits()).toBeNull();
+    });
+  });
+
+  describe("getPoolCapAwuCreditsForGroups", () => {
+    it("returns a map of caps for the capped groups only", async () => {
+      const cappedGroup = await GroupResource.makeNew({
+        name: "Batch Capped Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      await cappedGroup.updatePoolCap(authenticator, 700);
+
+      const uncappedGroup = await GroupResource.makeNew({
+        name: "Batch Uncapped Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+
+      const caps = await GroupResource.getPoolCapAwuCreditsForGroups(
+        authenticator,
+        [cappedGroup, uncappedGroup]
+      );
+
+      expect(caps.get(cappedGroup.id)).toBe(700);
+      expect(caps.has(uncappedGroup.id)).toBe(false);
+
+      const emptyCaps = await GroupResource.getPoolCapAwuCreditsForGroups(
+        authenticator,
+        []
+      );
+      expect(emptyCaps.size).toBe(0);
     });
   });
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -7,6 +7,7 @@ import type { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupPoolCapModel } from "@app/lib/resources/storage/models/group_pool_caps";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
@@ -78,7 +79,6 @@ type CachedGroup = {
   kind: GroupKind;
   workspaceId: ModelId;
   workOSGroupId: string | null;
-  poolCapAwuCredits: number | null;
   createdAt: number;
   updatedAt: number;
 };
@@ -133,7 +133,6 @@ export class GroupResource extends BaseResource<GroupModel> {
       kind: g.kind,
       workspaceId: g.workspaceId,
       workOSGroupId: g.workOSGroupId,
-      poolCapAwuCredits: g.poolCapAwuCredits,
       createdAt: g.createdAt.getTime(),
       updatedAt: g.updatedAt.getTime(),
     }));
@@ -173,7 +172,6 @@ export class GroupResource extends BaseResource<GroupModel> {
       kind: data.kind,
       workspaceId: data.workspaceId,
       workOSGroupId: data.workOSGroupId,
-      poolCapAwuCredits: data.poolCapAwuCredits,
       createdAt: new Date(data.createdAt),
       updatedAt: new Date(data.updatedAt),
     });
@@ -1340,21 +1338,34 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     const groupModelIds = [...new Set(memberships.map((m) => m.groupId))];
-    const groups = await GroupModel.findAll({
+    const caps = await GroupPoolCapModel.findAll({
       where: {
-        id: groupModelIds,
+        groupId: groupModelIds,
         workspaceId: workspace.id,
-        kind: [...CAP_ELIGIBLE_GROUP_KINDS],
-        poolCapAwuCredits: { [Op.ne]: null },
       },
     });
+    if (caps.length === 0) {
+      return result;
+    }
+
+    const groups = await GroupModel.findAll({
+      where: {
+        id: caps.map((c) => c.groupId),
+        workspaceId: workspace.id,
+        kind: [...CAP_ELIGIBLE_GROUP_KINDS],
+      },
+      attributes: ["id"],
+    });
+    const eligibleGroupIds = new Set(groups.map((g) => g.id));
     const capByGroupId = new Map(
-      groups.map((g) => [g.id, g.poolCapAwuCredits])
+      caps
+        .filter((c) => eligibleGroupIds.has(c.groupId))
+        .map((c) => [c.groupId, c.poolCapAwuCredits])
     );
 
     for (const m of memberships) {
       const cap = capByGroupId.get(m.groupId);
-      if (cap === undefined || cap === null) {
+      if (cap === undefined) {
         continue;
       }
       const existing = result.get(m.userId);
@@ -2306,8 +2317,51 @@ export class GroupResource extends BaseResource<GroupModel> {
       return new Err(new Error("Only admins can update group spend limits."));
     }
 
-    await this.update({ poolCapAwuCredits });
+    if (poolCapAwuCredits === null) {
+      await GroupPoolCapModel.destroy({
+        where: {
+          groupId: this.id,
+          workspaceId: this.workspaceId,
+        },
+      });
+    } else {
+      await GroupPoolCapModel.upsert({
+        groupId: this.id,
+        workspaceId: this.workspaceId,
+        poolCapAwuCredits,
+      });
+    }
+
     return new Ok(undefined);
+  }
+
+  // Per-group usage spend limit (excluding seat allowance), applied per member.
+  // null means the group carries no cap (falls back to the workspace default).
+  async getPoolCapAwuCredits(): Promise<number | null> {
+    const cap = await GroupPoolCapModel.findOne({
+      where: {
+        groupId: this.id,
+        workspaceId: this.workspaceId,
+      },
+    });
+    return cap?.poolCapAwuCredits ?? null;
+  }
+
+  static async getPoolCapAwuCreditsForGroups(
+    auth: Authenticator,
+    groups: GroupResource[]
+  ): Promise<Map<ModelId, number>> {
+    if (groups.length === 0) {
+      return new Map();
+    }
+
+    const caps = await GroupPoolCapModel.findAll({
+      where: {
+        groupId: groups.map((g) => g.id),
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    return new Map(caps.map((c) => [c.groupId, c.poolCapAwuCredits]));
   }
 
   // Deletion
@@ -2362,6 +2416,14 @@ export class GroupResource extends BaseResource<GroupModel> {
       });
 
       await GroupMembershipModel.destroy({
+        where: {
+          groupId: this.id,
+          workspaceId: owner.id,
+        },
+        transaction,
+      });
+
+      await GroupPoolCapModel.destroy({
         where: {
           groupId: this.id,
           workspaceId: owner.id,
@@ -2630,7 +2692,6 @@ export class GroupResource extends BaseResource<GroupModel> {
       workspaceId: this.workspaceId,
       kind: this.kind,
       memberCount: 0, // Default value, use toJSONWithMemberCount for actual count
-      poolCapAwuCredits: this.poolCapAwuCredits,
     };
   }
 
@@ -2643,7 +2704,6 @@ export class GroupResource extends BaseResource<GroupModel> {
       workspaceId: this.workspaceId,
       kind: this.kind,
       memberCount,
-      poolCapAwuCredits: this.poolCapAwuCredits,
     };
   }
 }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -8,6 +8,7 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
+import { GroupPoolCapModel } from "@app/lib/resources/storage/models/group_pool_caps";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -81,7 +82,6 @@ type CachedGroup = {
   kind: GroupKind;
   workspaceId: ModelId;
   workOSGroupId: string | null;
-  poolCapAwuCredits: number | null;
   createdAt: number;
   updatedAt: number;
 };
@@ -131,7 +131,6 @@ export class GroupResource extends BaseResource<GroupModel> {
       kind: g.kind,
       workspaceId: g.workspaceId,
       workOSGroupId: g.workOSGroupId,
-      poolCapAwuCredits: g.poolCapAwuCredits,
       createdAt: g.createdAt.getTime(),
       updatedAt: g.updatedAt.getTime(),
     }));
@@ -171,7 +170,6 @@ export class GroupResource extends BaseResource<GroupModel> {
       kind: data.kind,
       workspaceId: data.workspaceId,
       workOSGroupId: data.workOSGroupId,
-      poolCapAwuCredits: data.poolCapAwuCredits,
       createdAt: new Date(data.createdAt),
       updatedAt: new Date(data.updatedAt),
     });
@@ -1394,20 +1392,34 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     const groupModelIds = [...new Set(memberships.map((m) => m.groupId))];
+    const caps = await GroupPoolCapModel.findAll({
+      where: {
+        groupId: groupModelIds,
+        workspaceId: workspace.id,
+      },
+    });
+    if (caps.length === 0) {
+      return result;
+    }
+
     const groups = await GroupModel.findAll({
       where: {
-        id: groupModelIds,
+        id: caps.map((c) => c.groupId),
         workspaceId: workspace.id,
         kind: [...CAP_ELIGIBLE_GROUP_KINDS],
-        poolCapAwuCredits: { [Op.ne]: null },
       },
     });
     const groupById = new Map(groups.map((g) => [g.id, g]));
+    const capByGroupId = new Map(
+      caps
+        .filter((c) => groupById.has(c.groupId))
+        .map((c) => [c.groupId, c.poolCapAwuCredits])
+    );
 
     for (const m of memberships) {
       const group = groupById.get(m.groupId);
-      const cap = group?.poolCapAwuCredits;
-      if (group === undefined || cap === undefined || cap === null) {
+      const cap = capByGroupId.get(m.groupId);
+      if (group === undefined || cap === undefined) {
         continue;
       }
       const existing = result.get(m.userId);
@@ -2450,8 +2462,51 @@ export class GroupResource extends BaseResource<GroupModel> {
   async updatePoolCap(
     poolCapAwuCredits: number | null
   ): Promise<Result<undefined, Error>> {
-    await this.update({ poolCapAwuCredits });
+    if (poolCapAwuCredits === null) {
+      await GroupPoolCapModel.destroy({
+        where: {
+          groupId: this.id,
+          workspaceId: this.workspaceId,
+        },
+      });
+    } else {
+      await GroupPoolCapModel.upsert({
+        groupId: this.id,
+        workspaceId: this.workspaceId,
+        poolCapAwuCredits,
+      });
+    }
+
     return new Ok(undefined);
+  }
+
+  // Per-group usage spend limit (excluding seat allowance), applied per member.
+  // null means the group carries no cap (falls back to the workspace default).
+  async getPoolCapAwuCredits(): Promise<number | null> {
+    const cap = await GroupPoolCapModel.findOne({
+      where: {
+        groupId: this.id,
+        workspaceId: this.workspaceId,
+      },
+    });
+    return cap?.poolCapAwuCredits ?? null;
+  }
+
+  static async getPoolCapAwuCreditsForGroups(
+    auth: Authenticator,
+    groups: GroupResource[]
+  ): Promise<Map<ModelId, number>> {
+    if (groups.length === 0) {
+      return new Map();
+    }
+
+    const caps = await GroupPoolCapModel.findAll({
+      where: {
+        groupId: groups.map((g) => g.id),
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    return new Map(caps.map((c) => [c.groupId, c.poolCapAwuCredits]));
   }
 
   // Deletion
@@ -2506,6 +2561,14 @@ export class GroupResource extends BaseResource<GroupModel> {
       });
 
       await GroupPermissionModel.destroy({
+        where: {
+          groupId: this.id,
+          workspaceId: owner.id,
+        },
+        transaction,
+      });
+
+      await GroupPoolCapModel.destroy({
         where: {
           groupId: this.id,
           workspaceId: owner.id,
@@ -2750,7 +2813,6 @@ export class GroupResource extends BaseResource<GroupModel> {
       workspaceId: this.workspaceId,
       kind: this.kind,
       memberCount: 0, // Default value, use toJSONWithMemberCount for actual count
-      poolCapAwuCredits: this.poolCapAwuCredits,
     };
   }
 
@@ -2763,7 +2825,6 @@ export class GroupResource extends BaseResource<GroupModel> {
       workspaceId: this.workspaceId,
       kind: this.kind,
       memberCount,
-      poolCapAwuCredits: this.poolCapAwuCredits,
     };
   }
 

--- a/front/lib/resources/storage/models/group_pool_caps.ts
+++ b/front/lib/resources/storage/models/group_pool_caps.ts
@@ -1,0 +1,47 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey } from "sequelize";
+
+// Per-group usage spend limit (excluding seat allowance), applied per member.
+// The absence of a row means the group carries no cap.
+export class GroupPoolCapModel extends WorkspaceAwareModel<GroupPoolCapModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare groupId: ForeignKey<GroupModel["id"]>;
+  declare poolCapAwuCredits: number;
+}
+
+GroupPoolCapModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    poolCapAwuCredits: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "group_pool_caps",
+    sequelize: frontSequelize,
+    indexes: [
+      { unique: true, fields: ["groupId"] },
+      { fields: ["workspaceId"], concurrently: true },
+    ],
+  }
+);
+
+GroupPoolCapModel.belongsTo(GroupModel, {
+  foreignKey: { name: "groupId", allowNull: false },
+  onDelete: "RESTRICT",
+});

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -14,10 +14,6 @@ export class GroupModel extends WorkspaceAwareModel<GroupModel> {
 
   // Group ID on workOS, unique across all directories.
   declare workOSGroupId: string | null;
-
-  // Per-group usage spend limit (excluding seat allowance), applied per member.
-  // null means the group carries no cap (falls back to the workspace default).
-  declare poolCapAwuCredits: CreationOptional<number | null>;
 }
 
 GroupModel.init(
@@ -42,10 +38,6 @@ GroupModel.init(
     },
     workOSGroupId: {
       type: DataTypes.STRING,
-      allowNull: true,
-    },
-    poolCapAwuCredits: {
-      type: DataTypes.INTEGER,
       allowNull: true,
     },
   },

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -156,7 +156,13 @@ export function useCreateGroup({ owner }: { owner: LightWorkspaceType }) {
         await mutateGroups(
           (previous) =>
             previous
-              ? { ...previous, groups: [body.group, ...previous.groups] }
+              ? {
+                  ...previous,
+                  groups: [
+                    { ...body.group, poolCapAwuCredits: null },
+                    ...previous.groups,
+                  ],
+                }
               : previous,
           { revalidate: false }
         );
@@ -233,7 +239,12 @@ export function useUpdateGroup({
               ? {
                   ...previous,
                   groups: previous.groups.map((g) =>
-                    g.sId === body.group.sId ? body.group : g
+                    g.sId === body.group.sId
+                      ? {
+                          ...body.group,
+                          poolCapAwuCredits: g.poolCapAwuCredits,
+                        }
+                      : g
                   ),
                 }
               : previous,

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -351,7 +351,13 @@ export function useCreateGroup({ owner }: { owner: LightWorkspaceType }) {
         await mutateGroups(
           (previous) =>
             previous
-              ? { ...previous, groups: [body.group, ...previous.groups] }
+              ? {
+                  ...previous,
+                  groups: [
+                    { ...body.group, poolCapAwuCredits: null },
+                    ...previous.groups,
+                  ],
+                }
               : previous,
           { revalidate: false }
         );
@@ -428,7 +434,12 @@ export function useUpdateGroup({
               ? {
                   ...previous,
                   groups: previous.groups.map((g) =>
-                    g.sId === body.group.sId ? body.group : g
+                    g.sId === body.group.sId
+                      ? {
+                          ...body.group,
+                          poolCapAwuCredits: g.poolCapAwuCredits,
+                        }
+                      : g
                   ),
                 }
               : previous,

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -24,6 +24,7 @@ export function useGroups({
   owner,
   kinds,
   withMembers,
+  withPoolCaps,
   disabled,
 }: {
   owner: LightWorkspaceType;
@@ -31,6 +32,10 @@ export function useGroups({
   // Also resolves each group's member sIds (one extra batched query
   // server-side) instead of just its memberCount.
   withMembers?: boolean;
+  // Declares that this caller reads `poolCapAwuCredits`. The cap is still
+  // returned unconditionally, so callers that omit this keep working; a
+  // follow-up makes it conditional once every bundle sends the flag.
+  withPoolCaps?: boolean;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -42,9 +47,12 @@ export function useGroups({
     if (withMembers) {
       params.append("withMembers", "true");
     }
+    if (withPoolCaps) {
+      params.append("withPoolCaps", "true");
+    }
     const queryString = params.toString();
     return `/api/w/${owner.sId}/groups${queryString ? `?${queryString}` : ""}`;
-  }, [owner.sId, kinds, withMembers]);
+  }, [owner.sId, kinds, withMembers, withPoolCaps]);
 
   const groupsFetcher: Fetcher<GetGroupsResponseBody> = fetcher;
 

--- a/front/migrations/post-deploy/20260720114500_drop_pool_cap_awu_credits_from_groups.sql
+++ b/front/migrations/post-deploy/20260720114500_drop_pool_cap_awu_credits_from_groups.sql
@@ -1,0 +1,24 @@
+/*
+Post-deploy: drop the groups."poolCapAwuCredits" column.
+
+The per-group usage spend limit now lives in the group_pool_caps table
+(created and backfilled in the pre-deploy migration). Run after the code
+reading/writing group_pool_caps is live.
+
+The catch-up backfill below covers caps created by old code between the
+pre-deploy backfill and the deploy. ON CONFLICT DO NOTHING keeps rows
+already written to group_pool_caps by the new code (which no longer touches
+the groups column) as the source of truth.
+ */
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+INSERT INTO "public"."group_pool_caps" ("createdAt", "updatedAt", "workspaceId", "groupId", "poolCapAwuCredits")
+SELECT now(), now(), "workspaceId", "id", "poolCapAwuCredits"
+FROM "public"."groups"
+WHERE "poolCapAwuCredits" IS NOT NULL
+ON CONFLICT ("groupId") DO NOTHING;
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."groups"
+    DROP COLUMN "poolCapAwuCredits";

--- a/front/migrations/pre-deploy/20260720114000_add_group_pool_caps_table.sql
+++ b/front/migrations/pre-deploy/20260720114000_add_group_pool_caps_table.sql
@@ -1,0 +1,110 @@
+/*
+Pre-deploy: create the group_pool_caps table.
+
+Moves the per-group usage spend limit (groups."poolCapAwuCredits") to a
+dedicated table.
+
+The backfill at the end copies existing caps from the groups column so the
+new code sees them immediately at deploy time.
+ */
+
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE SEQUENCE "public"."group_pool_caps_id_seq"
+	AS bigint
+	INCREMENT BY 1
+	MINVALUE 1 MAXVALUE 9223372036854775807
+	START WITH 1 CACHE 1 NO CYCLE
+;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."group_pool_caps" (
+	"createdAt" timestamp with time zone NOT NULL,
+	"updatedAt" timestamp with time zone NOT NULL,
+	"workspaceId" bigint NOT NULL,
+	"id" bigint DEFAULT nextval('group_pool_caps_id_seq'::regclass) NOT NULL,
+	"groupId" bigint NOT NULL,
+	"poolCapAwuCredits" integer NOT NULL
+);
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY group_pool_caps_pkey ON public.group_pool_caps USING btree (id);
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."group_pool_caps" ADD CONSTRAINT "group_pool_caps_pkey" PRIMARY KEY USING INDEX "group_pool_caps_pkey";
+
+/*
+Statement 4
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY group_pool_caps_group_id ON public.group_pool_caps USING btree ("groupId");
+
+/*
+Statement 5
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY group_pool_caps_workspace_id ON public.group_pool_caps USING btree ("workspaceId");
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER SEQUENCE "public"."group_pool_caps_id_seq" OWNED BY "public"."group_pool_caps"."id";
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."group_pool_caps" ADD CONSTRAINT "group_pool_caps_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 8
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."group_pool_caps" VALIDATE CONSTRAINT "group_pool_caps_workspaceId_fkey";
+
+/*
+Statement 9
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."group_pool_caps" ADD CONSTRAINT "group_pool_caps_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES groups(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 10
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."group_pool_caps" VALIDATE CONSTRAINT "group_pool_caps_groupId_fkey";
+
+/*
+Statement 11
+Backfill existing caps from the groups column.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+INSERT INTO "public"."group_pool_caps" ("createdAt", "updatedAt", "workspaceId", "groupId", "poolCapAwuCredits")
+SELECT now(), now(), "workspaceId", "id", "poolCapAwuCredits"
+FROM "public"."groups"
+WHERE "poolCapAwuCredits" IS NOT NULL
+ON CONFLICT ("groupId") DO NOTHING;

--- a/front/poke/swr/groups.ts
+++ b/front/poke/swr/groups.ts
@@ -3,11 +3,20 @@ import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 
-export function usePokeGroups({ disabled, owner }: PokeConditionalFetchProps) {
+export function usePokeGroups({
+  disabled,
+  owner,
+  withPoolCaps,
+}: PokeConditionalFetchProps & {
+  // Declares that this caller reads `poolCapAwuCredits`. The cap is still
+  // returned unconditionally, so callers that omit this keep working; a
+  // follow-up makes it conditional once every bundle sends the flag.
+  withPoolCaps?: boolean;
+}) {
   const { fetcher } = useFetcher();
   const groupsFetcher: Fetcher<PokeListGroups> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/poke/workspaces/${owner.sId}/groups`,
+    `/api/poke/workspaces/${owner.sId}/groups${withPoolCaps ? "?withPoolCaps=true" : ""}`,
     groupsFetcher,
     { disabled }
   );

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -58,6 +58,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
 import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupPoolCapModel } from "@app/lib/resources/storage/models/group_pool_caps";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import {
   LabsTranscriptsConfigurationModel,
@@ -777,6 +778,9 @@ export async function deleteWorkspaceActivity({
   await RunResource.deleteAllForWorkspace(auth);
   await MembershipResource.deleteAllForWorkspace(auth);
   await GroupMembershipModel.destroy({
+    where: { workspaceId: workspace.id },
+  });
+  await GroupPoolCapModel.destroy({
     where: { workspaceId: workspace.id },
   });
   await GroupModel.destroy({

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -65,6 +65,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
 import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupPoolCapModel } from "@app/lib/resources/storage/models/group_pool_caps";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import {
   LabsTranscriptsConfigurationModel,
@@ -827,6 +828,9 @@ export async function deleteWorkspaceActivity({
   await MembershipResource.deleteAllForWorkspace(auth);
   await GroupPermissionResource.deleteAllForWorkspace(auth);
   await GroupMembershipModel.destroy({
+    where: { workspaceId: workspace.id },
+  });
+  await GroupPoolCapModel.destroy({
     where: { workspaceId: workspace.id },
   });
   await GroupModel.destroy({

--- a/front/types/api/groups.ts
+++ b/front/types/api/groups.ts
@@ -1,5 +1,5 @@
 import type { GroupType } from "@app/types/groups";
 
 export type GetGroupsResponseBody = {
-  groups: GroupType[];
+  groups: (GroupType & { poolCapAwuCredits: number | null })[];
 };

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -97,9 +97,6 @@ export type GroupType = {
   kind: GroupKind;
   workspaceId: ModelId;
   memberCount: number;
-  // Per-group usage spend limit (excluding seat allowance), applied per member.
-  // null means the group carries no cap (falls back to the workspace default).
-  poolCapAwuCredits: number | null;
 };
 
 export const GroupKindCodec = z.enum([

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -103,9 +103,6 @@ export type GroupType = {
   kind: GroupKind;
   workspaceId: ModelId;
   memberCount: number;
-  // Per-group usage spend limit (excluding seat allowance), applied per member.
-  // null means the group carries no cap (falls back to the workspace default).
-  poolCapAwuCredits: number | null;
   // Member sIds, only populated when explicitly requested
   memberIds?: string[];
 };


### PR DESCRIPTION
## Description

Moves the per-group usage spend limit off the `groups` table into a new `group_pool_caps` table storing just `workspaceId`, `groupId` and `poolCapAwuCredits`. A row means the group carries a cap; the absence of a row means no cap (falls back to the workspace default), so the column's `NULL` state maps to "no row" and the new column is `NOT NULL`.


## Migrations (expand/contract)

- **pre-deploy**: create `group_pool_caps` and backfill it from `groups."poolCapAwuCredits"`.
- **post-deploy**: catch-up backfill with `ON CONFLICT ("groupId") DO NOTHING` (covers caps created by old code during the deploy window, without clobbering rows the new code wrote), then drop the `groups."poolCapAwuCredits"` column.

Known edge: a cap *modified or cleared* by old code during the deploy window keeps its pre-deploy value in the new table. Caps change rarely, so this window is accepted.

## Tests


## Deploy Plan

1. Run the pre-deploy migration (creates + backfills `group_pool_caps`).
2. Deploy `front` / `front-api`.
3. Run the post-deploy migration (catch-up backfill + drop the old column).