### PR TITLE
[front] fix: update font color and copy in pod settings page

### DIFF
--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -247,8 +247,8 @@ export function PodSettingsTab({
       tabIndex={interactive ? 0 : -1}
       aria-label={
         isInheritingWorkspaceDefault
-          ? `Default agent: ${displayedDefaultAgent?.name ?? "Dust"} (workspace default)`
-          : `Default agent: ${displayedDefaultAgent?.name ?? "Dust"}`
+          ? `Default Agent: ${displayedDefaultAgent?.name ?? "Dust"} (workspace default)`
+          : `Default Agent: ${displayedDefaultAgent?.name ?? "Dust"}`
       }
       aria-disabled={!interactive}
       className={cn(
@@ -586,7 +586,7 @@ export function PodSettingsTab({
         {isDefaultSkillsEnabled && (
           <div className="flex w-full flex-col gap-2">
             <div className="heading-lg">Default Skills</div>
-            <p className="text-sm text-muted-foregroundt">
+            <p className="text-sm text-muted-foreground">
               The skills pre-selected when anyone starts a new conversation in
               this Pod. Members can still edit the skills in each conversation.
             </p>


### PR DESCRIPTION
## Description

This PR fixes two UI nits on the Pods setting page:
- Capitalize the a in Agent to match the other titles (Default Skills notably).
- Fix the font color for `"The skills pre-selected when anyone"` (typo in the class name).

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
