### PR TITLE
[marketing] feat: A/B test homepage hero copy + conversion funnel

### DIFF
--- a/front/components/onboarding/useProfileOnboardingForm.ts
+++ b/front/components/onboarding/useProfileOnboardingForm.ts
@@ -10,7 +10,8 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { useCompleteUserOnboarding, usePatchUser } from "@app/lib/swr/user";
 import { useWelcomeData } from "@app/lib/swr/workspaces";
-import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import { readHeroVariantFromDocumentCookie } from "@app/lib/experiments/hero_variant_cookie";
+import { TRACKING_AREAS, trackEvent, withTracking } from "@app/lib/tracking";
 import { getStoredUTMParams } from "@app/lib/utils/utm";
 import type { FavoritePlatform } from "@app/types/favorite_platforms";
 import { useEffect, useMemo, useState } from "react";
@@ -91,6 +92,19 @@ export function useProfileOnboardingForm({
         fbclid: utmParams.fbclid ?? null,
         msclkid: utmParams.msclkid ?? null,
         li_fat_id: utmParams.li_fat_id ?? null,
+      });
+
+      // Fire a PostHog goal event for the sign-up completion so the homepage
+      // hero A/B experiment has a terminal conversion metric for the "Try for
+      // free" arm. When the visitor came through the experiment, tag it with the
+      // variant carried in the shared `_dust_hv` cookie; PostHog also attributes
+      // it at the person level via the shared `_dust_aid` identity.
+      const heroVariant = readHeroVariantFromDocumentCookie();
+      trackEvent({
+        area: TRACKING_AREAS.AUTH,
+        object: "signup",
+        action: "completed",
+        extra: heroVariant ? { hero_variant: heroVariant } : undefined,
       });
     }
 

--- a/front/lib/experiments/hero_variant_cookie.test.ts
+++ b/front/lib/experiments/hero_variant_cookie.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  HERO_VARIANT_COOKIE,
+  readHeroVariantFromDocumentCookie,
+} from "./hero_variant_cookie";
+
+// Expire anything jsdom retained between tests so cookie reads start clean.
+afterEach(() => {
+  for (const cookie of document.cookie.split("; ")) {
+    const name = cookie.split("=")[0];
+    if (name) {
+      document.cookie = `${name}=; max-age=0`;
+    }
+  }
+});
+
+describe("readHeroVariantFromDocumentCookie", () => {
+  it("reads the hero variant marketing set in the shared cookie", () => {
+    document.cookie = `${HERO_VARIANT_COOKIE}=collaboration`;
+    expect(readHeroVariantFromDocumentCookie()).toBe("collaboration");
+  });
+
+  it("returns the value opaquely without validating against known variants", () => {
+    // `front` treats the value as an opaque tracking property, so a variant it
+    // has never heard of (added on the marketing side) still round-trips.
+    document.cookie = `${HERO_VARIANT_COOKIE}=some-future-variant`;
+    expect(readHeroVariantFromDocumentCookie()).toBe("some-future-variant");
+  });
+
+  it("finds the cookie among other cookies", () => {
+    document.cookie = "foo=bar";
+    document.cookie = `${HERO_VARIANT_COOKIE}=control`;
+    expect(readHeroVariantFromDocumentCookie()).toBe("control");
+  });
+
+  it("returns null when the cookie is absent", () => {
+    expect(readHeroVariantFromDocumentCookie()).toBeNull();
+  });
+});

--- a/front/lib/experiments/hero_variant_cookie.ts
+++ b/front/lib/experiments/hero_variant_cookie.ts
@@ -1,0 +1,20 @@
+// Reads the homepage hero A/B experiment variant that `marketing` stored in a
+// shared `.dust.tt` cookie when the visitor was served the homepage. Lets
+// `front` attribute the sign-up completion — which happens after the WorkOS
+// redirect chain, on the far side of the marketing/app boundary — back to the
+// variant the visitor saw.
+//
+// The cookie is written by `marketing/lib/experiments/hero_variant_cookie.ts`;
+// keep the name in sync. The value is one of the marketing-side variant keys
+// ("control" | "collaboration" | ...); `front` treats it as an opaque string
+// tracking property and does not need the union type.
+export const HERO_VARIANT_COOKIE = "_dust_hv";
+
+export function readHeroVariantFromDocumentCookie(): string | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const prefix = `${HERO_VARIANT_COOKIE}=`;
+  const match = document.cookie.split("; ").find((c) => c.startsWith(prefix));
+  return match ? match.slice(prefix.length) : null;
+}

--- a/marketing/components/app/PostHogTracker.tsx
+++ b/marketing/components/app/PostHogTracker.tsx
@@ -35,18 +35,27 @@ interface PostHogTrackerProps {
   // When true, assume cookies are accepted (logged in users).
   // Use in authenticated contexts (e.g. SPA) where the user is always logged in.
   authenticated?: boolean;
+  // Feature flags evaluated server-side (e.g. an A/B experiment resolved in
+  // getServerSideProps). Seeded into posthog-js at init so the client agrees
+  // with the server-rendered variant and can record the exposure synchronously,
+  // without waiting for a /decide round-trip (which would flash + mis-report).
+  bootstrapFlags?: Record<string, string>;
 }
 
 export function PostHogTracker({
   children,
   authenticated,
+  bootstrapFlags,
 }: PostHogTrackerProps) {
   // Always render PostHogProvider to avoid unmounting/remounting the entire
   // tree when tracking state changes. Tracking is controlled via
   // posthog.opt_in_capturing() / posthog.opt_out_capturing() instead.
   return (
     <PostHogProvider client={posthog}>
-      <PostHogTrackerInner authenticated={authenticated} />
+      <PostHogTrackerInner
+        authenticated={authenticated}
+        bootstrapFlags={bootstrapFlags}
+      />
       {children}
     </PostHogProvider>
   );
@@ -60,9 +69,13 @@ export function PostHogTracker({
  */
 interface PostHogTrackerInnerProps {
   authenticated?: boolean;
+  bootstrapFlags?: Record<string, string>;
 }
 
-function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
+function PostHogTrackerInner({
+  authenticated,
+  bootstrapFlags,
+}: PostHogTrackerInnerProps) {
   const router = useAppRouter();
   const [cookies] = useCookies([DUST_COOKIES_ACCEPTED]);
 
@@ -129,6 +142,20 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
     // prior anonymous browsing events are orphaned.
     const anonymousId = getOrCreateAnonymousId();
 
+    // Combine the anonymous distinct_id and any server-evaluated feature flags
+    // into a single bootstrap so posthog-js has both available synchronously at
+    // init time.
+    const bootstrap: {
+      distinctID?: string;
+      featureFlags?: Record<string, string>;
+    } = {};
+    if (anonymousId) {
+      bootstrap.distinctID = anonymousId;
+    }
+    if (bootstrapFlags && Object.keys(bootstrapFlags).length > 0) {
+      bootstrap.featureFlags = bootstrapFlags;
+    }
+
     posthog.init(POSTHOG_KEY, {
       // /subtle1 is rewritten to PostHog by marketing's own next.config.js.
       // Use a relative path so requests hit marketing's origin (not front).
@@ -136,7 +163,7 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
       person_profiles: "identified_only",
       defaults: "2025-05-24",
       persistence: "memory",
-      ...(anonymousId ? { bootstrap: { distinctID: anonymousId } } : {}),
+      ...(Object.keys(bootstrap).length > 0 ? { bootstrap } : {}),
       // Share PostHog cookies (including distinct_id) across all *.dust.tt
       // subdomains so the same identity persists through dust.tt → signin →
       // app.dust.tt. Takes effect when persistence upgrades to cookie in Phase 2.
@@ -258,7 +285,22 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
     });
 
     hasInitialized.current = true;
-  }, [isTrackablePage]);
+  }, [isTrackablePage, bootstrapFlags]);
+
+  // Record the experiment exposure for any server-bootstrapped feature flags.
+  // getFeatureFlag() emits PostHog's `$feature_flag_called` event (deduped per
+  // session), and since the value was bootstrapped from the server it resolves
+  // synchronously and matches the variant the visitor actually saw. Runs on
+  // initial load (after the init effect above sets posthog.__loaded) and again
+  // on client-side navigations that carry a fresh bootstrap.
+  useEffect(() => {
+    if (!posthog.__loaded || !bootstrapFlags) {
+      return;
+    }
+    for (const flagKey of Object.keys(bootstrapFlags)) {
+      posthog.getFeatureFlag(flagKey);
+    }
+  }, [bootstrapFlags]);
 
   // Identify the user as soon as possible after auth completes — NOT gated on
   // cookie consent. identify() is a first-party operation on an already-

--- a/marketing/components/home/ContactForm.tsx
+++ b/marketing/components/home/ContactForm.tsx
@@ -11,6 +11,7 @@ import {
   HEADQUARTERS_REGION_OPTIONS,
   LANGUAGE_OPTIONS,
 } from "@marketing/lib/api/hubspot/contactFormSchema";
+import { readHeroVariantFromDocumentCookie } from "@marketing/lib/experiments/hero_variant_cookie";
 import { clientFetch } from "@marketing/lib/egress/client";
 import { useGeolocation } from "@marketing/lib/swr/geo";
 import { TRACKING_AREAS, trackEvent } from "@marketing/lib/tracking";
@@ -90,11 +91,16 @@ function useContactFormSubmit() {
         return;
       }
 
-      // Track successful submission
+      // Track successful submission. When the visitor reached the contact form
+      // from the homepage hero A/B test, tag the completion with the variant
+      // (carried in the shared `_dust_hv` cookie) so the demo funnel is
+      // comparable across arms.
+      const heroVariant = readHeroVariantFromDocumentCookie();
       trackEvent({
         area: TRACKING_AREAS.CONTACT,
         object: "contact_form",
         action: "submit_success",
+        extra: heroVariant ? { hero_variant: heroVariant } : undefined,
       });
 
       // Push GTM event with qualification status, form details, and tracking params

--- a/marketing/components/home/content/Product/HeroOfficeSection.tsx
+++ b/marketing/components/home/content/Product/HeroOfficeSection.tsx
@@ -5,15 +5,15 @@ import { homeScenarios } from "@marketing/components/home/content/Product/heroOf
 import { mountFloorScene } from "@marketing/components/home/content/Product/heroOfficeScene";
 import type { TeamMember } from "@marketing/components/home/content/shared/team";
 import { useSignUpModal } from "@marketing/hooks/useSignUpModal";
+import type { HeroVariantKey } from "@marketing/lib/experiments/hero_experiment";
+import {
+  DEFAULT_HERO_VARIANT,
+  HERO_CONTENT,
+} from "@marketing/lib/experiments/hero_experiment";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { LegacyButton as Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useEffect, useRef } from "react";
-
-const HEADLINE_LINE_1 = "Multiplayer AI for";
-const HEADLINE_LINE_2 = "human-agent collaboration.";
-const LEAD_COPY =
-  "Dust is where people and agents collaborate as co-contributors, so that work doesn't just get done – it gets rewired.";
 
 const OFFICE_FIRST_NAMES = [
   "Aisha",
@@ -46,9 +46,16 @@ const TEAM_POOL: TeamMember[] = OFFICE_FIRST_NAMES.map((firstName) => ({
   github: "",
 }));
 
-export function HeroOfficeSection() {
+interface HeroOfficeSectionProps {
+  variant?: HeroVariantKey;
+}
+
+export function HeroOfficeSection({
+  variant = DEFAULT_HERO_VARIANT,
+}: HeroOfficeSectionProps = {}) {
   const { openSignUpModal } = useSignUpModal();
   const sceneRef = useRef<HTMLDivElement>(null);
+  const content = HERO_CONTENT[variant];
 
   useEffect(() => {
     const host = sceneRef.current;
@@ -136,14 +143,14 @@ export function HeroOfficeSection() {
               className="m-0 text-balance text-[clamp(40px,4.8vw,76px)] font-semibold leading-[90%] tracking-[-0.04em] text-foreground"
               style={{ fontFamily: "var(--font-sans, inherit)" }}
             >
-              {HEADLINE_LINE_1}
+              {content.headlineLine1}
               <br />
-              {HEADLINE_LINE_2}
+              {content.headlineLine2}
             </h1>
           </HomeReveal>
           <HomeReveal delay={80}>
             <p className="copy-lg max-w-[520px] text-pretty leading-[1.55] text-muted-foreground">
-              {LEAD_COPY}
+              {content.leadCopy}
             </p>
           </HomeReveal>
           <HomeReveal delay={160}>
@@ -152,14 +159,14 @@ export function HeroOfficeSection() {
                 <Button
                   variant="highlight"
                   size="md"
-                  label="Request a demo"
+                  label={content.primaryCtaLabel}
                   onClick={withTracking(TRACKING_AREAS.HOME, "hero_book_demo")}
                 />
               </Link>
               <Button
                 variant="ghost-secondary"
                 size="md"
-                label="Try for free →"
+                label={content.secondaryCtaLabel}
                 onClick={withTracking(
                   TRACKING_AREAS.HOME,
                   "hero_start_free",

--- a/marketing/components/home/content/Product/HeroOfficeSection.tsx
+++ b/marketing/components/home/content/Product/HeroOfficeSection.tsx
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 
+import { HeroVideo } from "@marketing/components/home/content/Product/HeroVideo";
 import { HomeReveal } from "@marketing/components/home/content/Product/HomeReveal";
 import { homeScenarios } from "@marketing/components/home/content/Product/heroOfficeScenario";
 import { mountFloorScene } from "@marketing/components/home/content/Product/heroOfficeScene";
@@ -58,6 +59,11 @@ export function HeroOfficeSection({
   const content = HERO_CONTENT[variant];
 
   useEffect(() => {
+    if (content.heroVideo) {
+      // Video variants render an embed instead of the animated floor scene, so
+      // there is nothing to mount.
+      return;
+    }
     const host = sceneRef.current;
     if (!host) {
       return;
@@ -132,7 +138,7 @@ export function HeroOfficeSection({
       }
       cleanup?.();
     };
-  }, []);
+  }, [content.heroVideo]);
 
   return (
     <section className="relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen bg-background pb-12">
@@ -181,11 +187,18 @@ export function HeroOfficeSection({
           delay={80}
           className="relative hidden w-full lg:block lg:w-[58%]"
         >
-          <div
-            ref={sceneRef}
-            className="dust-floor-host w-full lg:h-[min(86vh,900px)]"
-            aria-hidden="true"
-          />
+          {content.heroVideo ? (
+            <HeroVideo
+              videoId={content.heroVideo.youtubeId}
+              title={content.heroVideo.title}
+            />
+          ) : (
+            <div
+              ref={sceneRef}
+              className="dust-floor-host w-full lg:h-[min(86vh,900px)]"
+              aria-hidden="true"
+            />
+          )}
         </HomeReveal>
       </div>
     </section>

--- a/marketing/components/home/content/Product/HeroOfficeSection.tsx
+++ b/marketing/components/home/content/Product/HeroOfficeSection.tsx
@@ -166,7 +166,12 @@ export function HeroOfficeSection({
                   variant="highlight"
                   size="md"
                   label={content.primaryCtaLabel}
-                  onClick={withTracking(TRACKING_AREAS.HOME, "hero_book_demo")}
+                  onClick={withTracking(
+                    TRACKING_AREAS.HOME,
+                    "hero_book_demo",
+                    undefined,
+                    { hero_variant: variant }
+                  )}
                 />
               </Link>
               <Button
@@ -176,7 +181,8 @@ export function HeroOfficeSection({
                 onClick={withTracking(
                   TRACKING_AREAS.HOME,
                   "hero_start_free",
-                  openSignUpModal
+                  openSignUpModal,
+                  { hero_variant: variant }
                 )}
               />
             </div>

--- a/marketing/components/home/content/Product/HeroVideo.tsx
+++ b/marketing/components/home/content/Product/HeroVideo.tsx
@@ -1,0 +1,41 @@
+// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
+
+interface HeroVideoProps {
+  /** YouTube video id rendered in the hero's right column. */
+  videoId: string;
+  /** Accessible iframe title. */
+  title: string;
+}
+
+// Video treatment for the hero's right column (collaboration variant). It plays
+// the same role the animated office scene does in the control — an ambient,
+// self-playing visual — but shows a customer-story clip instead. Autoplays
+// muted and loops so it behaves like the scene it replaces; controls stay
+// available so visitors can unmute and watch. Unlike the office scene (which
+// fills the viewport height), the embed sizes to its natural 16:9 ratio so it
+// sits at the top of the hero without a tall empty gap; the parent row centers
+// it against the copy column. On brand: rounded corners with a soft border and
+// shadow to match the rest of the landing surface.
+export function HeroVideo({ videoId, title }: HeroVideoProps) {
+  const src = new URL(`https://www.youtube.com/embed/${videoId}`);
+  src.searchParams.set("autoplay", "1");
+  src.searchParams.set("mute", "1");
+  src.searchParams.set("loop", "1");
+  // `loop` only takes effect when the video is also listed as the playlist.
+  src.searchParams.set("playlist", videoId);
+  src.searchParams.set("playsinline", "1");
+  src.searchParams.set("modestbranding", "1");
+  src.searchParams.set("rel", "0");
+
+  return (
+    <div className="relative aspect-video w-full overflow-hidden rounded-2xl border border-border bg-gray-100 shadow-[0_24px_60px_-28px_rgba(20,22,28,0.24)]">
+      <iframe
+        src={src.toString()}
+        title={title}
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        className="absolute inset-0 h-full w-full"
+      />
+    </div>
+  );
+}

--- a/marketing/components/home/content/Product/IntroSection.tsx
+++ b/marketing/components/home/content/Product/IntroSection.tsx
@@ -9,6 +9,8 @@ import { HomeSecuritySection } from "@marketing/components/home/content/Product/
 import { HomeTeamSportSection } from "@marketing/components/home/content/Product/HomeTeamSportSection";
 import { HomeTeamUsageSection } from "@marketing/components/home/content/Product/HomeTeamUsageSection";
 import { HomeTrustedSection } from "@marketing/components/home/content/Product/HomeTrustedSection";
+import type { HeroVariantKey } from "@marketing/lib/experiments/hero_experiment";
+import { DEFAULT_HERO_VARIANT } from "@marketing/lib/experiments/hero_experiment";
 import type { NewsItem } from "@marketing/lib/homepage_news";
 
 const TESTIMONIAL_IMAGE = "/static/landing/people/quote-testimonial.png";
@@ -34,14 +36,18 @@ const QUOTES = [
 
 interface IntroSectionProps {
   news?: NewsItem[];
+  heroVariant?: HeroVariantKey;
 }
 
-export function IntroSection({ news }: IntroSectionProps = {}) {
+export function IntroSection({
+  news,
+  heroVariant = DEFAULT_HERO_VARIANT,
+}: IntroSectionProps = {}) {
   return (
     <section className="w-full">
       <HomeRevealStyles />
       <div className="flex flex-col">
-        <HeroOfficeSection />
+        <HeroOfficeSection variant={heroVariant} />
         <div className="relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] flex w-screen flex-col">
           <HomeTrustedSection />
           <HomeTeamSportSection />

--- a/marketing/lib/api/config.ts
+++ b/marketing/lib/api/config.ts
@@ -60,6 +60,11 @@ const config = {
   getPostHogApiKey: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("NEXT_PUBLIC_POSTHOG_KEY");
   },
+  getNodeEnv: (): string => {
+    // NODE_ENV is inlined by Next at build time; read it directly here (like the
+    // NEXT_PUBLIC_* getters above) so the helper works on both server and client.
+    return process.env.NODE_ENV ?? "development";
+  },
 };
 
 export default config;

--- a/marketing/lib/api/posthog_server.ts
+++ b/marketing/lib/api/posthog_server.ts
@@ -1,0 +1,56 @@
+import config from "@marketing/lib/api/config";
+import logger from "@marketing/logger/logger";
+import { PostHog } from "posthog-node";
+
+const POSTHOG_HOST = "https://eu.i.posthog.com";
+
+let posthogClient: PostHog | null = null;
+
+// Lazily-constructed, process-wide PostHog server client. Shared by every
+// server-side PostHog use (pageview capture, feature-flag evaluation) so we
+// keep a single client + flush loop per process.
+export function getPosthogServerClient(): PostHog | null {
+  if (posthogClient) {
+    return posthogClient;
+  }
+
+  const apiKey = config.getPostHogApiKey();
+  if (!apiKey) {
+    return null;
+  }
+
+  posthogClient = new PostHog(apiKey, { host: POSTHOG_HOST });
+  return posthogClient;
+}
+
+// Evaluating a flag without local evaluation configured makes a remote request,
+// so we bound it: the homepage must render even when PostHog is slow or down.
+const FLAG_EVAL_TIMEOUT_MS = 1000;
+
+// Resolve a feature flag / experiment variant for a given distinct id. Returns
+// `undefined` when PostHog is unconfigured, times out, or errors — callers fall
+// back to their control experience in that case.
+export async function getServerFeatureFlagVariant(
+  flagKey: string,
+  distinctId: string
+): Promise<string | boolean | undefined> {
+  const client = getPosthogServerClient();
+  if (!client) {
+    return undefined;
+  }
+
+  try {
+    const timeout = new Promise<undefined>((resolve) => {
+      setTimeout(() => resolve(undefined), FLAG_EVAL_TIMEOUT_MS);
+    });
+    // The client records the exposure event when the variant actually renders,
+    // so suppress the server-side `$feature_flag_called` event here.
+    const evaluation = client.getFeatureFlag(flagKey, distinctId, {
+      sendFeatureFlagEvents: false,
+    });
+    return await Promise.race([evaluation, timeout]);
+  } catch (err) {
+    logger.error({ err, flagKey }, "Failed to evaluate PostHog feature flag");
+    return undefined;
+  }
+}

--- a/marketing/lib/api/track_pageview.ts
+++ b/marketing/lib/api/track_pageview.ts
@@ -1,26 +1,7 @@
-import config from "@marketing/lib/api/config";
+import { getPosthogServerClient } from "@marketing/lib/api/posthog_server";
 import { DUST_COOKIES_ACCEPTED } from "@marketing/lib/cookies";
 import { readAnonymousIdFromCookies } from "@marketing/lib/utils/anonymous_id";
 import logger from "@marketing/logger/logger";
-import { PostHog } from "posthog-node";
-
-const POSTHOG_HOST = "https://eu.i.posthog.com";
-
-let posthogClient: PostHog | null = null;
-
-function getClient(): PostHog | null {
-  if (posthogClient) {
-    return posthogClient;
-  }
-
-  const apiKey = config.getPostHogApiKey();
-  if (!apiKey) {
-    return null;
-  }
-
-  posthogClient = new PostHog(apiKey, { host: POSTHOG_HOST });
-  return posthogClient;
-}
 
 // In-memory IP rate limit: 4 requests per 2s per IP. Per-process only — across
 // pods this is best-effort, which is acceptable for pageview spam control.
@@ -72,7 +53,7 @@ export async function trackPageview({
     return { type: "rate_limited" };
   }
 
-  const client = getClient();
+  const client = getPosthogServerClient();
   if (!client) {
     return { type: "ok" };
   }

--- a/marketing/lib/experiments/hero_experiment.test.ts
+++ b/marketing/lib/experiments/hero_experiment.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_HERO_VARIANT,
+  HERO_CONTENT,
+  HERO_VARIANT_KEYS,
+  isHeroVariantKey,
+  toHeroVariant,
+} from "@marketing/lib/experiments/hero_experiment";
+
+describe("hero_experiment", () => {
+  describe("toHeroVariant", () => {
+    it("returns the variant for a known key", () => {
+      expect(toHeroVariant("control")).toBe("control");
+      expect(toHeroVariant("collaboration")).toBe("collaboration");
+    });
+
+    it("falls back to control for unknown / absent flag values", () => {
+      // These mirror what PostHog can hand back: an unmapped multivariate
+      // string, a boolean flag, undefined on eval failure, or null.
+      expect(toHeroVariant("some-other-variant")).toBe(DEFAULT_HERO_VARIANT);
+      expect(toHeroVariant(true)).toBe(DEFAULT_HERO_VARIANT);
+      expect(toHeroVariant(false)).toBe(DEFAULT_HERO_VARIANT);
+      expect(toHeroVariant(undefined)).toBe(DEFAULT_HERO_VARIANT);
+      expect(toHeroVariant(null)).toBe(DEFAULT_HERO_VARIANT);
+    });
+
+    it("uses control as the default variant", () => {
+      expect(DEFAULT_HERO_VARIANT).toBe("control");
+    });
+  });
+
+  describe("isHeroVariantKey", () => {
+    it("is true only for exact, valid variant keys", () => {
+      expect(isHeroVariantKey("control")).toBe(true);
+      expect(isHeroVariantKey("collaboration")).toBe(true);
+    });
+
+    it("is false for anything else", () => {
+      expect(isHeroVariantKey("Control")).toBe(false);
+      expect(isHeroVariantKey("")).toBe(false);
+      expect(isHeroVariantKey("bogus")).toBe(false);
+      expect(isHeroVariantKey(undefined)).toBe(false);
+      expect(isHeroVariantKey(null)).toBe(false);
+      expect(isHeroVariantKey(true)).toBe(false);
+    });
+  });
+
+  describe("HERO_CONTENT", () => {
+    it("has content for every declared variant key", () => {
+      for (const key of HERO_VARIANT_KEYS) {
+        expect(HERO_CONTENT[key]).toBeDefined();
+        expect(HERO_CONTENT[key].headlineLine1.length).toBeGreaterThan(0);
+        expect(HERO_CONTENT[key].primaryCtaLabel.length).toBeGreaterThan(0);
+        expect(HERO_CONTENT[key].secondaryCtaLabel.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("renders the office scene for control (no video)", () => {
+      expect(HERO_CONTENT.control.heroVideo).toBeUndefined();
+    });
+
+    it("renders a customer-story video for collaboration", () => {
+      expect(HERO_CONTENT.collaboration.heroVideo?.youtubeId).toBeTruthy();
+      expect(HERO_CONTENT.collaboration.heroVideo?.title).toBeTruthy();
+    });
+  });
+});

--- a/marketing/lib/experiments/hero_experiment.ts
+++ b/marketing/lib/experiments/hero_experiment.ts
@@ -25,6 +25,9 @@ export interface HeroContent {
   leadCopy: string;
   primaryCtaLabel: string;
   secondaryCtaLabel: string;
+  // When set, the hero's right column plays this customer-story clip instead of
+  // the animated office scene.
+  heroVideo?: { youtubeId: string; title: string };
 }
 
 export const HERO_CONTENT: Record<HeroVariantKey, HeroContent> = {
@@ -43,6 +46,12 @@ export const HERO_CONTENT: Record<HeroVariantKey, HeroContent> = {
       "Dust gives your whole organization shared context, smarter agents, and AI that actually knows your business.",
     primaryCtaLabel: "Request a demo",
     secondaryCtaLabel: "Try for free →",
+    // Laurel customer story:
+    // /customers/how-laurel-runs-like-a-400-person-company-with-a-100-person-team-using-dust
+    heroVideo: {
+      youtubeId: "FHbleyDAtEk",
+      title: "How Laurel runs like a 400-person company with Dust",
+    },
   },
 };
 

--- a/marketing/lib/experiments/hero_experiment.ts
+++ b/marketing/lib/experiments/hero_experiment.ts
@@ -1,0 +1,63 @@
+// Shared definition of the homepage hero A/B experiment.
+//
+// Imported by BOTH the server (flag evaluation in `getServerSideProps`) and the
+// client (hero rendering + exposure tracking), so this module must stay free of
+// server-only imports (`posthog-node`, `fs`, request objects, ...).
+//
+// The variant is resolved server-side against the PostHog multivariate feature
+// flag `home-hero-experiment` and rendered into the initial HTML, so visitors
+// never see the control copy flash to the test copy.
+
+export const HERO_EXPERIMENT_FLAG_KEY = "home-hero-experiment";
+
+export type HeroVariantKey = "control" | "collaboration";
+
+export const HERO_VARIANT_KEYS: readonly HeroVariantKey[] = [
+  "control",
+  "collaboration",
+] as const;
+
+export const DEFAULT_HERO_VARIANT: HeroVariantKey = "control";
+
+export interface HeroContent {
+  headlineLine1: string;
+  headlineLine2: string;
+  leadCopy: string;
+  primaryCtaLabel: string;
+  secondaryCtaLabel: string;
+}
+
+export const HERO_CONTENT: Record<HeroVariantKey, HeroContent> = {
+  control: {
+    headlineLine1: "Multiplayer AI for",
+    headlineLine2: "human-agent collaboration.",
+    leadCopy:
+      "Dust is where people and agents collaborate as co-contributors, so that work doesn't just get done – it gets rewired.",
+    primaryCtaLabel: "Request a demo",
+    secondaryCtaLabel: "Try for free →",
+  },
+  collaboration: {
+    headlineLine1: "The best teams aren't just using AI.",
+    headlineLine2: "They're running it.",
+    leadCopy:
+      "Dust gives your whole organization shared context, smarter agents, and AI that actually knows your business.",
+    primaryCtaLabel: "Request a demo",
+    secondaryCtaLabel: "Try for free →",
+  },
+};
+
+// Narrow an arbitrary PostHog flag value (multivariate string, boolean, or
+// undefined when evaluation fails) down to a known hero variant, falling back
+// to control for anything unexpected.
+export function toHeroVariant(value: unknown): HeroVariantKey {
+  return (
+    HERO_VARIANT_KEYS.find((key) => key === value) ?? DEFAULT_HERO_VARIANT
+  );
+}
+
+// Type guard for an explicit, valid variant key. Unlike toHeroVariant() this
+// does NOT coerce unknown values to control — use it when you need to know a
+// caller genuinely asked for a specific variant (e.g. a dev preview override).
+export function isHeroVariantKey(value: unknown): value is HeroVariantKey {
+  return HERO_VARIANT_KEYS.some((key) => key === value);
+}

--- a/marketing/lib/experiments/hero_variant_cookie.test.ts
+++ b/marketing/lib/experiments/hero_variant_cookie.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  HERO_VARIANT_COOKIE,
+  buildHeroVariantServerCookieString,
+  readHeroVariantFromDocumentCookie,
+} from "@marketing/lib/experiments/hero_variant_cookie";
+
+// Expire anything jsdom retained between tests so cookie reads start clean.
+afterEach(() => {
+  for (const cookie of document.cookie.split("; ")) {
+    const name = cookie.split("=")[0];
+    if (name) {
+      document.cookie = `${name}=; max-age=0`;
+    }
+  }
+});
+
+describe("hero_variant_cookie", () => {
+  describe("buildHeroVariantServerCookieString", () => {
+    it("scopes the cookie to .dust.tt on production hosts", () => {
+      const cookie = buildHeroVariantServerCookieString(
+        "collaboration",
+        "dust.tt"
+      );
+      expect(cookie).toContain(`${HERO_VARIANT_COOKIE}=collaboration`);
+      expect(cookie).toContain("domain=.dust.tt");
+      expect(cookie).toContain("path=/");
+      expect(cookie).toContain("SameSite=Lax");
+      expect(cookie).toContain("Secure");
+    });
+
+    it("shares the cookie across app/eu subdomains", () => {
+      expect(
+        buildHeroVariantServerCookieString("control", "app.dust.tt")
+      ).toContain("domain=.dust.tt");
+      expect(
+        buildHeroVariantServerCookieString("control", "eu.dust.tt")
+      ).toContain("domain=.dust.tt");
+    });
+
+    it("stays host-only on localhost / preview hosts (no domain attribute)", () => {
+      expect(
+        buildHeroVariantServerCookieString("control", "localhost:3000")
+      ).not.toContain("domain=");
+      expect(
+        buildHeroVariantServerCookieString("control", undefined)
+      ).not.toContain("domain=");
+    });
+
+    it("bounds the cookie to a 30-day attribution window", () => {
+      const thirtyDaysSeconds = 60 * 60 * 24 * 30;
+      expect(
+        buildHeroVariantServerCookieString("control", "dust.tt")
+      ).toContain(`max-age=${thirtyDaysSeconds}`);
+    });
+  });
+
+  describe("readHeroVariantFromDocumentCookie", () => {
+    it("reads back a valid variant", () => {
+      document.cookie = `${HERO_VARIANT_COOKIE}=collaboration`;
+      expect(readHeroVariantFromDocumentCookie()).toBe("collaboration");
+    });
+
+    it("returns null when the cookie is absent", () => {
+      expect(readHeroVariantFromDocumentCookie()).toBeNull();
+    });
+
+    it("returns null for an unrecognized variant value", () => {
+      // Guards against a stale/tampered cookie leaking a bogus variant into
+      // conversion tracking.
+      document.cookie = `${HERO_VARIANT_COOKIE}=bogus`;
+      expect(readHeroVariantFromDocumentCookie()).toBeNull();
+    });
+  });
+});

--- a/marketing/lib/experiments/hero_variant_cookie.ts
+++ b/marketing/lib/experiments/hero_variant_cookie.ts
@@ -1,0 +1,59 @@
+import type { HeroVariantKey } from "@marketing/lib/experiments/hero_experiment";
+import { isHeroVariantKey } from "@marketing/lib/experiments/hero_experiment";
+import { serverCookieDomainForHost } from "@marketing/lib/utils/anonymous_id";
+
+// Cross-subdomain cookie carrying the hero A/B variant the visitor was served on
+// the homepage. The two conversion endpoints that live off the homepage — the
+// contact form (`/home/contact`) and, after the WorkOS sign-up redirect chain,
+// `front`'s onboarding — read it to attribute their completion back to the
+// variant. Mirrors `_dust_aid`: scoped to `.dust.tt` in production so it
+// survives dust.tt -> app.dust.tt / eu.dust.tt.
+//
+// The matching reader on the `front` side lives in
+// `front/lib/experiments/hero_variant_cookie.ts`; keep the name in sync.
+export const HERO_VARIANT_COOKIE = "_dust_hv";
+
+// Bounded to a conversion-attribution window rather than `_dust_aid`'s full
+// year: the variant should only tag conversions that plausibly stem from the
+// homepage visit that set it.
+const HERO_VARIANT_MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days.
+
+function buildHeroVariantCookieStringForDomain(
+  variant: HeroVariantKey,
+  domain: string | null
+): string {
+  const domainPart = domain ? `; domain=${domain}` : "";
+  return `${HERO_VARIANT_COOKIE}=${variant}; path=/${domainPart}; SameSite=Lax; Secure; max-age=${HERO_VARIANT_MAX_AGE_SECONDS}`;
+}
+
+// Build a `Set-Cookie` string for the hero variant from the server. Derives the
+// cookie scope from the request host, exactly like `_dust_aid`, so the value is
+// readable back on `/home/contact` and on `*.dust.tt` after sign-up redirects.
+export function buildHeroVariantServerCookieString(
+  variant: HeroVariantKey,
+  host: string | undefined
+): string {
+  return buildHeroVariantCookieStringForDomain(
+    variant,
+    serverCookieDomainForHost(host)
+  );
+}
+
+function parseHeroVariantFromCookieString(
+  cookies: string
+): HeroVariantKey | null {
+  const prefix = `${HERO_VARIANT_COOKIE}=`;
+  const match = cookies.split("; ").find((c) => c.startsWith(prefix));
+  if (!match) {
+    return null;
+  }
+  const value = match.slice(prefix.length);
+  return isHeroVariantKey(value) ? value : null;
+}
+
+export function readHeroVariantFromDocumentCookie(): HeroVariantKey | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  return parseHeroVariantFromCookieString(document.cookie);
+}

--- a/marketing/lib/utils/anonymous_id.test.ts
+++ b/marketing/lib/utils/anonymous_id.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DUST_ANONYMOUS_ID_COOKIE,
+  buildDustAidServerCookieString,
+  readAnonymousIdFromCookies,
+  serverCookieDomainForHost,
+} from "@marketing/lib/utils/anonymous_id";
+
+describe("anonymous_id", () => {
+  describe("serverCookieDomainForHost", () => {
+    it("returns .dust.tt for the apex and its subdomains", () => {
+      expect(serverCookieDomainForHost("dust.tt")).toBe(".dust.tt");
+      expect(serverCookieDomainForHost("app.dust.tt")).toBe(".dust.tt");
+      expect(serverCookieDomainForHost("eu.dust.tt")).toBe(".dust.tt");
+    });
+
+    it("ignores the port when matching the host", () => {
+      expect(serverCookieDomainForHost("dust.tt:443")).toBe(".dust.tt");
+    });
+
+    it("returns null (host-only) for localhost and preview hosts", () => {
+      expect(serverCookieDomainForHost("localhost:3000")).toBeNull();
+      expect(serverCookieDomainForHost("some-preview.vercel.app")).toBeNull();
+      expect(serverCookieDomainForHost(undefined)).toBeNull();
+    });
+
+    it("does not match look-alike suffixes", () => {
+      // `notdust.tt` ends with "dust.tt" as a string but is a different domain;
+      // only "dust.tt" or a real ".dust.tt" subdomain should share the cookie.
+      expect(serverCookieDomainForHost("notdust.tt")).toBeNull();
+    });
+  });
+
+  describe("buildDustAidServerCookieString", () => {
+    it("produces a cookie the client-side parser reads back identically", () => {
+      const cookie = buildDustAidServerCookieString("abc-123", "dust.tt");
+      expect(cookie).toContain(`${DUST_ANONYMOUS_ID_COOKIE}=abc-123`);
+      expect(cookie).toContain("domain=.dust.tt");
+      expect(cookie).toContain("SameSite=Lax");
+      expect(cookie).toContain("Secure");
+    });
+
+    it("omits the domain attribute on host-only hosts", () => {
+      expect(
+        buildDustAidServerCookieString("abc-123", "localhost:3000")
+      ).not.toContain("domain=");
+    });
+  });
+
+  describe("readAnonymousIdFromCookies", () => {
+    it("extracts the id from a Cookie header among other cookies", () => {
+      const header = `foo=bar; ${DUST_ANONYMOUS_ID_COOKIE}=abc-123; baz=qux`;
+      expect(readAnonymousIdFromCookies(header)).toBe("abc-123");
+    });
+
+    it("returns null when the id cookie or header is absent", () => {
+      expect(readAnonymousIdFromCookies("foo=bar")).toBeNull();
+      expect(readAnonymousIdFromCookies(undefined)).toBeNull();
+    });
+  });
+});

--- a/marketing/lib/utils/anonymous_id.ts
+++ b/marketing/lib/utils/anonymous_id.ts
@@ -21,10 +21,48 @@ export function getPostHogCookieDomain(): string | undefined {
   return domain ?? undefined;
 }
 
-export function buildDustAidCookieString(value: string): string {
-  const domain = getRootCookieDomain();
+function buildDustAidCookieStringForDomain(
+  value: string,
+  domain: string | null
+): string {
   const domainPart = domain ? `; domain=${domain}` : "";
   return `${DUST_ANONYMOUS_ID_COOKIE}=${value}; path=/${domainPart}; SameSite=Lax; Secure; max-age=${ANONYMOUS_ID_MAX_AGE_SECONDS}`;
+}
+
+export function buildDustAidCookieString(value: string): string {
+  return buildDustAidCookieStringForDomain(value, getRootCookieDomain());
+}
+
+// Server-side cookie domain: `window` is unavailable in `getServerSideProps`, so
+// derive the scope from the request host instead of `window.location`. Mirrors
+// getRootCookieDomain(): share the id across *.dust.tt in production, host-only
+// on localhost / preview hosts.
+export function serverCookieDomainForHost(
+  host: string | undefined
+): string | null {
+  if (!host) {
+    return null;
+  }
+
+  const hostname = host.split(":")[0];
+  if (hostname === "dust.tt" || hostname.endsWith(".dust.tt")) {
+    return ".dust.tt";
+  }
+
+  return null;
+}
+
+// Build a `Set-Cookie` string for the anonymous id from the server. Kept in sync
+// with buildDustAidCookieString() so an id minted server-side is read back
+// identically by the client's getOrCreateAnonymousId().
+export function buildDustAidServerCookieString(
+  value: string,
+  host: string | undefined
+): string {
+  return buildDustAidCookieStringForDomain(
+    value,
+    serverCookieDomainForHost(host)
+  );
 }
 
 export function getOrCreateAnonymousId(): string | null {

--- a/marketing/package.json
+++ b/marketing/package.json
@@ -10,7 +10,9 @@
     "build": "NODE_ENV=production next build",
     "start": "next start --keepAliveTimeout 5000",
     "sitemap": "next-sitemap",
-    "tsgo": "tsgo"
+    "tsgo": "tsgo",
+    "test": "vitest --run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@contentful/rich-text-react-renderer": "^16.1.6",
@@ -60,6 +62,8 @@
     "@types/react-dom": "^18.3.5",
     "@types/uuid": "^9.0.1",
     "@typescript/native-preview": "^7.0.0-dev.20260224.1",
+    "jsdom": "^26.0.0",
+    "vitest": "^4.0.16",
     "@tailwindcss/postcss": "^4.3.0",
 
     "next-sitemap": "^4.2.3",

--- a/marketing/pages/_app.tsx
+++ b/marketing/pages/_app.tsx
@@ -121,9 +121,15 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
     []
   );
 
+  // Feature flags evaluated server-side for this page (e.g. the homepage hero
+  // A/B experiment) are passed through to posthog-js so the client matches the
+  // server-rendered variant. `pageProps` is untyped, so read defensively.
+  const posthogBootstrapFlags: Record<string, string> | undefined =
+    pageProps?.posthogBootstrap?.featureFlags;
+
   return (
     <FetcherProvider fetcher={fetcher} fetcherWithBody={fetcherWithBody}>
-      <PostHogTracker>
+      <PostHogTracker bootstrapFlags={posthogBootstrapFlags}>
         <SparkleContext.Provider value={sparkleContextValue}>
           <SignUpModalProvider>
             {getLayout(<Component {...pageProps} />, pageProps)}

--- a/marketing/pages/home/index.tsx
+++ b/marketing/pages/home/index.tsx
@@ -2,6 +2,8 @@ import { IntroSection } from "@marketing/components/home/content/Product/IntroSe
 import type { LandingLayoutProps } from "@marketing/components/home/LandingLayout";
 import LandingLayout from "@marketing/components/home/LandingLayout";
 import { PageMetadata } from "@marketing/components/home/PageMetadata";
+import type { HeroVariantKey } from "@marketing/lib/experiments/hero_experiment";
+import { DEFAULT_HERO_VARIANT } from "@marketing/lib/experiments/hero_experiment";
 import type { NewsItem } from "@marketing/lib/homepage_news";
 import { fetchHomepageNews } from "@marketing/lib/homepage_news";
 import { useRouter } from "next/router";
@@ -9,6 +11,9 @@ import type { ReactElement } from "react";
 
 interface HomeProps {
   news?: NewsItem[];
+  // Only the server-rendered root (`/`) resolves the hero experiment; the
+  // statically-generated `/home` route renders the control by default.
+  heroVariant?: HeroVariantKey;
 }
 
 // Revalidate the homepage every 5 minutes so news edits in the Google
@@ -26,7 +31,10 @@ export async function getStaticProps() {
   };
 }
 
-export function Landing({ news }: HomeProps) {
+export function Landing({
+  news,
+  heroVariant = DEFAULT_HERO_VARIANT,
+}: HomeProps) {
   const router = useRouter();
 
   return (
@@ -36,7 +44,7 @@ export function Landing({ news }: HomeProps) {
         description="Dust is where people and agents collaborate as co-contributors, so that work doesn't just get done – it gets rewired."
         pathname={router.asPath}
       />
-      <IntroSection news={news} />
+      <IntroSection news={news} heroVariant={heroVariant} />
     </>
   );
 }

--- a/marketing/pages/index.tsx
+++ b/marketing/pages/index.tsx
@@ -5,20 +5,39 @@ import {
   fetchAuthContext,
   hasWorkosSessionCookie,
 } from "@marketing/lib/api/authContext";
+import { getServerFeatureFlagVariant } from "@marketing/lib/api/posthog_server";
+import type { HeroVariantKey } from "@marketing/lib/experiments/hero_experiment";
+import {
+  HERO_EXPERIMENT_FLAG_KEY,
+  isHeroVariantKey,
+  toHeroVariant,
+} from "@marketing/lib/experiments/hero_experiment";
 import type { NewsItem } from "@marketing/lib/homepage_news";
 import { fetchHomepageNews } from "@marketing/lib/homepage_news";
+import {
+  buildDustAidServerCookieString,
+  readAnonymousIdFromCookies,
+} from "@marketing/lib/utils/anonymous_id";
 import { extractUTMParams } from "@marketing/lib/utils/utm";
 import { Landing } from "@marketing/pages/home";
 import logger from "@marketing/logger/logger";
 import type { GetServerSideProps } from "next";
 import type { ParsedUrlQuery } from "querystring";
 import type { ReactElement } from "react";
+import { v4 as uuidv4 } from "uuid";
 
 interface HomeProps {
   postLoginReturnToUrl: string;
   news: NewsItem[];
   shape: number;
   gtmTrackingId: string | null;
+  // Server-resolved hero A/B variant, rendered into the initial HTML so the
+  // control copy never flashes to the test copy.
+  heroVariant: HeroVariantKey;
+  // Feature flags to seed posthog-js with, so the client agrees with the
+  // server-rendered variant and can record the exposure without a re-fetch.
+  // Null when flag evaluation was unavailable (client falls back to its own).
+  posthogBootstrap: { featureFlags: Record<string, string> } | null;
 }
 
 /**
@@ -99,7 +118,47 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async (
     postLoginCallbackUrl += `?inviteToken=${inviteToken}`;
   }
 
-  const news = await fetchHomepageNews();
+  // Resolve the PostHog distinct id from the persistent `_dust_aid` cookie so
+  // the server buckets the hero experiment identically to the client. On a
+  // visitor's very first request the cookie doesn't exist yet, so mint one here
+  // and set it on the response — otherwise the flag would be evaluated against a
+  // throwaway id and diverge from the client, reintroducing the flash we set out
+  // to avoid.
+  let distinctId = readAnonymousIdFromCookies(cookieHeader);
+  if (!distinctId) {
+    distinctId = uuidv4();
+    context.res.setHeader(
+      "Set-Cookie",
+      buildDustAidServerCookieString(distinctId, context.req.headers.host)
+    );
+  }
+
+  const [news, heroFlagValue] = await Promise.all([
+    fetchHomepageNews(),
+    getServerFeatureFlagVariant(HERO_EXPERIMENT_FLAG_KEY, distinctId),
+  ]);
+
+  let heroVariant = toHeroVariant(heroFlagValue);
+  // Only bootstrap the client when evaluation actually succeeded; on failure we
+  // rendered control and let posthog-js resolve the flag on its own.
+  let posthogBootstrap: { featureFlags: Record<string, string> } | null =
+    heroFlagValue === undefined
+      ? null
+      : { featureFlags: { [HERO_EXPERIMENT_FLAG_KEY]: heroVariant } };
+
+  // Dev-only override to preview a specific hero variant without a live PostHog
+  // experiment, e.g. `/?hero_variant=collaboration`. Never honored in
+  // production, where the variant must come from the real experiment.
+  if (config.getNodeEnv() !== "production") {
+    const requested = context.query.hero_variant;
+    const requestedValue = Array.isArray(requested) ? requested[0] : requested;
+    if (isHeroVariantKey(requestedValue)) {
+      heroVariant = requestedValue;
+      posthogBootstrap = {
+        featureFlags: { [HERO_EXPERIMENT_FLAG_KEY]: requestedValue },
+      };
+    }
+  }
 
   return {
     props: {
@@ -107,13 +166,15 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async (
       shape: 0,
       gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
       news,
+      heroVariant,
+      posthogBootstrap,
     },
   };
 };
 
 // biome-ignore lint/plugin/nextjsPageComponentNaming: pre-existing
-export default function Home({ news }: HomeProps) {
-  return <Landing news={news} />;
+export default function Home({ news, heroVariant }: HomeProps) {
+  return <Landing news={news} heroVariant={heroVariant} />;
 }
 
 Home.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {

--- a/marketing/pages/index.tsx
+++ b/marketing/pages/index.tsx
@@ -12,6 +12,7 @@ import {
   isHeroVariantKey,
   toHeroVariant,
 } from "@marketing/lib/experiments/hero_experiment";
+import { buildHeroVariantServerCookieString } from "@marketing/lib/experiments/hero_variant_cookie";
 import type { NewsItem } from "@marketing/lib/homepage_news";
 import { fetchHomepageNews } from "@marketing/lib/homepage_news";
 import {
@@ -124,11 +125,11 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async (
   // and set it on the response — otherwise the flag would be evaluated against a
   // throwaway id and diverge from the client, reintroducing the flash we set out
   // to avoid.
+  const cookiesToSet: string[] = [];
   let distinctId = readAnonymousIdFromCookies(cookieHeader);
   if (!distinctId) {
     distinctId = uuidv4();
-    context.res.setHeader(
-      "Set-Cookie",
+    cookiesToSet.push(
       buildDustAidServerCookieString(distinctId, context.req.headers.host)
     );
   }
@@ -158,6 +159,18 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async (
         featureFlags: { [HERO_EXPERIMENT_FLAG_KEY]: requestedValue },
       };
     }
+  }
+
+  // Persist the resolved variant in a shared `.dust.tt` cookie so the two
+  // off-homepage conversion endpoints (the contact form and, after the WorkOS
+  // sign-up redirect chain, `front`'s onboarding) can attribute their
+  // completion back to the variant the visitor actually saw. Set on every
+  // homepage SSR, including control, so both arms are attributable.
+  cookiesToSet.push(
+    buildHeroVariantServerCookieString(heroVariant, context.req.headers.host)
+  );
+  if (cookiesToSet.length > 0) {
+    context.res.setHeader("Set-Cookie", cookiesToSet);
   }
 
   return {

--- a/marketing/vite.config.mjs
+++ b/marketing/vite.config.mjs
@@ -1,0 +1,20 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+// Standalone unit-test harness for the marketing workspace. Unlike `front`'s
+// config there is no globalSetup/DB — marketing tests are pure logic (cookie
+// scoping, experiment variant narrowing), so they run without external infra.
+export default defineConfig({
+  test: {
+    globals: true,
+    // jsdom provides `document`/`window` for the cookie readers.
+    environment: "jsdom",
+    passWithNoTests: true,
+    exclude: ["**/node_modules/**", "**/dist/**", "**/.next/**"],
+  },
+  resolve: {
+    alias: {
+      "@marketing": path.resolve(__dirname, "./"),
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1645,9 +1645,11 @@
         "@types/react-dom": "^18.3.5",
         "@types/uuid": "^9.0.1",
         "@typescript/native-preview": "^7.0.0-dev.20260224.1",
+        "jsdom": "^26.0.0",
         "next-sitemap": "^4.2.3",
         "postcss": "^8.5.6",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "vitest": "^4.0.16"
       },
       "engines": {
         "node": ">=24.16.0"
@@ -3547,9 +3549,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3567,9 +3566,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3587,9 +3583,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3607,9 +3600,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -9090,9 +9080,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9112,9 +9099,6 @@
       "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9136,9 +9120,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9159,9 +9140,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9181,9 +9159,6 @@
       "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -13570,9 +13545,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13590,9 +13562,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13610,9 +13579,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13630,9 +13596,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13650,9 +13613,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13670,9 +13630,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13690,9 +13647,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13710,9 +13664,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13803,7 +13754,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -13842,11 +13793,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -13862,11 +13815,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -13882,11 +13837,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -13902,11 +13859,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -13922,11 +13881,13 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -13942,11 +13903,13 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -13962,11 +13925,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -13982,11 +13947,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14002,11 +13969,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14022,11 +13991,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14042,11 +14013,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14062,11 +14035,13 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14082,11 +14057,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14099,14 +14076,14 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@parcel/watcher/node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -19746,9 +19723,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19766,9 +19740,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19786,9 +19757,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19806,9 +19774,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28521,9 +28486,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28541,9 +28503,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28561,9 +28520,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28581,9 +28537,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28601,9 +28554,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28621,9 +28571,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28641,9 +28588,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28661,9 +28605,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -29663,6 +29604,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "prr": "~1.0.1"
       },
@@ -34812,7 +34754,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -34854,7 +34796,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -36741,6 +36683,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -36755,6 +36698,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
@@ -36770,6 +36714,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -36784,6 +36729,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -36795,6 +36741,7 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -36806,6 +36753,7 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -36892,6 +36840,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -36913,6 +36862,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -36934,6 +36884,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -36955,6 +36906,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -36976,6 +36928,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -36997,6 +36950,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -37018,6 +36972,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -37039,6 +36994,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -37060,6 +37016,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -37081,6 +37038,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -37102,6 +37060,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -40798,6 +40757,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
@@ -44313,9 +44273,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44333,9 +44290,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44353,9 +44307,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44373,9 +44324,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44393,9 +44341,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44413,9 +44358,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44433,9 +44375,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44453,9 +44392,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -46742,7 +46678,8 @@
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",


### PR DESCRIPTION
# Experiment Control

<img width="2708" height="1864" alt="image" src="https://github.com/user-attachments/assets/7ececff4-892f-4f10-9d79-7f23840b4cd8" />

### Hypothesis: "Multiplayer AI" positioning is not resonating as a clear value prop
- "Multiplayer AI" is jargon, no one wakes up wanting this
- "Human-agent collaboration" defines a category, not a pain
- "Gets rewired" is vague, what actually changes?
- The illustration is too complex to read in 3 seconds 

### Feedback heard:
- "We already have agents, why Dust?"
- "Why can't Claude just do this?"

# Experiment Variant
<img width="2722" height="1870" alt="image" src="https://github.com/user-attachments/assets/b584d78b-d189-4987-a27e-4151969365bf" />

### Hypothesis: Teams convert when they see how AI makes them better, not what the product does
- Drop "multiplayer AI", it's a feature frame not a market frame
- People want to use AI if it makes them better, they need to see that outcome clearly
- Focus on how teams are getting value, not how the platform works

# Techical Notes

A/B test the homepage hero copy (and visual) via PostHog, with full conversion attribution across the `marketing` to `front` boundary.

**Two hero variants**, resolved from the PostHog multivariate flag `home-hero-experiment`:
- `control` — current "Multiplayer AI for human-agent collaboration" copy + animated office scene
- `collaboration` — new "The best teams aren't just using AI. They're running it." copy + Laurel customer-story video (replaces the office scene)

**No flash of control copy.** The variant is evaluated server-side in `getServerSideProps` and rendered into the initial HTML. The same value is bootstrapped into `posthog-js` at init, so the client agrees with the server and records the exposure synchronously (no `/decide` round-trip). Flag eval is bounded to 1s and falls back to control if PostHog is slow, down, or unconfigured.

**Consistent bucketing.** Server and client bucket against the same `_dust_aid` distinct id. On a visitor's first request the cookie doesn't exist yet, so we mint the id server-side and set it on the response before evaluating the flag.

**Conversion funnel per variant.** The served variant is stored in a shared `.dust.tt` cookie (`_dust_hv`, 30-day window). Both terminal conversions read it back and tag their events with `hero_variant`:
- Contact form submit (`submit_success`) in `marketing`
- Sign-up completion (`signup.completed`) in `front`, on the far side of the WorkOS redirect chain

**Dev preview:** `/?hero_variant=collaboration` forces a variant locally (never honored in production).

Also refactors the PostHog server client out of `track_pageview.ts` into a shared `posthog_server.ts` (single client + flush loop per process).

## Metrics tracked

All experiment metrics are keyed to the variant via the `hero_variant` property, and PostHog also ties them together at the person level through the shared `_dust_aid` identity.

**Exposure (denominator)**
- `$feature_flag_called` — PostHog built-in, fired once per session when the variant renders. Carries `$feature_flag = home-hero-experiment` and `$feature_flag_response = control | collaboration`.

**Engagement (hero CTA clicks, `marketing`)**
- `home:hero_book_demo_click` — primary "Request a demo" CTA, tagged with `{ hero_variant }`
- `home:hero_start_free_click` — secondary "Try for free" CTA, tagged with `{ hero_variant }`

**Conversions (goal metrics)**
- `contact:contact_form_submit_success` — demo request completed (`marketing`), tagged with `{ hero_variant }`
- `auth:signup_completed` — sign-up completed (`front`, after the WorkOS redirect chain), tagged with `{ hero_variant }`

Funnel per arm: **exposure > hero CTA click > conversion** (demo request or sign-up completion).

## Tests

- New `marketing` Vitest harness (pure-logic, no DB/infra; jsdom for the cookie readers) with `npm test` / `test:watch` added.
- Unit tests cover: variant narrowing (`toHeroVariant`/`isHeroVariantKey`), cookie build/parse + `.dust.tt` domain scoping, and the anonymous-id helpers on both `marketing` and `front` sides.
- Manual: verified SSR variant rendering, no copy flash, exposure event fires once, and `hero_variant` tagging on both contact-form and sign-up events (including the `/?hero_variant=` override).

## Risk

Low. Homepage-only, additive, and gated behind a PostHog flag.

- Flag eval failure/timeout renders control, so the homepage always renders.
- No schema or API changes. The new cookie is read-only attribution metadata.
- Safe to roll back: disabling the PostHog experiment returns everyone to control, and reverting the PR removes the cookie/flag wiring cleanly.

## Deploy Plan

1. Create the `home-hero-experiment` multivariate flag in PostHog (values: `control`, `collaboration`). Can ship at 0% rollout first.
2. Deploy `marketing` and `front` (order independent; `front` only reads the cookie).
3. Ramp the experiment in PostHog once both are live.