### PR TITLE
Complete model tier resource and resolution policy.

### DIFF
--- a/front/lib/api/assistant/token_pricing/tiers.ts
+++ b/front/lib/api/assistant/token_pricing/tiers.ts
@@ -77,22 +77,22 @@ export const STATIC_MODEL_TIERS: StaticModelTiersLookup = {
     none: "cost_efficient",
   },
   "gpt-4-turbo": {
-    none: "balanced",
+    none: "cost_efficient",
   },
   "gpt-4o": {
-    none: "balanced",
+    none: "cost_efficient",
   },
   "gpt-4.1-2025-04-14": {
-    none: "balanced",
+    none: "cost_efficient",
   },
   "gpt-4.1-mini-2025-04-14": {
-    none: "balanced",
+    none: "cost_efficient",
   },
   "gpt-4o-2024-08-06": {
-    none: "balanced",
+    none: "cost_efficient",
   },
   "gpt-4o-mini": {
-    none: "balanced",
+    none: "cost_efficient",
   },
   "gpt-5.1": {
     none: "balanced",
@@ -109,8 +109,8 @@ export const STATIC_MODEL_TIERS: StaticModelTiersLookup = {
   "gpt-5.4-mini": {
     none: "cost_efficient",
     light: "cost_efficient",
-    medium: "balanced",
-    high: "balanced",
+    medium: "cost_efficient",
+    high: "cost_efficient",
   },
   "gpt-5.4": {
     none: "balanced",
@@ -145,7 +145,7 @@ export const STATIC_MODEL_TIERS: StaticModelTiersLookup = {
   "gpt-5.4-nano": {
     none: "cost_efficient",
     light: "cost_efficient",
-    medium: "balanced",
+    medium: "cost_efficient",
     high: "cost_efficient",
   },
   "gpt-5": {
@@ -155,13 +155,13 @@ export const STATIC_MODEL_TIERS: StaticModelTiersLookup = {
   },
   "gpt-5-mini": {
     light: "cost_efficient",
-    medium: "balanced",
-    high: "balanced",
+    medium: "cost_efficient",
+    high: "cost_efficient",
   },
   "gpt-5-nano": {
     light: "cost_efficient",
-    medium: "balanced",
-    high: "balanced",
+    medium: "cost_efficient",
+    high: "cost_efficient",
   },
   o1: {
     none: "balanced",
@@ -251,8 +251,8 @@ export const STATIC_MODEL_TIERS: StaticModelTiersLookup = {
   },
   "claude-haiku-4-5-20251001": {
     light: "cost_efficient",
-    medium: "balanced",
-    high: "balanced",
+    medium: "cost_efficient",
+    high: "cost_efficient",
   },
   "mistral-large-latest": {
     none: "balanced",

--- a/front/lib/model_tiers/group_kinds.test.ts
+++ b/front/lib/model_tiers/group_kinds.test.ts
@@ -1,0 +1,18 @@
+import {
+  isModelTierOverrideGroupKind,
+  MODEL_TIER_OVERRIDE_GROUP_KINDS,
+} from "@app/lib/model_tiers/group_kinds";
+import { describe, expect, it } from "vitest";
+
+describe("model tier override group kinds", () => {
+  it("only allows regular_auto and provisioned groups to carry overrides", () => {
+    expect(MODEL_TIER_OVERRIDE_GROUP_KINDS).toEqual([
+      "regular_auto",
+      "provisioned",
+    ]);
+    expect(isModelTierOverrideGroupKind("regular_auto")).toBe(true);
+    expect(isModelTierOverrideGroupKind("provisioned")).toBe(true);
+    expect(isModelTierOverrideGroupKind("global")).toBe(false);
+    expect(isModelTierOverrideGroupKind("system")).toBe(false);
+  });
+});

--- a/front/lib/model_tiers/group_kinds.ts
+++ b/front/lib/model_tiers/group_kinds.ts
@@ -1,0 +1,18 @@
+import type { GroupKind } from "@app/types/groups";
+
+// Groups that can carry a model-tier override grant via setGroupMaxAllowedTier.
+export const MODEL_TIER_OVERRIDE_GROUP_KINDS = [
+  "regular_auto",
+  "provisioned",
+] as const satisfies readonly GroupKind[];
+
+export type ModelTierOverrideGroupKind =
+  (typeof MODEL_TIER_OVERRIDE_GROUP_KINDS)[number];
+
+export function isModelTierOverrideGroupKind(
+  kind: GroupKind
+): kind is ModelTierOverrideGroupKind {
+  return MODEL_TIER_OVERRIDE_GROUP_KINDS.some(
+    (allowedKind) => allowedKind === kind
+  );
+}

--- a/front/lib/model_tiers/resolve_allowed.test.ts
+++ b/front/lib/model_tiers/resolve_allowed.test.ts
@@ -1,0 +1,52 @@
+import { resolveAllowedModelTiers } from "@app/lib/model_tiers/resolve_allowed";
+import { describe, expect, it } from "vitest";
+
+describe("resolveAllowedModelTiers", () => {
+  it("uses workspace tiers when no overrides exist", () => {
+    const result = resolveAllowedModelTiers({
+      workspaceAllowedTierNames: ["cost_efficient", "balanced"],
+      groupAllowedTierNamesList: [[], []],
+      userAllowedTierNames: [],
+    });
+
+    expect(result.tiers).toEqual(["cost_efficient", "balanced"]);
+    expect(result.source).toBe("workspace");
+  });
+
+  it("uses the max group tier across groups, overriding workspace", () => {
+    const result = resolveAllowedModelTiers({
+      workspaceAllowedTierNames: ["cost_efficient"],
+      groupAllowedTierNamesList: [
+        ["cost_efficient", "balanced"],
+        ["cost_efficient", "balanced", "premium"],
+      ],
+      userAllowedTierNames: [],
+    });
+
+    expect(result.tiers).toEqual(["cost_efficient", "balanced", "premium"]);
+    expect(result.source).toBe("groups");
+  });
+
+  it("uses user tier override over groups and workspace", () => {
+    const result = resolveAllowedModelTiers({
+      workspaceAllowedTierNames: ["cost_efficient", "balanced", "premium"],
+      groupAllowedTierNamesList: [["cost_efficient", "balanced", "premium"]],
+      userAllowedTierNames: ["cost_efficient"],
+    });
+
+    expect(result.tiers).toEqual(["cost_efficient"]);
+    expect(result.source).toBe("user");
+  });
+
+  it("treats workspace grants on the global group as workspace, not groups", () => {
+    const result = resolveAllowedModelTiers({
+      workspaceAllowedTierNames: ["cost_efficient", "balanced"],
+      // Callers must exclude global-group grants from the group override layer.
+      groupAllowedTierNamesList: [[]],
+      userAllowedTierNames: [],
+    });
+
+    expect(result.tiers).toEqual(["cost_efficient", "balanced"]);
+    expect(result.source).toBe("workspace");
+  });
+});

--- a/front/lib/model_tiers/resolve_allowed.ts
+++ b/front/lib/model_tiers/resolve_allowed.ts
@@ -1,0 +1,50 @@
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import {
+  expandTiersUpTo,
+  getMaxTierName,
+} from "@app/lib/model_tiers/tier_order";
+
+export type ModelTierResolutionSource = "workspace" | "groups" | "user";
+
+export type ResolvedAllowedModelTiers = {
+  tiers: ModelsTierName[];
+  source: ModelTierResolutionSource;
+};
+
+export function resolveAllowedModelTiers({
+  workspaceAllowedTierNames,
+  groupAllowedTierNamesList,
+  userAllowedTierNames,
+}: {
+  workspaceAllowedTierNames: ModelsTierName[];
+  groupAllowedTierNamesList: ModelsTierName[][];
+  userAllowedTierNames: ModelsTierName[];
+}): ResolvedAllowedModelTiers {
+  let maxTierName: ModelsTierName | null = null;
+  let source: ModelTierResolutionSource;
+
+  if (userAllowedTierNames.length > 0) {
+    maxTierName = getMaxTierName(userAllowedTierNames);
+    source = "user";
+  } else {
+    const groupMaxTierNames = groupAllowedTierNamesList.flatMap(
+      (groupTiers) => {
+        const groupMaxTierName = getMaxTierName(groupTiers);
+        return groupMaxTierName ? [groupMaxTierName] : [];
+      }
+    );
+
+    if (groupMaxTierNames.length > 0) {
+      maxTierName = getMaxTierName(groupMaxTierNames);
+      source = "groups";
+    } else {
+      maxTierName = getMaxTierName(workspaceAllowedTierNames);
+      source = "workspace";
+    }
+  }
+
+  return {
+    tiers: maxTierName ? expandTiersUpTo(maxTierName) : [],
+    source,
+  };
+}

--- a/front/lib/model_tiers/tier_order.test.ts
+++ b/front/lib/model_tiers/tier_order.test.ts
@@ -1,0 +1,29 @@
+import {
+  expandTiersUpTo,
+  getMaxTierName,
+  isTierWithinMax,
+} from "@app/lib/model_tiers/tier_order";
+import { describe, expect, it } from "vitest";
+
+describe("tier_order", () => {
+  it("expands tiers up to the selected ceiling", () => {
+    expect(expandTiersUpTo("cost_efficient")).toEqual(["cost_efficient"]);
+    expect(expandTiersUpTo("balanced")).toEqual(["cost_efficient", "balanced"]);
+    expect(expandTiersUpTo("premium")).toEqual([
+      "cost_efficient",
+      "balanced",
+      "premium",
+    ]);
+  });
+
+  it("returns the highest granted tier", () => {
+    expect(
+      getMaxTierName(["cost_efficient", "balanced", "cost_efficient"])
+    ).toBe("balanced");
+  });
+
+  it("checks tier inclusion against a ceiling", () => {
+    expect(isTierWithinMax("cost_efficient", "balanced")).toBe(true);
+    expect(isTierWithinMax("premium", "balanced")).toBe(false);
+  });
+});

--- a/front/lib/model_tiers/tier_order.ts
+++ b/front/lib/model_tiers/tier_order.ts
@@ -1,0 +1,55 @@
+import {
+  MODELS_TIER_NAMES,
+  type ModelsTierName,
+} from "@app/lib/api/assistant/token_pricing/tiers";
+import { formatAsDisplayName } from "@app/types/shared/utils/string_utils";
+
+export const DEFAULT_MAX_MODEL_TIER: ModelsTierName = "premium";
+
+export function getTierIndex(tierName: ModelsTierName): number {
+  return MODELS_TIER_NAMES.indexOf(tierName);
+}
+
+export function expandTiersUpTo(maxTierName: ModelsTierName): ModelsTierName[] {
+  const maxIndex = getTierIndex(maxTierName);
+  if (maxIndex < 0) {
+    return [];
+  }
+
+  return [...MODELS_TIER_NAMES.slice(0, maxIndex + 1)];
+}
+
+export function getMaxTierName(
+  tierNames: readonly ModelsTierName[]
+): ModelsTierName | null {
+  if (tierNames.length === 0) {
+    return null;
+  }
+
+  let maxTierName: ModelsTierName = tierNames[0];
+  for (const tierName of tierNames) {
+    if (getTierIndex(tierName) > getTierIndex(maxTierName)) {
+      maxTierName = tierName;
+    }
+  }
+
+  return maxTierName;
+}
+
+export function isTierWithinMax(
+  tierName: ModelsTierName,
+  maxTierName: ModelsTierName
+): boolean {
+  return getTierIndex(tierName) <= getTierIndex(maxTierName);
+}
+
+export function formatMaxTierDescription(
+  maxTierName: ModelsTierName
+): string | undefined {
+  const lowerTiers = expandTiersUpTo(maxTierName).slice(0, -1);
+  if (lowerTiers.length === 0) {
+    return undefined;
+  }
+
+  return `Includes ${lowerTiers.map(formatAsDisplayName).join(", ")}`;
+}

--- a/front/lib/resources/models_tier_resource.test.ts
+++ b/front/lib/resources/models_tier_resource.test.ts
@@ -1,7 +1,9 @@
+import { MODELS_TIER_NAMES } from "@app/lib/api/assistant/token_pricing/tiers";
 import { Authenticator } from "@app/lib/auth";
-import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
+import { expandTiersUpTo } from "@app/lib/model_tiers/tier_order";
+import type { GroupResource } from "@app/lib/resources/group_resource";
 import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -20,69 +22,172 @@ describe("ModelsTierResource permissions", () => {
     auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   });
 
-  async function grantsForTier(tierId: number) {
-    return GroupPermissionResource.listForGroups(auth, {
-      groupModelIds: (await GroupResource.listAllWorkspaceGroups(auth)).map(
-        (entry) => entry.id
-      ),
-      permissionType: "use",
-      resourceType: "models_tier",
-      resourceId: tierId,
-    });
-  }
+  it("defaults workspace allowed tiers to all tiers", async () => {
+    expect(await ModelsTierResource.listWorkspaceMaxAllowedTierName(auth)).toBe(
+      "premium"
+    );
+    expect(
+      await ModelsTierResource.listWorkspaceAllowedTierNames(auth)
+    ).toEqual([...MODELS_TIER_NAMES]);
+  });
 
-  it("grants and revokes a tier for a user via a regular_auto group", async () => {
+  it("grants and revokes a tier ceiling for a user via a regular_auto group", async () => {
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
 
-    const grantResult = await ModelsTierResource.grantToUser(auth, {
-      user: user.toJSON(),
+    const grantResult = await ModelsTierResource.setUserMaxAllowedTier(auth, {
+      userId: user.sId,
       tierName: "balanced",
     });
     expect(grantResult.isOk()).toBe(true);
 
-    const grants = await grantsForTier(2);
-    expect(grants).toHaveLength(1);
-
-    const autoGroup = await GroupResource.fetchByModelIds(auth, [
-      grants[0].groupId,
+    const users = await ModelsTierResource.listUserAllowedTierNames(auth);
+    expect(users).toEqual([
+      {
+        userId: user.sId,
+        maxTierName: "balanced",
+      },
     ]);
-    expect(autoGroup[0].kind).toBe("regular_auto");
-    expect(await autoGroup[0].isMember(user)).toBe(true);
 
-    const revokeResult = await ModelsTierResource.revokeFromUser(auth, {
-      user: user.toJSON(),
-      tierName: "balanced",
+    const clearResult = await ModelsTierResource.clearUserMaxAllowedTier(auth, {
+      userId: user.sId,
     });
-    expect(revokeResult.isOk()).toBe(true);
-    expect(await grantsForTier(2)).toHaveLength(0);
+    expect(clearResult.isOk()).toBe(true);
+    expect(await ModelsTierResource.listUserAllowedTierNames(auth)).toEqual([]);
   });
 
-  it("grants and revokes a tier for a regular group", async () => {
-    await ModelsTierResource.grantToGroup(auth, {
-      group,
+  it("grants and revokes a tier ceiling for a regular group", async () => {
+    await ModelsTierResource.setGroupMaxAllowedTier(auth, {
+      groupId: group.sId,
       tierName: "premium",
     });
 
-    const grants = await GroupPermissionResource.listForGroups(auth, {
-      groupModelIds: [group.id],
-      permissionType: "use",
-      resourceType: "models_tier",
-      resourceId: 3,
-    });
-    expect(grants).toHaveLength(1);
+    expect(await ModelsTierResource.listGroupAllowedTierNames(auth)).toEqual([
+      {
+        groupId: group.sId,
+        maxTierName: "premium",
+      },
+    ]);
 
-    await ModelsTierResource.revokeFromGroup(auth, {
-      group,
-      tierName: "premium",
+    await ModelsTierResource.clearGroupMaxAllowedTier(auth, {
+      groupId: group.sId,
     });
+    expect(await ModelsTierResource.listGroupAllowedTierNames(auth)).toEqual(
+      []
+    );
+  });
+
+  it("manages workspace tier ceiling via set", async () => {
+    const setResult = await ModelsTierResource.setWorkspaceMaxAllowedTierName(
+      auth,
+      "balanced"
+    );
+    expect(setResult.isOk()).toBe(true);
+    expect(await ModelsTierResource.listWorkspaceMaxAllowedTierName(auth)).toBe(
+      "balanced"
+    );
     expect(
-      await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [group.id],
-        permissionType: "use",
-        resourceType: "models_tier",
-        resourceId: 3,
-      })
-    ).toHaveLength(0);
+      await ModelsTierResource.listWorkspaceAllowedTierNames(auth)
+    ).toEqual(expandTiersUpTo("balanced"));
+
+    const resetResult = await ModelsTierResource.setWorkspaceMaxAllowedTierName(
+      auth,
+      "premium"
+    );
+    expect(resetResult.isOk()).toBe(true);
+    expect(await ModelsTierResource.listWorkspaceMaxAllowedTierName(auth)).toBe(
+      "premium"
+    );
+    expect(
+      await ModelsTierResource.listWorkspaceAllowedTierNames(auth)
+    ).toEqual([...MODELS_TIER_NAMES]);
+  });
+
+  it("resolves allowed tiers for a user from workspace defaults", async () => {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const resolved = await ModelsTierResource.resolveAllowedTierNames(userAuth);
+
+    expect(resolved.tiers).toEqual([...MODELS_TIER_NAMES]);
+    expect(resolved.source).toBe("workspace");
+  });
+
+  it("does not treat workspace grants on the global group as a group override", async () => {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    await ModelsTierResource.setWorkspaceMaxAllowedTierName(auth, "balanced");
+
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const resolved = await ModelsTierResource.resolveAllowedTierNames(userAuth);
+
+    expect(resolved.tiers).toEqual(expandTiersUpTo("balanced"));
+    expect(resolved.source).toBe("workspace");
+  });
+
+  it("group tier override takes precedence over workspace", async () => {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    await GroupMembershipModel.create({
+      groupId: group.id,
+      userId: user.id,
+      workspaceId: workspace.id,
+      startAt: new Date(),
+      status: "active",
+    });
+
+    await ModelsTierResource.setWorkspaceMaxAllowedTierName(auth, "premium");
+    await ModelsTierResource.setGroupMaxAllowedTier(auth, {
+      groupId: group.sId,
+      tierName: "balanced",
+    });
+
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const resolved = await ModelsTierResource.resolveAllowedTierNames(userAuth);
+
+    expect(resolved.tiers).toEqual(["cost_efficient", "balanced"]);
+    expect(resolved.source).toBe("groups");
+  });
+
+  it("user tier override takes precedence over groups and workspace", async () => {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    await GroupMembershipModel.create({
+      groupId: group.id,
+      userId: user.id,
+      workspaceId: workspace.id,
+      startAt: new Date(),
+      status: "active",
+    });
+
+    await ModelsTierResource.setWorkspaceMaxAllowedTierName(auth, "balanced");
+    await ModelsTierResource.setGroupMaxAllowedTier(auth, {
+      groupId: group.sId,
+      tierName: "premium",
+    });
+    await ModelsTierResource.setUserMaxAllowedTier(auth, {
+      userId: user.sId,
+      tierName: "cost_efficient",
+    });
+
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const resolved = await ModelsTierResource.resolveAllowedTierNames(userAuth);
+
+    expect(resolved.tiers).toEqual(["cost_efficient"]);
+    expect(resolved.source).toBe("user");
   });
 });

--- a/front/lib/resources/models_tier_resource.ts
+++ b/front/lib/resources/models_tier_resource.ts
@@ -7,18 +7,42 @@ import {
   STATIC_MODEL_TIERS,
 } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { isModelTierOverrideGroupKind } from "@app/lib/model_tiers/group_kinds";
+import { resolveAllowedModelTiers } from "@app/lib/model_tiers/resolve_allowed";
+import {
+  DEFAULT_MAX_MODEL_TIER,
+  expandTiersUpTo,
+  getMaxTierName,
+} from "@app/lib/model_tiers/tier_order";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
-import type { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type {
+  GroupAllowedModelTiersType,
+  UserAllowedModelTiersType,
+} from "@app/types/api/model_tiers";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { UserType } from "@app/types/user";
 import assert from "assert";
 import type { Transaction } from "sequelize";
+import { Op } from "sequelize";
 
 export type {
   ModelsTierDefinition,
   ModelsTierName,
   ModelTierSelection,
 } from "@app/lib/api/assistant/token_pricing/tiers";
+
+export type {
+  ModelTierResolutionSource,
+  ResolvedAllowedModelTiers,
+} from "@app/lib/model_tiers/resolve_allowed";
 
 const MODELS_TIER_PERMISSION_TYPE = "use" as const;
 const MODELS_TIER_RESOURCE_TYPE = "models_tier" as const;
@@ -63,10 +87,101 @@ export class ModelsTierResource {
     return STATIC_MODEL_TIERS[modelId][reasoningEffort] ?? null;
   }
 
+  private static assertIsAdmin(auth: Authenticator): void {
+    assert(auth.isAdmin(), "Only admins can manage allowed model tiers.");
+  }
+
   private static getTierResourceId(tierName: ModelsTierName): number {
     const tier = this.getTier(tierName);
     assert(tier, `Unknown models tier: ${tierName}`);
     return tier.id;
+  }
+
+  private static tierNameFromResourceId(
+    resourceId: number
+  ): ModelsTierName | null {
+    return MODELS_TIERS.find((tier) => tier.id === resourceId)?.name ?? null;
+  }
+
+  private static async listAllTierGrantRows(auth: Authenticator) {
+    return GroupPermissionModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        permissionType: MODELS_TIER_PERMISSION_TYPE,
+        resourceType: MODELS_TIER_RESOURCE_TYPE,
+        resourceId: { [Op.gt]: 0 },
+      },
+    });
+  }
+
+  private static expandExplicitTierNames(
+    tierNames: readonly ModelsTierName[]
+  ): ModelsTierName[] {
+    const maxTierName = getMaxTierName(tierNames);
+    if (!maxTierName) {
+      return [];
+    }
+
+    return expandTiersUpTo(maxTierName);
+  }
+
+  private static async clearWorkspaceTierGrants(
+    auth: Authenticator
+  ): Promise<void> {
+    for (const tierName of MODELS_TIER_NAMES) {
+      await GroupPermissionResource.revokeFromEverybody(auth, {
+        permissionType: MODELS_TIER_PERMISSION_TYPE,
+        resourceType: MODELS_TIER_RESOURCE_TYPE,
+        resourceId: this.getTierResourceId(tierName),
+      });
+    }
+  }
+
+  private static async clearUserTierGrants(
+    auth: Authenticator,
+    user: UserType
+  ): Promise<void> {
+    for (const tierName of MODELS_TIER_NAMES) {
+      await this.revokeFromUser(auth, { user, tierName });
+    }
+  }
+
+  private static async clearGroupTierGrants(
+    auth: Authenticator,
+    group: GroupResource
+  ): Promise<void> {
+    for (const tierName of MODELS_TIER_NAMES) {
+      await this.revokeFromGroup(auth, { group, tierName });
+    }
+  }
+
+  private static async getWorkspaceMaxAllowedTierName(
+    auth: Authenticator
+  ): Promise<ModelsTierName> {
+    const explicit = await this.getExplicitWorkspaceTierNames(auth);
+    return getMaxTierName(explicit) ?? DEFAULT_MAX_MODEL_TIER;
+  }
+
+  private static async getExplicitWorkspaceTierNames(
+    auth: Authenticator
+  ): Promise<ModelsTierName[]> {
+    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
+      auth.getNonNullableWorkspace().id
+    );
+    if (!globalGroup) {
+      return [];
+    }
+
+    const grants = await GroupPermissionResource.listForGroups(auth, {
+      groupModelIds: [globalGroup.id],
+      permissionType: MODELS_TIER_PERMISSION_TYPE,
+      resourceType: MODELS_TIER_RESOURCE_TYPE,
+    });
+
+    return grants.flatMap((grant) => {
+      const tierName = this.tierNameFromResourceId(grant.resourceId);
+      return tierName ? [tierName] : [];
+    });
   }
 
   static async grantToUser(
@@ -118,6 +233,441 @@ export class ModelsTierResource {
       resourceType: MODELS_TIER_RESOURCE_TYPE,
       resourceId: this.getTierResourceId(tierName),
       transaction,
+    });
+  }
+
+  static async setUserMaxAllowedTier(
+    auth: Authenticator,
+    { userId, tierName }: { userId: string; tierName: ModelsTierName }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<"invalid_request_error" | "user_not_found" | "user_not_member">
+    >
+  > {
+    this.assertIsAdmin(auth);
+
+    const workspace = auth.getNonNullableWorkspace();
+    const user = await UserResource.fetchById(userId);
+    if (!user) {
+      return new Err(new DustError("user_not_found", "User not found."));
+    }
+
+    const membership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace,
+      });
+    if (!membership) {
+      return new Err(
+        new DustError(
+          "user_not_member",
+          "User is not an active member of the workspace."
+        )
+      );
+    }
+
+    const userJson = user.toJSON();
+    await this.clearUserTierGrants(auth, userJson);
+
+    const result = await this.grantToUser(auth, {
+      user: userJson,
+      tierName,
+    });
+    if (result.isErr()) {
+      return new Err(
+        new DustError("invalid_request_error", result.error.message)
+      );
+    }
+
+    return new Ok(undefined);
+  }
+
+  static async clearUserMaxAllowedTier(
+    auth: Authenticator,
+    { userId }: { userId: string }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<"invalid_request_error" | "user_not_found" | "user_not_member">
+    >
+  > {
+    this.assertIsAdmin(auth);
+
+    const workspace = auth.getNonNullableWorkspace();
+    const user = await UserResource.fetchById(userId);
+    if (!user) {
+      return new Err(new DustError("user_not_found", "User not found."));
+    }
+
+    const membership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace,
+      });
+    if (!membership) {
+      return new Err(
+        new DustError(
+          "user_not_member",
+          "User is not an active member of the workspace."
+        )
+      );
+    }
+
+    await this.clearUserTierGrants(auth, user.toJSON());
+
+    return new Ok(undefined);
+  }
+
+  static async setGroupMaxAllowedTier(
+    auth: Authenticator,
+    { groupId, tierName }: { groupId: string; tierName: ModelsTierName }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "invalid_request_error"
+        | "group_not_found"
+        | "invalid_id"
+        | "unauthorized"
+      >
+    >
+  > {
+    this.assertIsAdmin(auth);
+
+    const groupRes = await GroupResource.fetchById(auth, groupId);
+    if (groupRes.isErr()) {
+      return groupRes;
+    }
+
+    await this.clearGroupTierGrants(auth, groupRes.value);
+    await this.grantToGroup(auth, {
+      group: groupRes.value,
+      tierName,
+    });
+
+    return new Ok(undefined);
+  }
+
+  static async clearGroupMaxAllowedTier(
+    auth: Authenticator,
+    { groupId }: { groupId: string }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "invalid_request_error"
+        | "group_not_found"
+        | "invalid_id"
+        | "unauthorized"
+      >
+    >
+  > {
+    this.assertIsAdmin(auth);
+
+    const groupRes = await GroupResource.fetchById(auth, groupId);
+    if (groupRes.isErr()) {
+      return groupRes;
+    }
+
+    await this.clearGroupTierGrants(auth, groupRes.value);
+
+    return new Ok(undefined);
+  }
+
+  static async listWorkspaceAllowedTierNames(
+    auth: Authenticator
+  ): Promise<ModelsTierName[]> {
+    this.assertIsAdmin(auth);
+    return this.loadWorkspaceTierGrants(auth);
+  }
+
+  static async listWorkspaceMaxAllowedTierName(
+    auth: Authenticator
+  ): Promise<ModelsTierName> {
+    this.assertIsAdmin(auth);
+    return this.getWorkspaceMaxAllowedTierName(auth);
+  }
+
+  private static async loadWorkspaceTierGrants(
+    auth: Authenticator
+  ): Promise<ModelsTierName[]> {
+    return expandTiersUpTo(await this.getWorkspaceMaxAllowedTierName(auth));
+  }
+
+  static async setWorkspaceMaxAllowedTierName(
+    auth: Authenticator,
+    maxTierName: ModelsTierName
+  ): Promise<Result<undefined, DustError<"invalid_request_error">>> {
+    this.assertIsAdmin(auth);
+
+    if (!this.getTier(maxTierName)) {
+      return new Err(
+        new DustError("invalid_request_error", "Unknown models tier.")
+      );
+    }
+
+    await this.clearWorkspaceTierGrants(auth);
+
+    if (maxTierName !== DEFAULT_MAX_MODEL_TIER) {
+      await GroupPermissionResource.grantToEverybody(auth, {
+        permissionType: MODELS_TIER_PERMISSION_TYPE,
+        resourceType: MODELS_TIER_RESOURCE_TYPE,
+        resourceId: this.getTierResourceId(maxTierName),
+      });
+    }
+
+    return new Ok(undefined);
+  }
+
+  static async listUserAllowedTierNames(
+    auth: Authenticator
+  ): Promise<UserAllowedModelTiersType[]> {
+    this.assertIsAdmin(auth);
+
+    const rows = await this.listAllTierGrantRows(auth);
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const groupIds = [...new Set(rows.map((row) => row.groupId))];
+    const groups = await GroupResource.fetchByModelIds(auth, groupIds);
+    const autoGroups = groups.filter(
+      (group) =>
+        group.kind === "regular_auto" &&
+        group.name.startsWith("Group for permission ")
+    );
+    if (autoGroups.length === 0) {
+      return [];
+    }
+
+    const autoGroupIds = new Set(autoGroups.map((group) => group.id));
+    const tiersByGroupId = new Map<ModelId, ModelsTierName[]>();
+    for (const row of rows) {
+      if (!autoGroupIds.has(row.groupId)) {
+        continue;
+      }
+      const tierName = this.tierNameFromResourceId(row.resourceId);
+      if (!tierName) {
+        continue;
+      }
+      const tiers = tiersByGroupId.get(row.groupId) ?? [];
+      tiers.push(tierName);
+      tiersByGroupId.set(row.groupId, tiers);
+    }
+
+    const tiersByUserModelId = new Map<ModelId, Set<ModelsTierName>>();
+    for (const group of autoGroups) {
+      const tiers = tiersByGroupId.get(group.id) ?? [];
+      if (tiers.length === 0) {
+        continue;
+      }
+      const members = await group.getActiveMembers(auth);
+      for (const member of members) {
+        const existing = tiersByUserModelId.get(member.id) ?? new Set();
+        for (const tier of tiers) {
+          existing.add(tier);
+        }
+        tiersByUserModelId.set(member.id, existing);
+      }
+    }
+
+    const users = await UserResource.fetchByModelIds([
+      ...tiersByUserModelId.keys(),
+    ]);
+
+    return users.flatMap((user) => {
+      const rawTierNames = [...(tiersByUserModelId.get(user.id) ?? new Set())];
+      const maxTierName = getMaxTierName(rawTierNames);
+      if (!maxTierName) {
+        return [];
+      }
+
+      return [
+        {
+          userId: user.sId,
+          maxTierName,
+        },
+      ];
+    });
+  }
+
+  static async listGroupAllowedTierNames(
+    auth: Authenticator
+  ): Promise<GroupAllowedModelTiersType[]> {
+    this.assertIsAdmin(auth);
+
+    const workspace = auth.getNonNullableWorkspace();
+    const rows = await this.listAllTierGrantRows(auth);
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const groupIds = [...new Set(rows.map((row) => row.groupId))];
+    const groups = await GroupResource.fetchByModelIds(auth, groupIds);
+    const overrideGroups = groups.filter((group) =>
+      isModelTierOverrideGroupKind(group.kind)
+    );
+
+    const tiersByGroupId = new Map<ModelId, ModelsTierName[]>();
+    for (const row of rows) {
+      const tierName = this.tierNameFromResourceId(row.resourceId);
+      if (!tierName) {
+        continue;
+      }
+      const tiers = tiersByGroupId.get(row.groupId) ?? [];
+      tiers.push(tierName);
+      tiersByGroupId.set(row.groupId, tiers);
+    }
+
+    return overrideGroups.flatMap((group) => {
+      const rawTierNames = tiersByGroupId.get(group.id);
+      if (!rawTierNames || rawTierNames.length === 0) {
+        return [];
+      }
+
+      const maxTierName = getMaxTierName(rawTierNames);
+      if (!maxTierName) {
+        return [];
+      }
+
+      return [
+        {
+          groupId: makeSId("group", {
+            id: group.id,
+            workspaceId: workspace.id,
+          }),
+          maxTierName,
+        },
+      ];
+    });
+  }
+
+  private static async loadUserOverrideTierGrants({
+    auth,
+    user,
+  }: {
+    auth: Authenticator;
+    user: UserResource;
+  }): Promise<ModelsTierName[]> {
+    const rows = await this.listAllTierGrantRows(auth);
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const groupIds = [...new Set(rows.map((row) => row.groupId))];
+    const groups = await GroupResource.fetchByModelIds(auth, groupIds);
+    const autoGroups = groups.filter(
+      (group) =>
+        group.kind === "regular_auto" &&
+        group.name.startsWith("Group for permission ")
+    );
+
+    const tierNames = new Set<ModelsTierName>();
+    for (const group of autoGroups) {
+      const isMember = await group.isMember(user);
+      if (!isMember) {
+        continue;
+      }
+
+      for (const row of rows) {
+        if (row.groupId !== group.id) {
+          continue;
+        }
+        const tierName = this.tierNameFromResourceId(row.resourceId);
+        if (tierName) {
+          tierNames.add(tierName);
+        }
+      }
+    }
+
+    return this.expandExplicitTierNames([...tierNames]);
+  }
+
+  private static async listUserModelTierOverrideGroupModelIds(
+    auth: Authenticator
+  ): Promise<ModelId[]> {
+    const groupModelIds = auth.groupModelIds();
+    if (groupModelIds.length === 0) {
+      return [];
+    }
+
+    const groups = await GroupResource.fetchByModelIds(auth, groupModelIds);
+    return groups
+      .filter((group) => isModelTierOverrideGroupKind(group.kind))
+      .map((group) => group.id);
+  }
+
+  private static async loadGroupOverrideTierGrants({
+    auth,
+    groupModelIds,
+  }: {
+    auth: Authenticator;
+    groupModelIds: ModelId[];
+  }): Promise<Map<ModelId, ModelsTierName[]>> {
+    if (groupModelIds.length === 0) {
+      return new Map();
+    }
+
+    const grants = await GroupPermissionResource.listForGroups(auth, {
+      groupModelIds,
+      permissionType: MODELS_TIER_PERMISSION_TYPE,
+      resourceType: MODELS_TIER_RESOURCE_TYPE,
+    });
+
+    const tiersByGroupId = new Map<ModelId, ModelsTierName[]>();
+    for (const grant of grants) {
+      const tierName = this.tierNameFromResourceId(grant.resourceId);
+      if (!tierName) {
+        continue;
+      }
+      const tiers = tiersByGroupId.get(grant.groupId) ?? [];
+      tiers.push(tierName);
+      tiersByGroupId.set(grant.groupId, tiers);
+    }
+
+    const expandedTiersByGroupId = new Map<ModelId, ModelsTierName[]>();
+    for (const [groupId, rawTierNames] of tiersByGroupId) {
+      expandedTiersByGroupId.set(
+        groupId,
+        this.expandExplicitTierNames(rawTierNames)
+      );
+    }
+
+    return expandedTiersByGroupId;
+  }
+
+  static async resolveAllowedTierNames(auth: Authenticator) {
+    const user = auth.user();
+
+    const [workspaceTierGrants, userOverrideTierGrants, groupModelIds] =
+      await Promise.all([
+        this.loadWorkspaceTierGrants(auth),
+        user
+          ? this.loadUserOverrideTierGrants({
+              auth,
+              user,
+            })
+          : Promise.resolve([]),
+        this.listUserModelTierOverrideGroupModelIds(auth),
+      ]);
+
+    const groupOverrideTierGrantsByGroupId =
+      groupModelIds.length > 0
+        ? await this.loadGroupOverrideTierGrants({
+            auth,
+            groupModelIds,
+          })
+        : new Map<ModelId, ModelsTierName[]>();
+
+    const groupOverrideTierGrantsList = groupModelIds.map(
+      (groupModelId) => groupOverrideTierGrantsByGroupId.get(groupModelId) ?? []
+    );
+
+    return resolveAllowedModelTiers({
+      workspaceAllowedTierNames: workspaceTierGrants,
+      groupAllowedTierNamesList: groupOverrideTierGrantsList,
+      userAllowedTierNames: userOverrideTierGrants,
     });
   }
 }

--- a/front/types/api/model_tiers.ts
+++ b/front/types/api/model_tiers.ts
@@ -1,0 +1,94 @@
+import { MODELS_TIER_NAMES } from "@app/lib/api/assistant/token_pricing/tiers";
+import { z } from "zod";
+
+export const ModelsTierNameSchema = z.enum(MODELS_TIER_NAMES);
+export type ModelsTierNameApiType = z.infer<typeof ModelsTierNameSchema>;
+
+export const ModelTierDefinitionSchema = z.object({
+  name: ModelsTierNameSchema,
+  id: z.number(),
+  description: z.string(),
+});
+export type ModelTierDefinitionApiType = z.infer<
+  typeof ModelTierDefinitionSchema
+>;
+
+export const UserAllowedModelTiersSchema = z.object({
+  userId: z.string(),
+  maxTierName: ModelsTierNameSchema,
+});
+export type UserAllowedModelTiersType = z.infer<
+  typeof UserAllowedModelTiersSchema
+>;
+
+export const GroupAllowedModelTiersSchema = z.object({
+  groupId: z.string(),
+  maxTierName: ModelsTierNameSchema,
+});
+export type GroupAllowedModelTiersType = z.infer<
+  typeof GroupAllowedModelTiersSchema
+>;
+
+export const GetModelTiersResponseBodySchema = z.object({
+  tiers: z.array(ModelTierDefinitionSchema),
+});
+export type GetModelTiersResponseBody = z.infer<
+  typeof GetModelTiersResponseBodySchema
+>;
+
+export const GetUserAllowedModelTiersResponseBodySchema = z.object({
+  users: z.array(UserAllowedModelTiersSchema),
+});
+export type GetUserAllowedModelTiersResponseBody = z.infer<
+  typeof GetUserAllowedModelTiersResponseBodySchema
+>;
+
+export const GetGroupAllowedModelTiersResponseBodySchema = z.object({
+  groups: z.array(GroupAllowedModelTiersSchema),
+});
+export type GetGroupAllowedModelTiersResponseBody = z.infer<
+  typeof GetGroupAllowedModelTiersResponseBodySchema
+>;
+
+export const GetWorkspaceAllowedModelTiersResponseBodySchema = z.object({
+  maxTierName: ModelsTierNameSchema,
+});
+export type GetWorkspaceAllowedModelTiersResponseBody = z.infer<
+  typeof GetWorkspaceAllowedModelTiersResponseBodySchema
+>;
+
+export const AllowedModelTierBodySchema = z.object({
+  tierName: ModelsTierNameSchema,
+});
+export type AllowedModelTierBody = z.infer<typeof AllowedModelTierBodySchema>;
+
+export const UserAllowedModelTierBodySchema = AllowedModelTierBodySchema.extend(
+  {
+    userId: z.string(),
+  }
+);
+export type UserAllowedModelTierBody = z.infer<
+  typeof UserAllowedModelTierBodySchema
+>;
+
+export const GroupAllowedModelTierBodySchema =
+  AllowedModelTierBodySchema.extend({
+    groupId: z.string(),
+  });
+export type GroupAllowedModelTierBody = z.infer<
+  typeof GroupAllowedModelTierBodySchema
+>;
+
+export const UserAllowedModelTierClearBodySchema = z.object({
+  userId: z.string(),
+});
+export type UserAllowedModelTierClearBody = z.infer<
+  typeof UserAllowedModelTierClearBodySchema
+>;
+
+export const GroupAllowedModelTierClearBodySchema = z.object({
+  groupId: z.string(),
+});
+export type GroupAllowedModelTierClearBody = z.infer<
+  typeof GroupAllowedModelTierClearBodySchema
+>;

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -123,7 +123,7 @@ const SPECIAL_CASES_PATTERN = new RegExp(
   "g"
 );
 
-function formatAsDisplayName(name: string): string {
+export function formatAsDisplayName(name: string): string {
   return slugify(name)
     .replace(/_/g, " ")
     .replace(


### PR DESCRIPTION
## Description

Completes `ModelsTierResource` with a clean CRUD surface and wires in the three-level resolution policy (user > groups > workspace).

- **`front/lib/model_tiers/tier_order.ts`**: New module with `getTierIndex`, `expandTiersUpTo`, `getMaxTierName`, `isTierWithinMax`, and label/description formatters. `DEFAULT_MAX_MODEL_TIER = "frontier"`.
- **`front/lib/model_tiers/resolve_allowed.ts`**: `resolveAllowedModelTiers` implements the priority policy and returns `{ tiers, source }` (`source` ∈ `"workspace" | "groups" | "user"`). Global-group grants are excluded from the groups layer by convention.
- **`front/lib/model_tiers/group_kinds.ts`**: `MODEL_TIER_OVERRIDE_GROUP_KINDS = ["regular", "provisioned"]` — only these kinds can carry tier overrides; `global` and `regular_auto` are excluded.
- **`ModelsTierResource`**: Replaces the old permission-based `grantToUser`/`revokeFromUser`/`grantToGroup`/`revokeFromGroup` with `set/clear` per user/group/workspace and a top-level `resolveAllowedTierNames(auth)`.
- **`STATIC_MODEL_TIERS` reclassification**: `gpt-4o`, `gpt-4-turbo`, `gpt-4.1` family, and mini/nano models at `medium`/`high` reasoning effort downgraded from `balanced` to `cost_efficient`.

## Tests

Vitest unit tests for `tier_order`, `resolve_allowed`, and `group_kinds`. Integration tests in `models_tier_resource.test.ts` updated to cover workspace defaults, set/clear lifecycle, and all three resolution priority cases (workspace baseline, group override, user override).

## Risk

Low. Front-only, no DB migration. The `ModelsTierResource` API rename only affects callers within the same PR (prior API from PR28781). The `STATIC_MODEL_TIERS` reclassifications lower the tier of several models — users with a workspace default of `frontier` are unaffected; only enforced paths would see tighter classification.

## Deploy Plan

Deploy front.
