### PR TITLE
Configure programmatic cap for migrated workspaces

### DIFF
--- a/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.test.ts
+++ b/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.test.ts
@@ -20,7 +20,7 @@ vi.mock("@app/lib/api/credits/programmatic_usage_limit", async () => {
 const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
 
 async function makeMetronomeWorkspace(): Promise<WorkspaceType> {
-  return WorkspaceFactory.metronome({
+  return WorkspaceFactory.creditPriced({
     metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
   });
 }
@@ -256,6 +256,25 @@ describe("/api/w/[wId]/usage_settings/programmatic_usage_limit", () => {
       });
 
       expect(response.status).toBe(500);
+    });
+
+    it("returns 400 when the workspace is not on a credit-priced plan", async () => {
+      const workspace = await WorkspaceFactory.metronome({
+        metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+      });
+      await createPrivateApiMockRequest({
+        role: "admin",
+        workspace,
+      });
+
+      const response = await putRequest(workspace.sId, {
+        monthlyCapCredits: 500,
+      });
+
+      expect(response.status).toBe(400);
+      const data = (await response.json()) as { error: { type: string } };
+      expect(data.error.type).toBe("invalid_request_error");
+      expect(businessLayer.syncProgrammaticUsageLimit).not.toHaveBeenCalled();
     });
   });
 });

--- a/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
+++ b/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
@@ -9,6 +9,7 @@ import type {
   GetProgrammaticUsageLimitResponseBody,
   PutProgrammaticUsageLimitResponseBody,
 } from "@app/types/api/credits/programmatic_usage_limit";
+import { isCreditPricedPlan } from "@app/types/plan";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -48,6 +49,18 @@ app.put(
   async (ctx): HandlerResult<PutProgrammaticUsageLimitResponseBody> => {
     const auth = ctx.get("auth");
     const { monthlyCapCredits } = ctx.req.valid("json");
+
+    const plan = auth.plan();
+    if (!plan || !isCreditPricedPlan(plan)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Programmatic monthly cap is only available on credit-priced plans.",
+        },
+      });
+    }
 
     const auditContext = getAuditLogContext(auth);
     const result = await syncProgrammaticUsageLimit({

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -11,7 +11,6 @@ import {
 } from "@app/lib/metronome/alerts/programmatic_cap";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -64,18 +63,6 @@ export async function syncProgrammaticUsageLimit({
   if (!workspace.metronomeCustomerId) {
     return new Err(
       new Error(`Workspace ${workspace.sId} has no Metronome customer ID.`)
-    );
-  }
-
-  // Programmatic cap alerts are AWU-credit based and only meaningful on
-  // credit-priced (new-pricing) plans. Legacy programmatic usage is billed in
-  // USD via Stripe PAYG and must never create Metronome alerts.
-  const plan = auth.plan();
-  if (!plan || !isCreditPricedPlan(plan)) {
-    return new Err(
-      new Error(
-        `Programmatic usage limit only applies to credit-priced plans (workspace ${workspace.sId}).`
-      )
     );
   }
 

--- a/front/scripts/set_programmatic_monthly_limit_legacy_credits.ts
+++ b/front/scripts/set_programmatic_monthly_limit_legacy_credits.ts
@@ -1,0 +1,120 @@
+import { syncProgrammaticUsageLimit } from "@app/lib/api/credits/programmatic_usage_limit";
+import { Authenticator } from "@app/lib/auth";
+import { CreditModel } from "@app/lib/resources/storage/models/credits";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import { Op, Sequelize } from "sequelize";
+
+/**
+ * For every workspace that has consumed legacy (microUSD-based) credits from
+ * the `credits` table, set the Metronome "Programmatic monthly limit" to
+ * `--monthlyCapCredits`. This persists the cap on `credit_usage_configurations`
+ * and creates/updates the corresponding Metronome spend-threshold alerts, via
+ * `syncProgrammaticUsageLimit`.
+ *
+ * Intended to run BEFORE these workspaces' credit-priced (CP/AWU) plan is
+ * activated, so the cap is already in place at cutover. `syncProgrammaticUsageLimit`
+ * (like `syncCreditBasedPayg` and `syncDefaultPoolCapAlertsForWorkspace`) only
+ * gates on the workspace having a Metronome customer id, not on plan type, so
+ * it can be called ahead of the plan switch.
+ *
+ * Workspaces without a Metronome customer id are skipped and logged.
+ *
+ * Run with: npx tsx scripts/set_programmatic_monthly_limit_legacy_credits.ts \
+ *   --monthlyCapCredits <n> [--execute] [--wId <workspaceId>]
+ */
+makeScript(
+  {
+    monthlyCapCredits: {
+      type: "number",
+      required: true,
+      description: "Programmatic monthly limit to set, in AWU credits.",
+    },
+    wId: {
+      type: "string",
+      required: false,
+      description: "Restrict the run to a single workspace (sId).",
+    },
+  },
+  async ({ execute, monthlyCapCredits, wId }, logger) => {
+    const rows = (await CreditModel.findAll({
+      attributes: [
+        [Sequelize.fn("DISTINCT", Sequelize.col("workspaceId")), "workspaceId"],
+      ],
+      where: { consumedAmountMicroUsd: { [Op.gt]: 0 } },
+      raw: true,
+    })) as unknown as { workspaceId: number }[];
+
+    const workspaceModelIds = rows.map((r) => r.workspaceId);
+    const workspaceResources =
+      await WorkspaceResource.fetchByModelIds(workspaceModelIds);
+    let workspaces = workspaceResources.map((workspace) =>
+      renderLightWorkspaceType({ workspace })
+    );
+
+    if (wId) {
+      workspaces = workspaces.filter((workspace) => workspace.sId === wId);
+    }
+
+    logger.info(
+      { count: workspaces.length, monthlyCapCredits },
+      "Found workspaces with consumed legacy credits."
+    );
+
+    let updated = 0;
+    let skipped = 0;
+
+    await concurrentExecutor(
+      workspaces,
+      async (workspace) => {
+        if (!workspace.metronomeCustomerId) {
+          logger.info(
+            { workspaceId: workspace.sId },
+            "Skipping workspace with no Metronome customer id."
+          );
+          skipped++;
+          return;
+        }
+
+        logger.info(
+          { workspaceId: workspace.sId, monthlyCapCredits },
+          execute
+            ? "Setting programmatic monthly limit."
+            : "Would set programmatic monthly limit."
+        );
+
+        if (!execute) {
+          updated++;
+          return;
+        }
+
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId
+        );
+        const result = await syncProgrammaticUsageLimit({
+          auth,
+          monthlyCapCredits,
+        });
+
+        if (result.isErr()) {
+          logger.warn(
+            { workspaceId: workspace.sId, err: result.error.message },
+            "Failed to set programmatic monthly limit; skipping."
+          );
+          skipped++;
+          return;
+        }
+
+        updated++;
+      },
+      { concurrency: 4 }
+    );
+
+    logger.info(
+      { updated, skipped },
+      execute ? "Run completed." : "Dry run completed."
+    );
+  }
+);


### PR DESCRIPTION
## Description

Adds an admin script (`scripts/set_programmatic_monthly_limit_legacy_credits.ts`) to set the Metronome "Programmatic monthly limit" for every workspace that has consumed legacy (microUSD-based) credits, so the cap and its spend alerts are pre-staged before these workspaces' credit-priced (CP/AWU) plan is activated.

`syncProgrammaticUsageLimit` (`front/lib/api/credits/programmatic_usage_limit.ts`) previously refused to run on non-credit-priced plans, which would have blocked this pre-migration use case. It now gates only on `workspace.metronomeCustomerId`, matching sibling functions (`syncCreditBasedPayg`, `syncDefaultPoolCapAlertsForWorkspace`). The one live caller that relied on that internal gate — `PUT /api/w/:wId/usage_settings/programmatic_usage_limit` — now does its own `isCreditPricedPlan` check, so customer-facing behavior for legacy-plan admins is unchanged.

## Tests

- Updated/added unit tests in `front-api/.../programmatic_usage_limit.test.ts`, including a new case asserting the endpoint rejects legacy-plan workspaces with 400.
- Existing `front/lib/api/credits/programmatic_usage_limit.test.ts` suite passes unchanged.
- Type-checked and formatted both workspaces.

## Risk

Low: the new script is dry-run by default (`--execute` required) and only touches workspaces with a Metronome customer id. The business-layer gate removal only affects internal/script callers and one endpoint, which now has an equivalent guard.

## Deploy Plan

Standard deploy. Run the script with `--execute` after deploy, before the affected workspaces' CP plan switchContract runs.