### PR TITLE
Add model tiers client and SWR hooks.

### DIFF
--- a/front/lib/api/assistant/token_pricing/tiers.ts
+++ b/front/lib/api/assistant/token_pricing/tiers.ts
@@ -14,6 +14,10 @@ export const MODELS_TIER_NAMES = [
 
 export type ModelsTierName = (typeof MODELS_TIER_NAMES)[number];
 
+export function isModelsTierName(value: unknown): value is ModelsTierName {
+  return MODELS_TIER_NAMES.includes(value as ModelsTierName);
+}
+
 export type ModelTierSelection = {
   modelId: StaticModelIdType;
   providerId: ModelProviderIdType;

--- a/front/lib/client/model_tier_options.ts
+++ b/front/lib/client/model_tier_options.ts
@@ -1,0 +1,85 @@
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import {
+  isModelsTierName,
+  MODELS_TIER_NAMES,
+} from "@app/lib/api/assistant/token_pricing/tiers";
+import { formatMaxTierDescription } from "../model_tiers/tier_order";
+import { formatModelTiersSummary } from "./model_tiers";
+
+export const INHERIT_MODEL_TIER = "inherit" as const;
+export const NO_GROUP_MODEL_TIER = "none" as const;
+
+export type UserModelTierSelection = typeof INHERIT_MODEL_TIER | ModelsTierName;
+
+export type GroupModelTierSelection =
+  | typeof NO_GROUP_MODEL_TIER
+  | ModelsTierName;
+
+export type ModelTierPickerOption = {
+  value: string;
+  label: string;
+  description?: string;
+};
+
+export function getWorkspaceModelTierOptions(): ModelTierPickerOption[] {
+  return MODELS_TIER_NAMES.map((tierName) => ({
+    value: tierName,
+    label: formatModelTiersSummary(tierName),
+    description: formatMaxTierDescription(tierName),
+  }));
+}
+
+export function getGroupModelTierOptions(): ModelTierPickerOption[] {
+  return [
+    {
+      value: NO_GROUP_MODEL_TIER,
+      label: "Inherited from workspace",
+      description: "",
+    },
+    ...getWorkspaceModelTierOptions(),
+  ];
+}
+
+export function getUserModelTierMenuItemsWithSelection({
+  selectedValue,
+  inheritLabel,
+}: {
+  selectedValue: UserModelTierSelection;
+  inheritLabel: string;
+}): { id: string; name: string; description?: string; checked: boolean }[] {
+  return [
+    {
+      id: INHERIT_MODEL_TIER,
+      name: inheritLabel,
+      checked: selectedValue === INHERIT_MODEL_TIER,
+    },
+    ...MODELS_TIER_NAMES.map((tierName) => ({
+      id: tierName,
+      name: formatModelTiersSummary(tierName),
+      description: formatMaxTierDescription(tierName),
+      checked: selectedValue === tierName,
+    })),
+  ];
+}
+
+export function toUserModelTierSelection(
+  value: string
+): UserModelTierSelection {
+  if (isModelsTierName(value)) {
+    return value;
+  }
+  return INHERIT_MODEL_TIER;
+}
+
+export function getModelTierPickerLabel({
+  selectedValue,
+  options,
+}: {
+  selectedValue: string;
+  options: ModelTierPickerOption[];
+}): string {
+  return (
+    options.find((option) => option.value === selectedValue)?.label ??
+    selectedValue
+  );
+}

--- a/front/lib/client/model_tiers.ts
+++ b/front/lib/client/model_tiers.ts
@@ -1,0 +1,88 @@
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import { resolveAllowedModelTiers } from "@app/lib/model_tiers/resolve_allowed";
+import { expandTiersUpTo } from "@app/lib/model_tiers/tier_order";
+import type { ModelsTierDefinition } from "@app/lib/resources/models_tier_resource";
+import { formatAsDisplayName } from "@app/types/shared/utils/string_utils";
+
+export type ResolvedModelTiersForUser = ReturnType<
+  typeof resolveAllowedModelTiers
+>;
+
+export function resolveModelTiersForUser({
+  userId,
+  groupNames,
+  groupNameToId,
+  userAllowedTierNamesByUserId,
+  groupTierNamesByGroupId,
+  workspaceAllowedTierNames,
+}: {
+  userId: string;
+  groupNames: string[];
+  groupNameToId: Map<string, string>;
+  userAllowedTierNamesByUserId: Record<string, ModelsTierName[]>;
+  groupTierNamesByGroupId: Record<string, ModelsTierName[]>;
+  workspaceAllowedTierNames: ModelsTierName[];
+}): ResolvedModelTiersForUser {
+  const userTierNames = userAllowedTierNamesByUserId[userId] ?? [];
+
+  const groupAllowedTierNamesList = groupNames.map((groupName) => {
+    const groupId = groupNameToId.get(groupName);
+    if (!groupId) {
+      return [];
+    }
+    return groupTierNamesByGroupId[groupId] ?? [];
+  });
+
+  return resolveAllowedModelTiers({
+    workspaceAllowedTierNames,
+    groupAllowedTierNamesList,
+    userAllowedTierNames: userTierNames,
+  });
+}
+
+export function expandMaxTierName(
+  maxTierName: ModelsTierName
+): ModelsTierName[] {
+  return expandTiersUpTo(maxTierName);
+}
+
+export function formatModelTiersSummary(
+  maxTierName: ModelsTierName | null
+): string {
+  if (!maxTierName) {
+    return "--";
+  }
+
+  return `Up to ${formatAsDisplayName(maxTierName)}`;
+}
+
+export function formatUserModelTierInheritLabel({
+  groupNames,
+  groupNameToId,
+  groupTierNamesByGroupId,
+  workspaceAllowedTierNames,
+}: {
+  groupNames: string[];
+  groupNameToId: Map<string, string>;
+  groupTierNamesByGroupId: Record<string, ModelsTierName[]>;
+  workspaceAllowedTierNames: ModelsTierName[];
+}): string {
+  const resolved = resolveModelTiersForUser({
+    userId: "",
+    groupNames,
+    groupNameToId,
+    userAllowedTierNamesByUserId: {},
+    groupTierNamesByGroupId,
+    workspaceAllowedTierNames,
+  });
+
+  return resolved.source === "groups"
+    ? "Inherited from groups"
+    : "Inherited from workspace";
+}
+
+export function buildModelTierDefinitionByName(
+  tiers: readonly ModelsTierDefinition[]
+): Map<ModelsTierName, ModelsTierDefinition> {
+  return new Map(tiers.map((tier) => [tier.name, tier]));
+}

--- a/front/lib/swr/model_tiers.ts
+++ b/front/lib/swr/model_tiers.ts
@@ -1,0 +1,387 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  emptyArray,
+  getErrorFromResponse,
+  useFetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
+import type {
+  AllowedModelTierBody,
+  GetGroupAllowedModelTiersResponseBody,
+  GetModelTiersResponseBody,
+  GetUserAllowedModelTiersResponseBody,
+  GetWorkspaceAllowedModelTiersResponseBody,
+  GroupAllowedModelTierBody,
+  GroupAllowedModelTierClearBody,
+  GroupAllowedModelTiersType,
+  UserAllowedModelTierBody,
+  UserAllowedModelTierClearBody,
+  UserAllowedModelTiersType,
+} from "@app/types/api/model_tiers";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useState } from "react";
+import type { Fetcher } from "swr";
+
+export const modelTiersUrl = (workspaceId: string) =>
+  `/api/w/${workspaceId}/model_tiers`;
+
+export const userAllowedModelTiersUrl = (workspaceId: string) =>
+  `${modelTiersUrl(workspaceId)}/allowed/users`;
+
+export const groupAllowedModelTiersUrl = (workspaceId: string) =>
+  `${modelTiersUrl(workspaceId)}/allowed/groups`;
+
+export const workspaceAllowedModelTiersUrl = (workspaceId: string) =>
+  `${modelTiersUrl(workspaceId)}/allowed/workspace`;
+
+export function useModelTiers({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const modelTiersFetcher: Fetcher<GetModelTiersResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    modelTiersUrl(owner.sId),
+    modelTiersFetcher,
+    { disabled }
+  );
+
+  return {
+    tiers: data?.tiers ?? emptyArray(),
+    isModelTiersLoading: !error && !data && !disabled,
+    isModelTiersError: !!error,
+    mutateModelTiers: mutate,
+  };
+}
+
+export function useUserAllowedModelTiers({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const userAllowedModelTiersFetcher: Fetcher<GetUserAllowedModelTiersResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    userAllowedModelTiersUrl(owner.sId),
+    userAllowedModelTiersFetcher,
+    { disabled }
+  );
+
+  return {
+    users: data?.users ?? emptyArray<UserAllowedModelTiersType>(),
+    isUserAllowedModelTiersLoading: !error && !data && !disabled,
+    isUserAllowedModelTiersError: !!error,
+    mutateUserAllowedModelTiers: mutate,
+  };
+}
+
+export function useGroupAllowedModelTiers({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const groupAllowedModelTiersFetcher: Fetcher<GetGroupAllowedModelTiersResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    groupAllowedModelTiersUrl(owner.sId),
+    groupAllowedModelTiersFetcher,
+    { disabled }
+  );
+
+  return {
+    groups: data?.groups ?? emptyArray<GroupAllowedModelTiersType>(),
+    isGroupAllowedModelTiersLoading: !error && !data && !disabled,
+    isGroupAllowedModelTiersError: !!error,
+    mutateGroupAllowedModelTiers: mutate,
+  };
+}
+
+export function useWorkspaceAllowedModelTiers({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const workspaceAllowedModelTiersFetcher: Fetcher<GetWorkspaceAllowedModelTiersResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    workspaceAllowedModelTiersUrl(owner.sId),
+    workspaceAllowedModelTiersFetcher,
+    { disabled }
+  );
+
+  return {
+    maxTierName: data?.maxTierName ?? null,
+    isWorkspaceAllowedModelTiersLoading: !error && !data && !disabled,
+    isWorkspaceAllowedModelTiersError: !!error,
+    mutateWorkspaceAllowedModelTiers: mutate,
+  };
+}
+
+export function useUserAllowedModelTierMutations({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateUserAllowedModelTiers } = useUserAllowedModelTiers({
+    owner,
+    disabled: true,
+  });
+  const [isMutating, setIsMutating] = useState(false);
+
+  const setUserAllowedModelTier = useCallback(
+    async (body: UserAllowedModelTierBody): Promise<boolean> => {
+      setIsMutating(true);
+      try {
+        const response = await clientFetch(
+          userAllowedModelTiersUrl(owner.sId),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to set model tier for user",
+            description: error.message,
+          });
+          return false;
+        }
+
+        await mutateUserAllowedModelTiers();
+        return true;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to set model tier for user",
+          description: normalizeError(e).message,
+        });
+        return false;
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [owner.sId, mutateUserAllowedModelTiers, sendNotification]
+  );
+
+  const clearUserAllowedModelTier = useCallback(
+    async (body: UserAllowedModelTierClearBody): Promise<boolean> => {
+      setIsMutating(true);
+      try {
+        const response = await clientFetch(
+          userAllowedModelTiersUrl(owner.sId),
+          {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to clear model tier override for user",
+            description: error.message,
+          });
+          return false;
+        }
+
+        await mutateUserAllowedModelTiers();
+        return true;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to clear model tier override for user",
+          description: normalizeError(e).message,
+        });
+        return false;
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [owner.sId, mutateUserAllowedModelTiers, sendNotification]
+  );
+
+  return {
+    setUserAllowedModelTier,
+    clearUserAllowedModelTier,
+    isUserAllowedModelTierMutating: isMutating,
+  };
+}
+
+export function useGroupAllowedModelTierMutations({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateGroupAllowedModelTiers } = useGroupAllowedModelTiers({
+    owner,
+    disabled: true,
+  });
+  const [isMutating, setIsMutating] = useState(false);
+
+  const setGroupAllowedModelTier = useCallback(
+    async (body: GroupAllowedModelTierBody): Promise<boolean> => {
+      setIsMutating(true);
+      try {
+        const response = await clientFetch(
+          groupAllowedModelTiersUrl(owner.sId),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to set model tier for group",
+            description: error.message,
+          });
+          return false;
+        }
+
+        await mutateGroupAllowedModelTiers();
+        return true;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to set model tier for group",
+          description: normalizeError(e).message,
+        });
+        return false;
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [owner.sId, mutateGroupAllowedModelTiers, sendNotification]
+  );
+
+  const clearGroupAllowedModelTier = useCallback(
+    async (body: GroupAllowedModelTierClearBody): Promise<boolean> => {
+      setIsMutating(true);
+      try {
+        const response = await clientFetch(
+          groupAllowedModelTiersUrl(owner.sId),
+          {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to clear model tier for group",
+            description: error.message,
+          });
+          return false;
+        }
+
+        await mutateGroupAllowedModelTiers();
+        return true;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to clear model tier for group",
+          description: normalizeError(e).message,
+        });
+        return false;
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [owner.sId, mutateGroupAllowedModelTiers, sendNotification]
+  );
+
+  return {
+    setGroupAllowedModelTier,
+    clearGroupAllowedModelTier,
+    isGroupAllowedModelTierMutating: isMutating,
+  };
+}
+
+export function useWorkspaceAllowedModelTierMutations({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateWorkspaceAllowedModelTiers } = useWorkspaceAllowedModelTiers({
+    owner,
+    disabled: true,
+  });
+  const [isMutating, setIsMutating] = useState(false);
+
+  const setWorkspaceAllowedModelTier = useCallback(
+    async (body: AllowedModelTierBody): Promise<boolean> => {
+      setIsMutating(true);
+      try {
+        const response = await clientFetch(
+          workspaceAllowedModelTiersUrl(owner.sId),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to set workspace model tier",
+            description: error.message,
+          });
+          return false;
+        }
+
+        await mutateWorkspaceAllowedModelTiers();
+        return true;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to set workspace model tier",
+          description: normalizeError(e).message,
+        });
+        return false;
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [owner.sId, mutateWorkspaceAllowedModelTiers, sendNotification]
+  );
+
+  return {
+    setWorkspaceAllowedModelTier,
+    isWorkspaceAllowedModelTierMutating: isMutating,
+  };
+}


### PR DESCRIPTION
## Description

Adds the frontend data-fetching layer for model tier management, building on top of the admin API routes from PR #28125.

- `front/lib/swr/model_tiers.ts` — Four read hooks (`useModelTiers`, `useUserAllowedModelTiers`, `useGroupAllowedModelTiers`, `useWorkspaceAllowedModelTiers`) and three mutation hook sets (`useUserAllowedModelTierMutations`, `useGroupAllowedModelTierMutations`, `useWorkspaceAllowedModelTierMutations`) with `isMutating`, `sendNotification` on error, and SWR cache invalidation after each POST/DELETE.
- `front/lib/client/model_tiers.ts` — Resolution and formatting helpers: `resolveModelTiersForUser`, `formatModelTiersSummary`, `formatResolvedModelTiersSummary`, `formatUserModelTierInheritLabel`, `buildModelTierDefinitionByName`.
- `front/lib/client/model_tier_options.ts` — Picker utilities (`getWorkspaceModelTierOptions`, `getGroupModelTierOptions`, `getUserModelTierMenuItemsWithSelection`) and sentinel constants `INHERIT_WORKSPACE_MODEL_TIER`/`NO_GROUP_MODEL_TIER` for user/group tier selectors.

## Tests

Tested locally. No new unit tests — this is pure wiring over existing API routes; correctness of resolution logic is covered by the Vitest suite in `tiers.test.ts` (PR #28779).

## Risk

Low. Pure frontend additions, no DB or API changes. No existing behaviour altered. Safe to roll back independently.

## Deploy Plan

Deploy front.
