### PR TITLE
Add workspace UI for model tier management.

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -11,31 +11,35 @@ import {
   seatTypeDisplayName,
 } from "@app/components/workspace/billing/seatTypeUtils";
 import { ChangeSeatModal } from "@app/components/workspace/ChangeSeatModal";
-import {
-  EditAdvancedModelsModal,
-  type EditAdvancedModelsTarget,
-} from "@app/components/workspace/EditAdvancedModelsModal";
 import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitModal";
+import { GroupModelTierPickerDropdown } from "@app/components/workspace/GroupModelTierPickerDropdown";
 import { GroupsUsageTable } from "@app/components/workspace/GroupsUsageTable";
 import { MembersSelectionBanner } from "@app/components/workspace/MembersSelectionBanner";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
 import { TopUpsHistoryTable } from "@app/components/workspace/TopUpsHistoryTable";
 import { UpgradeRequestsTable } from "@app/components/workspace/UpgradeRequestsTable";
-import { AdvancedModelsSettingsCard } from "@app/components/workspace/usage/AdvancedModelsSettingsCard";
 import { LockedSection } from "@app/components/workspace/usage/LockedSection";
+import { ModelTiersSettingsCard } from "@app/components/workspace/usage/ModelTiersSettingsCard";
 import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNotificationsCard";
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
 import { useMembersSelection } from "@app/hooks/useMembersSelection";
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import {
   useAuth,
   useFeatureFlags,
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
-import { buildAdvancedModelDisplayNameMap } from "@app/lib/client/advanced_models";
 import { formatCredits } from "@app/lib/client/credits";
+import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
+import { INHERIT_MODEL_TIER } from "@app/lib/client/model_tier_options";
+import {
+  buildModelTierDefinitionByName,
+  expandMaxTierName,
+} from "@app/lib/client/model_tiers";
+import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
 import {
   isCreditPricedFreePlan,
   isEnterprisePlanPrefix,
@@ -43,12 +47,6 @@ import {
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
-import {
-  useAdvancedModels,
-  useGroupAllowedAdvancedModels,
-  useUserAllowedAdvancedModels,
-  useWorkspaceAllowedAdvancedModels,
-} from "@app/lib/swr/advanced_models";
 import {
   useAwuPoolSummary,
   useAwuPurchaseInfo,
@@ -65,6 +63,13 @@ import {
   useMembersUsage,
   useUpdateMemberSeatType,
 } from "@app/lib/swr/memberships";
+import {
+  useGroupAllowedModelTiers,
+  useModelTiers,
+  useUserAllowedModelTierMutations,
+  useUserAllowedModelTiers,
+  useWorkspaceAllowedModelTiers,
+} from "@app/lib/swr/model_tiers";
 import {
   useResolveUpgradeRequest,
   useUpgradeRequests,
@@ -230,8 +235,6 @@ export function UsagePage() {
   );
   const [editSpendLimitMember, setEditSpendLimitMember] =
     useState<MemberUsageType | null>(null);
-  const [editAdvancedModelsTarget, setEditAdvancedModelsTarget] =
-    useState<EditAdvancedModelsTarget | null>(null);
   const [
     totalAllowedUsagePendingMemberIds,
     setTotalAllowedUsagePendingMemberIds,
@@ -302,22 +305,21 @@ export function UsagePage() {
     },
     []
   );
-  const handleEditAdvancedModelsFromTable = useCallback(
-    (member: MemberUsageType) => {
-      setEditAdvancedModelsTarget({
-        scope: "user",
+  const { setUserAllowedModelTier, clearUserAllowedModelTier } =
+    useUserAllowedModelTierMutations({ owner });
+  const handleSetUserModelTier = useCallback(
+    (member: MemberUsageType, selection: UserModelTierSelection) => {
+      if (selection === INHERIT_MODEL_TIER) {
+        void clearUserAllowedModelTier({ userId: member.sId });
+        return;
+      }
+
+      void setUserAllowedModelTier({
         userId: member.sId,
-        name: member.name,
-        image: member.image,
+        tierName: selection,
       });
     },
-    []
-  );
-  const handleEditWorkspaceAdvancedModels = useCallback(
-    (target: Extract<EditAdvancedModelsTarget, { scope: "workspace" }>) => {
-      setEditAdvancedModelsTarget(target);
-    },
-    []
+    [clearUserAllowedModelTier, setUserAllowedModelTier]
   );
   const handleUpgradePlanRequest = useCallback(
     (request: MembershipUpgradeRequestType) => {
@@ -473,47 +475,51 @@ export function UsagePage() {
   const selectedGroupName =
     groups.find((g) => g.sId === groupFilter)?.name ?? null;
 
-  const { models: advancedModelsCatalog } = useAdvancedModels({
+  const { tiers: modelTiersCatalog } = useModelTiers({
     owner,
     disabled: !modelsPickerEnabled,
   });
-  const { users: userAllowedAdvancedModels } = useUserAllowedAdvancedModels({
+  const { users: userAllowedModelTiers } = useUserAllowedModelTiers({
     owner,
     disabled: !modelsPickerEnabled,
   });
-  const { groups: groupAllowedAdvancedModels } = useGroupAllowedAdvancedModels({
+  const { groups: groupAllowedModelTiers } = useGroupAllowedModelTiers({
     owner,
     disabled: !modelsPickerEnabled,
   });
-  const { models: workspaceAllowedAdvancedModels } =
-    useWorkspaceAllowedAdvancedModels({
-      owner,
-      disabled: !modelsPickerEnabled,
-    });
-  const advancedModelDisplayNameByKey = useMemo(
-    () => buildAdvancedModelDisplayNameMap(advancedModelsCatalog),
-    [advancedModelsCatalog]
+  const { maxTierName: workspaceMaxTierName } = useWorkspaceAllowedModelTiers({
+    owner,
+    disabled: !modelsPickerEnabled,
+  });
+  const modelTierDefinitionByName = useMemo(
+    () => buildModelTierDefinitionByName(modelTiersCatalog),
+    [modelTiersCatalog]
   );
-  const userAllowedAdvancedModelsByUserId = useMemo(() => {
-    const map: Record<
-      string,
-      (typeof userAllowedAdvancedModels)[number]["models"]
-    > = {};
-    for (const entry of userAllowedAdvancedModels) {
-      map[entry.userId] = entry.models;
+  const workspaceAllowedModelTiers = useMemo(
+    () => expandMaxTierName(workspaceMaxTierName ?? DEFAULT_MAX_MODEL_TIER),
+    [workspaceMaxTierName]
+  );
+  const userModelTierSelectionByUserId = useMemo(() => {
+    const map: Record<string, UserModelTierSelection> = {};
+    for (const entry of userAllowedModelTiers) {
+      map[entry.userId] = entry.maxTierName;
     }
     return map;
-  }, [userAllowedAdvancedModels]);
-  const groupAdvancedModelsByGroupId = useMemo(() => {
-    const map: Record<
-      string,
-      (typeof groupAllowedAdvancedModels)[number]["models"]
-    > = {};
-    for (const entry of groupAllowedAdvancedModels) {
-      map[entry.groupId] = entry.models;
+  }, [userAllowedModelTiers]);
+  const userAllowedModelTiersByUserId = useMemo(() => {
+    const map: Record<string, ModelsTierName[]> = {};
+    for (const entry of userAllowedModelTiers) {
+      map[entry.userId] = expandMaxTierName(entry.maxTierName);
     }
     return map;
-  }, [groupAllowedAdvancedModels]);
+  }, [userAllowedModelTiers]);
+  const groupModelTiersByGroupId = useMemo(() => {
+    const map: Record<string, ModelsTierName[]> = {};
+    for (const entry of groupAllowedModelTiers) {
+      map[entry.groupId] = expandMaxTierName(entry.maxTierName);
+    }
+    return map;
+  }, [groupAllowedModelTiers]);
   const groupNameToId = useMemo(() => {
     const map = new Map<string, string>();
     for (const group of groups) {
@@ -521,21 +527,6 @@ export function UsagePage() {
     }
     return map;
   }, [groups]);
-
-  const handleEditGroupAdvancedModels = useCallback(() => {
-    if (!groupFilter) {
-      return;
-    }
-    const group = groups.find((g) => g.sId === groupFilter);
-    if (!group) {
-      return;
-    }
-    setEditAdvancedModelsTarget({
-      scope: "group",
-      groupId: group.sId,
-      name: group.name,
-    });
-  }, [groupFilter, groups]);
 
   // Cross-page selection for batch actions on the members table. Resets when the
   // filter identity changes (the "all matching" set is no longer the same).
@@ -921,19 +912,20 @@ export function UsagePage() {
       isRefreshing={isMembersUsageRefreshing}
       readOnly={isReadOnly}
       showSpendLimit={!isFreePlanWorkspace}
-      showAdvancedModelsColumn={modelsPickerEnabled}
-      userAllowedAdvancedModelsByUserId={userAllowedAdvancedModelsByUserId}
-      groupAdvancedModelsByGroupId={groupAdvancedModelsByGroupId}
-      workspaceAllowedAdvancedModels={workspaceAllowedAdvancedModels}
+      showModelTiersColumn={modelsPickerEnabled}
+      userModelTierSelectionByUserId={userModelTierSelectionByUserId}
+      userAllowedModelTiersByUserId={userAllowedModelTiersByUserId}
+      groupModelTiersByGroupId={groupModelTiersByGroupId}
+      workspaceAllowedModelTiers={workspaceAllowedModelTiers}
       groupNameToId={groupNameToId}
-      advancedModelDisplayNameByKey={advancedModelDisplayNameByKey}
+      modelTierDefinitionByName={modelTierDefinitionByName}
       totalAllowedUsagePendingMemberIds={totalAllowedUsagePendingMemberIds}
       seatChangePendingMemberIds={seatChangePendingMemberIds}
       isSeatBased={isSeatBased}
       onChangeSeat={handleChangeSeatFromTable}
       onRemoveSeat={onRemoveSeat}
       onEditSpendLimit={handleEditSpendLimitFromTable}
-      onEditAdvancedModels={handleEditAdvancedModelsFromTable}
+      onSetUserModelTier={handleSetUserModelTier}
       pagination={pagination}
       setPagination={setPagination}
       totalRowCount={totalMembersUsage}
@@ -1113,12 +1105,10 @@ export function UsagePage() {
                     <div className="flex flex-row items-center gap-2">
                       {groupsFilterDropdown}
                       {modelsPickerEnabled && groupFilter && (
-                        <Button
-                          label="Edit group advanced models"
-                          variant="outline"
-                          size="sm"
-                          disabled={isReadOnly}
-                          onClick={handleEditGroupAdvancedModels}
+                        <GroupModelTierPickerDropdown
+                          owner={owner}
+                          groupId={groupFilter}
+                          readOnly={isReadOnly}
                         />
                       )}
                       {seatFilterDropdown}
@@ -1149,7 +1139,11 @@ export function UsagePage() {
 
           {isWorkspaceAdmin && (
             <TabsContent value="groups">
-              <GroupsUsageTable owner={owner} readOnly={isReadOnly} />
+              <GroupsUsageTable
+                owner={owner}
+                readOnly={isReadOnly}
+                showModelTiersColumn={modelsPickerEnabled}
+              />
             </TabsContent>
           )}
 
@@ -1168,13 +1162,7 @@ export function UsagePage() {
                   hasPool={hasPool}
                 />
                 {modelsPickerEnabled && (
-                  <AdvancedModelsSettingsCard
-                    owner={owner}
-                    readOnly={isReadOnly}
-                    onEditWorkspaceAdvancedModels={
-                      handleEditWorkspaceAdvancedModels
-                    }
-                  />
+                  <ModelTiersSettingsCard owner={owner} readOnly={isReadOnly} />
                 )}
                 <LockedSection
                   locked={!isAwuPoolSummaryLoading && !hasPool}
@@ -1245,13 +1233,6 @@ export function UsagePage() {
         seatPlans={seatPlans}
         onFetchPreview={handleBulkSeatChangePreview}
         onValidate={handleBulkChangeSeatValidate}
-      />
-      <EditAdvancedModelsModal
-        isOpen={editAdvancedModelsTarget !== null}
-        onClose={() => setEditAdvancedModelsTarget(null)}
-        owner={owner}
-        target={editAdvancedModelsTarget}
-        readOnly={isReadOnly}
       />
     </>
   );

--- a/front/components/workspace/GroupModelTierPickerDropdown.tsx
+++ b/front/components/workspace/GroupModelTierPickerDropdown.tsx
@@ -1,0 +1,56 @@
+import { ModelTierPickerDropdown } from "@app/components/workspace/ModelTierPickerDropdown";
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import {
+  getGroupModelTierOptions,
+  NO_GROUP_MODEL_TIER,
+} from "@app/lib/client/model_tier_options";
+import {
+  useGroupAllowedModelTierMutations,
+  useGroupAllowedModelTiers,
+} from "@app/lib/swr/model_tiers";
+import type { LightWorkspaceType } from "@app/types/user";
+
+interface GroupModelTierPickerDropdownProps {
+  owner: LightWorkspaceType;
+  groupId: string;
+  readOnly?: boolean;
+}
+
+export function GroupModelTierPickerDropdown({
+  owner,
+  groupId,
+  readOnly = false,
+}: GroupModelTierPickerDropdownProps) {
+  const { groups: groupAllowedModelTiers, isGroupAllowedModelTiersLoading } =
+    useGroupAllowedModelTiers({ owner });
+  const {
+    setGroupAllowedModelTier,
+    clearGroupAllowedModelTier,
+    isGroupAllowedModelTierMutating,
+  } = useGroupAllowedModelTierMutations({ owner });
+
+  const selectedValue =
+    groupAllowedModelTiers.find((entry) => entry.groupId === groupId)
+      ?.maxTierName ?? NO_GROUP_MODEL_TIER;
+
+  return (
+    <ModelTierPickerDropdown
+      selectedValue={selectedValue}
+      options={getGroupModelTierOptions()}
+      onSelect={async (value) => {
+        if (value === NO_GROUP_MODEL_TIER) {
+          await clearGroupAllowedModelTier({ groupId });
+          return;
+        }
+
+        await setGroupAllowedModelTier({
+          groupId,
+          tierName: value as ModelsTierName,
+        });
+      }}
+      readOnly={readOnly}
+      isLoading={isGroupAllowedModelTiersLoading}
+      isMutating={isGroupAllowedModelTierMutating}
+    />
+  );
+}

--- a/front/components/workspace/GroupsUsageTable.tsx
+++ b/front/components/workspace/GroupsUsageTable.tsx
@@ -1,3 +1,4 @@
+import { GroupModelTierPickerDropdown } from "@app/components/workspace/GroupModelTierPickerDropdown";
 import { useGroups, useUpdateGroupSpendLimit } from "@app/lib/swr/groups";
 import type { GroupSpendLimit } from "@app/types/api/groups/spend_limit";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
@@ -9,6 +10,7 @@ import { useMemo, useState } from "react";
 interface GroupsUsageTableProps {
   owner: LightWorkspaceType;
   readOnly: boolean;
+  showModelTiersColumn?: boolean;
 }
 
 type GroupRowData = {
@@ -70,7 +72,11 @@ function GroupCapCell({ group, readOnly, onSave }: GroupCapCellProps) {
   );
 }
 
-export function GroupsUsageTable({ owner, readOnly }: GroupsUsageTableProps) {
+export function GroupsUsageTable({
+  owner,
+  readOnly,
+  showModelTiersColumn = false,
+}: GroupsUsageTableProps) {
   const { groups, isGroupsLoading } = useGroups({
     owner,
     kinds: [...CAP_ELIGIBLE_GROUP_KINDS],
@@ -134,8 +140,25 @@ export function GroupsUsageTable({ owner, readOnly }: GroupsUsageTableProps) {
         ),
         enableSorting: false,
       },
+      ...(showModelTiersColumn
+        ? [
+            {
+              id: "modelTiers",
+              header: "Models tier",
+              meta: { className: "w-64" },
+              cell: (info: GroupInfo) => (
+                <GroupModelTierPickerDropdown
+                  owner={owner}
+                  groupId={info.row.original.groupId}
+                  readOnly={readOnly}
+                />
+              ),
+              enableSorting: false,
+            } satisfies ColumnDef<GroupRowData, string>,
+          ]
+        : []),
     ],
-    [readOnly, doUpdateGroupSpendLimit]
+    [owner, readOnly, showModelTiersColumn, doUpdateGroupSpendLimit]
   );
 
   if (isGroupsLoading) {

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -9,14 +9,23 @@ import {
   MUTED_BAR_CLASSES,
   OVERAGE_BAR_CLASSES,
 } from "@app/components/workspace/seat_styles";
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
-import {
-  getAdvancedModelDisplayNames,
-  resolveAdvancedModelsForUser,
-} from "@app/lib/client/advanced_models";
 import { formatCredits } from "@app/lib/client/credits";
+import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
+import {
+  getUserModelTierMenuItemsWithSelection,
+  INHERIT_MODEL_TIER,
+  toUserModelTierSelection,
+} from "@app/lib/client/model_tier_options";
+import {
+  formatModelTiersSummary,
+  formatUserModelTierInheritLabel,
+  resolveModelTiersForUser,
+} from "@app/lib/client/model_tiers";
+import { getMaxTierName } from "@app/lib/model_tiers/tier_order";
+import type { ModelsTierDefinition } from "@app/lib/resources/models_tier_resource";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
-import type { AllowedAdvancedModelType } from "@app/types/api/advanced_models";
 import {
   isPaidSeatType,
   type MembershipSeatType,
@@ -43,17 +52,22 @@ import type {
 } from "@tanstack/react-table";
 import { useMemo } from "react";
 
-const EMPTY_USER_ALLOWED_ADVANCED_MODELS_BY_USER_ID: Record<
+const EMPTY_USER_MODEL_TIER_SELECTION_BY_USER_ID: Record<
   string,
-  AllowedAdvancedModelType[]
+  UserModelTierSelection
 > = {};
-const EMPTY_GROUP_ADVANCED_MODELS_BY_GROUP_ID: Record<
+const EMPTY_USER_ALLOWED_MODEL_TIERS_BY_USER_ID: Record<
   string,
-  AllowedAdvancedModelType[]
+  ModelsTierName[]
 > = {};
-const EMPTY_WORKSPACE_ALLOWED_ADVANCED_MODELS: AllowedAdvancedModelType[] = [];
+const EMPTY_GROUP_MODEL_TIERS_BY_GROUP_ID: Record<string, ModelsTierName[]> =
+  {};
+const EMPTY_WORKSPACE_ALLOWED_MODEL_TIERS: ModelsTierName[] = [];
 const EMPTY_GROUP_NAME_TO_ID = new Map<string, string>();
-const EMPTY_ADVANCED_MODEL_DISPLAY_NAME_BY_KEY = new Map<string, string>();
+const EMPTY_MODEL_TIER_DEFINITION_BY_NAME = new Map<
+  ModelsTierName,
+  ModelsTierDefinition
+>();
 
 type RowData = {
   sId: string;
@@ -73,8 +87,8 @@ type RowData = {
   scheduledSeatChangeAt: string | null;
   isTotalAllowedUsagePending: boolean;
   isSeatChangePending: boolean;
-  advancedModelDisplayNames: string[];
-  hasUserLevelAdvancedModelsOverride: boolean;
+  modelTiersSummary: string;
+  hasUserLevelModelTiersOverride: boolean;
   menuItems: MenuItem[];
 };
 
@@ -509,56 +523,23 @@ function buildConsumedAwuCreditsColumn(
   };
 }
 
-const advancedModelsColumn: ColumnDef<RowData, string> = {
-  id: "advancedModels" as const,
-  header: "Advanced models",
+const modelTiersColumn: ColumnDef<RowData, string> = {
+  id: "modelTiers" as const,
+  header: "Models tier",
   enableSorting: false,
-  accessorFn: (row) => row.advancedModelDisplayNames.join(", "),
+  accessorFn: (row) => row.modelTiersSummary,
   cell: (info: Info) => {
-    const displayNames = info.row.original.advancedModelDisplayNames;
-    const customSuffix = info.row.original.hasUserLevelAdvancedModelsOverride
+    const summary = info.row.original.modelTiersSummary;
+    const customSuffix = info.row.original.hasUserLevelModelTiersOverride
       ? " (custom)"
       : "";
 
-    if (displayNames.length === 0) {
-      return (
-        <DataTable.CellContent>
-          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            --
-          </span>
-        </DataTable.CellContent>
-      );
-    }
-
-    if (displayNames.length === 1) {
-      return (
-        <DataTable.CellContent>
-          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            {displayNames[0]}
-            {customSuffix}
-          </span>
-        </DataTable.CellContent>
-      );
-    }
-
     return (
       <DataTable.CellContent>
-        <Tooltip
-          label={
-            <div className="flex flex-col gap-0.5">
-              {displayNames.map((name, index) => (
-                <span key={`${name}-${index}`}>{name}</span>
-              ))}
-            </div>
-          }
-          tooltipTriggerAsChild
-          trigger={
-            <span className="cursor-default text-sm text-muted-foreground dark:text-muted-foreground-night">
-              {displayNames.length} models
-              {customSuffix}
-            </span>
-          }
-        />
+        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {summary}
+          {customSuffix}
+        </span>
       </DataTable.CellContent>
     );
   },
@@ -573,7 +554,12 @@ const actionsColumn: ColumnDef<RowData, string> = {
   enableSorting: false,
   accessorKey: "actions",
   cell: (info: Info) => (
-    <DataTable.MoreButton menuItems={info.row.original.menuItems} />
+    <div
+      onClick={(event) => event.stopPropagation()}
+      onPointerDown={(event) => event.stopPropagation()}
+    >
+      <DataTable.MoreButton menuItems={info.row.original.menuItems} />
+    </div>
   ),
   meta: {
     className: "w-14",
@@ -583,19 +569,19 @@ const actionsColumn: ColumnDef<RowData, string> = {
 function buildColumns({
   enableSelection,
   showGroupsColumn,
-  showAdvancedModelsColumn,
+  showModelTiersColumn,
   creditsResetAt,
 }: {
   enableSelection: boolean;
   showGroupsColumn: boolean;
-  showAdvancedModelsColumn: boolean;
+  showModelTiersColumn: boolean;
   creditsResetAt: string | null;
 }): ColumnDef<RowData, string>[] {
   return [
     ...(enableSelection ? [createSelectionColumn<RowData>()] : []),
     nameColumn,
     ...(showGroupsColumn ? [groupsColumn] : []),
-    ...(showAdvancedModelsColumn ? [advancedModelsColumn] : []),
+    ...(showModelTiersColumn ? [modelTiersColumn] : []),
     seatTypeColumn,
     {
       ...buildConsumedAwuCreditsColumn(creditsResetAt),
@@ -620,16 +606,17 @@ interface MembersUsageTableProps {
   onChangeSeat: (member: MemberUsageType) => void;
   onRemoveSeat: (member: MemberUsageType) => void;
   onEditSpendLimit: (member: MemberUsageType) => void;
-  onEditAdvancedModels?: (member: MemberUsageType) => void;
-  showAdvancedModelsColumn?: boolean;
-  userAllowedAdvancedModelsByUserId?: Record<
-    string,
-    AllowedAdvancedModelType[]
-  >;
-  groupAdvancedModelsByGroupId?: Record<string, AllowedAdvancedModelType[]>;
-  workspaceAllowedAdvancedModels?: AllowedAdvancedModelType[];
+  onSetUserModelTier?: (
+    member: MemberUsageType,
+    selection: UserModelTierSelection
+  ) => void;
+  showModelTiersColumn?: boolean;
+  userModelTierSelectionByUserId?: Record<string, UserModelTierSelection>;
+  userAllowedModelTiersByUserId?: Record<string, ModelsTierName[]>;
+  groupModelTiersByGroupId?: Record<string, ModelsTierName[]>;
+  workspaceAllowedModelTiers?: ModelsTierName[];
   groupNameToId?: Map<string, string>;
-  advancedModelDisplayNameByKey?: Map<string, string>;
+  modelTierDefinitionByName?: Map<ModelsTierName, ModelsTierDefinition>;
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
   totalRowCount: number;
@@ -654,13 +641,14 @@ export function MembersUsageTable({
   onChangeSeat,
   onRemoveSeat,
   onEditSpendLimit,
-  onEditAdvancedModels,
-  showAdvancedModelsColumn = false,
-  userAllowedAdvancedModelsByUserId = EMPTY_USER_ALLOWED_ADVANCED_MODELS_BY_USER_ID,
-  groupAdvancedModelsByGroupId = EMPTY_GROUP_ADVANCED_MODELS_BY_GROUP_ID,
-  workspaceAllowedAdvancedModels = EMPTY_WORKSPACE_ALLOWED_ADVANCED_MODELS,
+  onSetUserModelTier,
+  showModelTiersColumn = false,
+  userModelTierSelectionByUserId = EMPTY_USER_MODEL_TIER_SELECTION_BY_USER_ID,
+  userAllowedModelTiersByUserId = EMPTY_USER_ALLOWED_MODEL_TIERS_BY_USER_ID,
+  groupModelTiersByGroupId = EMPTY_GROUP_MODEL_TIERS_BY_GROUP_ID,
+  workspaceAllowedModelTiers = EMPTY_WORKSPACE_ALLOWED_MODEL_TIERS,
   groupNameToId = EMPTY_GROUP_NAME_TO_ID,
-  advancedModelDisplayNameByKey = EMPTY_ADVANCED_MODEL_DISPLAY_NAME_BY_KEY,
+  modelTierDefinitionByName = EMPTY_MODEL_TIER_DEFINITION_BY_NAME,
   pagination,
   setPagination,
   totalRowCount,
@@ -674,14 +662,14 @@ export function MembersUsageTable({
   const rows: RowData[] = useMemo(
     () =>
       members.map((m) => {
-        const resolvedAdvancedModels = showAdvancedModelsColumn
-          ? resolveAdvancedModelsForUser({
+        const resolvedModelTiers = showModelTiersColumn
+          ? resolveModelTiersForUser({
               userId: m.sId,
               groupNames: m.groups,
               groupNameToId,
-              userAllowedAdvancedModelsByUserId,
-              groupAdvancedModelsByGroupId,
-              workspaceAllowedAdvancedModels,
+              userAllowedTierNamesByUserId: userAllowedModelTiersByUserId,
+              groupTierNamesByGroupId: groupModelTiersByGroupId,
+              workspaceAllowedTierNames: workspaceAllowedModelTiers,
             })
           : null;
 
@@ -705,14 +693,10 @@ export function MembersUsageTable({
             m.sId
           ),
           isSeatChangePending: seatChangePendingMemberIds.has(m.sId),
-          advancedModelDisplayNames: resolvedAdvancedModels
-            ? getAdvancedModelDisplayNames({
-                models: resolvedAdvancedModels.models,
-                displayNameByKey: advancedModelDisplayNameByKey,
-              })
-            : [],
-          hasUserLevelAdvancedModelsOverride:
-            resolvedAdvancedModels?.hasUserLevelOverride ?? false,
+          modelTiersSummary: formatModelTiersSummary(
+            getMaxTierName(resolvedModelTiers?.tiers ?? [])
+          ),
+          hasUserLevelModelTiersOverride: resolvedModelTiers?.source === "user",
           menuItems: [
             ...(!m.seatType || m.seatType === "none"
               ? [
@@ -734,9 +718,6 @@ export function MembersUsageTable({
                   },
                 ]
               : []),
-            // Only paid, message-sending seats have a spend limit to edit. Free
-            // seats have no pool (their cap is just the fixed free allowance), and
-            // "none"/seatless members can't send anything — so the option hides.
             ...(showSpendLimit &&
             m.seatType &&
             m.seatType !== "free" &&
@@ -750,17 +731,34 @@ export function MembersUsageTable({
                   },
                 ]
               : []),
-            ...(showAdvancedModelsColumn && onEditAdvancedModels
+            ...(showModelTiersColumn && onSetUserModelTier
               ? [
                   {
-                    kind: "item" as const,
-                    label: "Edit advanced models",
+                    kind: "submenu" as const,
+                    label: "Models tier",
                     disabled: readOnly,
-                    onClick: () => onEditAdvancedModels(m),
+                    selectionMode: "checkbox" as const,
+                    items: getUserModelTierMenuItemsWithSelection({
+                      selectedValue:
+                        userModelTierSelectionByUserId[m.sId] ??
+                        INHERIT_MODEL_TIER,
+                      inheritLabel: formatUserModelTierInheritLabel({
+                        groupNames: m.groups,
+                        groupNameToId,
+                        groupTierNamesByGroupId: groupModelTiersByGroupId,
+                        workspaceAllowedTierNames: workspaceAllowedModelTiers,
+                      }),
+                    }).map((tierItem) => ({
+                      id: tierItem.id,
+                      name: tierItem.name,
+                      description: tierItem.description,
+                      checked: tierItem.checked,
+                    })),
+                    onSelect: (itemId: string) =>
+                      onSetUserModelTier(m, toUserModelTierSelection(itemId)),
                   },
                 ]
               : []),
-            // Only members who currently hold a billable seat can have it removed.
             ...(isSeatBased && m.seatType && m.seatType !== "none"
               ? [
                   {
@@ -781,17 +779,17 @@ export function MembersUsageTable({
       seatChangePendingMemberIds,
       isSeatBased,
       showSpendLimit,
-      showAdvancedModelsColumn,
-      userAllowedAdvancedModelsByUserId,
-      groupAdvancedModelsByGroupId,
-      workspaceAllowedAdvancedModels,
+      showModelTiersColumn,
+      userModelTierSelectionByUserId,
+      userAllowedModelTiersByUserId,
+      groupModelTiersByGroupId,
+      workspaceAllowedModelTiers,
       groupNameToId,
-      advancedModelDisplayNameByKey,
       readOnly,
       onChangeSeat,
       onRemoveSeat,
       onEditSpendLimit,
-      onEditAdvancedModels,
+      onSetUserModelTier,
     ]
   );
 
@@ -800,15 +798,10 @@ export function MembersUsageTable({
       buildColumns({
         enableSelection,
         showGroupsColumn,
-        showAdvancedModelsColumn,
+        showModelTiersColumn,
         creditsResetAt,
       }),
-    [
-      enableSelection,
-      showGroupsColumn,
-      showAdvancedModelsColumn,
-      creditsResetAt,
-    ]
+    [enableSelection, showGroupsColumn, showModelTiersColumn, creditsResetAt]
   );
 
   if (isLoading) {

--- a/front/components/workspace/ModelTierPickerDropdown.tsx
+++ b/front/components/workspace/ModelTierPickerDropdown.tsx
@@ -1,0 +1,70 @@
+import type { ModelTierPickerOption } from "@app/lib/client/model_tier_options";
+import { getModelTierPickerLabel } from "@app/lib/client/model_tier_options";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  Spinner,
+} from "@dust-tt/sparkle";
+
+interface ModelTierPickerDropdownProps {
+  selectedValue: string;
+  options: ModelTierPickerOption[];
+  onSelect: (value: string) => void | Promise<void>;
+  readOnly?: boolean;
+  isLoading?: boolean;
+  isMutating?: boolean;
+  className?: string;
+}
+
+export function ModelTierPickerDropdown({
+  selectedValue,
+  options,
+  onSelect,
+  readOnly = false,
+  isLoading = false,
+  isMutating = false,
+  className,
+}: ModelTierPickerDropdownProps) {
+  if (isLoading) {
+    return <Spinner size="xs" />;
+  }
+
+  const label = getModelTierPickerLabel({ selectedValue, options });
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          isSelect
+          label={label}
+          disabled={readOnly || isMutating}
+          className={className ?? "min-w-48 justify-between"}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-(--radix-dropdown-menu-trigger-width)">
+        {options.map((option) => (
+          <DropdownMenuCheckboxItem
+            key={option.value}
+            label={option.label}
+            description={option.description}
+            checked={selectedValue === option.value}
+            onCheckedChange={(checked) => {
+              if (!checked) {
+                return;
+              }
+              void onSelect(option.value);
+            }}
+            onSelect={(event) => {
+              event.preventDefault();
+            }}
+          />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/components/workspace/usage/ModelTiersSettingsCard.tsx
+++ b/front/components/workspace/usage/ModelTiersSettingsCard.tsx
@@ -1,0 +1,57 @@
+import { ModelTierPickerDropdown } from "@app/components/workspace/ModelTierPickerDropdown";
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import { getWorkspaceModelTierOptions } from "@app/lib/client/model_tier_options";
+import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
+import {
+  useWorkspaceAllowedModelTierMutations,
+  useWorkspaceAllowedModelTiers,
+} from "@app/lib/swr/model_tiers";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Page, SettingsList } from "@dust-tt/sparkle";
+
+interface ModelTiersSettingsCardProps {
+  owner: LightWorkspaceType;
+  readOnly: boolean;
+}
+
+export function ModelTiersSettingsCard({
+  owner,
+  readOnly,
+}: ModelTiersSettingsCardProps) {
+  const {
+    maxTierName: workspaceMaxTierName,
+    isWorkspaceAllowedModelTiersLoading,
+  } = useWorkspaceAllowedModelTiers({ owner });
+  const { setWorkspaceAllowedModelTier, isWorkspaceAllowedModelTierMutating } =
+    useWorkspaceAllowedModelTierMutations({ owner });
+
+  const selectedValue = workspaceMaxTierName ?? DEFAULT_MAX_MODEL_TIER;
+
+  return (
+    <Page.Vertical gap="sm" align="stretch">
+      <span className="heading-base text-foreground dark:text-foreground-night">
+        Models tier
+      </span>
+      <SettingsList>
+        <SettingsList.Row
+          title="Workspace access"
+          description="Set the highest model tier available to all members of this workspace."
+          action={
+            <ModelTierPickerDropdown
+              selectedValue={selectedValue}
+              options={getWorkspaceModelTierOptions()}
+              onSelect={async (value) => {
+                await setWorkspaceAllowedModelTier({
+                  tierName: value as ModelsTierName,
+                });
+              }}
+              readOnly={readOnly}
+              isLoading={isWorkspaceAllowedModelTiersLoading}
+              isMutating={isWorkspaceAllowedModelTierMutating}
+            />
+          }
+        />
+      </SettingsList>
+    </Page.Vertical>
+  );
+}

--- a/front/lib/client/model_tiers.ts
+++ b/front/lib/client/model_tiers.ts
@@ -47,7 +47,7 @@ export function expandMaxTierName(
 }
 
 export function formatModelTiersSummary(
-  maxTierName: ModelsTierName | null
+  maxTierName: ModelsTierName | null | undefined
 ): string {
   if (!maxTierName) {
     return "--";


### PR DESCRIPTION
## Description

Replaces the modal-based `EditAdvancedModelsModal` flow with inline tier pickers throughout the workspace admin UI:

- `ModelTierPickerDropdown` — new generic Sparkle dropdown (checkbox items, loading/mutating states) used everywhere
- `GroupModelTierPickerDropdown` — wraps the generic dropdown with group-scoped SWR hooks; renders inline in the group filter bar and as a column in `GroupsUsageTable`
- `MembersUsageTable` — "Advanced models" column renamed to "Models tier"; user tier changes moved from a modal-open callback to an inline submenu in the `MoreButton` actions; row data simplified to a `modelTiersSummary` string + `hasUserLevelModelTiersOverride` flag
- `ModelTiersSettingsCard` — replaces `AdvancedModelsSettingsCard` in the settings tab with a `SettingsList.Row` picker for workspace-level max tier
- `UsagePage` — drops `editAdvancedModelsTarget` state, removes `EditAdvancedModelsModal`, switches all `advanced_models` SWR hooks to their `model_tiers` equivalents, calls `setUserAllowedModelTier` / `clearUserAllowedModelTier` directly

<img width="1296" height="839" alt="file-6e0b7058d4961012651031ce3937c40a" src="https://github.com/user-attachments/assets/d0a5cbe1-f825-4e26-b518-279835c049c3" />

<img width="1161" height="714" alt="file-0f4b2a5690dca7ce52aac8c67ef48417" src="https://github.com/user-attachments/assets/a1168fe1-494a-4631-ab3e-76be934fbc09" />

<img width="1145" height="1195" alt="image" src="https://github.com/user-attachments/assets/9f6b95b3-b64c-4b9b-b534-90189159ab1e" />


## Tests

Tested locally on the workspace admin Usage page: workspace tier picker, group tier picker (filter bar + groups tab column), and per-user tier submenu all update correctly and reflect inherited vs. overridden state.

## Risk

Low. Front-only — no API, no DB changes. Removes modal state in favour of inline SWR mutations already exercised by existing hooks. The `models_picker` feature flag gates all new UI, so non-FF workspaces are unaffected. Safe to rollback by reverting the front deploy.

## Deploy Plan

Deploy front.
