### PR TITLE
Gate Anthropic tool search on real per-model support

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -547,7 +547,12 @@ export async function runModel(
   // Specs carry the intrinsic `eager` property only. Whether a non-eager tool is
   // deferred behind tool search is an Anthropic-specific policy applied in the
   // Anthropic client, gated on `toolSearchEnabled` (threaded through below).
-  const toolSearchEnabled = featureFlags.includes("anthropic_tool_search");
+  // Gated on model.supportsToolSearch too: unsupported models reject the
+  // request outright if deferred tools are included, so the feature flag alone
+  // is not enough to decide this.
+  const toolSearchEnabled =
+    featureFlags.includes("anthropic_tool_search") &&
+    !!model.supportsToolSearch;
   const baseSpecifications: AgentActionSpecification[] =
     buildBaseSpecifications(availableActions, agentConfiguration);
 

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -118,6 +118,7 @@ export const CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   regionalAvailability: {
     "us-central1": true,
@@ -207,6 +208,7 @@ export const CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   regionalAvailability: {
     "us-central1": true,
@@ -239,6 +241,7 @@ export const CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   availableIfOneOf: {
     featureFlag: "claude_4_5_opus_feature",
   },
@@ -274,6 +277,7 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   availableIfOneOf: {
@@ -315,6 +319,7 @@ export const CLAUDE_OPUS_4_7_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT * 1.35,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   availableIfOneOf: {
@@ -357,6 +362,7 @@ export const CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT * 1.35,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   availableIfOneOf: {
@@ -404,6 +410,7 @@ export const CLAUDE_FABLE_5_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT * 1.35,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   availableIfOneOf: {
@@ -485,6 +492,7 @@ export const CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -456,6 +456,7 @@ export const CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
   supportsBatchProcessing: false,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -115,7 +115,7 @@ export const ModelConfigurationSchema = z.object({
   supportsBatchProcessing: z.boolean().optional(),
   // If true, the model supports deferring rarely-used tool definitions out of
   // its active context until searched/discovered on demand. Provider-specific
-  // (currently only consulted for Anthropic models); must not be enabled based
+  // (currently only consulted for Anthropic models). Must not be enabled based
   // on a feature flag alone, since unsupported models reject the request.
   supportsToolSearch: z.boolean().optional(),
   // Specify if the model is available in specific regions.

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -113,6 +113,11 @@ export const ModelConfigurationSchema = z.object({
   useEapKey: z.boolean().optional(),
   disablePrefill: z.boolean().optional(),
   supportsBatchProcessing: z.boolean().optional(),
+  // If true, the model supports deferring rarely-used tool definitions out of
+  // its active context until searched/discovered on demand. Provider-specific
+  // (currently only consulted for Anthropic models); must not be enabled based
+  // on a feature flag alone, since unsupported models reject the request.
+  supportsToolSearch: z.boolean().optional(),
   // Specify if the model is available in specific regions.
   regionalAvailability: z.record(z.enum(SUPPORTED_REGIONS), z.boolean()),
   availableIfOneOf: AvailabilityConditionSchema.optional(),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The `anthropic_tool_search` feature flag alone was enough to make the agent loop send `defer_loading`/the `tool-search-tool` entry on every Anthropic request, with no check for whether the specific model in use actually supports the feature. Anthropic only supports tool search on a handful of recent models, so a workspace with the flag on but an agent configured for an older Claude model would have gotten a request Anthropic likely rejects outright. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
