### PR TITLE
[front] fix: allow admins to become agent editors

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -137,6 +137,23 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/editors", () => 
     expect(editorIds).toContain(newEditor.sId);
   });
 
+  it("admin who is not an agent editor can become an editor", async () => {
+    const { workspace, agent, agentOwner, requestUser } = await setupTest({
+      agentOwnerRole: "builder",
+      requestUserRole: "admin",
+    });
+
+    const response = await patchEditors(workspace, agent.sId, {
+      addEditorIds: [requestUser.sId],
+    });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.editors).toHaveLength(2);
+    const editorIds = data.editors.map((e: UserType) => e.sId);
+    expect(editorIds).toContain(agentOwner.sId);
+    expect(editorIds).toContain(requestUser.sId);
+  });
+
   it("admin should successfully remove an editor", async () => {
     const { workspace, agent, agentOwner } = await setupTest({
       requestUserRole: "admin",

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -203,7 +203,7 @@ app.patch(
     }
 
     const editorGroup = editorGroupRes.value;
-    if (!editorGroup.canWrite(auth)) {
+    if (!editorGroup.canAdministrate(auth)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
@@ -79,6 +79,32 @@ describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
     );
   });
 
+  it("admin who is not a skill editor can become an editor", async () => {
+    const { workspace, user } = await setup();
+
+    const builderUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, builderUser, {
+      role: "builder",
+    });
+    const builderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      builderUser.sId,
+      workspace.sId
+    );
+    const skill = await SkillFactory.create(builderAuth);
+
+    const response = await patch(workspace, skill.sId, {
+      addEditorIds: [user.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.editors).toHaveLength(2);
+    expect(data.editors.map((e: { sId: string }) => e.sId)).toContain(
+      builderUser.sId
+    );
+    expect(data.editors.map((e: { sId: string }) => e.sId)).toContain(user.sId);
+  });
+
   it("rejects adding regular user as editor", async () => {
     const { workspace, auth } = await setup();
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1808,7 +1808,7 @@ export async function updateAgentPermissions(
     const transactionResult = await withTransaction(async (t) => {
       if (usersToAdd.length > 0) {
         // Check authorization for agent_editors groups (allowing members and admins)
-        if (!editorGroupRes.value.canWrite(auth)) {
+        if (!editorGroupRes.value.canAdministrate(auth)) {
           return new Err(
             new DustError(
               "unauthorized",
@@ -1827,7 +1827,7 @@ export async function updateAgentPermissions(
 
       if (usersToRemove.length > 0) {
         // Check authorization for agent_editors groups (allowing members and admins)
-        if (!editorGroupRes.value.canWrite(auth)) {
+        if (!editorGroupRes.value.canAdministrate(auth)) {
           return new Err(
             new DustError(
               "unauthorized",


### PR DESCRIPTION
## Description

Follow-up to https://github.com/dust-tt/dust/pull/28649, which split write/admin permissions for editor groups. This PR fixes the agent editors endpoint so workspace admins use the admin permission path when modifying agent editors, including adding themselves as editors.

It also adds regression coverage for both skills and agents to keep the "Become an editor" path working for workspace admins who are not already in the resource editor group.

## Tests

- Added regression tests.

## Risk

- Low. Narrow editor-management permission check.

## Deploy Plan

- Deploy front.
