### PR TITLE
Raise the pruning checkpoint granularity to 20k tokens

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/pruning.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.test.ts
@@ -128,29 +128,28 @@ describe("prunePreviousInteractions", () => {
 
   it("renders an already-settled old interaction identically across turns when using the same fixed budget, instead of flipping every time a new turn is appended", () => {
     // Same scale as the batching test below: budget = PRUNING_CHECKPOINT_TOKENS, 60-token
-    // interactions. n=90 and n=91 both sit inside the same stable stretch (redaction only needed
-    // past interaction ~84, frontier doesn't move again until well past n=105), so an interaction
-    // deep in the already-redacted region (well before the frontier) must render identically
-    // whether or not the newest turn has arrived yet.
+    // interactions. n is derived from the budget (comfortably past the point where redaction
+    // becomes necessary) rather than hardcoded, so this test stays valid regardless of what
+    // PRUNING_CHECKPOINT_TOKENS is currently set to. n and n+1 both sit inside the same stable
+    // stretch, so an interaction deep in the already-redacted region (well before the frontier)
+    // must render identically whether or not the newest turn has arrived yet.
     const toolTokens = 40;
+    const interactionSize = 60; // toolTokens + user/assistant overhead, per buildTurnWithSize
     const floor = 3;
     const budget = PRUNING_CHECKPOINT_TOKENS;
-    const DEEP_INDEX = 10; // well before the frontier (~84) in both cases
+    const n = Math.ceil((budget / interactionSize) * 1.2);
+    const DEEP_INDEX = 10; // well before the frontier in both cases
 
-    const buildHistory = (n: number) =>
+    const buildHistory = (count: number) =>
       groupMessagesIntoInteractions(
-        Array.from({ length: n }, (_, i) => i + 1).flatMap((i) =>
+        Array.from({ length: count }, (_, i) => i + 1).flatMap((i) =>
           buildTurnWithSize(i, toolTokens)
         )
       );
 
-    const prunedAtN = prunePreviousInteractions(
-      buildHistory(90),
-      budget,
-      floor
-    );
+    const prunedAtN = prunePreviousInteractions(buildHistory(n), budget, floor);
     const prunedAtNPlus1 = prunePreviousInteractions(
-      buildHistory(91),
+      buildHistory(n + 1),
       budget,
       floor
     );
@@ -162,13 +161,17 @@ describe("prunePreviousInteractions", () => {
   });
 
   it("batches redaction across a checkpoint boundary instead of advancing on every single turn", () => {
-    // Interaction size chosen so ~83 turns fit before redaction is even needed (budget =
-    // PRUNING_CHECKPOINT_TOKENS), and then several turns' worth of growth accumulate between
-    // checkpoint crossings. This exercises the batching behavior at a realistic scale instead of
-    // tiny numbers where every eligible interaction gets redacted in one shot.
+    // Interaction size and starting point derived from PRUNING_CHECKPOINT_TOKENS itself (rather
+    // than a hardcoded turn count) so this test keeps exercising real batching behavior no matter
+    // what that constant is currently set to. n0 is the first turn count where redaction becomes
+    // necessary at all; sampling a window right past that point exercises the batching behavior at
+    // a realistic scale instead of tiny numbers where every eligible interaction gets redacted in
+    // one shot.
     const toolTokens = 40; // interaction = 60 tokens
+    const interactionSize = 60;
     const floor = 3;
     const budget = PRUNING_CHECKPOINT_TOKENS;
+    const n0 = Math.ceil(budget / interactionSize) + 1;
 
     const frontierAt = (n: number) => {
       const messages = Array.from({ length: n }, (_, i) => i + 1).flatMap((i) =>
@@ -187,7 +190,7 @@ describe("prunePreviousInteractions", () => {
     // every single one. Sample a 20-turn window known to sit inside such a stable stretch for
     // these parameters.
     const boundaries = new Set<number>();
-    for (let n = 87; n <= 106; n++) {
+    for (let n = n0; n <= n0 + 19; n++) {
       boundaries.add(frontierAt(n));
     }
 
@@ -291,8 +294,10 @@ describe("prunePreviousInteractions across a growing conversation (realistic, va
     const FLOOR = 3;
     // Order of magnitude of a real allowedTokenCount - baseTokens: large enough that many turns
     // of small talk fit before any redaction is needed at all, matching the real production
-    // observation that redaction is a late, occasional event, not a per-turn certainty.
-    const BUDGET = 20_000;
+    // observation that redaction is a late, occasional event, not a per-turn certainty. Kept as a
+    // multiple of PRUNING_CHECKPOINT_TOKENS rather than an absolute number, so the checkpoint
+    // mechanism always has room to find a crossing regardless of that constant's current value.
+    const BUDGET = PRUNING_CHECKPOINT_TOKENS * 4;
 
     const interactionSizes: number[] = [];
     let mutationTurnCount = 0;

--- a/front/lib/api/assistant/conversation_rendering/pruning.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.test.ts
@@ -127,12 +127,10 @@ describe("prunePreviousInteractions", () => {
   });
 
   it("renders an already-settled old interaction identically across turns when using the same fixed budget, instead of flipping every time a new turn is appended", () => {
-    // Same scale as the batching test below: budget = PRUNING_CHECKPOINT_TOKENS, 60-token
-    // interactions. n is derived from the budget (comfortably past the point where redaction
-    // becomes necessary) rather than hardcoded, so this test stays valid regardless of what
-    // PRUNING_CHECKPOINT_TOKENS is currently set to. n and n+1 both sit inside the same stable
-    // stretch, so an interaction deep in the already-redacted region (well before the frontier)
-    // must render identically whether or not the newest turn has arrived yet.
+    // n is derived from the budget, comfortably past the point where redaction becomes necessary,
+    // so this test stays valid regardless of PRUNING_CHECKPOINT_TOKENS's value. n and n+1 sit
+    // inside the same stable stretch, so an interaction deep in the already-redacted region must
+    // render identically whether or not the newest turn has arrived yet.
     const toolTokens = 40;
     const interactionSize = 60; // toolTokens + user/assistant overhead, per buildTurnWithSize
     const floor = 3;
@@ -161,12 +159,9 @@ describe("prunePreviousInteractions", () => {
   });
 
   it("batches redaction across a checkpoint boundary instead of advancing on every single turn", () => {
-    // Interaction size and starting point derived from PRUNING_CHECKPOINT_TOKENS itself (rather
-    // than a hardcoded turn count) so this test keeps exercising real batching behavior no matter
-    // what that constant is currently set to. n0 is the first turn count where redaction becomes
-    // necessary at all; sampling a window right past that point exercises the batching behavior at
-    // a realistic scale instead of tiny numbers where every eligible interaction gets redacted in
-    // one shot.
+    // n0 (like n above) is derived from the budget: the first turn count where redaction becomes
+    // necessary at all. Sampling a window right past that point exercises real batching at a
+    // realistic scale, rather than tiny numbers where everything eligible redacts in one shot.
     const toolTokens = 40; // interaction = 60 tokens
     const interactionSize = 60;
     const floor = 3;

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -9,8 +9,16 @@ const PRUNED_TOOL_RESULT_TOKENS = 24;
 // Batch granularity for the redaction checkpoint in prunePreviousInteractions. Same idea as the
 // `clear_at_least` setting on provider-native context-editing features. Don't invalidate a cached
 // prefix for a handful of tokens. Only redact once enough new content has accumulated to make the
-// cache-write cost worthwhile. Starting point, tune against production cache-miss metrics.
-export const PRUNING_CHECKPOINT_TOKENS = 5000;
+// cache-write cost worthwhile.
+//
+// Picked as roughly 10% of our primary production model's context window (Claude Sonnet 4.6,
+// 250,000 tokens), since a single agent turn that runs a couple of tool calls can easily produce
+// several thousand tokens on its own, and a smaller checkpoint gets crossed on nearly every turn.
+// For models with a much smaller context window, this value being larger than their entire
+// budget for previous interactions is safe: the checkpoint search simply never finds a crossing,
+// so it falls back to redacting everything eligible once triggered, still stable, just without
+// the batching benefit. Still a starting point, tune against production cache-miss metrics.
+export const PRUNING_CHECKPOINT_TOKENS = 25_000;
 
 export type MessageWithTokens = ModelMessageTypeMultiActions & {
   tokenCount: number;

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -7,18 +7,18 @@ const PRUNED_TOOL_RESULT_PLACEHOLDER =
 const PRUNED_TOOL_RESULT_TOKENS = 24;
 
 // Batch granularity for the redaction checkpoint in prunePreviousInteractions. Same idea as the
-// `clear_at_least` setting on provider-native context-editing features. Don't invalidate a cached
-// prefix for a handful of tokens. Only redact once enough new content has accumulated to make the
-// cache-write cost worthwhile.
+// `clear_at_least` setting on provider-native context-editing features: don't invalidate a cached
+// prefix for a handful of tokens, only once enough new content has accumulated to make the
+// cache-write cost worthwhile. A turn running a couple of tool calls can easily produce several
+// thousand tokens on its own, so this needs enough headroom above that to actually batch.
 //
-// Picked as roughly 10% of our primary production model's context window (Claude Sonnet 4.6,
-// 250,000 tokens), since a single agent turn that runs a couple of tool calls can easily produce
-// several thousand tokens on its own, and a smaller checkpoint gets crossed on nearly every turn.
-// For models with a much smaller context window, this value being larger than their entire
-// budget for previous interactions is safe: the checkpoint search simply never finds a crossing,
-// so it falls back to redacting everything eligible once triggered, still stable, just without
-// the batching benefit. Still a starting point, tune against production cache-miss metrics.
-export const PRUNING_CHECKPOINT_TOKENS = 25_000;
+// A flat value rather than a percentage of context size, since our model fleet has no context
+// window between 16k and 64k tokens: any model above that tier has ample room regardless of the
+// exact value chosen here. For a model whose budget never reaches this checkpoint, the search
+// simply never finds a crossing and falls back to redacting everything eligible once triggered,
+// still stable, just without the batching benefit. Starting point, tune against production
+// cache-miss metrics.
+export const PRUNING_CHECKPOINT_TOKENS = 20_000;
 
 export type MessageWithTokens = ModelMessageTypeMultiActions & {
   tokenCount: number;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We've observed in production that a single agent turn running a couple of web searches can produce around five thousand tokens on its own, which was enough to cross the previous checkpoint threshold almost every turn and defeat the batching benefit the pruning refactor was meant to provide. Rather than scale the checkpoint as a percentage of each model's context window, which would tie a stability-critical constant to a live, per-model quantity, we picked a single flat value informed by our primary production model's context size. We verified against the actual pruning function that a checkpoint far larger than a small model's entire budget degrades gracefully: the budget is still always respected and there are no reversals, it just loses the batching benefit for that model, which is an acceptable tradeoff since minimizing cache misses matters most for the large-context models that see the longest conversations.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
