### PR TITLE
fix(front): let workspace admins manage agent editors

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -137,6 +137,27 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/editors", () => 
     expect(editorIds).toContain(newEditor.sId);
   });
 
+  it("admin who is not an editor should be able to add self as editor", async () => {
+    // Regression test for the "Become an editor" flow: a workspace admin who is
+    // not already an editor of the agent must be able to add themselves. Admins
+    // have "admin" (not "write") on editor groups, so the endpoint gates on
+    // canAdministrate rather than canWrite (see #28649).
+    const { workspace, agent, agentOwner, requestUser } = await setupTest({
+      agentOwnerRole: "builder",
+      requestUserRole: "admin",
+    });
+
+    const response = await patchEditors(workspace, agent.sId, {
+      addEditorIds: [requestUser.sId],
+    });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.editors).toHaveLength(2);
+    const editorIds = data.editors.map((e: UserType) => e.sId);
+    expect(editorIds).toContain(agentOwner.sId);
+    expect(editorIds).toContain(requestUser.sId);
+  });
+
   it("admin should successfully remove an editor", async () => {
     const { workspace, agent, agentOwner } = await setupTest({
       requestUserRole: "admin",

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -203,7 +203,7 @@ app.patch(
     }
 
     const editorGroup = editorGroupRes.value;
-    if (!editorGroup.canWrite(auth)) {
+    if (!editorGroup.canAdministrate(auth)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -146,10 +146,10 @@ export async function createPendingAgentConfiguration(
       authorId: user.id,
     });
     await auth.refresh({ transaction: t });
-    if (!group.canWrite(auth)) {
+    if (!group.canAdministrate(auth)) {
       throw new DustError(
         "unauthorized",
-        "User does not have write permission for the agent editors group."
+        "User does not have permission to manage the agent editors group."
       );
     }
     await group.dangerouslySetMembers(auth, {
@@ -850,7 +850,7 @@ export async function createAgentConfiguration(
             }
           }
 
-          if (!group.canWrite(auth) && auth.user()) {
+          if (!group.canAdministrate(auth) && auth.user()) {
             logger.error(
               {
                 workspaceId: owner.sId,
@@ -1808,7 +1808,7 @@ export async function updateAgentPermissions(
     const transactionResult = await withTransaction(async (t) => {
       if (usersToAdd.length > 0) {
         // Check authorization for agent_editors groups (allowing members and admins)
-        if (!editorGroupRes.value.canWrite(auth)) {
+        if (!editorGroupRes.value.canAdministrate(auth)) {
           return new Err(
             new DustError(
               "unauthorized",
@@ -1827,7 +1827,7 @@ export async function updateAgentPermissions(
 
       if (usersToRemove.length > 0) {
         // Check authorization for agent_editors groups (allowing members and admins)
-        if (!editorGroupRes.value.canWrite(auth)) {
+        if (!editorGroupRes.value.canAdministrate(auth)) {
           return new Err(
             new DustError(
               "unauthorized",


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/9541

## Description

Fixes workspace admins getting a 403 ("Failed to update editors" toast) when clicking "Become an editor" on the *"You are not an editor of this agent"* gate in the agent builder.

#28649 split write and admin access on editor groups: admins keep `admin` but no longer have `write`, and managing the editor list became a `canAdministrate` action. That PR updated the **skill** editors endpoint but missed the **agent** side, which shares the same `agent_editors` permission block. The agent editors PATCH and the agent editor member-management paths in `agent.ts` still gated on `canWrite`, so admins were blocked.

This gates agent editor management on `canAdministrate`, mirroring the skill side. Members still pass (they have `admin`); content-write checks are unchanged.

Confirmed in prod: `PATCH …/editors` returned 403 176× in 14 days with `usr.role: admin` and message *"Only editors of the agent or workspace admins can modify editors."*

## Tests

Added a regression test (admin who isn't an editor adds self → 200). It fails with the old `canWrite` gate and passes with `canAdministrate`. Agent + skill editors suites green; typecheck and biome clean.

## Risk

Low. Broadens editor management from `write` to `admin` on editor groups, which is exactly the pre-#28649 behavior for admins. Members are unaffected. Rollback is a straight revert.

## Deploy Plan

Standard deploy, no migration.