### PR TITLE
feat(activation): add origin column to ActivationRecommendationModel

### DIFF
--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -30,6 +30,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         content,
         rationale,
         conversationId,
+        origin: "user",
       });
 
       return new Ok([

--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -16,12 +16,17 @@ export type ActivationRecommendationStatus =
   | "executed"
   | "dismissed";
 
+// "user": recommendation surfaced organically in a user's conversation
+// "system": recommendation proactively generated and delivered by the orchestrator
+export type ActivationRecommendationOrigin = "user" | "system";
+
 export class ActivationRecommendationModel extends WorkspaceAwareModel<ActivationRecommendationModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare userId: ForeignKey<UserModel["id"]>;
   declare status: ActivationRecommendationStatus;
+  declare origin: ActivationRecommendationOrigin;
   declare content: string;
   declare rationale: string;
 
@@ -50,6 +55,10 @@ ActivationRecommendationModel.init(
       allowNull: false,
     },
     status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    origin: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -96,6 +105,10 @@ ActivationRecommendationModel.init(
       },
       {
         fields: ["createdTriggerId"],
+        concurrently: true,
+      },
+      {
+        fields: ["workspaceId", "userId", "origin", "createdAt"],
         concurrently: true,
       },
     ],

--- a/front/lib/resources/activation_recommendation_resource.test.ts
+++ b/front/lib/resources/activation_recommendation_resource.test.ts
@@ -5,23 +5,38 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { describe, expect, it } from "vitest";
 
-const makeRec = (auth: Authenticator) =>
+const makeRec = (
+  auth: Authenticator,
+  overrides: { origin?: "user" | "system" } = {}
+) =>
   ActivationRecommendationResource.makeNew(auth, {
     content: "Try the Slack integration",
     rationale: "User has Slack but no Slack skill",
     conversationId: null,
+    origin: overrides.origin ?? "user",
   });
 
 describe("ActivationRecommendationResource", () => {
   describe("makeNew", () => {
-    it("creates a recommendation with status 'suggested'", async () => {
+    it("creates a conversation recommendation with status 'suggested'", async () => {
       const { authenticator } = await createResourceTest({ role: "user" });
 
       const rec = await makeRec(authenticator);
 
       expect(rec.status).toBe("suggested");
+      expect(rec.origin).toBe("user");
       expect(rec.content).toBe("Try the Slack integration");
       expect(rec.rationale).toBe("User has Slack but no Slack skill");
+      expect(rec.sId).toBeTruthy();
+    });
+
+    it("creates a system recommendation with status 'suggested'", async () => {
+      const { authenticator } = await createResourceTest({ role: "user" });
+
+      const rec = await makeRec(authenticator, { origin: "system" });
+
+      expect(rec.status).toBe("suggested");
+      expect(rec.origin).toBe("system");
       expect(rec.sId).toBeTruthy();
     });
   });
@@ -100,6 +115,60 @@ describe("ActivationRecommendationResource", () => {
         await ActivationRecommendationResource.fetchByUser(authenticator);
 
       expect(recs).toHaveLength(0);
+    });
+  });
+
+  describe("fetchLatestSystemRecommendationForUser", () => {
+    it("returns null when no system recommendations exist", async () => {
+      const { authenticator } = await createResourceTest({ role: "user" });
+      await makeRec(authenticator, { origin: "user" });
+
+      const result =
+        await ActivationRecommendationResource.fetchLatestSystemRecommendationForUser(
+          authenticator
+        );
+
+      expect(result).toBeNull();
+    });
+
+    it("returns the most recent system recommendation", async () => {
+      const { authenticator } = await createResourceTest({ role: "user" });
+      const first = await makeRec(authenticator, { origin: "system" });
+      const second = await makeRec(authenticator, { origin: "system" });
+
+      const result =
+        await ActivationRecommendationResource.fetchLatestSystemRecommendationForUser(
+          authenticator
+        );
+
+      expect(result).not.toBeNull();
+      expect(result!.sId).toBe(second.sId);
+      expect(result!.origin).toBe("system");
+      // first was created earlier, second is the latest
+      expect(result!.sId).not.toBe(first.sId);
+    });
+
+    it("does not return system recommendations from another user", async () => {
+      const { workspace, authenticator } = await createResourceTest({
+        role: "user",
+      });
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, {
+        role: "user",
+      });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      await makeRec(otherAuth, { origin: "system" });
+
+      const result =
+        await ActivationRecommendationResource.fetchLatestSystemRecommendationForUser(
+          authenticator
+        );
+
+      expect(result).toBeNull();
     });
   });
 

--- a/front/lib/resources/activation_recommendation_resource.ts
+++ b/front/lib/resources/activation_recommendation_resource.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
   ActivationRecommendationModel,
+  type ActivationRecommendationOrigin,
   type ActivationRecommendationStatus,
 } from "@app/lib/models/activation/activation_recommendation";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -53,7 +54,7 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
     blob: Pick<
       CreationAttributes<ActivationRecommendationModel>,
       "content" | "rationale" | "conversationId"
-    >
+    > & { origin: ActivationRecommendationOrigin }
   ): Promise<ActivationRecommendationResource> {
     const workspace = auth.getNonNullableWorkspace();
     const user = auth.getNonNullableUser();
@@ -62,6 +63,7 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
       workspaceId: workspace.id,
       userId: user.id,
       status: "suggested",
+      origin: blob.origin,
       content: blob.content,
       rationale: blob.rationale,
       conversationId: blob.conversationId ?? null,
@@ -108,6 +110,22 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
     });
 
     return recs.map((rec) => new this(this.model, rec.get()));
+  }
+
+  static async fetchLatestSystemRecommendationForUser(
+    auth: Authenticator
+  ): Promise<ActivationRecommendationResource | null> {
+    const user = auth.getNonNullableUser();
+    const rec = await this.model.findOne({
+      where: {
+        userId: user.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        origin: "system" satisfies ActivationRecommendationOrigin,
+      },
+      order: [["createdAt", "DESC"]],
+    });
+
+    return rec ? new this(this.model, rec.get()) : null;
   }
 
   async updateFields(fields: {

--- a/front/migrations/pre-deploy/20260709000000_add_origin_to_activation_recommendations.sql
+++ b/front/migrations/pre-deploy/20260709000000_add_origin_to_activation_recommendations.sql
@@ -1,0 +1,28 @@
+/*
+Add origin column to activation_recommendations.
+Backfill all existing rows as "conversation" (the only origin that existed before),
+then drop the default so the application must set it explicitly.
+
+Statement 0 — add column with temporary default for the backfill
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations"
+  ADD COLUMN "origin" character varying(255) NOT NULL DEFAULT 'user';
+
+/*
+Statement 1 — drop the default; all new rows must supply origin explicitly
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations"
+  ALTER COLUMN "origin" DROP DEFAULT;
+
+/*
+Statement 2 — composite index supporting the frequency-cap query:
+  latest system recommendation per (workspace, user)
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "activation_recommendations_workspace_user_origin_created"
+  ON public.activation_recommendations USING btree ("workspaceId", "userId", "origin", "createdAt");


### PR DESCRIPTION
## Summary

- Adds `ActivationRecommendationOrigin = "user" | "system"` type
- `"user"`: recommendation surfaced organically in a user's conversation (existing behavior)
- `"system"`: recommendation proactively generated and delivered by the orchestrator
- Migration adds the column with a backfill of `"user"` for all existing rows, then drops the default so the application must always set it explicitly
- Adds composite index on `(workspaceId, userId, origin, createdAt)` for the frequency-cap query (latest system nudge per user)
- `makeNew` now requires `origin`; the one existing caller (activation_recommendations MCP server) sets `origin: "user"`
- Adds `fetchLatestSystemRecommendationForUser` — returns the most recent `origin = "system"` row for the calling user, used by the orchestrator frequency cap

No other schema changes. A system row is created in the same transaction as its nudge conversation, so row existence = sent, `createdAt` = send time, and the existing `conversationId` is the nudge conversation.

## Test plan

- [x] 14/14 tests pass (`activation_recommendation_resource.test.ts`)
- [x] Type-check clean on changed files
- [x] Lint clean