### PR TITLE
[front] fix: prevent table width shift on scrollbar toggle in People settings

### DIFF
--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -147,7 +147,7 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
                   "flex flex-1 flex-col",
                   isMobile
                     ? MOBILE_DOCUMENT_SCROLL_CLASSES.contentArea
-                    : "min-h-0 h-panel overflow-y-auto"
+                    : "min-h-0 h-panel overflow-y-auto [scrollbar-gutter:stable]"
                 )}
               >
                 <AppLayoutTitle />
@@ -157,7 +157,7 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
                       "flex w-full flex-col items-center",
                       isMobile
                         ? MOBILE_DOCUMENT_SCROLL_CLASSES.contentArea
-                        : "h-full overflow-y-auto",
+                        : "h-full overflow-y-auto [scrollbar-gutter:stable]",
                       contentWidth === "centered" ? "pt-4" : "pt-8",
                       contentClassName
                     )}
@@ -182,7 +182,7 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
                   "flex flex-1 flex-col",
                   isMobile
                     ? MOBILE_DOCUMENT_SCROLL_CLASSES.contentArea
-                    : "min-h-0 overflow-y-auto"
+                    : "min-h-0 overflow-y-auto [scrollbar-gutter:stable]"
                 )}
               >
                 {contentWidth ? (
@@ -193,7 +193,7 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
                         "flex w-full flex-col items-center",
                         isMobile
                           ? MOBILE_DOCUMENT_SCROLL_CLASSES.contentArea
-                          : "overflow-y-auto",
+                          : "overflow-y-auto [scrollbar-gutter:stable]",
                         contentWidth === "centered"
                           ? cn(
                               title ? "h-[calc(100vh-3.5rem)]" : "h-full",


### PR DESCRIPTION
## Description

On Settings > People, switching between the Members and Invitations tabs caused the table width to shift. The tables use the plain `DataTable`, which has no scroll container of its own; the scrollbar that toggles is the shared page scroll container in `AppContentLayout`. The Members tab makes the page tall enough to need a vertical scrollbar, while Invitations (few rows) or a filtered search removes it, reflowing the full-width table by the scrollbar width (~15px).

Fix: add `scrollbar-gutter: stable` to the desktop page scroll containers so the gutter is reserved whether or not the scrollbar is active. Applied in the shared app shell so the shift is fixed consistently across pages, not just People.

## Tests

Manual. Settings > People: toggled Members/Invitations tabs and typed in search, table width now stays constant.

## Risk

Low. CSS-only change to the shared content scroll containers. On overlay-scrollbar systems it's a no-op; on classic-scrollbar systems it reserves a constant gutter instead of jumping. Trivially rollback-able.

## Deploy Plan

Standard front deploy, no migration.