### PR TITLE
Pricing: unify group filter behind single variable

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -75,6 +75,7 @@ import {
   usePerSeatPricing,
   useWorkspaceSeatAvailability,
 } from "@app/lib/swr/workspaces";
+import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type {
   MembershipSeatType,
   MembershipUpgradeRequestType,
@@ -468,7 +469,7 @@ export function UsagePage() {
 
   const { groups } = useGroups({
     owner,
-    kinds: ["provisioned"],
+    kinds: [...CAP_ELIGIBLE_GROUP_KINDS],
     disabled: !pricingGroupsEnabled && !modelsPickerEnabled,
   });
   const selectedGroupName =

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -49,6 +49,7 @@ import {
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
+import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type {
   MembershipSeatType,
   NormalizedPoolLimitSeatType,
@@ -1353,7 +1354,7 @@ export async function getMembersUsage({
     GroupResource.listGroupNamesByUserModelIdInWorkspace({
       workspace,
       userModelIds: users.map((u) => u.id),
-      groupKinds: ["provisioned"],
+      groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
     }),
     GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
       workspace,

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -14,6 +14,7 @@ import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
@@ -291,7 +292,7 @@ export async function getUserGroupMemberships(
             required: true,
             where: {
               kind: {
-                [Op.in]: ["provisioned"],
+                [Op.in]: [...CAP_ELIGIBLE_GROUP_KINDS],
               },
             },
           },


### PR DESCRIPTION
## Description

Rely on CAP_ELIGIBLE_GROUP_KINDS variable to ease tha addition of the new regular_manual type

## Tests



## Risk

very low

## Deploy Plan

deploy front
