### PR TITLE
Batch the tool-output-content fetch window instead of sliding it every turn

### DIFF
--- a/front/lib/api/assistant/conversation/fetch.test.ts
+++ b/front/lib/api/assistant/conversation/fetch.test.ts
@@ -1,0 +1,104 @@
+import {
+  computeMessagesWithToolOutputContent,
+  TOOL_OUTPUT_FETCH_BATCH_SIZE,
+} from "@app/lib/api/assistant/conversation/fetch";
+import type { Interaction } from "@app/lib/api/assistant/conversation_rendering/pruning";
+import { describe, expect, it } from "vitest";
+
+// Builds n interactions, each a user message followed by an agent message. Agent message ids are
+// 1, 2, 3, ... in order, matching the interaction's position, so tests can assert on exactly which
+// interactions' content ended up included.
+function buildInteractions(
+  n: number
+): Interaction<{ id: number; role: "user" | "agent" }>[] {
+  return Array.from({ length: n }, (_, i) => ({
+    messages: [
+      { id: 1000 + i, role: "user" as const },
+      { id: i + 1, role: "agent" as const },
+    ],
+  }));
+}
+
+describe("computeMessagesWithToolOutputContent", () => {
+  it("includes every interaction when there are fewer than the floor", () => {
+    const result = computeMessagesWithToolOutputContent(
+      buildInteractions(3),
+      4
+    );
+
+    expect(result).toEqual(new Set([1, 2, 3]));
+  });
+
+  it("returns nothing when floorCount is 0 or negative", () => {
+    expect(
+      computeMessagesWithToolOutputContent(buildInteractions(10), 0)
+    ).toEqual(new Set());
+    expect(
+      computeMessagesWithToolOutputContent(buildInteractions(10), -1)
+    ).toEqual(new Set());
+  });
+
+  it("includes everything while the floor's start hasn't crossed the first batch boundary", () => {
+    // floorCount 4, batch size 10: floorStart only reaches 10 once there are 14 interactions, so
+    // anything below that still includes the full history.
+    const n = TOOL_OUTPUT_FETCH_BATCH_SIZE + 4 - 1; // 13
+    const result = computeMessagesWithToolOutputContent(
+      buildInteractions(n),
+      4
+    );
+
+    expect(result).toEqual(new Set(Array.from({ length: n }, (_, i) => i + 1)));
+  });
+
+  it("excludes the oldest batch once the floor's start crosses a batch boundary, and stays put across many turns", () => {
+    // At n=14, floorStart=10, which is the first batch boundary: interactions 1-10 (ids) get
+    // excluded, 11-14 stay included.
+    const atFirstCrossing = computeMessagesWithToolOutputContent(
+      buildInteractions(14),
+      4
+    );
+    expect(atFirstCrossing).toEqual(new Set([11, 12, 13, 14]));
+
+    // Ten turns later (n=23, floorStart=19), the boundary hasn't moved yet: still exactly
+    // interactions 1-10 excluded, everything from 11 onward included.
+    const tenTurnsLater = computeMessagesWithToolOutputContent(
+      buildInteractions(23),
+      4
+    );
+    expect(tenTurnsLater).toEqual(
+      new Set(Array.from({ length: 13 }, (_, i) => i + 11))
+    );
+
+    // One more turn (n=24, floorStart=20) crosses the next batch boundary: interactions 11-20 now
+    // also get excluded, in one jump.
+    const nextCrossing = computeMessagesWithToolOutputContent(
+      buildInteractions(24),
+      4
+    );
+    expect(nextCrossing).toEqual(new Set([21, 22, 23, 24]));
+  });
+
+  it("never re-includes an interaction once it stops being fetched, as the conversation grows", () => {
+    // Interactions are EXPECTED to eventually stop being fetched as the conversation grows past a
+    // batch boundary, that's the whole point. What must never happen is the opposite: something
+    // that's already excluded coming back once more interactions arrive.
+    let previouslyExcluded = new Set<number>();
+
+    for (let n = 1; n <= 50; n++) {
+      const included = computeMessagesWithToolOutputContent(
+        buildInteractions(n),
+        4
+      );
+      const excludedNow = new Set(
+        Array.from({ length: n }, (_, i) => i + 1).filter(
+          (id) => !included.has(id)
+        )
+      );
+
+      for (const id of previouslyExcluded) {
+        expect(excludedNow.has(id)).toBe(true);
+      }
+      previouslyExcluded = excludedNow;
+    }
+  });
+});

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -1,4 +1,5 @@
 import { groupMessagesIntoInteractions } from "@app/lib/api/assistant/conversation/interactions";
+import type { Interaction } from "@app/lib/api/assistant/conversation_rendering/pruning";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -88,6 +89,43 @@ export const getLightConversation = async (
     lastInteractionsToFetchToolOutputContentFor,
     messagePagination
   );
+
+// Batch size (in interactions) for extending the tool-output-content fetch window beyond the
+// guaranteed floor. The boundary is anchored on a fixed, absolute interaction index rather than
+// distance from the most recent interaction, so it only advances once a full batch of new
+// interactions has accumulated instead of sliding by one every single turn.
+export const TOOL_OUTPUT_FETCH_BATCH_SIZE = 10;
+
+/**
+ * Decides which agent messages should have their tool-output content fetched.
+ *
+ * The last `floorCount` interactions are always included. Beyond that floor, the window extends
+ * backward to the most recent checkpoint at or before the floor's start, a fixed multiple of
+ * TOOL_OUTPUT_FETCH_BATCH_SIZE. Because checkpoints are fixed positions counted from the start of
+ * the conversation, not from the tail, the boundary stays put across most turns and only jumps
+ * forward once a whole batch has accumulated.
+ */
+export function computeMessagesWithToolOutputContent(
+  interactions: Interaction<{ id: ModelId; role: "user" | "agent" }>[],
+  floorCount: number
+): Set<ModelId> {
+  if (floorCount <= 0) {
+    return new Set();
+  }
+
+  const floorStart = Math.max(interactions.length - floorCount, 0);
+  const checkpointStart =
+    Math.floor(floorStart / TOOL_OUTPUT_FETCH_BATCH_SIZE) *
+    TOOL_OUTPUT_FETCH_BATCH_SIZE;
+
+  return new Set(
+    interactions
+      .slice(checkpointStart)
+      .flatMap((i) =>
+        i.messages.filter((m) => m.role === "agent").map((m) => m.id)
+      )
+  );
+}
 
 async function _getConversation<V extends "light" | "full">(
   auth: Authenticator,
@@ -211,42 +249,33 @@ async function _getConversation<V extends "light" | "full">(
 
   let messagesWithToolOutputContent: Set<ModelId> | null = null;
 
-  // In the case of the agentic loop, to save memory and latency, we only want to fetch content for the last N interactions.
+  // In the case of the agentic loop, to save memory and latency, we don't want to fetch tool
+  // output content for every interaction in the conversation. See
+  // computeMessagesWithToolOutputContent for how the fetch window is decided.
   if (lastInteractionsToFetchToolOutputContentFor !== null) {
-    if (lastInteractionsToFetchToolOutputContentFor <= 0) {
-      messagesWithToolOutputContent = new Set();
-    } else {
-      const interactions = groupMessagesIntoInteractions(
-        removeNulls(
-          messages.map((m) => {
-            if (m.userMessageId) {
-              return {
-                id: m.userMessageId,
-                role: "user",
-              };
-            } else if (m.agentMessageId) {
-              return {
-                id: m.agentMessageId,
-                role: "agent",
-              };
-            }
-            // We don't care about the other messages.
-          })
-        )
-      );
+    const interactions = groupMessagesIntoInteractions(
+      removeNulls(
+        messages.map((m) => {
+          if (m.userMessageId) {
+            return {
+              id: m.userMessageId,
+              role: "user" as const,
+            };
+          } else if (m.agentMessageId) {
+            return {
+              id: m.agentMessageId,
+              role: "agent" as const,
+            };
+          }
+          // We don't care about the other messages.
+        })
+      )
+    );
 
-      // Keep the last N interactions with the highest ranks (order is correct because of the sort above).
-      const interactionsToKeep = interactions.slice(
-        -lastInteractionsToFetchToolOutputContentFor
-      );
-
-      // We only need to fetch content for the actions of the last N interactions.
-      messagesWithToolOutputContent = new Set(
-        interactionsToKeep.flatMap((i) =>
-          i.messages.filter((m) => m.role === "agent").map((m) => m.id)
-        )
-      );
-    }
+    messagesWithToolOutputContent = computeMessagesWithToolOutputContent(
+      interactions,
+      lastInteractionsToFetchToolOutputContentFor
+    );
   }
 
   const renderRes = await batchRenderMessages(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When loading a conversation for the agent to run on, we only fetch tool-output content from the database for a limited number of recent interactions, both to bound memory usage and to avoid unnecessary reads of large or file-backed tool results. Today that window is a fixed size that always covers the most recent handful of interactions, which means as a conversation grows, exactly one older interaction loses its tool-output content on every single turn, the boundary just slides forward by one each time.

With the recent changes from https://github.com/dust-tt/dust/pull/28751, that interaction's content changes from what the model actually produced to a generic "no output" placeholder, which breaks Anthropic's prompt cache the same way our earlier pruning fix addressed, except this happens upstream of that fix entirely, before rendering ever gets a say, so it was quietly capping how much of that improvement could actually land.

This change keeps the same guaranteed floor of always-fresh recent interactions, but anchors the boundary for everything older to a fixed position counted from the start of the conversation rather than distance from the latest turn. In practice that means the window stays exactly the same for many consecutive turns and only moves forward once a full batch of new interactions has accumulated, instead of creeping by one every time. No caller of this function needed to change. The fix is entirely internal to how the window is computed.

The tradeoff worth naming: instead of losing one interaction's content every turn forever, the conversation now goes through longer stable stretches punctuated by an occasional larger jump, several interactions' worth of content disappearing at once when a batch boundary is crossed. That's a real change in shape, not just frequency, and the batch size is a tunable starting guess rather than something empirically measured yet.

> [!NOTE]
> Not a big fan but will see how we can improve later.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
