### PR TITLE
Add partner package, + recurring free credits

### DIFF
--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -114,6 +114,17 @@ const SwitchContractFormSchema = z
       .min(2, "Number of periods must be at least 2")
       .max(60, "Number of periods must be at most 60")
       .optional(),
+    // Optional recurring free AWU credit pool, granted directly on the
+    // contract (not tied to the package) — e.g. the Partner Demo shared
+    // monthly pool. Toggled via `showRecurringFreeCredit`; assembled into
+    // `recurringFreeCreditAwuPerMonth` on submit. No invoice involved, so no
+    // Stripe customer is required.
+    showRecurringFreeCredit: z.boolean().default(false),
+    recurringFreeCreditAwuPerMonth: z
+      .number()
+      .int("Recurring free credit must be an integer number of AWU credits")
+      .min(1, "Recurring free credit must be at least 1 credit")
+      .optional(),
     // Per-seat-type settings, keyed by seat type. Every seat type the selected
     // package knows about is shown; only `selected` ones are submitted. `selected`
     // is pre-checked for the seats the package entitles by default, and can be
@@ -266,6 +277,8 @@ export default function SwitchContractDialog({
       initialCreditsInvoiceAmount: undefined,
       initialCreditsFrequency: "one_time",
       initialCreditsPeriods: undefined,
+      showRecurringFreeCredit: false,
+      recurringFreeCreditAwuPerMonth: undefined,
       seats: {},
     },
   });
@@ -503,9 +516,33 @@ export default function SwitchContractDialog({
 
   const showInitialCredits = form.watch("showInitialCredits");
   const initialCreditsFrequency = form.watch("initialCreditsFrequency");
+  const showRecurringFreeCredit = form.watch("showRecurringFreeCredit");
 
   const stripeCollectionMethod = form.watch("stripeCollectionMethod");
   const watchedSeats = form.watch("seats");
+  const forceSeatType = form.watch("forceSeatType");
+
+  // "Force seat type" may only promote members onto a seat that is actually
+  // entitled (checked) on the contract being created — offering an
+  // unentitled seat type would silently fail server-side. Recomputed on
+  // every render (not memoized against `watchedSeats`'s object identity,
+  // which doesn't reliably change across nested-field updates) so this
+  // stays in sync with the live checkbox state, same as each row's own
+  // `isSelected`.
+  const enterableSeatTypes = BILLABLE_SEAT_TYPES.filter(
+    (seatType) => watchedSeats?.[seatType]?.selected ?? false
+  );
+
+  // Clear a forced seat type that's no longer entitled (e.g. the operator
+  // unchecked it) so a stale override can't be submitted silently.
+  useEffect(() => {
+    if (
+      forceSeatType &&
+      !enterableSeatTypes.some((seatType) => seatType === forceSeatType)
+    ) {
+      form.setValue("forceSeatType", "");
+    }
+  }, [forceSeatType, enterableSeatTypes, form]);
 
   // When any payment frequency field changes, pre-fill its sibling periods
   // field with the canonical default. Uses form.watch(callback) — the only
@@ -629,6 +666,16 @@ export default function SwitchContractDialog({
                 : undefined,
           },
         };
+      }
+      // Recurring free credit pool: only sent when the operator toggled the
+      // section on. No invoice involved, so no Stripe customer is required.
+      if (values.showRecurringFreeCredit) {
+        if (values.recurringFreeCreditAwuPerMonth === undefined) {
+          setError("Recurring free credit requires an amount.");
+          return;
+        }
+        cleaned.recurringFreeCreditAwuPerMonth =
+          values.recurringFreeCreditAwuPerMonth;
       }
       // Resolve the start moment. "immediately" leaves `startingAt` unset so
       // the server swaps at the current hour.
@@ -1191,7 +1238,7 @@ export default function SwitchContractDialog({
                           mountPortalContainer={portalContainer}
                           options={[
                             { value: "", display: "— No override —" },
-                            ...BILLABLE_SEAT_TYPES.map((seatType) => ({
+                            ...enterableSeatTypes.map((seatType) => ({
                               value: seatType,
                               display: seatType,
                             })),
@@ -1276,6 +1323,34 @@ export default function SwitchContractDialog({
                     </div>
                   </div>
                 )}
+                <div className="border-t pt-4">
+                  <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
+                    <Label className="text-sm font-medium">
+                      Recurring free credit pool (monthly)
+                    </Label>
+                    <SliderToggle
+                      selected={showRecurringFreeCredit}
+                      onClick={() =>
+                        form.setValue(
+                          "showRecurringFreeCredit",
+                          !showRecurringFreeCredit
+                        )
+                      }
+                    />
+                    {showRecurringFreeCredit && (
+                      <>
+                        <Label className="text-sm">Credits (AWU) / month</Label>
+                        <InputField
+                          control={form.control}
+                          name="recurringFreeCreditAwuPerMonth"
+                          hideLabel
+                          type="number"
+                          placeholder="e.g., 10000"
+                        />
+                      </>
+                    )}
+                  </div>
+                </div>
               </DialogContainer>
               <DialogFooter>
                 <Button

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -17,6 +17,7 @@ import {
   CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
   CURRENCY_TO_CREDIT_TYPE_ID,
   getCreditTypeAwuId,
+  getProductFreeCreditId,
   getProductPrepaidCommitId,
   getProductSeatSubscriptionCommitId,
   HUBSPOT_DEAL_ID_CUSTOM_FIELD_KEY,
@@ -120,6 +121,18 @@ export const SwitchContractBodySchema = z.object({
       invoiceAmount: z.number().min(0, "Invoice amount must be zero or more"),
       paymentSchedule: paymentScheduleSchema,
     })
+    .optional(),
+  // Optional recurring free AWU credit grant, applied as a contract-level
+  // (non-seat) `add_recurring_credits` edit rather than baked into a
+  // package — e.g. the Partner Demo shared monthly pool
+  // (dust-tt/decisions#937). Usable with any package/tier; recurs monthly,
+  // for the life of the contract (no end date). Unlike `initialCredits`,
+  // this is a pure credit grant with no invoice, so no Stripe customer is
+  // required.
+  recurringFreeCreditAwuPerMonth: z
+    .number()
+    .int("Recurring free credit must be an integer number of AWU credits")
+    .min(1, "Recurring free credit must be at least 1 credit")
     .optional(),
   // Optional per-seat-type settings for the new contract. `minSeats` is the
   // billing floor persisted to `workspace_seat_limits`. `rate` is the per-seat
@@ -741,6 +754,32 @@ async function stepContractEdits({
 }: PostProvisionCtx): Promise<string | null> {
   const addCommits: NonNullable<ContractEditParams["add_commits"]> = [];
   const addOverrides: NonNullable<ContractEditParams["add_overrides"]> = [];
+  const addRecurringCredits: NonNullable<
+    ContractEditParams["add_recurring_credits"]
+  > = [];
+
+  // Optional recurring free AWU credit pool, granted directly on this
+  // contract (not baked into the package) — e.g. the Partner Demo shared
+  // monthly pool. Reuses the "Free Credits" FIXED product; won't be
+  // misclassified as a legacy free credit by `isMetronomeFreeCredit` since
+  // that additionally requires priority 1 and the programmatic-USD credit
+  // type.
+  if (body.recurringFreeCreditAwuPerMonth) {
+    addRecurringCredits.push({
+      product_id: getProductFreeCreditId(),
+      access_amount: {
+        credit_type_id: getCreditTypeAwuId(),
+        unit_price: body.recurringFreeCreditAwuPerMonth,
+        quantity: 1,
+      },
+      commit_duration: { value: 1, unit: "PERIODS" },
+      priority: AWU_PRIORITY_PURCHASED_COMMIT,
+      starting_at: floorToHourISO(alignedStart),
+      applicable_product_tags: ["usage"],
+      recurrence_frequency: "MONTHLY",
+      name: `Recurring free credit: ${body.recurringFreeCreditAwuPerMonth.toLocaleString()} AWU/month`,
+    });
+  }
 
   // Initial credits prepaid commit.
   if (body.initialCredits && resolvedCurrency) {
@@ -896,7 +935,8 @@ async function stepContractEdits({
   if (
     netPaymentTermsDays === undefined &&
     addCommits.length === 0 &&
-    addOverrides.length === 0
+    addOverrides.length === 0 &&
+    addRecurringCredits.length === 0
   ) {
     return null;
   }
@@ -909,6 +949,9 @@ async function stepContractEdits({
       : {}),
     ...(addCommits.length > 0 ? { add_commits: addCommits } : {}),
     ...(addOverrides.length > 0 ? { add_overrides: addOverrides } : {}),
+    ...(addRecurringCredits.length > 0
+      ? { add_recurring_credits: addRecurringCredits }
+      : {}),
   });
   if (result.isErr()) {
     return `contract_edits: ${result.error.message}`;

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -672,6 +672,18 @@ export async function listMetronomePackages(): Promise<
         );
         continue;
       }
+      const filteredSeatTypes = new Map(
+        productSeatTypes
+          .entries()
+          .filter(
+            (entry) =>
+              pkg.subscriptions &&
+              pkg.subscriptions.some(
+                (s) => s.subscription_rate.product.id === entry[0]
+              )
+          )
+      );
+
       packages.push({
         id: pkg.id,
         name,
@@ -679,7 +691,10 @@ export async function listMetronomePackages(): Promise<
         rateCardId: pkg.rate_card_id ?? undefined,
         tier,
         currency: classifyMetronomePackageCurrencyByName(name),
-        seats: seatConfigsFromPackageOverrides(pkg.overrides, productSeatTypes),
+        seats: seatConfigsFromPackageOverrides(
+          pkg.overrides,
+          filteredSeatTypes
+        ),
         // billing_anchor_date is not exposed on PackageListResponse; default to
         // contract_start_date which all current packages use.
         billingAnchor: "contract_start_date" as const,

--- a/front/lib/metronome/setup_new_pricing.ts
+++ b/front/lib/metronome/setup_new_pricing.ts
@@ -618,6 +618,48 @@ export function getNewPackages(): PackageDef[] {
       ]),
       ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
     },
+    // Partner Demo — unlimited free Platform Seats (pooled, monthly, $0).
+    // Usage draws from the standard AWU rates with no included credits here;
+    // a workspace-specific shared pool is granted separately, as an optional
+    // recurring credit at switch-contract time (see `recurringFreeCreditAwuPerMonth`
+    // in `lib/api/poke/switch_contract.ts`) rather than baked into the
+    // package. PAYG at list price beyond the pool via the same Standard
+    // USD/EUR rate card every other non-legacy package uses.
+    // dust-tt/decisions#937.
+    {
+      name: "Partner Demo Enterprise USD",
+      aliases: [{ name: "partner-demo-enterprise-usd" }],
+      rate_card_name: "Standard USD",
+      subscriptions: [WORKSPACE_SEATS.monthly],
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: [
+        getFreeExcessRecurringCredits(
+          getCreditTypeAwuId(),
+          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
+        ),
+      ],
+      overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_USD_ID, [
+        { product_name: WORKSPACE_SEAT_PRODUCT_NAME, price: 0 },
+      ]),
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Partner Demo Enterprise EUR",
+      aliases: [{ name: "partner-demo-enterprise-eur" }],
+      rate_card_name: "Standard EUR",
+      subscriptions: [WORKSPACE_SEATS.monthly],
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: [
+        getFreeExcessRecurringCredits(
+          getCreditTypeAwuId(),
+          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
+        ),
+      ],
+      overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_EUR_ID, [
+        { product_name: WORKSPACE_SEAT_PRODUCT_NAME, price: 0 },
+      ]),
+      ...BILLING_CYCLE_CONFIG,
+    },
     {
       name: "Enterprise Seat-based USD",
       aliases: [{ name: "enterprise-seat-based-usd" }],


### PR DESCRIPTION
## Description

Adds a "Partner Demo Enterprise USD/EUR" Metronome package for partner demo workspaces (dust-tt/decisions#937): unlimited free pooled Platform Seat, no per-seat credits, PAYG beyond a workspace pool at the standard rate.

Rather than baking a fixed credit pool into the package, adds a generic, optional `recurringFreeCreditAwuPerMonth` field to `switch_contract` that grants a configurable recurring AWU credit directly on the contract (reuses the existing "Free Credits" product) — usable with any package, not just Partner Demo, wired into the poke Switch Contract dialog.

Also trims the Partner Demo package to its bare-minimum subscriptions/recurring credits (no dormant Pro/Max seats), and fixes a stale-`useMemo` bug in the Switch Contract dialog where "Force seat type" wasn't updating when seats were checked/unchecked.

## Tests

- `npx tsgo --noEmit`
- Dry-run of `scripts/metronome_setup.ts` against sandbox (only the two new packages diff; no other package/product affected)
- Manually exercised the Switch Contract dialog against a sandbox workspace to confirm the recurring credit field and "Force seat type" reactivity

## Risk

Net-new package + optional field; no changes to existing package definitions or contract-edit behavior. Low risk.

## Deploy Plan

Merge, then run `scripts/metronome_setup.ts --execute` against production to create the new packages (already applied to sandbox).