### PR TITLE
Switch runtime model enforcement to model tiers.

### DIFF
--- a/front-api/routes/w/[wId]/models.ts
+++ b/front-api/routes/w/[wId]/models.ts
@@ -1,4 +1,4 @@
-import { getModelsForAuth } from "@app/lib/advanced_models/enabled_models";
+import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
 import type { GetEnabledModelsResponseType } from "@app/types/api/assistant/models";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1,5 +1,4 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
-import { getModelsForAuth } from "@app/lib/advanced_models/enabled_models";
 import {
   WEB_SEARCH_BROWSE_ACTION_DESCRIPTION,
   WEB_SEARCH_BROWSE_SERVER_NAME,
@@ -27,6 +26,7 @@ import config from "@app/lib/api/config";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { isRemoteDatabase } from "@app/lib/data_sources";
 import { DustError } from "@app/lib/error";
+import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import {
   AgentChildAgentConfigurationModel,

--- a/front/lib/api/assistant/configuration/create_or_upgrade.ts
+++ b/front/lib/api/assistant/configuration/create_or_upgrade.ts
@@ -3,7 +3,6 @@ import type {
   MCPServerConfigurationType,
   ServerSideMCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
-import { getAdvancedModelAccessErrorForAgentConfiguration } from "@app/lib/advanced_models/access";
 import { pruneSuggestionsForAgent } from "@app/lib/api/assistant/agent_suggestion_pruning";
 import { createAgentActionConfiguration } from "@app/lib/api/assistant/configuration/actions";
 import {
@@ -15,6 +14,7 @@ import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import { getModelTierAccessErrorForAgentConfiguration } from "@app/lib/model_tiers/access";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
@@ -158,14 +158,12 @@ export async function createOrUpgradeAgentConfiguration({
     );
   }
 
-  const accessError = await getAdvancedModelAccessErrorForAgentConfiguration(
-    auth,
-    {
-      agentName: assistant.name,
-      model: modelConfig,
-      featureFlags,
-    }
-  );
+  const accessError = await getModelTierAccessErrorForAgentConfiguration(auth, {
+    agentName: assistant.name,
+    model: modelConfig,
+    reasoningEffort: assistant.model.reasoningEffort,
+    featureFlags,
+  });
   if (accessError) {
     return new Err(new Error(accessError.message));
   }

--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -1,4 +1,3 @@
-import * as enabledModels from "@app/lib/advanced_models/enabled_models";
 import { pickPreferredLargeModel } from "@app/lib/api/assistant/model_preferences";
 import {
   getWhitelistedProviders,
@@ -7,6 +6,7 @@ import {
 import { resolveModel } from "@app/lib/api/assistant/resolve_model";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
+import * as enabledModels from "@app/lib/model_tiers/enabled_models";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -1,7 +1,7 @@
-import { getAutoModelForAuth } from "@app/lib/advanced_models/enabled_models";
 import { PREFERRED_LARGE_MODEL_CONFIGS } from "@app/lib/api/assistant/model_preferences";
 import { selectEnabledModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
+import { getAutoModelForAuth } from "@app/lib/model_tiers/enabled_models";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";

--- a/front/lib/model_tiers/access.ts
+++ b/front/lib/model_tiers/access.ts
@@ -1,0 +1,66 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
+import type { GenericErrorContent } from "@app/types/assistant/agent";
+import type {
+  ModelConfigurationType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
+import { getMinimumReasoningEffort } from "@app/types/assistant/models/types";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+export const MODEL_TIER_NOT_ENABLED_ERROR_CODE = "model_tier_not_enabled";
+
+export function buildModelTierAccessDeniedError(
+  agentName: string
+): GenericErrorContent {
+  return {
+    code: MODEL_TIER_NOT_ENABLED_ERROR_CODE,
+    message:
+      `Assistant ${agentName} uses a model tier that is not enabled for you. ` +
+      `Please contact your workspace admin or use another assistant.`,
+    metadata: {
+      errorTitle: "Model tier not enabled",
+      category: "unknown_error",
+    },
+  };
+}
+
+export async function getModelTierAccessErrorForAgentConfiguration(
+  auth: Authenticator,
+  {
+    agentName,
+    model,
+    reasoningEffort,
+    featureFlags,
+  }: {
+    agentName: string;
+    model: ModelConfigurationType;
+    reasoningEffort?: ReasoningEffort;
+    featureFlags: WhitelistableFeature[];
+  }
+): Promise<GenericErrorContent | null> {
+  if (!featureFlags.includes("models_picker")) {
+    return null;
+  }
+
+  const effectiveReasoningEffort =
+    reasoningEffort ??
+    getMinimumReasoningEffort(model.supportedReasoningEfforts);
+  const tierName = ModelsTierResource.getTierForModel(
+    model.modelId,
+    effectiveReasoningEffort
+  );
+
+  if (!tierName) {
+    return null;
+  }
+
+  const { tiers: allowedTierNames } =
+    await ModelsTierResource.resolveAllowedTierNames(auth);
+
+  if (allowedTierNames.includes(tierName)) {
+    return null;
+  }
+
+  return buildModelTierAccessDeniedError(agentName);
+}

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -1,0 +1,129 @@
+import { Authenticator } from "@app/lib/auth";
+import { withModelSelectability } from "@app/lib/model_tiers/enabled_models";
+import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import {
+  CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+} from "@app/types/assistant/models/anthropic";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("withModelSelectability", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let adminAuth: Authenticator;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  });
+
+  async function userAuthForTierCap(tierName: "cost_efficient" | "balanced") {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    await ModelsTierResource.setUserMaxAllowedTier(adminAuth, {
+      userId: user.sId,
+      tierName,
+    });
+
+    return Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+  }
+
+  it("keeps full reasoning efforts when models_picker is disabled", async () => {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const [model] = await withModelSelectability(auth, {
+      models: [CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG],
+    });
+
+    expect(model.isSelectable).toBe(true);
+    expect(model.supportedReasoningEfforts).toEqual(
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.supportedReasoningEfforts
+    );
+    expect(model.defaultReasoningEffort).toBe(
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort
+    );
+  });
+
+  it("keeps full reasoning efforts when models_picker is enabled and user has no tier cap", async () => {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "models_picker");
+
+    const [model] = await withModelSelectability(auth, {
+      models: [CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG],
+    });
+
+    expect(model.isSelectable).toBe(true);
+    expect(model.supportedReasoningEfforts).toEqual(
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.supportedReasoningEfforts
+    );
+    expect(model.defaultReasoningEffort).toBe(
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort
+    );
+  });
+
+  it("filters reasoning efforts to those allowed by the user's tier cap", async () => {
+    await FeatureFlagFactory.basic(adminAuth, "models_picker");
+    const auth = await userAuthForTierCap("cost_efficient");
+
+    const [model] = await withModelSelectability(auth, {
+      models: [CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG],
+    });
+
+    expect(model.isSelectable).toBe(true);
+    expect(model.supportedReasoningEfforts).toEqual({
+      none: false,
+      light: true,
+      medium: false,
+      high: false,
+    });
+    expect(model.defaultReasoningEffort).toBe("light");
+  });
+
+  it("keeps all reasoning efforts when the user's tier cap includes them", async () => {
+    await FeatureFlagFactory.basic(adminAuth, "models_picker");
+    const auth = await userAuthForTierCap("balanced");
+
+    const [model] = await withModelSelectability(auth, {
+      models: [CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG],
+    });
+
+    expect(model.isSelectable).toBe(true);
+    expect(model.supportedReasoningEfforts).toEqual({
+      none: false,
+      light: true,
+      medium: true,
+      high: true,
+    });
+    expect(model.defaultReasoningEffort).toBe("medium");
+  });
+
+  it("marks frontier-only models as not selectable when capped at balanced", async () => {
+    await FeatureFlagFactory.basic(adminAuth, "models_picker");
+    const auth = await userAuthForTierCap("balanced");
+
+    const [model] = await withModelSelectability(auth, {
+      models: [CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG],
+    });
+
+    expect(model.isSelectable).toBe(false);
+    expect(model.supportedReasoningEfforts).toEqual({
+      none: false,
+      light: false,
+      medium: false,
+      high: false,
+    });
+  });
+});

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -1,0 +1,132 @@
+import { pickPreferredLargeModel } from "@app/lib/api/assistant/model_preferences";
+import {
+  type ModelsTierName,
+  STATIC_MODEL_TIERS,
+} from "@app/lib/api/assistant/token_pricing/tiers";
+import { getAvailableModelsForWorkspace } from "@app/lib/api/assistant/workspace_capabilities";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
+import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import { ORDERED_REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
+import type {
+  ModelConfigurationType,
+  ReasoningEffortSupport,
+} from "@app/types/assistant/models/types";
+import { getMinimumReasoningEffort } from "@app/types/assistant/models/types";
+
+function isTieredModelId(
+  modelId: string
+): modelId is keyof typeof STATIC_MODEL_TIERS {
+  return modelId in STATIC_MODEL_TIERS;
+}
+
+function restrictModelConfigToAllowedTiers(
+  model: ModelConfigurationType,
+  allowedTierNamesSet: Set<ModelsTierName>
+): EnabledModelConfigurationType {
+  if (!isTieredModelId(model.modelId)) {
+    return {
+      ...model,
+      isSelectable: false,
+    };
+  }
+
+  const supportedReasoningEfforts: ReasoningEffortSupport = {
+    none: false,
+    light: false,
+    medium: false,
+    high: false,
+  };
+
+  for (const effort of ORDERED_REASONING_EFFORTS) {
+    if (!model.supportedReasoningEfforts[effort]) {
+      continue;
+    }
+
+    const tierName = ModelsTierResource.getTierForModel(model.modelId, effort);
+    if (tierName && allowedTierNamesSet.has(tierName)) {
+      supportedReasoningEfforts[effort] = true;
+    }
+  }
+
+  const defaultReasoningEffort = supportedReasoningEfforts[
+    model.defaultReasoningEffort
+  ]
+    ? model.defaultReasoningEffort
+    : getMinimumReasoningEffort(supportedReasoningEfforts);
+
+  return {
+    ...model,
+    supportedReasoningEfforts,
+    defaultReasoningEffort,
+    isSelectable: ORDERED_REASONING_EFFORTS.some(
+      (effort) => supportedReasoningEfforts[effort]
+    ),
+  };
+}
+
+export async function withModelSelectability(
+  auth: Authenticator,
+  { models }: { models: ModelConfigurationType[] }
+): Promise<EnabledModelConfigurationType[]> {
+  const featureFlags = await getFeatureFlags(auth);
+
+  if (!featureFlags.includes("models_picker")) {
+    return models.map((model) => ({
+      ...model,
+      isSelectable: true,
+    }));
+  }
+
+  const { tiers: allowedTierNames } =
+    await ModelsTierResource.resolveAllowedTierNames(auth);
+  const allowedTierNamesSet = new Set(allowedTierNames);
+
+  return models.map((model) =>
+    restrictModelConfigToAllowedTiers(model, allowedTierNamesSet)
+  );
+}
+
+export async function getEnabledModelsForAuth(
+  auth: Authenticator
+): Promise<EnabledModelConfigurationType[]> {
+  const availableModels = await getAvailableModelsForWorkspace(auth);
+  return withModelSelectability(auth, { models: availableModels });
+}
+
+export function getDefaultModelFromEnabledModels(
+  models: EnabledModelConfigurationType[]
+): EnabledModelConfigurationType {
+  const selectableModels = models.filter((m) => m.isSelectable);
+  const autoModel = selectableModels.find((m) => m.modelId === AUTO_MODEL_ID);
+  if (autoModel) {
+    return autoModel;
+  }
+
+  return {
+    ...pickPreferredLargeModel(selectableModels),
+    isSelectable: true,
+  };
+}
+
+export async function getAutoModelForAuth(
+  auth: Authenticator
+): Promise<EnabledModelConfigurationType | null> {
+  const availableModels = await getEnabledModelsForAuth(auth);
+  return {
+    ...pickPreferredLargeModel(availableModels.filter((m) => m.isSelectable)),
+  };
+}
+
+export async function getModelsForAuth(auth: Authenticator): Promise<{
+  models: EnabledModelConfigurationType[];
+  defaultModel: EnabledModelConfigurationType;
+}> {
+  const models = await getEnabledModelsForAuth(auth);
+  return {
+    models,
+    defaultModel: getDefaultModelFromEnabledModels(models),
+  };
+}

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -12,7 +12,6 @@ import {
   isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
 import { computeStepContexts } from "@app/lib/actions/utils";
-import { getAdvancedModelAccessErrorForAgentConfiguration } from "@app/lib/advanced_models/access";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { categorizeConversationRenderErrorMessage } from "@app/lib/api/assistant/errors";
@@ -58,6 +57,7 @@ import {
   getDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
 import { TOOL_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
+import { getModelTierAccessErrorForAgentConfiguration } from "@app/lib/model_tiers/access";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -410,7 +410,7 @@ export async function runModel(
   const featureFlags = await getFeatureFlags(auth);
 
   if (step === 0) {
-    const accessError = await getAdvancedModelAccessErrorForAgentConfiguration(
+    const accessError = await getModelTierAccessErrorForAgentConfiguration(
       auth,
       {
         agentName: agentConfiguration.name,


### PR DESCRIPTION
## Description

Migrate model enforcement from the `advanced_models` access layer to the new `model_tiers` module. Creates `front/lib/model_tiers/enabled_models.ts` and `front/lib/model_tiers/access.ts` replacing their `advanced_models/` counterparts across all consumers: the `/models` route, `createOrUpgradeAgentConfiguration`, the Temporal `runModel` activity, and `resolveModel`.

Key behavioral changes over the old `advanced_models` approach:
- `withModelSelectability` now filters `supportedReasoningEfforts` per-tier rather than blocking entire models — a user capped at `cost_efficient` sees only the `light` effort on Sonnet instead of the model being hidden.
- `getModelTierAccessErrorForAgentConfiguration` takes `reasoningEffort` into account when resolving the tier, so the save-time guard matches the run-time guard exactly.
- Both paths are no-ops when the `models_picker` FF is off; legacy `advanced_models` code remains untouched.

## Tests

Added Vitest integration tests in `front/lib/model_tiers/enabled_models.test.ts` covering: FF disabled (full selectability), `cost_efficient` cap (only `light` effort on Sonnet), `balanced` cap (light/medium/high on Sonnet), and frontier-only models marked not selectable when capped at balanced.

## Risk

Low. Fully gated behind the `models_picker` feature flag. Legacy `advanced_models` code is left in place. No DB changes, no new migrations.

## Deploy Plan

Deploy front.