### PR TITLE
[front] fix: stable sort LLM tool specification

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -268,6 +268,47 @@ describe("buildBaseSpecifications", () => {
     expect(specifications[0].eager).toBeUndefined();
   });
 
+  it("sorts specifications by tool name before model calls", () => {
+    const specifications = buildBaseSpecifications(
+      [
+        makeServerSideToolConfiguration("zeta_tool", {
+          mcpServerViewId: "view_zeta",
+          serverConfigurationModelId: 102,
+        }),
+        makeClientSideToolConfiguration("alpha_tool"),
+        makeServerSideToolConfiguration("middle_tool", {
+          mcpServerViewId: "view_middle",
+          serverConfigurationModelId: 101,
+        }),
+      ],
+      {
+        sId: "custom_agent",
+        actions: [
+          makeAgentServerConfiguration({
+            mcpServerViewId: "view_zeta",
+            serverConfigurationModelId: 102,
+          }),
+          makeAgentServerConfiguration({
+            mcpServerViewId: "view_middle",
+            serverConfigurationModelId: 101,
+          }),
+        ],
+      }
+    );
+
+    expect(specifications.map((s) => s.name)).toEqual([
+      "alpha_tool",
+      "middle_tool",
+      "zeta_tool",
+    ]);
+    expect(specifications.find((s) => s.name === "middle_tool")?.eager).toBe(
+      true
+    );
+    expect(specifications.find((s) => s.name === "zeta_tool")?.eager).toBe(
+      true
+    );
+  });
+
   it("preserves the intrinsic eager flag on non-configured tools", () => {
     const specifications = buildBaseSpecifications(
       [
@@ -384,6 +425,29 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     const placeholder = specifications[1];
     expect(placeholder.name).toBe("removed_tool");
     expect(placeholder.eager).toBeUndefined();
+  });
+
+  it("sorts replay placeholders with the current tool specifications", () => {
+    const baseSpecifications = [
+      makeSpecification("zeta_tool"),
+      makeSpecification("alpha_tool"),
+    ];
+    const conversation = makeConversation([
+      assistantMessageWithFunctionCalls(["middle_tool"]),
+    ]);
+
+    const { specifications, missingReplayedToolNames } =
+      buildSpecificationsWithReplayPlaceholders(
+        baseSpecifications,
+        conversation
+      );
+
+    expect(missingReplayedToolNames).toEqual(["middle_tool"]);
+    expect(specifications.map((s) => s.name)).toEqual([
+      "alpha_tool",
+      "middle_tool",
+      "zeta_tool",
+    ]);
   });
 
   it("appends placeholders for tools referenced by replayed tool search results", () => {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -211,20 +211,6 @@ function buildReplayOnlyToolSpecification(
   };
 }
 
-function sortToolSpecifications(
-  specifications: AgentActionSpecification[]
-): AgentActionSpecification[] {
-  return [...specifications].sort((left, right) => {
-    if (left.name < right.name) {
-      return -1;
-    }
-    if (left.name > right.name) {
-      return 1;
-    }
-    return 0;
-  });
-}
-
 // A custom agent's configured tools are its identity: they stay in the eagerly
 // loaded set so the model always sees them instead of having to discover them
 // through tool search. The set is small and stable per agent version, so the
@@ -250,8 +236,8 @@ export function buildBaseSpecifications(
       .filter((id) => id !== -1)
   );
 
-  return sortToolSpecifications(
-    availableActions.map((action) => {
+  return availableActions
+    .map((action) => {
       const specification = buildToolSpecification(action);
       if (
         isCustomAgent &&
@@ -263,7 +249,7 @@ export function buildBaseSpecifications(
 
       return specification;
     })
-  );
+    .sort((left, right) => left.name.localeCompare(right.name));
 }
 
 // Replayed tools keep their intrinsic `eager` flag: providers resolve deferred
@@ -284,12 +270,12 @@ export function buildSpecificationsWithReplayPlaceholders(
     .sort();
 
   return {
-    specifications: sortToolSpecifications([
+    specifications: [
       ...baseSpecifications,
       ...missingReplayedToolNames.map((name) =>
         buildReplayOnlyToolSpecification(name)
       ),
-    ]),
+    ].sort((left, right) => left.name.localeCompare(right.name)),
     missingReplayedToolNames,
   };
 }

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -211,6 +211,24 @@ function buildReplayOnlyToolSpecification(
   };
 }
 
+function compareToolNames(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+}
+
+function sortToolSpecifications(
+  specifications: AgentActionSpecification[]
+): AgentActionSpecification[] {
+  return [...specifications].sort((left, right) =>
+    compareToolNames(left.name, right.name)
+  );
+}
+
 // A custom agent's configured tools are its identity: they stay in the eagerly
 // loaded set so the model always sees them instead of having to discover them
 // through tool search. The set is small and stable per agent version, so the
@@ -236,18 +254,20 @@ export function buildBaseSpecifications(
       .filter((id) => id !== -1)
   );
 
-  return availableActions.map((action) => {
-    const specification = buildToolSpecification(action);
-    if (
-      isCustomAgent &&
-      isServerSideMCPToolConfiguration(action) &&
-      agentActionModelIds.has(action.id)
-    ) {
-      return { ...specification, eager: true };
-    }
+  return sortToolSpecifications(
+    availableActions.map((action) => {
+      const specification = buildToolSpecification(action);
+      if (
+        isCustomAgent &&
+        isServerSideMCPToolConfiguration(action) &&
+        agentActionModelIds.has(action.id)
+      ) {
+        return { ...specification, eager: true };
+      }
 
-    return specification;
-  });
+      return specification;
+    })
+  );
 }
 
 // Replayed tools keep their intrinsic `eager` flag: providers resolve deferred
@@ -263,17 +283,17 @@ export function buildSpecificationsWithReplayPlaceholders(
   missingReplayedToolNames: string[];
 } {
   const currentToolNames = new Set(baseSpecifications.map((spec) => spec.name));
-  const missingReplayedToolNames = getReplayedToolNames(
-    modelConversation
-  ).filter((name) => !currentToolNames.has(name));
+  const missingReplayedToolNames = getReplayedToolNames(modelConversation)
+    .filter((name) => !currentToolNames.has(name))
+    .sort(compareToolNames);
 
   return {
-    specifications: [
+    specifications: sortToolSpecifications([
       ...baseSpecifications,
       ...missingReplayedToolNames.map((name) =>
         buildReplayOnlyToolSpecification(name)
       ),
-    ],
+    ]),
     missingReplayedToolNames,
   };
 }

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -211,22 +211,18 @@ function buildReplayOnlyToolSpecification(
   };
 }
 
-function compareToolNames(left: string, right: string): number {
-  if (left < right) {
-    return -1;
-  }
-  if (left > right) {
-    return 1;
-  }
-  return 0;
-}
-
 function sortToolSpecifications(
   specifications: AgentActionSpecification[]
 ): AgentActionSpecification[] {
-  return [...specifications].sort((left, right) =>
-    compareToolNames(left.name, right.name)
-  );
+  return [...specifications].sort((left, right) => {
+    if (left.name < right.name) {
+      return -1;
+    }
+    if (left.name > right.name) {
+      return 1;
+    }
+    return 0;
+  });
 }
 
 // A custom agent's configured tools are its identity: they stay in the eagerly
@@ -285,7 +281,7 @@ export function buildSpecificationsWithReplayPlaceholders(
   const currentToolNames = new Set(baseSpecifications.map((spec) => spec.name));
   const missingReplayedToolNames = getReplayedToolNames(modelConversation)
     .filter((name) => !currentToolNames.has(name))
-    .sort(compareToolNames);
+    .sort();
 
   return {
     specifications: sortToolSpecifications([


### PR DESCRIPTION
## Description

This PR adds a stable sorting on the order of tools specifications sent to LLM providers to avoid bursting cache (example [here](https://langfuse.dust.tt/project/cmi4ft2qm00061707q4a9azyc/traces?filter=metadata%3BstringObject%3BconversationId%3B%3D%3BxnwzwGSBbN&peek=7b2df67767c1e73a5c237c81df5d39c9&timestamp=2026-07-09T18%3A54%3A27.649Z&observation=c07ff238fa87b0fb)).

Replay-only placeholder specs are sorted as well, they are sorted separately; replacing a spec with a placeholder will burst the cache anyway since the JSON schema and descriptions are different.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
