### PR TITLE
[Agent Loop] Heartbeat during tool activity setup to survive DB stalls

### DIFF
--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -14,8 +14,10 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getShutdownSignal } from "@app/lib/shutdown_signal";
+import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
+import { TOOL_SETUP_HEARTBEAT_INTERVAL_MS } from "@app/temporal/agent_loop/config";
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import type {
@@ -101,25 +103,53 @@ export async function runToolActivity(
     runIds?: string[];
   }
 ): Promise<ToolExecutionResult> {
-  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+  // The setup phase below is DB-bound and can stall past the heartbeat timeout under
+  // connection-pool contention. Tool activities are not retried, so a missed first heartbeat
+  // kills the whole run: heartbeat immediately and periodically until setup completes.
+  heartbeat();
+
   const deferredEvents: ToolExecutionResult["deferredEvents"] = [];
 
-  const [runAgentDataRes, action] = await startActiveObservation(
-    "get-agent-loop-data",
-    () =>
-      Promise.all([
-        // Cache conversation fetches to reduce DB load when multiple tool activities run in parallel
-        // during the same step. Each tool would otherwise fetch the same conversation independently.
-        getAgentLoopDataWithAuth(auth, {
-          ...runAgentArgs,
-          caching: {
-            useCachedGetConversation: true,
-            unicitySuffix: `${runAgentArgs.agentMessageId}:${runAgentArgs.agentMessageVersion}:${step}`,
-            ttlMs: CONVERSATION_CACHE_TTL_MS,
+  const { auth, runAgentDataRes, action } = await withPeriodicHeartbeat(
+    async () => {
+      const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+
+      const [runAgentDataRes, action] = await startActiveObservation(
+        "get-agent-loop-data",
+        () =>
+          Promise.all([
+            // Cache conversation fetches to reduce DB load when multiple tool activities run in parallel
+            // during the same step. Each tool would otherwise fetch the same conversation independently.
+            getAgentLoopDataWithAuth(auth, {
+              ...runAgentArgs,
+              caching: {
+                useCachedGetConversation: true,
+                unicitySuffix: `${runAgentArgs.agentMessageId}:${runAgentArgs.agentMessageVersion}:${step}`,
+                ttlMs: CONVERSATION_CACHE_TTL_MS,
+              },
+            }),
+            AgentMCPActionResource.fetchByModelIdWithAuth(auth, actionId),
+          ])
+      );
+
+      return { auth, runAgentDataRes, action };
+    },
+    {
+      intervalMs: TOOL_SETUP_HEARTBEAT_INTERVAL_MS,
+      heartbeatFn: () => {
+        heartbeat();
+        logger.info(
+          {
+            actionId,
+            conversationId: runAgentArgs.conversationId,
+            agentMessageId: runAgentArgs.agentMessageId,
+            step,
+            workspaceId: authType.workspaceId,
           },
-        }),
-        AgentMCPActionResource.fetchByModelIdWithAuth(auth, actionId),
-      ])
+          "MCP tool setup heartbeat"
+        );
+      },
+    }
   );
   if (runAgentDataRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -17,3 +17,9 @@ const TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS = 5 * 1000;
 export const TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS =
   TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS -
   TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS;
+
+// Heartbeat cadence while the tool activity's DB-bound setup (auth + conversation + action
+// fetches) runs. Setup normally completes in well under a second, so a firing means the fetch
+// phase is stalling (DB contention): the log emitted alongside each firing is monitored in
+// Datadog. Aligned with the worker's maxHeartbeatThrottleInterval.
+export const TOOL_SETUP_HEARTBEAT_INTERVAL_MS = 20 * 1000;


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9160

`runToolActivity` performs all of its setup DB work (auth rebuild + conversation fetch + action fetch) before its first Temporal heartbeat. Under DB connection-pool contention on the agent-loop workers, that setup phase can stall past the 60s heartbeat timeout. Since tool activities run with `maximumAttempts: 1` (tools are not idempotent), a single missed first heartbeat kills the whole run with the user-facing *"The agent took too long to respond. Please try again."* — even though the stalled fetch typically resolves seconds later and the tool itself completes fine as a discarded zombie execution. ~1,200 occurrences surfaced through `run_agent` sub-agents alone over the last 14 days (full trace in the issue).

Fix: heartbeat immediately at activity entry, then periodically (20s, aligned with the worker's `maxHeartbeatThrottleInterval`) while the setup phase runs — the same `withPeriodicHeartbeat` pattern already used for tool result processing. A slow setup now just delays the run instead of terminally failing it.

The heartbeat timeout keeps doing its real job: the periodic heartbeat is timer-driven, so if the worker process dies or its event loop seizes for >60s, heartbeats stop and the 60s timeout still fires. Only the false positive (slow DB await on a healthy pod) is eliminated.

The `MCP tool setup heartbeat` log only fires when setup exceeds 20s (healthy setup completes in well under a second), so it doubles as the DB-contention signal: a Datadog monitor on it will replace the failed-run-plus-support-ticket as our notification channel (next step, not in this PR).

## Risks

Blast radius: all agent tool executions (agent-loop workers).
Risk: low

## Deploy Plan

- deploy front
