### PR TITLE
Exclude deferred tool schemas from the token-budget estimate

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -5,6 +5,7 @@ import { ANTHROPIC_PROVIDER_ID } from "@app/lib/api/llm/clients/anthropic/types"
 import {
   buildBaseSpecifications,
   buildSpecificationsWithReplayPlaceholders,
+  buildToolDefinitionsForTokenCount,
 } from "@app/temporal/agent_loop/lib/run_model";
 import type {
   ModelConversationTypeMultiActions,
@@ -157,6 +158,47 @@ function makeAgentServerConfiguration({
     internalMCPServerId: null,
   };
 }
+
+describe("buildToolDefinitionsForTokenCount", () => {
+  it("includes every spec, eager or not, when tool search is disabled", () => {
+    const specs = [
+      makeSpecification("eager_tool", { eager: true }),
+      makeSpecification("deferred_tool", { eager: false }),
+    ];
+
+    const tools = JSON.parse(buildToolDefinitionsForTokenCount(specs, false));
+
+    expect(tools.map((t: { name: string }) => t.name)).toEqual([
+      "eager_tool",
+      "deferred_tool",
+    ]);
+  });
+
+  it("keeps only eager specs, plus the tool-search tool itself, when tool search is enabled", () => {
+    const specs = [
+      makeSpecification("eager_tool", { eager: true }),
+      makeSpecification("deferred_tool", { eager: false }),
+      makeSpecification("another_deferred_tool"),
+    ];
+
+    const tools = JSON.parse(buildToolDefinitionsForTokenCount(specs, true));
+
+    expect(tools).toEqual([
+      { type: "tool_search_tool_bm25_20251119", name: "tool_search_tool_bm25" },
+      expect.objectContaining({ name: "eager_tool" }),
+    ]);
+  });
+
+  it("still includes the tool-search tool when no spec is eager", () => {
+    const specs = [makeSpecification("deferred_tool", { eager: false })];
+
+    const tools = JSON.parse(buildToolDefinitionsForTokenCount(specs, true));
+
+    expect(tools).toEqual([
+      { type: "tool_search_tool_bm25_20251119", name: "tool_search_tool_bm25" },
+    ]);
+  });
+});
 
 describe("buildBaseSpecifications", () => {
   it("marks a custom agent's configured tools eager", () => {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -57,6 +57,7 @@ import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
+import { TOOL_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -120,6 +121,29 @@ const ASK_USER_QUESTION_BLOCKED_ORIGINS: readonly UserMessageOrigin[] = [
   "reinforcement",
   "branch_anchor",
 ];
+
+// Builds the JSON blob whose token count estimates how many tokens the tool
+// definitions actually cost in context, for the model's token budget. When
+// tool search is active, deferred (non-eager) tool schemas are excluded from
+// the model's context until discovered, so they must not count toward the
+// budget the same way eager specs do: only eager specs, plus the tool-search
+// tool itself, are actually in context up front.
+export function buildToolDefinitionsForTokenCount(
+  specifications: AgentActionSpecification[],
+  toolSearchEnabled: boolean
+): string {
+  const specsInContext = toolSearchEnabled
+    ? specifications.filter((s) => s.eager)
+    : specifications;
+  return JSON.stringify([
+    ...(toolSearchEnabled ? [TOOL_SEARCH_TOOL] : []),
+    ...specsInContext.map((s) => ({
+      name: s.name,
+      description: s.description,
+      inputSchema: s.inputSchema,
+    })),
+  ]);
+}
 
 // Concatenate two content strings, ensuring at least one whitespace character
 // between them when both are non-empty. This prevents words from being glued
@@ -558,12 +582,9 @@ export async function runModel(
 
   // Count the number of tokens used by the functions presented to the model.
   // This is a rough estimate of the number of tokens.
-  const tools = JSON.stringify(
-    baseSpecifications.map((s) => ({
-      name: s.name,
-      description: s.description,
-      inputSchema: s.inputSchema,
-    }))
+  const tools = buildToolDefinitionsForTokenCount(
+    baseSpecifications,
+    toolSearchEnabled
   );
 
   // Turn the conversation into a digest that can be presented to the model.

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -547,7 +547,12 @@ export async function runModel(
   // Specs carry the intrinsic `eager` property only. Whether a non-eager tool is
   // deferred behind tool search is an Anthropic-specific policy applied in the
   // Anthropic client, gated on `toolSearchEnabled` (threaded through below).
-  const toolSearchEnabled = featureFlags.includes("anthropic_tool_search");
+  // Gated on model.supportsToolSearch too: unsupported models reject the
+  // request outright if deferred tools are included, so the feature flag alone
+  // is not enough to decide this.
+  const toolSearchEnabled =
+    featureFlags.includes("anthropic_tool_search") &&
+    !!model.supportsToolSearch;
   const baseSpecifications: AgentActionSpecification[] =
     buildBaseSpecifications(availableActions, agentConfiguration);
 

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -118,6 +118,7 @@ export const CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   regionalAvailability: {
     "us-central1": true,
@@ -207,6 +208,7 @@ export const CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   regionalAvailability: {
     "us-central1": true,
@@ -239,6 +241,7 @@ export const CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   availableIfOneOf: {
     featureFlag: "claude_4_5_opus_feature",
   },
@@ -274,6 +277,7 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   availableIfOneOf: {
@@ -315,6 +319,7 @@ export const CLAUDE_OPUS_4_7_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT * 1.35,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   availableIfOneOf: {
@@ -357,6 +362,7 @@ export const CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT * 1.35,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   availableIfOneOf: {
@@ -404,6 +410,7 @@ export const CLAUDE_FABLE_5_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT * 1.35,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   availableIfOneOf: {
@@ -485,6 +492,7 @@ export const CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -456,6 +456,7 @@ export const CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
   supportsBatchProcessing: false,
+  supportsToolSearch: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -115,7 +115,7 @@ export const ModelConfigurationSchema = z.object({
   supportsBatchProcessing: z.boolean().optional(),
   // If true, the model supports deferring rarely-used tool definitions out of
   // its active context until searched/discovered on demand. Provider-specific
-  // (currently only consulted for Anthropic models); must not be enabled based
+  // (currently only consulted for Anthropic models). Must not be enabled based
   // on a feature flag alone, since unsupported models reject the request.
   supportsToolSearch: z.boolean().optional(),
   // Specify if the model is available in specific regions.

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -113,6 +113,11 @@ export const ModelConfigurationSchema = z.object({
   useEapKey: z.boolean().optional(),
   disablePrefill: z.boolean().optional(),
   supportsBatchProcessing: z.boolean().optional(),
+  // If true, the model supports deferring rarely-used tool definitions out of
+  // its active context until searched/discovered on demand. Provider-specific
+  // (currently only consulted for Anthropic models); must not be enabled based
+  // on a feature flag alone, since unsupported models reject the request.
+  supportsToolSearch: z.boolean().optional(),
   // Specify if the model is available in specific regions.
   regionalAvailability: z.record(z.enum(SUPPORTED_REGIONS), z.boolean()),
   availableIfOneOf: AvailabilityConditionSchema.optional(),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Based on https://github.com/dust-tt/dust/pull/28816. Anthropic's tool-search feature excludes deferred tool definitions from the model's active context until they're actually discovered mid-conversation, confirmed directly from their own documentation: only tool definitions loaded into context by a search count as input tokens, and deferred ones sit outside the prefix entirely. Our own token-budget estimate didn't reflect that at all, it tokenized every available tool's full schema regardless of eager or deferred status, which meant the budget looked meaningfully tighter than it really was on any workspace with tool search active and a large tool catalog, since most tools in a typical setup end up deferred.

The fix only changes what gets fed into the existing token-counting call for the tools portion of the budget: eager specs plus the tool-search tool itself when tool search is active, everything as before when it isn't. 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Low risk, since as of today, we use very conservative context window for most models.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
