### PR TITLE
[front] fix fair-use limits when cost overshoots the limit

### DIFF
--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -14,8 +14,8 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import {
+  addRateLimiterCount,
   getTimeframeSecondsFromLiteral,
-  rateLimiter,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import {
@@ -141,15 +141,17 @@ export async function computeAndStoreAgentMessageCredits(
     costCredits > 0 &&
     assistantLimits.maxAwuCredits !== -1
   ) {
-    // We use rateLimiter infrastructure to enforce the fair use but ignore failure here since
-    // this is run post message execution. The next agent loop will be stopped if we dropped to 0.
-    await rateLimiter({
+    // Always record the credit cost unconditionally. The limit guard lives in
+    // isMessagesLimitReached (pre-message), which reads the count via getRateLimiterCount and
+    // blocks the next message once the total reaches maxAwuCredits. Using rateLimiter here was
+    // incorrect: its Lua script silently drops the write when count + costCredits > limit,
+    // causing the counter to stall below the limit and never trigger enforcement.
+    await addRateLimiterCount({
       key: makeFairUseAwuCreditsRateLimitKeyForUser(
         auth.getNonNullableWorkspace(),
         user.toJSON(),
         assistantLimits.maxAwuCreditsTimeframe
       ),
-      maxPerTimeframe: assistantLimits.maxAwuCredits,
       timeframeSeconds: getTimeframeSecondsFromLiteral(
         assistantLimits.maxAwuCreditsTimeframe
       ),

--- a/front/lib/utils/rate_limiter.test.ts
+++ b/front/lib/utils/rate_limiter.test.ts
@@ -33,6 +33,7 @@ type RateLimiterModule = typeof import("@app/lib/utils/rate_limiter");
 
 let closeRedisClients: RedisModule["closeRedisClients"];
 let runOnRedis: RedisModule["runOnRedis"];
+let addRateLimiterCount: RateLimiterModule["addRateLimiterCount"];
 let expireRateLimiterKey: RateLimiterModule["expireRateLimiterKey"];
 let getRateLimiterCount: RateLimiterModule["getRateLimiterCount"];
 let rateLimiter: RateLimiterModule["rateLimiter"];
@@ -50,6 +51,7 @@ describe("rateLimiter", () => {
 
     closeRedisClients = redisModule.closeRedisClients;
     runOnRedis = redisModule.runOnRedis;
+    addRateLimiterCount = rateLimiterModule.addRateLimiterCount;
     expireRateLimiterKey = rateLimiterModule.expireRateLimiterKey;
     getRateLimiterCount = rateLimiterModule.getRateLimiterCount;
     RATE_LIMITER_PREFIX = rateLimiterModule.RATE_LIMITER_PREFIX;
@@ -213,6 +215,80 @@ describe("rateLimiter", () => {
     expect(count.isOk()).toBe(true);
     if (count.isOk()) {
       expect(count.value).toBe(1);
+    }
+  });
+});
+
+describe("addRateLimiterCount", () => {
+  beforeAll(async () => {
+    const redisModule = await import("@app/lib/api/redis");
+    const rateLimiterModule = await import("@app/lib/utils/rate_limiter");
+
+    closeRedisClients = redisModule.closeRedisClients;
+    addRateLimiterCount = rateLimiterModule.addRateLimiterCount;
+    expireRateLimiterKey = rateLimiterModule.expireRateLimiterKey;
+    getRateLimiterCount = rateLimiterModule.getRateLimiterCount;
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      [...keysToExpire].map((key) => expireRateLimiterKey({ key }))
+    );
+    keysToExpire.clear();
+  });
+
+  afterAll(async () => {
+    await closeRedisClients();
+  });
+
+  it("records the full amount even when it overshoots what a limit-guarded write would allow", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    await expireTestKey(key);
+
+    // Reproduces the fair-use AWU bug: count is already at 9/10, and the message that just ran
+    // cost 2 credits. A limit-guarded `rateLimiter` write would silently drop this because
+    // 9 + 2 > 10; `addRateLimiterCount` must persist all of it regardless.
+    await addRateLimiterCount({
+      key,
+      timeframeSeconds: 60,
+      incrementBy: 9,
+      logger,
+    });
+    await addRateLimiterCount({
+      key,
+      timeframeSeconds: 60,
+      incrementBy: 2,
+      logger,
+    });
+
+    const count = await getRateLimiterCount({
+      key,
+      timeframeSeconds: 60,
+    });
+    expect(count.isOk()).toBe(true);
+    if (count.isOk()) {
+      expect(count.value).toBe(11);
+    }
+  });
+
+  it("is counted correctly by getRateLimiterCount alongside plain rateLimiter writes", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    await expireTestKey(key);
+
+    await addRateLimiterCount({
+      key,
+      timeframeSeconds: 60,
+      incrementBy: 3,
+      logger,
+    });
+
+    const count = await getRateLimiterCount({
+      key,
+      timeframeSeconds: 60,
+    });
+    expect(count.isOk()).toBe(true);
+    if (count.isOk()) {
+      expect(count.value).toBe(3);
     }
   });
 });

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -121,6 +121,68 @@ export async function rateLimiter({
   }
 }
 
+/**
+ * Unconditionally records `incrementBy` consumption units against `key`, with no limit guard.
+ *
+ * Unlike `rateLimiter`, which drops the write entirely when count + incrementBy would exceed the
+ * limit, this always persists the entries. Use this for post-hoc recording of a cost that already
+ * happened (e.g. AWU credits for a message that already ran) — enforcement must happen beforehand
+ * via `getRateLimiterCount` + a limit check, not by relying on this function to gatekeep.
+ */
+export async function addRateLimiterCount({
+  key,
+  timeframeSeconds,
+  incrementBy,
+  logger,
+}: {
+  key: string;
+  timeframeSeconds: number;
+  incrementBy: number;
+  logger: LoggerInterface;
+}): Promise<void> {
+  if (!Number.isInteger(incrementBy) || incrementBy <= 0) {
+    throw new Error("incrementBy must be a positive integer.");
+  }
+  if (!Number.isInteger(timeframeSeconds) || timeframeSeconds <= 0) {
+    throw new Error("timeframeSeconds must be a positive integer.");
+  }
+
+  const redisKey = makeRateLimiterKey(key);
+  const windowMs = timeframeSeconds * 1000;
+
+  const luaScript = `
+    local key = KEYS[1]
+    local window_ms = tonumber(ARGV[1])
+    local increment_by = tonumber(ARGV[2])
+
+    -- Use Redis server time to avoid client clock skew
+    local t = redis.call('TIME') -- { seconds, microseconds }
+    local now_ms = tonumber(t[1]) * 1000 + math.floor(tonumber(t[2]) / 1000)
+
+    -- Always record unconditionally: no limit check, no dropped writes.
+    for i = 1, increment_by do
+      redis.call('ZADD', key, now_ms, ARGV[2 + i])
+    end
+
+    -- Keep the key around a bit longer than the window to allow trims
+    redis.call('PEXPIRE', key, window_ms + 60000)
+  `;
+
+  try {
+    const redis = await getRedisStreamClient({ origin: "rate_limiter" });
+    const values = Array.from({ length: incrementBy }, () => uuidv4());
+    await redis.eval(luaScript, {
+      keys: [redisKey],
+      arguments: [windowMs.toString(), incrementBy.toString(), ...values],
+    });
+  } catch (e) {
+    getStatsDClient().increment("ratelimiter.error.count", 1, [
+      "operation:add",
+    ]);
+    logger.error({ key, incrementBy, error: e }, "addRateLimiterCount error");
+  }
+}
+
 export async function expireRateLimiterKey({
   key,
 }: {


### PR DESCRIPTION
## Description

Fix fair-use AWU credits silently dropped when cost overshoots the limit

* computeAndStoreAgentMessageCredits (credit_cost.ts) persisted a message's AWU credit cost by calling rateLimiter, but rateLimiter's Lua script is a gatekeeper: it drops the write entirely when count + incrementBy > limit. Enforcement already happens earlier, pre-message, via getRateLimiterCount + a >= maxAwuCredits check — so gating the recording write too meant the counter could get stuck just below the limit (e.g. 9/10) and never actually reach it, since any message costing more than the remaining headroom silently failed to record. Users could keep sending messages indefinitely without ever tripping the fair-use limit.
* Added addRateLimiterCount to rate_limiter.ts: an unconditional-write variant with no limit guard, for post-hoc recording of a cost that already happened. Enforcement stays exactly where it was (getRateLimiterCount pre-message).
* Swapped the rateLimiter call in computeAndStoreAgentMessageCredits for addRateLimiterCount.


## Tests

 * npx tsgo --noEmit clean
 * biome check clean
 * Added regression tests in rate_limiter.test.ts against real Redis, including one that reproduces the exact 9+2>10 overshoot from the bug and confirms the full amount is now persisted (previously the write would've been dropped)
 * credit_cost.test.ts and rate_limiter.test.ts pass (22 tests)

## Risk

Low, impacts only AWU fair use limits (that are not used yet)

## Deploy Plan

Deploy front