### PR TITLE
Revert "refactor(mcp): narrow tool handler context to runContext (#28761)"

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -142,9 +142,7 @@ vi.mock("@app/lib/api/actions/servers/search/tools", async () => {
       mockSearchFunction({
         ...(params as object),
         auth: (extra as { auth?: unknown }).auth,
-        toolContext: {
-          runContext: (extra as { runContext?: unknown }).runContext,
-        },
+        toolContext: (extra as { toolContext?: unknown }).toolContext,
       }),
   };
   const handlersWithTags = {

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -188,7 +188,7 @@ export async function processToolResults(
   }[] = await concurrentExecutor(
     toolCallResultContent,
     async (block, idx) => {
-      const res = await persistToolOutput(auth, runContext, block, {
+      const res = await persistToolOutput(auth, toolContext, block, {
         toolName: toolConfiguration.name,
         serverName: toolConfiguration.mcpServerName,
       });

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -1,6 +1,6 @@
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPError } from "@app/lib/actions/mcp_errors";
-import type { ToolRunContext } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import type {
   InternalMCPServerDefinitionType,
   MCPToolType,
@@ -22,7 +22,7 @@ export type ToolHandlerExtra = RequestHandlerExtra<
   ServerNotification
 > & {
   auth: Authenticator;
-  runContext: ToolRunContext;
+  toolContext?: ToolContextType;
 };
 
 export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;

--- a/front/lib/actions/mcp_internal_actions/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.test.ts
@@ -6,7 +6,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContext } from "@app/lib/actions/types";
 import { Authenticator } from "@app/lib/auth";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -62,22 +61,11 @@ async function authForRole(role: MembershipRoleType): Promise<Authenticator> {
 }
 
 // Stands up an in-memory MCP server with the test tools registered for `auth`,
-// connects a client over the in-memory transport, and calls one tool. Handlers only ever execute
-// with a run context (enforced by registerTool), so a minimal fake one is provided; the test
-// handlers only read `auth`.
+// connects a client over the in-memory transport, and calls one tool.
 async function callTestTool(auth: Authenticator, toolName: string) {
-  const toolContext = {
-    runContext: {
-      contextType: "agent_loop",
-      agentConfiguration: { sId: "agent-id", version: 0 },
-      toolConfiguration: { sId: "tool-configuration-id" },
-      conversation: { sId: "conversation-id" },
-      agentMessage: { sId: "message-id" },
-    },
-  } as unknown as ToolContext;
   const server = new McpServer({ name: "admin_guard_test", version: "1.0.0" });
   for (const tool of TEST_TOOLS) {
-    registerTool(auth, toolContext, server, tool, {
+    registerTool(auth, undefined, server, tool, {
       monitoringName: "admin_guard_test",
     });
   }

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -5,13 +5,12 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   isAgentLoopRunContext,
-  isSandboxFunctionRunContext,
-  type ToolContext,
-  type ToolRunContext,
+  type ToolContextType,
 } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
+
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { errorToString } from "@app/types/shared/utils/error_utils";
@@ -23,13 +22,12 @@ import type {
   ServerNotification,
   ServerRequest,
 } from "@modelcontextprotocol/sdk/types.js";
-import assert from "assert";
 
 const MAX_LOGGED_ERROR_MESSAGE_LENGTH = 200;
 
 export function registerTool(
   auth: Authenticator,
-  toolContext: ToolContext | undefined,
+  toolContext: ToolContextType | undefined,
   server: McpServer,
   tool: ToolDefinition,
   { monitoringName }: { monitoringName: string }
@@ -51,18 +49,13 @@ export function registerTool(
       auth,
       {
         toolNameForMonitoring: monitoringName,
-        runContext: toolContext?.runContext,
+        toolContext,
         enableAlerting: tool.enableAlerting,
       },
-      (params, extra) => {
-        // Handlers registered during the listing phase are never invoked: tools only execute on
-        // a connection established with a run context.
-        const runContext = toolContext?.runContext;
-        assert(runContext, "Tool handlers require a tool run context.");
-        return withToolResultProcessing(
-          tool.handler(params, { ...extra, runContext, auth })
-        );
-      }
+      (params, extra) =>
+        withToolResultProcessing(
+          tool.handler(params, { ...extra, toolContext, auth })
+        )
     )
   );
 }
@@ -116,12 +109,11 @@ function withToolLogging<T>(
   auth: Authenticator,
   {
     toolNameForMonitoring,
-    runContext,
+    toolContext,
     enableAlerting = false,
   }: {
     toolNameForMonitoring: string;
-    // Undefined at listing-phase registration; always set when the callback actually runs.
-    runContext: ToolRunContext | undefined;
+    toolContext: ToolContextType | undefined;
     enableAlerting?: boolean;
   },
   toolCallback: (
@@ -149,15 +141,15 @@ function withToolLogging<T>(
       toolName: toolNameForMonitoring,
     };
 
-    // Adding run context identifiers if available.
-    if (runContext) {
-      if (isAgentLoopRunContext(runContext)) {
+    // Adding agent loop context if available.
+    if (toolContext?.runContext) {
+      if (isAgentLoopRunContext(toolContext.runContext)) {
         const {
           agentConfiguration,
           toolConfiguration,
           conversation,
           agentMessage,
-        } = runContext;
+        } = toolContext.runContext;
         loggerArgs = {
           ...loggerArgs,
           actionConfigurationId: toolConfiguration.sId,
@@ -165,14 +157,6 @@ function withToolLogging<T>(
           agentConfigurationVersion: agentConfiguration.version,
           agentMessageId: agentMessage.sId,
           conversationId: conversation.sId,
-        };
-      } else if (isSandboxFunctionRunContext(runContext)) {
-        const { invocation, toolConfiguration } = runContext;
-        loggerArgs = {
-          ...loggerArgs,
-          actionConfigurationId: toolConfiguration.sId,
-          sandboxFunctionId: invocation.sandboxFunction.sId,
-          invocationId: invocation.sId,
         };
       }
     }

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -164,7 +164,7 @@ export type ToolOutputItemType = {
   workspaceId: ModelId;
 };
 
-export type AgentLoopRunContext = {
+export type AgentLoopRunContextType = {
   contextType: "agent_loop";
   action: AgentMCPActionResource;
   agentConfiguration: AgentConfigurationWithoutModelType;
@@ -176,14 +176,14 @@ export type AgentLoopRunContext = {
   userMessage: UserMessageType;
 };
 
-export type SandboxFunctionRunContext = {
+export type SandboxFunctionRunContextType = {
   contextType: "sandbox_function";
   action: SandboxFunctionMCPActionResource;
   invocation: SandboxFunctionInvocationResource;
   toolConfiguration: LightMCPToolConfigurationType;
 };
 
-export type AgentLoopListToolsContext = {
+export type AgentLoopListToolsContextType = {
   agentConfiguration: AgentConfigurationWithoutModelType;
   agentActionConfiguration: MCPServerConfigurationType;
   clientSideActionConfigurations?: ClientSideMCPServerConfigurationType[];
@@ -191,28 +191,24 @@ export type AgentLoopListToolsContext = {
   agentMessage: AgentMessageType;
 };
 
-// Context available to tool handlers at execution time: tools only ever run on a connection
-// established with a run context, never on a listing-phase connection.
-export type ToolRunContext = AgentLoopRunContext | SandboxFunctionRunContext;
-
 export function isSandboxFunctionRunContext(
-  value: ToolRunContext | undefined
-): value is SandboxFunctionRunContext {
+  value: AgentLoopRunContextType | SandboxFunctionRunContextType | undefined
+): value is SandboxFunctionRunContextType {
   return value?.contextType === "sandbox_function";
 }
 
 export function isAgentLoopRunContext(
-  value: ToolRunContext | undefined
-): value is AgentLoopRunContext {
+  value: AgentLoopRunContextType | SandboxFunctionRunContextType | undefined
+): value is AgentLoopRunContextType {
   return value?.contextType === "agent_loop";
 }
 
-export type ToolContext =
+export type ToolContextType =
   | {
-      runContext: ToolRunContext;
+      runContext: AgentLoopRunContextType | SandboxFunctionRunContextType;
       listToolsContext?: never;
     }
   | {
       runContext?: never;
-      listToolsContext: AgentLoopListToolsContext;
+      listToolsContext: AgentLoopListToolsContextType;
     };

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -20,10 +20,10 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
   {
     create_recommendation: async (
       { content, rationale },
-      { auth, runContext }
+      { auth, toolContext }
     ) => {
-      const conversationId = isAgentLoopRunContext(runContext)
-        ? runContext.conversation.id
+      const conversationId = isAgentLoopRunContext(toolContext?.runContext)
+        ? toolContext.runContext.conversation.id
         : null;
 
       const rec = await ActivationRecommendationResource.makeNew(auth, {

--- a/front/lib/api/actions/servers/agent_memory/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_memory/tools/index.ts
@@ -37,7 +37,7 @@ const renderMemory = (
 };
 
 const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
-  [AGENT_MEMORY_RETRIEVE_TOOL_NAME]: async (_, { auth, runContext }) => {
+  [AGENT_MEMORY_RETRIEVE_TOOL_NAME]: async (_, { auth, toolContext }) => {
     const user = auth.user();
     if (!user) {
       return new Err(
@@ -47,8 +47,11 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
       );
     }
 
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
-    const { agentConfiguration } = runContext;
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
+    const { agentConfiguration } = toolContext.runContext;
 
     const memory = await AgentMemoryResource.retrieveMemory(auth, {
       agentConfiguration,
@@ -59,7 +62,7 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
 
   [AGENT_MEMORY_RECORD_TOOL_NAME]: async (
     { entries },
-    { auth, runContext }
+    { auth, toolContext }
   ) => {
     const user = auth.user();
     if (!user) {
@@ -70,8 +73,11 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
       );
     }
 
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
-    const { agentConfiguration } = runContext;
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
+    const { agentConfiguration } = toolContext.runContext;
 
     const result = await AgentMemoryResource.recordEntries(auth, {
       agentConfiguration,
@@ -86,7 +92,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     return renderMemory(result.value);
   },
 
-  [AGENT_MEMORY_ERASE_TOOL_NAME]: async ({ indexes }, { auth, runContext }) => {
+  [AGENT_MEMORY_ERASE_TOOL_NAME]: async (
+    { indexes },
+    { auth, toolContext }
+  ) => {
     const user = auth.user();
     if (!user) {
       return new Err(
@@ -96,8 +105,11 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
       );
     }
 
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
-    const { agentConfiguration } = runContext;
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
+    const { agentConfiguration } = toolContext.runContext;
 
     const memory = await AgentMemoryResource.eraseEntries(auth, {
       agentConfiguration,
@@ -107,7 +119,7 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     return renderMemory(memory);
   },
 
-  [AGENT_MEMORY_EDIT_TOOL_NAME]: async ({ edits }, { auth, runContext }) => {
+  [AGENT_MEMORY_EDIT_TOOL_NAME]: async ({ edits }, { auth, toolContext }) => {
     const user = auth.user();
     if (!user) {
       return new Err(
@@ -117,8 +129,11 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
       );
     }
 
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
-    const { agentConfiguration } = runContext;
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
+    const { agentConfiguration } = toolContext.runContext;
 
     const result = await AgentMemoryResource.editEntries(auth, {
       agentConfiguration,
@@ -133,7 +148,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     return renderMemory(result.value);
   },
 
-  [AGENT_MEMORY_COMPACT_TOOL_NAME]: async ({ edits }, { auth, runContext }) => {
+  [AGENT_MEMORY_COMPACT_TOOL_NAME]: async (
+    { edits },
+    { auth, toolContext }
+  ) => {
     const user = auth.user();
     if (!user) {
       return new Err(
@@ -143,8 +161,11 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
       );
     }
 
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
-    const { agentConfiguration } = runContext;
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
+    const { agentConfiguration } = toolContext.runContext;
 
     const result = await AgentMemoryResource.editEntries(auth, {
       agentConfiguration,

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/agent_sidekick_agent_state.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/agent_sidekick_agent_state.test.ts
@@ -25,11 +25,11 @@ function getToolByName(name: string) {
 }
 
 // Create a minimal extra object for testing.
-function createTestExtra(auth: Authenticator, runContext?: unknown) {
+function createTestExtra(auth: Authenticator, toolContext?: unknown) {
   return {
     signal: new AbortController().signal,
     auth,
-    runContext,
+    toolContext,
   } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
 }
 

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/tools/index.ts
@@ -12,10 +12,9 @@ import { Err, Ok } from "@app/types/shared/result";
 
 const handlers: ToolHandlers<typeof AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA> =
   {
-    get_agent_info: async (_, { auth, runContext }) => {
-      const agentConfigurationId = getAgentConfigurationIdFromContext({
-        runContext,
-      });
+    get_agent_info: async (_, { auth, toolContext }) => {
+      const agentConfigurationId =
+        getAgentConfigurationIdFromContext(toolContext);
 
       if (!agentConfigurationId) {
         return new Err(
@@ -26,9 +25,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA> =
         );
       }
 
-      const agentVersion = getAgentConfigurationVersionFromContext({
-        runContext,
-      });
+      const agentVersion = getAgentConfigurationVersionFromContext(toolContext);
 
       // Fetch the agent configuration with full details to get the actions.
       const agentConfiguration = await getAgentConfiguration(auth, {

--- a/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
@@ -65,11 +65,11 @@ function getToolByName(name: string) {
 }
 
 // Create a minimal extra object for testing.
-function createTestExtra(auth: Authenticator, runContext?: unknown) {
+function createTestExtra(auth: Authenticator, toolContext?: unknown) {
   return {
     signal: new AbortController().signal,
     auth,
-    runContext,
+    toolContext,
   } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
 }
 

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -694,11 +694,10 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
 
   get_agent_feedback: async (
     { limit, filter, latestVersionOnly },
-    { auth, runContext }
+    { auth, toolContext }
   ) => {
-    const agentConfigurationId = getAgentConfigurationIdFromContext({
-      runContext,
-    });
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -797,10 +796,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_agent_insights: async ({ days }, { auth, runContext }) => {
-    const agentConfigurationId = getAgentConfigurationIdFromContext({
-      runContext,
-    });
+  get_agent_insights: async ({ days }, { auth, toolContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -874,10 +872,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
   },
 
   // Suggestion handlers
-  suggest_prompt_edits: async (params, { auth, runContext }) => {
-    const agentConfigurationId = getAgentConfigurationIdFromContext({
-      runContext,
-    });
+  suggest_prompt_edits: async (params, { auth, toolContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -919,10 +916,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  suggest_tools: async (params, { auth, runContext }) => {
-    const agentConfigurationId = getAgentConfigurationIdFromContext({
-      runContext,
-    });
+  suggest_tools: async (params, { auth, toolContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -964,10 +960,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  suggest_sub_agent: async (params, { auth, runContext }) => {
-    const agentConfigurationId = getAgentConfigurationIdFromContext({
-      runContext,
-    });
+  suggest_sub_agent: async (params, { auth, toolContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -1086,10 +1081,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  suggest_skills: async (params, { auth, runContext }) => {
-    const agentConfigurationId = getAgentConfigurationIdFromContext({
-      runContext,
-    });
+  suggest_skills: async (params, { auth, toolContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -1131,7 +1125,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  suggest_model: async (params, { auth, runContext }) => {
+  suggest_model: async (params, { auth, toolContext }) => {
     const availableModels = await getAvailableModelsForWorkspace(auth);
     const availableModelIds = availableModels.map((m) => m.modelId);
 
@@ -1145,9 +1139,8 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       );
     }
 
-    const agentConfigurationId = getAgentConfigurationIdFromContext({
-      runContext,
-    });
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -1322,10 +1315,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  suggest_knowledge: async (params, { auth, runContext }) => {
-    const agentConfigurationId = getAgentConfigurationIdFromContext({
-      runContext,
-    });
+  suggest_knowledge: async (params, { auth, toolContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -1428,10 +1420,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  list_suggestions: async (params, { auth, runContext }) => {
-    const agentConfigurationId = getAgentConfigurationIdFromContext({
-      runContext,
-    });
+  list_suggestions: async (params, { auth, toolContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(toolContext);
 
     if (!agentConfigurationId) {
       return new Err(

--- a/front/lib/api/actions/servers/agent_templates/agent_templates.test.ts
+++ b/front/lib/api/actions/servers/agent_templates/agent_templates.test.ts
@@ -26,11 +26,11 @@ function getToolByName(name: string) {
   return tool;
 }
 
-function createTestExtra(auth: Authenticator, runContext?: unknown) {
+function createTestExtra(auth: Authenticator) {
   return {
     signal: new AbortController().signal,
     auth,
-    runContext,
+    toolContext: undefined,
   } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
 }
 

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -17,11 +17,14 @@ import assert from "assert";
 const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
   ask_user_question: async (
     { question, options, multiSelect },
-    { runContext }
+    { toolContext }
   ) => {
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
-    const resumeState = runContext.stepContext.resumeState;
+    const resumeState = toolContext?.runContext?.stepContext?.resumeState;
     if (isUserQuestionResumeState(resumeState) && resumeState.answer) {
       const { answer } = resumeState;
       const selections = getUserQuestionSelections(

--- a/front/lib/api/actions/servers/common_utilities/tools/index.ts
+++ b/front/lib/api/actions/servers/common_utilities/tools/index.ts
@@ -101,11 +101,12 @@ const handlers: ToolHandlers<typeof COMMON_UTILITIES_TOOLS_METADATA> = {
 
   [SET_CONVERSATION_TITLE_TOOL_NAME]: async (
     { title },
-    { auth, runContext }
+    { auth, toolContext }
   ) => {
-    const conversation = isAgentLoopRunContext(runContext)
-      ? runContext.conversation
-      : null;
+    const conversation =
+      (isAgentLoopRunContext(toolContext?.runContext)
+        ? toolContext.runContext.conversation
+        : null) ?? toolContext?.listToolsContext?.conversation;
 
     if (!conversation) {
       return new Err(

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -90,11 +90,14 @@ const listAttachmentsHandler: ToolHandlers<
   typeof CONVERSATION_FILES_TOOLS_METADATA
 >[typeof CONVERSATION_LIST_FILES_ACTION_NAME] = async (
   _,
-  { auth, runContext }
+  { auth, toolContext }
 ) => {
-  assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+  assert(
+    isAgentLoopRunContext(toolContext?.runContext),
+    "AgentLoopRunContext expected"
+  );
 
-  const conversation = runContext.conversation;
+  const conversation = toolContext.runContext.conversation;
   const allAttachments = await listAttachments(auth, { conversation });
 
   // When the conversation uses the new file system, regular files are surfaced via the
@@ -134,12 +137,15 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
 
   [CONVERSATION_CAT_FILE_ACTION_NAME]: async (
     { fileId, offset, limit, grep },
-    { auth, runContext }
+    { auth, toolContext }
   ) => {
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
-    const conversation = runContext.conversation;
-    const model = runContext.model;
+    const conversation = toolContext.runContext.conversation;
+    const model = toolContext.runContext.model;
 
     const fileRes = await getFileFromConversation(
       auth,
@@ -263,11 +269,14 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
 
   [CONVERSATION_SEARCH_FILES_ACTION_NAME]: async (
     { query },
-    { auth, runContext }
+    { auth, toolContext }
   ) => {
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
-    const conversation = runContext.conversation;
+    const conversation = toolContext.runContext.conversation;
     const attachments = await listAttachments(auth, { conversation });
     const filesUsableAsRetrievalQuery = attachments.filter(
       (f) => f.isSearchable
@@ -331,7 +340,7 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
         uri: getDataSourceURI(dataSource),
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       })),
-      toolContext: { runContext },
+      toolContext,
     });
 
     return searchResults;

--- a/front/lib/api/actions/servers/data_warehouses/tools/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/tools/index.ts
@@ -205,12 +205,15 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
 
   query: async (
     { dataSources, tableIds, query, fileName },
-    { auth, runContext }
+    { auth, toolContext }
   ) => {
     // TODO(spolu): move query CSV output to DFS
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
-    const agentLoopRunContext = runContext;
+    const agentLoopRunContext = toolContext.runContext;
 
     const dataSourceConfigurationsResult =
       await getAgentDataSourceConfigurations(

--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -1,6 +1,6 @@
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type { ToolRunContext } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import type { CoreDataSourceSearchCriteria } from "@app/lib/api/assistant/process_data_sources";
 import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
@@ -122,14 +122,14 @@ const EXTRACT_RESULT_SNIPPET_MAX_LENGTH = 1000;
 
 export async function generateProcessToolOutput({
   auth,
-  runContext,
+  toolContext,
   outputs,
   jsonSchema,
   timeFrame,
   objective,
 }: {
   auth: Authenticator;
-  runContext: ToolRunContext;
+  toolContext: ToolContextType;
   outputs: ProcessActionOutputsType | null;
   jsonSchema: JSONSchema;
   timeFrame: TimeFrame | null;
@@ -150,7 +150,7 @@ export async function generateProcessToolOutput({
   const fileName = makeFileName({ name: stem, ext: ".json" });
   const content = JSON.stringify(outputs?.data ?? [], null, 2);
 
-  const writeResult = await writeToToolOutputsFolder(auth, runContext, {
+  const writeResult = await writeToToolOutputsFolder(auth, toolContext, {
     fileName,
     content,
     contentType: "application/json",

--- a/front/lib/api/actions/servers/extract_data/tools/index.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.ts
@@ -199,7 +199,7 @@ export function createExtractDataTools(
 
     const result = await generateProcessToolOutput({
       auth,
-      runContext: toolContext.runContext,
+      toolContext,
       outputs,
       jsonSchema: jsonSchemaForExtraction,
       timeFrame: timeFrameForExtraction ?? null,

--- a/front/lib/api/actions/servers/file_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/file_generation/tools/index.ts
@@ -55,7 +55,7 @@ const handlers: ToolHandlers<typeof FILE_GENERATION_TOOLS_METADATA> = {
 
   convert_file_format: async (
     { file_id_or_url, source_format, output_format },
-    { auth, runContext }
+    { auth, toolContext }
   ) => {
     const convertAPIKey = config.getConvertAPIKey();
     const contentType = getContentTypeFromOutputFormat(output_format);
@@ -68,9 +68,11 @@ const handlers: ToolHandlers<typeof FILE_GENERATION_TOOLS_METADATA> = {
     // as returned by generate_file for text outputs. Resolve it to a signed URL
     // that ConvertAPI can fetch.
     if (!validateUrl(file_id_or_url).valid) {
-      const refResult = await resolveConversationFileRef(auth, file_id_or_url, {
-        runContext,
-      });
+      const refResult = await resolveConversationFileRef(
+        auth,
+        file_id_or_url,
+        toolContext
+      );
       if (refResult.isErr()) {
         return new Err(
           new MCPError(`File not found: ${file_id_or_url}`, {

--- a/front/lib/api/actions/servers/files/tools/agent_loop_fs.ts
+++ b/front/lib/api/actions/servers/files/tools/agent_loop_fs.ts
@@ -8,13 +8,13 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-type ToolConversationExtra = Pick<ToolHandlerExtra, "runContext">;
+type ToolConversationExtra = Pick<ToolHandlerExtra, "toolContext">;
 
 export function requireAgentLoopConversation(
   extra: ToolConversationExtra
 ): Result<ConversationWithoutContentType, MCPError> {
-  const conversation = isAgentLoopRunContext(extra.runContext)
-    ? extra.runContext.conversation
+  const conversation = isAgentLoopRunContext(extra.toolContext?.runContext)
+    ? extra.toolContext?.runContext?.conversation
     : null;
   if (!conversation) {
     return new Err(

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -142,9 +142,9 @@ async function catText(
 
 export async function catHandler(
   { path, offset, limit }: { path: string; offset?: number; limit?: number },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ runContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContext } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { copyHandler } from "@app/lib/api/actions/servers/files/tools/copy";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -15,11 +15,10 @@ function makeExtra(
   auth: Authenticator,
   conversation: ConversationType
 ): ToolHandlerExtra {
-  const runContext = {
-    contextType: "agent_loop",
-    conversation,
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
+  const toolContext = {
+    runContext: { contextType: "agent_loop", conversation },
+  } as unknown as ToolContextType;
+  return { auth, toolContext } as unknown as ToolHandlerExtra;
 }
 
 async function setupProjectConversation(

--- a/front/lib/api/actions/servers/files/tools/copy.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.ts
@@ -25,9 +25,9 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 export async function copyHandler(
   { source, dest }: { source: string; dest: string },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ runContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/create.test.ts
+++ b/front/lib/api/actions/servers/files/tools/create.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContext } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
 import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
 import { createConversation } from "@app/lib/api/assistant/conversation";
@@ -15,11 +15,10 @@ function makeExtra(
   auth: Authenticator,
   conversation: ConversationType
 ): ToolHandlerExtra {
-  const runContext = {
-    contextType: "agent_loop",
-    conversation,
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
+  const toolContext = {
+    runContext: { contextType: "agent_loop", conversation },
+  } as unknown as ToolContextType;
+  return { auth, toolContext } as unknown as ToolHandlerExtra;
 }
 
 async function setupProjectConversation(): Promise<{

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -27,9 +27,9 @@ export async function createHandler(
     content,
     content_type,
   }: { path: string; content: string; content_type: string },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ runContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/delete.test.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContext } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { deleteHandler } from "@app/lib/api/actions/servers/files/tools/delete";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -21,11 +21,10 @@ function makeExtra(
   auth: Authenticator,
   conversation: ConversationType
 ): ToolHandlerExtra {
-  const runContext = {
-    contextType: "agent_loop",
-    conversation,
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
+  const toolContext = {
+    runContext: { contextType: "agent_loop", conversation },
+  } as unknown as ToolContextType;
+  return { auth, toolContext } as unknown as ToolHandlerExtra;
 }
 
 async function setupProjectConversation(): Promise<{

--- a/front/lib/api/actions/servers/files/tools/delete.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.ts
@@ -12,9 +12,9 @@ import { Err, Ok } from "@app/types/shared/result";
 
 export async function deleteHandler(
   { path }: { path: string },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ runContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContext } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
 import { editHandler } from "@app/lib/api/actions/servers/files/tools/edit";
 import { FRAME_SOURCE_MAX_BYTES } from "@app/lib/api/actions/servers/interactive_content/metadata";
@@ -24,11 +24,10 @@ function makeExtra(
   auth: Authenticator,
   conversation: ConversationType
 ): ToolHandlerExtra {
-  const runContext = {
-    contextType: "agent_loop",
-    conversation,
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
+  const toolContext = {
+    runContext: { contextType: "agent_loop", conversation },
+  } as unknown as ToolContextType;
+  return { auth, toolContext } as unknown as ToolHandlerExtra;
 }
 
 async function setupProjectConversation(): Promise<{

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -39,9 +39,9 @@ export async function editHandler(
     new_string: string;
     expected_replacements?: number;
   },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ runContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/extract_text.ts
+++ b/front/lib/api/actions/servers/files/tools/extract_text.ts
@@ -28,9 +28,9 @@ function deriveExtractedPath(sourcePath: string): string {
 
 export async function extractTextHandler(
   { path }: { path: string },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ runContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/grep.ts
+++ b/front/lib/api/actions/servers/files/tools/grep.ts
@@ -21,9 +21,9 @@ import * as readline from "readline";
 
 export async function grepHandler(
   { path, pattern }: { path: string; pattern: string },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ runContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/list.test.ts
+++ b/front/lib/api/actions/servers/files/tools/list.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContext } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -57,11 +57,10 @@ function makeExtra(
   auth: Authenticator,
   conversation: ConversationType
 ): ToolHandlerExtra {
-  const runContext = {
-    contextType: "agent_loop",
-    conversation,
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
+  const toolContext = {
+    runContext: { contextType: "agent_loop", conversation },
+  } as unknown as ToolContextType;
+  return { auth, toolContext } as unknown as ToolHandlerExtra;
 }
 
 function makeStorageFile(

--- a/front/lib/api/actions/servers/files/tools/move.test.ts
+++ b/front/lib/api/actions/servers/files/tools/move.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContext } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { moveHandler } from "@app/lib/api/actions/servers/files/tools/move";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
@@ -15,11 +15,10 @@ function makeExtra(
   auth: Authenticator,
   conversation: ConversationType
 ): ToolHandlerExtra {
-  const runContext = {
-    contextType: "agent_loop",
-    conversation,
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
+  const toolContext = {
+    runContext: { contextType: "agent_loop", conversation },
+  } as unknown as ToolContextType;
+  return { auth, toolContext } as unknown as ToolHandlerExtra;
 }
 
 async function setupProjectConversation(

--- a/front/lib/api/actions/servers/files/tools/move.ts
+++ b/front/lib/api/actions/servers/files/tools/move.ts
@@ -20,9 +20,9 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 export async function moveHandler(
   { source, dest }: { source: string; dest: string },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ runContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/files/tools/upload_from_url.ts
+++ b/front/lib/api/actions/servers/files/tools/upload_from_url.ts
@@ -21,9 +21,9 @@ export async function uploadFromUrlHandler(
     url,
     content_type,
   }: { path: string; url: string; content_type?: string },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversationRes = requireAgentLoopConversation({ runContext });
+  const conversationRes = requireAgentLoopConversation({ toolContext });
   if (conversationRes.isErr()) {
     return conversationRes;
   }

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -260,7 +260,7 @@ async function buildReplyContext(params: {
 async function fetchAttachment(
   auth: ToolHandlerExtra["auth"],
   attachmentFilePath: string | undefined,
-  runContext: ToolHandlerExtra["runContext"]
+  toolContext: ToolHandlerExtra["toolContext"]
 ): Promise<
   | Ok<{ buffer: Buffer; filename: string; contentType: string } | null>
   | Err<MCPError>
@@ -269,10 +269,14 @@ async function fetchAttachment(
     return new Ok(null);
   }
 
+  if (!toolContext) {
+    return new Err(new MCPError("No agent context available"));
+  }
+
   const fileResult = await getFileFromConversationAttachment(
     auth,
     attachmentFilePath,
-    { runContext }
+    toolContext
   );
 
   if (fileResult.isErr()) {
@@ -366,7 +370,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       replyToMessageId,
       attachmentFilePath,
     },
-    { authInfo, auth, runContext }
+    { authInfo, auth, toolContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -400,7 +404,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     const attachmentResult = await fetchAttachment(
       auth,
       attachmentFilePath,
-      runContext
+      toolContext
     );
     if (attachmentResult.isErr()) {
       return attachmentResult;
@@ -979,7 +983,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       replyToMessageId,
       attachmentFilePath,
     },
-    { authInfo, auth, runContext }
+    { authInfo, auth, toolContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -1012,7 +1016,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     const attachmentResult = await fetchAttachment(
       auth,
       attachmentFilePath,
-      runContext
+      toolContext
     );
     if (attachmentResult.isErr()) {
       return attachmentResult;

--- a/front/lib/api/actions/servers/google_calendar/tools/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/tools/index.ts
@@ -48,7 +48,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
 
   list_events: async (
     { calendarId = "primary", q, timeMin, timeMax, maxResults, pageToken },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const calendar = await getCalendarClient(authInfo);
     assert(
@@ -68,7 +68,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         orderBy: "startTime",
       });
 
-      const userTimezone = getUserTimezone({ runContext });
+      const userTimezone = getUserTimezone(toolContext);
 
       const enrichedEvents = res.data.items
         ? res.data.items
@@ -92,7 +92,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
 
   get_event: async (
     { calendarId = "primary", eventId },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const calendar = await getCalendarClient(authInfo);
     assert(
@@ -106,7 +106,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         eventId,
       });
 
-      const userTimezone = getUserTimezone({ runContext });
+      const userTimezone = getUserTimezone(toolContext);
       const enrichedEvent = isGoogleCalendarEvent(res.data)
         ? enrichEventWithDayOfWeek(res.data, userTimezone)
         : null;
@@ -142,7 +142,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       extendedProperties,
       eventType,
     },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const calendar = await getCalendarClient(authInfo);
     assert(
@@ -192,7 +192,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         },
       });
 
-      const userTimezone = getUserTimezone({ runContext });
+      const userTimezone = getUserTimezone(toolContext);
       const enrichedEvent = isGoogleCalendarEvent(res.data)
         ? enrichEventWithDayOfWeek(res.data, userTimezone)
         : null;
@@ -233,7 +233,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       reminders,
       extendedProperties,
     },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const calendar = await getCalendarClient(authInfo);
     assert(
@@ -271,7 +271,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         },
       });
 
-      const userTimezone = getUserTimezone({ runContext });
+      const userTimezone = getUserTimezone(toolContext);
       const enrichedEvent = isGoogleCalendarEvent(res.data)
         ? enrichEventWithDayOfWeek(res.data, userTimezone)
         : null;

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -52,14 +52,18 @@ function createGaxiosError(code: number, message: string): Common.GaxiosError {
 }
 
 describe("handleFileAccessError", () => {
-  const createMockExtra = (toolServerId: string): ToolHandlerExtra =>
+  const createMockExtra = (toolServerId?: string): ToolHandlerExtra =>
     ({
       authInfo: undefined,
-      runContext: {
-        toolConfiguration: {
-          toolServerId,
-        },
-      },
+      toolContext: toolServerId
+        ? {
+            runContext: {
+              toolConfiguration: {
+                toolServerId,
+              },
+            },
+          }
+        : undefined,
     }) as ToolHandlerExtra;
 
   it("should return file authorization error for 403 with 'has not granted' message", async () => {
@@ -109,7 +113,7 @@ describe("handleFileAccessError", () => {
     const result = await handleFileAccessError(
       createGaxiosError(404, "File not found: has not granted write access"),
       "test-file-id",
-      createMockExtra("my-connection")
+      createMockExtra()
     );
 
     expect(result.isOk()).toBe(true);
@@ -118,7 +122,7 @@ describe("handleFileAccessError", () => {
       const item = content[0] as any;
       expect(item.type).toBe("resource");
       expect(item.resource).toMatchObject({
-        connectionId: "my-connection",
+        connectionId: "google_drive",
       });
     }
   });
@@ -245,11 +249,11 @@ describe("get_file_content", () => {
   const XLSX_MIMETYPE =
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
-  // Partial stub: the get_file_content handler only reads authInfo and runContext.
+  // Partial stub: the get_file_content handler only reads authInfo and toolContext.
   // Same pattern as the other MCP tool tests (files/tools).
   const extra = {
     authInfo: undefined,
-    runContext: undefined,
+    toolContext: undefined,
   } as unknown as ToolHandlerExtra;
 
   function isTextBlock(

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -147,7 +147,7 @@ function normalizeCode(code: string | number | undefined): string | undefined {
 export async function handleFileAccessError(
   err: unknown,
   fileId: string,
-  { authInfo, runContext }: Pick<ToolHandlerExtra, "authInfo" | "runContext">,
+  { authInfo, toolContext }: Pick<ToolHandlerExtra, "authInfo" | "toolContext">,
   fileMeta?: { name?: string; mimeType?: string }
 ): Promise<ToolHandlerResult> {
   if (err instanceof Common.GaxiosError) {
@@ -172,7 +172,9 @@ export async function handleFileAccessError(
         message.includes("has not granted") ||
         message.includes("write access"))
     ) {
-      const connectionId = runContext.toolConfiguration.toolServerId;
+      const connectionId =
+        toolContext?.runContext?.toolConfiguration.toolServerId ??
+        "google_drive";
 
       return new Ok(
         makeFileAuthorizationError({
@@ -294,10 +296,10 @@ function handleDriveAccessError(
  */
 function addAgentAttribution(
   content: string,
-  { runContext }: Pick<ToolHandlerExtra, "runContext">
+  { toolContext }: Pick<ToolHandlerExtra, "toolContext">
 ): string {
-  if (isAgentLoopRunContext(runContext)) {
-    const agentConfig = runContext.agentConfiguration;
+  if (isAgentLoopRunContext(toolContext?.runContext)) {
+    const agentConfig = toolContext.runContext.agentConfiguration;
     return `${content}\n\nSent via ${agentConfig.name} Agent on Dust`;
   }
   return content;
@@ -443,7 +445,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
 
   get_file_content: async (
     { fileId, offset = 0, limit = MAX_CONTENT_SIZE },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const drive = await getDriveClient(authInfo);
     if (!drive) {
@@ -644,12 +646,12 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, fileId, {
         authInfo,
-        runContext,
+        toolContext,
       });
     }
   },
 
-  get_spreadsheet: async ({ spreadsheetId }, { authInfo, runContext }) => {
+  get_spreadsheet: async ({ spreadsheetId }, { authInfo, toolContext }) => {
     const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
       return new Err(new MCPError("Failed to authenticate with Google Sheets"));
@@ -666,7 +668,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, spreadsheetId, {
         authInfo,
-        runContext,
+        toolContext,
       });
     }
   },
@@ -678,7 +680,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
       majorDimension = "ROWS",
       valueRenderOption = "FORMATTED_VALUE",
     },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
@@ -699,7 +701,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, spreadsheetId, {
         authInfo,
-        runContext,
+        toolContext,
       });
     }
   },
@@ -736,7 +738,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
 
   get_document_structure: async (
     { documentId, offset = 0, limit = 100 },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const docs = await getDocsClient(authInfo);
     if (!docs) {
@@ -750,14 +752,14 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, documentId, {
         authInfo,
-        runContext,
+        toolContext,
       });
     }
   },
 
   get_presentation_structure: async (
     { presentationId, offset = 0, limit = 10 },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const slides = await getSlidesClient(authInfo);
     if (!slides) {
@@ -771,14 +773,14 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, presentationId, {
         authInfo,
-        runContext,
+        toolContext,
       });
     }
   },
 
   list_file_permissions: async (
     { fileId, capabilities },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const shareError = await ensureCapability(
       "canShare",
@@ -820,7 +822,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, fileId, {
         authInfo,
-        runContext,
+        toolContext,
       });
     }
   },
@@ -967,7 +969,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   copy_file: async (
     { fileId, name, parentId, capabilities },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canCopy",
@@ -1002,7 +1004,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, fileId, {
         authInfo,
-        runContext,
+        toolContext,
       });
     }
 
@@ -1039,7 +1041,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   create_comment: async (
     { fileId, content, capabilities },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canComment",
@@ -1056,7 +1058,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     }
 
     const finalContent = addAgentAttribution(content, {
-      runContext,
+      toolContext,
     });
 
     try {
@@ -1084,14 +1086,14 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, fileId, {
         authInfo,
-        runContext,
+        toolContext,
       });
     }
   },
 
   create_reply: async (
     { fileId, commentId, content, capabilities },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canComment",
@@ -1108,7 +1110,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     }
 
     const finalContent = addAgentAttribution(content, {
-      runContext,
+      toolContext,
     });
 
     try {
@@ -1139,14 +1141,14 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, fileId, {
         authInfo,
-        runContext,
+        toolContext,
       });
     }
   },
 
   update_document: async (
     { documentId, operations, capabilities },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canEdit",
@@ -1197,7 +1199,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return handleFileAccessError(
         err,
         documentId,
-        { authInfo, runContext },
+        { authInfo, toolContext },
         {
           name: documentId,
           mimeType: "application/vnd.google-apps.document",
@@ -1216,7 +1218,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       insertDataOption = "INSERT_ROWS",
       capabilities,
     },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canEdit",
@@ -1251,7 +1253,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return handleFileAccessError(
         err,
         spreadsheetId,
-        { authInfo, runContext },
+        { authInfo, toolContext },
         {
           name: spreadsheetId,
           mimeType: "application/vnd.google-apps.spreadsheet",
@@ -1262,7 +1264,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   update_spreadsheet: async (
     { spreadsheetId, operations, capabilities },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canEdit",
@@ -1342,7 +1344,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return handleFileAccessError(
         err,
         spreadsheetId,
-        { authInfo, runContext },
+        { authInfo, toolContext },
         {
           name: spreadsheetId,
           mimeType: "application/vnd.google-apps.spreadsheet",
@@ -1353,7 +1355,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   update_presentation: async (
     { presentationId, operations, capabilities },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const accessError = await ensureCapability(
       "canEdit",
@@ -1404,7 +1406,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return handleFileAccessError(
         err,
         presentationId,
-        { authInfo, runContext },
+        { authInfo, toolContext },
         {
           name: presentationId,
           mimeType: "application/vnd.google-apps.presentation",
@@ -1425,7 +1427,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       emailMessage,
       capabilities,
     },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const shareError = await ensureCapability(
       "canShare",
@@ -1462,7 +1464,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, fileId, {
         authInfo,
-        runContext,
+        toolContext,
       });
     }
 
@@ -1488,7 +1490,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   update_file_permission: async (
     { fileId, permissionId, role, capabilities },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const shareError = await ensureCapability(
       "canShare",
@@ -1515,7 +1517,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, fileId, {
         authInfo,
-        runContext,
+        toolContext,
       });
     }
 
@@ -1537,7 +1539,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   revoke_file_sharing: async (
     { fileId, permissionId, capabilities },
-    { authInfo, runContext }
+    { authInfo, toolContext }
   ) => {
     const shareError = await ensureCapability(
       "canShare",
@@ -1563,7 +1565,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     } catch (err) {
       return handleFileAccessError(err, fileId, {
         authInfo,
-        runContext,
+        toolContext,
       });
     }
 
@@ -1585,17 +1587,25 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
 
   upload_file: async (
     { fileId, parentId, fileName },
-    { auth, authInfo, runContext }
+    { auth, authInfo, toolContext }
   ) => {
     const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
 
+    if (!toolContext) {
+      return new Err(
+        new MCPError("No conversation context available for file access")
+      );
+    }
+
     try {
-      const fileResult = await getFileFromConversationAttachment(auth, fileId, {
-        runContext,
-      });
+      const fileResult = await getFileFromConversationAttachment(
+        auth,
+        fileId,
+        toolContext
+      );
 
       if (fileResult.isErr()) {
         return new Err(new MCPError(fileResult.error));

--- a/front/lib/api/actions/servers/http_client/tools/index.ts
+++ b/front/lib/api/actions/servers/http_client/tools/index.ts
@@ -113,7 +113,7 @@ async function handleSendRequest(
     body?: string;
     timeout_ms?: number;
   },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ) {
   const timeoutMs = timeout_ms ?? DEFAULT_TIMEOUT_MS;
   const controller = new AbortController();
@@ -121,7 +121,7 @@ async function handleSendRequest(
 
   const requestHeaders = validateAndSanitizeHeaders(headers);
 
-  const bearerToken = await getBearerToken(auth, { runContext });
+  const bearerToken = await getBearerToken(auth, toolContext);
   if (bearerToken) {
     requestHeaders["Authorization"] = `Bearer ${bearerToken}`;
   }

--- a/front/lib/api/actions/servers/jira/tools/index.ts
+++ b/front/lib/api/actions/servers/jira/tools/index.ts
@@ -862,7 +862,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   upload_attachment: async (
     { issueKey, attachment },
-    { auth, authInfo, runContext }
+    { auth, authInfo, toolContext }
   ) => {
     return withAuth({
       action: async (baseUrl, _resourceInfo, accessToken) => {
@@ -873,10 +873,18 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
         };
 
         if (attachment.type === "conversation_file") {
+          if (!toolContext) {
+            return new Err(
+              new MCPError(
+                "Conversation context required for conversation file attachments"
+              )
+            );
+          }
+
           const fileResult = await getFileFromConversationAttachment(
             auth,
             attachment.fileId,
-            { runContext }
+            toolContext
           );
 
           if (fileResult.isErr()) {

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -82,7 +82,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
     }
   },
 
-  search_drive_items: async ({ query }, { auth, authInfo, runContext }) => {
+  search_drive_items: async ({ query }, { auth, authInfo, toolContext }) => {
     const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
@@ -90,9 +90,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       );
     }
 
-    const allowedLabels = await getAllowedLabelsForMCPServer(auth, {
-      runContext,
-    });
+    const allowedLabels = await getAllowedLabelsForMCPServer(auth, toolContext);
 
     try {
       const response = await searchMicrosoftDriveItems({
@@ -318,7 +316,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
 
   get_file_content: async (
     { itemId, driveId, siteId, offset, limit, getAsXml },
-    { auth, authInfo, runContext }
+    { auth, authInfo, toolContext }
   ) => {
     const client = await getGraphClient(authInfo);
     if (!client) {
@@ -327,9 +325,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       );
     }
 
-    const allowedLabels = await getAllowedLabelsForMCPServer(auth, {
-      runContext,
-    });
+    const allowedLabels = await getAllowedLabelsForMCPServer(auth, toolContext);
 
     try {
       const endpoint = await getDriveItemEndpoint(itemId, driveId, siteId);
@@ -463,7 +459,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
 
   upload_file: async (
     { fileId, driveId, siteId, folderPath, fileName },
-    { auth, authInfo, runContext }
+    { auth, authInfo, toolContext }
   ) => {
     const client = await getGraphClient(authInfo);
     if (!client) {
@@ -472,11 +468,19 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       );
     }
 
+    if (!toolContext) {
+      return new Err(
+        new MCPError("No conversation context available for file access")
+      );
+    }
+
     try {
       // Get the file from conversation attachment
-      const fileResult = await getFileFromConversationAttachment(auth, fileId, {
-        runContext,
-      });
+      const fileResult = await getFileFromConversationAttachment(
+        auth,
+        fileId,
+        toolContext
+      );
 
       if (fileResult.isErr()) {
         return new Err(new MCPError(fileResult.error));

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -395,7 +395,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       parentMessageId,
       mentions,
     },
-    { auth, authInfo, runContext }
+    { auth, authInfo, toolContext }
   ) => {
     const client = await getGraphClient(authInfo);
     if (!client) {
@@ -531,14 +531,14 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       // Add footer with link to Dust conversation if agent context is available
       let finalContent = messageContent;
 
-      if (isAgentLoopRunContext(runContext)) {
+      if (isAgentLoopRunContext(toolContext?.runContext)) {
         const agentUrl = getConversationRoute(
           auth.getNonNullableWorkspace().sId,
           "new",
-          `agentDetails=${runContext.agentConfiguration.sId}`,
+          `agentDetails=${toolContext.runContext.agentConfiguration.sId}`,
           config.getAppUrl()
         );
-        const agentName = runContext.agentConfiguration.name;
+        const agentName = toolContext.runContext.agentConfiguration.name;
         const footerMessage = `<em>Sent via <a href="${agentUrl}">${agentName} Agent</a> on Dust</em>`;
         finalContent = `${messageContent}<br/><br/>${footerMessage}`;
       }

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -26,7 +26,7 @@ const MAX_ATTACHMENT_SIZE_BYTES = 3 * 1024 * 1024; // 3MB — Graph API inline a
 async function fetchAttachment(
   auth: ToolHandlerExtra["auth"],
   attachmentFilePath: string | undefined,
-  runContext: ToolHandlerExtra["runContext"]
+  toolContext: ToolHandlerExtra["toolContext"]
 ): Promise<
   | Ok<{ buffer: Buffer; filename: string; contentType: string } | null>
   | Err<MCPError>
@@ -35,10 +35,14 @@ async function fetchAttachment(
     return new Ok(null);
   }
 
+  if (!toolContext) {
+    return new Err(new MCPError("No agent context available"));
+  }
+
   const fileResult = await getFileFromConversationAttachment(
     auth,
     attachmentFilePath,
-    { runContext }
+    toolContext
   );
 
   if (fileResult.isErr()) {
@@ -810,7 +814,7 @@ function validateMailParams({
 const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
   get_messages: async (
     { search, folderName, top = 10, skip = 0, select, sharedMailboxAddress },
-    { authInfo, auth, runContext }
+    { authInfo, auth, toolContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -837,9 +841,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       folderId = resolved.folderId;
     }
 
-    const allowedLabels = await getAllowedLabelsForMCPServer(auth, {
-      runContext,
-    });
+    const allowedLabels = await getAllowedLabelsForMCPServer(auth, toolContext);
 
     if (allowedLabels.length > 0) {
       // Two parallel requests:
@@ -1480,7 +1482,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       sharedMailboxAddress,
       attachmentFilePath,
     },
-    { authInfo, auth, runContext }
+    { authInfo, auth, toolContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -1490,7 +1492,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     const attachmentResult = await fetchAttachment(
       auth,
       attachmentFilePath,
-      runContext
+      toolContext
     );
     if (attachmentResult.isErr()) {
       return attachmentResult;
@@ -1594,7 +1596,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       replyAll = false,
       attachmentFilePath,
     },
-    { authInfo, auth, runContext }
+    { authInfo, auth, toolContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -1614,7 +1616,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     const attachmentResult = await fetchAttachment(
       auth,
       attachmentFilePath,
-      runContext
+      toolContext
     );
     if (attachmentResult.isErr()) {
       return attachmentResult;

--- a/front/lib/api/actions/servers/plan_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/tools/index.ts
@@ -23,9 +23,12 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 
 const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
-  create_plan: async ({ content }, { auth, runContext }) => {
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
-    const { conversation } = runContext;
+  create_plan: async ({ content }, { auth, toolContext }) => {
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
+    const { conversation } = toolContext.runContext;
 
     return withPlanModeLock(conversation.sId, async () => {
       const existing = await getActivePlanContent(auth, conversation);
@@ -57,9 +60,12 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     });
   },
 
-  edit_plan: async ({ old_string, new_string }, { auth, runContext }) => {
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
-    const { conversation } = runContext;
+  edit_plan: async ({ old_string, new_string }, { auth, toolContext }) => {
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
+    const { conversation } = toolContext.runContext;
 
     try {
       return await withPlanModeLock(conversation.sId, async () => {
@@ -128,9 +134,12 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     }
   },
 
-  close_plan: async ({ reason }, { auth, runContext }) => {
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
-    const { conversation } = runContext;
+  close_plan: async ({ reason }, { auth, toolContext }) => {
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
+    const { conversation } = toolContext.runContext;
 
     const closed = await closeActivePlan(auth, conversation);
     if (closed.isErr()) {

--- a/front/lib/api/actions/servers/poke/tools/index.test.ts
+++ b/front/lib/api/actions/servers/poke/tools/index.test.ts
@@ -15,11 +15,11 @@ function getToolByName(name: string) {
   return tool;
 }
 
-function createTestExtra(auth: Authenticator, runContext?: unknown) {
+function createTestExtra(auth: Authenticator, toolContext?: unknown) {
   return {
     signal: new AbortController().signal,
     auth,
-    runContext,
+    toolContext,
   } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
 }
 

--- a/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
@@ -238,12 +238,15 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
 
   [EXECUTE_DATABASE_QUERY_TOOL_NAME]: async (
     { tables, query, fileName },
-    { auth, runContext }
+    { auth, toolContext }
   ) => {
     // TODO(mcp): @fontanierh: we should not have a strict dependency on the agentLoopRunContext.
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
-    const agentLoopRunContext = runContext;
+    const agentLoopRunContext = toolContext.runContext;
 
     const resolvedRes = await resolveTableConfigurations(auth, tables);
     if (resolvedRes.isErr()) {

--- a/front/lib/api/actions/servers/run_dust_app/helpers.ts
+++ b/front/lib/api/actions/servers/run_dust_app/helpers.ts
@@ -12,8 +12,8 @@ import type {
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
-  AgentLoopRunContext,
-  ToolRunContext,
+  AgentLoopRunContextType,
+  ToolContextType,
 } from "@app/lib/actions/types";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { getDatasetSchema } from "@app/lib/api/datasets";
@@ -159,7 +159,7 @@ export async function prepareAppContext(
 
 export async function processDustFileOutput(
   auth: Authenticator,
-  runContext: ToolRunContext,
+  toolContext: ToolContextType,
   sanitizedOutput: DustFileOutput,
   conversation: ConversationWithoutContentType,
   appName: string
@@ -256,7 +256,7 @@ export async function processDustFileOutput(
       fileName = makeFileName({ name: appName, ext: ".txt" });
     }
 
-    const result = await writeToToolOutputsFolder(auth, runContext, {
+    const result = await writeToToolOutputsFolder(auth, toolContext, {
       fileName,
       content: fileContent,
       contentType,
@@ -286,7 +286,7 @@ export async function processDustFileOutput(
 export async function prepareParamsWithHistory(
   params: { [p: string]: unknown },
   schema: DatasetSchema | null,
-  agentLoopRunContext: AgentLoopRunContext,
+  agentLoopRunContext: AgentLoopRunContextType,
   auth: Authenticator
 ): Promise<{ [p: string]: unknown }> {
   if (

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -211,7 +211,7 @@ export default async function createServer(
         if (containsFileOutput(sanitizedOutput) && runContext.conversation) {
           const fileContentResult = await processDustFileOutput(
             auth,
-            runContext,
+            toolContext,
             sanitizedOutput,
             runContext.conversation,
             app.name

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -234,24 +234,26 @@ describe("runSandboxBashTool", () => {
           sId: "workspace-id",
         }),
       },
-      runContext: {
-        contextType: "agent_loop",
-        agentConfiguration: {
-          sId: "agent-id",
-        },
-        model: { providerId: "openai" },
-        agentMessage: { sId: "message-id", agentMessageId: 1 },
-        conversation: { sId: "conversation-id" },
-        action: {
-          sId: "sandbox-action-id",
-          toJSON: () => ({ sId: "sandbox-action-id" }),
-        },
-        stepContext: {
-          citationsCount: 0,
-          citationsOffset: 0,
-          resumeState: null,
-          retrievalTopK: 0,
-          websearchResultCount: 0,
+      toolContext: {
+        runContext: {
+          contextType: "agent_loop",
+          agentConfiguration: {
+            sId: "agent-id",
+          },
+          model: { providerId: "openai" },
+          agentMessage: { sId: "message-id", agentMessageId: 1 },
+          conversation: { sId: "conversation-id" },
+          action: {
+            sId: "sandbox-action-id",
+            toJSON: () => ({ sId: "sandbox-action-id" }),
+          },
+          stepContext: {
+            citationsCount: 0,
+            citationsOffset: 0,
+            resumeState: null,
+            retrievalTopK: 0,
+            websearchResultCount: 0,
+          },
         },
       },
       signal: new AbortController().signal,
@@ -672,24 +674,26 @@ describe("runSandboxBashTool", () => {
   describe("resume mode", () => {
     function resumeStepContext(execId: string) {
       return {
-        runContext: {
-          contextType: "agent_loop",
-          agentConfiguration: {
-            sId: "agent-id",
-          },
-          model: { providerId: "openai" },
-          agentMessage: { sId: "message-id", agentMessageId: 1 },
-          conversation: { sId: "conversation-id" },
-          action: {
-            sId: "sandbox-action-id",
-            toJSON: () => ({ sId: "sandbox-action-id" }),
-          },
-          stepContext: {
-            citationsCount: 0,
-            citationsOffset: 0,
-            resumeState: { execId },
-            retrievalTopK: 0,
-            websearchResultCount: 0,
+        toolContext: {
+          runContext: {
+            contextType: "agent_loop",
+            agentConfiguration: {
+              sId: "agent-id",
+            },
+            model: { providerId: "openai" },
+            agentMessage: { sId: "message-id", agentMessageId: 1 },
+            conversation: { sId: "conversation-id" },
+            action: {
+              sId: "sandbox-action-id",
+              toJSON: () => ({ sId: "sandbox-action-id" }),
+            },
+            stepContext: {
+              citationsCount: 0,
+              citationsOffset: 0,
+              resumeState: { execId },
+              retrievalTopK: 0,
+              websearchResultCount: 0,
+            },
           },
         },
         auth: {
@@ -785,9 +789,11 @@ describe("addEgressDomainTool", () => {
           },
         }),
       },
-      runContext: {
-        contextType: "agent_loop",
-        conversation: { sId: "conversation-id" },
+      toolContext: {
+        runContext: {
+          contextType: "agent_loop",
+          conversation: { sId: "conversation-id" },
+        },
       },
       signal: new AbortController().signal,
     } as never;

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -230,9 +230,9 @@ export async function createSandboxTools(
 ): Promise<ToolDefinition[]> {
   const handlers: ToolHandlers<typeof SANDBOX_TOOLS_METADATA> = {
     bash: runSandboxBashTool,
-    describe_toolset: async ({ format }, { auth, runContext }) => {
-      const providerId = isAgentLoopRunContext(runContext)
-        ? runContext.model.providerId
+    describe_toolset: async ({ format }, { auth, toolContext }) => {
+      const providerId = isAgentLoopRunContext(toolContext?.runContext)
+        ? toolContext.runContext.model.providerId
         : null;
       if (!providerId) {
         return new Err(new MCPError("Missing model provider ID"));
@@ -290,7 +290,7 @@ export async function runSandboxBashTool(
     timeoutMs?: number;
     workingDirectory?: string;
   },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<
   Result<
     Array<
@@ -303,8 +303,12 @@ export async function runSandboxBashTool(
     MCPError
   >
 > {
-  assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+  assert(
+    isAgentLoopRunContext(toolContext?.runContext),
+    "AgentLoopRunContext expected"
+  );
 
+  const runContext = toolContext?.runContext;
   const {
     conversation,
     agentConfiguration,
@@ -484,9 +488,12 @@ export async function runSandboxBashTool(
 
 export async function addEgressDomainTool(
   { domain, reason }: { domain: string; reason: string },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<Result<Array<{ type: "text"; text: string }>, MCPError>> {
-  assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+  assert(
+    isAgentLoopRunContext(toolContext?.runContext),
+    "AgentLoopRunContext expected"
+  );
   // Defense-in-depth: createSandboxTools already filters this tool out when
   // the workspace setting is off, so this metadata-only check is enough to
   // reject any caller that bypasses tool-list filtering.
@@ -500,7 +507,7 @@ export async function addEgressDomainTool(
 
   const ensureResult = await ensureConversationSandboxReady(
     auth,
-    runContext.conversation
+    toolContext.runContext.conversation
   );
   if (ensureResult.isErr()) {
     return new Err(new MCPError(ensureResult.error.message));

--- a/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
@@ -10,9 +10,9 @@ import { Err, Ok } from "@app/types/shared/result";
 
 export async function callHandler(
   { slug, input }: { slug: string; input?: Record<string, unknown> },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(auth, { toolContext });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
@@ -17,9 +17,9 @@ export function formatSandboxFunction(fn: SandboxFunctionResource): string {
 
 export async function getHandler(
   { slug }: { slug: string },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(auth, { toolContext });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
@@ -23,9 +23,9 @@ export function formatSandboxFunctionsList(
 
 export async function listHandler(
   _params: Record<string, never>,
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(auth, { toolContext });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -19,10 +19,10 @@ export async function publishHandler(
     path: string;
     slug: string;
   },
-  { auth, runContext }: ToolHandlerExtra
+  { auth, toolContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   const podResult = await getWritablePodContext(auth, {
-    toolContext: { runContext },
+    toolContext,
   });
   if (podResult.isErr()) {
     return new Err(podResult.error);

--- a/front/lib/api/actions/servers/search/tools/index.ts
+++ b/front/lib/api/actions/servers/search/tools/index.ts
@@ -195,11 +195,11 @@ export async function searchFunction(
 }
 
 const handlers: ToolHandlers<typeof SEARCH_TOOLS_METADATA> = {
-  [SEARCH_TOOL_NAME]: (params, { auth, runContext }) =>
+  [SEARCH_TOOL_NAME]: (params, { auth, toolContext }) =>
     searchFunction(auth, {
       ...params,
       relativeTimeFrame: params.relativeTimeFrame ?? "all",
-      toolContext: { runContext },
+      toolContext,
     }),
 };
 

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
@@ -44,13 +44,8 @@ function getTool(name: string) {
   return tool;
 }
 
-// The tools under test never read runContext, so a partial extra cast to ToolHandlerExtra is
-// sufficient (mirroring the poke tools test).
 function makeExtra(auth: Authenticator) {
-  const extra: Pick<
-    ToolHandlerExtra,
-    "auth" | "requestId" | "sendNotification" | "sendRequest" | "signal"
-  > = {
+  return {
     auth,
     requestId: "test-request",
     sendNotification: async () => {},
@@ -58,9 +53,7 @@ function makeExtra(auth: Authenticator) {
       throw new Error("Unexpected MCP request in skill_authoring test.");
     },
     signal: new AbortController().signal,
-  };
-
-  return extra as ToolHandlerExtra;
+  } satisfies ToolHandlerExtra;
 }
 
 // Seed a skill directly and refresh the authenticator so it picks up the editor

--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -108,12 +108,14 @@ describe("skill_management enable_skill tool", () => {
   } = {}) {
     return {
       auth,
-      runContext: {
-        contextType: "agent_loop",
-        agentConfiguration,
-        agentMessage,
-        conversation: conversationOverride,
-        userMessage: userMessageOverride,
+      toolContext: {
+        runContext: {
+          contextType: "agent_loop",
+          agentConfiguration,
+          agentMessage,
+          conversation: conversationOverride,
+          userMessage: userMessageOverride,
+        },
       },
       signal: new AbortController().signal,
     } as never;

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -97,8 +97,11 @@ async function findAvailableSkillForAgentLoop({
 }
 
 const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
-  [ENABLE_SKILL_TOOL_NAME]: async ({ skillName }, { auth, runContext }) => {
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+  [ENABLE_SKILL_TOOL_NAME]: async ({ skillName }, { auth, toolContext }) => {
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
     const {
       agentConfiguration,
@@ -106,7 +109,7 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       agentMessage,
       conversation,
       userMessage,
-    } = runContext;
+    } = toolContext.runContext;
 
     const agentLoopData = {
       agentConfiguration,

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -135,12 +135,8 @@ async function getClientFromAuthInfo(
 }
 
 const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
-  list_databases: async (_params, { authInfo, runContext, auth }) => {
-    const clientRes = await getClientFromAuthInfo(
-      authInfo,
-      { runContext },
-      auth
-    );
+  list_databases: async (_params, { authInfo, toolContext, auth }) => {
+    const clientRes = await getClientFromAuthInfo(authInfo, toolContext, auth);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -163,12 +159,8 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     ]);
   },
 
-  list_schemas: async ({ database }, { authInfo, runContext, auth }) => {
-    const clientRes = await getClientFromAuthInfo(
-      authInfo,
-      { runContext },
-      auth
-    );
+  list_schemas: async ({ database }, { authInfo, toolContext, auth }) => {
+    const clientRes = await getClientFromAuthInfo(authInfo, toolContext, auth);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -191,12 +183,11 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     ]);
   },
 
-  list_tables: async ({ database, schema }, { authInfo, runContext, auth }) => {
-    const clientRes = await getClientFromAuthInfo(
-      authInfo,
-      { runContext },
-      auth
-    );
+  list_tables: async (
+    { database, schema },
+    { authInfo, toolContext, auth }
+  ) => {
+    const clientRes = await getClientFromAuthInfo(authInfo, toolContext, auth);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -221,13 +212,9 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
   describe_table: async (
     { database, schema, table },
-    { authInfo, runContext, auth }
+    { authInfo, toolContext, auth }
   ) => {
-    const clientRes = await getClientFromAuthInfo(
-      authInfo,
-      { runContext },
-      auth
-    );
+    const clientRes = await getClientFromAuthInfo(authInfo, toolContext, auth);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -261,13 +248,9 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
   describe_semantic_view: async (
     { database, schema, semantic_view },
-    { authInfo, runContext, auth }
+    { authInfo, toolContext, auth }
   ) => {
-    const clientRes = await getClientFromAuthInfo(
-      authInfo,
-      { runContext },
-      auth
-    );
+    const clientRes = await getClientFromAuthInfo(authInfo, toolContext, auth);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -300,13 +283,9 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
   query: async (
     { sql, database, schema, warehouse, max_rows },
-    { authInfo, runContext, auth }
+    { authInfo, toolContext, auth }
   ) => {
-    const clientRes = await getClientFromAuthInfo(
-      authInfo,
-      { runContext },
-      auth
-    );
+    const clientRes = await getClientFromAuthInfo(authInfo, toolContext, auth);
     if (clientRes.isErr()) {
       return clientRes;
     }

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -22,13 +22,16 @@ import { DustAPI, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
 
 const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
-  list: async (_, { auth, runContext }) => {
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+  list: async (_, { auth, toolContext }) => {
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
     const mcpServerViewIdsFromAgentConfiguration =
-      runContext.agentConfiguration.actions
+      toolContext?.runContext?.agentConfiguration.actions
         .filter(isServerSideMCPServerConfiguration)
-        .map((action) => action.mcpServerViewId);
+        .map((action) => action.mcpServerViewId) ?? [];
 
     const owner = auth.getNonNullableWorkspace();
     const user = auth.user();
@@ -79,10 +82,18 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
     );
   },
 
-  enable: async ({ toolsetId }, { auth, runContext }) => {
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+  enable: async ({ toolsetId }, { auth, toolContext }) => {
+    assert(
+      isAgentLoopRunContext(toolContext?.runContext),
+      "AgentLoopRunContext expected"
+    );
 
-    const conversationId = runContext.conversation.sId;
+    const conversationId = toolContext?.runContext?.conversation.sId;
+    if (!conversationId) {
+      return new Err(
+        new MCPError("No active conversation context", { tracked: false })
+      );
+    }
 
     const owner = auth.getNonNullableWorkspace();
     const user = auth.user();
@@ -108,7 +119,8 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
       config.nodeEnv === "development" ? "http://localhost:3000" : null
     );
 
-    const agentConfigurationId = runContext.agentConfiguration.sId;
+    const agentConfigurationId =
+      toolContext?.runContext?.agentConfiguration.sId;
 
     const res = await api.postConversationTools({
       conversationId,

--- a/front/lib/api/actions/servers/user_mentions/tools/index.ts
+++ b/front/lib/api/actions/servers/user_mentions/tools/index.ts
@@ -18,7 +18,7 @@ import { DustAPI } from "@dust-tt/client";
 const handlers: ToolHandlers<typeof USER_MENTIONS_TOOLS_METADATA> = {
   [SEARCH_AVAILABLE_USERS_TOOL_NAME]: async (
     { searchTerm },
-    { auth, runContext }
+    { auth, toolContext }
   ) => {
     const user = auth.user();
     const prodCredentials = await prodAPICredentialsForOwner(
@@ -42,8 +42,8 @@ const handlers: ToolHandlers<typeof USER_MENTIONS_TOOLS_METADATA> = {
     const r = await api.getMentionsSuggestions({
       query: searchTerm,
       select: ["users"],
-      conversationId: isAgentLoopRunContext(runContext)
-        ? runContext.conversation.sId
+      conversationId: isAgentLoopRunContext(toolContext?.runContext)
+        ? toolContext.runContext.conversation.sId
         : undefined,
     });
 

--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -48,12 +48,12 @@ async function handleWebsearch(
   { query }: { query: string },
   extra: ToolHandlerExtra
 ) {
-  const { runContext } = extra;
+  const { toolContext } = extra;
 
   const { websearchResultCount, citationsOffset } = isAgentLoopRunContext(
-    runContext
+    toolContext?.runContext
   )
-    ? runContext.stepContext
+    ? toolContext.runContext.stepContext
     : {
         websearchResultCount: AGENT_LESS_DEFAULT_WEBSEARCH_RESULT_COUNT,
         citationsOffset: 0,
@@ -121,11 +121,14 @@ async function handleWebbrowser(
   },
   extra: ToolHandlerExtra
 ) {
-  const { runContext, auth } = extra;
+  const { toolContext, auth } = extra;
+  if (!toolContext?.runContext) {
+    return new Err(new MCPError("No conversation context available"));
+  }
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
   });
-  const { toolConfiguration } = runContext;
+  const { toolConfiguration } = toolContext.runContext;
   const useSummarization =
     isLightServerSideMCPToolConfiguration(toolConfiguration) &&
     toolConfiguration.additionalConfiguration[USE_SUMMARY_SWITCH] === true;
@@ -159,7 +162,7 @@ async function handleWebbrowser(
   });
 
   if (useSummarization) {
-    if (!isAgentLoopRunContext(runContext)) {
+    if (!isAgentLoopRunContext(toolContext.runContext)) {
       return new Err(
         new MCPError(
           "Summarization cannot be enabled outside of an agent loop context."
@@ -167,7 +170,7 @@ async function handleWebbrowser(
       );
     }
 
-    const runCtx = runContext;
+    const runCtx = toolContext.runContext;
     const { citationsOffset, websearchResultCount } = runCtx.stepContext;
     const refs = getRefs().slice(
       citationsOffset,
@@ -236,7 +239,7 @@ async function handleWebbrowser(
           ext: ".txt",
         });
 
-        const writeResult = await writeToToolOutputsFolder(auth, runCtx, {
+        const writeResult = await writeToToolOutputsFolder(auth, toolContext, {
           fileName,
           content: fileContent,
           contentType: "text/plain",

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -14,11 +14,11 @@ function getToolByName(name: string) {
   return tool;
 }
 
-function createTestExtra(auth: Authenticator, runContext?: unknown) {
+function createTestExtra(auth: Authenticator) {
   return {
     signal: new AbortController().signal,
     auth,
-    runContext,
+    toolContext: undefined,
   } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
 }
 

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -1,6 +1,6 @@
 import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
 import { isResourceContentWithText } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { ToolRunContext } from "@app/lib/actions/types";
+import type { ToolContextType } from "@app/lib/actions/types";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import {
   conversationScopedPath,
@@ -28,14 +28,21 @@ export interface PersistedToolOutput {
 }
 
 /**
- * Builds the DustFileSystem associated with a tool run context: the conversation file system when
+ * Builds the DustFileSystem associated with a tool context: the conversation file system when
  * running in an agent loop, the pod (project space) file system when running in a sandbox
  * function invocation.
  */
-async function getDustFileSystemForRunContext(
+async function getDustFileSystemForToolContext(
   auth: Authenticator,
-  runContext: ToolRunContext
+  toolContext: ToolContextType
 ): Promise<Result<DustFileSystem, Error>> {
+  const { runContext } = toolContext;
+  if (!runContext) {
+    return new Err(
+      new Error("Tool outputs can only be persisted from a tool run context.")
+    );
+  }
+
   switch (runContext.contextType) {
     case "agent_loop":
       return DustFileSystem.forConversation(auth, runContext.conversation);
@@ -50,23 +57,34 @@ async function getDustFileSystemForRunContext(
 }
 
 function getToolOutputsScopedPath(
-  runContext: ToolRunContext,
+  toolContext: ToolContextType,
   fileName: string
-): string {
+): Result<string, Error> {
+  const { runContext } = toolContext;
+  if (!runContext) {
+    return new Err(
+      new Error("Tool outputs can only be persisted from a tool run context.")
+    );
+  }
+
   switch (runContext.contextType) {
     case "agent_loop":
-      return conversationScopedPath({
-        conversationId: runContext.conversation.sId,
-        rel: `${TOOL_OUTPUTS_FOLDER_NAME}/${fileName}`,
-      });
+      return new Ok(
+        conversationScopedPath({
+          conversationId: runContext.conversation.sId,
+          rel: `${TOOL_OUTPUTS_FOLDER_NAME}/${fileName}`,
+        })
+      );
     case "sandbox_function":
       // Scoped by function slug (unique within the pod): a pod outlives its functions, so a
       // flat folder would mix outputs across functions. The slug is preferred over the
       // invocation sId as it is shorter and less error-prone for the model to reference. The
       // folder is visible in-sandbox at /files/pod-{pId}/.tool_outputs/{slug}/.
-      return podScopedPath(
-        runContext.invocation.sandboxFunction.space.sId,
-        `${TOOL_OUTPUTS_FOLDER_NAME}/${runContext.invocation.sandboxFunction.slug}/${fileName}`
+      return new Ok(
+        podScopedPath(
+          runContext.invocation.sandboxFunction.space.sId,
+          `${TOOL_OUTPUTS_FOLDER_NAME}/${runContext.invocation.sandboxFunction.slug}/${fileName}`
+        )
       );
     default:
       return assertNever(runContext);
@@ -151,14 +169,14 @@ export async function writeToPodFolder(
 }
 
 /**
- * Writes content to the .tool_outputs folder of the file system associated with the tool run
- * context (conversation in an agent loop, pod in a sandbox function invocation) via
- * DustFileSystem. Returns the scoped path (e.g. "conversation-{cId}/.tool_outputs/{fileName}" or
+ * Writes content to the .tool_outputs folder of the file system associated with the tool context
+ * (conversation in an agent loop, pod in a sandbox function invocation) via DustFileSystem.
+ * Returns the scoped path (e.g. "conversation-{cId}/.tool_outputs/{fileName}" or
  * "pod-{pId}/.tool_outputs/{fileName}") on success.
  */
 export async function writeToToolOutputsFolder(
   auth: Authenticator,
-  runContext: ToolRunContext,
+  toolContext: ToolContextType,
   {
     fileName,
     content,
@@ -169,12 +187,16 @@ export async function writeToToolOutputsFolder(
     contentType: AllSupportedFileContentType;
   }
 ): Promise<Result<string, Error>> {
-  const fsResult = await getDustFileSystemForRunContext(auth, runContext);
+  const fsResult = await getDustFileSystemForToolContext(auth, toolContext);
   if (fsResult.isErr()) {
     return new Err(new Error(fsResult.error.message));
   }
 
-  const scopedPath = getToolOutputsScopedPath(runContext, fileName);
+  const scopedPathResult = getToolOutputsScopedPath(toolContext, fileName);
+  if (scopedPathResult.isErr()) {
+    return scopedPathResult;
+  }
+  const scopedPath = scopedPathResult.value;
 
   const writeResult = await fsResult.value.write(
     scopedPath,
@@ -189,14 +211,14 @@ export async function writeToToolOutputsFolder(
 }
 
 /**
- * Attempts to persist a tool output block to the run context's .tool_outputs folder via
+ * Attempts to persist a tool output block to the tool context's .tool_outputs folder via
  * DustFileSystem. Returns null if the block does not qualify for persistence.
  *
  * Call this as a side effect from processToolResults.
  */
 export async function persistToolOutput(
   auth: Authenticator,
-  runContext: ToolRunContext,
+  toolContext: ToolContextType,
   block: CallToolResult["content"][number],
   { toolName, serverName }: { toolName: string; serverName: string }
 ): Promise<Result<PersistedToolOutput | null, Error>> {
@@ -207,7 +229,7 @@ export async function persistToolOutput(
     const ext = storageContentType === "application/json" ? ".json" : ".md";
     const fileName = makeFileName({ name: rawName, ext });
 
-    const result = await writeToToolOutputsFolder(auth, runContext, {
+    const result = await writeToToolOutputsFolder(auth, toolContext, {
       fileName,
       content,
       contentType: storageContentType,
@@ -230,7 +252,7 @@ export async function persistToolOutput(
       toolName
     );
 
-    const result = await writeToToolOutputsFolder(auth, runContext, {
+    const result = await writeToToolOutputsFolder(auth, toolContext, {
       fileName,
       content: block.text,
       contentType,
@@ -251,7 +273,7 @@ export async function persistToolOutput(
     const text = block.resource.text;
     const { fileName, contentType } = inferTextFileMetadata(text, toolName);
 
-    const result = await writeToToolOutputsFolder(auth, runContext, {
+    const result = await writeToToolOutputsFolder(auth, toolContext, {
       fileName,
       content: text,
       contentType,


### PR DESCRIPTION
## Summary

Reverts #28761 — restores the pre-refactor tool handler context shape where `ToolHandlerExtra` carries `toolContext?: ToolContextType` (with a nested `runContext`) rather than the flattened `runContext: ToolRunContext`.

## Testing

Direct revert — no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)