### PR TITLE
fix(mcp): update cat and search tool handlers to use runContext

### DIFF
--- a/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
@@ -8,7 +8,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import {
   isAgentLoopRunContext,
-  type ToolContext,
+  type ToolRunContext,
 } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
@@ -76,9 +76,9 @@ export async function cat(
     limit?: number;
     grep?: string;
   },
-  { auth, toolContext }: { auth: Authenticator; toolContext?: ToolContext }
+  { auth, runContext }: { auth: Authenticator; runContext: ToolRunContext }
 ) {
-  if (!toolContext?.runContext) {
+  if (!runContext) {
     return new Err(new MCPError("No conversation context available"));
   }
 
@@ -169,8 +169,8 @@ export async function cat(
     );
   }
 
-  const { citationsOffset } = isAgentLoopRunContext(toolContext.runContext)
-    ? toolContext.runContext.stepContext
+  const { citationsOffset } = isAgentLoopRunContext(runContext)
+    ? runContext.stepContext
     : { citationsOffset: 0 };
 
   if (citationsOffset >= getRefs().length) {

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -14,7 +14,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/types";
 import {
   isAgentLoopRunContext,
-  type ToolContext,
+  type ToolRunContext,
 } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
@@ -45,22 +45,20 @@ export async function search(
     tagsIn,
     tagsNot,
   }: SearchWithNodesInputType & TagsInputType,
-  { auth, toolContext }: { auth: Authenticator; toolContext?: ToolContext }
+  { auth, runContext }: { auth: Authenticator; runContext: ToolRunContext }
 ): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const credentials = await getLlmCredentials(auth);
   const timeFrame = parseTimeFrame(relativeTimeFrame ?? "all");
 
-  if (!toolContext?.runContext) {
+  if (!runContext) {
     throw new Error(
       "agentLoopRunContext is required where the tool is called."
     );
   }
 
-  const { retrievalTopK, citationsOffset } = isAgentLoopRunContext(
-    toolContext.runContext
-  )
-    ? toolContext.runContext.stepContext
+  const { retrievalTopK, citationsOffset } = isAgentLoopRunContext(runContext)
+    ? runContext.stepContext
     : { retrievalTopK: AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K, citationsOffset: 0 };
 
   const agentDataSourceConfigurationsResult =


### PR DESCRIPTION
## Summary

- After #28761 renamed `ToolHandlerExtra.toolContext` → `runContext`, `cat.ts` and `search.ts` were not updated.
- Because `toolContext` was typed optional, TypeScript accepted the mismatch silently — at runtime `toolContext` was always `undefined`, causing every `cat` call to return `"No conversation context available"`.
- Fix: both handlers now destructure `runContext: ToolRunContext` directly from `extra`, matching the current `ToolHandlerExtra` shape.

## Testing

Incident fix — `search.ts` had the same stale signature but the missing guard was a `throw` rather than an `Err` return; still needs the update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)