### PR TITLE
Compact resource-shaped tool output before sending it to the model

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -474,7 +474,7 @@ describe("vision image rendering in getSteps", () => {
     }
   });
 
-  it("falls back to JSON when the model does not support vision", async () => {
+  it("falls back to JSON when the model does not support vision, flattened and without the resource wrapper or mimeType", async () => {
     const { auth, message, model, workspaceId, conversationId } =
       await buildVisionTest();
     const nonVisionModel = { ...model, supportsVision: false };
@@ -490,6 +490,19 @@ describe("vision image rendering in getSteps", () => {
 
     const result = steps[0].actions[0].result;
     expect(typeof result.content).toBe("string");
+    assert(typeof result.content === "string");
+
+    const parsed = JSON.parse(result.content);
+    // Flattened: the resource's own fields directly, no "type"/"resource" wrapper and no
+    // mimeType (a pure internal type discriminator the model never reads).
+    expect(parsed).toEqual([
+      {
+        uri: "dust://files/conversation/photo.png",
+        text: "",
+        filePath: `w/${workspaceId}/conversations/${conversationId}/files/photo.png`,
+        imageContentType: "image/png",
+      },
+    ]);
   });
 
   it("renders [Image unavailable] when the path does not belong to the conversation", async () => {

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -3,9 +3,9 @@ import { renderEquippedSkillsUserMessage } from "@app/lib/api/assistant/skills_r
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { mockFullAgentMessage } from "@app/tests/utils/conversation_test_factories";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
-import type { AgentMessageType } from "@app/types/assistant/conversation";
 import type { TextContent } from "@app/types/assistant/generation";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
@@ -248,69 +248,20 @@ The following skills are available for use with the skill_management__enable_ski
       text: `Skill "${commitSkill.name}" has been enabled.`,
     });
 
-    const message = {
-      id: 1,
-      agentMessageId: 1,
-      type: "agent_message",
-      sId: "agent_msg_1",
-      version: 1,
-      rank: 1,
-      branchId: null,
-      created: Date.now(),
-      completedTs: null,
-      parentMessageId: "user_msg_1",
-      parentAgentMessageId: null,
-      status: "succeeded",
-      content: null,
-      chainOfThought: null,
-      error: null,
-      visibility: "visible",
+    const message = mockFullAgentMessage({
       configuration: agentConfig,
-      skipToolsValidation: false,
       actions: [
         {
-          id: 1,
-          sId: "action_1",
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-          agentMessageId: 1,
-          internalMCPServerName: "skill_management",
-          toolName: "enable_skill",
-          mcpServerId: null,
           functionCallName: "skill_management__enable_skill",
           functionCallId: "toolu_enable_skill",
+          internalMCPServerName: "skill_management",
+          toolName: "enable_skill",
           params: { skillName: commitSkill.name },
-          citationsAllocated: 0,
           status: "succeeded",
-          step: 0,
-          executionDurationMs: null,
-          displayLabels: null,
-          generatedFiles: [],
           output: [outputBlock],
-          citations: null,
         },
       ],
-      contents: [
-        {
-          step: 0,
-          content: {
-            type: "function_call",
-            value: {
-              id: "toolu_enable_skill",
-              name: "skill_management__enable_skill",
-              arguments: '{"skillName":"commit"}',
-            },
-          },
-        },
-      ],
-      modelInteractionDurationMs: null,
-      richMentions: [],
-      completionDurationMs: null,
-      reactions: [],
-      costCredits: null,
-      resolvedModel: null,
-      modelResolutionMethod: null,
-    } satisfies AgentMessageType;
+    });
 
     const steps = await getSteps(authenticator, {
       enabledSkillById: new Map([[commitSkill.sId, commitSkill]]),
@@ -371,78 +322,28 @@ describe("vision image rendering in getSteps", () => {
       gcsPathOverride ??
       `w/${workspaceId}/conversations/${conversationId}/files/photo.png`;
 
-    const message: AgentMessageType = {
-      id: 1,
-      agentMessageId: 1,
-      type: "agent_message" as const,
-      sId: "agent_msg_1",
-      version: 1,
-      rank: 1,
-      branchId: null,
-      created: Date.now(),
-      completedTs: null,
-      parentMessageId: "user_msg_1",
-      parentAgentMessageId: null,
-      status: "succeeded" as const,
-      content: null,
-      chainOfThought: null,
-      error: null,
-      visibility: "visible" as const,
+    const visionResource = {
+      uri: "dust://files/conversation/photo.png",
+      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.MODEL_VISION_IMAGE,
+      text: "" as const,
+      filePath: gcsPath,
+      imageContentType: "image/png",
+    };
+
+    const message = mockFullAgentMessage({
       configuration: agentConfig,
-      skipToolsValidation: false,
       actions: [
         {
-          id: 1,
-          sId: "action_1",
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-          agentMessageId: 1,
-          internalMCPServerName: "files",
-          toolName: "cat",
-          mcpServerId: null,
           functionCallName: "files__cat",
           functionCallId: "toolu_cat_1",
+          internalMCPServerName: "files",
+          toolName: "cat",
           params: { path: "conversation/photo.png" },
-          citationsAllocated: 0,
-          status: "succeeded" as const,
-          step: 0,
-          executionDurationMs: null,
-          displayLabels: null,
-          generatedFiles: [],
-          citations: null,
-          output: (() => {
-            const resource = {
-              uri: "dust://files/conversation/photo.png",
-              mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.MODEL_VISION_IMAGE,
-              text: "" as const,
-              filePath: gcsPath,
-              imageContentType: "image/png",
-            };
-            return [{ type: "resource" as const, resource }];
-          })(),
+          status: "succeeded",
+          output: [{ type: "resource" as const, resource: visionResource }],
         },
       ],
-      contents: [
-        {
-          step: 0,
-          content: {
-            type: "function_call" as const,
-            value: {
-              id: "toolu_cat_1",
-              name: "files__cat",
-              arguments: '{"path":"conversation/photo.png"}',
-            },
-          },
-        },
-      ],
-      modelInteractionDurationMs: null,
-      richMentions: [],
-      completionDurationMs: null,
-      reactions: [],
-      costCredits: null,
-      resolvedModel: null,
-      modelResolutionMethod: null,
-    };
+    });
 
     return { auth: authenticator, message, model, workspaceId, conversationId };
   };
@@ -532,10 +433,7 @@ describe("vision image rendering in getSteps", () => {
 
 describe("websearch resource array compaction in getSteps", () => {
   it("flattens every result in a multi-result websearch output, dropping the resource wrapper and mimeType from each", async () => {
-    const { authenticator, conversationsSpace } = await createResourceTest({
-      role: "admin",
-    });
-    const workspaceId = authenticator.getNonNullableWorkspace().sId;
+    const { authenticator } = await createResourceTest({ role: "admin" });
 
     const agentConfig = await AgentConfigurationFactory.createTestAgent(
       authenticator,
@@ -545,16 +443,8 @@ describe("websearch resource array compaction in getSteps", () => {
         model: { providerId: "anthropic", modelId: "claude-sonnet-4-6" },
       }
     );
-    const conversation = await ConversationFactory.create(authenticator, {
-      agentConfigurationId: agentConfig.sId,
-      messagesCreatedAt: [],
-      spaceId: conversationsSpace.id,
-    });
-    const conversationId = conversation.sId;
     const model = getSupportedModelConfig(agentConfig.model);
-    if (!model) {
-      throw new Error("Expected a supported model configuration.");
-    }
+    assert(model, "Expected a supported model configuration.");
 
     const websearchResults = [
       {
@@ -578,45 +468,17 @@ describe("websearch resource array compaction in getSteps", () => {
       },
     ];
 
-    const message: AgentMessageType = {
-      id: 1,
-      agentMessageId: 1,
-      type: "agent_message" as const,
-      sId: "agent_msg_1",
-      version: 1,
-      rank: 1,
-      branchId: null,
-      created: Date.now(),
-      completedTs: null,
-      parentMessageId: "user_msg_1",
-      parentAgentMessageId: null,
-      status: "succeeded" as const,
-      content: null,
-      chainOfThought: null,
-      error: null,
-      visibility: "visible" as const,
+    const message = mockFullAgentMessage({
       configuration: agentConfig,
-      skipToolsValidation: false,
       actions: [
         {
-          id: 1,
-          sId: "action_1",
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-          agentMessageId: 1,
-          internalMCPServerName: "web_search_&_browse",
-          toolName: "websearch",
-          mcpServerId: null,
           functionCallName: "web_search_browse__websearch",
           functionCallId: "toolu_websearch_1",
+          internalMCPServerName: "web_search_&_browse",
+          toolName: "websearch",
           params: { query: "world cup 2026 schedule" },
           citationsAllocated: websearchResults.length,
-          status: "succeeded" as const,
-          step: 0,
-          executionDurationMs: null,
-          displayLabels: null,
-          generatedFiles: [],
-          citations: null,
+          status: "succeeded",
           output: websearchResults.map((r) => ({
             type: "resource" as const,
             resource: {
@@ -626,32 +488,13 @@ describe("websearch resource array compaction in getSteps", () => {
           })),
         },
       ],
-      contents: [
-        {
-          step: 0,
-          content: {
-            type: "function_call" as const,
-            value: {
-              id: "toolu_websearch_1",
-              name: "web_search_browse__websearch",
-              arguments: '{"query":"world cup 2026 schedule"}',
-            },
-          },
-        },
-      ],
-      modelInteractionDurationMs: null,
-      richMentions: [],
-      completionDurationMs: null,
-      reactions: [],
-      costCredits: null,
-      resolvedModel: null,
-    };
+    });
 
     const steps = await getSteps(authenticator, {
       model,
       message,
-      workspaceId,
-      conversationId,
+      workspaceId: "workspace_123",
+      conversationId: "conv_1",
       enabledSkillById: new Map(),
       onMissingAction: "skip",
     });

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -529,3 +529,140 @@ describe("vision image rendering in getSteps", () => {
     }
   });
 });
+
+describe("websearch resource array compaction in getSteps", () => {
+  it("flattens every result in a multi-result websearch output, dropping the resource wrapper and mimeType from each", async () => {
+    const { authenticator, conversationsSpace } = await createResourceTest({
+      role: "admin",
+    });
+    const workspaceId = authenticator.getNonNullableWorkspace().sId;
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Websearch Agent",
+        description: "An agent that searches the web",
+        model: { providerId: "anthropic", modelId: "claude-sonnet-4-6" },
+      }
+    );
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: conversationsSpace.id,
+    });
+    const conversationId = conversation.sId;
+    const model = getSupportedModelConfig(agentConfig.model);
+    if (!model) {
+      throw new Error("Expected a supported model configuration.");
+    }
+
+    const websearchResults = [
+      {
+        uri: "https://www.foxsports.com/soccer/fifa-world-cup/schedule",
+        text: "STREAM FIFA WORLD CUP 2026 · GROUP STAGE · Match Day 1. Jun 11 - Jun 17 · Match Day 2. Jun 18 - Jun 23 · Match Day 3. Jun 24 - Jun 27.",
+        title: "2026 FIFA World Cup Schedule | FOX Sports",
+        reference: "g8q",
+      },
+      {
+        uri: "https://www.france24.com/en/full-coverage/world-cup/fixtures-results/",
+        text: "June 11 to July 19, 2026. A total of 104 matches will be played over 39 days. Knockout stage: June 28 to July 19. July 14 and 15.",
+        title:
+          "World Cup 2026 fixtures and results: full match schedule - France 24",
+        reference: "duj",
+      },
+      {
+        uri: "https://www.espn.com/soccer/team/fixtures/_/id/478/france",
+        text: "France Fixtures ; September, 2026 · Fri, Sep 25. TUR · FRA · Mon, Sep 28 ; October, 2026 · Fri, Oct 2. FRA · ITA · Mon, Oct 5 ; November, 2026 · Thu, Nov 12. ITA · FRA.",
+        title: "France Fixtures - ESPN",
+        reference: "cvs",
+      },
+    ];
+
+    const message: AgentMessageType = {
+      id: 1,
+      agentMessageId: 1,
+      type: "agent_message" as const,
+      sId: "agent_msg_1",
+      version: 1,
+      rank: 1,
+      branchId: null,
+      created: Date.now(),
+      completedTs: null,
+      parentMessageId: "user_msg_1",
+      parentAgentMessageId: null,
+      status: "succeeded" as const,
+      content: null,
+      chainOfThought: null,
+      error: null,
+      visibility: "visible" as const,
+      configuration: agentConfig,
+      skipToolsValidation: false,
+      actions: [
+        {
+          id: 1,
+          sId: "action_1",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          agentMessageId: 1,
+          internalMCPServerName: "web_search_&_browse",
+          toolName: "websearch",
+          mcpServerId: null,
+          functionCallName: "web_search_browse__websearch",
+          functionCallId: "toolu_websearch_1",
+          params: { query: "world cup 2026 schedule" },
+          citationsAllocated: websearchResults.length,
+          status: "succeeded" as const,
+          step: 0,
+          executionDurationMs: null,
+          displayLabels: null,
+          generatedFiles: [],
+          citations: null,
+          output: websearchResults.map((r) => ({
+            type: "resource" as const,
+            resource: {
+              mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.WEBSEARCH_RESULT,
+              ...r,
+            },
+          })),
+        },
+      ],
+      contents: [
+        {
+          step: 0,
+          content: {
+            type: "function_call" as const,
+            value: {
+              id: "toolu_websearch_1",
+              name: "web_search_browse__websearch",
+              arguments: '{"query":"world cup 2026 schedule"}',
+            },
+          },
+        },
+      ],
+      modelInteractionDurationMs: null,
+      richMentions: [],
+      completionDurationMs: null,
+      reactions: [],
+      costCredits: null,
+      resolvedModel: null,
+    };
+
+    const steps = await getSteps(authenticator, {
+      model,
+      message,
+      workspaceId,
+      conversationId,
+      enabledSkillById: new Map(),
+      onMissingAction: "skip",
+    });
+
+    const result = steps[0].actions[0].result;
+    expect(typeof result.content).toBe("string");
+    assert(typeof result.content === "string");
+
+    const parsed = JSON.parse(result.content);
+    // Every result is flattened to its own fields directly, no "type"/"resource" wrapper and
+    // no mimeType, for the whole array, not just a single item.
+    expect(parsed).toEqual(websearchResults);
+  });
+});

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -45,8 +45,24 @@ import type {
 } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { removeNulls } from "@app/types/shared/utils/general";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 const RENDER_ACTIONS_CONCURRENCY = 5;
+
+/**
+ * Drops the internal "type": "resource" wrapper and the top-level mimeType discriminator from a
+ * resource-shaped tool output item before it's serialized for the model. Every resource schema's
+ * mimeType is a fixed literal used only to distinguish shapes in our own code (see
+ * output_schemas.ts); it's never a real content type, and never what the model reads. Other item
+ * types (text, image) are returned unchanged.
+ */
+function compactResourceItem(item: CallToolResult["content"][number]) {
+  if (item.type !== "resource") {
+    return item;
+  }
+  const { mimeType: _mimeType, ...resource } = item.resource;
+  return resource;
+}
 
 async function getDustFileSystemDownloadUrl(
   auth: Authenticator,
@@ -193,7 +209,7 @@ async function renderActionForMultiActionsModel(
     }
     output = contentArray;
   } else {
-    output = JSON.stringify(outputItems);
+    output = JSON.stringify(outputItems.map(compactResourceItem));
   }
 
   return {

--- a/front/tests/utils/conversation_test_factories.ts
+++ b/front/tests/utils/conversation_test_factories.ts
@@ -2,12 +2,15 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
+  AgentMessageType,
   LightAgentMessageWithActionsType,
   LightConversationType,
   MessageFeedback,
   UserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { UserType } from "@app/types/user";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 function mockUser(username: string): UserType {
   return {
@@ -60,29 +63,38 @@ export function mockAction(params: {
   functionCallName: string;
   status: "succeeded" | "failed";
   params?: Record<string, unknown>;
-  output?: string | null;
+  output?: string | CallToolResult["content"] | null;
+  internalMCPServerName?: AgentMCPActionWithOutputType["internalMCPServerName"];
+  toolName?: string;
+  functionCallId?: string;
+  step?: number;
+  citationsAllocated?: number;
 }): AgentMCPActionWithOutputType {
   const status: ToolExecutionStatus =
     params.status === "succeeded" ? "succeeded" : "errored";
+  const output =
+    typeof params.output === "string"
+      ? [{ type: "text" as const, text: params.output }]
+      : (params.output ?? null);
   return {
     id: 0,
     sId: "",
     createdAt: 0,
     updatedAt: 0,
     agentMessageId: 0,
-    internalMCPServerName: null,
-    toolName: params.functionCallName,
+    internalMCPServerName: params.internalMCPServerName ?? null,
+    toolName: params.toolName ?? params.functionCallName,
     mcpServerId: null,
     functionCallName: params.functionCallName,
-    functionCallId: "",
+    functionCallId: params.functionCallId ?? "",
     params: params.params ?? {},
-    citationsAllocated: 0,
+    citationsAllocated: params.citationsAllocated ?? 0,
     status,
-    step: 0,
+    step: params.step ?? 0,
     executionDurationMs: null,
     displayLabels: null,
     generatedFiles: [],
-    output: params.output ? [{ type: "text", text: params.output }] : null,
+    output,
     citations: null,
   };
 }
@@ -133,6 +145,74 @@ export function mockAgentMessage(
       thumbDirection: f.direction,
       content: f.comment ?? null,
     })),
+  };
+}
+
+export type MockFullAgentMessageParams = {
+  id?: ModelId;
+  agentMessageId?: ModelId;
+  sId?: string;
+  parentMessageId?: string;
+  content?: string | null;
+  // Unlike mockAgentMessage's stubbed configuration, AgentMessageType.configuration is the full
+  // LightAgentConfigurationType (model, instructions, tags, etc.), so there's no sensible stub to
+  // default to here: pass the real agent configuration (e.g. from AgentConfigurationFactory).
+  configuration: AgentMessageType["configuration"];
+  actions?: Parameters<typeof mockAction>[0][];
+  // Defaults to one function_call content per action, mirroring its functionCallId/
+  // functionCallName/params. Override only when a test needs to exercise contents that diverge
+  // from the actions (e.g. error or cross-provider reasoning content).
+  contents?: AgentMessageType["contents"];
+};
+
+// Full AgentMessageType, as consumed by getSteps. Unlike mockAgentMessage (the light variant used
+// for streaming/reconstruction tests), this includes the id/agentMessageId/contents fields getSteps
+// actually reads.
+export function mockFullAgentMessage(
+  params: MockFullAgentMessageParams
+): AgentMessageType {
+  const actions = (params.actions ?? []).map(mockAction);
+
+  return {
+    id: params.id ?? 1,
+    agentMessageId: params.agentMessageId ?? 1,
+    type: "agent_message",
+    sId: params.sId ?? "agent_msg_1",
+    version: 1,
+    rank: 1,
+    branchId: null,
+    created: 0,
+    completedTs: null,
+    parentMessageId: params.parentMessageId ?? "user_msg_1",
+    parentAgentMessageId: null,
+    status: "succeeded",
+    content: params.content ?? null,
+    chainOfThought: null,
+    error: null,
+    visibility: "visible",
+    configuration: params.configuration,
+    skipToolsValidation: false,
+    actions,
+    contents:
+      params.contents ??
+      actions.map((action) => ({
+        step: action.step,
+        content: {
+          type: "function_call" as const,
+          value: {
+            id: action.functionCallId,
+            name: action.functionCallName,
+            arguments: JSON.stringify(action.params),
+          },
+        },
+      })),
+    modelInteractionDurationMs: null,
+    resolvedModel: null,
+    modelResolutionMethod: null,
+    richMentions: [],
+    completionDurationMs: null,
+    reactions: [],
+    costCredits: null,
   };
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Despite improving our pruning strategy, we are still pruning way too often. Zooming-in, we noticed that MCP tools that return resource-type output, websearch results being the clearest example, currently have their entire raw structure serialized verbatim into the tool-result content sent to the model, including an internal `type` wrapper and a `mimeType` field that only exist so our own code can tell tool-output shapes apart.
Every resource schema in the codebase uses a fixed constant for that field, and wherever a real content type genuinely matters, like an actual file's format, it already lives under a differently named field that's left untouched, so nothing informative is lost. This only touches the branch that already falls back to a raw dump for the model, after existing text and vision-image handling has run, so tool-generated files and vision images are unaffected.

On a full websearch call this cuts a little over 1/6 of the tokens with no change in the actual information the model sees, which matters given a couple of web searches alone can produce enough tokens to force a cache-invalidating redaction almost every turn.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
