### PR TITLE
[CONNECTORS] Fix Confluence skipped pages being deleted on every sync

### DIFF
--- a/connectors/src/connectors/confluence/lib/content/pages.ts
+++ b/connectors/src/connectors/confluence/lib/content/pages.ts
@@ -233,6 +233,9 @@ export async function confluenceCheckAndUpsertSinglePage({
   );
   if (isPageSkipped) {
     logger.info("Confluence page skipped.");
+    // Mark the page as visited so the garbage collector does not delete the
+    // row (and its skipReason) on the next full space sync.
+    await markPageHasVisited({ connectorId, pageId, spaceId, visitedAtMs });
     return true;
   }
 


### PR DESCRIPTION
## Description

When a Confluence page is given a `skipReason`, `confluenceCheckAndUpsertSinglePage` returns early without updating `lastVisitedAt`, so the next full space sync's garbage collector (`confluenceRemoveUnvisitedPages`) sees the row as stale and destroys it — wiping the `skipReason` and re-including the page, over and over; this bumps `lastVisitedAt` on the skip path so skipped pages persist.

## Tests

Not tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `connectors`