### PR TITLE
feat(egress-proxy): workspace-prefixed, owner-keyed policy layout (dual-read)

### DIFF
--- a/egress-proxy/src/connection.rs
+++ b/egress-proxy/src/connection.rs
@@ -195,7 +195,12 @@ async fn handle_connection_inner(
     if !default_allows
         && !state
             .policy_provider
-            .evaluate(token.w_id.as_deref(), sb_id, &request.domain)
+            .evaluate(
+                token.w_id.as_deref(),
+                token.owner_id.as_deref(),
+                sb_id,
+                &request.domain,
+            )
             .await
     {
         deny(
@@ -336,6 +341,7 @@ async fn handle_connection_inner(
 
     info!(
         sb_id = sb_id,
+        owner_id = token.owner_id.as_deref(),
         domain = %request.domain,
         original_dest_port = request.original_dest_port,
         upstream_addr = %upstream_addr,
@@ -398,6 +404,7 @@ fn log_deny(
     warn!(
         deny_reason = %reason,
         sb_id = token.and_then(|token| token.sb_id.as_deref()),
+        owner_id = token.and_then(|token| token.owner_id.as_deref()),
         domain = request.map(|request| request.domain.as_str()),
         original_dest_port = request.map(|request| request.original_dest_port),
         upstream_addr = upstream_addr.map(|address| address.to_string()),

--- a/egress-proxy/src/gcs.rs
+++ b/egress-proxy/src/gcs.rs
@@ -68,17 +68,58 @@ impl GcsPolicyProvider {
         self.cache.invalidate(cache_key).await;
     }
 
+    // Workspace policy lives at `w/{wId}/sandbox-egress-policy.json`. During the layout
+    // migration we fall back to the legacy `workspaces/{wId}.json` path when
+    // the new object is absent (not on errors: those stay fail-closed).
+    // TODO(2026-08-15 EGRESS_RELAYOUT): drop the legacy fallback once the
+    // backfill has run and legacy objects are deleted.
     pub async fn get_workspace_policy(&self, w_id: &str) -> Result<Option<Policy>> {
+        let current = self
+            .get_policy(
+                &format!("w2:{w_id}"),
+                &format!("w/{w_id}/sandbox-egress-policy.json"),
+            )
+            .await?;
+
+        if current.is_some() {
+            return Ok(current);
+        }
+
         self.get_policy(&format!("w:{w_id}"), &format!("workspaces/{w_id}.json"))
             .await
     }
 
+    // Legacy per-sandbox policy, keyed by the ephemeral provider id. Still
+    // read (unioned with the owner policy) so in-flight approvals from before
+    // the layout migration keep working until those sandboxes age out.
+    // TODO(2026-08-15 EGRESS_RELAYOUT): drop once pre-migration sandboxes are
+    // gone.
     pub async fn get_sandbox_policy(&self, sb_id: &str) -> Result<Option<Policy>> {
         self.get_policy(&format!("s:{sb_id}"), &format!("sandboxes/{sb_id}.json"))
             .await
     }
 
-    pub async fn evaluate(&self, w_id: Option<&str>, sb_id: &str, domain: &str) -> bool {
+    // Owner policy: the stable per-owner allowlist at
+    // `w/{wId}/sandboxes/{ownerId}.json`, where ownerId is a conversation sId
+    // (conversation sandboxes) or a space sId (pod sandboxes). Survives
+    // sandbox destroy/recreate cycles.
+    pub async fn get_owner_policy(&self, w_id: &str, owner_id: &str) -> Result<Option<Policy>> {
+        self.get_policy(
+            &format!("o:{w_id}:{owner_id}"),
+            &format!("w/{w_id}/sandboxes/{owner_id}.json"),
+        )
+        .await
+    }
+
+    // A domain is allowed if ANY of the workspace, owner, or legacy sandbox
+    // policies allows it. Every lookup fails closed: a GCS error never grants.
+    pub async fn evaluate(
+        &self,
+        w_id: Option<&str>,
+        owner_id: Option<&str>,
+        sb_id: &str,
+        domain: &str,
+    ) -> bool {
         let workspace_allows = match w_id {
             Some(workspace_id) => match self.get_workspace_policy(workspace_id).await {
                 Ok(Some(policy)) => policy.allows(domain),
@@ -92,6 +133,24 @@ impl GcsPolicyProvider {
         };
 
         if workspace_allows {
+            return true;
+        }
+
+        // The owner path needs both ids; tokens minted before the layout
+        // migration carry no ownerId and skip straight to the legacy file.
+        let owner_allows = match (w_id, owner_id) {
+            (Some(w_id), Some(owner_id)) => match self.get_owner_policy(w_id, owner_id).await {
+                Ok(Some(policy)) => policy.allows(domain),
+                Ok(None) => false,
+                Err(error) => {
+                    warn!(error = %error, w_id, owner_id, "owner policy lookup failed");
+                    false
+                }
+            },
+            _ => false,
+        };
+
+        if owner_allows {
             return true;
         }
 

--- a/egress-proxy/src/health.rs
+++ b/egress-proxy/src/health.rs
@@ -77,23 +77,34 @@ async fn invalidate_policy(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    // Derive the cache key from claims: exactly one of wId or sbId must be set.
-    let cache_key = match (validated.w_id.as_deref(), validated.sb_id.as_deref()) {
-        (Some(w_id), None) => format!("w:{w_id}"),
-        (None, Some(sb_id)) => format!("s:{sb_id}"),
+    // Derive the cache keys from claims:
+    // - wId alone evicts the workspace policy (both layouts during the
+    //   migration window);
+    // - wId + ownerId evicts the owner policy (the cache key needs both);
+    // - sbId alone evicts the legacy per-sandbox policy.
+    let cache_keys = match (
+        validated.w_id.as_deref(),
+        validated.owner_id.as_deref(),
+        validated.sb_id.as_deref(),
+    ) {
+        (Some(w_id), None, None) => vec![format!("w2:{w_id}"), format!("w:{w_id}")],
+        (Some(w_id), Some(owner_id), None) => vec![format!("o:{w_id}:{owner_id}")],
+        (None, None, Some(sb_id)) => vec![format!("s:{sb_id}")],
         _ => {
-            warn!("invalidate-policy: token must have exactly one of wId or sbId");
+            warn!("invalidate-policy: token must have wId, wId + ownerId, or sbId");
             return Err(StatusCode::BAD_REQUEST);
         }
     };
 
-    state.policy_provider.invalidate(&cache_key).await;
+    for cache_key in &cache_keys {
+        state.policy_provider.invalidate(cache_key).await;
+    }
 
-    info!(cache_key = %cache_key, "invalidated policy cache entry");
+    let invalidated = cache_keys.join(",");
 
-    Ok(Json(InvalidateResponse {
-        invalidated: cache_key,
-    }))
+    info!(cache_keys = %invalidated, "invalidated policy cache entries");
+
+    Ok(Json(InvalidateResponse { invalidated }))
 }
 
 fn extract_bearer_token(headers: &HeaderMap) -> Option<&str> {

--- a/egress-proxy/src/jwt.rs
+++ b/egress-proxy/src/jwt.rs
@@ -15,6 +15,11 @@ pub struct JwtValidator {
 pub struct ValidatedToken {
     pub sb_id: Option<String>,
     pub w_id: Option<String>,
+    // Stable policy-scope key for the sandbox's owner: a conversation sId for
+    // conversation sandboxes, a space sId for pod sandboxes. Selects the
+    // owner policy file `w/{wId}/sandboxes/{ownerId}.json`. Optional for
+    // back-compat with tokens minted before the owner-keyed layout.
+    pub owner_id: Option<String>,
     pub action: Option<String>,
 }
 
@@ -34,6 +39,8 @@ struct Claims {
     sb_id: Option<String>,
     #[serde(rename = "wId")]
     w_id: Option<String>,
+    #[serde(rename = "ownerId")]
+    owner_id: Option<String>,
     action: Option<String>,
     exp: usize,
 }
@@ -73,37 +80,27 @@ fn claims_to_validated_token(
         return Err(JwtValidationError::Expired);
     }
 
-    let sb_id = claims.sb_id.and_then(|value| {
-        let trimmed = value.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        }
-    });
-
-    let w_id = claims.w_id.and_then(|value| {
-        let trimmed = value.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        }
-    });
-
-    let action = claims.action.and_then(|value| {
-        let trimmed = value.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        }
-    });
+    let sb_id = normalize_claim(claims.sb_id);
+    let w_id = normalize_claim(claims.w_id);
+    let owner_id = normalize_claim(claims.owner_id);
+    let action = normalize_claim(claims.action);
 
     Ok(ValidatedToken {
         sb_id,
         w_id,
+        owner_id,
         action,
+    })
+}
+
+fn normalize_claim(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
     })
 }
 
@@ -141,6 +138,8 @@ mod tests {
         sb_id: Option<&'a str>,
         #[serde(rename = "wId", skip_serializing_if = "Option::is_none")]
         w_id: Option<&'a str>,
+        #[serde(rename = "ownerId", skip_serializing_if = "Option::is_none")]
+        owner_id: Option<&'a str>,
         #[serde(skip_serializing_if = "Option::is_none")]
         action: Option<&'a str>,
         iss: &'a str,
@@ -168,6 +167,7 @@ mod tests {
         let token = token_with_claims(TestClaims {
             sb_id: None,
             w_id: None,
+            owner_id: None,
             action: Some("invalidate-policy"),
             iss: EXPECTED_ISSUER,
             aud: EXPECTED_AUDIENCE,
@@ -226,6 +226,7 @@ mod tests {
         let token = token_with_claims(TestClaims {
             sb_id: None,
             w_id: Some("workspace"),
+            owner_id: None,
             action: Some("invalidate-policy"),
             iss: EXPECTED_ISSUER,
             aud: EXPECTED_AUDIENCE,
@@ -241,9 +242,66 @@ mod tests {
             ValidatedToken {
                 sb_id: None,
                 w_id: Some("workspace".to_string()),
+                owner_id: None,
                 action: Some("invalidate-policy".to_string()),
             }
         );
+    }
+
+    #[test]
+    fn validates_token_with_owner_id() {
+        let validator = JwtValidator::new("secret");
+        let token = token_with_claims(TestClaims {
+            sb_id: Some("sbx"),
+            w_id: Some("workspace"),
+            owner_id: Some("owner"),
+            action: None,
+            iss: EXPECTED_ISSUER,
+            aud: EXPECTED_AUDIENCE,
+            exp: future_exp(60),
+        });
+
+        let validated = validator
+            .validate(&token)
+            .expect("token with ownerId should validate");
+
+        assert_eq!(validated.sb_id.as_deref(), Some("sbx"));
+        assert_eq!(validated.w_id.as_deref(), Some("workspace"));
+        assert_eq!(validated.owner_id.as_deref(), Some("owner"));
+    }
+
+    #[test]
+    fn accepts_tokens_without_owner_id() {
+        // Back-compat: tokens minted before the owner-keyed layout carry no
+        // ownerId and must keep validating.
+        let validator = JwtValidator::new("secret");
+        let token = sandbox_token("secret", "sbx", Some("workspace"), 60);
+
+        let validated = validator
+            .validate(&token)
+            .expect("token without ownerId should validate");
+
+        assert_eq!(validated.owner_id, None);
+    }
+
+    #[test]
+    fn normalizes_empty_owner_id_to_none() {
+        let validator = JwtValidator::new("secret");
+        let token = token_with_claims(TestClaims {
+            sb_id: Some("sbx"),
+            w_id: Some("workspace"),
+            owner_id: Some("   "),
+            action: None,
+            iss: EXPECTED_ISSUER,
+            aud: EXPECTED_AUDIENCE,
+            exp: future_exp(60),
+        });
+
+        let validated = validator
+            .validate(&token)
+            .expect("empty ownerId should normalize to None");
+
+        assert_eq!(validated.owner_id, None);
     }
 
     #[test]
@@ -263,6 +321,7 @@ mod tests {
         let token = token_with_claims(TestClaims {
             sb_id: Some("sbx"),
             w_id: Some("workspace"),
+            owner_id: None,
             action: None,
             iss: EXPECTED_ISSUER,
             aud: "wrong",
@@ -284,6 +343,7 @@ mod tests {
         let claims = TestClaims {
             sb_id: Some(sb_id),
             w_id,
+            owner_id: None,
             action: None,
             iss: EXPECTED_ISSUER,
             aud: EXPECTED_AUDIENCE,

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -61,10 +61,13 @@ enum MockGcsResponse {
 #[derive(Default)]
 struct MockPolicies {
     workspace: Option<MockGcsResponse>,
+    workspace_new: Option<MockGcsResponse>,
+    owner: Option<MockGcsResponse>,
     sandbox: Option<MockGcsResponse>,
 }
 
 const TEST_WORKSPACE_ID: &str = "workspace-456";
+const TEST_OWNER_ID: &str = "owner-789";
 
 #[derive(Debug, Serialize)]
 struct TestClaims {
@@ -72,6 +75,8 @@ struct TestClaims {
     sb_id: Option<String>,
     #[serde(rename = "wId", skip_serializing_if = "Option::is_none")]
     w_id: Option<String>,
+    #[serde(rename = "ownerId", skip_serializing_if = "Option::is_none")]
+    owner_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     action: Option<String>,
     iss: String,
@@ -184,6 +189,8 @@ async fn workspace_policy_allows_domain() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: Some(policy_response(&["localhost"])),
+            workspace_new: None,
+            owner: None,
             sandbox: None,
         },
         None,
@@ -219,6 +226,8 @@ async fn sandbox_policy_allows_when_workspace_has_no_policy() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
+            workspace_new: None,
+            owner: None,
             sandbox: Some(policy_response(&["localhost"])),
         },
         None,
@@ -248,10 +257,237 @@ async fn sandbox_policy_allows_when_workspace_has_no_policy() -> Result<()> {
 }
 
 #[tokio::test]
+async fn workspace_policy_new_layout_allows_domain() -> Result<()> {
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: None,
+            workspace_new: Some(policy_response(&["localhost"])),
+            owner: None,
+            sandbox: None,
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token_with_workspace(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn workspace_policy_new_layout_preferred_over_legacy() -> Result<()> {
+    // When the new-layout file exists, the legacy file is NOT consulted:
+    // fallback happens only when the new object is absent.
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: Some(policy_response(&["localhost"])),
+            workspace_new: Some(policy_response(&["other.example.com"])),
+            owner: None,
+            sandbox: None,
+        },
+        None,
+        false,
+        "production",
+    )
+    .await?;
+    let token = make_token_with_workspace(SECRET, 60);
+
+    let response = send_handshake(&proxy, &token, "localhost", 254).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn owner_policy_allows_domain() -> Result<()> {
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: None,
+            workspace_new: None,
+            owner: Some(policy_response(&["localhost"])),
+            sandbox: None,
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token_with_owner(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn owner_policy_ignored_without_owner_id_claim() -> Result<()> {
+    // Back-compat / fail-closed: a token without the ownerId claim must not
+    // pick up owner-level grants, even when the owner policy file exists.
+    let (upstream_port, _upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: None,
+            workspace_new: None,
+            owner: Some(policy_response(&["localhost"])),
+            sandbox: None,
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token_with_workspace(SECRET, 60);
+
+    let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn legacy_sandbox_policy_unioned_with_owner_policy() -> Result<()> {
+    // In-flight approvals from before the layout migration live in the legacy
+    // per-sandbox file; tokens that already carry ownerId must still honor
+    // them until those sandboxes age out.
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: None,
+            workspace_new: None,
+            owner: Some(policy_response(&["other.example.com"])),
+            sandbox: Some(policy_response(&["localhost"])),
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token_with_owner(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn owner_gcs_failure_falls_back_to_legacy_sandbox() -> Result<()> {
+    // An owner policy lookup error fails closed for the owner policy but the
+    // union still consults the legacy sandbox policy.
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: None,
+            workspace_new: None,
+            owner: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
+            sandbox: Some(policy_response(&["localhost"])),
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token_with_owner(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn denied_when_no_policy_allows_with_owner_id() -> Result<()> {
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: Some(policy_response(&["a.example.com"])),
+            workspace_new: Some(policy_response(&["b.example.com"])),
+            owner: Some(policy_response(&["c.example.com"])),
+            sandbox: Some(policy_response(&["d.example.com"])),
+        },
+        None,
+        false,
+        "production",
+    )
+    .await?;
+    let token = make_token_with_owner(SECRET, 60);
+
+    let response = send_handshake(&proxy, &token, "localhost", 254).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
 async fn denied_when_neither_workspace_nor_sandbox_allows_domain() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: Some(policy_response(&["other.example.com"])),
+            workspace_new: None,
+            owner: None,
             sandbox: Some(policy_response(&["another.example.com"])),
         },
         None,
@@ -274,6 +510,8 @@ async fn workspace_gcs_failure_falls_back_to_sandbox() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
+            workspace_new: None,
+            owner: None,
             sandbox: Some(policy_response(&["localhost"])),
         },
         None,
@@ -307,6 +545,8 @@ async fn sandbox_gcs_failure_denies_connection() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
+            workspace_new: None,
+            owner: None,
             sandbox: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
         },
         None,
@@ -390,6 +630,7 @@ async fn invalid_issuer_returns_deny() -> Result<()> {
         FullClaims {
             sb_id: Some(TEST_SANDBOX_ID),
             w_id: None,
+            owner_id: None,
             action: None,
             iss: "wrong-front",
             aud: "dust-egress-proxy",
@@ -411,6 +652,7 @@ async fn invalid_audience_returns_deny() -> Result<()> {
         FullClaims {
             sb_id: Some(TEST_SANDBOX_ID),
             w_id: None,
+            owner_id: None,
             action: None,
             iss: "dust-front",
             aud: "wrong-audience",
@@ -432,6 +674,7 @@ async fn empty_sandbox_id_claim_returns_deny() -> Result<()> {
         FullClaims {
             sb_id: Some("   "),
             w_id: None,
+            owner_id: None,
             action: None,
             iss: "dust-front",
             aud: "dust-egress-proxy",
@@ -754,6 +997,8 @@ async fn invalidate_policy_evicts_cached_workspace_entry() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: Some(policy_response(&["localhost"])),
+            workspace_new: None,
+            owner: None,
             sandbox: None,
         },
         None,
@@ -833,6 +1078,131 @@ async fn invalidate_policy_rejects_token_with_both_wid_and_sbid() -> Result<()> 
         FullClaims {
             sb_id: Some(TEST_SANDBOX_ID),
             w_id: Some(TEST_WORKSPACE_ID),
+            owner_id: None,
+            action: Some("invalidate-policy"),
+            iss: "dust-front",
+            aud: "dust-egress-proxy",
+            exp_offset_seconds: 60,
+        },
+    );
+
+    let status =
+        http_post_status(proxy.health_addr, "/invalidate-policy", "", Some(&token)).await?;
+
+    assert_eq!(status, 400);
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalidate_policy_evicts_cached_owner_entry() -> Result<()> {
+    let (upstream_port, _upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: None,
+            workspace_new: None,
+            owner: Some(policy_response(&["localhost"])),
+            sandbox: None,
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+
+    // First request populates the cache with an owner policy allowing
+    // "localhost".
+    let token = make_token_with_owner(SECRET, 60);
+    let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
+    assert_eq!(response, Some(ALLOW_RESPONSE));
+
+    // Change the backing GCS owner policy to deny "localhost".
+    {
+        let mut objects = proxy.mock_gcs.as_ref().unwrap().objects.write().unwrap();
+        objects.insert(
+            format!("w/{TEST_WORKSPACE_ID}/sandboxes/{TEST_OWNER_ID}.json"),
+            policy_response(&["other.example.com"]),
+        );
+    }
+
+    // Invalidate the owner cache entry via a wId + ownerId invalidation token.
+    let admin_token = make_owner_invalidation_token(SECRET, 60);
+    let status = http_post_status(
+        proxy.health_addr,
+        "/invalidate-policy",
+        "",
+        Some(&admin_token),
+    )
+    .await?;
+    assert_eq!(status, 200);
+
+    // After invalidation the proxy re-fetches and the new policy denies.
+    let token = make_token_with_owner(SECRET, 60);
+    let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
+    assert_eq!(response, Some(DENY_RESPONSE));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalidate_policy_workspace_evicts_both_layouts() -> Result<()> {
+    let (upstream_port, _upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: None,
+            workspace_new: Some(policy_response(&["localhost"])),
+            owner: None,
+            sandbox: None,
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+
+    // Populate the new-layout workspace cache entry.
+    let token = make_token_with_workspace(SECRET, 60);
+    let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
+    assert_eq!(response, Some(ALLOW_RESPONSE));
+
+    // Change the backing new-layout policy to deny "localhost".
+    {
+        let mut objects = proxy.mock_gcs.as_ref().unwrap().objects.write().unwrap();
+        objects.insert(
+            format!("w/{TEST_WORKSPACE_ID}/sandbox-egress-policy.json"),
+            policy_response(&["other.example.com"]),
+        );
+    }
+
+    // A plain wId invalidation token must evict the new-layout entry too.
+    let admin_token = make_invalidation_token(SECRET, 60);
+    let status = http_post_status(
+        proxy.health_addr,
+        "/invalidate-policy",
+        "",
+        Some(&admin_token),
+    )
+    .await?;
+    assert_eq!(status, 200);
+
+    let token = make_token_with_workspace(SECRET, 60);
+    let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
+    assert_eq!(response, Some(DENY_RESPONSE));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalidate_policy_rejects_owner_without_wid() -> Result<()> {
+    let proxy = start_proxy(false, "production").await?;
+    // ownerId alone is ambiguous: the owner cache key needs the workspace.
+    let token = make_token_with_claims(
+        SECRET,
+        FullClaims {
+            sb_id: None,
+            w_id: None,
+            owner_id: Some(TEST_OWNER_ID),
             action: Some("invalidate-policy"),
             iss: "dust-front",
             aud: "dust-egress-proxy",
@@ -894,6 +1264,8 @@ async fn start_proxy_with_sandbox_policy(
     start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
+            workspace_new: None,
+            owner: None,
             sandbox: Some(policy_response(allowed_domains)),
         },
         None,
@@ -958,6 +1330,18 @@ async fn start_mock_gcs_server(policies: MockPolicies) -> Result<MockGcsServer> 
     let mut objects = HashMap::new();
     if let Some(workspace) = policies.workspace {
         objects.insert(format!("workspaces/{TEST_WORKSPACE_ID}.json"), workspace);
+    }
+    if let Some(workspace_new) = policies.workspace_new {
+        objects.insert(
+            format!("w/{TEST_WORKSPACE_ID}/sandbox-egress-policy.json"),
+            workspace_new,
+        );
+    }
+    if let Some(owner) = policies.owner {
+        objects.insert(
+            format!("w/{TEST_WORKSPACE_ID}/sandboxes/{TEST_OWNER_ID}.json"),
+            owner,
+        );
     }
     if let Some(sandbox) = policies.sandbox {
         objects.insert(format!("sandboxes/{TEST_SANDBOX_ID}.json"), sandbox);
@@ -1184,6 +1568,7 @@ fn make_token(secret: &str, exp_offset_seconds: i64) -> String {
         FullClaims {
             sb_id: Some(TEST_SANDBOX_ID),
             w_id: None,
+            owner_id: None,
             action: None,
             iss: "dust-front",
             aud: "dust-egress-proxy",
@@ -1198,6 +1583,7 @@ fn make_token_with_workspace(secret: &str, exp_offset_seconds: i64) -> String {
         FullClaims {
             sb_id: Some(TEST_SANDBOX_ID),
             w_id: Some(TEST_WORKSPACE_ID),
+            owner_id: None,
             action: None,
             iss: "dust-front",
             aud: "dust-egress-proxy",
@@ -1212,6 +1598,37 @@ fn make_invalidation_token(secret: &str, exp_offset_seconds: i64) -> String {
         FullClaims {
             sb_id: None,
             w_id: Some(TEST_WORKSPACE_ID),
+            owner_id: None,
+            action: Some("invalidate-policy"),
+            iss: "dust-front",
+            aud: "dust-egress-proxy",
+            exp_offset_seconds,
+        },
+    )
+}
+
+fn make_token_with_owner(secret: &str, exp_offset_seconds: i64) -> String {
+    make_token_with_claims(
+        secret,
+        FullClaims {
+            sb_id: Some(TEST_SANDBOX_ID),
+            w_id: Some(TEST_WORKSPACE_ID),
+            owner_id: Some(TEST_OWNER_ID),
+            action: None,
+            iss: "dust-front",
+            aud: "dust-egress-proxy",
+            exp_offset_seconds,
+        },
+    )
+}
+
+fn make_owner_invalidation_token(secret: &str, exp_offset_seconds: i64) -> String {
+    make_token_with_claims(
+        secret,
+        FullClaims {
+            sb_id: None,
+            w_id: Some(TEST_WORKSPACE_ID),
+            owner_id: Some(TEST_OWNER_ID),
             action: Some("invalidate-policy"),
             iss: "dust-front",
             aud: "dust-egress-proxy",
@@ -1233,6 +1650,7 @@ fn make_token_with_claims(secret: &str, claims: FullClaims<'_>) -> String {
     let claims = TestClaims {
         sb_id: claims.sb_id.map(|s| s.to_string()),
         w_id: claims.w_id.map(|s| s.to_string()),
+        owner_id: claims.owner_id.map(|s| s.to_string()),
         action: claims.action.map(|s| s.to_string()),
         iss: claims.iss.to_string(),
         aud: claims.aud.to_string(),
@@ -1256,6 +1674,7 @@ struct TestCerts {
 struct FullClaims<'a> {
     sb_id: Option<&'a str>,
     w_id: Option<&'a str>,
+    owner_id: Option<&'a str>,
     action: Option<&'a str>,
     iss: &'a str,
     aud: &'a str,


### PR DESCRIPTION
First phase of the egress policy re-layout. Target layout:

  w/{wId}/sandbox-egress-policy.json  workspace-wide policy (moved)
  w/{wId}/sandboxes/{ownerId}.json    owner policy; ownerId is a conversation
                                      sId or a pod space sId

Owner-keying makes the per-sandbox policy stable across sandbox
destroy/recreate cycles, lets pods reuse the same file slot with no third
storage location, and the w/{wId}/ prefix makes relocation and scrubbing a
prefix operation.

This proxy build reads BOTH layouts so it can deploy before front changes
anything:

- Optional ownerId JWT claim (back-compatible; sbId stays the required
  identity claim and remains in logs).
- Workspace lookup prefers w/{wId}/sandbox-egress-policy.json and falls back
  to the legacy workspaces/{wId}.json when absent (dated TODO to drop).
- Evaluation unions workspace + owner + legacy per-sandbox policies, all
  fail-closed, so in-flight approvals in legacy sandbox files keep working
  until those sandboxes age out (dated TODO to drop).
- /invalidate-policy accepts: wId (evicts both workspace layouts),
  wId + ownerId (owner entry), or sbId (legacy sandbox entry).

Inert until front mints ownerId and writes the new paths; this build must
deploy and be healthy before the front cutover.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
