### PR TITLE
[front] enh: add cache miss reason (type and tokens) to Langfuse traces

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -232,6 +232,9 @@ export abstract class LLM<TPayload = unknown> {
           this.generation.updateTrace({
             metadata: {
               modelInteractionId: currentEvent.content.modelInteractionId,
+              ...(currentEvent.content.cacheMissReason && {
+                cacheMissReasonType: currentEvent.content.cacheMissReason.type,
+              }),
             },
           });
         }

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -228,12 +228,17 @@ export abstract class LLM<TPayload = unknown> {
         buffer.addEvent(currentEvent);
 
         if (currentEvent.type === "interaction_id") {
-          buffer.setModelInteractionId(currentEvent.content.modelInteractionId);
+          const { modelInteractionId, cacheMissReason } = currentEvent.content;
+          buffer.setModelInteractionId(modelInteractionId);
           this.generation.updateTrace({
             metadata: {
-              modelInteractionId: currentEvent.content.modelInteractionId,
-              ...(currentEvent.content.cacheMissReason && {
-                cacheMissReasonType: currentEvent.content.cacheMissReason.type,
+              modelInteractionId,
+              ...(cacheMissReason && {
+                cacheMissReasonType: cacheMissReason.type,
+                ...(cacheMissReason.cacheMissedInputTokens !== undefined && {
+                  cacheMissedInputTokens:
+                    cacheMissReason.cacheMissedInputTokens,
+                }),
               }),
             },
           });

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -235,10 +235,7 @@ export abstract class LLM<TPayload = unknown> {
               modelInteractionId,
               ...(cacheMissReason && {
                 cacheMissReasonType: cacheMissReason.type,
-                ...(cacheMissReason.cacheMissedInputTokens !== undefined && {
-                  cacheMissedInputTokens:
-                    cacheMissReason.cacheMissedInputTokens,
-                }),
+                cacheMissedInputTokens: cacheMissReason.cacheMissedInputTokens,
               }),
             },
           });


### PR DESCRIPTION
## Description

Add the `cacheMissReasonType` to Langfuse traces when Anthropic prompt-cache diagnostics report a cache miss.
This is going to be handy to work on caching optimizations.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
