### PR TITLE
fix(skill_authoring): address list_skills pagination review comments

### DIFF
--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -48,13 +48,15 @@ export const SKILL_AUTHORING_TOOLS_METADATA = [
         .enum(["all", "writable", "agent_discoverable"])
         .optional()
         .describe(
-          "Scope of skills to return. `writable` (default): only skills the user can edit. `all`: every skill in the workspace. `agent_discoverable`: only skills the agent can invoke in this conversation."
+          "Scope of skills to return. `writable` (default): only skills the user can edit. `all`: every skill in the workspace. `agent_discoverable`: only workspace-default skills discoverable by agents (independent of conversation context)."
         ),
       cursor: z
-        .string()
+        .number()
+        .int()
+        .nonnegative()
         .optional()
         .describe(
-          "Pagination cursor from a previous call. Omit for the first page."
+          "Pagination offset from a previous call's nextCursor. Omit for the first page."
         ),
       limit: z
         .number()

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -364,16 +364,22 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
           : allSkills;
     }
 
+    skills = [...skills].sort((a, b) => a.sId.localeCompare(b.sId));
+
     const pageSize = Math.min(limit ?? 20, 50);
-    const offset = cursor
-      ? parseInt(Buffer.from(cursor, "base64").toString(), 10)
-      : 0;
+    const offset = cursor ?? 0;
+
+    if (offset > skills.length) {
+      return new Err(
+        new MCPError(
+          `cursor ${offset} is out of range (total: ${skills.length})`
+        )
+      );
+    }
+
     const page = skills.slice(offset, offset + pageSize);
     const nextOffset = offset + pageSize;
-    const nextCursor =
-      nextOffset < skills.length
-        ? Buffer.from(String(nextOffset)).toString("base64")
-        : null;
+    const nextCursor = nextOffset < skills.length ? nextOffset : null;
 
     const summaries = page.map((skill) => ({
       sId: skill.sId,

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -369,10 +369,11 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
     const pageSize = Math.min(limit ?? 20, 50);
     const offset = cursor ?? 0;
 
-    if (offset > skills.length) {
+    if (offset >= skills.length && offset > 0) {
       return new Err(
         new MCPError(
-          `cursor ${offset} is out of range (total: ${skills.length})`
+          `cursor ${offset} is out of range (total: ${skills.length})`,
+          { tracked: false }
         )
       );
     }


### PR DESCRIPTION
## Summary

- **Stable ordering**: skills are now sorted by `sId` before slicing, so pagination is consistent regardless of DB return order
- **cursor as integer**: dropped the opaque base64 string in favour of a plain `z.number().int().nonnegative()` offset — schema enforces validity, simpler for the agent to reason about, and out-of-bounds cursor returns a tool error so the agent self-corrects
- **`agent_discoverable` description**: clarified that this filter returns workspace-default discoverable skills regardless of conversation context — this is the intended behavior, the description was just misleading

## Testing
Local validation

## Risk
Fixing existing issue

## Deploy
1. Deploy front