### PR TITLE
Publish a terminal error event on sandbox function invocation failure

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -12174,6 +12174,9 @@
           },
           {
             "$ref": "#/components/schemas/PrivateSandboxFunctionInvocationResultEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateSandboxFunctionInvocationErrorEvent"
           }
         ]
       },
@@ -12250,6 +12253,37 @@
           },
           "result": {
             "description": "Result returned by the sandbox function."
+          }
+        }
+      },
+      "PrivateSandboxFunctionInvocationErrorEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "invocationId",
+          "functionId",
+          "message"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "sandbox_function_invocation_error"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "invocationId": {
+            "type": "string"
+          },
+          "functionId": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Why the invocation failed before producing a result."
           }
         }
       },

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1406,6 +1406,7 @@
  *       oneOf:
  *         - $ref: '#/components/schemas/PrivateSandboxFunctionInvocationCreatedEvent'
  *         - $ref: '#/components/schemas/PrivateSandboxFunctionInvocationResultEvent'
+ *         - $ref: '#/components/schemas/PrivateSandboxFunctionInvocationErrorEvent'
  *     PrivateSandboxFunctionInvocationCreatedEvent:
  *       type: object
  *       required: [type, created, invocation]
@@ -1444,6 +1445,22 @@
  *           type: string
  *         result:
  *           description: Result returned by the sandbox function.
+ *     PrivateSandboxFunctionInvocationErrorEvent:
+ *       type: object
+ *       required: [type, created, invocationId, functionId, message]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [sandbox_function_invocation_error]
+ *         created:
+ *           type: integer
+ *         invocationId:
+ *           type: string
+ *         functionId:
+ *           type: string
+ *         message:
+ *           type: string
+ *           description: Why the invocation failed before producing a result.
  *     PrivateAgentMessageEvent:
  *       type: object
  *       description: Server-Sent Event for agent message streaming. Discriminated on the `type` field. Each event also includes a `step` integer.

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -160,6 +160,9 @@ async function waitForSandboxFunctionInvocationResult({
           case "sandbox_function_invocation_result":
             finish({ result: eventPayload.data.result });
             break;
+          case "sandbox_function_invocation_error":
+            finish({ result: null, error: eventPayload.data.message });
+            break;
           case "tool_approve_execution":
             // TODO(SANDBOX_FUNCTIONS): surface a tool approval flow to the user and post the
             // validation back; not emitted by the tool execution activity yet.

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -68,6 +68,11 @@ export async function callSandboxFunction(
     lastEventId: null,
     signal: AbortSignal.timeout(CALL_RESULT_WAIT_TIMEOUT_MS),
   })) {
+    // Terminal error published when the invocation failed before producing a result.
+    if (data.type === "sandbox_function_invocation_error") {
+      return new Err(new Error(data.message));
+    }
+
     if (data.type !== "sandbox_function_invocation_result") {
       continue;
     }

--- a/front/lib/api/sandbox_functions/events.ts
+++ b/front/lib/api/sandbox_functions/events.ts
@@ -3,6 +3,7 @@ import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import { createCallbackReader } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import type { SandboxFunctionInvocationEvent } from "@app/types/api/sandbox_functions";
+import { isSandboxFunctionInvocationTerminalEvent } from "@app/types/api/sandbox_functions";
 
 const SANDBOX_FUNCTION_INVOCATION_EVENTS_ORIGIN =
   "sandbox_function_invocation_events" as const;
@@ -58,7 +59,7 @@ export async function* getSandboxFunctionInvocationEvents({
     for (const rawEvent of history) {
       const event = parseSandboxFunctionInvocationEvent(rawEvent);
       yield event;
-      if (event.data.type === "sandbox_function_invocation_result") {
+      if (isSandboxFunctionInvocationTerminalEvent(event.data)) {
         return;
       }
     }
@@ -83,7 +84,7 @@ export async function* getSandboxFunctionInvocationEvents({
 
       const event = parseSandboxFunctionInvocationEvent(rawEvent);
       yield event;
-      if (event.data.type === "sandbox_function_invocation_result") {
+      if (isSandboxFunctionInvocationTerminalEvent(event.data)) {
         break;
       }
     }

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -9,6 +9,7 @@ import {
 } from "@app/lib/api/sandbox/access_tokens";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
+import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -379,6 +380,41 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     auth: Authenticator,
     body: PostSandboxFunctionInvocationRequestBody
   ): Promise<Result<SandboxFunctionInvocationType, Error>> {
+    let invocation: SandboxFunctionInvocationResource | null = null;
+
+    // Once the invocation exists, listeners may be waiting on its event channel for a terminal
+    // event: publish the error so they settle instead of waiting forever, then propagate it.
+    const failInvocation = async (
+      error: Error
+    ): Promise<Result<SandboxFunctionInvocationType, Error>> => {
+      if (invocation) {
+        try {
+          await publishSandboxFunctionInvocationEvent(
+            {
+              type: "sandbox_function_invocation_error",
+              created: Date.now(),
+              invocationId: invocation.sId,
+              functionId: this.sId,
+              message: error.message,
+            },
+            { invocationId: invocation.sId }
+          );
+        } catch (publishError) {
+          // Best effort: the error is still propagated to the caller through the Err below.
+          logger.error(
+            {
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              sandboxFunctionId: this.sId,
+              invocationId: invocation.sId,
+              error: normalizeError(publishError),
+            },
+            "Failed to publish sandbox function invocation error event"
+          );
+        }
+      }
+      return new Err(error);
+    };
+
     try {
       if (!this.space.canReadOrAdministrate(auth)) {
         return new Err(new Error("Sandbox function space is not accessible."));
@@ -389,7 +425,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         return ensureResult;
       }
 
-      const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
+      invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
         sandboxFunction: this,
       });
       await ensureResult.value.sandbox.updateLastActivityAt();
@@ -433,7 +469,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         user: "agent-proxied",
       });
       if (execResult.isErr()) {
-        return execResult;
+        return failInvocation(execResult.error);
       }
       if (execResult.value.exitCode !== 0) {
         const { exitCode, stdout, stderr } = execResult.value;
@@ -456,7 +492,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
           stderr || stdout,
           SANDBOX_FUNCTION_ERROR_DETAIL_MAX_CHARS
         ).trim();
-        return new Err(
+        return failInvocation(
           new Error(
             `Sandbox function invocation failed with exit code ${exitCode}${
               detail ? `:\n${detail}` : "."
@@ -475,7 +511,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         createdAt: invocation.createdAt.toISOString(),
       });
     } catch (error) {
-      return new Err(normalizeError(error));
+      return failInvocation(normalizeError(error));
     }
   }
 

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -46,10 +46,31 @@ export type SandboxFunctionInvocationResultEvent = {
   result: unknown;
 };
 
+// Published when the invocation failed before producing a result, so listeners settle instead of
+// waiting forever.
+export type SandboxFunctionInvocationErrorEvent = {
+  type: "sandbox_function_invocation_error";
+  created: number;
+  invocationId: string;
+  functionId: string;
+  message: string;
+};
+
 export type SandboxFunctionInvocationEvent =
   | SandboxFunctionInvocationCreatedEvent
   | SandboxFunctionInvocationResultEvent
+  | SandboxFunctionInvocationErrorEvent
   | SandboxFunctionMCPApproveExecutionEvent;
+
+// The events that end an invocation stream: no further event is published after them.
+export function isSandboxFunctionInvocationTerminalEvent(
+  event: SandboxFunctionInvocationEvent
+): boolean {
+  return (
+    event.type === "sandbox_function_invocation_result" ||
+    event.type === "sandbox_function_invocation_error"
+  );
+}
 
 export type PostSandboxFunctionInvocationRequestBody = {
   input?: unknown;


### PR DESCRIPTION
## Description

Establishes the terminal-signal guarantee on the invocation event channel, mirroring the agent loop's `agent_error` / `tool_error` pattern:

- New `sandbox_function_invocation_error` event in the `SandboxFunctionInvocationEvent` union.
- `invoke()` publishes it on every failure path once the invocation exists (exec error, non-zero exit code, unexpected throw) — previously those paths returned an `Err` to the caller without publishing anything, leaving channel listeners waiting forever.
- Shared `isSandboxFunctionInvocationTerminalEvent` guard; the stream generator treats result and error events as terminal (history replay and live loop).
- `callSandboxFunction` surfaces the error event as `Err`; the viz wrapper client change is minimal (one switch case settling the pending call with the error).
- Swagger schema for the new event.

## Tests

`call_sandbox_function.test.ts` passes.

## Risk

Low. Feature-flagged `sandbox_functions`; error paths previously left listeners to time out client-side, they now settle immediately with the error.

## Deploy Plan

- deploy `front`
- deploy `front-sse`
