### PR TITLE
Analytics: expose parent message id in message table export

### DIFF
--- a/front/lib/api/analytics/messages_export.test.ts
+++ b/front/lib/api/analytics/messages_export.test.ts
@@ -101,4 +101,34 @@ describe("fetchMessageExportRows", () => {
     }
     expect(result.value[0].credits).toBe(0);
   });
+
+  it("reports the direct parent in parentMessageId and defaults to empty", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    mockMessageHits([
+      messageDoc({
+        message_id: "msg_child",
+        ancestor_message_ids: ["msg_parent"],
+      }),
+      messageDoc({ message_id: "msg_root" }),
+    ]);
+
+    const result = await fetchMessageExportRows({
+      auth: authenticator,
+      owner: workspace,
+      startDate: "2026-07-01",
+      endDate: "2026-07-02",
+      timezone: "UTC",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value).toHaveLength(2);
+    expect(result.value[0].parentMessageId).toBe("msg_parent");
+    expect(result.value[1].parentMessageId).toBe("");
+  });
 });

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -21,6 +21,9 @@ interface AgentMessageDocument extends ElasticsearchBaseDocument {
   timestamp: string;
   agent_id: string;
   conversation_id: string;
+  // SIds of the agent messages that triggered this message through `run_agent`,
+  // direct parent first. Empty or absent for user-initiated messages.
+  ancestor_message_ids?: string[];
   user_id: string;
   context_origin: string;
   status: string;
@@ -37,6 +40,7 @@ export interface MessageExportRow {
   assistantName: string;
   assistantSettings: string;
   conversationId: string;
+  parentMessageId: string;
   userId: string;
   userEmail: string;
   source: string;
@@ -52,6 +56,7 @@ export const MESSAGE_EXPORT_HEADERS: (keyof MessageExportRow)[] = [
   "assistantName",
   "assistantSettings",
   "conversationId",
+  "parentMessageId",
   "userId",
   "userEmail",
   "source",
@@ -160,6 +165,7 @@ export async function fetchMessageExportRows({
       assistantName: agent?.name ?? doc.agent_id,
       assistantSettings: agent?.settings ?? "unknown",
       conversationId: doc.conversation_id,
+      parentMessageId: doc.ancestor_message_ids?.[0] ?? "",
       userId: doc.user_id,
       userEmail: userEmails.get(doc.user_id) ?? "",
       source: doc.context_origin ?? "",

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -21,7 +21,7 @@ interface AgentMessageDocument extends ElasticsearchBaseDocument {
   timestamp: string;
   agent_id: string;
   conversation_id: string;
-  // SIds of the agent messages that triggered this message through `run_agent`,
+  // Ids of the agent messages that triggered this message through `run_agent`,
   // direct parent first. Empty or absent for user-initiated messages.
   ancestor_message_ids?: string[];
   user_id: string;


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9443

Add parent message id for sub-agent in sub-conversations so user can track what triggerred the subconversation.
This value is only present for sub-agent in background mode (sub conversation).
For normal messages and sub-agent in handoff mode there is no need for the parent message id as there is a unique conversation id for them (and we don't currently track these parent id in ES anyway ^^)

## Tests

tested locally

Here is an export event, we can see the 2 calls to the agent "FrenchDelegateInBakcground" generated a call to a subagent "WebInfoSearcher" in a background conversation and these can be linked by the message parent id `iy1ZpKGdPl`

<img width="1858" height="1418" alt="image" src="https://github.com/user-attachments/assets/13f1c041-40d6-40f1-9dbb-c74f6104c067" />


## Risk

low, this is a new field in the analytics export.

## Deploy Plan

deploy front
