### PR TITLE
Add model tiers admin API routes.

### DIFF
--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -56,6 +56,7 @@ import mcp from "./mcp";
 import me from "./me";
 import members from "./members";
 import metronome from "./metronome";
+import modelTiers from "./model_tiers";
 import models from "./models";
 import oauthSetup from "./oauth/[provider]/setup";
 import pods from "./pods";
@@ -774,6 +775,7 @@ app.post(
 // targets declared above.
 app.route("/analytics", analytics);
 app.route("/advanced_models", advancedModels);
+app.route("/model_tiers", modelTiers);
 app.route("/assistant", assistant);
 app.route("/audit-logs", auditLogs);
 app.route("/billing", billing);

--- a/front-api/routes/w/[wId]/model_tiers/allowed/groups.ts
+++ b/front-api/routes/w/[wId]/model_tiers/allowed/groups.ts
@@ -1,0 +1,70 @@
+import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
+import type { GetGroupAllowedModelTiersResponseBody } from "@app/types/api/model_tiers";
+import {
+  GroupAllowedModelTierBodySchema,
+  GroupAllowedModelTierClearBodySchema,
+} from "@app/types/api/model_tiers";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { modelTierErrorToApiError } from "../errors";
+
+// Mounted at /api/w/:wId/model_tiers/allowed/groups.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetGroupAllowedModelTiersResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const groups = await ModelsTierResource.listGroupAllowedTierNames(auth);
+
+    return ctx.json({ groups });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  validate("json", GroupAllowedModelTierBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result = await ModelsTierResource.setGroupMaxAllowedTier(auth, body);
+
+    if (result.isErr()) {
+      return apiError(ctx, modelTierErrorToApiError(result.error));
+    }
+
+    return ctx.body(null, 201);
+  }
+);
+
+/** @ignoreswagger */
+app.delete(
+  "/",
+  ensureIsAdmin(),
+  validate("json", GroupAllowedModelTierClearBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result = await ModelsTierResource.clearGroupMaxAllowedTier(
+      auth,
+      body
+    );
+
+    if (result.isErr()) {
+      return apiError(ctx, modelTierErrorToApiError(result.error));
+    }
+
+    return ctx.body(null, 204);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/model_tiers/allowed/index.ts
+++ b/front-api/routes/w/[wId]/model_tiers/allowed/index.ts
@@ -1,0 +1,13 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import groups from "./groups";
+import users from "./users";
+import workspace from "./workspace";
+
+// Mounted at /api/w/:wId/model_tiers/allowed.
+const app = workspaceApp();
+
+app.route("/users", users);
+app.route("/groups", groups);
+app.route("/workspace", workspace);
+
+export default app;

--- a/front-api/routes/w/[wId]/model_tiers/allowed/users.ts
+++ b/front-api/routes/w/[wId]/model_tiers/allowed/users.ts
@@ -1,0 +1,68 @@
+import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
+import type { GetUserAllowedModelTiersResponseBody } from "@app/types/api/model_tiers";
+import {
+  UserAllowedModelTierBodySchema,
+  UserAllowedModelTierClearBodySchema,
+} from "@app/types/api/model_tiers";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+import { modelTierErrorToApiError } from "../errors";
+
+// Mounted at /api/w/:wId/model_tiers/allowed/users.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetUserAllowedModelTiersResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const users = await ModelsTierResource.listUserAllowedTierNames(auth);
+
+    return ctx.json({ users });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  validate("json", UserAllowedModelTierBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result = await ModelsTierResource.setUserMaxAllowedTier(auth, body);
+
+    if (result.isErr()) {
+      return apiError(ctx, modelTierErrorToApiError(result.error));
+    }
+
+    return ctx.body(null, 201);
+  }
+);
+
+/** @ignoreswagger */
+app.delete(
+  "/",
+  ensureIsAdmin(),
+  validate("json", UserAllowedModelTierClearBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result = await ModelsTierResource.clearUserMaxAllowedTier(auth, body);
+
+    if (result.isErr()) {
+      return apiError(ctx, modelTierErrorToApiError(result.error));
+    }
+
+    return ctx.body(null, 204);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/model_tiers/allowed/workspace.ts
+++ b/front-api/routes/w/[wId]/model_tiers/allowed/workspace.ts
@@ -1,0 +1,49 @@
+import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
+import type { GetWorkspaceAllowedModelTiersResponseBody } from "@app/types/api/model_tiers";
+import { AllowedModelTierBodySchema } from "@app/types/api/model_tiers";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { modelTierErrorToApiError } from "../errors";
+
+// Mounted at /api/w/:wId/model_tiers/allowed/workspace.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetWorkspaceAllowedModelTiersResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const maxTierName =
+      await ModelsTierResource.listWorkspaceMaxAllowedTierName(auth);
+
+    return ctx.json({ maxTierName });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  validate("json", AllowedModelTierBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result = await ModelsTierResource.setWorkspaceMaxAllowedTierName(
+      auth,
+      body.tierName
+    );
+
+    if (result.isErr()) {
+      return apiError(ctx, modelTierErrorToApiError(result.error));
+    }
+
+    return ctx.body(null, 201);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/model_tiers/errors.ts
+++ b/front-api/routes/w/[wId]/model_tiers/errors.ts
@@ -1,0 +1,51 @@
+import type { DustError } from "@app/lib/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+
+export function modelTierErrorToApiError(
+  error: DustError
+): APIErrorWithContentfulStatusCode {
+  switch (error.code) {
+    case "invalid_request_error":
+      return {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: error.message,
+        },
+      };
+    case "user_not_found":
+    case "user_not_member":
+      return {
+        status_code: 404,
+        api_error: {
+          type: "workspace_user_not_found",
+          message: error.message,
+        },
+      };
+    case "group_not_found":
+    case "invalid_id":
+      return {
+        status_code: 404,
+        api_error: {
+          type: "group_not_found",
+          message: error.message,
+        },
+      };
+    case "unauthorized":
+      return {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: error.message,
+        },
+      };
+    default:
+      return {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: error.message,
+        },
+      };
+  }
+}

--- a/front-api/routes/w/[wId]/model_tiers/index.ts
+++ b/front-api/routes/w/[wId]/model_tiers/index.ts
@@ -1,0 +1,29 @@
+import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
+import type { GetModelTiersResponseBody } from "@app/types/api/model_tiers";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+
+import allowed from "./allowed";
+
+// Mounted at /api/w/:wId/model_tiers.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetModelTiersResponseBody> => {
+    const tiers = ModelsTierResource.listTiers().map((tier) => ({
+      name: tier.name,
+      id: tier.id,
+      description: tier.description,
+    }));
+
+    return ctx.json({ tiers });
+  }
+);
+
+app.route("/allowed", allowed);
+
+export default app;


### PR DESCRIPTION
## Description

Wires up the `ModelsTierResource` (from #28779) into front-api by adding admin-only routes under `/api/w/:wId/model_tiers/`:

- `GET /model_tiers/` — list all available tiers (catalog, via `ModelsTierResource.listTiers()`)
- `GET/POST /model_tiers/allowed/workspace` — read/set the workspace-level max tier
- `GET/POST/DELETE /model_tiers/allowed/users` — read/set/clear per-user tier overrides
- `GET/POST/DELETE /model_tiers/allowed/groups` — read/set/clear per-group tier overrides

All routes are `@ignoreswagger` and gated behind `ensureIsAdmin()`. `modelTierErrorToApiError` maps `DustError` codes (`user_not_found`, `group_not_found`, `invalid_request_error`, `unauthorized`) to typed HTTP responses. These routes coexist with the legacy `/advanced_models` endpoints pending cleanup.

## Tests

Tested manually against a local front-api instance. No new automated tests — the resource logic is already covered by `tiers.test.ts` from the prior PR.

## Risk

Low. Admin-only, not exposed in swagger, no DB changes, and `ModelsTierResource` is fully static with no side effects on read.

## Deploy Plan

Deploy front-api.