### PR TITLE
Reconnect and lifetime handling for the sandbox function invocation event stream

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -101,12 +101,8 @@ interface SandboxFunctionInvocationProps {
   ) => void;
 }
 
-// Owns the client side of one in-flight invocation: consumes its SSE stream through
-// useEventSource (which handles the `done` idle sentinel, lastEventId resumes, reconnection
-// backoff and bfcache recovery) and settles the pending `callFunction` promise held by the
-// parent. Will also render the blocking-event UI (tool approval, personal authentication) for the
-// invocation; renders nothing until then. No client-side deadline: the server guarantees a
-// terminal event (result or error) once the invocation exists.
+// Consumes one invocation's event stream, settles the pending iframe call, and will render
+// approval or authentication UI when needed.
 function SandboxFunctionInvocation({
   workspaceId,
   functionId,
@@ -170,22 +166,19 @@ function SandboxFunctionInvocation({
     [invocationId, onSettle]
   );
 
-  const { isError } = useEventSource(
+  const onTerminalError = useCallback(() => {
+    onSettle(invocationId, {
+      result: null,
+      error: "Failed to listen to function invocation events.",
+    });
+  }, [invocationId, onSettle]);
+
+  useEventSource(
     buildEventSourceURL,
     onEventCallback,
-    `sandbox-function-invocation-${invocationId}`
+    `sandbox-function-invocation-${invocationId}`,
+    { onTerminalError }
   );
-
-  // useEventSource only exposes its terminal failure (reconnect attempts exhausted) as state, so
-  // an effect is the only place to propagate it into the pending call settlement.
-  useEffect(() => {
-    if (isError) {
-      onSettle(invocationId, {
-        result: null,
-        error: "Failed to listen to function invocation events.",
-      });
-    }
-  }, [isError, invocationId, onSettle]);
 
   return null;
 }

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -1,6 +1,7 @@
 import { useVisualizationRetry } from "@app/hooks/conversations";
+import { useEventSource } from "@app/hooks/useEventSource";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientEventSource, clientFetch } from "@app/lib/egress/client";
+import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import datadogLogger from "@app/logger/datadogLogger";
 import type {
@@ -90,103 +91,103 @@ const getExtensionFromBlob = (blob: Blob): string => {
   return mimeToExt[blob.type] || "txt"; // Default to 'txt' if mime type is unknown.
 };
 
-const SANDBOX_FUNCTION_INVOCATION_RESULT_TIMEOUT_MS = 5 * 60 * 1000;
-
-async function waitForSandboxFunctionInvocationResult({
-  functionId,
-  invocationId,
-  workspaceId,
-}: {
+interface SandboxFunctionInvocationProps {
+  workspaceId: string;
   functionId: string;
   invocationId: string;
-  workspaceId: string;
-}): Promise<CommandResultMap["callFunction"]> {
-  let source: Awaited<ReturnType<typeof clientEventSource>>;
-  try {
-    source = await clientEventSource(
-      `/api/sse/w/${workspaceId}/sandbox-functions/${functionId}/invocations/${invocationId}/events`
-    );
-  } catch (error) {
-    return {
-      result: null,
-      error:
-        "Failed to listen to function invocation events: " +
-        normalizeError(error).message,
-    };
-  }
+  onSettle: (
+    invocationId: string,
+    response: CommandResultMap["callFunction"]
+  ) => void;
+}
 
-  return new Promise((resolve) => {
-    let isDone = false;
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-    const finish = (response: CommandResultMap["callFunction"]) => {
-      if (isDone) {
-        return;
+// Owns the client side of one in-flight invocation: consumes its SSE stream through
+// useEventSource (which handles the `done` idle sentinel, lastEventId resumes, reconnection
+// backoff and bfcache recovery) and settles the pending `callFunction` promise held by the
+// parent. Will also render the blocking-event UI (tool approval, personal authentication) for the
+// invocation; renders nothing until then. No client-side deadline: the server guarantees a
+// terminal event (result or error) once the invocation exists.
+function SandboxFunctionInvocation({
+  workspaceId,
+  functionId,
+  invocationId,
+  onSettle,
+}: SandboxFunctionInvocationProps) {
+  const buildEventSourceURL = useCallback(
+    (lastEvent: string | null) => {
+      const esURL = `/api/sse/w/${workspaceId}/sandbox-functions/${functionId}/invocations/${invocationId}/events`;
+      let lastEventId = "";
+      if (lastEvent) {
+        const eventPayload: { eventId: string } = JSON.parse(lastEvent);
+        lastEventId = eventPayload.eventId;
       }
+      return esURL + "?lastEventId=" + lastEventId;
+    },
+    [workspaceId, functionId, invocationId]
+  );
 
-      isDone = true;
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-      }
-      source.close();
-      resolve(response);
-    };
-
-    timeoutId = setTimeout(() => {
-      finish({
-        result: null,
-        error: "Timed out waiting for function invocation result.",
-      });
-    }, SANDBOX_FUNCTION_INVOCATION_RESULT_TIMEOUT_MS);
-
-    source.onmessage = (event) => {
-      if (event.data === "done") {
-        finish({
-          result: null,
-          error: "Function invocation stream ended before a result.",
-        });
-        return;
-      }
-
+  const onEventCallback = useCallback(
+    (eventStr: string) => {
       try {
         const eventPayload: {
+          eventId: string;
           data: SandboxFunctionInvocationEvent;
-        } = JSON.parse(event.data);
+        } = JSON.parse(eventStr);
 
         switch (eventPayload.data.type) {
           case "sandbox_function_invocation_created":
             // NO-OP
             break;
           case "sandbox_function_invocation_result":
-            finish({ result: eventPayload.data.result });
+            onSettle(invocationId, { result: eventPayload.data.result });
             break;
           case "sandbox_function_invocation_error":
-            finish({ result: null, error: eventPayload.data.message });
+            onSettle(invocationId, {
+              result: null,
+              error: eventPayload.data.message,
+            });
             break;
           case "tool_approve_execution":
             // TODO(SANDBOX_FUNCTIONS): surface a tool approval flow to the user and post the
             // validation back; not emitted by the tool execution activity yet.
             break;
+          case "tool_personal_auth_required":
+            // TODO(SANDBOX_FUNCTIONS): surface a personal authentication flow to the user and
+            // post the resolution back; not emitted by the tool execution activity yet.
+            break;
           default:
             assertNeverAndIgnore(eventPayload.data);
         }
       } catch (error) {
-        finish({
+        onSettle(invocationId, {
           result: null,
           error:
             "Failed to parse function invocation event: " +
             normalizeError(error).message,
         });
       }
-    };
+    },
+    [invocationId, onSettle]
+  );
 
-    source.onerror = () => {
-      finish({
+  const { isError } = useEventSource(
+    buildEventSourceURL,
+    onEventCallback,
+    `sandbox-function-invocation-${invocationId}`
+  );
+
+  // useEventSource only exposes its terminal failure (reconnect attempts exhausted) as state, so
+  // an effect is the only place to propagate it into the pending call settlement.
+  useEffect(() => {
+    if (isError) {
+      onSettle(invocationId, {
         result: null,
         error: "Failed to listen to function invocation events.",
       });
-    };
-  });
+    }
+  }, [isError, invocationId, onSettle]);
+
+  return null;
 }
 
 // Custom hook to encapsulate the logic for handling visualization messages.
@@ -194,12 +195,12 @@ function useVisualizationDataHandler({
   createSandboxFunctionInvocation,
   getFileBlob,
   onEditText,
-  workspaceId,
   setCodeDrawerOpened,
   setContentHeight,
   setErrorMessage,
   visualization,
   vizIframeRef,
+  waitForSandboxFunctionInvocationResult,
 }: {
   createSandboxFunctionInvocation: (
     functionIdOrSlug: string,
@@ -212,7 +213,10 @@ function useVisualizationDataHandler({
   setErrorMessage: (v: SetStateAction<string | null>) => void;
   visualization: Visualization;
   vizIframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
-  workspaceId: string;
+  waitForSandboxFunctionInvocationResult: (params: {
+    functionId: string;
+    invocationId: string;
+  }) => Promise<CommandResultMap["callFunction"]>;
 }) {
   const sendNotification = useSendNotification();
   const { code } = visualization;
@@ -289,7 +293,6 @@ function useVisualizationDataHandler({
           }
 
           const result = await waitForSandboxFunctionInvocationResult({
-            workspaceId,
             functionId: invocationRes.value.functionId,
             invocationId: invocationRes.value.sId,
           });
@@ -372,7 +375,7 @@ function useVisualizationDataHandler({
     visualization.identifier,
     vizIframeRef,
     sendNotification,
-    workspaceId,
+    waitForSandboxFunctionInvocationResult,
   ]);
 }
 
@@ -432,6 +435,43 @@ export const VisualizationActionIframe = forwardRef<
   const [retryClicked, setRetryClicked] = useState(false);
   const [isCodeDrawerOpen, setCodeDrawerOpened] = useState(false);
   const vizIframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  // In-flight sandbox function invocations. Each entry mounts a
+  // SandboxFunctionInvocation; the resolver of the pending `callFunction` promise is kept
+  // in a ref so settling stays a pure state update.
+  const [activeInvocations, setActiveInvocations] = useState<
+    { functionId: string; invocationId: string }[]
+  >([]);
+  const invocationResolversRef = useRef<
+    Map<string, (response: CommandResultMap["callFunction"]) => void>
+  >(new Map());
+
+  const waitForSandboxFunctionInvocationResult = useCallback(
+    ({
+      functionId,
+      invocationId,
+    }: {
+      functionId: string;
+      invocationId: string;
+    }) =>
+      new Promise<CommandResultMap["callFunction"]>((resolve) => {
+        invocationResolversRef.current.set(invocationId, resolve);
+        setActiveInvocations((prev) => [...prev, { functionId, invocationId }]);
+      }),
+    []
+  );
+
+  const settleSandboxFunctionInvocation = useCallback(
+    (invocationId: string, response: CommandResultMap["callFunction"]) => {
+      const resolve = invocationResolversRef.current.get(invocationId);
+      invocationResolversRef.current.delete(invocationId);
+      setActiveInvocations((prev) =>
+        prev.filter((invocation) => invocation.invocationId !== invocationId)
+      );
+      resolve?.(response);
+    },
+    []
+  );
 
   // Combine internal ref with forwarded ref.
   const combinedRef = useCallback(
@@ -557,7 +597,7 @@ export const VisualizationActionIframe = forwardRef<
     setErrorMessage,
     visualization,
     vizIframeRef,
-    workspaceId,
+    waitForSandboxFunctionInvocationResult,
   });
 
   const { code, complete: codeFullyGenerated } = visualization;
@@ -617,6 +657,15 @@ export const VisualizationActionIframe = forwardRef<
           code={code}
         />
       )}
+      {activeInvocations.map((invocation) => (
+        <SandboxFunctionInvocation
+          key={invocation.invocationId}
+          workspaceId={workspaceId}
+          functionId={invocation.functionId}
+          invocationId={invocation.invocationId}
+          onSettle={settleSandboxFunctionInvocation}
+        />
+      ))}
       <div
         className={cn(
           "relative w-full overflow-hidden",

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -435,9 +435,14 @@ export const VisualizationActionIframe = forwardRef<
   const [activeInvocations, setActiveInvocations] = useState<
     { functionId: string; invocationId: string }[]
   >([]);
-  const invocationResolversRef = useRef<
-    Map<string, (response: CommandResultMap["callFunction"]) => void>
-  >(new Map());
+  const invocationResolversRef = useRef<Map<
+    string,
+    (response: CommandResultMap["callFunction"]) => void
+  > | null>(null);
+  if (invocationResolversRef.current === null) {
+    invocationResolversRef.current = new Map();
+  }
+  const invocationResolvers = invocationResolversRef.current;
 
   const waitForSandboxFunctionInvocationResult = useCallback(
     ({
@@ -448,22 +453,22 @@ export const VisualizationActionIframe = forwardRef<
       invocationId: string;
     }) =>
       new Promise<CommandResultMap["callFunction"]>((resolve) => {
-        invocationResolversRef.current.set(invocationId, resolve);
+        invocationResolvers.set(invocationId, resolve);
         setActiveInvocations((prev) => [...prev, { functionId, invocationId }]);
       }),
-    []
+    [invocationResolvers]
   );
 
   const settleSandboxFunctionInvocation = useCallback(
     (invocationId: string, response: CommandResultMap["callFunction"]) => {
-      const resolve = invocationResolversRef.current.get(invocationId);
-      invocationResolversRef.current.delete(invocationId);
+      const resolve = invocationResolvers.get(invocationId);
+      invocationResolvers.delete(invocationId);
       setActiveInvocations((prev) =>
         prev.filter((invocation) => invocation.invocationId !== invocationId)
       );
       resolve?.(response);
     },
-    []
+    [invocationResolvers]
   );
 
   // Combine internal ref with forwarded ref.

--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -88,11 +88,16 @@ const stableEventSourceManager = {
   },
 };
 
+interface UseEventSourceOptions {
+  isReadyToConsumeStream?: boolean;
+  onTerminalError?: (error: Error) => void;
+}
+
 export function useEventSource(
   buildURL: (lastEvent: string | null) => string | null,
   onEventCallback: (event: string) => void,
   uniqueId: string,
-  { isReadyToConsumeStream = true }: { isReadyToConsumeStream?: boolean } = {}
+  { isReadyToConsumeStream = true, onTerminalError }: UseEventSourceOptions = {}
 ) {
   const [isError, setIsError] = useState<Error | null>(null);
   const lastEvent = useRef<string | null>(null);
@@ -164,7 +169,9 @@ export function useEventSource(
 
         if (reconnectAttempts.current >= MAX_RECONNECT_ATTEMPTS) {
           logger.error("EventSource: too many errors, not reconnecting.");
-          setIsError(new Error("Too many errors, closing connection."));
+          const error = new Error("Too many errors, closing connection.");
+          setIsError(error);
+          onTerminalError?.(error);
 
           return;
         }
@@ -186,7 +193,7 @@ export function useEventSource(
 
       return source;
     },
-    [buildURL, onEventCallback, uniqueId, sourceManager]
+    [buildURL, onEventCallback, uniqueId, sourceManager, onTerminalError]
   );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: `connect` is intentionally excluded — its identity may change every render if callers don't memoize buildURL/onEventCallback, which would abort in-flight connections.

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -1,4 +1,7 @@
-import type { SandboxFunctionMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
+import type {
+  SandboxFunctionMCPApproveExecutionEvent,
+  SandboxFunctionToolPersonalAuthRequiredEvent,
+} from "@app/lib/actions/mcp_internal_actions/events";
 import type { ToolExecutionBaseStatus } from "@app/lib/actions/statuses";
 
 export const SANDBOX_FUNCTION_INVOCATION_STATUSES = ["created"] as const;
@@ -60,7 +63,8 @@ export type SandboxFunctionInvocationEvent =
   | SandboxFunctionInvocationCreatedEvent
   | SandboxFunctionInvocationResultEvent
   | SandboxFunctionInvocationErrorEvent
-  | SandboxFunctionMCPApproveExecutionEvent;
+  | SandboxFunctionMCPApproveExecutionEvent
+  | SandboxFunctionToolPersonalAuthRequiredEvent;
 
 // The events that end an invocation stream: no further event is published after them.
 export function isSandboxFunctionInvocationTerminalEvent(


### PR DESCRIPTION
## Description

Third sandbox function approval slice, after #28766 and #28788.

Sandbox function invocation events now use `useEventSource`, reusing its `done` sentinel reconnects, `lastEventId` resumes, bounded backoff, heartbeat, and page lifecycle recovery. Each in-flight invocation mounts a component that settles the iframe call and will host approval and authentication UI.

`useEventSource` accepts an optional terminal-error callback so invocation failures settle directly without an error-watching effect. The fixed client timeout is removed because the server publishes a terminal result or error once an invocation exists.

The personal authentication event is added to the invocation event union ahead of the follow-up UI.

## Tests

N/A, tested locally.

## Risk

Low. Limited to feature-flagged sandbox function invocations.

## Deploy Plan

- deploy `front`