### PR TITLE
Add: new tools to move conversation in/out of pods and change access.

### DIFF
--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -3,10 +3,14 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import {
+  EDIT_INFORMATION_TOOL_NAME,
   POD_MANAGER_SERVER_NAME,
   UPDATE_MEMBERS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/pod_manager/metadata";
-import { isPodManagerUpdateMembersInput } from "@app/lib/api/actions/servers/pod_manager/types";
+import {
+  isPodManagerEditInformationInput,
+  isPodManagerUpdateMembersInput,
+} from "@app/lib/api/actions/servers/pod_manager/types";
 import {
   CREATE_TASKS_TOOL_NAME,
   POD_TASKS_SERVER_NAME,
@@ -91,6 +95,31 @@ const MCP_TOOL_OVERRIDES: Partial<
     },
   },
   [POD_MANAGER_SERVER_NAME]: {
+    [EDIT_INFORMATION_TOOL_NAME]: {
+      title: (inputs) => {
+        if (!isPodManagerEditInformationInput(inputs)) {
+          return `Allow agent to edit Pod information?`;
+        }
+        const fields: string[] = [];
+        if (inputs.title !== undefined) {
+          fields.push("title");
+        }
+        if (inputs.description !== undefined) {
+          fields.push("description");
+        }
+        if (inputs.access !== undefined) {
+          fields.push("access");
+        }
+        if (inputs.pinnedFramePath !== undefined) {
+          fields.push("pinned frame");
+        }
+        if (fields.length === 0) {
+          return `Allow agent to edit Pod information?`;
+        }
+        return `Allow agent to update Pod ${fields.join(", ")}?`;
+      },
+      alwaysAllowLabel: () => `Always allow agent to edit Pod information`,
+    },
     [UPDATE_MEMBERS_TOOL_NAME]: {
       title: (inputs) => {
         if (!isPodManagerUpdateMembersInput(inputs)) {

--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -2,6 +2,7 @@ import {
   AshbyJobPostingUpdateDetails,
   AshbyReferralDetails,
 } from "@app/components/assistant/conversation/tool_validation/AshbyValidationDetails";
+import { PodEditInformationValidationDetails } from "@app/components/assistant/conversation/tool_validation/PodEditInformationValidationDetails";
 import { PodMembersUpdateValidationDetails } from "@app/components/assistant/conversation/tool_validation/PodMembersUpdateValidationDetails";
 import { PodTasksCreateValidationDetails } from "@app/components/assistant/conversation/tool_validation/PodTasksCreateValidationDetails";
 import { PodTasksUpdateValidationDetails } from "@app/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails";
@@ -16,10 +17,14 @@ import {
   isAshbyUpdateJobPostingInput,
 } from "@app/lib/api/actions/servers/ashby/types";
 import {
+  EDIT_INFORMATION_TOOL_NAME,
   POD_MANAGER_SERVER_NAME,
   UPDATE_MEMBERS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/pod_manager/metadata";
-import { isPodManagerUpdateMembersInput } from "@app/lib/api/actions/servers/pod_manager/types";
+import {
+  isPodManagerEditInformationInput,
+  isPodManagerUpdateMembersInput,
+} from "@app/lib/api/actions/servers/pod_manager/types";
 import {
   CREATE_TASKS_TOOL_NAME,
   POD_TASKS_SERVER_NAME,
@@ -182,6 +187,20 @@ export function ToolValidationDetails({
         input={blockedAction.inputs}
         owner={owner}
         user={user}
+        conversationId={conversationId}
+      />
+    );
+  }
+
+  if (
+    blockedAction.metadata.mcpServerName === POD_MANAGER_SERVER_NAME &&
+    blockedAction.metadata.toolName === EDIT_INFORMATION_TOOL_NAME &&
+    isPodManagerEditInformationInput(blockedAction.inputs)
+  ) {
+    return (
+      <PodEditInformationValidationDetails
+        input={blockedAction.inputs}
+        owner={owner}
         conversationId={conversationId}
       />
     );

--- a/front/components/assistant/conversation/tool_validation/PodEditInformationValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodEditInformationValidationDetails.tsx
@@ -1,0 +1,163 @@
+import { usePodLabel } from "@app/components/assistant/conversation/tool_validation/usePodLabel";
+import { useConversation } from "@app/hooks/conversations/useConversation";
+import { parsePodConfigurationURI } from "@app/lib/actions/mcp_internal_actions/pod_configuration_uri";
+import type { PodManagerEditInformationInput } from "@app/lib/api/actions/servers/pod_manager/types";
+import { useSpaceInfo } from "@app/lib/swr/spaces";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Chip } from "@dust-tt/sparkle";
+import { useMemo } from "react";
+
+interface PodEditInformationValidationDetailsProps {
+  input: PodManagerEditInformationInput;
+  owner: LightWorkspaceType;
+  conversationId?: string | null;
+}
+
+interface ChangeRowProps {
+  label: string;
+  before: string;
+  after: string;
+}
+
+function formatAccess(access: "restricted" | "open"): string {
+  return access === "open" ? "Open" : "Restricted";
+}
+
+function formatPinnedFramePath(path: string | null | undefined): string {
+  if (path === null) {
+    return "Unpinned";
+  }
+  if (path === undefined) {
+    return "—";
+  }
+  return path;
+}
+
+function ChangeRow({ label, before, after }: ChangeRowProps) {
+  const hasChanged = before !== after;
+
+  return (
+    <div className="flex flex-col gap-1 px-3 py-2.5">
+      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        <span className="text-muted-foreground">{before}</span>
+        {hasChanged && (
+          <>
+            <span className="text-muted-foreground">→</span>
+            <span className="font-medium text-foreground">{after}</span>
+          </>
+        )}
+        {!hasChanged && <Chip size="xs" color="primary" label="No change" />}
+      </div>
+    </div>
+  );
+}
+
+export function PodEditInformationValidationDetails({
+  input,
+  owner,
+  conversationId,
+}: PodEditInformationValidationDetailsProps) {
+  const { podLabel, isPodLabelLoading } = usePodLabel({
+    owner,
+    dustPodUri: input.dustPod?.uri,
+    conversationId,
+  });
+
+  const { conversation, isConversationLoading } = useConversation({
+    workspaceId: owner.sId,
+    conversationId: conversationId ?? null,
+    options: { disabled: !conversationId },
+  });
+
+  const podSpaceId = useMemo(() => {
+    if (input.dustPod?.uri) {
+      const parsed = parsePodConfigurationURI(input.dustPod.uri);
+      if (parsed.isOk()) {
+        return parsed.value.podId;
+      }
+      return null;
+    }
+    return conversation?.spaceId ?? null;
+  }, [conversation?.spaceId, input.dustPod?.uri]);
+
+  const isWaitingForConversationSpaceId =
+    !input.dustPod?.uri && !!conversationId && isConversationLoading;
+
+  const { spaceInfo, isSpaceInfoLoading } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId: podSpaceId,
+    disabled: !podSpaceId,
+  });
+
+  const isCurrentPodInfoLoading =
+    isWaitingForConversationSpaceId ||
+    (podSpaceId !== null && isSpaceInfoLoading && !spaceInfo);
+
+  const currentAccess = spaceInfo
+    ? spaceInfo.isRestricted
+      ? "restricted"
+      : "open"
+    : null;
+
+  const changes: ChangeRowProps[] = [];
+
+  if (input.title !== undefined) {
+    changes.push({
+      label: "Title",
+      before: spaceInfo?.name ?? (isCurrentPodInfoLoading ? "Loading…" : "—"),
+      after: input.title,
+    });
+  }
+
+  if (input.description !== undefined) {
+    changes.push({
+      label: "Description",
+      before:
+        spaceInfo?.description ?? (isCurrentPodInfoLoading ? "Loading…" : "—"),
+      after: input.description,
+    });
+  }
+
+  if (input.access !== undefined) {
+    changes.push({
+      label: "Access",
+      before: currentAccess
+        ? formatAccess(currentAccess)
+        : isCurrentPodInfoLoading
+          ? "Loading…"
+          : "—",
+      after: formatAccess(input.access),
+    });
+  }
+
+  if (input.pinnedFramePath !== undefined) {
+    changes.push({
+      label: "Pinned frame",
+      before: isCurrentPodInfoLoading
+        ? "Loading…"
+        : formatPinnedFramePath(spaceInfo?.pinnedFramePath ?? undefined),
+      after: formatPinnedFramePath(input.pinnedFramePath),
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3 pt-2">
+      <p className="text-sm text-muted-foreground">
+        The agent wants to update information for{" "}
+        <span className="font-medium text-foreground">
+          {isPodLabelLoading ? "Loading…" : podLabel}
+        </span>
+        .
+      </p>
+
+      {changes.length > 0 && (
+        <div className="divide-y divide-separator overflow-hidden rounded-xl border border-separator bg-background">
+          {changes.map((change) => (
+            <ChangeRow key={change.label} {...change} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -1762,6 +1762,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
+    "move_conversation": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
     "remove_content_node": {
       "freeUsage": false,
       "toolCostCategory": "basic",
@@ -3035,6 +3039,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_conversations": "never_ask",
     "list_members": "never_ask",
     "list_pods": "never_ask",
+    "move_conversation": "never_ask",
     "remove_content_node": "medium",
     "retrieve_recent_documents": "never_ask",
     "semantic_search": "never_ask",

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -946,8 +946,9 @@ const QUERIES: LabeledQuery[] = [
     expected: "pod_manager.list_pods",
   },
   {
-    query: "create a new private pod for the launch plan",
+    query: "create a new restricted pod for the launch plan",
     expected: "pod_manager.create_pod",
+    maxRank: 2,
   },
   {
     query: "what is this pod's title description and linked content",
@@ -956,6 +957,7 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "rename this pod and update its description",
     expected: "pod_manager.edit_information",
+    maxRank: 2,
   },
   {
     query: "add a teammate as an editor to this pod",
@@ -993,6 +995,19 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "send a follow up message to an existing pod conversation",
     expected: "pod_manager.add_message_to_conversation",
+  },
+  {
+    query: "move this conversation into the marketing pod",
+    expected: "pod_manager.move_conversation",
+  },
+  {
+    query: "move this conversation out of the pod",
+    expected: "pod_manager.move_conversation",
+  },
+  {
+    query: "make this pod open to the whole workspace",
+    expected: "pod_manager.edit_information",
+    maxRank: 2,
   },
 
   // --- val_town ---

--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -305,6 +305,25 @@ export async function resolvePodUserRolesBySId(
   return roleByUserSId;
 }
 
+export async function getPodMemberAndEditorSIds(
+  auth: Authenticator,
+  pod: SpaceResource
+): Promise<{ editorIds: string[]; memberIds: string[] }> {
+  const roleByUserSId = await resolvePodUserRolesBySId(auth, pod);
+  const editorIds: string[] = [];
+  const memberIds: string[] = [];
+
+  for (const [userSId, role] of roleByUserSId.entries()) {
+    if (role === "editor") {
+      editorIds.push(userSId);
+    } else {
+      memberIds.push(userSId);
+    }
+  }
+
+  return { editorIds, memberIds };
+}
+
 export function partitionMembersToRemove(
   membersToRemove: string[],
   roleByUserSId: Map<string, "editor" | "member">

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -21,6 +21,8 @@ export const POD_MANAGER_SERVER_NAME = "pod_manager" as const;
 export const UPDATE_MEMBERS_TOOL_NAME = "update_members" as const;
 export const LIST_MEMBERS_TOOL_NAME = "list_members" as const;
 export const SEMANTIC_SEARCH_TOOL_NAME = "semantic_search" as const;
+export const EDIT_INFORMATION_TOOL_NAME = "edit_information" as const;
+export const MOVE_CONVERSATION_TOOL_NAME = "move_conversation" as const;
 
 export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   add_content_node: {
@@ -77,11 +79,12 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  edit_information: {
+  [EDIT_INFORMATION_TOOL_NAME]: {
     description:
-      "Edit Pod information: title, description, and/or pinned frame. " +
+      "Edit Pod information: title, description, access, and/or pinned frame. " +
       "Provide at least one field to update. Descriptions must be plain text only (no markdown, HTML, or formatting). " +
-      "The pinned frame must be an existing Pod file path under `pod/` (use null to unpin).",
+      "The pinned frame must be an existing Pod file path under `pod/` (use null to unpin). " +
+      "Access can be set to open or restricted; open Pods are subject to workspace policy.",
     schema: {
       title: z.string().optional().describe("New Pod title"),
       description: z
@@ -89,6 +92,12 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
         .optional()
         .describe(
           "New Pod description. Must be plain text only (no markdown, HTML, or other formatting). Keep it brief and concise: 1-2 short sentences max."
+        ),
+      access: z
+        .enum(["restricted", "open"])
+        .optional()
+        .describe(
+          "Pod access. restricted = limited to invited members; open = all workspace members can join. Open Pods are subject to workspace policy."
         ),
       pinnedFramePath: z
         .string()
@@ -145,7 +154,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   get_information: {
     description:
-      "Get metadata about the Pod: URL, title, description, pinned frame, " +
+      "Get metadata about the Pod: URL, title, description, access, pinned frame, " +
       "and linked Company Data content-node references attached to the " +
       "Pod context. This returns metadata only, not document bodies or " +
       "transcript bodies. Scoped path operations live under " +
@@ -248,20 +257,20 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   create_pod: {
     description:
-      "Create a new Pod. By default the Pod is private. The creator is always added as a Pod editor. " +
-      "You can optionally set visibility to open and add initial members or editors via membersToAdd.",
+      "Create a new Pod. By default the Pod is restricted. The creator is always added as a Pod editor. " +
+      "You can optionally set access to open and add initial members or editors via membersToAdd.",
     schema: {
       title: z.string().describe("Pod title"),
       description: z
         .string()
         .optional()
         .describe("Optional Pod description (plain text recommended)"),
-      visibility: z
-        .enum(["private", "open"])
+      access: z
+        .enum(["restricted", "open"])
         .optional()
-        .default("private")
+        .default("restricted")
         .describe(
-          "Pod visibility. Defaults to private. Open Pods are subject to workspace policy."
+          "Pod access. Defaults to restricted. Open Pods are subject to workspace policy."
         ),
       membersToAdd: PodMembersToAddSchema.optional().describe(
         "Optional user ids to add after creation mapped to their Pod role (member or editor). The creator is always an editor."
@@ -436,6 +445,39 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Listing Pod conversations",
       done: "List conversations",
+    },
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
+  [MOVE_CONVERSATION_TOOL_NAME]: {
+    description:
+      "Move a conversation into a Pod or out of its Pod to the user's personal conversations. " +
+      "Set destination to 'pod' to move into a Pod (requires dustPod), or 'personal' to move out of the current Pod. " +
+      "If conversationId is omitted, the current agent conversation is used when available.",
+    schema: {
+      destination: z
+        .enum(["pod", "personal"])
+        .describe(
+          "Where to move the conversation: 'pod' = into a Pod; 'personal' = out of the Pod to personal conversations."
+        ),
+      conversationId: z
+        .string()
+        .optional()
+        .describe(
+          "Conversation id to move; defaults to the conversation this agent run is in when omitted"
+        ),
+      dustPod: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD
+      ]
+        .optional()
+        .describe(
+          "Target Pod when destination is 'pod'. Required when moving into a Pod."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Moving conversation",
+      done: "Move conversation",
     },
     toolCostCategory: "basic",
     freeUsage: true,

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -19,6 +19,7 @@ import { buildPodSearchDataSources } from "@app/lib/api/actions/servers/pod_mana
 import {
   buildProjectRetrieveDataSources,
   getPod,
+  getPodMemberAndEditorSIds,
   getWritablePodContext,
   makeSuccessResponse,
   partitionMembersToRemove,
@@ -26,7 +27,9 @@ import {
   withErrorHandling,
 } from "@app/lib/api/actions/servers/pod_manager/helpers";
 import {
+  EDIT_INFORMATION_TOOL_NAME,
   LIST_MEMBERS_TOOL_NAME,
+  MOVE_CONVERSATION_TOOL_NAME,
   POD_MANAGER_TOOLS_METADATA,
   SEMANTIC_SEARCH_TOOL_NAME,
   UPDATE_MEMBERS_TOOL_NAME,
@@ -50,6 +53,10 @@ import {
   listProjectContextAttachments,
   removeContentNodesFromProject,
 } from "@app/lib/api/projects/context";
+import {
+  moveConversationOutOfProject,
+  moveConversationToProject,
+} from "@app/lib/api/projects/conversations";
 import { listPodsForScope } from "@app/lib/api/projects/list";
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
@@ -235,7 +242,7 @@ export function createProjectManagerTools(
       }, "Failed to remove linked content from Pod");
     },
 
-    edit_information: async (params) => {
+    [EDIT_INFORMATION_TOOL_NAME]: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
           toolContext,
@@ -256,21 +263,25 @@ export function createProjectManagerTools(
           );
         }
 
-        const { title, description, pinnedFramePath } = params;
+        const { title, description, pinnedFramePath, access } = params;
         if (
           title === undefined &&
           description === undefined &&
-          pinnedFramePath === undefined
+          pinnedFramePath === undefined &&
+          access === undefined
         ) {
           return new Err(
             new MCPError(
-              "At least one of title, description, or pinnedFramePath must be provided",
+              "At least one of title, description, access, or pinnedFramePath must be provided",
               { tracked: false }
             )
           );
         }
 
-        const updates: ProjectMetadataBlob & { title?: string } = {};
+        const updates: ProjectMetadataBlob & {
+          title?: string;
+          access?: "restricted" | "open";
+        } = {};
 
         if (title !== undefined) {
           const updateNameRes = await pod.updateName(auth, title);
@@ -302,7 +313,43 @@ export function createProjectManagerTools(
           updates.pinnedFramePath = validation.value;
         }
 
-        const { title: _title, ...podUpdates } = updates;
+        if (access !== undefined) {
+          const owner = auth.getNonNullableWorkspace();
+          if (access === "open" && !areOpenPodsAllowed(owner)) {
+            return new Err(
+              new MCPError(
+                "Open Pods are disabled by your workspace admin. Set access to restricted instead.",
+                { tracked: false }
+              )
+            );
+          }
+
+          const newIsRestricted = access !== "open";
+          const currentlyRestricted = !pod.isOpen();
+          if (newIsRestricted !== currentlyRestricted) {
+            const { editorIds, memberIds } = await getPodMemberAndEditorSIds(
+              auth,
+              pod
+            );
+            const updatePermissionsRes = await pod.updatePermissions(auth, {
+              name: pod.name,
+              isRestricted: newIsRestricted,
+              managementMode: "manual",
+              memberIds,
+              editorIds,
+            });
+            if (updatePermissionsRes.isErr()) {
+              return new Err(
+                new MCPError(updatePermissionsRes.error.message, {
+                  tracked: false,
+                })
+              );
+            }
+            updates.access = access;
+          }
+        }
+
+        const { title: _title, access: _access, ...podUpdates } = updates;
         let metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
         if (!metadata) {
           metadata = await ProjectMetadataResource.makeNew(
@@ -529,6 +576,7 @@ export function createProjectManagerTools(
               id: pod.sId,
               name: pod.name,
               url: projectUrl,
+              access: pod.isOpen() ? "open" : "restricted",
               description: metadata?.description ?? null,
               pinnedFramePath: metadata?.pinnedFramePath ?? null,
               contentNodes,
@@ -784,10 +832,10 @@ export function createProjectManagerTools(
       return withErrorHandling(async () => {
         const owner = auth.getNonNullableWorkspace();
 
-        if (params.visibility === "open" && !areOpenPodsAllowed(owner)) {
+        if (params.access === "open" && !areOpenPodsAllowed(owner)) {
           return new Err(
             new MCPError(
-              "Open Pods are disabled by your workspace admin. Create a private Pod instead.",
+              "Open Pods are disabled by your workspace admin. Create a restricted Pod instead.",
               { tracked: false }
             )
           );
@@ -795,7 +843,7 @@ export function createProjectManagerTools(
 
         const createSpaceRes = await createSpaceAndGroup(auth, {
           name: params.title,
-          isRestricted: params.visibility !== "open",
+          isRestricted: params.access !== "open",
           spaceKind: "project",
           managementMode: "manual",
           memberIds: [],
@@ -931,7 +979,7 @@ export function createProjectManagerTools(
             pod: {
               id: pod.sId,
               title: pod.name,
-              visibility: pod.isOpen() ? "open" : "private",
+              access: pod.isOpen() ? "open" : "restricted",
               dustPod: {
                 uri: makePodConfigurationURI(owner.sId, pod.sId),
                 mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,
@@ -1447,6 +1495,112 @@ export function createProjectManagerTools(
           })
         );
       }, "Failed to add message to conversation");
+    },
+
+    [MOVE_CONVERSATION_TOOL_NAME]: async (params) => {
+      return withErrorHandling(async () => {
+        const owner = auth.getNonNullableWorkspace();
+
+        const conversationId =
+          params.conversationId ??
+          (isAgentLoopRunContext(toolContext?.runContext)
+            ? toolContext.runContext.conversation.sId
+            : null);
+
+        if (!conversationId) {
+          return new Err(
+            new MCPError(
+              "No conversationId provided and no conversation in agent context; pass conversationId explicitly.",
+              { tracked: false }
+            )
+          );
+        }
+
+        const conversationRes = await getConversation(
+          auth,
+          conversationId,
+          false
+        );
+        if (conversationRes.isErr()) {
+          return new Err(
+            new MCPError(`Conversation not found: ${conversationId}`, {
+              tracked: false,
+            })
+          );
+        }
+
+        const conversation = conversationRes.value;
+        const conversationUrl = getConversationRoute(
+          owner.sId,
+          conversation.sId,
+          undefined,
+          config.getAppUrl()
+        );
+
+        if (params.destination === "pod") {
+          if (!params.dustPod) {
+            return new Err(
+              new MCPError("dustPod is required when destination is 'pod'.", {
+                tracked: false,
+              })
+            );
+          }
+
+          const contextRes = await getPod(auth, {
+            toolContext,
+            dustPod: params.dustPod,
+          });
+          if (contextRes.isErr()) {
+            return contextRes;
+          }
+
+          const { pod } = contextRes.value;
+          const moveRes = await moveConversationToProject(auth, {
+            conversation,
+            spaceId: pod.sId,
+          });
+
+          if (moveRes.isErr()) {
+            return new Err(
+              new MCPError(moveRes.error.message, { tracked: false })
+            );
+          }
+
+          return new Ok(
+            makeSuccessResponse({
+              success: true,
+              destination: "pod",
+              conversationId: conversation.sId,
+              podId: pod.sId,
+              podName: pod.name,
+              conversationUrl,
+              message: `Conversation moved to Pod "${pod.name}".`,
+            })
+          );
+        }
+
+        const previousPodId = conversation.spaceId ?? null;
+        const moveRes = await moveConversationOutOfProject(auth, {
+          conversation,
+        });
+
+        if (moveRes.isErr()) {
+          return new Err(
+            new MCPError(moveRes.error.message, { tracked: false })
+          );
+        }
+
+        return new Ok(
+          makeSuccessResponse({
+            success: true,
+            destination: "personal",
+            conversationId: conversation.sId,
+            previousPodId,
+            conversationUrl,
+            message: "Conversation moved out of Pod successfully.",
+          })
+        );
+      }, "Failed to move conversation");
     },
   };
 

--- a/front/lib/api/actions/servers/pod_manager/types.ts
+++ b/front/lib/api/actions/servers/pod_manager/types.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 
 export const PodMemberRoleSchema = z.enum(["member", "editor"]);
 
+export const PodAccessSchema = z.enum(["restricted", "open"]);
+
 export const PodMembersToAddSchema = z.record(z.string(), PodMemberRoleSchema);
 
 export const PodMembersToRemoveSchema = z.array(z.string());
@@ -13,16 +15,49 @@ export const PodManagerUpdateMembersInputSchema = z.object({
   dustPod: DustPodConfigurationSchema.optional(),
 });
 
+export const PodManagerEditInformationInputSchema = z.object({
+  title: z.string().optional(),
+  description: z.string().optional(),
+  access: PodAccessSchema.optional(),
+  pinnedFramePath: z.string().nullable().optional(),
+  dustPod: DustPodConfigurationSchema.optional(),
+});
+
+export const PodManagerMoveConversationInputSchema = z.object({
+  destination: z.enum(["pod", "personal"]),
+  conversationId: z.string().optional(),
+  dustPod: DustPodConfigurationSchema.optional(),
+});
+
 export type PodMemberRole = z.infer<typeof PodMemberRoleSchema>;
+export type PodAccess = z.infer<typeof PodAccessSchema>;
 export type PodMembersToAdd = z.infer<typeof PodMembersToAddSchema>;
 export type PodManagerUpdateMembersInput = z.infer<
   typeof PodManagerUpdateMembersInputSchema
+>;
+export type PodManagerEditInformationInput = z.infer<
+  typeof PodManagerEditInformationInputSchema
+>;
+export type PodManagerMoveConversationInput = z.infer<
+  typeof PodManagerMoveConversationInputSchema
 >;
 
 export function isPodManagerUpdateMembersInput(
   input: Record<string, unknown>
 ): input is PodManagerUpdateMembersInput {
   return PodManagerUpdateMembersInputSchema.safeParse(input).success;
+}
+
+export function isPodManagerEditInformationInput(
+  input: Record<string, unknown>
+): input is PodManagerEditInformationInput {
+  return PodManagerEditInformationInputSchema.safeParse(input).success;
+}
+
+export function isPodManagerMoveConversationInput(
+  input: Record<string, unknown>
+): input is PodManagerMoveConversationInput {
+  return PodManagerMoveConversationInputSchema.safeParse(input).success;
 }
 
 export function partitionMembersToAdd(membersToAdd: PodMembersToAdd): {


### PR DESCRIPTION
## Description

Three additions to the `pod_manager` MCP server:

- **`move_conversation_to_pod` / `move_conversation_out_of_pod`**: new tools (stake `never_ask`) that reassign a conversation's space to a target Pod or back to the user's personal space. Both default to the current agent conversation when no `conversationId` is provided. Backed by `moveConversationToProject` / `moveConversationOutOfProject` in `projects/conversations`.
- **`edit_information` gains `access` field**: agents can now flip a Pod between `restricted` and `open`. Respects the `areOpenPodsAllowed` workspace policy. Uses the new `getPodMemberAndEditorSIds` helper to preserve existing memberships when calling `pod.updatePermissions()`.
- **`create_pod` renames `visibility` → `access`** (`private` → `restricted`): aligns terminology with `edit_information`. This is a breaking schema change for any agent already calling `create_pod` with `visibility`.

UI: `PodEditInformationValidationDetails` shows a before/after diff card for each field being changed (title, description, access, pinned frame). `get_information` response now includes `access`.

## Tests

- Updated BM25 tool search test with queries for the three new intents.
- Snapshot updated for tool billing info and stakes.
- Tested manually.

## Risk

Medium. The `create_pod` `visibility` → `access` rename is a breaking schema change — agents currently generating `visibility` in their tool call will get a validation error until they re-read the updated tool definition. The `edit_information` access change calls `pod.updatePermissions()` which is the same path used by the UI; safe to rollback.

## Deploy Plan

Deploy front.
