### PR TITLE
Add: model tier resource and user / group / workspace management.

### DIFF
--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -44,6 +44,16 @@ describe("assertValidGrant", () => {
       ).not.toThrow();
     });
 
+    it("models tier use with a tier id", () => {
+      expect(() =>
+        assertValidGrant({
+          permissionType: "use",
+          resourceType: "models_tier",
+          resourceId: 2,
+        })
+      ).not.toThrow();
+    });
+
     it("full wildcard with -1", () => {
       expect(() =>
         assertValidGrant({
@@ -104,6 +114,16 @@ describe("assertValidGrant", () => {
           resourceId: 0,
         })
       ).toThrow(/positive resourceId/);
+    });
+
+    it("type-wide grant on models_tier", () => {
+      expect(() =>
+        assertValidGrant({
+          permissionType: "use",
+          resourceType: "models_tier",
+          resourceId: WHOLE_TYPE_RESOURCE_ID,
+        })
+      ).toThrow(/cannot be granted type-wide/);
     });
   });
 });

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -61,6 +61,10 @@ const REGISTRY: Record<ConcreteResourceType, ResourceTypeRule> = {
     instanceLevelPermissions: [],
     typeLevelPermissions: ["read"],
   },
+  models_tier: {
+    instanceLevelPermissions: ["use"],
+    typeLevelPermissions: [],
+  },
 };
 
 interface GrantSpec {

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -484,4 +484,53 @@ describe("GroupPermissionResource", () => {
       expect(await group.isMember(user2)).toBe(true);
     });
   });
+
+  describe("grantToEverybody / revokeFromEverybody", () => {
+    it("grants and revokes an instance-level permission on the global group", async () => {
+      const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
+        workspace.id
+      );
+      if (!globalGroup) {
+        throw new Error("global group should exist");
+      }
+
+      await GroupPermissionResource.grantToEverybody(auth, {
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 42,
+      });
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupModelIds: [globalGroup.id],
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 42,
+      });
+      expect(grants).toHaveLength(1);
+
+      await GroupPermissionResource.revokeFromEverybody(auth, {
+        permissionType: "read",
+        resourceType: "space",
+        resourceId: 42,
+      });
+      expect(
+        await GroupPermissionResource.listForGroups(auth, {
+          groupModelIds: [globalGroup.id],
+          permissionType: "read",
+          resourceType: "space",
+          resourceId: 42,
+        })
+      ).toHaveLength(0);
+    });
+
+    it("rejects type-wide grants", async () => {
+      await expect(
+        GroupPermissionResource.grantToEverybody(auth, {
+          permissionType: "create",
+          resourceType: "agent",
+          resourceId: -1,
+        })
+      ).rejects.toThrow(/instance-level/);
+    });
+  });
 });

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -78,6 +78,13 @@ interface UserGrantSpec {
   transaction?: Transaction;
 }
 
+interface EverybodyGrantSpec {
+  permissionType: PermissionType;
+  resourceType: GroupPermissionResourceType;
+  resourceId: number;
+  transaction?: Transaction;
+}
+
 function autoGroupName({
   permissionType,
   resourceType,
@@ -119,6 +126,8 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
 
   // Grant an instance-level permission (a specific resource). Idempotent: the unique index dedupes,
   // so granting twice is a no-op. Type-wide grants (resourceId = -1) go through dedicated methods.
+  // TODO(admin-governance): Decide whether system group should be rejected here (and in
+  // revoke) or left to callers; align with setGroups / setForEverybody conventions.
   static async grant(
     auth: Authenticator,
     {
@@ -306,8 +315,58 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     }, transaction);
   }
 
+  // Grant an instance-level permission to the whole workspace via the global group. Idempotent.
+  // Distinct from setForEverybody, which grants a type-wide (-1) governance capability.
+  static async grantToEverybody(
+    auth: Authenticator,
+    {
+      permissionType,
+      resourceType,
+      resourceId,
+      transaction,
+    }: EverybodyGrantSpec
+  ): Promise<void> {
+    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
+      auth.getNonNullableWorkspace().id
+    );
+    assert(globalGroup, "Workspace is missing its global group.");
+
+    await this.grant(auth, {
+      group: globalGroup,
+      permissionType,
+      resourceType,
+      resourceId,
+      transaction,
+    });
+  }
+
+  // Revoke an instance-level permission from the whole workspace (the global group). No-op if absent.
+  static async revokeFromEverybody(
+    auth: Authenticator,
+    {
+      permissionType,
+      resourceType,
+      resourceId,
+      transaction,
+    }: EverybodyGrantSpec
+  ): Promise<void> {
+    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
+      auth.getNonNullableWorkspace().id
+    );
+    assert(globalGroup, "Workspace is missing its global group.");
+
+    await this.revoke(auth, {
+      group: globalGroup,
+      permissionType,
+      resourceType,
+      resourceId,
+      transaction,
+    });
+  }
+
   // Revoke a single instance-level grant. No-op if absent. Type-wide (-1) grants are removed via
   // revokeTypeWide, mirroring the instance-only contract of grant().
+  // TODO(admin-governance): See grant() — same open question on system/global group restrictions.
   static async revoke(
     auth: Authenticator,
     {

--- a/front/lib/resources/models_tier_resource.test.ts
+++ b/front/lib/resources/models_tier_resource.test.ts
@@ -1,0 +1,88 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("ModelsTierResource permissions", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let auth: Authenticator;
+  let group: GroupResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+    group = await GroupFactory.regular(workspace, "tier-users");
+    auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  });
+
+  async function grantsForTier(tierId: number) {
+    return GroupPermissionResource.listForGroups(auth, {
+      groupModelIds: (await GroupResource.listAllWorkspaceGroups(auth)).map(
+        (entry) => entry.id
+      ),
+      permissionType: "use",
+      resourceType: "models_tier",
+      resourceId: tierId,
+    });
+  }
+
+  it("grants and revokes a tier for a user via a regular_auto group", async () => {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const grantResult = await ModelsTierResource.grantToUser(auth, {
+      user: user.toJSON(),
+      tierName: "balanced",
+    });
+    expect(grantResult.isOk()).toBe(true);
+
+    const grants = await grantsForTier(2);
+    expect(grants).toHaveLength(1);
+
+    const autoGroup = await GroupResource.fetchByModelIds(auth, [
+      grants[0].groupId,
+    ]);
+    expect(autoGroup[0].kind).toBe("regular_auto");
+    expect(await autoGroup[0].isMember(user)).toBe(true);
+
+    const revokeResult = await ModelsTierResource.revokeFromUser(auth, {
+      user: user.toJSON(),
+      tierName: "balanced",
+    });
+    expect(revokeResult.isOk()).toBe(true);
+    expect(await grantsForTier(2)).toHaveLength(0);
+  });
+
+  it("grants and revokes a tier for a regular group", async () => {
+    await ModelsTierResource.grantToGroup(auth, {
+      group,
+      tierName: "premium",
+    });
+
+    const grants = await GroupPermissionResource.listForGroups(auth, {
+      groupModelIds: [group.id],
+      permissionType: "use",
+      resourceType: "models_tier",
+      resourceId: 3,
+    });
+    expect(grants).toHaveLength(1);
+
+    await ModelsTierResource.revokeFromGroup(auth, {
+      group,
+      tierName: "premium",
+    });
+    expect(
+      await GroupPermissionResource.listForGroups(auth, {
+        groupModelIds: [group.id],
+        permissionType: "use",
+        resourceType: "models_tier",
+        resourceId: 3,
+      })
+    ).toHaveLength(0);
+  });
+});

--- a/front/lib/resources/models_tier_resource.ts
+++ b/front/lib/resources/models_tier_resource.ts
@@ -6,12 +6,34 @@ import {
   type ModelTierSelection,
   STATIC_MODEL_TIERS,
 } from "@app/lib/api/assistant/token_pricing/tiers";
+import type { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import type { GroupResource } from "@app/lib/resources/group_resource";
+import type { Result } from "@app/types/shared/result";
+import type { UserType } from "@app/types/user";
+import assert from "assert";
+import type { Transaction } from "sequelize";
 
 export type {
   ModelsTierDefinition,
   ModelsTierName,
   ModelTierSelection,
 } from "@app/lib/api/assistant/token_pricing/tiers";
+
+const MODELS_TIER_PERMISSION_TYPE = "use" as const;
+const MODELS_TIER_RESOURCE_TYPE = "models_tier" as const;
+
+interface ModelsTierUserGrantSpec {
+  user: UserType;
+  tierName: ModelsTierName;
+  transaction?: Transaction;
+}
+
+interface ModelsTierGroupGrantSpec {
+  group: GroupResource;
+  tierName: ModelsTierName;
+  transaction?: Transaction;
+}
 
 export class ModelsTierResource {
   static readonly TIERS = MODELS_TIERS;
@@ -39,5 +61,63 @@ export class ModelsTierResource {
     reasoningEffort: ModelTierSelection["reasoningEffort"]
   ): ModelsTierName | null {
     return STATIC_MODEL_TIERS[modelId][reasoningEffort] ?? null;
+  }
+
+  private static getTierResourceId(tierName: ModelsTierName): number {
+    const tier = this.getTier(tierName);
+    assert(tier, `Unknown models tier: ${tierName}`);
+    return tier.id;
+  }
+
+  static async grantToUser(
+    auth: Authenticator,
+    { user, tierName, transaction }: ModelsTierUserGrantSpec
+  ): Promise<Result<undefined, Error>> {
+    return GroupPermissionResource.grantToUser(auth, {
+      user,
+      permissionType: MODELS_TIER_PERMISSION_TYPE,
+      resourceType: MODELS_TIER_RESOURCE_TYPE,
+      resourceId: this.getTierResourceId(tierName),
+      transaction,
+    });
+  }
+
+  static async revokeFromUser(
+    auth: Authenticator,
+    { user, tierName, transaction }: ModelsTierUserGrantSpec
+  ): Promise<Result<undefined, Error>> {
+    return GroupPermissionResource.revokeFromUser(auth, {
+      user,
+      permissionType: MODELS_TIER_PERMISSION_TYPE,
+      resourceType: MODELS_TIER_RESOURCE_TYPE,
+      resourceId: this.getTierResourceId(tierName),
+      transaction,
+    });
+  }
+
+  static async grantToGroup(
+    auth: Authenticator,
+    { group, tierName, transaction }: ModelsTierGroupGrantSpec
+  ): Promise<void> {
+    await GroupPermissionResource.grant(auth, {
+      group,
+      permissionType: MODELS_TIER_PERMISSION_TYPE,
+      resourceType: MODELS_TIER_RESOURCE_TYPE,
+      resourceId: this.getTierResourceId(tierName),
+      transaction,
+    });
+  }
+
+  static async revokeFromGroup(
+    auth: Authenticator,
+    { group, tierName, transaction }: ModelsTierGroupGrantSpec
+  ): Promise<void> {
+    await GroupPermissionResource.revoke(auth, {
+      group,
+      permissionType: MODELS_TIER_PERMISSION_TYPE,
+      resourceType: MODELS_TIER_RESOURCE_TYPE,
+      resourceId: this.getTierResourceId(tierName),
+      transaction,
+    });
   }
 }

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -17,6 +17,7 @@ export const PERMISSION_TYPES = [
   "create",
   "publish",
   "invite",
+  "use",
   "*",
 ] as const;
 export type PermissionType = (typeof PERMISSION_TYPES)[number];
@@ -30,6 +31,7 @@ export const GROUP_PERMISSION_RESOURCE_TYPES = [
   "billing",
   "identity",
   "audit_log",
+  "models_tier",
   "*",
 ] as const;
 export type GroupPermissionResourceType =


### PR DESCRIPTION
## Description

Wires model tier access into the group permission system. Adds `"use"` to `PERMISSION_TYPES` and `"models_tier"` to `GROUP_PERMISSION_RESOURCE_TYPES`, registers the type in the permission registry (instance-level only — no type-wide grants), and extends `ModelsTierResource` with `grantToUser`, `revokeFromUser`, `grantToGroup`, and `revokeFromGroup`, all delegating to `GroupPermissionResource` using the tier's numeric ID as `resourceId`. User grants go through a `regular_auto` group (existing pattern from `grantToUser`); group grants target the group directly. Also adds `grantToEverybody`/`revokeFromEverybody` to `GroupPermissionResource` for instance-level grants to the workspace global group.

## Tests

Added `models_tier_resource.test.ts` covering user and group grant/revoke flows end-to-end. Updated `group_permission_registry.test.ts` to assert `models_tier` validates correctly and rejects type-wide grants. Updated `group_permission_resource.test.ts` to cover `grantToEverybody`/`revokeFromEverybody`.

## Risk

Low. No DB migration — uses the existing `group_permissions` table. No new API routes. The `models_tier` resource type is inert until callers use it.

## Deploy Plan

Deploy front.
